### PR TITLE
Update cursor visibility docs

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -638,7 +638,9 @@ impl Window {
         self.window.set_cursor_grab(grab)
     }
 
-    /// Hides the cursor, making it invisible but still usable.
+    /// Modifies the cursor's visibility.
+    ///
+    /// If `false`, this will hide the cursor. If `true`, this will show the cursor.
     ///
     /// ## Platform-specific
     ///


### PR DESCRIPTION
The cursor visibility docs were still outdated from the rename and
talking about setting the invisibility, rather than visibility.

The platform-specific docs are unchanged since those should be fine and
the rest has been adapted using similar docs.
