### PR TITLE
Update parking_lot to 0.8 for windows too (eventloop-2.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,7 @@ wayland-client = { version = "0.23.0", features = [ "dlopen", "egl", "cursor", "
 calloop = "0.4.2"
 smithay-client-toolkit = "0.6"
 x11-dl = "2.18.3"
-parking_lot = "0.8"
 percent-encoding = "1.0"
 
-[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "windows"))'.dependencies.parking_lot]
-version = "0.7"
+[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows"))'.dependencies.parking_lot]
+version = "0.8"


### PR DESCRIPTION
The previous attempt to update parking_lot missed the windows platform.

The parking_lot dependency is now no longer specified twice to help prevent that mistake from happening again.
