### PR TITLE
WIP - Make EL2 DPI changes and implement on Windows

### DIFF
--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -4,12 +4,13 @@ extern crate winit;
 use std::{collections::HashMap, sync::mpsc, thread, time::Duration};
 
 use winit::{
+    dpi::{PhysicalPosition, PhysicalSize},
     event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop}, window::{CursorIcon, WindowBuilder},
 };
 
 const WINDOW_COUNT: usize = 3;
-const WINDOW_SIZE: (u32, u32) = (600, 400);
+const WINDOW_SIZE: PhysicalSize = PhysicalSize::new(600, 400);
 
 fn main() {
     env_logger::init();
@@ -17,7 +18,7 @@ fn main() {
     let mut window_senders = HashMap::with_capacity(WINDOW_COUNT);
     for _ in 0..WINDOW_COUNT {
         let window = WindowBuilder::new()
-            .with_inner_size(WINDOW_SIZE.into())
+            .with_inner_size(WINDOW_SIZE)
             .build(&event_loop)
             .unwrap();
         let (tx, rx) = mpsc::channel();
@@ -55,7 +56,7 @@ fn main() {
                                 println!("-> inner_size     : {:?}", window.inner_size());
                             },
                             L => window.set_min_inner_size(match state {
-                                true => Some(WINDOW_SIZE.into()),
+                                true => Some(WINDOW_SIZE),
                                 false => None,
                             }),
                             M => window.set_maximized(state),
@@ -69,13 +70,13 @@ fn main() {
                             Q => window.request_redraw(),
                             R => window.set_resizable(state),
                             S => window.set_inner_size(match state {
-                                true => (WINDOW_SIZE.0 + 100, WINDOW_SIZE.1 + 100),
+                                true => PhysicalSize::new(WINDOW_SIZE.width + 100, WINDOW_SIZE.height + 100),
                                 false => WINDOW_SIZE,
-                            }.into()),
-                            W => window.set_cursor_position((
-                                WINDOW_SIZE.0 as i32 / 2,
-                                WINDOW_SIZE.1 as i32 / 2,
-                            ).into()).unwrap(),
+                            }),
+                            W => window.set_cursor_position(PhysicalPosition::new(
+                                WINDOW_SIZE.width as f64 / 2.0,
+                                WINDOW_SIZE.height as f64 / 2.0,
+                            )).unwrap(),
                             Z => {
                                 window.set_visible(false);
                                 thread::sleep(Duration::from_secs(1));

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -106,7 +106,9 @@ fn main() {
                         window_senders.remove(&window_id);
                     },
                     _ => if let Some(tx) = window_senders.get(&window_id) {
-                        tx.send(event).unwrap();
+                        if let Some(event) = event.to_static() {
+                            tx.send(event).unwrap();
+                        }
                     },
                 }
             }

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,5 +1,6 @@
 extern crate winit;
 use winit::window::WindowBuilder;
+use winit::dpi::LogicalSize;
 use winit::event::{Event, WindowEvent, VirtualKeyCode, ElementState, KeyboardInput};
 use winit::event_loop::{EventLoop, ControlFlow};
 
@@ -10,7 +11,7 @@ fn main() {
 
     let window = WindowBuilder::new()
         .with_title("Hit space to toggle resizability.")
-        .with_inner_size((400, 200).into())
+        .with_inner_size(LogicalSize::new(400.0, 200.0))
         .with_resizable(resizable)
         .build(&event_loop)
         .unwrap();

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -8,6 +8,7 @@ fn main() {
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
+        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
         .build(&event_loop)
         .unwrap();
 

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -100,7 +100,7 @@ pub struct LogicalPosition {
 
 impl LogicalPosition {
     #[inline]
-    pub fn new(x: f64, y: f64) -> Self {
+    pub const fn new(x: f64, y: f64) -> Self {
         LogicalPosition { x, y }
     }
 
@@ -161,7 +161,7 @@ pub struct PhysicalPosition {
 
 impl PhysicalPosition {
     #[inline]
-    pub fn new(x: f64, y: f64) -> Self {
+    pub const fn new(x: f64, y: f64) -> Self {
         PhysicalPosition { x, y }
     }
 
@@ -222,7 +222,7 @@ pub struct LogicalSize {
 
 impl LogicalSize {
     #[inline]
-    pub fn new(width: f64, height: f64) -> Self {
+    pub const fn new(width: f64, height: f64) -> Self {
         LogicalSize { width, height }
     }
 
@@ -279,7 +279,7 @@ pub struct PhysicalSize {
 
 impl PhysicalSize {
     #[inline]
-    pub fn new(width: u32, height: u32) -> Self {
+    pub const fn new(width: u32, height: u32) -> Self {
         PhysicalSize { width, height }
     }
 
@@ -350,5 +350,47 @@ impl From<LogicalSize> for Size {
     #[inline]
     fn from(size: LogicalSize) -> Size {
         Size::Logical(size)
+    }
+}
+
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Position {
+    Physical(PhysicalPosition),
+    Logical(LogicalPosition),
+}
+
+impl Position {
+    pub fn new<S: Into<Position>>(position: S) -> Position {
+        position.into()
+    }
+
+    pub fn to_logical(&self, dpi_factor: f64) -> LogicalPosition {
+        match *self {
+            Position::Physical(position) => position.to_logical(dpi_factor),
+            Position::Logical(position) => position,
+        }
+    }
+
+    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalPosition {
+        match *self {
+            Position::Physical(position) => position,
+            Position::Logical(position) => position.to_physical(dpi_factor),
+        }
+    }
+}
+
+impl From<PhysicalPosition> for Position {
+    #[inline]
+    fn from(position: PhysicalPosition) -> Position {
+        Position::Physical(position)
+    }
+}
+
+impl From<LogicalPosition> for Position {
+    #[inline]
+    fn from(position: LogicalPosition) -> Position {
+        Position::Logical(position)
     }
 }

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -236,7 +236,7 @@ impl LogicalSize {
         assert!(validate_hidpi_factor(dpi_factor));
         let width = self.width * dpi_factor;
         let height = self.height * dpi_factor;
-        PhysicalSize::new(width, height)
+        PhysicalSize::new(width.round() as _, height.round() as _)
     }
 }
 
@@ -270,20 +270,16 @@ impl Into<(u32, u32)> for LogicalSize {
 }
 
 /// A size represented in physical pixels.
-///
-/// The size is stored as floats, so please be careful. Casting floats to integers truncates the fractional part,
-/// which can cause noticable issues. To help with that, an `Into<(u32, u32)>` implementation is provided which
-/// does the rounding for you.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PhysicalSize {
-    pub width: f64,
-    pub height: f64,
+    pub width: u32,
+    pub height: u32,
 }
 
 impl PhysicalSize {
     #[inline]
-    pub fn new(width: f64, height: f64) -> Self {
+    pub fn new(width: u32, height: u32) -> Self {
         PhysicalSize { width, height }
     }
 
@@ -295,30 +291,16 @@ impl PhysicalSize {
     #[inline]
     pub fn to_logical(&self, dpi_factor: f64) -> LogicalSize {
         assert!(validate_hidpi_factor(dpi_factor));
-        let width = self.width / dpi_factor;
-        let height = self.height / dpi_factor;
+        let width = self.width as f64 / dpi_factor;
+        let height = self.height as f64 / dpi_factor;
         LogicalSize::new(width, height)
-    }
-}
-
-impl From<(f64, f64)> for PhysicalSize {
-    #[inline]
-    fn from((width, height): (f64, f64)) -> Self {
-        Self::new(width, height)
     }
 }
 
 impl From<(u32, u32)> for PhysicalSize {
     #[inline]
     fn from((width, height): (u32, u32)) -> Self {
-        Self::new(width as f64, height as f64)
-    }
-}
-
-impl Into<(f64, f64)> for PhysicalSize {
-    #[inline]
-    fn into(self) -> (f64, f64) {
-        (self.width, self.height)
+        Self::new(width, height)
     }
 }
 
@@ -326,6 +308,47 @@ impl Into<(u32, u32)> for PhysicalSize {
     /// Note that this rounds instead of truncating.
     #[inline]
     fn into(self) -> (u32, u32) {
-        (self.width.round() as _, self.height.round() as _)
+        (self.width, self.height)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum Size {
+    Physical(PhysicalSize),
+    Logical(LogicalSize),
+}
+
+impl Size {
+    pub fn new<S: Into<Size>>(size: S) -> Size {
+        size.into()
+    }
+
+    pub fn to_logical(&self, dpi_factor: f64) -> LogicalSize {
+        match *self {
+            Size::Physical(size) => size.to_logical(dpi_factor),
+            Size::Logical(size) => size,
+        }
+    }
+
+    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalSize {
+        match *self {
+            Size::Physical(size) => size,
+            Size::Logical(size) => size.to_physical(dpi_factor),
+        }
+    }
+}
+
+impl From<PhysicalSize> for Size {
+    #[inline]
+    fn from(size: PhysicalSize) -> Size {
+        Size::Physical(size)
+    }
+}
+
+impl From<LogicalSize> for Size {
+    #[inline]
+    fn from(size: LogicalSize) -> Size {
+        Size::Logical(size)
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -56,6 +56,8 @@ impl<'a, T> Event<'a, T> {
         }
     }
 
+    /// If the event doesn't contain a reference, turn it into an event with a `'static` lifetime.
+    /// Otherwise, return `None`.
     pub fn to_static(self) -> Option<Event<'static, T>> {
         use self::Event::*;
         match self {

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,7 +7,7 @@
 use std::time::Instant;
 use std::path::PathBuf;
 
-use crate::dpi::{LogicalPosition, LogicalSize};
+use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::window::WindowId;
 use crate::platform_impl;
 
@@ -87,10 +87,10 @@ pub enum StartCause {
 #[derive(Clone, Debug, PartialEq)]
 pub enum WindowEvent {
     /// The size of the window has changed. Contains the client area's new dimensions.
-    Resized(LogicalSize),
+    Resized(PhysicalSize),
 
     /// The position of the window has changed. Contains the window's new position.
-    Moved(LogicalPosition),
+    Moved(PhysicalPosition),
 
     /// The window has been requested to close.
     CloseRequested,
@@ -134,7 +134,7 @@ pub enum WindowEvent {
         /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range of this data is
         /// limited by the display area and it may have been transformed by the OS to implement effects such as cursor
         /// acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
-        position: LogicalPosition,
+        position: PhysicalPosition,
         modifiers: ModifiersState
     },
 
@@ -291,7 +291,7 @@ pub enum TouchPhase {
 pub struct Touch {
     pub device_id: DeviceId,
     pub phase: TouchPhase,
-    pub location: LogicalPosition,
+    pub location: PhysicalPosition,
     /// unique identifier of a finger.
     pub id: u64
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -12,12 +12,12 @@ use crate::window::WindowId;
 use crate::platform_impl;
 
 /// Describes a generic event.
-#[derive(Clone, Debug, PartialEq)]
-pub enum Event<T> {
+#[derive(Debug, PartialEq)]
+pub enum Event<'a, T: 'static> {
     /// Emitted when the OS sends an event to a winit window.
     WindowEvent {
         window_id: WindowId,
-        event: WindowEvent,
+        event: WindowEvent<'a>,
     },
     /// Emitted when the OS sends an event to a device.
     DeviceEvent {
@@ -42,8 +42,8 @@ pub enum Event<T> {
     Suspended(bool),
 }
 
-impl<T> Event<T> {
-    pub fn map_nonuser_event<U>(self) -> Result<Event<U>, Event<T>> {
+impl<'a, T> Event<'a, T> {
+    pub fn map_nonuser_event<U>(self) -> Result<Event<'a, U>, Event<'a, T>> {
         use self::Event::*;
         match self {
             UserEvent(_) => Err(self),
@@ -53,6 +53,19 @@ impl<T> Event<T> {
             EventsCleared => Ok(EventsCleared),
             LoopDestroyed => Ok(LoopDestroyed),
             Suspended(suspended) => Ok(Suspended(suspended)),
+        }
+    }
+
+    pub fn to_static(self) -> Option<Event<'static, T>> {
+        use self::Event::*;
+        match self {
+            WindowEvent{window_id, event} => event.to_static().map(|event| WindowEvent{window_id, event}),
+            UserEvent(e) => Some(UserEvent(e)),
+            DeviceEvent{device_id, event} => Some(DeviceEvent{device_id, event}),
+            NewEvents(cause) => Some(NewEvents(cause)),
+            EventsCleared => Some(EventsCleared),
+            LoopDestroyed => Some(LoopDestroyed),
+            Suspended(suspended) => Some(Suspended(suspended)),
         }
     }
 }
@@ -84,8 +97,8 @@ pub enum StartCause {
 }
 
 /// Describes an event from a `Window`.
-#[derive(Clone, Debug, PartialEq)]
-pub enum WindowEvent {
+#[derive(Debug, PartialEq)]
+pub enum WindowEvent<'a> {
     /// The size of the window has changed. Contains the client area's new dimensions.
     Resized(PhysicalSize),
 
@@ -175,8 +188,44 @@ pub enum WindowEvent {
     /// * Changing the display's DPI factor (e.g. in Control Panel on Windows).
     /// * Moving the window to a display with a different DPI factor.
     ///
+    /// After this event callback has been processed, the window will be resized to whatever value
+    /// is pointed to by the `new_inner_size` reference. By default, this will contain the size suggested
+    /// by the OS, but it can be changed to any value. If `new_inner_size` is set to `None`, no resizing
+    /// will occur.
+    ///
     /// For more information about DPI in general, see the [`dpi`](dpi/index.html) module.
-    HiDpiFactorChanged(f64),
+    HiDpiFactorChanged {
+        hidpi_factor: f64,
+        new_inner_size: &'a mut Option<PhysicalSize>
+    },
+}
+
+impl<'a> WindowEvent<'a> {
+    pub fn to_static(self) -> Option<WindowEvent<'static>> {
+        use self::WindowEvent::*;
+        match self {
+            Resized(size) => Some(Resized(size)),
+            Moved(position) => Some(Moved(position)),
+            CloseRequested => Some(CloseRequested),
+            Destroyed => Some(Destroyed),
+            DroppedFile(file) => Some(DroppedFile(file)),
+            HoveredFile(file) => Some(HoveredFile(file)),
+            HoveredFileCancelled => Some(HoveredFileCancelled),
+            ReceivedCharacter(c) => Some(ReceivedCharacter(c)),
+            Focused(focused) => Some(Focused(focused)),
+            KeyboardInput { device_id, input } => Some(KeyboardInput { device_id, input }),
+            CursorMoved { device_id, position, modifiers } => Some(CursorMoved { device_id, position, modifiers }),
+            CursorEntered { device_id } => Some(CursorEntered { device_id }),
+            CursorLeft { device_id } => Some(CursorLeft { device_id }),
+            MouseWheel { device_id, delta, phase, modifiers } => Some(MouseWheel { device_id, delta, phase, modifiers }),
+            MouseInput { device_id, state, button, modifiers } => Some(MouseInput { device_id, state, button, modifiers }),
+            TouchpadPressure { device_id, pressure, stage } => Some(TouchpadPressure { device_id, pressure, stage }),
+            AxisMotion { device_id, axis, value } => Some(AxisMotion { device_id, axis, value }),
+            RedrawRequested => Some(RedrawRequested),
+            Touch(touch) => Some(Touch(touch)),
+            HiDpiFactorChanged{..} => None,
+        }
+    }
 }
 
 /// Identifier of an input device.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -133,7 +133,7 @@ impl<T> EventLoop<T> {
     /// [`ControlFlow`]: ./enum.ControlFlow.html
     #[inline]
     pub fn run<F>(self, event_handler: F) -> !
-        where F: 'static + FnMut(Event<T>, &EventLoopWindowTarget<T>, &mut ControlFlow)
+        where F: 'static + FnMut(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow)
     {
         self.event_loop.run(event_handler)
     }

--- a/src/platform/desktop.rs
+++ b/src/platform/desktop.rs
@@ -27,14 +27,14 @@ pub trait EventLoopExtDesktop {
     ///
     /// You are strongly encouraged to use `run`, unless the use of this is absolutely necessary.
     fn run_return<F>(&mut self, event_handler: F)
-        where F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
+        where F: FnMut(Event<'_, Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
 }
 
 impl<T> EventLoopExtDesktop for EventLoop<T> {
     type UserEvent = T;
 
     fn run_return<F>(&mut self, event_handler: F)
-        where F: FnMut(Event<T>, &EventLoopWindowTarget<T>, &mut ControlFlow)
+        where F: FnMut(Event<'_, Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow)
     {
         self.event_loop.run_return(event_handler)
     }

--- a/src/platform_impl/windows/dpi.rs
+++ b/src/platform_impl/windows/dpi.rs
@@ -183,7 +183,3 @@ pub unsafe fn hwnd_dpi(hwnd: HWND) -> u32 {
         }
     }
 }
-
-pub fn hwnd_scale_factor(hwnd: HWND) -> f64 {
-    dpi_to_scale_factor(unsafe { hwnd_dpi(hwnd) })
-}

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -24,7 +24,7 @@ pub struct FileDropHandlerData {
     pub interface: IDropTarget,
     refcount: AtomicUsize,
     window: HWND,
-    send_event: Box<dyn Fn(Event<()>)>,
+    send_event: Box<dyn Fn(Event<'static, ()>)>,
     cursor_effect: DWORD,
     hovered_is_valid: bool, // If the currently hovered item is not valid there must not be any `HoveredFileCancelled` emitted
 }
@@ -35,7 +35,7 @@ pub struct FileDropHandler {
 
 #[allow(non_snake_case)]
 impl FileDropHandler {
-    pub fn new(window: HWND, send_event: Box<dyn Fn(Event<()>)>) -> FileDropHandler {
+    pub fn new(window: HWND, send_event: Box<dyn Fn(Event<'static, ()>)>) -> FileDropHandler {
         let data = Box::new(FileDropHandlerData {
             interface: IDropTarget {
                 lpVtbl: &DROP_TARGET_VTBL as *const IDropTargetVtbl,
@@ -208,7 +208,7 @@ impl FileDropHandler {
 }
 
 impl FileDropHandlerData {
-    fn send_event(&self, event: Event<()>) {
+    fn send_event(&self, event: Event<'static, ()>) {
         (self.send_event)(event);
     }
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -27,6 +27,7 @@ use std::marker::PhantomData;
 use parking_lot::Mutex;
 
 use winapi::shared::minwindef::{
+    BOOL,
     DWORD,
     HIWORD,
     INT,
@@ -43,7 +44,7 @@ use winapi::um::winnt::{LPCSTR, SHORT};
 
 use crate::window::WindowId as RootWindowId;
 use crate::event_loop::{ControlFlow, EventLoopWindowTarget as RootELW, EventLoopClosed};
-use crate::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
+use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::event::{DeviceEvent, Touch, TouchPhase, StartCause, KeyboardInput, Event, WindowEvent};
 use crate::platform_impl::platform::{event, WindowId, DEVICE_ID, wrap_device_id, util};
 use crate::platform_impl::platform::dpi::{
@@ -57,25 +58,29 @@ use crate::platform_impl::platform::raw_input::{get_raw_input_data, get_raw_mous
 use crate::platform_impl::platform::window::adjust_size;
 use crate::platform_impl::platform::window_state::{CursorFlags, WindowFlags, WindowState};
 
-pub(crate) struct SubclassInput<T> {
+pub(crate) struct SubclassInput<T: 'static> {
     pub window_state: Arc<Mutex<WindowState>>,
     pub event_loop_runner: EventLoopRunnerShared<T>,
     pub file_drop_handler: FileDropHandler,
 }
 
 impl<T> SubclassInput<T> {
-    unsafe fn send_event(&self, event: Event<T>) {
+    unsafe fn send_event(&self, event: Event<'static, T>) {
         self.event_loop_runner.send_event(event);
+    }
+
+    unsafe fn send_event_unbuffered<'e>(&self, event: Event<'e, T>) -> Result<(), Event<'e, T>>{
+        self.event_loop_runner.send_event_unbuffered(event)
     }
 }
 
-struct ThreadMsgTargetSubclassInput<T> {
+struct ThreadMsgTargetSubclassInput<T: 'static> {
     event_loop_runner: EventLoopRunnerShared<T>,
     user_event_receiver: Receiver<T>,
 }
 
 impl<T> ThreadMsgTargetSubclassInput<T> {
-    unsafe fn send_event(&self, event: Event<T>) {
+    unsafe fn send_event(&self, event: Event<'static, T>) {
         self.event_loop_runner.send_event(event);
     }
 }
@@ -85,7 +90,7 @@ pub struct EventLoop<T: 'static> {
     window_target: RootELW<T>,
 }
 
-pub struct EventLoopWindowTarget<T> {
+pub struct EventLoopWindowTarget<T: 'static> {
     thread_id: DWORD,
     trigger_newevents_on_redraw: Arc<AtomicBool>,
     thread_msg_target: HWND,
@@ -126,14 +131,14 @@ impl<T: 'static> EventLoop<T> {
     }
 
     pub fn run<F>(mut self, event_handler: F) -> !
-        where F: 'static + FnMut(Event<T>, &RootELW<T>, &mut ControlFlow)
+        where F: 'static + FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow)
     {
         self.run_return(event_handler);
         ::std::process::exit(0);
     }
 
     pub fn run_return<F>(&mut self, mut event_handler: F)
-        where F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow)
+        where F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow)
     {
         unsafe{ winuser::IsGUIThread(1); }
 
@@ -224,23 +229,31 @@ impl<T> EventLoopWindowTarget<T> {
 }
 
 pub(crate) type EventLoopRunnerShared<T> = Rc<ELRShared<T>>;
-pub(crate) struct ELRShared<T> {
+pub(crate) struct ELRShared<T: 'static> {
     runner: RefCell<Option<EventLoopRunner<T>>>,
-    buffer: RefCell<VecDeque<Event<T>>>,
+    buffer: RefCell<VecDeque<Event<'static, T>>>,
 }
-pub(crate) struct EventLoopRunner<T> {
+pub(crate) struct EventLoopRunner<T: 'static> {
     trigger_newevents_on_redraw: Arc<AtomicBool>,
     control_flow: ControlFlow,
     runner_state: RunnerState,
     modal_redraw_window: HWND,
     in_modal_loop: bool,
-    event_handler: Box<dyn FnMut(Event<T>, &mut ControlFlow)>,
+    event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
     panic_error: Option<PanicError>,
 }
 type PanicError = Box<dyn Any + Send + 'static>;
 
 impl<T> ELRShared<T> {
-    pub(crate) unsafe fn send_event(&self, event: Event<T>) {
+    pub(crate) unsafe fn send_event(&self, event: Event<'static, T>) {
+        if let Err(event) = self.send_event_unbuffered(event) {
+            // If the runner is already borrowed, we're in the middle of an event loop invocation. Add
+            // the event to a buffer to be processed later.
+            self.buffer.borrow_mut().push_back(event)
+        }
+    }
+
+    pub(crate) unsafe fn send_event_unbuffered<'e>(&self, event: Event<'e, T>) -> Result<(), Event<'e, T>> {
         if let Ok(mut runner_ref) = self.runner.try_borrow_mut() {
             if let Some(ref mut runner) = *runner_ref {
                 runner.process_event(event);
@@ -258,13 +271,11 @@ impl<T> ELRShared<T> {
                     }
                 }
 
-                return;
+                return Ok(());
             }
         }
 
-        // If the runner is already borrowed, we're in the middle of an event loop invocation. Add
-        // the event to a buffer to be processed later.
-        self.buffer.borrow_mut().push_back(event)
+        Err(event)
     }
 }
 
@@ -285,7 +296,7 @@ enum RunnerState {
 
 impl<T> EventLoopRunner<T> {
     unsafe fn new<F>(event_loop: &EventLoop<T>, f: F) -> EventLoopRunner<T>
-        where F: FnMut(Event<T>, &mut ControlFlow)
+        where F: FnMut(Event<'_, T>, &mut ControlFlow)
     {
         EventLoopRunner {
             trigger_newevents_on_redraw: event_loop.window_target.p.trigger_newevents_on_redraw.clone(),
@@ -294,8 +305,8 @@ impl<T> EventLoopRunner<T> {
             in_modal_loop: false,
             modal_redraw_window: event_loop.window_target.p.thread_msg_target,
             event_handler: mem::transmute::<
-                Box<dyn FnMut(Event<T>, &mut ControlFlow)>,
-                Box<dyn FnMut(Event<T>, &mut ControlFlow)>
+                Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
+                Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>
             >(Box::new(f)),
             panic_error: None,
         }
@@ -352,7 +363,7 @@ impl<T> EventLoopRunner<T> {
         };
     }
 
-    fn process_event(&mut self, event: Event<T>) {
+    fn process_event(&mut self, event: Event<'_, T>) {
         // If we're in the modal loop, we need to have some mechanism for finding when the event
         // queue has been cleared so we can call `events_cleared`. Windows doesn't give any utilities
         // for doing this, but it DOES guarantee that WM_PAINT will only occur after input events have
@@ -457,7 +468,7 @@ impl<T> EventLoopRunner<T> {
         }
     }
 
-    fn call_event_handler(&mut self, event: Event<T>) {
+    fn call_event_handler(&mut self, event: Event<'_, T>) {
         match event {
             Event::NewEvents(_) => self.trigger_newevents_on_redraw.store(true, Ordering::Relaxed),
             Event::EventsCleared => self.trigger_newevents_on_redraw.store(false, Ordering::Relaxed),
@@ -759,7 +770,7 @@ pub(crate) fn subclass_window<T>(window: HWND, subclass_input: SubclassInput<T>)
 //
 // Returning 0 tells the Win32 API that the message has been processed.
 // FIXME: detect WM_DWMCOMPOSITIONCHANGED and call DwmEnableBlurBehindWindow if necessary
-unsafe extern "system" fn public_window_callback<T>(
+unsafe extern "system" fn public_window_callback<T: 'static>(
     window: HWND,
     msg: UINT,
     wparam: WPARAM,
@@ -1425,26 +1436,65 @@ unsafe extern "system" fn public_window_callback<T>(
                 new_dpi_factor != old_dpi_factor && window_state.fullscreen.is_none()
             };
 
-            // This prevents us from re-applying DPI adjustment to the restored size after exiting
-            // fullscreen (the restored size is already DPI adjusted).
-            if allow_resize {
-                // Resize window to the size suggested by Windows.
-                let rect = &*(lparam as *const RECT);
+            let style = winuser::GetWindowLongW(window, winuser::GWL_STYLE) as _;
+            let style_ex = winuser::GetWindowLongW(window, winuser::GWL_EXSTYLE) as _;
+            let b_menu = !winuser::GetMenu(window).is_null() as BOOL;
+
+            // New size as suggested by Windows.
+            let rect = *(lparam as *const RECT);
+
+            // The window rect provided is the window's outer size, not it's inner size. However,
+            // win32 doesn't provide an `UnadjustWindowRectEx` function to get the client rect from
+            // the outer rect, so we instead adjust the window rect to get the decoration margins
+            // and remove them from the outer size.
+            let margins_horizontal: u32;
+            let margins_vertical: u32;
+            {
+                let mut adjusted_rect = rect;
+                winuser::AdjustWindowRectExForDpi(
+                    &mut adjusted_rect,
+                    style,
+                    b_menu,
+                    style_ex,
+                    new_dpi_x
+                );
+                let margin_left = rect.left - adjusted_rect.left;
+                let margin_right = adjusted_rect.right - rect.right;
+                let margin_top = rect.top - adjusted_rect.top;
+                let margin_bottom = adjusted_rect.bottom - rect.bottom;
+
+                margins_horizontal = (margin_left + margin_right) as u32;
+                margins_vertical = (margin_bottom + margin_top) as u32;
+            }
+
+            let physical_inner_rect = PhysicalSize::new(
+                (rect.right - rect.left) as u32 - margins_horizontal,
+                (rect.bottom - rect.top) as u32 - margins_vertical
+            );
+
+            // `allow_resize` prevents us from re-applying DPI adjustment to the restored size after
+            // exiting fullscreen (the restored size is already DPI adjusted).
+            let mut new_inner_rect_opt = Some(physical_inner_rect).filter(|_| allow_resize);
+
+            let _ = subclass_input.send_event_unbuffered(Event::WindowEvent {
+                window_id: RootWindowId(WindowId(window)),
+                event: HiDpiFactorChanged {
+                    hidpi_factor: new_dpi_factor,
+                    new_inner_size: &mut new_inner_rect_opt
+                },
+            });
+
+            if let Some(new_inner_rect) = new_inner_rect_opt {
                 winuser::SetWindowPos(
                     window,
                     ptr::null_mut(),
                     rect.left,
                     rect.top,
-                    rect.right - rect.left,
-                    rect.bottom - rect.top,
+                    (new_inner_rect.width + margins_horizontal) as _,
+                    (new_inner_rect.height + margins_vertical) as _,
                     winuser::SWP_NOZORDER | winuser::SWP_NOACTIVATE,
                 );
             }
-
-            subclass_input.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
-                event: HiDpiFactorChanged(new_dpi_factor),
-            });
 
             0
         },
@@ -1464,7 +1514,7 @@ unsafe extern "system" fn public_window_callback<T>(
     }
 }
 
-unsafe extern "system" fn thread_event_target_callback<T>(
+unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     window: HWND,
     msg: UINT,
     wparam: WPARAM,

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -1,6 +1,5 @@
 use winapi::shared::minwindef::{BOOL, DWORD, LPARAM, TRUE, WORD};
 use winapi::shared::windef::{HDC, HMONITOR, HWND, LPRECT, POINT};
-use winapi::um::winnt::LONG;
 use winapi::um::{wingdi, winuser};
 
 use std::collections::{HashSet, VecDeque};

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -138,14 +138,6 @@ impl MonitorHandle {
         }
     }
 
-    pub(crate) fn contains_point(&self, point: &POINT) -> bool {
-        let left = self.position.0 as LONG;
-        let right = left + self.dimensions.0 as LONG;
-        let top = self.position.1 as LONG;
-        let bottom = top + self.dimensions.1 as LONG;
-        point.x >= left && point.x <= right && point.y >= top && point.y <= bottom
-    }
-
     #[inline]
     pub fn name(&self) -> Option<String> {
         Some(self.monitor_name.clone())

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use crate::window::CursorIcon;
 use winapi::ctypes::wchar_t;
 use winapi::shared::minwindef::{BOOL, DWORD};
-use winapi::shared::windef::{HWND, POINT, RECT};
+use winapi::shared::windef::{HWND, RECT};
 use winapi::um::winbase::lstrlenW;
 use winapi::um::winuser;
 
@@ -41,10 +41,6 @@ fn win_to_err<F: FnOnce() -> BOOL>(f: F) -> Result<(), io::Error> {
     } else {
         Err(io::Error::last_os_error())
     }
-}
-
-pub fn get_cursor_pos() -> Option<POINT> {
-    unsafe { status_map(|cursor_pos| winuser::GetCursorPos(cursor_pos)) }
 }
 
 pub fn get_window_rect(hwnd: HWND) -> Option<RECT> {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -654,14 +654,14 @@ unsafe fn init<T: 'static>(
         thread_executor: event_loop.create_thread_executor(),
     };
 
+    let dimensions = attributes.inner_size.unwrap_or_else(|| PhysicalSize::new(1024, 768).into());
+    win.set_inner_size(dimensions);
+    win.set_visible(attributes.visible);
+
     if let Some(_) = attributes.fullscreen {
         win.set_fullscreen(attributes.fullscreen);
         force_window_active(win.window.0);
     }
-
-    let dimensions = attributes.inner_size.unwrap_or_else(|| PhysicalSize::new(1024, 768).into());
-    win.set_inner_size(dimensions);
-    win.set_visible(attributes.visible);
 
     Ok(win)
 }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -2,7 +2,7 @@ use crate::monitor::MonitorHandle;
 use crate::window::{CursorIcon, WindowAttributes};
 use std::{io, ptr};
 use parking_lot::MutexGuard;
-use crate::dpi::LogicalSize;
+use crate::dpi::Size;
 use crate::platform_impl::platform::{util, event_loop};
 use crate::platform_impl::platform::icon::WinIcon;
 use winapi::shared::windef::{RECT, HWND};
@@ -15,8 +15,8 @@ pub struct WindowState {
     pub mouse: MouseProperties,
 
     /// Used by `WM_GETMINMAXINFO`.
-    pub min_size: Option<LogicalSize>,
-    pub max_size: Option<LogicalSize>,
+    pub min_size: Option<Size>,
+    pub max_size: Option<Size>,
 
     pub window_icon: Option<WinIcon>,
     pub taskbar_icon: Option<WinIcon>,

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,7 +5,7 @@ use crate::platform_impl;
 use crate::error::{ExternalError, NotSupportedError, OsError};
 use crate::event_loop::EventLoopWindowTarget;
 use crate::monitor::{AvailableMonitorsIter, MonitorHandle};
-use crate::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Size};
+use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Size, Position};
 
 pub use crate::icon::*;
 
@@ -412,8 +412,8 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread. Sets the top left coordinates of the
     ///   window in the screen space coordinate system.
     #[inline]
-    pub fn set_outer_position(&self, position: PhysicalPosition) {
-        self.window.set_outer_position(position)
+    pub fn set_outer_position<P: Into<Position>>(&self, position: P) {
+        self.window.set_outer_position(position.into())
     }
 
     /// Returns the logical size of the window's client area.
@@ -594,8 +594,8 @@ impl Window {
     ///
     /// **iOS:** Has no effect.
     #[inline]
-    pub fn set_ime_position(&self, position: LogicalPosition) {
-        self.window.set_ime_position(position)
+    pub fn set_ime_position<P: Into<Position>>(&self, position: P) {
+        self.window.set_ime_position(position.into())
     }
 }
 
@@ -618,8 +618,8 @@ impl Window {
     ///
     /// - **iOS:** Always returns an `Err`.
     #[inline]
-    pub fn set_cursor_position(&self, position: LogicalPosition) -> Result<(), ExternalError> {
-        self.window.set_cursor_position(position)
+    pub fn set_cursor_position<P: Into<Position>>(&self, position: P) -> Result<(), ExternalError> {
+        self.window.set_cursor_position(position.into())
     }
 
     /// Grabs the cursor, preventing it from leaving the window.

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,7 +5,7 @@ use crate::platform_impl;
 use crate::error::{ExternalError, NotSupportedError, OsError};
 use crate::event_loop::EventLoopWindowTarget;
 use crate::monitor::{AvailableMonitorsIter, MonitorHandle};
-use crate::dpi::{LogicalPosition, LogicalSize};
+use crate::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Size};
 
 pub use crate::icon::*;
 
@@ -85,17 +85,17 @@ pub struct WindowAttributes {
     /// used.
     ///
     /// The default is `None`.
-    pub inner_size: Option<LogicalSize>,
+    pub inner_size: Option<Size>,
 
     /// The minimum dimensions a window can be, If this is `None`, the window will have no minimum dimensions (aside from reserved).
     ///
     /// The default is `None`.
-    pub min_inner_size: Option<LogicalSize>,
+    pub min_inner_size: Option<Size>,
 
     /// The maximum dimensions a window can be, If this is `None`, the maximum will have no maximum or will be set to the primary monitor's dimensions by the platform.
     ///
     /// The default is `None`.
-    pub max_inner_size: Option<LogicalSize>,
+    pub max_inner_size: Option<Size>,
 
     /// Whether the window is resizable or not.
     ///
@@ -175,22 +175,22 @@ impl WindowBuilder {
 
     /// Requests the window to be of specific dimensions.
     #[inline]
-    pub fn with_inner_size(mut self, size: LogicalSize) -> WindowBuilder {
-        self.window.inner_size = Some(size);
+    pub fn with_inner_size<S: Into<Size>>(mut self, size: S) -> WindowBuilder {
+        self.window.inner_size = Some(size.into());
         self
     }
 
     /// Sets a minimum dimension size for the window
     #[inline]
-    pub fn with_min_inner_size(mut self, min_size: LogicalSize) -> WindowBuilder {
-        self.window.min_inner_size = Some(min_size);
+    pub fn with_min_inner_size<S: Into<Size>>(mut self, min_size: S) -> WindowBuilder {
+        self.window.min_inner_size = Some(min_size.into());
         self
     }
 
     /// Sets a maximum dimension size for the window
     #[inline]
-    pub fn with_max_inner_size(mut self, max_size: LogicalSize) -> WindowBuilder {
-        self.window.max_inner_size = Some(max_size);
+    pub fn with_max_inner_size<S: Into<Size>>(mut self, max_size: S) -> WindowBuilder {
+        self.window.max_inner_size = Some(max_size.into());
         self
     }
 
@@ -286,11 +286,10 @@ impl WindowBuilder {
     pub fn build<T: 'static>(mut self, window_target: &EventLoopWindowTarget<T>) -> Result<Window, OsError> {
         self.window.inner_size = Some(self.window.inner_size.unwrap_or_else(|| {
             if let Some(ref monitor) = self.window.fullscreen {
-                // resizing the window to the dimensions of the monitor when fullscreen
-                LogicalSize::from_physical(monitor.size(), monitor.hidpi_factor()) // DPI factor applies here since this is a borderless window and not real fullscreen
+                Size::new(monitor.size())
             } else {
                 // default dimensions
-                (1024, 768).into()
+                Size::new(LogicalSize::new(1024.0, 768.0))
             }
         }));
 
@@ -379,7 +378,7 @@ impl Window {
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     #[inline]
-    pub fn inner_position(&self) -> Result<LogicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
         self.window.inner_position()
     }
 
@@ -398,7 +397,7 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread. Returns the top left coordinates of the
     ///   window in the screen space coordinate system.
     #[inline]
-    pub fn outer_position(&self) -> Result<LogicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
         self.window.outer_position()
     }
 
@@ -413,7 +412,7 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread. Sets the top left coordinates of the
     ///   window in the screen space coordinate system.
     #[inline]
-    pub fn set_outer_position(&self, position: LogicalPosition) {
+    pub fn set_outer_position(&self, position: PhysicalPosition) {
         self.window.set_outer_position(position)
     }
 
@@ -421,16 +420,14 @@ impl Window {
     ///
     /// The client area is the content of the window, excluding the title bar and borders.
     ///
-    /// Converting the returned `LogicalSize` to `PhysicalSize` produces the size your framebuffer should be.
-    ///
     /// ## Platform-specific
     ///
-    /// - **iOS:** Can only be called on the main thread. Returns the `LogicalSize` of the window's
+    /// - **iOS:** Can only be called on the main thread. Returns the `PhysicalSize` of the window's
     ///   [safe area] in screen space coordinates.
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     #[inline]
-    pub fn inner_size(&self) -> LogicalSize {
+    pub fn inner_size(&self) -> PhysicalSize {
         self.window.inner_size()
     }
 
@@ -443,8 +440,8 @@ impl Window {
     /// - **iOS:** Unimplemented. Currently this panics, as it's not clear what `set_inner_size`
     ///   would mean for iOS.
     #[inline]
-    pub fn set_inner_size(&self, size: LogicalSize) {
-        self.window.set_inner_size(size)
+    pub fn set_inner_size<S: Into<Size>>(&self, size: S) {
+        self.window.set_inner_size(size.into())
     }
 
     /// Returns the logical size of the entire window.
@@ -454,10 +451,10 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS:** Can only be called on the main thread. Returns the `LogicalSize` of the window in
+    /// - **iOS:** Can only be called on the main thread. Returns the `PhysicalSize` of the window in
     ///   screen space coordinates.
     #[inline]
-    pub fn outer_size(&self) -> LogicalSize {
+    pub fn outer_size(&self) -> PhysicalSize {
         self.window.outer_size()
     }
 
@@ -467,8 +464,8 @@ impl Window {
     ///
     /// - **iOS:** Has no effect.
     #[inline]
-    pub fn set_min_inner_size(&self, dimensions: Option<LogicalSize>) {
-        self.window.set_min_inner_size(dimensions)
+    pub fn set_min_inner_size<S: Into<Size>>(&self, min_size: Option<S>) {
+        self.window.set_min_inner_size(min_size.map(|s| s.into()))
     }
 
     /// Sets a maximum dimension size for the window.
@@ -477,8 +474,8 @@ impl Window {
     ///
     /// - **iOS:** Has no effect.
     #[inline]
-    pub fn set_max_inner_size(&self, dimensions: Option<LogicalSize>) {
-        self.window.set_max_inner_size(dimensions)
+    pub fn set_max_inner_size<S: Into<Size>>(&self, max_size: Option<S>) {
+        self.window.set_max_inner_size(max_size.map(|s| s.into()))
     }
 }
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
  - [x] Windows
  - [ ] macOS
  - [ ] iOS
  - [ ] Linux X11
  - [ ] Linux Wayland
- [x] Change `HiDPIFactorChanged` event.
- [x] Remove `LogicalSize` and `LogicalPosition` from `WindowEvent`s.
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Update examples
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Makes changes to the public API as discussed in #837, and implements them on Windows.

I was originally going to try and implement these changes on the other platforms, but given the number of DPI problems we've had in the past I figure it's unwise to attempt to hack on systems I don't understand and am unable to test.