### PR TITLE
Fix macos compile error in fullscreen example (eventloop-2.0)

### DIFF
--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -90,8 +90,8 @@ fn main() {
 
                         #[cfg(target_os = "macos")]
                         {
-                            use winit::os::macos::WindowExt;
-                            println!("window.get_simple_fullscreen {:?}", WindowExt::get_simple_fullscreen(&window));
+                            use winit::platform::macos::WindowExtMacOS;
+                            println!("window.get_simple_fullscreen {:?}", WindowExtMacOS::get_simple_fullscreen(&window));
                         }
                     }
                     (VirtualKeyCode::M, ElementState::Pressed) => {


### PR DESCRIPTION
Fix compile error for macos in fullscreen example.
