### PR TITLE
Feat/fullscreen getters

### DIFF
--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -82,6 +82,15 @@ fn main() {
                             window.set_fullscreen(Some(window.get_current_monitor()));
                         }
                     }
+                    (winit::VirtualKeyCode::S, winit::ElementState::Pressed) => {
+                        println!("window.get_fullscreen {:?}", window.get_fullscreen());
+
+                        #[cfg(target_os = "macos")]
+                        {
+                            use winit::os::macos::WindowExt;
+                            println!("window.get_simple_fullscreen {:?}", WindowExt::get_simple_fullscreen(&window));
+                        }
+                    }
                     (winit::VirtualKeyCode::M, winit::ElementState::Pressed) => {
                         is_maximized = !is_maximized;
                         window.set_maximized(is_maximized);

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -23,6 +23,9 @@ pub trait WindowExt {
     /// - `true`: the dock icon will bounce until the application is focused.
     fn request_user_attention(&self, is_critical: bool);
 
+    /// Returns whether or not the window is in simple fullscreen mode.
+    fn get_simple_fullscreen(&self) -> bool;
+
     /// Toggles a fullscreen mode that doesn't require a new macOS space.
     /// Returns a boolean indicating whether the transition was successful (this
     /// won't work if the window was already in the native fullscreen).
@@ -47,6 +50,11 @@ impl WindowExt for Window {
     #[inline]
     fn request_user_attention(&self, is_critical: bool) {
         self.window.request_user_attention(is_critical)
+    }
+
+    #[inline]
+    fn get_simple_fullscreen(&self) -> bool {
+        self.window.get_simple_fullscreen()
     }
 
     #[inline]

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -369,6 +369,13 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_fullscreen(&self) -> bool {
+        // N/A
+        // Android has single screen maximized apps so nothing to do
+        true
+    }
+
+    #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
         // N/A
         // Android has single screen maximized apps so nothing to do

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -369,10 +369,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_fullscreen(&self) -> bool {
+    pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
         // N/A
         // Android has single screen maximized apps so nothing to do
-        true
+        None
     }
 
     #[inline]

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -581,8 +581,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_fullscreen(&self) -> bool {
-        self.window.is_fullscreen
+    pub fn get_fullscreen(&self) -> Option<::MonitorId> {
+        None
     }
 
     #[inline]

--- a/src/platform/emscripten/mod.rs
+++ b/src/platform/emscripten/mod.rs
@@ -581,6 +581,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_fullscreen(&self) -> bool {
+        self.window.is_fullscreen
+    }
+
+    #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<::MonitorId>) {
         // iOS has single screen maximized apps so nothing to do
     }

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -474,10 +474,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_fullscreen(&self) -> bool {
+    pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
         // N/A
         // iOS has single screen maximized apps so nothing to do
-        true
+        None
     }
 
     #[inline]

--- a/src/platform/ios/mod.rs
+++ b/src/platform/ios/mod.rs
@@ -474,6 +474,13 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_fullscreen(&self) -> bool {
+        // N/A
+        // iOS has single screen maximized apps so nothing to do
+        true
+    }
+
+    #[inline]
     pub fn set_fullscreen(&self, _monitor: Option<RootMonitorId>) {
         // N/A
         // iOS has single screen maximized apps so nothing to do

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -306,6 +306,7 @@ impl Window {
         match self {
             &Window::X(ref w) => w.get_fullscreen(),
             &Window::Wayland(ref w) => w.get_fullscreen()
+                .map(|monitor_id| RootMonitorId { inner: MonitorId::Wayland(monitor_id) })
         }
     }
 

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -302,6 +302,14 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
+        match self {
+            &Window::X(ref w) => w.get_fullscreen(),
+            &Window::Wayland(ref w) => w.get_fullscreen()
+        }
+    }
+
+    #[inline]
     pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
         match self {
             &Window::X(ref w) => w.set_fullscreen(monitor),

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -7,7 +7,7 @@ use platform::{MonitorId as PlatformMonitorId, PlatformSpecificWindowBuilderAttr
 use window::MonitorId as RootMonitorId;
 
 use sctk::surface::{get_dpi_factor, get_outputs};
-use sctk::window::{ConceptFrame, Event as WEvent, Window as SWindow, Theme};
+use sctk::window::{ConceptFrame, Event as WEvent, State as WState, Window as SWindow, Theme};
 use sctk::reexports::client::{Display, Proxy};
 use sctk::reexports::client::protocol::{wl_seat, wl_surface};
 use sctk::reexports::client::protocol::wl_surface::RequestsTrait as SurfaceRequests;
@@ -24,7 +24,7 @@ pub struct Window {
     kill_switch: (Arc<Mutex<bool>>, Arc<Mutex<bool>>),
     display: Arc<Display>,
     need_frame_refresh: Arc<Mutex<bool>>,
-    fullscreen: Arc<Mutex<Option<RootMonitorId>>>,
+    fullscreen: Arc<Mutex<bool>>,
 }
 
 impl Window {
@@ -32,6 +32,7 @@ impl Window {
         let (width, height) = attributes.dimensions.map(Into::into).unwrap_or((800, 600));
         // Create the window
         let size = Arc::new(Mutex::new((width, height)));
+        let fullscreen = Arc::new(Mutex::new(false));
 
         let window_store = evlp.store.clone();
         let surface = evlp.env.create_surface(move |dpi, surface| {
@@ -46,12 +47,15 @@ impl Window {
             surface.clone(),
             (width, height),
             move |event| match event {
-                WEvent::Configure { new_size, .. } => {
+                WEvent::Configure { new_size, states } => {
                     let mut store = window_store.lock().unwrap();
+                    let is_fullscreen = states.contains(&WState::Fullscreen);
+
                     for window in &mut store.windows {
                         if window.surface.equals(&my_surface) {
                             window.newsize = new_size;
                             window.need_refresh = true;
+                            *(window.fullscreen.lock().unwrap()) = is_fullscreen;
                             *(window.need_frame_refresh.lock().unwrap()) = true;
                             return;
                         }
@@ -109,13 +113,13 @@ impl Window {
 
         let kill_switch = Arc::new(Mutex::new(false));
         let need_frame_refresh = Arc::new(Mutex::new(true));
-        let fullscreen = Arc::new(Mutex::new(None));
         let frame = Arc::new(Mutex::new(frame));
 
         evlp.store.lock().unwrap().windows.push(InternalWindow {
             closed: false,
             newsize: None,
             size: size.clone(),
+            fullscreen: fullscreen.clone(),
             need_refresh: false,
             need_frame_refresh: need_frame_refresh.clone(),
             surface: surface.clone(),
@@ -226,8 +230,12 @@ impl Window {
         }
     }
 
-    pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
-        *(self.fullscreen.lock().unwrap()).clone()
+    pub fn get_fullscreen(&self) -> Option<MonitorId> {
+        if *(self.fullscreen.lock().unwrap()) {
+            Some(self.get_current_monitor())
+        } else {
+            None
+        }
     }
 
     pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
@@ -242,8 +250,6 @@ impl Window {
         } else {
             self.frame.lock().unwrap().unset_fullscreen();
         }
-
-        *(self.fullscreen.lock().unwrap()) = monitor.clone();
     }
 
 
@@ -311,6 +317,7 @@ struct InternalWindow {
     surface: Proxy<wl_surface::WlSurface>,
     newsize: Option<(u32, u32)>,
     size: Arc<Mutex<(u32, u32)>>,
+    fullscreen: Arc<Mutex<bool>>,
     need_refresh: bool,
     need_frame_refresh: Arc<Mutex<bool>>,
     closed: bool,

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -24,6 +24,7 @@ pub struct Window {
     kill_switch: (Arc<Mutex<bool>>, Arc<Mutex<bool>>),
     display: Arc<Display>,
     need_frame_refresh: Arc<Mutex<bool>>,
+    fullscreen: Arc<Mutex<Option<RootMonitorId>>>,
 }
 
 impl Window {
@@ -108,6 +109,7 @@ impl Window {
 
         let kill_switch = Arc::new(Mutex::new(false));
         let need_frame_refresh = Arc::new(Mutex::new(true));
+        let fullscreen = Arc::new(Mutex::new(None));
         let frame = Arc::new(Mutex::new(frame));
 
         evlp.store.lock().unwrap().windows.push(InternalWindow {
@@ -132,6 +134,7 @@ impl Window {
             size: size,
             kill_switch: (kill_switch, evlp.cleanup_needed.clone()),
             need_frame_refresh: need_frame_refresh,
+            fullscreen: fullscreen,
         })
     }
 
@@ -223,6 +226,10 @@ impl Window {
         }
     }
 
+    pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
+        *(self.fullscreen.lock().unwrap()).clone()
+    }
+
     pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
         if let Some(RootMonitorId {
             inner: PlatformMonitorId::Wayland(ref monitor_id),
@@ -235,6 +242,8 @@ impl Window {
         } else {
             self.frame.lock().unwrap().unset_fullscreen();
         }
+
+        *(self.fullscreen.lock().unwrap()) = monitor.clone();
     }
 
 

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -536,7 +536,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
-        self.shared_state.lock().fullscreen
+        self.shared_state.lock().fullscreen.clone()
     }
 
     #[inline]

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -37,6 +37,7 @@ pub struct SharedState {
     pub guessed_dpi: Option<f64>,
     pub last_monitor: Option<X11MonitorId>,
     pub dpi_adjusted: Option<(f64, f64)>,
+    pub fullscreen: Option<RootMonitorId>,
     // Used to restore position after exiting fullscreen.
     pub restore_position: Option<(i32, i32)>,
     pub frame_extents: Option<util::FrameExtentsHeuristic>,
@@ -534,7 +535,13 @@ impl UnownedWindow {
     }
 
     #[inline]
+    pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
+        self.shared_state.lock().fullscreen
+    }
+
+    #[inline]
     pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
+        self.shared_state.lock().fullscreen = monitor.clone();
         self.set_fullscreen_inner(monitor)
             .flush()
             .expect("Failed to change window fullscreen state");

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -1143,15 +1143,11 @@ impl Window2 {
     }
 
     #[inline]
-    pub fn get_fullscreen(&self) -> bool {
-        if self.get_simple_fullscreen() {
-            return true;
-        }
-
+    pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
         let state = &self.delegate.state;
         let win_attribs = state.win_attribs.borrow();
 
-        win_attribs.fullscreen.is_some()
+        win_attribs.fullscreen.clone()
     }
 
     #[inline]

--- a/src/platform/macos/window.rs
+++ b/src/platform/macos/window.rs
@@ -619,6 +619,11 @@ impl WindowExt for Window2 {
     }
 
     #[inline]
+    fn get_simple_fullscreen(&self) -> bool {
+        self.delegate.state.is_simple_fullscreen.get()
+    }
+
+    #[inline]
     fn set_simple_fullscreen(&self, fullscreen: bool) -> bool {
         let state = &self.delegate.state;
 
@@ -1135,6 +1140,18 @@ impl Window2 {
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         self.delegate.state.perform_maximized(maximized)
+    }
+
+    #[inline]
+    pub fn get_fullscreen(&self) -> bool {
+        if self.get_simple_fullscreen() {
+            return true;
+        }
+
+        let state = &self.delegate.state;
+        let win_attribs = state.win_attribs.borrow();
+
+        win_attribs.fullscreen.is_some()
     }
 
     #[inline]

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -356,6 +356,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn get_fullscreen(&self) -> bool {
+        self.window_state.lock().unwrap().fullscreen.is_some()
+    }
+
+    #[inline]
     pub fn set_fullscreen(&self, monitor: Option<RootMonitorId>) {
         unsafe {
             let window = self.window.clone();

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -356,8 +356,9 @@ impl Window {
     }
 
     #[inline]
-    pub fn get_fullscreen(&self) -> bool {
-        self.window_state.lock().unwrap().fullscreen.is_some()
+    pub fn get_fullscreen(&self) -> Option<RootMonitorId> {
+        let window_state = self.window_state.lock().unwrap();
+        window_state.fullscreen.clone()
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -369,6 +369,12 @@ impl Window {
         self.window.set_fullscreen(monitor)
     }
 
+    /// Gets the window's current fullscreen state.
+    #[inline]
+    pub fn get_fullscreen(&self) -> bool {
+        self.window.get_fullscreen()
+    }
+
     /// Turn window decorations on or off.
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -371,7 +371,7 @@ impl Window {
 
     /// Gets the window's current fullscreen state.
     #[inline]
-    pub fn get_fullscreen(&self) -> bool {
+    pub fn get_fullscreen(&self) -> Option<MonitorId> {
         self.window.get_fullscreen()
     }
 


### PR DESCRIPTION
This change adds the `window.get_fullscreen()` method - this is useful for many reasons and makes using this library much easier.

It also adds a `get_simple_fullscreen()` method to the macos `WindowExt` as well, so macos users can distinguish which type of fullscreen mode is currently active.

I've tested this on the following platforms:

- [x] macOS
- [x] Linux (X11)
- [x] Windows 10

Closes #579