### PR TITLE
Fix Windows fullscreen toggle on windows that started invisible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Windows, fix `set_fullscreen` on windows that were created invisible (`with_visibility(false)`)
 - On X11, fix sanity check which checks that a monitor's reported width and height (in millimeters) are non-zero when calculating the DPI factor.
 
 # Version 0.19.1 (2019-04-08)

--- a/src/platform/windows/window.rs
+++ b/src/platform/windows/window.rs
@@ -76,13 +76,37 @@ impl Window {
 
     #[inline]
     pub fn show(&self) {
+        let window = self.window.clone();
+        let window_state = Arc::clone(&self.window_state);
+
+        self.events_loop_proxy.execute_in_thread(move |_| {
+            WindowState::set_window_flags(
+                window_state.lock().unwrap(),
+                window.0,
+                None,
+                |f| f.set(WindowFlags::VISIBLE, true),
+            );
+        });
+
         unsafe {
             winuser::ShowWindow(self.window.0, winuser::SW_SHOW);
-        }
+        }    
     }
 
     #[inline]
     pub fn hide(&self) {
+        let window = self.window.clone();
+        let window_state = Arc::clone(&self.window_state);
+
+        self.events_loop_proxy.execute_in_thread(move |_| {
+            WindowState::set_window_flags(
+                window_state.lock().unwrap(),
+                window.0,
+                None,
+                |f| f.set(WindowFlags::VISIBLE, false),
+            );
+        });
+
         unsafe {
             winuser::ShowWindow(self.window.0, winuser::SW_HIDE);
         }


### PR DESCRIPTION
If one created a window with `with_visibility(false)` and then done `show()` then `set_fullscreen` wasn't working properly and hid the window because the internal `WindowFlags` was still stored as `WindowFlags::VISIBLE = false`.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
