### PR TITLE
Prevent the event loop from pausing when entering modal loop (eventloop-2.0)

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -800,15 +800,16 @@ unsafe extern "system" fn public_window_callback<T>(
         },
 
         winuser::WM_NCLBUTTONDOWN => {
-            let mut runner = subclass_input.event_loop_runner.runner.borrow_mut();
-            if let Some(ref mut runner) = *runner {
-                let hwnd = runner.modal_redraw_window;
-                winuser::PostMessageW(hwnd, winuser::WM_NCLBUTTONDOWN, 0, 0);
-                if wparam == winuser::HTCAPTION as _ {
-                    winuser::PostMessageW(hwnd, winuser::WM_MOUSEMOVE, 0, 0);
-                }
+            // jumpstart the modal loop
+            winuser::RedrawWindow(
+                window,
+                ptr::null(),
+                ptr::null_mut(),
+                winuser::RDW_INTERNALPAINT
+            );
+            if wparam == winuser::HTCAPTION as _ {
+                winuser::PostMessageW(window, winuser::WM_MOUSEMOVE, 0, 0);
             }
-            drop(runner);
             commctrl::DefSubclassProc(window, msg, wparam, lparam)
         },
 
@@ -1525,19 +1526,7 @@ unsafe extern "system" fn thread_event_target_callback<T>(
     subclass_input_ptr: DWORD_PTR
 ) -> LRESULT {
     let subclass_input = &mut*(subclass_input_ptr as *mut ThreadMsgTargetSubclassInput<T>);
-    let queue_call_again = || {
-        winuser::RedrawWindow(
-            window,
-            ptr::null(),
-            ptr::null_mut(),
-            winuser::RDW_INTERNALPAINT
-        );
-    };
     match msg {
-        winuser::WM_NCLBUTTONDOWN => {
-            queue_call_again();
-            0
-        }
         winuser::WM_DESTROY => {
             Box::from_raw(subclass_input);
             drop(subclass_input);
@@ -1547,6 +1536,14 @@ unsafe extern "system" fn thread_event_target_callback<T>(
         // when the event queue has been emptied. See `process_event` for more details.
         winuser::WM_PAINT => {
             winuser::ValidateRect(window, ptr::null());
+            let queue_call_again = || {
+                winuser::RedrawWindow(
+                    window,
+                    ptr::null(),
+                    ptr::null_mut(),
+                    winuser::RDW_INTERNALPAINT
+                );
+            };
             let in_modal_loop = {
                 let runner = subclass_input.event_loop_runner.runner.borrow_mut();
                 if let Some(ref runner) = *runner {


### PR DESCRIPTION
After clicking the window title bar or border (for a drag or resize), the event loop pauses until the mouse is moved. This change relays the `WM_NCLBUTTONDOWN` message to the dummy window where it queues a redraw and consumes the message. This effectively jumpstarts the modal loop and it continues to fire draw requests.

- [x] Tested on all platforms changed
