### PR TITLE
WIP - wasm_bindgen backend for eventloop-2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
           paths:
             - target
 
-  wasm-test:
+  emscripten-test:
     working_directory: ~/winit
     docker:
       - image: tomaka/rustc-emscripten
@@ -43,7 +43,22 @@ jobs:
           key: wasm-test-cache-{{ checksum "Cargo.toml" }}
       - run: cargo build --example window --target wasm32-unknown-emscripten
       - save_cache:
+          key: emscripten-test-cache-{{ checksum "Cargo.toml" }}
+          paths:
+            - target
+
+  websys-test:
+    working_directory: ~/winit
+    docker:
+      - image: tomaka/rustc-emscripten
+    steps:
+      - run: apt-get -qq update && apt-get install -y git
+      - checkout
+      - restore_cache:
           key: wasm-test-cache-{{ checksum "Cargo.toml" }}
+      - run: cargo build --example wasm_bindgen --target wasm32-unknown-unknown --features websys
+      - save_cache:
+          key: websys-test-cache-{{ checksum "Cargo.toml" }}
           paths:
             - target
   
@@ -53,4 +68,5 @@ workflows:
     jobs:
       - android-test
       - asmjs-test
-      - wasm-test
+      - emscripten-test
+      - websys-test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,5 +92,7 @@ features = [
     'MouseEvent',
     'Node',
     'Window',
-    'console'
+    'console',
+    'CssStyleDeclaration',
+    'DomRect',
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ categories = ["gui"]
 [package.metadata.docs.rs]
 features = ["serde"]
 
+[features]
+websys = ["wasm-bindgen", "web-sys"]
+
 [dependencies]
 lazy_static = "1"
 libc = "0.2"
@@ -72,3 +75,19 @@ percent-encoding = "1.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows"))'.dependencies.parking_lot]
 version = "0.8"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
+version = "0.2"
+optional = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.web-sys]
+version = "0.3.4"
+optional = true
+features = [
+    'Document',
+    'Element',
+    'HtmlElement',
+    'Node',
+    'Window',
+    'console'
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ features = [
     'Document',
     'Element',
     'HtmlElement',
+    'HtmlCanvasElement',
     'Node',
     'Window',
     'console'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ features = [
     'HtmlElement',
     'HtmlCanvasElement',
     'CanvasRenderingContext2d',
+    'MouseEvent',
     'Node',
     'Window',
     'console'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ features = [
     'Element',
     'HtmlElement',
     'HtmlCanvasElement',
+    'CanvasRenderingContext2d',
     'Node',
     'Window',
     'console'

--- a/examples/wasm_bindgen.rs
+++ b/examples/wasm_bindgen.rs
@@ -6,6 +6,7 @@ extern crate winit;
 use winit::window::WindowBuilder;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{EventLoop, ControlFlow};
+use winit::platform::websys::{WebsysWindowBuilderExt, WebsysWindowExt};
 
 use wasm_bindgen::prelude::*;
 
@@ -35,17 +36,25 @@ impl App {
         let event_loop = EventLoop::new();
 
         // create a window and associate it with the event loop
-        let _window = WindowBuilder::new()
+        let window = WindowBuilder::new()
             .with_title("A fantastic window!")
+            .with_canvas_id("test")
             .build(&event_loop)
             .unwrap();
 
-        // run!
+        // do some drawing
+        let canvas = window.get_canvas();
+        let ctx = canvas.get_context("2d").unwrap().unwrap()
+                        .dyn_into::<web_sys::CanvasRenderingContext2d>().unwrap();
+        ctx.begin_path();
+        ctx.arc(95.0, 50.0, 40.0, 0.0, 2.0 * 3.14159).unwrap();
+        ctx.stroke();
+
+        // run forever
         //
         // when using wasm_bindgen, this will currently throw a js
         // exception once all browser event handlers have been installed.
         event_loop.run(|event, _, control_flow| {
-            log!("{:?}", event);
 
             match event {
                 Event::WindowEvent {

--- a/examples/wasm_bindgen.rs
+++ b/examples/wasm_bindgen.rs
@@ -1,14 +1,15 @@
-mod utils;
-
 extern crate web_sys;
+extern crate wasm_bindgen;
 
 extern crate winit;
 use winit::window::WindowBuilder;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{EventLoop, ControlFlow};
-use winit::platform::websys::{WebsysWindowBuilderExt, WebsysWindowExt};
+use winit::platform::websys::WebsysWindowExt;
+use winit::platform::websys::WebsysWindowBuilderExt;
 
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::JsCast;
 
 // A macro to provide `println!(..)`-style syntax for `console.log` logging.
 macro_rules! log {
@@ -65,4 +66,9 @@ impl App {
             }
         });
     }
+}
+
+pub fn main() {
+    let app = App::new();
+    app.run();
 }

--- a/examples/wasm_bindgen.rs
+++ b/examples/wasm_bindgen.rs
@@ -1,0 +1,59 @@
+mod utils;
+
+extern crate web_sys;
+
+extern crate winit;
+use winit::window::WindowBuilder;
+use winit::event::{Event, WindowEvent};
+use winit::event_loop::{EventLoop, ControlFlow};
+
+use wasm_bindgen::prelude::*;
+
+// A macro to provide `println!(..)`-style syntax for `console.log` logging.
+macro_rules! log {
+    ( $( $t:tt )* ) => {
+        web_sys::console::log_1(&format!( $( $t )* ).into());
+    }
+}
+
+// use wee_alloc if it is available
+#[cfg(feature = "wee_alloc")]
+#[global_allocator]
+static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+#[wasm_bindgen]
+struct App {}
+
+#[wasm_bindgen]
+impl App {
+    pub fn new() -> App {
+        App{}
+    }
+
+    pub fn run(&self) {
+        // create an event loop
+        let event_loop = EventLoop::new();
+
+        // create a window and associate it with the event loop
+        let _window = WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .build(&event_loop)
+            .unwrap();
+
+        // run!
+        //
+        // when using wasm_bindgen, this will currently throw a js
+        // exception once all browser event handlers have been installed.
+        event_loop.run(|event, _, control_flow| {
+            log!("{:?}", event);
+
+            match event {
+                Event::WindowEvent {
+                    event: WindowEvent::CloseRequested,
+                    ..
+                } => *control_flow = ControlFlow::Exit,
+                _ => *control_flow = ControlFlow::Poll,
+            }
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,10 @@ extern crate percent_encoding;
 extern crate smithay_client_toolkit as sctk;
 #[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 extern crate calloop;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "websys"))]
+extern crate wasm_bindgen;
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "websys"))]
+extern crate web_sys;
 
 pub mod dpi;
 #[macro_use]

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -19,5 +19,6 @@ pub mod ios;
 pub mod macos;
 pub mod unix;
 pub mod windows;
+pub mod websys;
 
 pub mod desktop;

--- a/src/platform/websys.rs
+++ b/src/platform/websys.rs
@@ -1,11 +1,8 @@
 extern crate wasm_bindgen;
 extern crate web_sys;
 
-use platform_impl::Window as CanvasWindow;
 use platform_impl::window::ElementSelection;
 use window::{Window, WindowBuilder};
-use platform::websys::wasm_bindgen::prelude::*;
-use platform::websys::wasm_bindgen::JsCast;
 
 pub trait WebsysWindowExt {
     fn get_canvas<'a>(&'a self) -> &'a web_sys::HtmlCanvasElement;
@@ -18,9 +15,9 @@ impl WebsysWindowExt for Window {
 }
 
 pub trait WebsysWindowBuilderExt {
-    fn with_canvas_id(mut self, canvas_id: &str) -> WindowBuilder;
+    fn with_canvas_id(self, canvas_id: &str) -> WindowBuilder;
 
-    fn with_container_id(mut self, container_id: &str) -> WindowBuilder;
+    fn with_container_id(self, container_id: &str) -> WindowBuilder;
 }
 
 impl WebsysWindowBuilderExt for WindowBuilder {

--- a/src/platform/websys.rs
+++ b/src/platform/websys.rs
@@ -1,0 +1,36 @@
+extern crate wasm_bindgen;
+extern crate web_sys;
+
+use platform_impl::Window as CanvasWindow;
+use platform_impl::window::ElementSelection;
+use window::{Window, WindowBuilder};
+use platform::websys::wasm_bindgen::prelude::*;
+use platform::websys::wasm_bindgen::JsCast;
+
+pub trait WebsysWindowExt {
+    fn get_canvas<'a>(&'a self) -> &'a web_sys::HtmlCanvasElement;
+}
+
+impl WebsysWindowExt for Window {
+    fn get_canvas<'a>(&'a self) -> &'a web_sys::HtmlCanvasElement {
+        &self.window.canvas
+    }
+}
+
+pub trait WebsysWindowBuilderExt {
+    fn with_canvas_id(mut self, canvas_id: &str) -> WindowBuilder;
+
+    fn with_container_id(mut self, container_id: &str) -> WindowBuilder;
+}
+
+impl WebsysWindowBuilderExt for WindowBuilder {
+    fn with_canvas_id(mut self, canvas_id: &str) -> WindowBuilder {
+        self.platform_specific.element = ElementSelection::CanvasId(canvas_id.to_string());
+        self
+    }
+
+    fn with_container_id(mut self, container_id: &str) -> WindowBuilder {
+        self.platform_specific.element = ElementSelection::ContainerId(container_id.to_string());
+        self
+    }
+}

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -18,9 +18,12 @@ mod platform;
 #[cfg(target_os = "emscripten")]
 #[path="emscripten/mod.rs"]
 mod platform;
+#[cfg(all(target_arch = "wasm32", feature = "websys"))]
+#[path="websys/mod.rs"]
+mod platform;
 
 #[cfg(all(not(target_os = "ios"), not(target_os = "windows"), not(target_os = "linux"),
   not(target_os = "macos"), not(target_os = "android"), not(target_os = "dragonfly"),
   not(target_os = "freebsd"), not(target_os = "netbsd"), not(target_os = "openbsd"),
-  not(target_os = "emscripten")))]
+  not(target_os = "emscripten"), not(all(target_arch = "wasm32", feature="websys"))))]
 compile_error!("The platform you're compiling for is not supported by winit");

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -18,7 +18,7 @@ mod platform;
 #[cfg(target_os = "emscripten")]
 #[path="emscripten/mod.rs"]
 mod platform;
-#[cfg(all(target_arch = "wasm32", feature = "websys"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown", feature = "websys"))]
 #[path="websys/mod.rs"]
 mod platform;
 

--- a/src/platform_impl/websys/event.rs
+++ b/src/platform_impl/websys/event.rs
@@ -4,7 +4,6 @@ use ::event::WindowEvent as WindowEvent;
 use ::event::DeviceId as WDeviceId;
 use ::event::{ElementState, MouseButton};
 
-use ::wasm_bindgen::prelude::*;
 use ::web_sys::MouseEvent;
 use super::window::DeviceId;
 

--- a/src/platform_impl/websys/event.rs
+++ b/src/platform_impl/websys/event.rs
@@ -1,0 +1,20 @@
+use std::convert::From;
+
+use ::event::WindowEvent as WindowEvent;
+use ::event::DeviceId as WDeviceId;
+use ::event::{ElementState, MouseButton};
+
+use ::wasm_bindgen::prelude::*;
+use ::web_sys::MouseEvent;
+use super::window::DeviceId;
+
+impl From<MouseEvent> for WindowEvent {
+    fn from(event: MouseEvent) -> Self {
+        WindowEvent::MouseInput {
+            device_id: WDeviceId(DeviceId::dummy()),
+            state: ElementState::Pressed,
+            button: MouseButton::Left,
+            modifiers: Default::default()
+        }
+    }
+}

--- a/src/platform_impl/websys/event_loop.rs
+++ b/src/platform_impl/websys/event_loop.rs
@@ -1,7 +1,7 @@
 use ::event_loop::{ControlFlow, EventLoopClosed};
 use ::event_loop::EventLoopWindowTarget as WinitELT;
 use ::event::{Event, StartCause};
-use super::window::{MonitorHandle, Window, WindowId, WindowInternal};
+use super::window::{MonitorHandle, WindowId};
 #[macro_use]
 use platform_impl::platform::wasm_util as util;
 
@@ -11,7 +11,7 @@ use std::cell::{Cell, RefCell};
 
 use ::wasm_bindgen::prelude::*;
 use ::wasm_bindgen::JsCast;
-use ::web_sys::{Element, HtmlCanvasElement};
+use ::web_sys::{HtmlCanvasElement};
 
 #[derive(Clone, Copy, Eq, PartialEq)]
 enum EventLoopState {

--- a/src/platform_impl/websys/event_loop.rs
+++ b/src/platform_impl/websys/event_loop.rs
@@ -102,12 +102,12 @@ impl<T: 'static> EventLoop<T> {
     }
 
     #[inline]
-    pub fn get_available_monitors(&self) -> VecDeque<MonitorHandle> {
+    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         vec!(MonitorHandle{}).into_iter().collect()
     }
 
     #[inline]
-    pub fn get_primary_monitor(&self) -> MonitorHandle {
+    pub fn primary_monitor(&self) -> MonitorHandle {
         MonitorHandle{}
     }
 

--- a/src/platform_impl/websys/event_loop.rs
+++ b/src/platform_impl/websys/event_loop.rs
@@ -1,0 +1,29 @@
+use {event_loop::EventLoopClosed};
+
+pub struct EventLoop<T: 'static> {
+    pending_events: Vec<T>
+}
+
+impl<T: 'static> EventLoop<T> {
+    pub fn new() -> EventLoop<T> {
+        EventLoop { pending_events: Vec::new() }
+    }
+
+    pub fn create_proxy(&self) -> EventLoopProxy<T> {
+        EventLoopProxy { _marker: std::marker::PhantomData }
+    }
+}
+
+pub struct EventLoopProxy<T: 'static> {
+    _marker: std::marker::PhantomData<T>
+}
+
+impl<T: 'static> EventLoopProxy<T> {
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
+        !unimplemented!()
+    }
+}
+
+pub struct EventLoopWindowTarget<T: 'static> {
+    _marker: std::marker::PhantomData<T>
+}

--- a/src/platform_impl/websys/event_loop.rs
+++ b/src/platform_impl/websys/event_loop.rs
@@ -3,7 +3,7 @@ extern crate wasm_bindgen;
 
 use event_loop::{ControlFlow, EventLoopClosed};
 use event::Event;
-use super::window::{MonitorHandle, Window, WindowInternal};
+use super::window::{MonitorHandle, Window, WindowId, WindowInternal};
 #[macro_use]
 use platform_impl::platform::wasm_util as util;
 
@@ -69,6 +69,12 @@ impl<T: 'static> EventLoop<T> {
         
         *g.borrow_mut() = Some(Closure::wrap(Box::new(move || {
             if control_flow == ControlFlow::Poll {
+                
+                let mut win_events = self.window_target.p.window().events();
+                win_events.drain(..).for_each(|e| {
+                    event_handler(::event::Event::WindowEvent{window_id: ::window::WindowId(WindowId{}), event: e}, &self.window_target, &mut control_flow);
+                });
+
                 event_handler(::event::Event::NewEvents(::event::StartCause::Poll), &self.window_target, &mut control_flow);
             }
 

--- a/src/platform_impl/websys/event_loop.rs
+++ b/src/platform_impl/websys/event_loop.rs
@@ -1,4 +1,8 @@
-use {event_loop::EventLoopClosed};
+use event_loop::{ControlFlow, EventLoopClosed};
+use event::Event;
+use super::window::MonitorHandle;
+
+use std::collections::VecDeque;
 
 pub struct EventLoop<T: 'static> {
     pending_events: Vec<T>
@@ -12,15 +16,48 @@ impl<T: 'static> EventLoop<T> {
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         EventLoopProxy { _marker: std::marker::PhantomData }
     }
+
+    #[inline]
+    pub fn get_available_monitors(&self) -> VecDeque<MonitorHandle> {
+        vec!(MonitorHandle{}).into_iter().collect()
+    }
+
+    #[inline]
+    pub fn get_primary_monitor(&self) -> MonitorHandle {
+        MonitorHandle{}
+    }
+
+        /// Hijacks the calling thread and initializes the `winit` event loop with the provided
+    /// closure. Since the closure is `'static`, it must be a `move` closure if it needs to
+    /// access any data from the calling context.
+    ///
+    /// See the [`ControlFlow`] docs for information on how changes to `&mut ControlFlow` impact the
+    /// event loop's behavior.
+    ///
+    /// Any values not passed to this function will *not* be dropped.
+    ///
+    /// [`ControlFlow`]: ./enum.ControlFlow.html
+    #[inline]
+    pub fn run<F>(self, event_handler: F) -> !
+        where F: 'static + FnMut(Event<T>, &::event_loop::EventLoopWindowTarget<T>, &mut ControlFlow)
+    {
+        unimplemented!()
+    }
+
+    pub fn window_target(&self) -> &::event_loop::EventLoopWindowTarget<T> {
+        unimplemented!()
+    }
+
 }
 
+#[derive(Clone)]
 pub struct EventLoopProxy<T: 'static> {
     _marker: std::marker::PhantomData<T>
 }
 
 impl<T: 'static> EventLoopProxy<T> {
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
-        !unimplemented!()
+        unimplemented!()
     }
 }
 

--- a/src/platform_impl/websys/event_loop.rs
+++ b/src/platform_impl/websys/event_loop.rs
@@ -1,6 +1,3 @@
-extern crate web_sys;
-extern crate wasm_bindgen;
-
 use event_loop::{ControlFlow, EventLoopClosed};
 use event::Event;
 use super::window::{MonitorHandle, Window, WindowId, WindowInternal};
@@ -11,9 +8,9 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use self::wasm_bindgen::prelude::*;
-use self::wasm_bindgen::JsCast;
-use self::web_sys::Element;
+use ::wasm_bindgen::prelude::*;
+use ::wasm_bindgen::JsCast;
+use ::web_sys::Element;
 
 pub struct EventLoop<T: 'static> {
     window_target: ::event_loop::EventLoopWindowTarget<T>

--- a/src/platform_impl/websys/mod.rs
+++ b/src/platform_impl/websys/mod.rs
@@ -1,0 +1,5 @@
+pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
+pub use self::window::{DeviceId, MonitorHandle, Window, WindowId, PlatformSpecificWindowBuilderAttributes};
+
+mod event_loop;
+pub mod window;

--- a/src/platform_impl/websys/mod.rs
+++ b/src/platform_impl/websys/mod.rs
@@ -1,8 +1,19 @@
 pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
 pub use self::window::{DeviceId, MonitorHandle, Window, WindowId, PlatformSpecificWindowBuilderAttributes};
 
+use std::fmt::{Display, Debug, Error, Formatter};
+
 #[macro_use]
 mod wasm_util;
 mod event_loop;
 mod event;
 pub mod window;
+
+#[derive(Debug)]
+pub struct OsError;
+
+impl Display for OsError {
+    fn fmt(&self, formatter: &mut Formatter) -> Result<(), Error> {
+        formatter.pad(&format!("websys error"))
+    }
+}

--- a/src/platform_impl/websys/mod.rs
+++ b/src/platform_impl/websys/mod.rs
@@ -1,5 +1,7 @@
 pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
 pub use self::window::{DeviceId, MonitorHandle, Window, WindowId, PlatformSpecificWindowBuilderAttributes};
 
+#[macro_use]
+mod wasm_util;
 mod event_loop;
 pub mod window;

--- a/src/platform_impl/websys/mod.rs
+++ b/src/platform_impl/websys/mod.rs
@@ -1,7 +1,7 @@
 pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
 pub use self::window::{DeviceId, MonitorHandle, Window, WindowId, PlatformSpecificWindowBuilderAttributes};
 
-use std::fmt::{Display, Debug, Error, Formatter};
+use std::fmt::{Display, Error, Formatter};
 
 #[macro_use]
 mod wasm_util;

--- a/src/platform_impl/websys/mod.rs
+++ b/src/platform_impl/websys/mod.rs
@@ -4,4 +4,5 @@ pub use self::window::{DeviceId, MonitorHandle, Window, WindowId, PlatformSpecif
 #[macro_use]
 mod wasm_util;
 mod event_loop;
+mod event;
 pub mod window;

--- a/src/platform_impl/websys/wasm_util.rs
+++ b/src/platform_impl/websys/wasm_util.rs
@@ -2,6 +2,7 @@ extern crate wasm_bindgen;
 extern crate web_sys;
 
 use self::wasm_bindgen::prelude::*;
+use window::CreationError;
 
 // A macro to provide `println!(..)`-style syntax for `console.log` logging.
 macro_rules! log {
@@ -13,4 +14,10 @@ macro_rules! log {
 #[wasm_bindgen(inline_js = "export function js_exit() { throw 'hacky exit!'; }")]
 extern "C" {
     pub fn js_exit();
+}
+ 
+impl From<wasm_bindgen::JsValue> for CreationError {
+    fn from(error: wasm_bindgen::JsValue) -> Self {
+        CreationError::OsError(error.as_string().unwrap_or("Window error".to_string()))
+    }
 }

--- a/src/platform_impl/websys/wasm_util.rs
+++ b/src/platform_impl/websys/wasm_util.rs
@@ -1,6 +1,4 @@
 use wasm_bindgen::prelude::*;
-
-#[macro_use]
 use ::error::OsError as WOsError;
 
 use super::OsError;

--- a/src/platform_impl/websys/wasm_util.rs
+++ b/src/platform_impl/websys/wasm_util.rs
@@ -1,7 +1,4 @@
-extern crate wasm_bindgen;
-extern crate web_sys;
-
-use self::wasm_bindgen::prelude::*;
+use wasm_bindgen::prelude::*;
 use window::CreationError;
 
 // A macro to provide `println!(..)`-style syntax for `console.log` logging.

--- a/src/platform_impl/websys/wasm_util.rs
+++ b/src/platform_impl/websys/wasm_util.rs
@@ -1,0 +1,16 @@
+extern crate wasm_bindgen;
+extern crate web_sys;
+
+use self::wasm_bindgen::prelude::*;
+
+// A macro to provide `println!(..)`-style syntax for `console.log` logging.
+macro_rules! log {
+    ( $( $t:tt )* ) => {
+        web_sys::console::log_1(&format!( $( $t )* ).into());
+    }
+}
+
+#[wasm_bindgen(inline_js = "export function js_exit() { throw 'hacky exit!'; }")]
+extern "C" {
+    pub fn js_exit();
+}

--- a/src/platform_impl/websys/wasm_util.rs
+++ b/src/platform_impl/websys/wasm_util.rs
@@ -1,5 +1,9 @@
 use wasm_bindgen::prelude::*;
-use window::CreationError;
+
+#[macro_use]
+use ::error::OsError as WOsError;
+
+use super::OsError;
 
 // A macro to provide `println!(..)`-style syntax for `console.log` logging.
 macro_rules! log {
@@ -13,8 +17,8 @@ extern "C" {
     pub fn js_exit();
 }
  
-impl From<wasm_bindgen::JsValue> for CreationError {
+impl From<wasm_bindgen::JsValue> for WOsError {
     fn from(error: wasm_bindgen::JsValue) -> Self {
-        CreationError::OsError(error.as_string().unwrap_or("Window error".to_string()))
+        os_error!(OsError{})
     }
 }

--- a/src/platform_impl/websys/window.rs
+++ b/src/platform_impl/websys/window.rs
@@ -1,10 +1,14 @@
-use window::{WindowAttributes, CreationError, MouseCursor};
+use window::{WindowAttributes};
 use std::collections::VecDeque;
 use std::rc::Rc;
 use std::cell::RefCell;
 use dpi::{PhysicalPosition, LogicalPosition, PhysicalSize, LogicalSize};
 use icon::Icon;
 use super::event_loop::{EventLoopWindowTarget};
+
+use ::error::{ExternalError, NotSupportedError};
+use ::monitor::AvailableMonitorsIter;
+use ::window::CursorIcon;
 
 use ::wasm_bindgen::prelude::*;
 use ::wasm_bindgen::JsCast;
@@ -49,20 +53,20 @@ impl MonitorHandle {
     ///
     /// Returns `None` if the monitor doesn't exist anymore.
     #[inline]
-    pub fn get_name(&self) -> Option<String> {
+    pub fn name(&self) -> Option<String> {
         unimplemented!()
     }
 
     /// Returns the monitor's resolution.
     #[inline]
-    pub fn get_dimensions(&self) -> PhysicalSize {
+    pub fn dimensions(&self) -> PhysicalSize {
         unimplemented!()
     }
 
     /// Returns the top-left corner position of the monitor relative to the larger full
     /// screen area.
     #[inline]
-    pub fn get_position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition {
         unimplemented!()
     }
 
@@ -75,7 +79,7 @@ impl MonitorHandle {
     /// - **X11:** Can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
     /// - **Android:** Always returns 1.0.
     #[inline]
-    pub fn get_hidpi_factor(&self) -> f64 {
+    pub fn hidpi_factor(&self) -> f64 {
         unimplemented!()
     }
 }
@@ -114,7 +118,7 @@ impl Window {
     pub fn new<T: 'static>(target: &EventLoopWindowTarget<T>, 
                            attr: WindowAttributes,
                            ps_attr: PlatformSpecificWindowBuilderAttributes) 
-                           -> Result<Window, CreationError> {
+                           -> Result<Window, ::error::OsError> {
         let window = ::web_sys::window()
             .expect("No global window object found!");
         let document = window.document()
@@ -165,145 +169,10 @@ impl Window {
         })
     }
 
-    /// Modifies the title of the window.
-    ///
-    /// This is a no-op if the window has already been closed.
+    /// Returns an identifier unique to the window.
     #[inline]
-    pub fn set_title(&self, title: &str) {
-    }
-
-    /// Shows the window if it was hidden.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - Has no effect on Android
-    ///
-    #[inline]
-    pub fn show(&self) {
-        unimplemented!()
-    }
-
-    /// Hides the window if it was visible.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - Has no effect on Android
-    ///
-    #[inline]
-    pub fn hide(&self) {
-        unimplemented!()
-    }
-
-    /// Emits a `WindowEvent::RedrawRequested` event in the associated event loop after all OS
-    /// events have been processed by the event loop.
-    ///
-    /// This is the **strongly encouraged** method of redrawing windows, as it can integrates with
-    /// OS-requested redraws (e.g. when a window gets resized).
-    ///
-    /// This function can cause `RedrawRequested` events to be emitted after `Event::EventsCleared`
-    /// but before `Event::NewEvents` if called in the following circumstances:
-    /// * While processing `EventsCleared`.
-    /// * While processing a `RedrawRequested` event that was sent during `EventsCleared` or any
-    ///   directly subsequent `RedrawRequested` event.
-    pub fn request_redraw(&self) {
-        unimplemented!()
-    }
-
-    /// Returns the position of the top-left hand corner of the window relative to the
-    ///  top-left hand corner of the desktop.
-    ///
-    /// Note that the top-left hand corner of the desktop is not necessarily the same as
-    ///  the screen. If the user uses a desktop with multiple monitors, the top-left hand corner
-    ///  of the desktop is the top-left hand corner of the monitor at the top-left of the desktop.
-    ///
-    /// The coordinates can be negative if the top-left hand corner of the window is outside
-    ///  of the visible screen region.
-    ///
-    /// Returns `None` if the window no longer exists.
-    #[inline]
-    pub fn get_position(&self) -> Option<LogicalPosition> {
-        unimplemented!()
-    }
-
-    /// Returns the position of the top-left hand corner of the window's client area relative to the
-    /// top-left hand corner of the desktop.
-    ///
-    /// The same conditions that apply to `get_position` apply to this method.
-    #[inline]
-    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
-        // websys: we have no concept of "inner" client area, so just return position.
-        self.get_position()
-    }
-
-    /// Modifies the position of the window.
-    ///
-    /// See `get_position` for more information about the coordinates.
-    ///
-    /// This is a no-op if the window has already been closed.
-    #[inline]
-    pub fn set_position(&self, position: LogicalPosition) {
-        unimplemented!()
-    }
-
-    /// Returns the logical size of the window's client area.
-    ///
-    /// The client area is the content of the window, excluding the title bar and borders.
-    ///
-    /// Converting the returned `LogicalSize` to `PhysicalSize` produces the size your framebuffer should be.
-    ///
-    /// Returns `None` if the window no longer exists.
-    #[inline]
-    pub fn get_inner_size(&self) -> Option<LogicalSize> {
-        // websys: we have no concept of "inner" client area, so just return size.
-        self.get_outer_size()
-    }
-
-    /// Returns the logical size of the entire window.
-    ///
-    /// These dimensions include the title bar and borders. If you don't want that (and you usually don't),
-    /// use `get_inner_size` instead.
-    ///
-    /// Returns `None` if the window no longer exists.
-    #[inline]
-    pub fn get_outer_size(&self) -> Option<LogicalSize> {
-        unimplemented!()
-    }
-
-    /// Modifies the inner size of the window.
-    ///
-    /// See `get_inner_size` for more information about the values.
-    ///
-    /// This is a no-op if the window has already been closed.
-    #[inline]
-    pub fn set_inner_size(&self, size: LogicalSize) {
-        unimplemented!()
-    }
-
-    /// Sets a minimum dimension size for the window.
-    #[inline]
-    pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
-        unimplemented!()
-    }
-
-    /// Sets a maximum dimension size for the window.
-    #[inline]
-    pub fn set_max_dimensions(&self, dimensions: Option<LogicalSize>) {
-        unimplemented!()
-    }
-
-    /// Sets whether the window is resizable or not.
-    ///
-    /// Note that making the window unresizable doesn't exempt you from handling `Resized`, as that event can still be
-    /// triggered by DPI scaling, entering fullscreen mode, etc.
-    ///
-    /// ## Platform-specific
-    ///
-    /// This only has an effect on desktop platforms.
-    ///
-    /// Due to a bug in XFCE, this has no effect on Xfwm.
-    #[inline]
-    pub fn set_resizable(&self, resizable: bool) {
-        unimplemented!()
+    pub fn id(&self) -> WindowId {
+        WindowId::dummy()
     }
 
     /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
@@ -318,70 +187,244 @@ impl Window {
     ///
     /// - **X11:** This respects Xft.dpi, and can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
     /// - **Android:** Always returns 1.0.
+    /// - **iOS:** Can only be called on the main thread. Returns the underlying `UIView`'s
+    ///   [`contentScaleFactor`].
+    ///
+    /// [`contentScaleFactor`]: https://developer.apple.com/documentation/uikit/uiview/1622657-contentscalefactor?language=objc
     #[inline]
-    pub fn get_hidpi_factor(&self) -> f64 {
+    pub fn hidpi_factor(&self) -> f64 {
         1.0
     }
 
-    /// Modifies the mouse cursor of the window.
-    /// Has no effect on Android.
-    #[inline]
-    pub fn set_cursor(&self, cursor: MouseCursor) {
-        unimplemented!()
-    }
-
-    /// Changes the position of the cursor in window coordinates.
-    #[inline]
-    pub fn set_cursor_position(&self, position: LogicalPosition) -> Result<(), String> {
-        unimplemented!()
-    }
-
-    /// Grabs the cursor, preventing it from leaving the window.
+    /// Emits a `WindowEvent::RedrawRequested` event in the associated event loop after all OS
+    /// events have been processed by the event loop.
+    ///
+    /// This is the **strongly encouraged** method of redrawing windows, as it can integrates with
+    /// OS-requested redraws (e.g. when a window gets resized).
+    ///
+    /// This function can cause `RedrawRequested` events to be emitted after `Event::EventsCleared`
+    /// but before `Event::NewEvents` if called in the following circumstances:
+    /// * While processing `EventsCleared`.
+    /// * While processing a `RedrawRequested` event that was sent during `EventsCleared` or any
+    ///   directly subsequent `RedrawRequested` event.
     ///
     /// ## Platform-specific
     ///
-    /// On macOS, this presently merely locks the cursor in a fixed location, which looks visually awkward.
-    ///
-    /// This has no effect on Android or iOS.
+    /// - **iOS:** Can only be called on the main thread.
     #[inline]
-    pub fn grab_cursor(&self, grab: bool) -> Result<(), String> {
+    pub fn request_redraw(&self) {
         unimplemented!()
     }
+}
 
-    /// Hides the cursor, making it invisible but still usable.
+/// Position and size functions.
+impl Window {
+    /// Returns the position of the top-left hand corner of the window's client area relative to the
+    /// top-left hand corner of the desktop.
+    ///
+    /// The same conditions that apply to `outer_position` apply to this method.
     ///
     /// ## Platform-specific
     ///
-    /// On Windows and X11, the cursor is only hidden within the confines of the window.
+    /// - **iOS:** Can only be called on the main thread. Returns the top left coordinates of the
+    ///   window's [safe area] in the screen space coordinate system.
     ///
-    /// On macOS, the cursor is hidden as long as the window has input focus, even if the cursor is outside of the
-    /// window.
-    ///
-    /// This has no effect on Android or iOS.
+    /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     #[inline]
-    pub fn hide_cursor(&self, hide: bool) {
+    pub fn inner_position(&self) -> Result<LogicalPosition, NotSupportedError> {
         unimplemented!()
     }
 
-    /// Sets the window to maximized or back
+    /// Returns the position of the top-left hand corner of the window relative to the
+    ///  top-left hand corner of the desktop.
+    ///
+    /// Note that the top-left hand corner of the desktop is not necessarily the same as
+    ///  the screen. If the user uses a desktop with multiple monitors, the top-left hand corner
+    ///  of the desktop is the top-left hand corner of the monitor at the top-left of the desktop.
+    ///
+    /// The coordinates can be negative if the top-left hand corner of the window is outside
+    ///  of the visible screen region.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Can only be called on the main thread. Returns the top left coordinates of the
+    ///   window in the screen space coordinate system.
+    #[inline]
+    pub fn outer_position(&self) -> Result<LogicalPosition, NotSupportedError> {
+        unimplemented!()
+    }
+
+    /// Modifies the position of the window.
+    ///
+    /// See `outer_position` for more information about the coordinates.
+    ///
+    /// This is a no-op if the window has already been closed.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Can only be called on the main thread. Sets the top left coordinates of the
+    ///   window in the screen space coordinate system.
+    #[inline]
+    pub fn set_outer_position(&self, position: LogicalPosition) {
+        unimplemented!()
+    }
+
+    /// Returns the logical size of the window's client area.
+    ///
+    /// The client area is the content of the window, excluding the title bar and borders.
+    ///
+    /// Converting the returned `LogicalSize` to `PhysicalSize` produces the size your framebuffer should be.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Can only be called on the main thread. Returns the `LogicalSize` of the window's
+    ///   [safe area] in screen space coordinates.
+    ///
+    /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
+    #[inline]
+    pub fn inner_size(&self) -> LogicalSize {
+        unimplemented!()
+    }
+
+    /// Modifies the inner size of the window.
+    ///
+    /// See `inner_size` for more information about the values.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Unimplemented. Currently this panics, as it's not clear what `set_inner_size`
+    ///   would mean for iOS.
+    #[inline]
+    pub fn set_inner_size(&self, size: LogicalSize) {
+        unimplemented!()
+    }
+
+    /// Returns the logical size of the entire window.
+    ///
+    /// These dimensions include the title bar and borders. If you don't want that (and you usually don't),
+    /// use `inner_size` instead.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Can only be called on the main thread. Returns the `LogicalSize` of the window in
+    ///   screen space coordinates.
+    #[inline]
+    pub fn outer_size(&self) -> LogicalSize {
+        unimplemented!()
+    }
+
+    /// Sets a minimum dimension size for the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Has no effect.
+    #[inline]
+    pub fn set_min_inner_size(&self, dimensions: Option<LogicalSize>) {
+        unimplemented!()
+    }
+
+    /// Sets a maximum dimension size for the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Has no effect.
+    #[inline]
+    pub fn set_max_inner_size(&self, dimensions: Option<LogicalSize>) {
+        unimplemented!()
+    }
+}
+
+/// Misc. attribute functions.
+impl Window {
+    /// Modifies the title of the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Has no effect on iOS.
+    #[inline]
+    pub fn set_title(&self, title: &str) {
+        unimplemented!()
+    }
+
+    /// Modifies the window's visibility.
+    ///
+    /// If `false`, this will hide the window. If `true`, this will show the window.
+    /// ## Platform-specific
+    ///
+    /// - **Android:** Has no effect.
+    /// - **iOS:** Can only be called on the main thread.
+    #[inline]
+    pub fn set_visible(&self, visible: bool) {
+        unimplemented!()
+    }
+
+    /// Sets whether the window is resizable or not.
+    ///
+    /// Note that making the window unresizable doesn't exempt you from handling `Resized`, as that event can still be
+    /// triggered by DPI scaling, entering fullscreen mode, etc.
+    ///
+    /// ## Platform-specific
+    ///
+    /// This only has an effect on desktop platforms.
+    ///
+    /// Due to a bug in XFCE, this has no effect on Xfwm.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Has no effect.
+    #[inline]
+    pub fn set_resizable(&self, resizable: bool) {
+        unimplemented!()
+    }
+
+    /// Sets the window to maximized or back.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Has no effect.
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         unimplemented!()
     }
 
-    /// Sets the window to fullscreen or back
+    /// Sets the window to fullscreen or back.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Can only be called on the main thread.
     #[inline]
     pub fn set_fullscreen(&self, monitor: Option<::monitor::MonitorHandle>) {
         unimplemented!()
     }
 
+    /// Gets the window's current fullscreen state.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Can only be called on the main thread.
+    #[inline]
+    pub fn fullscreen(&self) -> Option<::monitor::MonitorHandle> {
+        unimplemented!()
+    }
+
     /// Turn window decorations on or off.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Can only be called on the main thread. Controls whether the status bar is hidden
+    ///   via [`setPrefersStatusBarHidden`].
+    ///
+    /// [`setPrefersStatusBarHidden`]: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621440-prefersstatusbarhidden?language=objc
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         unimplemented!()
     }
 
     /// Change whether or not the window will always be on top of other windows.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Has no effect.
     #[inline]
     pub fn set_always_on_top(&self, always_on_top: bool) {
         unimplemented!()
@@ -401,40 +444,107 @@ impl Window {
     }
 
     /// Sets location of IME candidate box in client area coordinates relative to the top left.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **iOS:** Has no effect.
     #[inline]
-    pub fn set_ime_spot(&self, position: LogicalPosition) {
+    pub fn set_ime_position(&self, position: LogicalPosition) {
+        unimplemented!()
+    }
+}
+
+/// Cursor functions.
+impl Window {
+    /// Modifies the cursor icon of the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Has no effect.
+    /// - **Android:** Has no effect.
+    #[inline]
+    pub fn set_cursor_icon(&self, cursor: CursorIcon) {
         unimplemented!()
     }
 
-    /// Returns the monitor on which the window currently resides
+    /// Changes the position of the cursor in window coordinates.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS:** Always returns an `Err`.
     #[inline]
-    pub fn get_current_monitor(&self) -> ::monitor::MonitorHandle {
-        ::monitor::MonitorHandle{inner: MonitorHandle{}}
+    pub fn set_cursor_position(&self, position: LogicalPosition) -> Result<(), ExternalError> {
+        unimplemented!()
+    }
+
+    /// Grabs the cursor, preventing it from leaving the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** This presently merely locks the cursor in a fixed location, which looks visually
+    ///   awkward.
+    /// - **Android:** Has no effect.
+    /// - **iOS:** Always returns an Err.
+    #[inline]
+    pub fn set_cursor_grab(&self, grab: bool) -> Result<(), ExternalError> {
+        unimplemented!()
+    }
+
+    /// Modifies the cursor's visibility.
+    ///
+    /// If `false`, this will hide the cursor. If `true`, this will show the cursor.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Windows:** The cursor is only hidden within the confines of the window.
+    /// - **X11:** The cursor is only hidden within the confines of the window.
+    /// - **macOS:** The cursor is hidden as long as the window has input focus, even if the cursor is
+    ///   outside of the window.
+    /// - **iOS:** Has no effect.
+    /// - **Android:** Has no effect.
+    #[inline]
+    pub fn set_cursor_visible(&self, visible: bool) {
+        unimplemented!()
+    }
+}
+
+/// Monitor info functions.
+impl Window {
+    /// Returns the monitor on which the window currently resides
+    ///
+    /// ## Platform-specific
+    ///
+    /// **iOS:** Can only be called on the main thread.
+    #[inline]
+    pub fn current_monitor(&self) -> ::monitor::MonitorHandle {
+        unimplemented!()
     }
 
     /// Returns the list of all the monitors available on the system.
     ///
-    /// This is the same as `EventLoop::get_available_monitors`, and is provided for convenience.
+    /// This is the same as `EventLoop::available_monitors`, and is provided for convenience.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **iOS:** Can only be called on the main thread.
     #[inline]
-    pub fn get_available_monitors(&self) -> VecDeque<MonitorHandle> {
+    pub fn available_monitors(&self) -> std::collections::VecDeque<MonitorHandle> {
         unimplemented!()
     }
 
     /// Returns the primary monitor of the system.
     ///
-    /// This is the same as `EventLoop::get_primary_monitor`, and is provided for convenience.
+    /// This is the same as `EventLoop::primary_monitor`, and is provided for convenience.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **iOS:** Can only be called on the main thread.
     #[inline]
-    pub fn get_primary_monitor(&self) -> MonitorHandle {
-        MonitorHandle {}
+    pub fn primary_monitor(&self) -> MonitorHandle {
+        MonitorHandle { }
     }
-
-    /// Returns an identifier unique to the window.
-    #[inline]
-    pub fn id(&self) -> WindowId {
-        unimplemented!()
-    }
-
 }
+
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId {
@@ -447,7 +557,7 @@ impl WindowId {
     /// by this function.  No other guarantees are made. This may be equal to a real `WindowId`.
     ///
     /// **Passing this into a winit function will result in undefined behavior.**
-    pub unsafe fn dummy() -> Self {
+    pub fn dummy() -> Self {
         WindowId{}
     }
 }

--- a/src/platform_impl/websys/window.rs
+++ b/src/platform_impl/websys/window.rs
@@ -1,5 +1,3 @@
-extern crate wasm_bindgen;
-
 use window::{WindowAttributes, CreationError, MouseCursor};
 use std::collections::VecDeque;
 use std::rc::Rc;
@@ -8,8 +6,8 @@ use dpi::{PhysicalPosition, LogicalPosition, PhysicalSize, LogicalSize};
 use icon::Icon;
 use super::event_loop::{EventLoopWindowTarget};
 
-use self::wasm_bindgen::prelude::*;
-use self::wasm_bindgen::JsCast;
+use ::wasm_bindgen::prelude::*;
+use ::wasm_bindgen::JsCast;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId(u32);
@@ -83,7 +81,7 @@ impl MonitorHandle {
 }
 
 pub struct Window {
-    pub(crate) canvas: web_sys::HtmlCanvasElement,
+    pub(crate) canvas: ::web_sys::HtmlCanvasElement,
     internal: Rc<WindowInternal>
 }
 
@@ -109,7 +107,7 @@ impl Window {
                            attr: WindowAttributes,
                            ps_attr: PlatformSpecificWindowBuilderAttributes) 
                            -> Result<Window, CreationError> {
-        let window = web_sys::window()
+        let window = ::web_sys::window()
             .expect("No global window object found!");
         let document = window.document()
             .expect("Global window does not have a document!");
@@ -118,7 +116,7 @@ impl Window {
             ElementSelection::CanvasId(id) => {
                 document.get_element_by_id(&id)
                     .expect(&format!("No canvas with ID {} found", id))
-                    .dyn_into::<web_sys::HtmlCanvasElement>().unwrap()
+                    .dyn_into::<::web_sys::HtmlCanvasElement>().unwrap()
             },
             ElementSelection::ContainerId(id) => {
                 let parent = document.get_element_by_id(&id)
@@ -126,7 +124,7 @@ impl Window {
                 
                 let canvas = document.create_element("canvas")
                     .expect("Could not create a canvas")
-                    .dyn_into::<web_sys::HtmlCanvasElement>().unwrap();
+                    .dyn_into::<::web_sys::HtmlCanvasElement>().unwrap();
                 
                 parent.append_child(&canvas);
 
@@ -142,15 +140,10 @@ impl Window {
 
         // TODO: install WindowEvent handlers
         let mut win = internal.clone();
-        let click_handler = Closure::wrap(Box::new(move |event: web_sys::MouseEvent| {
+        let click_handler = Closure::wrap(Box::new(move |event: ::web_sys::MouseEvent| {
             // TODO: process the event
-            win.pending_events.borrow_mut().push(::event::WindowEvent::MouseInput {
-                device_id: ::event::DeviceId(DeviceId(0)),
-                state: ::event::ElementState::Pressed,
-                button: ::event::MouseButton::Left,
-                modifiers: Default::default()
-            });
-        }) as Box<FnMut(web_sys::MouseEvent)>);
+            win.pending_events.borrow_mut().push(event.into());
+        }) as Box<FnMut(::web_sys::MouseEvent)>);
         element.set_onmousedown(Some(click_handler.as_ref().unchecked_ref()));
         click_handler.forget();
 

--- a/src/platform_impl/websys/window.rs
+++ b/src/platform_impl/websys/window.rs
@@ -1,0 +1,26 @@
+
+#[derive(Clone, Copy)]
+pub struct DeviceId;
+
+pub struct PlatformSpecificWindowBuilderAttributes;
+
+pub struct MonitorHandle;
+
+pub struct Window {
+
+}
+
+#[derive(Clone, Copy)]
+pub struct WindowId {
+
+}
+
+impl WindowId {
+    pub fn new() -> WindowId {
+        WindowId {}
+    }
+
+    pub fn dummy() -> WindowId {
+        WindowId {}
+    }
+}

--- a/src/platform_impl/websys/window.rs
+++ b/src/platform_impl/websys/window.rs
@@ -70,7 +70,7 @@ impl Window {
                            attr: WindowAttributes,
                            ps_attr: PlatformSpecificWindowBuilderAttributes) 
                            -> Result<Window, CreationError> {
-        unimplemented!()
+        Ok(Window{})
     }
 
     /// Modifies the title of the window.

--- a/src/platform_impl/websys/window.rs
+++ b/src/platform_impl/websys/window.rs
@@ -14,8 +14,23 @@ impl DeviceId {
     }
 }
 
+///
+/// ElementSelection allows the window creator
+/// to select an existing canvas in the DOM
+/// or a container in which to create a canvas.
+///
+enum ElementSelection {
+    CanvasId(String),
+    ContainerId(String)
+}
+
+///
+/// Platform specific attributes for window creation.
+/// 
 #[derive(Clone, Default)]
-pub struct PlatformSpecificWindowBuilderAttributes;
+pub struct PlatformSpecificWindowBuilderAttributes {
+    pub element: ElementSelection
+}
 
 #[derive(Copy, Clone, Debug)]
 pub struct MonitorHandle;
@@ -89,6 +104,8 @@ impl Window {
 
         target.set_window(internal.clone());
 
+        // TODO: install WindowEvent handlers
+
         Ok(Window {
             canvas: element,
             internal: internal.clone()
@@ -161,7 +178,8 @@ impl Window {
     /// The same conditions that apply to `get_position` apply to this method.
     #[inline]
     pub fn get_inner_position(&self) -> Option<LogicalPosition> {
-        unimplemented!()
+        // websys: we have no concept of "inner" client area, so just return position.
+        self.get_position()
     }
 
     /// Modifies the position of the window.
@@ -183,7 +201,8 @@ impl Window {
     /// Returns `None` if the window no longer exists.
     #[inline]
     pub fn get_inner_size(&self) -> Option<LogicalSize> {
-        unimplemented!()
+        // websys: we have no concept of "inner" client area, so just return size.
+        self.get_outer_size()
     }
 
     /// Returns the logical size of the entire window.
@@ -366,12 +385,11 @@ impl Window {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId {
-
 }
 
 
 impl WindowId {
-        /// Returns a dummy `WindowId`, useful for unit testing. The only guarantee made about the return
+    /// Returns a dummy `WindowId`, useful for unit testing. The only guarantee made about the return
     /// value of this function is that it will always be equal to itself and to future values returned
     /// by this function.  No other guarantees are made. This may be equal to a real `WindowId`.
     ///

--- a/src/platform_impl/websys/window.rs
+++ b/src/platform_impl/websys/window.rs
@@ -1,26 +1,360 @@
+use window::{WindowAttributes, CreationError, MouseCursor};
+use std::collections::VecDeque;
+use dpi::{PhysicalPosition, LogicalPosition, PhysicalSize, LogicalSize};
+use icon::Icon;
+use super::event_loop::{EventLoopWindowTarget};
 
-#[derive(Clone, Copy)]
-pub struct DeviceId;
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeviceId(u32);
 
+impl DeviceId {
+    pub fn dummy() -> Self {
+        DeviceId(0)
+    }
+}
+
+#[derive(Clone, Default)]
 pub struct PlatformSpecificWindowBuilderAttributes;
 
+#[derive(Copy, Clone, Debug)]
 pub struct MonitorHandle;
 
+impl MonitorHandle {
+    /// Returns a human-readable name of the monitor.
+    ///
+    /// Returns `None` if the monitor doesn't exist anymore.
+    #[inline]
+    pub fn get_name(&self) -> Option<String> {
+        unimplemented!()
+    }
+
+    /// Returns the monitor's resolution.
+    #[inline]
+    pub fn get_dimensions(&self) -> PhysicalSize {
+        unimplemented!()
+    }
+
+    /// Returns the top-left corner position of the monitor relative to the larger full
+    /// screen area.
+    #[inline]
+    pub fn get_position(&self) -> PhysicalPosition {
+        unimplemented!()
+    }
+
+    /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
+    ///
+    /// See the [`dpi`](dpi/index.html) module for more information.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **X11:** Can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
+    /// - **Android:** Always returns 1.0.
+    #[inline]
+    pub fn get_hidpi_factor(&self) -> f64 {
+        unimplemented!()
+    }
+}
+
 pub struct Window {
+}
+
+impl Window {
+    /// Creates a new Window for platforms where this is appropriate.
+    ///
+    /// This function is equivalent to `WindowBuilder::new().build(event_loop)`.
+    ///
+    /// Error should be very rare and only occur in case of permission denied, incompatible system,
+    ///  out of memory, etc.
+    #[inline]
+    pub fn new<T: 'static>(target: &EventLoopWindowTarget<T>, 
+                           attr: WindowAttributes,
+                           ps_attr: PlatformSpecificWindowBuilderAttributes) 
+                           -> Result<Window, CreationError> {
+        unimplemented!()
+    }
+
+    /// Modifies the title of the window.
+    ///
+    /// This is a no-op if the window has already been closed.
+    #[inline]
+    pub fn set_title(&self, title: &str) {
+    }
+
+    /// Shows the window if it was hidden.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Has no effect on Android
+    ///
+    #[inline]
+    pub fn show(&self) {
+        unimplemented!()
+    }
+
+    /// Hides the window if it was visible.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Has no effect on Android
+    ///
+    #[inline]
+    pub fn hide(&self) {
+        unimplemented!()
+    }
+
+    /// Emits a `WindowEvent::RedrawRequested` event in the associated event loop after all OS
+    /// events have been processed by the event loop.
+    ///
+    /// This is the **strongly encouraged** method of redrawing windows, as it can integrates with
+    /// OS-requested redraws (e.g. when a window gets resized).
+    ///
+    /// This function can cause `RedrawRequested` events to be emitted after `Event::EventsCleared`
+    /// but before `Event::NewEvents` if called in the following circumstances:
+    /// * While processing `EventsCleared`.
+    /// * While processing a `RedrawRequested` event that was sent during `EventsCleared` or any
+    ///   directly subsequent `RedrawRequested` event.
+    pub fn request_redraw(&self) {
+        unimplemented!()
+    }
+
+    /// Returns the position of the top-left hand corner of the window relative to the
+    ///  top-left hand corner of the desktop.
+    ///
+    /// Note that the top-left hand corner of the desktop is not necessarily the same as
+    ///  the screen. If the user uses a desktop with multiple monitors, the top-left hand corner
+    ///  of the desktop is the top-left hand corner of the monitor at the top-left of the desktop.
+    ///
+    /// The coordinates can be negative if the top-left hand corner of the window is outside
+    ///  of the visible screen region.
+    ///
+    /// Returns `None` if the window no longer exists.
+    #[inline]
+    pub fn get_position(&self) -> Option<LogicalPosition> {
+        unimplemented!()
+    }
+
+    /// Returns the position of the top-left hand corner of the window's client area relative to the
+    /// top-left hand corner of the desktop.
+    ///
+    /// The same conditions that apply to `get_position` apply to this method.
+    #[inline]
+    pub fn get_inner_position(&self) -> Option<LogicalPosition> {
+        unimplemented!()
+    }
+
+    /// Modifies the position of the window.
+    ///
+    /// See `get_position` for more information about the coordinates.
+    ///
+    /// This is a no-op if the window has already been closed.
+    #[inline]
+    pub fn set_position(&self, position: LogicalPosition) {
+        unimplemented!()
+    }
+
+    /// Returns the logical size of the window's client area.
+    ///
+    /// The client area is the content of the window, excluding the title bar and borders.
+    ///
+    /// Converting the returned `LogicalSize` to `PhysicalSize` produces the size your framebuffer should be.
+    ///
+    /// Returns `None` if the window no longer exists.
+    #[inline]
+    pub fn get_inner_size(&self) -> Option<LogicalSize> {
+        unimplemented!()
+    }
+
+    /// Returns the logical size of the entire window.
+    ///
+    /// These dimensions include the title bar and borders. If you don't want that (and you usually don't),
+    /// use `get_inner_size` instead.
+    ///
+    /// Returns `None` if the window no longer exists.
+    #[inline]
+    pub fn get_outer_size(&self) -> Option<LogicalSize> {
+        unimplemented!()
+    }
+
+    /// Modifies the inner size of the window.
+    ///
+    /// See `get_inner_size` for more information about the values.
+    ///
+    /// This is a no-op if the window has already been closed.
+    #[inline]
+    pub fn set_inner_size(&self, size: LogicalSize) {
+        unimplemented!()
+    }
+
+    /// Sets a minimum dimension size for the window.
+    #[inline]
+    pub fn set_min_dimensions(&self, dimensions: Option<LogicalSize>) {
+        unimplemented!()
+    }
+
+    /// Sets a maximum dimension size for the window.
+    #[inline]
+    pub fn set_max_dimensions(&self, dimensions: Option<LogicalSize>) {
+        unimplemented!()
+    }
+
+    /// Sets whether the window is resizable or not.
+    ///
+    /// Note that making the window unresizable doesn't exempt you from handling `Resized`, as that event can still be
+    /// triggered by DPI scaling, entering fullscreen mode, etc.
+    ///
+    /// ## Platform-specific
+    ///
+    /// This only has an effect on desktop platforms.
+    ///
+    /// Due to a bug in XFCE, this has no effect on Xfwm.
+    #[inline]
+    pub fn set_resizable(&self, resizable: bool) {
+        unimplemented!()
+    }
+
+    /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
+    ///
+    /// See the [`dpi`](dpi/index.html) module for more information.
+    ///
+    /// Note that this value can change depending on user action (for example if the window is
+    /// moved to another screen); as such, tracking `WindowEvent::HiDpiFactorChanged` events is
+    /// the most robust way to track the DPI you need to use to draw.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **X11:** This respects Xft.dpi, and can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
+    /// - **Android:** Always returns 1.0.
+    #[inline]
+    pub fn get_hidpi_factor(&self) -> f64 {
+        1.0
+    }
+
+    /// Modifies the mouse cursor of the window.
+    /// Has no effect on Android.
+    #[inline]
+    pub fn set_cursor(&self, cursor: MouseCursor) {
+        unimplemented!()
+    }
+
+    /// Changes the position of the cursor in window coordinates.
+    #[inline]
+    pub fn set_cursor_position(&self, position: LogicalPosition) -> Result<(), String> {
+        unimplemented!()
+    }
+
+    /// Grabs the cursor, preventing it from leaving the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// On macOS, this presently merely locks the cursor in a fixed location, which looks visually awkward.
+    ///
+    /// This has no effect on Android or iOS.
+    #[inline]
+    pub fn grab_cursor(&self, grab: bool) -> Result<(), String> {
+        unimplemented!()
+    }
+
+    /// Hides the cursor, making it invisible but still usable.
+    ///
+    /// ## Platform-specific
+    ///
+    /// On Windows and X11, the cursor is only hidden within the confines of the window.
+    ///
+    /// On macOS, the cursor is hidden as long as the window has input focus, even if the cursor is outside of the
+    /// window.
+    ///
+    /// This has no effect on Android or iOS.
+    #[inline]
+    pub fn hide_cursor(&self, hide: bool) {
+        unimplemented!()
+    }
+
+    /// Sets the window to maximized or back
+    #[inline]
+    pub fn set_maximized(&self, maximized: bool) {
+        unimplemented!()
+    }
+
+    /// Sets the window to fullscreen or back
+    #[inline]
+    pub fn set_fullscreen(&self, monitor: Option<::monitor::MonitorHandle>) {
+        unimplemented!()
+    }
+
+    /// Turn window decorations on or off.
+    #[inline]
+    pub fn set_decorations(&self, decorations: bool) {
+        unimplemented!()
+    }
+
+    /// Change whether or not the window will always be on top of other windows.
+    #[inline]
+    pub fn set_always_on_top(&self, always_on_top: bool) {
+        unimplemented!()
+    }
+
+    /// Sets the window icon. On Windows and X11, this is typically the small icon in the top-left
+    /// corner of the titlebar.
+    ///
+    /// For more usage notes, see `WindowBuilder::with_window_icon`.
+    ///
+    /// ## Platform-specific
+    ///
+    /// This only has an effect on Windows and X11.
+    #[inline]
+    pub fn set_window_icon(&self, window_icon: Option<Icon>) {
+        unimplemented!()
+    }
+
+    /// Sets location of IME candidate box in client area coordinates relative to the top left.
+    #[inline]
+    pub fn set_ime_spot(&self, position: LogicalPosition) {
+        unimplemented!()
+    }
+
+    /// Returns the monitor on which the window currently resides
+    #[inline]
+    pub fn get_current_monitor(&self) -> ::monitor::MonitorHandle {
+        ::monitor::MonitorHandle{inner: MonitorHandle{}}
+    }
+
+    /// Returns the list of all the monitors available on the system.
+    ///
+    /// This is the same as `EventLoop::get_available_monitors`, and is provided for convenience.
+    #[inline]
+    pub fn get_available_monitors(&self) -> VecDeque<MonitorHandle> {
+        unimplemented!()
+    }
+
+    /// Returns the primary monitor of the system.
+    ///
+    /// This is the same as `EventLoop::get_primary_monitor`, and is provided for convenience.
+    #[inline]
+    pub fn get_primary_monitor(&self) -> MonitorHandle {
+        MonitorHandle {}
+    }
+
+    /// Returns an identifier unique to the window.
+    #[inline]
+    pub fn id(&self) -> WindowId {
+        unimplemented!()
+    }
 
 }
 
-#[derive(Clone, Copy)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId {
 
 }
 
-impl WindowId {
-    pub fn new() -> WindowId {
-        WindowId {}
-    }
 
-    pub fn dummy() -> WindowId {
-        WindowId {}
+impl WindowId {
+        /// Returns a dummy `WindowId`, useful for unit testing. The only guarantee made about the return
+    /// value of this function is that it will always be equal to itself and to future values returned
+    /// by this function.  No other guarantees are made. This may be equal to a real `WindowId`.
+    ///
+    /// **Passing this into a winit function will result in undefined behavior.**
+    pub unsafe fn dummy() -> Self {
+        WindowId{}
     }
 }


### PR DESCRIPTION
## `wasm_bindgen` support

This PR adds a wasm backend using `wasm_bindgen` and `web-sys`.  This backend will be used when `target_arch=wasm32` and the `websys` feature is enabled.

#### Implemenation status and todo
- [x] selectable backend 
- [x] basic event loop and window creation
- [x] wrap a canvas
- [ ] control flow
    * [x] `ControllFlow::Poll`
    * [x] `ControlFlow::Wait`
    * [ ] `ControlFlow::WaitUntil`
    * [x] `ControlFlow::Exit`
- [ ] install handlers for mouse and keyboard events - In Progress
- [ ] install handlers for resize events - In Progress
- [ ] **milestone 1** event loop feature-complete
- [ ] pointer capture/manipulation - rethinking this.  i'm not sure it makes sense to support?
- [ ] canvas placement/resize through window's getters and setters
- [ ] be responsive - play nice with media queries etc that resize the canvas
- [ ] Tested on all platforms changed - I'm testing using the `wasm-pack-template` and `wasm-app` project templates
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/tomaka/winit/blob/master/FEATURES.md), if new features were added or implemented
- and more i'm sure!  i'll be updating this list closer to milestone 1 being completed

Closes #395