### PR TITLE
Add wayland specific code to examples for windows to appear

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ features = [
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 wayland-client = { version = "0.21", features = [ "dlopen", "egl", "cursor"] }
-smithay-client-toolkit = "0.4.3"
+smithay-client-toolkit = { git = "https://github.com/smithay/client-toolkit" }
 x11-dl = "2.18.3"
 parking_lot = "0.7"
 percent-encoding = "1.0"

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -8,7 +8,10 @@ fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
     let window = winit::WindowBuilder::new().build(&events_loop).unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
+    
     window.set_title("A fantastic window!");
 
     let cursors = [MouseCursor::Default, MouseCursor::Crosshair, MouseCursor::Hand, MouseCursor::Arrow, MouseCursor::Move, MouseCursor::Text, MouseCursor::Wait, MouseCursor::Help, MouseCursor::Progress, MouseCursor::NotAllowed, MouseCursor::ContextMenu, MouseCursor::Cell, MouseCursor::VerticalText, MouseCursor::Alias, MouseCursor::Copy, MouseCursor::NoDrop, MouseCursor::Grab, MouseCursor::Grabbing, MouseCursor::AllScroll, MouseCursor::ZoomIn, MouseCursor::ZoomOut, MouseCursor::EResize, MouseCursor::NResize, MouseCursor::NeResize, MouseCursor::NwResize, MouseCursor::SResize, MouseCursor::SeResize, MouseCursor::SwResize, MouseCursor::WResize, MouseCursor::EwResize, MouseCursor::NsResize, MouseCursor::NeswResize, MouseCursor::NwseResize, MouseCursor::ColResize, MouseCursor::RowResize];

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,11 +1,14 @@
 extern crate winit;
 
+mod helpers;
+
 use winit::{Event, ElementState, MouseCursor, WindowEvent, KeyboardInput, ControlFlow};
 
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
     let window = winit::WindowBuilder::new().build(&events_loop).unwrap();
+    helpers::init_wayland(&window);
     window.set_title("A fantastic window!");
 
     let cursors = [MouseCursor::Default, MouseCursor::Crosshair, MouseCursor::Hand, MouseCursor::Arrow, MouseCursor::Move, MouseCursor::Text, MouseCursor::Wait, MouseCursor::Help, MouseCursor::Progress, MouseCursor::NotAllowed, MouseCursor::ContextMenu, MouseCursor::Cell, MouseCursor::VerticalText, MouseCursor::Alias, MouseCursor::Copy, MouseCursor::NoDrop, MouseCursor::Grab, MouseCursor::Grabbing, MouseCursor::AllScroll, MouseCursor::ZoomIn, MouseCursor::ZoomOut, MouseCursor::EResize, MouseCursor::NResize, MouseCursor::NeResize, MouseCursor::NwResize, MouseCursor::SResize, MouseCursor::SeResize, MouseCursor::SwResize, MouseCursor::WResize, MouseCursor::EwResize, MouseCursor::NsResize, MouseCursor::NeswResize, MouseCursor::NwseResize, MouseCursor::ColResize, MouseCursor::RowResize];

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -9,6 +9,8 @@ fn main() {
         .with_title("Super Cursor Grab'n'Hide Simulator 9000")
         .build(&events_loop)
         .unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -1,5 +1,7 @@
 extern crate winit;
 
+mod helpers;
+
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
@@ -7,6 +9,7 @@ fn main() {
         .with_title("Super Cursor Grab'n'Hide Simulator 9000")
         .build(&events_loop)
         .unwrap();
+    helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {
         if let winit::Event::WindowEvent { event, .. } = event {

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,5 +1,7 @@
 extern crate winit;
 
+mod helpers;
+
 use std::io::{self, Write};
 use winit::{ControlFlow, Event, WindowEvent};
 
@@ -45,6 +47,7 @@ fn main() {
         .with_fullscreen(monitor)
         .build(&events_loop)
         .unwrap();
+    helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {
         println!("{:?}", event);

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -47,6 +47,8 @@ fn main() {
         .with_fullscreen(monitor)
         .build(&events_loop)
         .unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -1,12 +1,15 @@
 extern crate winit;
 
+mod helpers;
+
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
-    let _window = winit::WindowBuilder::new()
+    let window = winit::WindowBuilder::new()
         .with_title("Your faithful window")
         .build(&events_loop)
         .unwrap();
+    helpers::init_wayland(&window);
 
     let mut close_requested = false;
 

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -9,6 +9,8 @@ fn main() {
         .with_title("Your faithful window")
         .build(&events_loop)
         .unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     let mut close_requested = false;

--- a/examples/helpers/mod.rs
+++ b/examples/helpers/mod.rs
@@ -1,0 +1,45 @@
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+extern crate smithay_client_toolkit as sctk;
+
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+use winit::os::unix::WindowExt;
+
+// Wayland requires the commiting of a surface to display a window
+pub fn init_wayland(window: &winit::Window) {
+    #[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+    {
+        if let Some(winit_display) = window.get_wayland_display() {
+            if let Some(surface) = window.get_wayland_surface() {
+                use self::sctk::reexports::client::protocol::wl_shm;
+                use self::sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
+                use self::sctk::reexports::client::{Display, Proxy};
+                use self::sctk::utils::DoubleMemPool;
+                use self::sctk::wayland_client::sys::client::wl_display;
+                use self::sctk::Environment;
+
+                let (width, height): (u32, u32) = window.get_inner_size().unwrap().into();
+                let (display, mut event_queue) =
+                    unsafe { Display::from_external_display(winit_display as *mut wl_display) };
+                let env = Environment::from_display(&*display, &mut event_queue).unwrap();
+                let mut pools =
+                    DoubleMemPool::new(&env.shm, || {}).expect("Failed to create a memory pool !");
+                let surface = unsafe { Proxy::from_c_ptr(surface as *mut _) };
+
+                if let Some(pool) = pools.pool() {
+                    pool.resize(4 * (width * height) as usize)
+                        .expect("Failed to resize the memory pool.");
+                    let new_buffer = pool.buffer(
+                        0,
+                        width as i32,
+                        height as i32,
+                        4 * width as i32,
+                        wl_shm::Format::Argb8888,
+                    );
+                    surface.attach(Some(&new_buffer), 0, 0);
+                    surface.commit();
+                    event_queue.sync_roundtrip().unwrap();
+                }
+            }
+        }
+    }
+}

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -1,5 +1,7 @@
 extern crate winit;
 
+mod helpers;
+
 use winit::dpi::LogicalSize;
 
 fn main() {
@@ -8,6 +10,7 @@ fn main() {
     let window = winit::WindowBuilder::new()
         .build(&events_loop)
         .unwrap();
+    helpers::init_wayland(&window);
 
     window.set_min_dimensions(Some(LogicalSize::new(400.0, 200.0)));
     window.set_max_dimensions(Some(LogicalSize::new(800.0, 400.0)));

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -10,6 +10,8 @@ fn main() {
     let window = winit::WindowBuilder::new()
         .build(&events_loop)
         .unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     window.set_min_dimensions(Some(LogicalSize::new(400.0, 200.0)));

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -5,6 +5,7 @@ mod helpers;
 fn main() {
     let event_loop = winit::EventsLoop::new();
     let window = winit::WindowBuilder::new().build(&event_loop).unwrap();
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
     println!("{:#?}\nPrimary: {:#?}", window.get_available_monitors(), window.get_primary_monitor());
 }

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -1,7 +1,10 @@
 extern crate winit;
 
+mod helpers;
+
 fn main() {
     let event_loop = winit::EventsLoop::new();
     let window = winit::WindowBuilder::new().build(&event_loop).unwrap();
+    helpers::init_wayland(&window);
     println!("{:#?}\nPrimary: {:#?}", window.get_available_monitors(), window.get_primary_monitor());
 }

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,5 +1,7 @@
 extern crate winit;
 
+mod helpers;
+
 use std::collections::HashMap;
 
 fn main() {
@@ -8,6 +10,7 @@ fn main() {
     let mut windows = HashMap::new();
     for _ in 0..3 {
         let window = winit::Window::new(&events_loop).unwrap();
+        helpers::init_wayland(&window);
         windows.insert(window.id(), window);
     }
 

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -10,6 +10,7 @@ fn main() {
     let mut windows = HashMap::new();
     for _ in 0..3 {
         let window = winit::Window::new(&events_loop).unwrap();
+        // Wayland requires the commiting of a surface to display a window
         helpers::init_wayland(&window);
         windows.insert(window.id(), window);
     }

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -9,6 +9,8 @@ fn main() {
         .with_title("A fantastic window!")
         .build(&events_loop)
         .unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     let proxy = events_loop.create_proxy();

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -1,12 +1,15 @@
 extern crate winit;
 
+mod helpers;
+
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
-    let _window = winit::WindowBuilder::new()
+    let window = winit::WindowBuilder::new()
         .with_title("A fantastic window!")
         .build(&events_loop)
         .unwrap();
+    helpers::init_wayland(&window);
 
     let proxy = events_loop.create_proxy();
 

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,5 +1,7 @@
 extern crate winit;
 
+mod helpers;
+
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
@@ -11,6 +13,7 @@ fn main() {
         .with_resizable(resizable)
         .build(&events_loop)
         .unwrap();
+    helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {
         match event {

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -13,6 +13,8 @@ fn main() {
         .with_resizable(resizable)
         .build(&events_loop)
         .unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -8,6 +8,8 @@ fn main() {
     let window = winit::WindowBuilder::new().with_decorations(false)
                                                  .with_transparency(true)
                                                  .build(&events_loop).unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     window.set_title("A fantastic window!");

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,11 +1,14 @@
 extern crate winit;
 
+mod helpers;
+
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
     let window = winit::WindowBuilder::new().with_decorations(false)
                                                  .with_transparency(true)
                                                  .build(&events_loop).unwrap();
+    helpers::init_wayland(&window);
 
     window.set_title("A fantastic window!");
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,12 +1,15 @@
 extern crate winit;
 
+mod helpers;
+
 fn main() {
     let mut events_loop = winit::EventsLoop::new();
 
-    let _window = winit::WindowBuilder::new()
+    let window = winit::WindowBuilder::new()
         .with_title("A fantastic window!")
         .build(&events_loop)
         .unwrap();
+    helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {
         println!("{:?}", event);

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -9,6 +9,8 @@ fn main() {
         .with_title("A fantastic window!")
         .build(&events_loop)
         .unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -6,6 +6,8 @@ extern crate winit;
 #[cfg(feature = "icon_loading")]
 extern crate image;
 
+mod helpers;
+
 #[cfg(feature = "icon_loading")]
 fn main() {
     use winit::Icon;
@@ -29,6 +31,7 @@ fn main() {
         .with_window_icon(Some(icon))
         .build(&events_loop)
         .unwrap();
+    helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {
         if let winit::Event::WindowEvent { event, .. } = event {

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -31,6 +31,8 @@ fn main() {
         .with_window_icon(Some(icon))
         .build(&events_loop)
         .unwrap();
+
+    // Wayland requires the commiting of a surface to display a window
     helpers::init_wayland(&window);
 
     events_loop.run_forever(|event| {


### PR DESCRIPTION
- [x] Tested on all platforms changed

Adds wayland specific code to the examples to allow for the windows to appear.

Once a version of SCTK with https://github.com/Smithay/client-toolkit/commit/74316f4d71f21ae5b53339ee39b8b0249341dbae is released the git dependency can be replaced to that.

Fixes https://github.com/tomaka/winit/issues/776