### PR TITLE
[x11-backend] Retrieve DPI from Xft.dpi XResource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - On iOS, the view is now set correctly. This makes it possible to render things (instead of being stuck on a black screen), and touch events work again.
 - Added NetBSD support.
+- X11 - Dpi scaling factor behavior changed. First, winit tries to read it from "Xft.dpi" XResource, and uses DPI calculation from xrandr dimensions as fallback behavior.
 
 # Version 0.16.2 (2018-07-07)
 

--- a/src/platform/linux/x11/util/randr.rs
+++ b/src/platform/linux/x11/util/randr.rs
@@ -79,6 +79,24 @@ impl From<*mut ffi::XRRCrtcInfo> for MonitorRepr {
 }
 
 impl XConnection {
+    // Retrieve DPI from Xft.dpi property
+    pub unsafe fn get_xft_dpi(&self) -> Option<f64> {
+        (self.xlib.XrmInitialize)();
+        let resource_manager_str = (self.xlib.XResourceManagerString)(self.display);
+        if resource_manager_str == ptr::null_mut() {
+            return None;
+        }
+        if let Ok(res) = ::std::ffi::CStr::from_ptr(resource_manager_str).to_str() {
+            let name : &str = "Xft.dpi:\t";
+            for pair in res.split("\n") {
+                if pair.starts_with(&name) {
+                    let res = &pair[name.len()..];
+                    return f64::from_str(&res).ok();
+                }
+            }
+        }
+        None
+    }
     pub unsafe fn get_output_info(&self, resources: *mut ffi::XRRScreenResources, repr: &MonitorRepr) -> (String, f64) {
         let output_info = (self.xrandr.XRRGetOutputInfo)(
             self.display,
@@ -90,10 +108,15 @@ impl XConnection {
             (*output_info).nameLen as usize,
         );
         let name = String::from_utf8_lossy(name_slice).into();
-        let hidpi_factor = calc_dpi_factor(
-            repr.get_dimensions(),
-            ((*output_info).mm_width as u64, (*output_info).mm_height as u64),
-        );
+        let hidpi_factor = if let Some(dpi) = self.get_xft_dpi() {
+            dpi / 96.
+        } else {
+            calc_dpi_factor(
+                repr.get_dimensions(),
+                ((*output_info).mm_width as u64, (*output_info).mm_height as u64),
+            )
+        };
+
         (self.xrandr.XRRFreeOutputInfo)(output_info);
         (name, hidpi_factor)
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -485,7 +485,7 @@ impl MonitorId {
     ///
     /// ## Platform-specific
     ///
-    /// - **X11:** Can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
+    /// - **X11:** This respects Xft.dpi XResource, and can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
     /// - **Android:** Always returns 1.0.
     #[inline]
     pub fn get_hidpi_factor(&self) -> f64 {


### PR DESCRIPTION
DPI Scaling on X11 is in rough shape. But I think calculating actual display DPI ourselves is not a way to go. The "Xft.dpi"  XResource is at least somewhat standard on several linuxes ( [Arch](https://wiki.archlinux.org/index.php/HiDPI#X_Resources) ). And is used in both [GLFW](https://github.com/glfw/glfw/blob/7ef34eb06de54dd9186d3d21a401b2ef819b59e7/src/x11_init.c#L802) and [QT](https://code.qt.io/cgit/qt/qtbase.git/tree/src/plugins/platforms/xcb/qxcbscreen.cpp?id=b393641888f18e3accf094c91808e2189c2138cc#n860) .

 This commit changes the behavior of DPI scaling on X11. The primary value of DPI scaling factor is retrieved from Xft.dpi XResource. The previous behavior is used as a fallback option.
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
