### PR TITLE
Build window with requested dimensions

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -148,8 +148,8 @@ impl WindowBuilder {
                 // resizing the window to the dimensions of the monitor when fullscreen
                 LogicalSize::from_physical(monitor.get_dimensions(), 1.0)
             } else {
-                // default dimensions
-                (1024, 768).into()
+                // use requested or fallback to default dimensions
+                self.window.dimensions.unwrap_or((1024, 768).into())
             }
         }));
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This caused me a headache in the past few weeks, because on Windows sometimes the window size was `1024 x 768` instead of what I requested. This fixes that issue. I didn't dig myself in the details, if anyone want's to reproduce it on Windows here are the steps:
1. clone https://github.com/szeged/webrender
2. `cd webrender/wrench`
3.  remove the `wrapper.resize()` from [here](https://github.com/szeged/webrender/blob/master/wrench/src/main.rs#L434)
4. Run any of the tests e.g. `cargo run --features=dx12 show reftests\aa\aa-dist-bug.yaml`
5. The window size should be `1920x1080` but it's `1024x768`

cc @Osspial
