### PR TITLE
Fix control flow issues with Window::request_redraw (eventloop-2.0)

### DIFF
--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -266,7 +266,11 @@ impl<T: 'static> EventLoop<T> {
                 ControlFlow::WaitUntil(deadline) => {
                     let start = Instant::now();
                     // compute the blocking duration
-                    let duration = deadline.duration_since(::std::cmp::max(deadline, start));
+                    let duration = if deadline > start {
+                        deadline - start
+                    } else {
+                        ::std::time::Duration::from_millis(0)
+                    };
                     self.inner_loop.dispatch(Some(duration), &mut ()).unwrap();
                     control_flow = ControlFlow::default();
                     let now = Instant::now();

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -300,7 +300,11 @@ impl<T: 'static> EventLoop<T> {
                 ControlFlow::WaitUntil(deadline) => {
                     let start = ::std::time::Instant::now();
                     // compute the blocking duration
-                    let duration = deadline.duration_since(::std::cmp::max(deadline, start));
+                    let duration = if deadline > start {
+                        deadline - start
+                    } else {
+                        ::std::time::Duration::from_millis(0)
+                    };
                     self.inner_loop.dispatch(Some(duration), &mut ()).unwrap();
                     control_flow = ControlFlow::default();
                     let now = std::time::Instant::now();

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -843,12 +843,27 @@ unsafe extern "system" fn public_window_callback<T>(
                 // handling dispatch `RedrawRequested` immediately after `EventsCleared`, without
                 // spinning up a new event loop iteration. We do this because that's what the API
                 // says to do.
-                match runner.runner_state {
-                    RunnerState::Idle(..) |
-                    RunnerState::DeferredNewEvents(..) => runner.call_event_handler(Event::WindowEvent {
+                let control_flow = runner.control_flow;
+                let mut request_redraw = || {
+                    runner.call_event_handler(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: RedrawRequested,
-                    }),
+                    });
+                };
+                match runner.runner_state {
+                    RunnerState::Idle(..) |
+                    RunnerState::DeferredNewEvents(..) => request_redraw(),
+                    RunnerState::HandlingEvents => {
+                        match control_flow {
+                            ControlFlow::Poll => request_redraw(),
+                            ControlFlow::WaitUntil(resume_time) => {
+                                if resume_time <= Instant::now() {
+                                    request_redraw()
+                                }
+                            },
+                            _ => ()
+                        }
+                    }
                     _ => ()
                 }
             }


### PR DESCRIPTION
- [X] Tested on all platforms changed

This PR fixes several issues in regards to `Window::request_redraw`.

1. The `RedrawRequested` callback was never fired on Windows when `request_redraw` was called from the `EventsCleared` callback and the control flow was set to `Poll`.
2. The `RedrawRequested` callback was never fired on Windows when `request_redraw` was called from the `EventsCleared` callback and the control flow was set to `WaitUntil(resume_time)` with `resume_time` in the past. (I believe this behavior was also in error when called from the `NewEvents` callback).
3. `WaitUntil(resume_time)` caused a panic in Linux/X11 when `resume_time` was in the past.

Having `WaitUntil(resume_time)` handle timestamps in the past correctly allows for very short durations to be used. This effectively results in the same behavior as `Poll` if the `resume_time` is calculated as a timestamp in the past **or is in the past by the time that winit processes it**.

The following worked as expected on Linux (printed `redraw` over and over), but did not work in Windows. This code now behaves the same on both X11 and Windows.

```rust
extern crate winit;
use std::time::{Instant, Duration};

use winit::window::WindowBuilder;
use winit::event::{Event, WindowEvent};
use winit::event_loop::{EventLoop, ControlFlow};

fn main() {
    let event_loop = EventLoop::new();

    let window = WindowBuilder::new()
        .with_title("A fantastic window!")
        .build(&event_loop)
        .unwrap();

    event_loop.run(move |event, _, control_flow| {
        match event {
            Event::WindowEvent {
                event: WindowEvent::CloseRequested,
                ..
            } => *control_flow = ControlFlow::Exit,
            Event::EventsCleared => {
                window.request_redraw();
            },
            Event::WindowEvent { event: WindowEvent::RedrawRequested, .. } => {
                println!("redraw: {:?}", Instant::now());
            },
            _ => ()
        }
    });
}
```
