### PR TITLE
Support listing available video modes for a monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - Rename several functions to improve both internal consistency and compliance with Rust API guidelines.
 - Remove `WindowBuilder::multitouch` field, since it was only implemented on a few platforms. Multitouch is always enabled now.
 - **Breaking:** On macOS, change `ns` identifiers to use snake_case for consistency with iOS's `ui` identifiers.
+- Add `MonitorHandle::video_modes` method for retrieving supported video modes for the given monitor.
 
 # Version 0.19.1 (2019-04-08)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ lazy_static = "1"
 libc = "0.2"
 log = "0.4"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
+derivative = "1.0.2"
 
 [dev-dependencies]
 image = "0.21"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ objc = "0.2.3"
 cocoa = "0.18.4"
 core-foundation = "0.6"
 core-graphics = "0.17.3"
+core-video-sys = "0.1.2"
 dispatch = "0.1.4"
 objc = "0.2.3"
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -156,6 +156,7 @@ Legend:
 |Window maximization toggle       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
 |Fullscreen                       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|❌        |
 |Fullscreen toggle                |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|❌        |
+|Video mode query                 |✔️     |✔️     |✔️         |✔️             |❌    |✔️     |❌        |
 |HiDPI support                    |✔️     |✔️     |✔️         |✔️             |▢[#721]|✔️    |✔️         |
 |Popup windows                    |❌     |❌     |❌         |❌             |❌    |❌     |❌        |
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -92,6 +92,7 @@ If your PR makes notable changes to Winit's features, please update this section
 
 ### System Information
 - **Monitor list**: Retrieve the list of monitors and their metadata, including which one is primary.
+- **Video mode query**: Monitors can be queried for their supported fullscreen video modes (consisting of resolution, refresh rate, and bit depth).
 
 ### Input Handling
 - **Mouse events**: Generating mouse events associated with pointer motion, click, and scrolling events.
@@ -156,14 +157,14 @@ Legend:
 |Window maximization toggle       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
 |Fullscreen                       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|❌        |
 |Fullscreen toggle                |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|❌        |
-|Video mode query                 |✔️     |✔️     |✔️         |✔️             |❌    |✔️     |❌        |
 |HiDPI support                    |✔️     |✔️     |✔️         |✔️             |▢[#721]|✔️    |✔️         |
 |Popup windows                    |❌     |❌     |❌         |❌             |❌    |❌     |❌        |
 
 ### System information
-|Feature      |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |Emscripten|
-|------------ | ----- | ---- | ------- | ----------- | ----- | ----- | -------- |
-|Monitor list |✔️    |✔️    |✔️       |✔️          |**N/A**|**N/A**|**N/A**   |
+|Feature          |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |Emscripten|
+|---------------- | ----- | ---- | ------- | ----------- | ----- | ----- | -------- |
+|Monitor list     |✔️    |✔️    |✔️       |✔️          |**N/A**|**N/A**|**N/A**   |
+|Video mode query |✔️    |✔️    |✔️       |✔️          |❌      |✔️     |❌         |
 
 ### Input handling
 |Feature                 |Windows   |MacOS   |Linux x11|Linux Wayland|Android|iOS    |Emscripten|

--- a/examples/video_modes.rs
+++ b/examples/video_modes.rs
@@ -1,0 +1,14 @@
+extern crate winit;
+
+use winit::event_loop::EventLoop;
+
+fn main() {
+    let event_loop = EventLoop::new();
+    let monitor = event_loop.primary_monitor();
+
+    println!("Listing available video modes:");
+
+    for mode in monitor.video_modes() {
+        println!("{:?}", mode);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,8 @@ extern crate log;
 #[cfg(feature = "serde")]
 #[macro_use]
 extern crate serde;
+#[macro_use]
+extern crate derivative;
 
 #[cfg(target_os = "windows")]
 extern crate winapi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,8 @@ extern crate dispatch;
 extern crate core_foundation;
 #[cfg(target_os = "macos")]
 extern crate core_graphics;
+#[cfg(target_os = "macos")]
+extern crate core_video_sys;
 #[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 extern crate x11_dl;
 #[cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd", target_os = "windows"))]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -44,6 +44,27 @@ impl Iterator for AvailableMonitorsIter {
     }
 }
 
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub struct VideoMode {
+    pub(crate) dimensions: (u32, u32),
+    pub(crate) bit_depth: u16,
+    pub(crate) refresh_rate: u16,
+}
+
+impl VideoMode {
+    pub fn dimensions(&self) -> PhysicalSize {
+        self.dimensions.into()
+    }
+
+    pub fn bit_depth(&self) -> u16 {
+        self.bit_depth
+    }
+
+    pub fn refresh_rate(&self) -> u16 {
+        self.refresh_rate
+    }
+}
+
 /// Handle to a monitor.
 ///
 /// Allows you to retrieve information about a given monitor and can be used in [`Window`] creation.
@@ -87,5 +108,11 @@ impl MonitorHandle {
     #[inline]
     pub fn hidpi_factor(&self) -> f64 {
         self.inner.hidpi_factor()
+    }
+
+    /// Returns all fullscreen video modes supported by this monitor.
+    #[inline]
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+        self.inner.video_modes()
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -44,6 +44,12 @@ impl Iterator for AvailableMonitorsIter {
     }
 }
 
+/// Describes a fullscreen video mode of a monitor.
+///
+/// Can be acquired with:
+/// - [`MonitorHandle::video_modes`][monitor_get].
+///
+/// [monitor_get]: ../monitor/struct.MonitorHandle.html#method.video_modes
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct VideoMode {
     pub(crate) dimensions: (u32, u32),
@@ -52,14 +58,26 @@ pub struct VideoMode {
 }
 
 impl VideoMode {
+    /// Returns the resolution of this video mode.
     pub fn dimensions(&self) -> PhysicalSize {
         self.dimensions.into()
     }
 
+    /// Returns the bit depth of this video mode, as in how many bits you have
+    /// available per color. This is generally 24 bits or 32 bits on modern
+    /// systems, depending on whether the alpha channel is counted or not.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland:** Always returns 32.
+    /// - **iOS:** Always returns 32.
     pub fn bit_depth(&self) -> u16 {
         self.bit_depth
     }
 
+    /// Returns the refresh rate of this video mode. **Note**: the returned
+    /// refresh rate is an integer approximation, and you shouldn't rely on this
+    /// value to be exact.
     pub fn refresh_rate(&self) -> u16 {
         self.refresh_rate
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -14,7 +14,7 @@ use icon::Icon;
 use error::{ExternalError, NotSupportedError, OsError as RootOsError};
 use event::Event;
 use event_loop::{EventLoopClosed, ControlFlow, EventLoopWindowTarget as RootELW};
-use monitor::MonitorHandle as RootMonitorHandle;
+use monitor::{MonitorHandle as RootMonitorHandle, VideoMode};
 use window::{WindowAttributes, CursorIcon};
 use self::x11::{XConnection, XError};
 use self::x11::ffi::XVisualInfo;
@@ -140,6 +140,14 @@ impl MonitorHandle {
         match self {
             &MonitorHandle::X(ref m) => m.hidpi_factor(),
             &MonitorHandle::Wayland(ref m) => m.hidpi_factor() as f64,
+        }
+    }
+
+    #[inline]
+    pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoMode>> {
+        match self {
+            MonitorHandle::X(m) => Box::new(m.video_modes()),
+            MonitorHandle::Wayland(m) => Box::new(m.video_modes()),
         }
     }
 }

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -9,6 +9,7 @@ use event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW}
 use event::ModifiersState;
 use dpi::{PhysicalPosition, PhysicalSize};
 use platform_impl::platform::sticky_exit_callback;
+use monitor::VideoMode;
 
 use super::window::WindowStore;
 use super::WindowId;
@@ -583,6 +584,20 @@ impl MonitorHandle {
         self.mgr
             .with_info(&self.proxy, |_, info| info.scale_factor)
             .unwrap_or(1)
+    }
+
+    #[inline]
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode>
+    {
+        self.mgr
+            .with_info(&self.proxy, |_, info| info.modes.clone())
+            .unwrap_or(vec![])
+            .into_iter()
+            .map(|x| VideoMode {
+                dimensions: (x.dimensions.0 as u32, x.dimensions.1 as u32),
+                refresh_rate: (x.refresh_rate as f32 / 1000.0).round() as u16,
+                bit_depth: 32
+            })
     }
 }
 

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -3,6 +3,7 @@ use std::os::raw::*;
 use parking_lot::Mutex;
 
 use dpi::{PhysicalPosition, PhysicalSize};
+use monitor::VideoMode;
 use super::{util, XConnection, XError};
 use super::ffi::{
     RRCrtcChangeNotifyMask,
@@ -56,6 +57,8 @@ pub struct MonitorHandle {
     pub(crate) hidpi_factor: f64,
     /// Used to determine which windows are on this monitor
     pub(crate) rect: util::AaRect,
+    /// Supported video modes on this monitor
+    video_modes: Vec<VideoMode>,
 }
 
 impl MonitorHandle {
@@ -66,7 +69,7 @@ impl MonitorHandle {
         repr: util::MonitorRepr,
         primary: bool,
     ) -> Option<Self> {
-        let (name, hidpi_factor) = unsafe { xconn.get_output_info(resources, &repr)? };
+        let (name, hidpi_factor, video_modes) = unsafe { xconn.get_output_info(resources, &repr)? };
         let (dimensions, position) = unsafe { (repr.dimensions(), repr.position()) };
         let rect = util::AaRect::new(position, dimensions);
         Some(MonitorHandle {
@@ -77,6 +80,7 @@ impl MonitorHandle {
             position,
             primary,
             rect,
+            video_modes,
         })
     }
 
@@ -100,6 +104,11 @@ impl MonitorHandle {
     #[inline]
     pub fn hidpi_factor(&self) -> f64 {
         self.hidpi_factor
+    }
+
+    #[inline]
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+        self.video_modes.clone().into_iter()
     }
 }
 

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -13,10 +13,12 @@ use platform_impl::platform::dpi::{dpi_to_scale_factor, get_monitor_dpi};
 use platform_impl::platform::window::Window;
 
 /// Win32 implementation of the main `MonitorHandle` object.
-#[derive(Clone)]
+#[derive(Derivative)]
+#[derivative(Debug, Clone)]
 pub struct MonitorHandle {
     /// Monitor handle.
     hmonitor: HMonitor,
+    #[derivative(Debug = "ignore")]
     monitor_info: winuser::MONITORINFOEXW,
     /// The system name of the monitor.
     monitor_name: String,
@@ -30,12 +32,6 @@ pub struct MonitorHandle {
     dimensions: (u32, u32),
     /// DPI scale factor.
     hidpi_factor: f64,
-}
-
-impl std::fmt::Debug for MonitorHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "MonitorHandle {{ hmonitor: {:?}, monitor_name: {:?}, primary: {}, position: {:?}, dimensions: {:?}, hidpi_factor: {} }}", self.hmonitor, self.monitor_name, self.primary, self.position, self.dimensions, self.hidpi_factor)
-    }
 }
 
 // Send is not implemented for HMONITOR, we have to wrap it and implement it manually.

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -186,15 +186,10 @@ impl MonitorHandle {
 
         loop {
             unsafe {
+                let device_name = self.monitor_info.szDevice.as_ptr();
                 let mut mode: wingdi::DEVMODEW = mem::zeroed();
                 mode.dmSize = mem::size_of_val(&mode) as WORD;
-                if winuser::EnumDisplaySettingsExW(
-                    self.monitor_info.szDevice.as_ptr(),
-                    i,
-                    &mut mode,
-                    0,
-                ) == 0
-                {
+                if winuser::EnumDisplaySettingsExW(device_name, i, &mut mode, 0) == 0 {
                     break;
                 }
                 i += 1;


### PR DESCRIPTION
Resolves #877.

- [x] Tested on all platforms changed
     - [x]  Windows
     - [x]  macOS
     - [x]  X11
     - [x]  Wayland
     - [x]  iOS
     - [ ]  Android
     - [ ]  Emscripten
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Adds a new method `get_video_modes` to the `MonitorId` struct in the public API, and implements it on the Windows platform. I'm going to look into implementing this on macOS as well..