### PR TITLE
Add ability to choose the  `NSEventMask` used by `EventsLoop` on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On X11, fix sanity check which checks that a monitor's reported width and height (in millimeters) are non-zero when calculating the DPI factor.
+- On macOS, added the ability to choose `NSEventMask` used by `EventsLoop`
 
 # Version 0.19.1 (2019-04-08)
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -10,7 +10,7 @@ pub trait EventsLoopExt {
     /// to the the given `NSEventMask`.
     ///
     /// The default is `NSAnyEventMask | NSEventMaskPressure`.
-    fn with_nseventmask(nseventmask: NSEventMask) -> Self;
+    fn with_nseventmask(nseventmask: NSEventMask) -> Self where Self: Sized;
 
     /// Returns the `NSEventMask` used for listening to events.
     fn get_nseventmask(&self) -> NSEventMask;

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -10,32 +10,32 @@ pub trait EventsLoopExt {
     /// to the the given `NSEventMask`.
     ///
     /// The default is `NSAnyEventMask | NSEventMaskPressure`.
-    fn with_mask(event_mask: NSEventMask) -> Self;
+    fn with_nseventmask(nseventmask: NSEventMask) -> Self;
 
     /// Returns the `NSEventMask` used for listening to events.
-    fn get_mask(&self) -> NSEventMask;
+    fn get_nseventmask(&self) -> NSEventMask;
 
     /// Sets the `NSEventMask` used for listening to events.
-    fn set_mask(&mut self, event_mask: NSEventMask);
+    fn set_nseventmask(&mut self, nseventmask: NSEventMask);
 }
 
 impl EventsLoopExt for EventsLoop {
     #[inline]
-    fn with_mask(event_mask: NSEventMask) -> Self {
+    fn with_nseventmask(nseventmask: NSEventMask) -> Self {
         EventsLoop {
-            events_loop: ::platform::EventsLoop::with_mask(event_mask),
+            events_loop: ::platform::EventsLoop::with_nseventmask(nseventmask),
             _marker: ::std::marker::PhantomData,
         }
     }
 
     #[inline]
-    fn get_mask(&self) -> NSEventMask {
-        self.events_loop.event_mask
+    fn get_nseventmask(&self) -> NSEventMask {
+        self.events_loop.nseventmask
     }
 
     #[inline]
-    fn set_mask(&mut self, mask: NSEventMask) {
-        self.events_loop.event_mask = mask;
+    fn set_nseventmask(&mut self, nseventmask: NSEventMask) {
+        self.events_loop.nseventmask = nseventmask;
     }
 }
 

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -1,7 +1,27 @@
 #![cfg(target_os = "macos")]
 
 use std::os::raw::c_void;
-use {LogicalSize, MonitorId, Window, WindowBuilder};
+use cocoa::appkit::NSEventMask;
+use {EventsLoop, LogicalSize, MonitorId, Window, WindowBuilder};
+
+/// Additional methods on `EventsLoop` that are specific to MacOS.
+pub trait EventsLoopExt {
+    /// Builds a new events loop that will only listen to events that correspond
+    /// to the the given `NSEventMask`.
+    ///
+    /// The default is `NSAnyEventMask | NSEventMaskPressure`.
+    fn with_mask(event_mask: NSEventMask) -> Self;
+}
+
+impl EventsLoopExt for EventsLoop {
+    #[inline]
+    fn with_mask(event_mask: NSEventMask) -> Self {
+        EventsLoop {
+            events_loop: ::platform::EventsLoop::with_mask(event_mask),
+            _marker: ::std::marker::PhantomData,
+        }
+    }
+}
 
 /// Additional methods on `Window` that are specific to MacOS.
 pub trait WindowExt {

--- a/src/os/macos.rs
+++ b/src/os/macos.rs
@@ -11,6 +11,12 @@ pub trait EventsLoopExt {
     ///
     /// The default is `NSAnyEventMask | NSEventMaskPressure`.
     fn with_mask(event_mask: NSEventMask) -> Self;
+
+    /// Returns the `NSEventMask` used for listening to events.
+    fn get_mask(&self) -> NSEventMask;
+
+    /// Sets the `NSEventMask` used for listening to events.
+    fn set_mask(&mut self, event_mask: NSEventMask);
 }
 
 impl EventsLoopExt for EventsLoop {
@@ -20,6 +26,16 @@ impl EventsLoopExt for EventsLoop {
             events_loop: ::platform::EventsLoop::with_mask(event_mask),
             _marker: ::std::marker::PhantomData,
         }
+    }
+
+    #[inline]
+    fn get_mask(&self) -> NSEventMask {
+        self.events_loop.event_mask
+    }
+
+    #[inline]
+    fn set_mask(&mut self, mask: NSEventMask) {
+        self.events_loop.event_mask = mask;
     }
 }
 

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -10,7 +10,7 @@ use std::os::raw::*;
 use super::DeviceId;
 
 pub struct EventsLoop {
-    event_mask: NSEventMask,
+    pub event_mask: NSEventMask,
     modifiers: Modifiers,
     pub shared: Arc<Shared>,
 }

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -255,7 +255,7 @@ impl EventsLoop {
 
                 // Wait for the next event. Note that this function blocks during resize.
                 let ns_event = appkit::NSApp().nextEventMatchingMask_untilDate_inMode_dequeue_(
-                    NSEventMask::NSAnyEventMask.bits() | NSEventMask::NSEventMaskPressure.bits(),
+                    self.nseventmask.bits(),
                     foundation::NSDate::distantFuture(cocoa::base::nil),
                     foundation::NSDefaultRunLoopMode,
                     cocoa::base::YES);

--- a/src/platform/macos/events_loop.rs
+++ b/src/platform/macos/events_loop.rs
@@ -10,7 +10,7 @@ use std::os::raw::*;
 use super::DeviceId;
 
 pub struct EventsLoop {
-    pub event_mask: NSEventMask,
+    pub nseventmask: NSEventMask,
     modifiers: Modifiers,
     pub shared: Arc<Shared>,
 }
@@ -164,10 +164,10 @@ impl UserCallback {
 impl EventsLoop {
 
     pub fn new() -> Self {
-        Self::with_mask(NSEventMask::NSAnyEventMask | NSEventMask::NSEventMaskPressure)
+        Self::with_nseventmask(NSEventMask::NSAnyEventMask | NSEventMask::NSEventMaskPressure)
     }
 
-    pub fn with_mask(event_mask: NSEventMask) -> Self {
+    pub fn with_nseventmask(nseventmask: NSEventMask) -> Self {
         // Mark this thread as the main thread of the Cocoa event system.
         //
         // This must be done before any worker threads get a chance to call it
@@ -178,7 +178,7 @@ impl EventsLoop {
         EventsLoop {
             shared: Arc::new(Shared::new()),
             modifiers: Modifiers::new(),
-            event_mask,
+            nseventmask,
         }
     }
 
@@ -203,7 +203,7 @@ impl EventsLoop {
 
                 // Poll for the next event, returning `nil` if there are none.
                 let ns_event = appkit::NSApp().nextEventMatchingMask_untilDate_inMode_dequeue_(
-                    self.event_mask.bits(),
+                    self.nseventmask.bits(),
                     foundation::NSDate::distantPast(cocoa::base::nil),
                     foundation::NSDefaultRunLoopMode,
                     cocoa::base::YES);


### PR DESCRIPTION
This allows for reducing the number of events that are handled by `winit`.

~The APIs are named with `nseventmask` for consistency with `nswindow`, `nsview`, and `nsscreen`. However, I think it should be named `ns_event_mask` and have the other API names follow suit. But that is a breaking change.~ Opened https://github.com/rust-windowing/winit/pull/904 to address this.

----

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented