### PR TITLE
Makes changes to CONTRIBUTING.md's table as discussed in #830

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,15 +56,14 @@ backends of winit. As such, depending on your platform of interest, your contact
 
 This table summarizes who can be contacted in which case, with the following legend:
 
-- `M`: is a main maintainer for this platform
-- `R`: can review code for this platform
-- `T`: has the ability of testing the platform
+- `M` - Maintainer: is a main maintainer for this platform
+- `C` - Collaborator: can review code and address issues on this platform
+- `T` - Tester: has the ability of testing the platform
 - ` `: knows nothing of this platform
 
-| Platform | Windows | macOS | X11 | Wayland | Android | iOS | Emscripten |
-| :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| @francesca64 | R | M | M |  | M | R | |
-| @mitchmindtree | T |  | T | T |  |  |  |
-| @Osspial | M |  | T | T | T |  | T |
-| @vberger |  |  | T | M |  |  |  |
-| @mtak- |  | T |  |  | T | M |  |
+| Platform            | Windows | macOS | X11   | Wayland | Android | iOS   | Emscripten |
+| :---                | :---:   | :---: | :---: | :---:   | :---:   | :---: | :---:      |
+| @mitchmindtree      | T       |       | T     | T       |         |       |            |
+| @Osspial            | M       |       | T     | T       | T       |       | T          |
+| @vberger            |         |       | T     | M       |         |       |            |
+| @mtak-              |         | T     |       |         | T       | M     |            |

--- a/HALL_OF_CHAMPIONS.md
+++ b/HALL_OF_CHAMPIONS.md
@@ -1,0 +1,11 @@
+# Hall of Champions
+
+The Winit maintainers would like to recognize the following former Winit
+contributors, without whom Winit would not exist in its current form. We thank
+them deeply for their time and efforts, and wish them best of luck in their
+future endeavors:
+
+* @tomaka: For creating the Winit project and guiding it through its early
+  years of existence.
+* @francesca64: For taking over the responsibility of maintaining almost every
+  Winit backend, and standardizing HiDPI support across all of them


### PR DESCRIPTION
This includes de-listing @francesca64 from the table, as I suggested. I realize that this is a controversial decision, and it's not a decision I make lightly, but I believe I have justification for doing so:

I contacted @francesca64 last month asking her about her inactivity as a maintainer on this project. She replied on March 26th as follows. For the sake of her privacy, I've removed removed certain sections of her response, as it contains some personal details that I'm not comfortable sharing with the world at large without her explicit permission.

> Hello! Thanks for reaching out!❤
>
> In short, I've moved on. [removed] ...in November, I was hired by a company that recently started using Rust. I'm very happily building infrastructure there!
>
> I'm simply not interested in spending more than 8 hours a day programming. You couldn't even pay me to do it! My time is best spent going on adventures with my beloved.
>
> I'll still be active in the Rust ecosystem, but only insofar as the company I work for is. We use winit on iOS, Android, and (to a limited extent) macOS, so I'll work on those backends as needed.
>
> Thank you for taking care of winit. I hope you're taking care of yourself too; [removed].

I don't begrudge her for her decision, and others shouldn't either - I firmly believe that, as this is unpaid, volunteer work, everybody should have the right to move on when they decide they no longer have the time or will to contribute.

The exact implication of this in regards to her status as maintainer is open to interpretation. I would argue that this means, should she in her work stumble upon an issue in any of her listed backends, she would be willing to submit PRs addressing those issues. However, it also means that she is not able to put in the time to be active as a maintainer on those platforms, or review PRs and issues for those platforms.

On March 28th I responded to her email as follows:

> Hey, thanks for responding.
>
> [removed, personal details]
>
> In the meanwhile, there are still a few loose ends from your time as maintainer that I'd like to get cleaned up. It's okay if you aren't going to be spending much time on Winit, but there's still a broad assumption that you're able to review PRs for them and that doesn't seem to be the case. Would you be able to do a couple things to ease the transition to whoever next takes over the macOS, X11, and Android backends?
>
> 1) Submit a PR downgrading yourself from maintainer for macOS, X11, and Android, so somebody else can more actively take them over.
> 2) Post your WIP macOS backend for EL2.0 as well as the issues it currently has, so whoever next maintains macOS can finish it.
>
> Going forward, I'd like to reach out to the broader Rust community and find more active maintainers so Winit can get to 1.0 and I can mostly move on from it.

I received no response to that email. On April 4th, I followed up on that email:

> If you aren't able to act as a maintainer for Winit, and aren't able to submit a PR updating your official status as maintainer to reflect reality, would you mind if I submitted a PR removing you as maintainer? That's not something I want to do since it's a bad image for me, a bad image for Winit, and sets an extremely uncomfortable precedent, but I'd like to start more aggressive outreach to ensure each backend is less dependent on one specific person and I don't want to see new contributors pinging you for help when you're unable to provide it.
>
> If you don't reply by the 11th that's the path I'm going to take, but I consider it the nuclear option and I want to avoid invoking it if at all possible.

Up to this date (April 13th), I have received no response. Given the amount of time I've given her to respond, as well as her lack of response, I believe we have the justification to remove her from the table. Should she show back up again, any clarifications on her status would be welcome, and she is welcome to submit a PR re-listing herself on the table with a more accurate description of her current contributor status. However, once we begin the contributor marketing push discussed in #830, I don't want new contributors to attempt to ask her questions on the macOS, X11, or Android backends when she isn't able to give a response.

-----------------------------------------------------------------------

This PR also introduces HALL_OF_CHAMPIONS.md, which commends the efforts of former maintainers that have contributed greatly to the Winit project. This wasn't discussed previously, but I think it's important to recognize the people that brought us to where we are today. It currently lists @tomaka and @francesca64, as they are the two individuals I'm aware of that both deserve such recognition and no longer actively contribute to Winit, but if there's anybody I missed feel free to suggest them and a blurb describing their work.
