### PR TITLE
Disable the maximize button on Windows if min and max dimensions equal.

### DIFF
--- a/examples/no_maximize.rs
+++ b/examples/no_maximize.rs
@@ -1,0 +1,22 @@
+extern crate winit;
+
+fn main() {
+    let mut events_loop = winit::EventsLoop::new();
+
+    let _window = winit::WindowBuilder::new()
+        .with_title("No maximize!")
+        .with_maximizable(false)
+        .build(&events_loop)
+        .unwrap();
+
+    events_loop.run_forever(|event| {
+        println!("{:?}", event);
+
+        match event {
+            winit::Event::WindowEvent { event: winit::WindowEvent::Closed, .. } => {
+                winit::ControlFlow::Break
+            },
+            _ => winit::ControlFlow::Continue,
+        }
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,6 +427,13 @@ pub struct WindowAttributes {
     /// The default is `false`.
     pub maximized: bool,
 
+    /// Whether the window's maximize button should be enabled.
+    ///
+    /// Setting this to `false` also causes the window not to be resizable.
+    ///
+    /// The default is `true`.
+    pub maximizable: bool,
+
     /// Whether the window should be immediately visible upon creation.
     ///
     /// The default is `true`.
@@ -457,6 +464,7 @@ impl Default for WindowAttributes {
             max_dimensions: None,
             title: "winit window".to_owned(),
             maximized: false,
+            maximizable: true,
             fullscreen: None,
             visible: true,
             transparent: false,

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -343,7 +343,7 @@ unsafe fn init(window: WindowAttributes, pl_attribs: PlatformSpecificWindowBuild
     };
 
     // computing the style and extended style of the window
-    let (ex_style, style) = if fullscreen || !window.decorations {
+    let (ex_style, mut style) = if fullscreen || !window.decorations {
         (winapi::WS_EX_APPWINDOW,
             //winapi::WS_POPUP is incompatible with winapi::WS_CHILD
             if pl_attribs.parent.is_some() {
@@ -357,6 +357,11 @@ unsafe fn init(window: WindowAttributes, pl_attribs: PlatformSpecificWindowBuild
         (winapi::WS_EX_APPWINDOW | winapi::WS_EX_WINDOWEDGE,
             winapi::WS_OVERLAPPEDWINDOW | winapi::WS_CLIPSIBLINGS | winapi::WS_CLIPCHILDREN)
     };
+
+    // disable maximize button if indicated
+    if !window.maximizable {
+        style &= !(winapi::WS_SIZEBOX | winapi::WS_MAXIMIZEBOX);
+    }
 
     // adjusting the window coordinates using the style
     user32::AdjustWindowRectEx(&mut rect, style, 0, ex_style);

--- a/src/window.rs
+++ b/src/window.rs
@@ -70,6 +70,16 @@ impl WindowBuilder {
         self
     }
 
+    /// Sets whether the window should be maximizable.
+    ///
+    /// Setting this to `false` means the maximize button is disabled, and the window is not
+    /// resizable.
+    #[inline]
+    pub fn with_maximizable(mut self, maximizable: bool) -> WindowBuilder {
+        self.window.maximizable = maximizable;
+        self
+    }
+
     /// Sets whether the window will be initially hidden or visible.
     #[inline]
     pub fn with_visibility(mut self, visible: bool) -> WindowBuilder {


### PR DESCRIPTION
This is part of the fix for https://github.com/PistonDevelopers/piston_window/issues/160

This disables the window maximize button on Windows if the min and max dimensions are both set and are equal.

 I've only tested this on Windows 10.