### PR TITLE
Fix second window on Linux

### DIFF
--- a/src/platform/linux/x11/ime/inner.rs
+++ b/src/platform/linux/x11/ime/inner.rs
@@ -49,7 +49,7 @@ impl ImeInner {
     }
 
     pub unsafe fn close_im_if_necessary(&self) -> Result<bool, XError> {
-        if !self.is_destroyed {
+        if !self.is_destroyed && self.im != ptr::null_mut() {
             close_im(&self.xconn, self.im).map(|_| true)
         } else {
             Ok(false)


### PR DESCRIPTION
I ran into a problem when having two open windows on Linux. On Windows
it worked just fine.

This was the stacktrace reported by valgrind

```
==10814== Invalid read of size 8
==10814==    at 0x6E4ADD4: XCloseIM (in /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0)
==10814==    by 0x17F1EB0: winit::platform::platform::x11::ime::inner::close_im::hbc9884d53ebb135d (inner.rs:12)
==10814==    by 0x17F2165: winit::platform::platform::x11::ime::inner::ImeInner::close_im_if_necessary::h66b984514f534c73 (inner.rs:53)
==10814==    by 0x1795FD6: winit::platform::platform::x11::ime::callbacks::replace_im::h24ec173b1f14fafb (callbacks.rs:132)
==10814==    by 0x1796457: winit::platform::platform::x11::ime::callbacks::xim_instantiate_callback::h7d468b9bb7725d0d (callbacks.rs:149)
==10814==    by 0x6E63D24: _XimRegisterIMInstantiateCallback (in /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0)
==10814==    by 0x6E4AE8B: XRegisterIMInstantiateCallback (in /usr/lib/x86_64-linux-gnu/libX11.so.6.3.0)
==10814==    by 0x17953A1: winit::platform::platform::x11::ime::callbacks::set_instantiate_callback::hc2cfe1836f29d39a (callbacks.rs:39)
==10814==    by 0x1797573: winit::platform::platform::x11::ime::Ime::new::_$u7b$$u7b$closure$u7d$$u7d$::h29e3c3099f3d0bd3 (mod.rs:57)
==10814==    by 0x17FDBD2: core::ops::function::impls::_$LT$impl$u20$core..ops..function..Fn$LT$A$GT$$u20$for$u20$$RF$F$GT$::call::h7296aa50456f6259 (function.rs:247)
==10814==    by 0x17F3FC2: winit::platform::platform::x11::ime::input_method::PotentialInputMethods::open_im::h09a3f2c789e7c5e2 (input_method.rs:269)
==10814==    by 0x1796AE9: winit::platform::platform::x11::ime::Ime::new::h7ab2dd81306c8874 (mod.rs:56)
==10814==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
```

I added a guard against null and my code now works fine.

Tested on Linux, Ubuntu 16.04.
