### PR TITLE
Add monitor changed event

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -37,19 +37,19 @@ pub enum WindowEvent {
     Destroyed,
 
     /// A file has been dropped into the window.
-    /// 
+    ///
     /// When the user drops multiple files at once, this event will be emitted for each file
     /// separately.
     DroppedFile(PathBuf),
 
     /// A file is being hovered over the window.
-    /// 
+    ///
     /// When the user hovers multiple files at once, this event will be emitted for each file
     /// separately.
     HoveredFile(PathBuf),
 
     /// A file was hovered, but has exited the window.
-    /// 
+    ///
     /// There will be a single `HoveredFileCancelled` event triggered even if multiple files were
     /// hovered.
     HoveredFileCancelled,
@@ -115,6 +115,9 @@ pub enum WindowEvent {
     ///
     /// For more information about DPI in general, see the [`dpi`](dpi/index.html) module.
     HiDpiFactorChanged(f64),
+
+    /// The window has moved to another monitor
+    MonitorChanged(String),
 }
 
 /// Represents raw hardware events that are not associated with any particular window.


### PR DESCRIPTION
Hey, my idea was to add another event if the monitor name has changed. I implemented it first for X11, because I am not sure if the approach is the right one. WDYT?