### PR TITLE
Make setting `LogicalPosition` and `LogicalSize` values generic over `Into` conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Removed `serde` implementations from `ControlFlow`.
 - Rename several functions to improve both internal consistency and compliance with Rust API guidelines.
 - Remove `WindowBuilder::multitouch` field, since it was only implemented on a few platforms. Multitouch is always enabled now.
+- Changed setting `LogicalPosition` and `LogicalSize` values to be generic over `Into` conversions
 
 # Version 0.19.1 (2019-04-08)
 

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -17,7 +17,7 @@ fn main() {
     let mut window_senders = HashMap::with_capacity(WINDOW_COUNT);
     for _ in 0..WINDOW_COUNT {
         let window = WindowBuilder::new()
-            .with_inner_size(WINDOW_SIZE.into())
+            .with_inner_size(WINDOW_SIZE)
             .build(&event_loop)
             .unwrap();
         let (tx, rx) = mpsc::channel();
@@ -55,7 +55,7 @@ fn main() {
                                 println!("-> inner_size     : {:?}", window.inner_size());
                             },
                             L => window.set_min_inner_size(match state {
-                                true => Some(WINDOW_SIZE.into()),
+                                true => Some(WINDOW_SIZE),
                                 false => None,
                             }),
                             M => window.set_maximized(state),
@@ -71,11 +71,11 @@ fn main() {
                             S => window.set_inner_size(match state {
                                 true => (WINDOW_SIZE.0 + 100, WINDOW_SIZE.1 + 100),
                                 false => WINDOW_SIZE,
-                            }.into()),
+                            }),
                             W => window.set_cursor_position((
                                 WINDOW_SIZE.0 as i32 / 2,
                                 WINDOW_SIZE.1 as i32 / 2,
-                            ).into()).unwrap(),
+                            )).unwrap(),
                             Z => {
                                 window.set_visible(false);
                                 thread::sleep(Duration::from_secs(1));

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -10,7 +10,7 @@ fn main() {
 
     let window = WindowBuilder::new()
         .with_title("Hit space to toggle resizability.")
-        .with_inner_size((400, 200).into())
+        .with_inner_size((400, 200))
         .with_resizable(resizable)
         .build(&event_loop)
         .unwrap();

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -109,7 +109,7 @@ pub trait WindowBuilderExtMacOS {
     /// Makes the window content appear behind the titlebar.
     fn with_fullsize_content_view(self, fullsize_content_view: bool) -> WindowBuilder;
     /// Build window with `resizeIncrements` property. Values must not be 0.
-    fn with_resize_increments(self, increments: LogicalSize) -> WindowBuilder;
+    fn with_resize_increments<S: Into<LogicalSize>>(self, increments: S) -> WindowBuilder;
 }
 
 impl WindowBuilderExtMacOS for WindowBuilder {
@@ -156,8 +156,8 @@ impl WindowBuilderExtMacOS for WindowBuilder {
     }
 
     #[inline]
-    fn with_resize_increments(mut self, increments: LogicalSize) -> WindowBuilder {
-        self.platform_specific.resize_increments = Some(increments.into());
+    fn with_resize_increments<S: Into<LogicalSize>>(mut self, increments: S) -> WindowBuilder {
+        self.platform_specific.resize_increments = Some(increments.into().into());
         self
     }
 }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -366,13 +366,13 @@ impl WindowBuilderExtUnix for WindowBuilder {
 
     #[inline]
     fn with_resize_increments<S: Into<LogicalSize>>(mut self, increments: S) -> WindowBuilder {
-        self.platform_specific.resize_increments = Some(increments.into());
+        self.platform_specific.resize_increments = Some(increments.into().into());
         self
     }
 
     #[inline]
     fn with_base_size<S: Into<LogicalSize>>(mut self, base_size: S) -> WindowBuilder {
-        self.platform_specific.base_size = Some(base_size.into());
+        self.platform_specific.base_size = Some(base_size.into().into());
         self
     }
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -319,9 +319,9 @@ pub trait WindowBuilderExtUnix {
     /// Build window with `_GTK_THEME_VARIANT` hint set to the specified value. Currently only relevant on X11.
     fn with_gtk_theme_variant(self, variant: String) -> WindowBuilder;
     /// Build window with resize increment hint. Only implemented on X11.
-    fn with_resize_increments(self, increments: LogicalSize) -> WindowBuilder;
+    fn with_resize_increments<S: Into<LogicalSize>>(self, increments: S) -> WindowBuilder;
     /// Build window with base size hint. Only implemented on X11.
-    fn with_base_size(self, base_size: LogicalSize) -> WindowBuilder;
+    fn with_base_size<S: Into<LogicalSize>>(self, base_size: S) -> WindowBuilder;
 
     /// Build window with a given application ID. It should match the `.desktop` file distributed with
     /// your program. Only relevant on Wayland.
@@ -365,13 +365,13 @@ impl WindowBuilderExtUnix for WindowBuilder {
     }
 
     #[inline]
-    fn with_resize_increments(mut self, increments: LogicalSize) -> WindowBuilder {
+    fn with_resize_increments<S: Into<LogicalSize>>(mut self, increments: S) -> WindowBuilder {
         self.platform_specific.resize_increments = Some(increments.into());
         self
     }
 
     #[inline]
-    fn with_base_size(mut self, base_size: LogicalSize) -> WindowBuilder {
+    fn with_base_size<S: Into<LogicalSize>>(mut self, base_size: S) -> WindowBuilder {
         self.platform_specific.base_size = Some(base_size.into());
         self
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -175,22 +175,22 @@ impl WindowBuilder {
 
     /// Requests the window to be of specific dimensions.
     #[inline]
-    pub fn with_inner_size(mut self, size: LogicalSize) -> WindowBuilder {
-        self.window.inner_size = Some(size);
+    pub fn with_inner_size<S: Into<LogicalSize>>(mut self, size: S) -> WindowBuilder {
+        self.window.inner_size = Some(size.into());
         self
     }
 
     /// Sets a minimum dimension size for the window
     #[inline]
-    pub fn with_min_inner_size(mut self, min_size: LogicalSize) -> WindowBuilder {
-        self.window.min_inner_size = Some(min_size);
+    pub fn with_min_inner_size<S: Into<LogicalSize>>(mut self, min_size: S) -> WindowBuilder {
+        self.window.min_inner_size = Some(min_size.into());
         self
     }
 
     /// Sets a maximum dimension size for the window
     #[inline]
-    pub fn with_max_inner_size(mut self, max_size: LogicalSize) -> WindowBuilder {
-        self.window.max_inner_size = Some(max_size);
+    pub fn with_max_inner_size<S: Into<LogicalSize>>(mut self, max_size: S) -> WindowBuilder {
+        self.window.max_inner_size = Some(max_size.into());
         self
     }
 
@@ -413,8 +413,8 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread. Sets the top left coordinates of the
     ///   window in the screen space coordinate system.
     #[inline]
-    pub fn set_outer_position(&self, position: LogicalPosition) {
-        self.window.set_outer_position(position)
+    pub fn set_outer_position<P: Into<LogicalPosition>>(&self, position: P) {
+        self.window.set_outer_position(position.into())
     }
 
     /// Returns the logical size of the window's client area.
@@ -443,8 +443,8 @@ impl Window {
     /// - **iOS:** Unimplemented. Currently this panics, as it's not clear what `set_inner_size`
     ///   would mean for iOS.
     #[inline]
-    pub fn set_inner_size(&self, size: LogicalSize) {
-        self.window.set_inner_size(size)
+    pub fn set_inner_size<S: Into<LogicalSize>>(&self, size: S) {
+        self.window.set_inner_size(size.into())
     }
 
     /// Returns the logical size of the entire window.
@@ -597,8 +597,8 @@ impl Window {
     ///
     /// **iOS:** Has no effect.
     #[inline]
-    pub fn set_ime_position(&self, position: LogicalPosition) {
-        self.window.set_ime_position(position)
+    pub fn set_ime_position<P: Into<LogicalPosition>>(&self, position: P) {
+        self.window.set_ime_position(position.into())
     }
 }
 
@@ -621,8 +621,8 @@ impl Window {
     ///
     /// - **iOS:** Always returns an `Err`.
     #[inline]
-    pub fn set_cursor_position(&self, position: LogicalPosition) -> Result<(), ExternalError> {
-        self.window.set_cursor_position(position)
+    pub fn set_cursor_position<P: Into<LogicalPosition>>(&self, position: P) -> Result<(), ExternalError> {
+        self.window.set_cursor_position(position.into())
     }
 
     /// Grabs the cursor, preventing it from leaving the window.

--- a/src/window.rs
+++ b/src/window.rs
@@ -467,8 +467,8 @@ impl Window {
     ///
     /// - **iOS:** Has no effect.
     #[inline]
-    pub fn set_min_inner_size(&self, dimensions: Option<LogicalSize>) {
-        self.window.set_min_inner_size(dimensions)
+    pub fn set_min_inner_size<S: Into<LogicalSize>>(&self, dimensions: Option<S>) {
+        self.window.set_min_inner_size(dimensions.map(Into::into))
     }
 
     /// Sets a maximum dimension size for the window.
@@ -477,8 +477,8 @@ impl Window {
     ///
     /// - **iOS:** Has no effect.
     #[inline]
-    pub fn set_max_inner_size(&self, dimensions: Option<LogicalSize>) {
-        self.window.set_max_inner_size(dimensions)
+    pub fn set_max_inner_size<S: Into<LogicalSize>>(&self, dimensions: Option<S>) {
+        self.window.set_max_inner_size(dimensions.map(Into::into))
     }
 }
 


### PR DESCRIPTION
This allows for doing:

```rust
let window: Window = ...;
window.set_outer_position((100, 200));
```

----

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] ~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- [x] ~Created an example program if it would help users understand this functionality~
- [x] ~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~
