### PR TITLE
Fix warnings on linux

### DIFF
--- a/src/platform/linux/dlopen.rs
+++ b/src/platform/linux/dlopen.rs
@@ -6,7 +6,7 @@ use std::os::raw::{c_void, c_char, c_int};
 pub const RTLD_LAZY: c_int = 0x001;
 pub const RTLD_NOW: c_int = 0x002;
 
-#[link="dl"]
+#[link(name = "dl")]
 extern {
     pub fn dlopen(filename: *const c_char, flag: c_int) -> *mut c_void;
     pub fn dlerror() -> *mut c_char;

--- a/src/platform/linux/wayland/mod.rs
+++ b/src/platform/linux/wayland/mod.rs
@@ -16,20 +16,8 @@ mod window;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
 
-impl DeviceId {
-    pub unsafe fn dummy() -> Self {
-        DeviceId
-    }
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(usize);
-
-impl WindowId {
-    pub unsafe fn dummy() -> Self {
-        WindowId(0)
-    }
-}
 
 #[inline]
 fn make_wid(s: &Proxy<wl_surface::WlSurface>) -> WindowId {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

```
warning: attribute must be of the form `#[link(name = "...", /*opt*/ kind = "dylib|static|...",
                                             /*opt*/ cfg = "...")]`
 --> src/platform/linux/dlopen.rs:9:1
  |
9 | #[link="dl"]
  | ^^^^^^^^^^^^
  |
  = note: #[warn(ill_formed_attribute_input)] on by default
  = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
  = note: for more information, see issue #57571 <https://github.com/rust-lang/rust/issues/57571>

warning: method is never used: `dummy`
  --> src/platform/linux/wayland/mod.rs:20:5
   |
20 |     pub unsafe fn dummy() -> Self {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: #[warn(dead_code)] on by default

warning: method is never used: `dummy`
  --> src/platform/linux/wayland/mod.rs:29:5
   |
29 |     pub unsafe fn dummy() -> Self {
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```
*   Fixed the attribute as explained by the warning.
*   The dummy methods for wayland aren't used as the linux dummy DeviceId and WindowId always create the x11 variant.