### PR TITLE
Fix compiler warning of undefined behavior on Windows

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -844,13 +844,14 @@ unsafe extern "system" fn public_window_callback<T>(
                 // spinning up a new event loop iteration. We do this because that's what the API
                 // says to do.
                 let control_flow = runner.control_flow;
+                let runner_state = runner.runner_state;
                 let mut request_redraw = || {
                     runner.call_event_handler(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: RedrawRequested,
                     });
                 };
-                match runner.runner_state {
+                match runner_state {
                     RunnerState::Idle(..) |
                     RunnerState::DeferredNewEvents(..) => request_redraw(),
                     RunnerState::HandlingEvents => {


### PR DESCRIPTION
It looks like #890 introduced this warning to the code, which was missed during review:

```rust
warning[E0503]: cannot use `runner.runner_state` because it was mutably borrowed
   --> src\platform_impl\windows\event_loop.rs:854:21
    |
847 |                 let mut request_redraw = || {
    |                                          -- borrow of `runner` occurs here
848 |                     runner.call_event_handler(Event::WindowEvent {
    |                     ------ borrow occurs due to use of `runner` in closure
...
854 |                     RunnerState::Idle(..) |
    |                     ^^^^^^^^^^^^^^^^^^^^^ use of borrowed `runner`
855 |                     RunnerState::DeferredNewEvents(..) => request_redraw(),
    |                                                           -------------- borrow later used here
    |
    = warning: this error has been downgraded to a warning for backwards compatibility with previous releases
    = warning: this represents potential undefined behavior in your code and this warning will become a hard error in the future
    = note: for more information, try `rustc --explain E0729`
```

Fortunately it's pretty trivial to fix, so this PR fixes it.