### PR TITLE
Fixed duplicate key events on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On macOS, fixed duplicate key events when pressing `Command + Period`.
 - Added serde serialization to `os::unix::XWindowType`.
 - **Breaking:** `image` crate upgraded to 0.21. This is exposed as part of the `icon_loading` API.
 

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -324,18 +324,6 @@ impl EventsLoop {
                 }
                 None
             },
-            // similar to above, but for `<Cmd-.>`, the keyDown is suppressed instead of the
-            // KeyUp, and the above trick does not appear to work.
-            appkit::NSKeyDown => {
-                let modifiers = event_mods(ns_event);
-                let keycode = NSEvent::keyCode(ns_event);
-                if modifiers.logo && keycode == 47 {
-                    modifier_event(ns_event, NSEventModifierFlags::NSCommandKeyMask, false)
-                        .map(into_event)
-                } else {
-                    None
-                }
-            },
             appkit::NSFlagsChanged => {
                 let mut events = std::collections::VecDeque::new();
 


### PR DESCRIPTION
Fixes the issue described in #734 using the suggested solution.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality