### PR TITLE
Add window centering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 - Added to `WindowAttributes` the attributes `center_window: bool` and `start_monitor: i16`. Window centering is by default enabled.
-- Added the following convenience functions for managing window centering: center(), and set_centered(). Refer to the documentation for how to use them.
+- Added the following convenience functions for managing window centering: `center()`, and `set_centered()`. Refer to the documentation for how to use them.
 # Version 0.19.1 (2019-04-08)
 
 - On Wayland, added a `get_wayland_display` function to `EventsLoopExt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 # Unreleased
 
-- Added in WindowAttributes `center_window: bool` `start_monitor: i16`, Window centering is by default enabled on windows.
-- Added convenience functions to manage window centering, `center()` ,`set_center_monitor()`, `set_centered()` see more in window struct.
-
 # Version 0.19.1 (2019-04-08)
 
 - On Wayland, added a `get_wayland_display` function to `EventsLoopExt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- Added in WindowAttributes `center_window: bool` `start_monitor: i16`, Window centering is by default enabled on windows.
+- Added convenience functions to manage window centering, `center()` ,`set_center_monitor()`, `set_centered()` see more in window struct.
+
 # Version 0.19.1 (2019-04-08)
 
 - On Wayland, added a `get_wayland_display` function to `EventsLoopExt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
-
+- Added in WindowAttributes `center_window: bool` `start_monitor: i16`, Window centering is by default enabled on windows.
+- Added convenience functions to manage window centering, `center()` ,`set_center_monitor()`, `set_centered()` see more in window struct.
 # Version 0.19.1 (2019-04-08)
 
 - On Wayland, added a `get_wayland_display` function to `EventsLoopExt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
-- Added to `WindowAttributes` the attributes `center_window: bool` and `start_monitor: i16`. Window centering is by default enabled.
-- Added the following convenience functions for managing window centering: `center()`, and `set_centered()`. Refer to the documentation for how to use them.
+
+- Added to `WindowAttributes` the `center_window: Option<MonitorId>`.
+- Added the following function for managing window centering `set_centered()`.
+
 # Version 0.19.1 (2019-04-08)
 
 - On Wayland, added a `get_wayland_display` function to `EventsLoopExt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-- Added to `WindowAttributes` the attributes `center_window: bool` and `monitor_index: i16`. Window centering is by default enabled.
-- Added the following convenience functions for managing window centering: center(), set_target_monitor(), and set_centered(). Refer to the documentation for how to use them.
+- Added to `WindowAttributes` the attributes `center_window: bool` and `start_monitor: i16`. Window centering is by default enabled.
+- Added the following convenience functions for managing window centering: center(), and set_centered(). Refer to the documentation for how to use them.
 # Version 0.19.1 (2019-04-08)
 
 - On Wayland, added a `get_wayland_display` function to `EventsLoopExt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
-- Added in WindowAttributes `center_window: bool` `start_monitor: i16`, Window centering is by default enabled on windows.
-- Added convenience functions to manage window centering, `center()` ,`set_center_monitor()`, `set_centered()` see more in window struct.
+- Added to `WindowAttributes` the attributes `center_window: bool` and `monitor_index: i16`. Window centering is by default enabled.
+- Added the following convenience functions for managing window centering: center(), set_target_monitor(), and set_centered(). Refer to the documentation for how to use them.
 # Version 0.19.1 (2019-04-08)
 
 - On Wayland, added a `get_wayland_display` function to `EventsLoopExt`.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -154,7 +154,7 @@ Legend:
 |Window transparency              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
 |Window maximization              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
 |Window maximization toggle       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
-|Window centering                 |✔️     |❌     |✔️         |❌             |**N/A**|**N/A**|**N/A**   |
+|Window centering                 |✔️     |❌     |✔️         |**N/A**         |**N/A**|**N/A**|**N/A**   |
 |Fullscreen                       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|❌        |
 |Fullscreen toggle                |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|❌        |
 |HiDPI support                    |✔️     |✔️     |✔️         |✔️             |▢[#721]|✔️    |✔️         |

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -88,7 +88,7 @@ If your PR makes notable changes to Winit's features, please update this section
 - **Popup / modal windows**: Windows can be created relative to the client area of other windows, and parent
   windows can be disabled in favor of popup windows. This feature also guarantees that popup windows
   get drawn above their owner.
-
+- **Window centering**: Sets the window position to be in the center of the given monitor.
 
 ### System Information
 - **Monitor list**: Retrieve the list of monitors and their metadata, including which one is primary.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -81,6 +81,7 @@ If your PR makes notable changes to Winit's features, please update this section
 - **Window maximization**: The windows created by winit can be maximized upon creation.
 - **Window maximization toggle**: The windows created by winit can be maximized and unmaximized after
   creation.
+- **Window centering**: Sets the window position to be in the center of the given monitor.
 - **Fullscreen**: The windows created by winit can be put into fullscreen mode.
 - **Fullscreen toggle**: The windows created by winit can be switched to and from fullscreen after
   creation.
@@ -88,7 +89,6 @@ If your PR makes notable changes to Winit's features, please update this section
 - **Popup / modal windows**: Windows can be created relative to the client area of other windows, and parent
   windows can be disabled in favor of popup windows. This feature also guarantees that popup windows
   get drawn above their owner.
-- **Window centering**: Sets the window position to be in the center of the given monitor.
 
 ### System Information
 - **Monitor list**: Retrieve the list of monitors and their metadata, including which one is primary.
@@ -154,6 +154,7 @@ Legend:
 |Window transparency              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
 |Window maximization              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
 |Window maximization toggle       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
+|Window centering                 |✔️     |❌     |✔️         |❌             |**N/A**|**N/A**|**N/A**   |
 |Fullscreen                       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|❌        |
 |Fullscreen toggle                |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|❌        |
 |HiDPI support                    |✔️     |✔️     |✔️         |✔️             |▢[#721]|✔️    |✔️         |

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -8,7 +8,6 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
-    _window.center();
 
     events_loop.run_forever(|event| {
         println!("{:?}", event);

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -8,6 +8,8 @@ fn main() {
         .build(&events_loop)
         .unwrap();
 
+    _window.center();
+
     events_loop.run_forever(|event| {
         println!("{:?}", event);
 

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -27,11 +27,9 @@ fn main() {
         // At present, this only does anything on Windows and X11, so if you want to save load
         // time, you can put icon loading behind a function that returns `None` on other platforms.
         .with_window_icon(Some(icon))
-        .with_centering(true)
         .build(&events_loop)
         .unwrap();
     
-    //window.center();
 
     events_loop.run_forever(|event| {
         if let winit::Event::WindowEvent { event, .. } = event {

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -27,8 +27,11 @@ fn main() {
         // At present, this only does anything on Windows and X11, so if you want to save load
         // time, you can put icon loading behind a function that returns `None` on other platforms.
         .with_window_icon(Some(icon))
+        .with_centering(true)
         .build(&events_loop)
         .unwrap();
+    
+    //window.center();
 
     events_loop.run_forever(|event| {
         if let winit::Event::WindowEvent { event, .. } = event {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,9 @@ extern crate image;
 extern crate serde;
 
 #[cfg(target_os = "windows")]
-extern crate backtrace;
-#[cfg(target_os = "windows")]
 extern crate winapi;
+#[cfg(target_os = "windows")]
+extern crate backtrace;
 #[macro_use]
 #[cfg(target_os = "windows")]
 extern crate bitflags;
@@ -112,43 +112,19 @@ extern crate cocoa;
 extern crate core_foundation;
 #[cfg(target_os = "macos")]
 extern crate core_graphics;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-extern crate parking_lot;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-extern crate percent_encoding;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-extern crate smithay_client_toolkit as sctk;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 extern crate x11_dl;
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+extern crate parking_lot;
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+extern crate percent_encoding;
+#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+extern crate smithay_client_toolkit as sctk;
 
 pub(crate) use dpi::*; // TODO: Actually change the imports throughout the codebase.
 pub use events::*;
-pub use icon::*;
 pub use window::{AvailableMonitorsIter, MonitorId};
+pub use icon::*;
 
 pub mod dpi;
 mod events;
@@ -241,7 +217,7 @@ impl DeviceId {
 /// `EventsLoopProxy` allows you to wakeup an `EventsLoop` from an other thread.
 pub struct EventsLoop {
     events_loop: platform::EventsLoop,
-    _marker: ::std::marker::PhantomData<*mut ()>, // Not Send nor Sync
+    _marker: ::std::marker::PhantomData<*mut ()> // Not Send nor Sync
 }
 
 impl std::fmt::Debug for EventsLoop {
@@ -282,17 +258,13 @@ impl EventsLoop {
     #[inline]
     pub fn get_available_monitors(&self) -> AvailableMonitorsIter {
         let data = self.events_loop.get_available_monitors();
-        AvailableMonitorsIter {
-            data: data.into_iter(),
-        }
+        AvailableMonitorsIter{ data: data.into_iter() }
     }
 
     /// Returns the primary monitor of the system.
     #[inline]
     pub fn get_primary_monitor(&self) -> MonitorId {
-        MonitorId {
-            inner: self.events_loop.get_primary_monitor(),
-        }
+        MonitorId { inner: self.events_loop.get_primary_monitor() }
     }
 
     /// Fetches all the events that are pending, calls the callback function for each of them,
@@ -314,6 +286,7 @@ impl EventsLoop {
     /// at a sufficient rate. Rendering in the callback with vsync enabled **will** cause significant lag.
     #[inline]
     pub fn run_forever<F>(&mut self, callback: F)
+        where F: FnMut(Event) -> ControlFlow
     {
         self.events_loop.run_forever(callback)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,8 +299,7 @@ impl EventsLoop {
     /// and returns.
     #[inline]
     pub fn poll_events<F>(&mut self, callback: F)
-    where
-        F: FnMut(Event),
+        where F: FnMut(Event)
     {
         self.events_loop.poll_events(callback)
     }
@@ -315,8 +314,6 @@ impl EventsLoop {
     /// at a sufficient rate. Rendering in the callback with vsync enabled **will** cause significant lag.
     #[inline]
     pub fn run_forever<F>(&mut self, callback: F)
-    where
-        F: FnMut(Event) -> ControlFlow,
     {
         self.events_loop.run_forever(callback)
     }
@@ -509,16 +506,6 @@ pub struct WindowAttributes {
     /// The default is `None`.
     pub fullscreen: Option<MonitorId>,
 
-    /// Whether the window will be centered on screen.
-    ///
-    /// The default is true.
-    pub center_window: bool,
-
-    /// Decides what monitor the window will start on. Users primary monitor is -1.
-    ///
-    /// The default is -1,
-    pub start_monitor: i16,
-
     /// The title of the window in the title bar.
     ///
     /// The default is `"winit window"`.
@@ -571,8 +558,6 @@ impl Default for WindowAttributes {
             title: "winit window".to_owned(),
             maximized: false,
             fullscreen: None,
-            center_window: true,
-            start_monitor: -1,
             visible: true,
             transparent: false,
             decorations: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,6 +510,16 @@ pub struct WindowAttributes {
     /// The default is `false`.
     pub always_on_top: bool,
 
+    /// Whether the window will be centered on screen.
+    ///
+    /// The default is true.
+    pub center_window: bool,
+
+    /// Decides what monitor the window will start on. Users primary monitor is -1.
+    ///
+    /// The default is -1,
+    pub start_monitor: i16,
+
     /// The window icon.
     ///
     /// The default is `None`.
@@ -531,6 +541,8 @@ impl Default for WindowAttributes {
             title: "winit window".to_owned(),
             maximized: false,
             fullscreen: None,
+            center_window: true,
+            start_monitor: -1,
             visible: true,
             transparent: false,
             decorations: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,8 @@ impl EventsLoop {
     /// and returns.
     #[inline]
     pub fn poll_events<F>(&mut self, callback: F)
-        where F: FnMut(Event)
+    where
+        F: FnMut(Event),
     {
         self.events_loop.poll_events(callback)
     }
@@ -314,6 +315,8 @@ impl EventsLoop {
     /// at a sufficient rate. Rendering in the callback with vsync enabled **will** cause significant lag.
     #[inline]
     pub fn run_forever<F>(&mut self, callback: F)
+    where
+        F: FnMut(Event) -> ControlFlow,
     {
         self.events_loop.run_forever(callback)
     }
@@ -506,6 +509,16 @@ pub struct WindowAttributes {
     /// The default is `None`.
     pub fullscreen: Option<MonitorId>,
 
+    /// Whether the window will be centered on screen.
+    ///
+    /// The default is true.
+    pub center_window: bool,
+
+    /// Decides what monitor the window will start on. Users primary monitor is -1.
+    ///
+    /// The default is -1,
+    pub start_monitor: i16,
+
     /// The title of the window in the title bar.
     ///
     /// The default is `"winit window"`.
@@ -558,6 +571,8 @@ impl Default for WindowAttributes {
             title: "winit window".to_owned(),
             maximized: false,
             fullscreen: None,
+            center_window: true,
+            start_monitor: -1,
             visible: true,
             transparent: false,
             decorations: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,9 +97,9 @@ extern crate image;
 extern crate serde;
 
 #[cfg(target_os = "windows")]
-extern crate winapi;
-#[cfg(target_os = "windows")]
 extern crate backtrace;
+#[cfg(target_os = "windows")]
+extern crate winapi;
 #[macro_use]
 #[cfg(target_os = "windows")]
 extern crate bitflags;
@@ -112,19 +112,43 @@ extern crate cocoa;
 extern crate core_foundation;
 #[cfg(target_os = "macos")]
 extern crate core_graphics;
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
-extern crate x11_dl;
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 extern crate parking_lot;
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 extern crate percent_encoding;
-#[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 extern crate smithay_client_toolkit as sctk;
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+extern crate x11_dl;
 
 pub(crate) use dpi::*; // TODO: Actually change the imports throughout the codebase.
 pub use events::*;
-pub use window::{AvailableMonitorsIter, MonitorId};
 pub use icon::*;
+pub use window::{AvailableMonitorsIter, MonitorId};
 
 pub mod dpi;
 mod events;
@@ -217,7 +241,7 @@ impl DeviceId {
 /// `EventsLoopProxy` allows you to wakeup an `EventsLoop` from an other thread.
 pub struct EventsLoop {
     events_loop: platform::EventsLoop,
-    _marker: ::std::marker::PhantomData<*mut ()> // Not Send nor Sync
+    _marker: ::std::marker::PhantomData<*mut ()>, // Not Send nor Sync
 }
 
 impl std::fmt::Debug for EventsLoop {
@@ -258,13 +282,17 @@ impl EventsLoop {
     #[inline]
     pub fn get_available_monitors(&self) -> AvailableMonitorsIter {
         let data = self.events_loop.get_available_monitors();
-        AvailableMonitorsIter{ data: data.into_iter() }
+        AvailableMonitorsIter {
+            data: data.into_iter(),
+        }
     }
 
     /// Returns the primary monitor of the system.
     #[inline]
     pub fn get_primary_monitor(&self) -> MonitorId {
-        MonitorId { inner: self.events_loop.get_primary_monitor() }
+        MonitorId {
+            inner: self.events_loop.get_primary_monitor(),
+        }
     }
 
     /// Fetches all the events that are pending, calls the callback function for each of them,
@@ -286,7 +314,6 @@ impl EventsLoop {
     /// at a sufficient rate. Rendering in the callback with vsync enabled **will** cause significant lag.
     #[inline]
     pub fn run_forever<F>(&mut self, callback: F)
-        where F: FnMut(Event) -> ControlFlow
     {
         self.events_loop.run_forever(callback)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,10 +515,10 @@ pub struct WindowAttributes {
     /// The default is `true`.
     pub center_window: bool,
 
-    /// Decides which monitor the window will start on. The user's primary monitor is `-1`.
+    /// Decides which monitor the window will start on. The user's primary monitor is `None`.
     ///
-    /// The default is `-1`,
-    pub monitor_index: i16,
+    /// The default is `None`,
+    pub start_monitor: Option<MonitorId>,
 
     /// The window icon.
     ///
@@ -542,7 +542,7 @@ impl Default for WindowAttributes {
             maximized: false,
             fullscreen: None,
             center_window: true,
-            monitor_index: -1,
+            start_monitor: None,
             visible: true,
             transparent: false,
             decorations: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,15 +510,10 @@ pub struct WindowAttributes {
     /// The default is `false`.
     pub always_on_top: bool,
 
-    /// Whether the window will be centered on screen.
-    ///
-    /// The default is `true`.
-    pub center_window: bool,
-
-    /// Decides which monitor the window will start on. The user's primary monitor is `None`.
+    /// Decides which monitor the window will start on.
     ///
     /// The default is `None`,
-    pub start_monitor: Option<MonitorId>,
+    pub center_window: Option<MonitorId>,
 
     /// The window icon.
     ///
@@ -541,8 +536,7 @@ impl Default for WindowAttributes {
             title: "winit window".to_owned(),
             maximized: false,
             fullscreen: None,
-            center_window: true,
-            start_monitor: None,
+            center_window: None,
             visible: true,
             transparent: false,
             decorations: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,13 +512,13 @@ pub struct WindowAttributes {
 
     /// Whether the window will be centered on screen.
     ///
-    /// The default is true.
+    /// The default is `true`.
     pub center_window: bool,
 
-    /// Decides what monitor the window will start on. Users primary monitor is -1.
+    /// Decides which monitor the window will start on. The user's primary monitor is `-1`.
     ///
-    /// The default is -1,
-    pub start_monitor: i16,
+    /// The default is `-1`,
+    pub monitor_index: i16,
 
     /// The window icon.
     ///
@@ -542,7 +542,7 @@ impl Default for WindowAttributes {
             maximized: false,
             fullscreen: None,
             center_window: true,
-            start_monitor: -1,
+            monitor_index: -1,
             visible: true,
             transparent: false,
             decorations: true,

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -115,6 +115,7 @@ impl Window {
         let need_frame_refresh = Arc::new(Mutex::new(true));
         let frame = Arc::new(Mutex::new(frame));
 
+
         evlp.store.lock().unwrap().windows.push(InternalWindow {
             closed: false,
             newsize: None,

--- a/src/platform/linux/wayland/window.rs
+++ b/src/platform/linux/wayland/window.rs
@@ -115,7 +115,6 @@ impl Window {
         let need_frame_refresh = Arc::new(Mutex::new(true));
         let frame = Arc::new(Mutex::new(frame));
 
-
         evlp.store.lock().unwrap().windows.push(InternalWindow {
             closed: false,
             newsize: None,

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -384,18 +384,13 @@ impl UnownedWindow {
             {
                 let window_size = window.get_outer_size();
 
-                let monitor_size;
-                let monitor_position;
+                let monitor = match window_attrs.start_monitor {
+                    None => window.get_primary_monitor(),
+                    Some(m) => m.inner,
+                };
 
-                if window_attrs.start_monitor.is_none() {
-                    let monitor = window.get_primary_monitor();
-                    monitor_size = monitor.get_dimensions();
-                    monitor_position = monitor.get_position();
-                } else {
-                    let monitor = window_attrs.start_monitor.unwrap().inner;
-                    monitor_size = monitor.get_dimensions();
-                    monitor_position = monitor.get_position();
-                }
+                monitor_size = monitor.get_dimensions();
+                monitor_position = monitor.get_position();
 
 
                 let mut monitor_window_position: LogicalPosition = (0.0, 0.0).into();

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -384,14 +384,12 @@ impl UnownedWindow {
             {
                 let window_size = window.get_outer_size();
 
-                let monitor = match window_attrs.start_monitor {
-                    None => window.get_primary_monitor(),
-                    Some(m) => m.inner,
+                let monitor_size; let monitor_position;
+                
+                match window_attrs.start_monitor {
+                    None => { monitor_size = window.get_primary_monitor().get_dimensions(); monitor_position = window.get_primary_monitor().get_position(); }
+                    Some(m) => { monitor_size = m.inner.get_dimensions(); monitor_position = m.inner.get_position(); }
                 };
-
-                monitor_size = monitor.get_dimensions();
-                monitor_position = monitor.get_position();
-
 
                 let mut monitor_window_position: LogicalPosition = (0.0, 0.0).into();
                 monitor_window_position.x =

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -380,13 +380,13 @@ impl UnownedWindow {
                 window.set_always_on_top_inner(window_attrs.always_on_top).queue();
             }
 
-            if window_attrs.center_window && !window_attrs.fullscreen.is_some() 
+            if window_attrs.center_window.is_some() && !window_attrs.fullscreen.is_some() 
             {
                 let window_size = window.get_outer_size();
 
                 let monitor_size; let monitor_position;
                 
-                match window_attrs.start_monitor {
+                match window_attrs.center_window {
                     None => { monitor_size = window.get_primary_monitor().get_dimensions(); monitor_position = window.get_primary_monitor().get_position(); }
                     Some(m) => { monitor_size = m.inner.get_dimensions(); monitor_position = m.inner.get_position(); }
                 };

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -380,6 +380,35 @@ impl UnownedWindow {
                 window.set_always_on_top_inner(window_attrs.always_on_top).queue();
             }
 
+            if window_attrs.center_window && !window_attrs.fullscreen.is_some() 
+            {
+                let window_size = window.get_outer_size();
+
+                let monitor;
+                if window_attrs.start_monitor == -1 {
+                    monitor = window.get_primary_monitor();
+                } else {
+                    if window_attrs.start_monitor < window.get_available_monitors().len() as i16 {
+                        monitor = window.get_available_monitors()[window_attrs.start_monitor as usize].clone();
+                    } else {
+                        monitor = window.get_primary_monitor();
+                    }
+                }
+
+                let monitor_size = monitor.get_dimensions();
+                let monitor_position = monitor.get_position();
+
+
+                let mut monitor_window_position: LogicalPosition = (0.0, 0.0).into();
+                monitor_window_position.x =
+                    monitor_position.x + (monitor_size.width * 0.5) - (&window_size.unwrap().width * 0.5);
+                monitor_window_position.y =
+                    monitor_position.y + (monitor_size.height * 0.5) - (&window_size.unwrap().height * 0.5);
+
+
+                window.set_position(monitor_window_position);
+            }
+
             if window_attrs.visible {
                 unsafe {
                     // XSetInputFocus generates an error if the window is not visible, so we wait

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -385,11 +385,11 @@ impl UnownedWindow {
                 let window_size = window.get_outer_size();
 
                 let monitor;
-                if window_attrs.start_monitor == -1 {
+                if window_attrs.monitor_index == -1 {
                     monitor = window.get_primary_monitor();
                 } else {
-                    if window_attrs.start_monitor < window.get_available_monitors().len() as i16 {
-                        monitor = window.get_available_monitors()[window_attrs.start_monitor as usize].clone();
+                    if window_attrs.monitor_index < window.get_available_monitors().len() as i16 {
+                        monitor = window.get_available_monitors()[window_attrs.monitor_index as usize].clone();
                     } else {
                         monitor = window.get_primary_monitor();
                     }

--- a/src/platform/linux/x11/window.rs
+++ b/src/platform/linux/x11/window.rs
@@ -384,19 +384,18 @@ impl UnownedWindow {
             {
                 let window_size = window.get_outer_size();
 
-                let monitor;
-                if window_attrs.monitor_index == -1 {
-                    monitor = window.get_primary_monitor();
-                } else {
-                    if window_attrs.monitor_index < window.get_available_monitors().len() as i16 {
-                        monitor = window.get_available_monitors()[window_attrs.monitor_index as usize].clone();
-                    } else {
-                        monitor = window.get_primary_monitor();
-                    }
-                }
+                let monitor_size;
+                let monitor_position;
 
-                let monitor_size = monitor.get_dimensions();
-                let monitor_position = monitor.get_position();
+                if window_attrs.start_monitor.is_none() {
+                    let monitor = window.get_primary_monitor();
+                    monitor_size = monitor.get_dimensions();
+                    monitor_position = monitor.get_position();
+                } else {
+                    let monitor = window_attrs.start_monitor.unwrap().inner;
+                    monitor_size = monitor.get_dimensions();
+                    monitor_position = monitor.get_position();
+                }
 
 
                 let mut monitor_window_position: LogicalPosition = (0.0, 0.0).into();

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -724,6 +724,34 @@ unsafe fn init(
         win.set_inner_size(dimensions);
     }
 
+        if attributes.center_window {
+        let window_size = win.get_outer_size();
+
+        let monitor;
+        if attributes.start_monitor == -1 {
+            monitor = win.get_primary_monitor();
+        } else {
+            if attributes.start_monitor < win.get_available_monitors().len() as i16 {
+                monitor = win.get_available_monitors()[attributes.start_monitor as usize].clone();
+            } else {
+                monitor = win.get_primary_monitor();
+            }
+        }
+
+        let monitor_size = monitor.get_dimensions();
+        let monitor_position = monitor.get_position();
+
+
+        let mut monitor_window_position: LogicalPosition = (0.0, 0.0).into();
+        monitor_window_position.x =
+            monitor_position.x + (monitor_size.width * 0.5) - (&window_size.unwrap().width * 0.5);
+        monitor_window_position.y =
+            monitor_position.y + (monitor_size.height * 0.5) - (&window_size.unwrap().height * 0.5);
+
+
+        win.set_position(monitor_window_position);
+    }
+
     inserter.insert(win.window.0, win.window_state.clone());
 
     Ok(win)

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -728,11 +728,11 @@ unsafe fn init(
         let window_size = win.get_outer_size();
 
         let monitor;
-        if attributes.start_monitor == -1 {
+        if attributes.monitor_index == -1 {
             monitor = win.get_primary_monitor();
         } else {
-            if attributes.start_monitor < win.get_available_monitors().len() as i16 {
-                monitor = win.get_available_monitors()[attributes.start_monitor as usize].clone();
+            if attributes.monitor_index < win.get_available_monitors().len() as i16 {
+                monitor = win.get_available_monitors()[attributes.monitor_index as usize].clone();
             } else {
                 monitor = win.get_primary_monitor();
             }

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -724,10 +724,10 @@ unsafe fn init(
         win.set_inner_size(dimensions);
     }
 
-    if attributes.center_window && !&attributes.fullscreen.is_some(){
+    if attributes.center_window.is_some() && !&attributes.fullscreen.is_some(){
         let window_size = win.get_outer_size();
 
-        let monitor = match attributes.start_monitor {
+        let monitor = match attributes.center_window {
             None => win.get_primary_monitor(),
             Some(m) => m.inner,
         };

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -727,12 +727,10 @@ unsafe fn init(
     if attributes.center_window && !&attributes.fullscreen.is_some(){
         let window_size = win.get_outer_size();
 
-        let monitor;
-        if attributes.start_monitor.is_none() {
-            monitor = win.get_primary_monitor();
-        } else {
-            monitor = attributes.start_monitor.unwrap().inner;
-        }
+        let monitor = match attributes.start_monitor {
+            None => win.get_primary_monitor(),
+            Some(m) => m.inner,
+        };
 
         let monitor_size = monitor.get_dimensions();
         let monitor_position = monitor.get_position();

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -1,32 +1,21 @@
 #![cfg(target_os = "windows")]
 
-use std::{io, mem, ptr};
 use std::cell::Cell;
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
-use std::sync::{Arc, Mutex};
 use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
+use std::{io, mem, ptr};
 
 use winapi::ctypes::c_int;
 use winapi::shared::minwindef::{DWORD, LPARAM, UINT, WORD, WPARAM};
 use winapi::shared::windef::{HWND, POINT, RECT};
-use winapi::um::{combaseapi, dwmapi, libloaderapi, winuser};
 use winapi::um::objbase::COINIT_MULTITHREADED;
 use winapi::um::shobjidl_core::{CLSID_TaskbarList, ITaskbarList2};
 use winapi::um::wingdi::{CreateRectRgn, DeleteObject};
 use winapi::um::winnt::{LONG, LPCWSTR};
+use winapi::um::{combaseapi, dwmapi, libloaderapi, winuser};
 
-use {
-    CreationError,
-    Icon,
-    LogicalPosition,
-    LogicalSize,
-    MonitorId as RootMonitorId,
-    MouseCursor,
-    PhysicalSize,
-    WindowAttributes,
-};
-use platform::platform::{PlatformSpecificWindowBuilderAttributes, WindowId};
 use platform::platform::dpi::{dpi_to_scale_factor, get_hwnd_dpi};
 use platform::platform::events_loop::{self, EventsLoop, DESTROY_MSG_ID, INITIAL_DPI_MSG_ID};
 use platform::platform::icon::{self, IconType, WinIcon};
@@ -34,6 +23,11 @@ use platform::platform::monitor::get_available_monitors;
 use platform::platform::raw_input::register_all_mice_and_keyboards_for_raw_input;
 use platform::platform::util;
 use platform::platform::window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState};
+use platform::platform::{PlatformSpecificWindowBuilderAttributes, WindowId};
+use {
+    CreationError, Icon, LogicalPosition, LogicalSize, MonitorId as RootMonitorId, MouseCursor,
+    PhysicalSize, WindowAttributes,
+};
 
 /// The Win32 implementation of the main `Window` object.
 pub struct Window {
@@ -89,17 +83,15 @@ impl Window {
     }
 
     pub(crate) fn get_position_physical(&self) -> Option<(i32, i32)> {
-        util::get_window_rect(self.window.0)
-            .map(|rect| (rect.left as i32, rect.top as i32))
+        util::get_window_rect(self.window.0).map(|rect| (rect.left as i32, rect.top as i32))
     }
 
     #[inline]
     pub fn get_position(&self) -> Option<LogicalPosition> {
-        self.get_position_physical()
-            .map(|physical_position| {
-                let dpi_factor = self.get_hidpi_factor();
-                LogicalPosition::from_physical(physical_position, dpi_factor)
-            })
+        self.get_position_physical().map(|physical_position| {
+            let dpi_factor = self.get_hidpi_factor();
+            LogicalPosition::from_physical(physical_position, dpi_factor)
+        })
     }
 
     pub(crate) fn get_inner_position_physical(&self) -> Option<(i32, i32)> {
@@ -112,11 +104,10 @@ impl Window {
 
     #[inline]
     pub fn get_inner_position(&self) -> Option<LogicalPosition> {
-        self.get_inner_position_physical()
-            .map(|physical_position| {
-                let dpi_factor = self.get_hidpi_factor();
-                LogicalPosition::from_physical(physical_position, dpi_factor)
-            })
+        self.get_inner_position_physical().map(|physical_position| {
+            let dpi_factor = self.get_hidpi_factor();
+            LogicalPosition::from_physical(physical_position, dpi_factor)
+        })
     }
 
     pub(crate) fn set_position_physical(&self, x: i32, y: i32) {
@@ -154,28 +145,27 @@ impl Window {
 
     #[inline]
     pub fn get_inner_size(&self) -> Option<LogicalSize> {
-        self.get_inner_size_physical()
-            .map(|physical_size| {
-                let dpi_factor = self.get_hidpi_factor();
-                LogicalSize::from_physical(physical_size, dpi_factor)
-            })
+        self.get_inner_size_physical().map(|physical_size| {
+            let dpi_factor = self.get_hidpi_factor();
+            LogicalSize::from_physical(physical_size, dpi_factor)
+        })
     }
 
     pub(crate) fn get_outer_size_physical(&self) -> Option<(u32, u32)> {
-        util::get_window_rect(self.window.0)
-            .map(|rect| (
+        util::get_window_rect(self.window.0).map(|rect| {
+            (
                 (rect.right - rect.left) as u32,
                 (rect.bottom - rect.top) as u32,
-            ))
+            )
+        })
     }
 
     #[inline]
     pub fn get_outer_size(&self) -> Option<LogicalSize> {
-        self.get_outer_size_physical()
-            .map(|physical_size| {
-                let dpi_factor = self.get_hidpi_factor();
-                LogicalSize::from_physical(physical_size, dpi_factor)
-            })
+        self.get_outer_size_physical().map(|physical_size| {
+            let dpi_factor = self.get_hidpi_factor();
+            LogicalSize::from_physical(physical_size, dpi_factor)
+        })
     }
 
     pub(crate) fn set_inner_size_physical(&self, x: u32, y: u32) {
@@ -187,8 +177,9 @@ impl Window {
                     left: 0,
                     bottom: y as LONG,
                     right: x as LONG,
-                }
-            ).expect("adjust_window_rect failed");
+                },
+            )
+            .expect("adjust_window_rect failed");
 
             let outer_x = (rect.right - rect.left).abs() as c_int;
             let outer_y = (rect.top - rect.bottom).abs() as c_int;
@@ -200,9 +191,9 @@ impl Window {
                 outer_x,
                 outer_y,
                 winuser::SWP_ASYNCWINDOWPOS
-                | winuser::SWP_NOZORDER
-                | winuser::SWP_NOREPOSITION
-                | winuser::SWP_NOMOVE,
+                    | winuser::SWP_NOZORDER
+                    | winuser::SWP_NOREPOSITION
+                    | winuser::SWP_NOMOVE,
             );
             winuser::UpdateWindow(self.window.0);
         }
@@ -253,12 +244,9 @@ impl Window {
         let window_state = Arc::clone(&self.window_state);
 
         self.events_loop_proxy.execute_in_thread(move |_| {
-            WindowState::set_window_flags(
-                window_state.lock().unwrap(),
-                window.0,
-                None,
-                |f| f.set(WindowFlags::RESIZABLE, resizable),
-            );
+            WindowState::set_window_flags(window_state.lock().unwrap(), window.0, None, |f| {
+                f.set(WindowFlags::RESIZABLE, resizable)
+            });
         });
     }
 
@@ -272,10 +260,7 @@ impl Window {
     pub fn set_cursor(&self, cursor: MouseCursor) {
         self.window_state.lock().unwrap().mouse.cursor = cursor;
         self.events_loop_proxy.execute_in_thread(move |_| unsafe {
-            let cursor = winuser::LoadCursorW(
-                ptr::null_mut(),
-                cursor.to_windows_cursor(),
-            );
+            let cursor = winuser::LoadCursorW(ptr::null_mut(), cursor.to_windows_cursor());
             winuser::SetCursor(cursor);
         });
     }
@@ -287,7 +272,10 @@ impl Window {
         let (tx, rx) = channel();
 
         self.events_loop_proxy.execute_in_thread(move |_| {
-            let result = window_state.lock().unwrap().mouse
+            let result = window_state
+                .lock()
+                .unwrap()
+                .mouse
                 .set_cursor_flags(window.0, |f| f.set(CursorFlags::GRABBED, grab))
                 .map_err(|e| e.to_string());
             let _ = tx.send(result);
@@ -302,7 +290,10 @@ impl Window {
         let (tx, rx) = channel();
 
         self.events_loop_proxy.execute_in_thread(move |_| {
-            let result = window_state.lock().unwrap().mouse
+            let result = window_state
+                .lock()
+                .unwrap()
+                .mouse
                 .set_cursor_flags(window.0, |f| f.set(CursorFlags::HIDDEN, hide))
                 .map_err(|e| e.to_string());
             let _ = tx.send(result);
@@ -346,12 +337,9 @@ impl Window {
         let window_state = Arc::clone(&self.window_state);
 
         self.events_loop_proxy.execute_in_thread(move |_| {
-            WindowState::set_window_flags(
-                window_state.lock().unwrap(),
-                window.0,
-                None,
-                |f| f.set(WindowFlags::MAXIMIZED, maximized),
-            );
+            WindowState::set_window_flags(window_state.lock().unwrap(), window.0, None, |f| {
+                f.set(WindowFlags::MAXIMIZED, maximized)
+            });
         });
     }
 
@@ -376,10 +364,11 @@ impl Window {
                     self.events_loop_proxy.execute_in_thread(move |_| {
                         let mut window_state_lock = window_state.lock().unwrap();
 
-                        let client_rect = util::get_client_rect(window.0).expect("get client rect failed!");
+                        let client_rect =
+                            util::get_client_rect(window.0).expect("get client rect failed!");
                         window_state_lock.saved_window = Some(SavedWindow {
                             client_rect,
-                            dpi_factor: window_state_lock.dpi_factor
+                            dpi_factor: window_state_lock.dpi_factor,
                         });
 
                         window_state_lock.fullscreen = monitor.take();
@@ -391,7 +380,7 @@ impl Window {
                                 top: y,
                                 right: x + width as c_int,
                                 bottom: y + height as c_int,
-                            })
+                            }),
                         );
 
                         mark_fullscreen(window.0, true);
@@ -402,14 +391,18 @@ impl Window {
                         let mut window_state_lock = window_state.lock().unwrap();
                         window_state_lock.fullscreen = None;
 
-                        if let Some(SavedWindow{client_rect, dpi_factor}) = window_state_lock.saved_window {
+                        if let Some(SavedWindow {
+                            client_rect,
+                            dpi_factor,
+                        }) = window_state_lock.saved_window
+                        {
                             window_state_lock.dpi_factor = dpi_factor;
                             window_state_lock.saved_window = None;
 
                             WindowState::refresh_window_state(
                                 window_state_lock,
                                 window.0,
-                                Some(client_rect)
+                                Some(client_rect),
                             );
                         }
 
@@ -442,12 +435,9 @@ impl Window {
         let window_state = Arc::clone(&self.window_state);
 
         self.events_loop_proxy.execute_in_thread(move |_| {
-            WindowState::set_window_flags(
-                window_state.lock().unwrap(),
-                window.0,
-                None,
-                |f| f.set(WindowFlags::ALWAYS_ON_TOP, always_on_top),
-            );
+            WindowState::set_window_flags(window_state.lock().unwrap(), window.0, None, |f| {
+                f.set(WindowFlags::ALWAYS_ON_TOP, always_on_top)
+            });
         });
     }
 
@@ -541,9 +531,7 @@ unsafe fn init(
         .collect::<Vec<_>>();
 
     let window_icon = {
-        let icon = attributes.window_icon
-            .take()
-            .map(WinIcon::from_icon);
+        let icon = attributes.window_icon.take().map(WinIcon::from_icon);
         if icon.is_some() {
             Some(icon.unwrap().map_err(|err| {
                 CreationError::OsError(format!("Failed to create `ICON_SMALL`: {:?}", err))
@@ -553,9 +541,7 @@ unsafe fn init(
         }
     };
     let taskbar_icon = {
-        let icon = pl_attribs.taskbar_icon
-            .take()
-            .map(WinIcon::from_icon);
+        let icon = pl_attribs.taskbar_icon.take().map(WinIcon::from_icon);
         if icon.is_some() {
             Some(icon.unwrap().map_err(|err| {
                 CreationError::OsError(format!("Failed to create `ICON_BIG`: {:?}", err))
@@ -579,7 +565,9 @@ unsafe fn init(
             }
             dpi_factor
         } else {
-            return Err(CreationError::OsError(format!("No monitors were detected.")));
+            return Err(CreationError::OsError(format!(
+                "No monitors were detected."
+            )));
         };
         dpi_factor.unwrap_or_else(|| {
             util::get_cursor_pos()
@@ -603,7 +591,10 @@ unsafe fn init(
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::DECORATIONS, attributes.decorations);
     window_flags.set(WindowFlags::ALWAYS_ON_TOP, attributes.always_on_top);
-    window_flags.set(WindowFlags::NO_BACK_BUFFER, pl_attribs.no_redirection_bitmap);
+    window_flags.set(
+        WindowFlags::NO_BACK_BUFFER,
+        pl_attribs.no_redirection_bitmap,
+    );
     window_flags.set(WindowFlags::TRANSPARENT, attributes.transparent);
     // WindowFlags::VISIBLE and MAXIMIZED are set down below after the window has been configured.
     window_flags.set(WindowFlags::RESIZABLE, attributes.resizable);
@@ -618,8 +609,10 @@ unsafe fn init(
             class_name.as_ptr(),
             title.as_ptr() as LPCWSTR,
             style,
-            winuser::CW_USEDEFAULT, winuser::CW_USEDEFAULT,
-            winuser::CW_USEDEFAULT, winuser::CW_USEDEFAULT,
+            winuser::CW_USEDEFAULT,
+            winuser::CW_USEDEFAULT,
+            winuser::CW_USEDEFAULT,
+            winuser::CW_USEDEFAULT,
             pl_attribs.parent.unwrap_or(ptr::null_mut()),
             ptr::null_mut(),
             libloaderapi::GetModuleHandleW(ptr::null()),
@@ -627,8 +620,10 @@ unsafe fn init(
         );
 
         if handle.is_null() {
-            return Err(CreationError::OsError(format!("CreateWindowEx function failed: {}",
-                                              format!("{}", io::Error::last_os_error()))));
+            return Err(CreationError::OsError(format!(
+                "CreateWindowEx function failed: {}",
+                format!("{}", io::Error::last_os_error())
+            )));
         }
 
         WindowWrapper(handle)
@@ -639,9 +634,9 @@ unsafe fn init(
 
     // Register for touch events if applicable
     {
-        let digitizer = winuser::GetSystemMetrics( winuser::SM_DIGITIZER ) as u32;
+        let digitizer = winuser::GetSystemMetrics(winuser::SM_DIGITIZER) as u32;
         if digitizer & winuser::NID_READY != 0 {
-            winuser::RegisterTouchWindow( real_window.0, winuser::TWF_WANTPALM );
+            winuser::RegisterTouchWindow(real_window.0, winuser::TWF_WANTPALM);
         }
     }
 
@@ -685,7 +680,12 @@ unsafe fn init(
             // The color key can be any value except for black (0x0).
             let color_key = 0x0030c100;
 
-            winuser::SetLayeredWindowAttributes(real_window.0, color_key, opacity, winuser::LWA_ALPHA);
+            winuser::SetLayeredWindowAttributes(
+                real_window.0,
+                color_key,
+                opacity,
+                winuser::LWA_ALPHA,
+            );
         }
     }
 
@@ -693,19 +693,11 @@ unsafe fn init(
     window_flags.set(WindowFlags::MAXIMIZED, attributes.maximized);
 
     let window_state = {
-        let mut window_state = WindowState::new(
-            &attributes,
-            window_icon,
-            taskbar_icon,
-            dpi_factor,
-        );
+        let mut window_state = WindowState::new(&attributes, window_icon, taskbar_icon, dpi_factor);
         let window_state = Arc::new(Mutex::new(window_state));
-        WindowState::set_window_flags(
-            window_state.lock().unwrap(),
-            real_window.0,
-            None,
-            |f| *f = window_flags,
-        );
+        WindowState::set_window_flags(window_state.lock().unwrap(), real_window.0, None, |f| {
+            *f = window_flags
+        });
         window_state
     };
 
@@ -722,6 +714,34 @@ unsafe fn init(
 
     if let Some(dimensions) = attributes.dimensions {
         win.set_inner_size(dimensions);
+    }
+
+    if attributes.center_window {
+        let window_size = win.get_outer_size();
+
+        let monitor;
+        if attributes.start_monitor == -1 {
+            monitor = win.get_primary_monitor();
+        } else {
+            if attributes.start_monitor < win.get_available_monitors().len() as i16 {
+                monitor = win.get_available_monitors()[attributes.start_monitor as usize].clone();
+            } else {
+                monitor = win.get_primary_monitor();
+            }
+        }
+
+        let monitor_size = monitor.get_dimensions();
+        let monitor_position = monitor.get_position();
+
+
+        let mut monitor_window_position: LogicalPosition = (0.0, 0.0).into();
+        monitor_window_position.x =
+            monitor_position.x + (monitor_size.width * 0.5) - (&window_size.unwrap().width * 0.5);
+        monitor_window_position.y =
+            monitor_position.y + (monitor_size.height * 0.5) - (&window_size.unwrap().height * 0.5);
+
+
+        win.set_position(monitor_window_position);
     }
 
     inserter.insert(win.window.0, win.window_state.clone());
@@ -778,7 +798,7 @@ impl Drop for ComInitialized {
     }
 }
 
-thread_local!{
+thread_local! {
     static COM_INITIALIZED: ComInitialized = {
         unsafe {
             combaseapi::CoInitializeEx(ptr::null_mut(), COINIT_MULTITHREADED);

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -728,14 +728,10 @@ unsafe fn init(
         let window_size = win.get_outer_size();
 
         let monitor;
-        if attributes.monitor_index == -1 {
+        if attributes.start_monitor.is_none() {
             monitor = win.get_primary_monitor();
         } else {
-            if attributes.monitor_index < win.get_available_monitors().len() as i16 {
-                monitor = win.get_available_monitors()[attributes.monitor_index as usize].clone();
-            } else {
-                monitor = win.get_primary_monitor();
-            }
+            monitor = attributes.start_monitor.unwrap().inner;
         }
 
         let monitor_size = monitor.get_dimensions();

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -715,8 +715,8 @@ unsafe fn init(
         events_loop_proxy,
     };
 
-    if let Some(_) = attributes.fullscreen {
-        win.set_fullscreen(attributes.fullscreen);
+    if let Some(_) = &attributes.fullscreen {
+        win.set_fullscreen(attributes.fullscreen.clone());
         force_window_active(win.window.0);
     }
 
@@ -724,7 +724,7 @@ unsafe fn init(
         win.set_inner_size(dimensions);
     }
 
-        if attributes.center_window {
+    if attributes.center_window && !&attributes.fullscreen.is_some(){
         let window_size = win.get_outer_size();
 
         let monitor;

--- a/src/window.rs
+++ b/src/window.rs
@@ -401,7 +401,7 @@ impl Window {
     /// ## Platform-specific
     /// 
     /// This only works on Windows and X11.
-    /// it's not tested on macOS.
+    /// It's not tested on macOS.
     /// 
     /// This has no effect on Android, Wayland or iOS.
     pub fn center(&self) {
@@ -414,7 +414,7 @@ impl Window {
     /// ## Platform-specific
     /// 
     /// This only works on Windows and X11.
-    /// it's not tested on macOS.
+    /// It's not tested on macOS.
     /// 
     /// This has no effect on Android, Wayland or iOS.
     pub fn set_centered(&self, monitor: MonitorId) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,8 +1,18 @@
 use std::collections::vec_deque::IntoIter as VecDequeIter;
 
 use {
-    platform, CreationError, EventsLoop, Icon, LogicalPosition, LogicalSize, MouseCursor,
-    PhysicalPosition, PhysicalSize, Window, WindowBuilder, WindowId,
+    CreationError,
+    EventsLoop,
+    Icon,
+    LogicalPosition,
+    LogicalSize,
+    MouseCursor,
+    PhysicalPosition,
+    PhysicalSize,
+    platform,
+    Window,
+    WindowBuilder,
+    WindowId,
 };
 
 impl WindowBuilder {
@@ -64,21 +74,6 @@ impl WindowBuilder {
     #[inline]
     pub fn with_fullscreen(mut self, monitor: Option<MonitorId>) -> WindowBuilder {
         self.window.fullscreen = monitor;
-        self
-    }
-
-    /// Sets so the window will start centered on screen.
-    #[inline]
-    pub fn with_centering(mut self, centered: bool) -> WindowBuilder {
-        self.window.center_window = centered;
-        self
-    }
-
-    /// Sets what monitor the window will start in.
-    /// where -1 is the users primary monitor.
-    #[inline]
-    pub fn with_target_monitor(mut self, start_monitor: i16) -> WindowBuilder {
-        self.window.start_monitor = start_monitor;
         self
     }
 
@@ -158,12 +153,12 @@ impl WindowBuilder {
             }
         }));
 
+        // building
         platform::Window::new(
             &events_loop.events_loop,
             self.window,
             self.platform_specific,
-        )
-        .map(|window| Window { window })
+        ).map(|window| Window { window })
     }
 }
 
@@ -380,40 +375,6 @@ impl Window {
         self.window.get_fullscreen()
     }
 
-    /// Centers the window on the current monitor the window lives in.
-    pub fn center(&self) {
-        self.set_centered(self.get_current_monitor())
-    }
-
-    /// Centers the window on the specified target monitor, falls back to primary monitor if out range.
-    pub fn set_center_monitor(&self, monitor_target: usize) {
-        if monitor_target < self.get_available_monitors().count() {
-            self.set_centered(self.get_available_monitors().nth(monitor_target).unwrap())
-        } else {
-            self.set_centered(self.get_primary_monitor());
-        }
-    }
-
-    /// Sets the window position to be in the center of the given monitor.
-    /// Will do nothing if the window is in fullscreen.
-    pub fn set_centered(&self, monitor: MonitorId) {
-        let window_size = match self.get_outer_size() {
-            Some(logical_size) => logical_size,
-            None => return,
-        };
-
-        let monitor_size = monitor.get_dimensions();
-        let monitor_position = monitor.get_position();
-
-        let mut monitor_window_position: LogicalPosition = (0.0, 0.0).into();
-        monitor_window_position.x =
-            monitor_position.x + (monitor_size.width * 0.5) - (&window_size.width * 0.5);
-        monitor_window_position.y =
-            monitor_position.y + (monitor_size.height * 0.5) - (&window_size.height * 0.5);
-
-        &self.set_position(monitor_window_position);
-    }
-
     /// Turn window decorations on or off.
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
@@ -457,9 +418,7 @@ impl Window {
     #[inline]
     pub fn get_available_monitors(&self) -> AvailableMonitorsIter {
         let data = self.window.get_available_monitors();
-        AvailableMonitorsIter {
-            data: data.into_iter(),
-        }
+        AvailableMonitorsIter { data: data.into_iter() }
     }
 
     /// Returns the primary monitor of the system.
@@ -467,9 +426,7 @@ impl Window {
     /// This is the same as `EventsLoop::get_primary_monitor`, and is provided for convenience.
     #[inline]
     pub fn get_primary_monitor(&self) -> MonitorId {
-        MonitorId {
-            inner: self.window.get_primary_monitor(),
-        }
+        MonitorId { inner: self.window.get_primary_monitor() }
     }
 
     #[inline]
@@ -503,7 +460,7 @@ impl Iterator for AvailableMonitorsIter {
 /// Identifier for a monitor.
 #[derive(Debug, Clone)]
 pub struct MonitorId {
-    pub(crate) inner: platform::MonitorId,
+    pub(crate) inner: platform::MonitorId
 }
 
 impl MonitorId {

--- a/src/window.rs
+++ b/src/window.rs
@@ -69,21 +69,6 @@ impl WindowBuilder {
         self
     }
 
-    /// Sets whether or not window will start centered on screen.
-    #[inline]
-    pub fn with_centering(mut self, centered: bool) -> WindowBuilder {
-        self.window.center_window = centered;
-        self
-    }
-
-    /// Sets which monitor the window will start in.
-    /// where `-1` is the user's primary monitor.
-    #[inline]
-    pub fn with_target_monitor(mut self, monitor_index: Option<MonitorId>) -> WindowBuilder {
-        self.window.start_monitor = monitor_index;
-        self
-    }
-
     /// Sets the window fullscreen state. None means a normal window, Some(MonitorId)
     /// means a fullscreen window on that specific monitor
     #[inline]
@@ -396,27 +381,15 @@ impl Window {
         self.window.set_decorations(decorations)
     }
     
-    /// Centers the window on the current monitor the window lives in.
-    /// 
-    /// ## Platform-specific
-    /// 
-    /// This only works on Windows and X11.
-    /// It's not tested on macOS.
-    /// 
-    /// This has no effect on Android, Wayland or iOS.
-    pub fn center(&self) {
-        self.set_centered(self.get_current_monitor())
-    }
-
     /// Sets the window position to be in the center of the given monitor.
     /// Will do nothing if the window is in fullscreen.
     /// 
     /// ## Platform-specific
     /// 
     /// This only works on Windows and X11.
-    /// It's not tested on macOS.
     /// 
     /// This has no effect on Android, Wayland or iOS.
+    #[inline]
     pub fn set_centered(&self, monitor: MonitorId) {
         let window_size = match self.get_outer_size() {
             Some(logical_size) => logical_size,

--- a/src/window.rs
+++ b/src/window.rs
@@ -79,8 +79,8 @@ impl WindowBuilder {
     /// Sets which monitor the window will start in.
     /// where `-1` is the user's primary monitor.
     #[inline]
-    pub fn with_target_monitor(mut self, monitor_index: i16) -> WindowBuilder {
-        self.window.monitor_index = monitor_index;
+    pub fn with_target_monitor(mut self, monitor_index: Option<MonitorId>) -> WindowBuilder {
+        self.window.start_monitor = monitor_index;
         self
     }
 
@@ -397,21 +397,26 @@ impl Window {
     }
     
     /// Centers the window on the current monitor the window lives in.
+    /// 
+    /// ## Platform-specific
+    /// 
+    /// This only works on Windows and X11.
+    /// it's not tested on macOS.
+    /// 
+    /// This has no effect on Android, Wayland or iOS.
     pub fn center(&self) {
         self.set_centered(self.get_current_monitor())
     }
 
-    /// Centers the window on the specified target monitor, falls back to primary monitor if out range.
-    pub fn set_target_monitor(&self, monitor_index: usize) {
-        if monitor_index < self.get_available_monitors().count() {
-            self.set_centered(self.get_available_monitors().nth(monitor_index).unwrap())
-        } else {
-            self.set_centered(self.get_primary_monitor());
-        }
-    }
-
     /// Sets the window position to be in the center of the given monitor.
     /// Will do nothing if the window is in fullscreen.
+    /// 
+    /// ## Platform-specific
+    /// 
+    /// This only works on Windows and X11.
+    /// it's not tested on macOS.
+    /// 
+    /// This has no effect on Android, Wayland or iOS.
     pub fn set_centered(&self, monitor: MonitorId) {
         let window_size = match self.get_outer_size() {
             Some(logical_size) => logical_size,

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,18 +1,8 @@
 use std::collections::vec_deque::IntoIter as VecDequeIter;
 
 use {
-    CreationError,
-    EventsLoop,
-    Icon,
-    LogicalPosition,
-    LogicalSize,
-    MouseCursor,
-    PhysicalPosition,
-    PhysicalSize,
-    platform,
-    Window,
-    WindowBuilder,
-    WindowId,
+    platform, CreationError, EventsLoop, Icon, LogicalPosition, LogicalSize, MouseCursor,
+    PhysicalPosition, PhysicalSize, Window, WindowBuilder, WindowId,
 };
 
 impl WindowBuilder {
@@ -74,6 +64,21 @@ impl WindowBuilder {
     #[inline]
     pub fn with_fullscreen(mut self, monitor: Option<MonitorId>) -> WindowBuilder {
         self.window.fullscreen = monitor;
+        self
+    }
+
+    /// Sets so the window will start centered on screen.
+    #[inline]
+    pub fn with_centering(mut self, centered: bool) -> WindowBuilder {
+        self.window.center_window = centered;
+        self
+    }
+
+    /// Sets what monitor the window will start in.
+    /// where -1 is the users primary monitor.
+    #[inline]
+    pub fn with_target_monitor(mut self, start_monitor: i16) -> WindowBuilder {
+        self.window.start_monitor = start_monitor;
         self
     }
 
@@ -153,12 +158,12 @@ impl WindowBuilder {
             }
         }));
 
-        // building
         platform::Window::new(
             &events_loop.events_loop,
             self.window,
             self.platform_specific,
-        ).map(|window| Window { window })
+        )
+        .map(|window| Window { window })
     }
 }
 
@@ -375,6 +380,40 @@ impl Window {
         self.window.get_fullscreen()
     }
 
+    /// Centers the window on the current monitor the window lives in.
+    pub fn center(&self) {
+        self.set_centered(self.get_current_monitor())
+    }
+
+    /// Centers the window on the specified target monitor, falls back to primary monitor if out range.
+    pub fn set_center_monitor(&self, monitor_target: usize) {
+        if monitor_target < self.get_available_monitors().count() {
+            self.set_centered(self.get_available_monitors().nth(monitor_target).unwrap())
+        } else {
+            self.set_centered(self.get_primary_monitor());
+        }
+    }
+
+    /// Sets the window position to be in the center of the given monitor.
+    /// Will do nothing if the window is in fullscreen.
+    pub fn set_centered(&self, monitor: MonitorId) {
+        let window_size = match self.get_outer_size() {
+            Some(logical_size) => logical_size,
+            None => return,
+        };
+
+        let monitor_size = monitor.get_dimensions();
+        let monitor_position = monitor.get_position();
+
+        let mut monitor_window_position: LogicalPosition = (0.0, 0.0).into();
+        monitor_window_position.x =
+            monitor_position.x + (monitor_size.width * 0.5) - (&window_size.width * 0.5);
+        monitor_window_position.y =
+            monitor_position.y + (monitor_size.height * 0.5) - (&window_size.height * 0.5);
+
+        &self.set_position(monitor_window_position);
+    }
+
     /// Turn window decorations on or off.
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
@@ -418,7 +457,9 @@ impl Window {
     #[inline]
     pub fn get_available_monitors(&self) -> AvailableMonitorsIter {
         let data = self.window.get_available_monitors();
-        AvailableMonitorsIter { data: data.into_iter() }
+        AvailableMonitorsIter {
+            data: data.into_iter(),
+        }
     }
 
     /// Returns the primary monitor of the system.
@@ -426,7 +467,9 @@ impl Window {
     /// This is the same as `EventsLoop::get_primary_monitor`, and is provided for convenience.
     #[inline]
     pub fn get_primary_monitor(&self) -> MonitorId {
-        MonitorId { inner: self.window.get_primary_monitor() }
+        MonitorId {
+            inner: self.window.get_primary_monitor(),
+        }
     }
 
     #[inline]
@@ -460,7 +503,7 @@ impl Iterator for AvailableMonitorsIter {
 /// Identifier for a monitor.
 #[derive(Debug, Clone)]
 pub struct MonitorId {
-    pub(crate) inner: platform::MonitorId
+    pub(crate) inner: platform::MonitorId,
 }
 
 impl MonitorId {

--- a/src/window.rs
+++ b/src/window.rs
@@ -69,18 +69,18 @@ impl WindowBuilder {
         self
     }
 
-        /// Sets so the window will start centered on screen.
+    /// Sets whether or not window will start centered on screen.
     #[inline]
     pub fn with_centering(mut self, centered: bool) -> WindowBuilder {
         self.window.center_window = centered;
         self
     }
 
-    /// Sets what monitor the window will start in.
-    /// where -1 is the users primary monitor.
+    /// Sets which monitor the window will start in.
+    /// where `-1` is the user's primary monitor.
     #[inline]
-    pub fn with_target_monitor(mut self, start_monitor: i16) -> WindowBuilder {
-        self.window.start_monitor = start_monitor;
+    pub fn with_target_monitor(mut self, monitor_index: i16) -> WindowBuilder {
+        self.window.monitor_index = monitor_index;
         self
     }
 
@@ -395,15 +395,16 @@ impl Window {
     pub fn set_decorations(&self, decorations: bool) {
         self.window.set_decorations(decorations)
     }
-        /// Centers the window on the current monitor the window lives in.
+    
+    /// Centers the window on the current monitor the window lives in.
     pub fn center(&self) {
         self.set_centered(self.get_current_monitor())
     }
 
     /// Centers the window on the specified target monitor, falls back to primary monitor if out range.
-    pub fn set_center_monitor(&self, monitor_target: usize) {
-        if monitor_target < self.get_available_monitors().count() {
-            self.set_centered(self.get_available_monitors().nth(monitor_target).unwrap())
+    pub fn set_target_monitor(&self, monitor_index: usize) {
+        if monitor_index < self.get_available_monitors().count() {
+            self.set_centered(self.get_available_monitors().nth(monitor_index).unwrap())
         } else {
             self.set_centered(self.get_primary_monitor());
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -427,7 +427,7 @@ impl Window {
         monitor_window_position.y =
             monitor_position.y + (monitor_size.height * 0.5) - (&window_size.height * 0.5);
 
-        &self.set_position(monitor_window_position);
+        self.set_position(monitor_window_position);
     }
 
     /// Change whether or not the window will always be on top of other windows.


### PR DESCRIPTION
Added window centering on windows and linux (x11) at least.

Added convenient functions to be able to center the window quickly, also made it default on windows, but this is togglable.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ - ] Created an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/tomaka/winit/blob/master/FEATURES.md), if new features were added or implemented
