### PR TITLE
Make `ns` identifiers use snake_case on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Removed `serde` implementations from `ControlFlow`.
 - Rename several functions to improve both internal consistency and compliance with Rust API guidelines.
 - Remove `WindowBuilder::multitouch` field, since it was only implemented on a few platforms. Multitouch is always enabled now.
+- **Breaking:** On macOS, change `ns` identifiers to use snake_case for consistency with iOS's `ui` identifiers.
 
 # Version 0.19.1 (2019-04-08)
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -11,12 +11,12 @@ pub trait WindowExtMacOS {
     /// Returns a pointer to the cocoa `NSWindow` that is used by this window.
     ///
     /// The pointer will become invalid when the `Window` is destroyed.
-    fn nswindow(&self) -> *mut c_void;
+    fn ns_window(&self) -> *mut c_void;
 
     /// Returns a pointer to the cocoa `NSView` that is used by this window.
     ///
     /// The pointer will become invalid when the `Window` is destroyed.
-    fn nsview(&self) -> *mut c_void;
+    fn ns_view(&self) -> *mut c_void;
 
     /// Request user attention, causing the application's dock icon to bounce.
     /// Note that this has no effect if the application is already focused.
@@ -41,13 +41,13 @@ pub trait WindowExtMacOS {
 
 impl WindowExtMacOS for Window {
     #[inline]
-    fn nswindow(&self) -> *mut c_void {
-        self.window.nswindow()
+    fn ns_window(&self) -> *mut c_void {
+        self.window.ns_window()
     }
 
     #[inline]
-    fn nsview(&self) -> *mut c_void {
-        self.window.nsview()
+    fn ns_view(&self) -> *mut c_void {
+        self.window.ns_view()
     }
 
     #[inline]
@@ -167,7 +167,7 @@ pub trait MonitorHandleExtMacOS {
     /// Returns the identifier of the monitor for Cocoa.
     fn native_id(&self) -> u32;
     /// Returns a pointer to the NSScreen representing this monitor.
-    fn nsscreen(&self) -> Option<*mut c_void>;
+    fn ns_screen(&self) -> Option<*mut c_void>;
 }
 
 impl MonitorHandleExtMacOS for MonitorHandle {
@@ -176,7 +176,7 @@ impl MonitorHandleExtMacOS for MonitorHandle {
         self.inner.native_identifier()
     }
 
-    fn nsscreen(&self) -> Option<*mut c_void> {
-        self.inner.nsscreen().map(|s| s as *mut c_void)
+    fn ns_screen(&self) -> Option<*mut c_void> {
+        self.inner.ns_screen().map(|s| s as *mut c_void)
     }
 }

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -86,14 +86,14 @@ impl MonitorHandle {
     }
 
     pub fn hidpi_factor(&self) -> f64 {
-        let screen = match self.nsscreen() {
+        let screen = match self.ns_screen() {
             Some(screen) => screen,
             None => return 1.0, // default to 1.0 when we can't find the screen
         };
         unsafe { NSScreen::backingScaleFactor(screen) as f64 }
     }
 
-    pub(crate) fn nsscreen(&self) -> Option<id> {
+    pub(crate) fn ns_screen(&self) -> Option<id> {
         unsafe {
             let native_id = self.native_identifier();
             let screens = NSScreen::screens(nil);

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -10,25 +10,25 @@ use dispatch::ffi::{dispatch_async_f, dispatch_get_main_queue, dispatch_sync_f};
 use dpi::LogicalSize;
 use platform_impl::platform::{ffi, window::SharedState};
 
-unsafe fn set_style_mask(nswindow: id, nsview: id, mask: NSWindowStyleMask) {
-    nswindow.setStyleMask_(mask);
+unsafe fn set_style_mask(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
+    ns_window.setStyleMask_(mask);
     // If we don't do this, key handling will break
     // (at least until the window is clicked again/etc.)
-    nswindow.makeFirstResponder_(nsview);
+    ns_window.makeFirstResponder_(ns_view);
 }
 
 struct SetStyleMaskData {
-    nswindow: id,
-    nsview: id,
+    ns_window: id,
+    ns_view: id,
     mask: NSWindowStyleMask,
 }
 impl SetStyleMaskData {
     fn new_ptr(
-        nswindow: id,
-        nsview: id,
+        ns_window: id,
+        ns_view: id,
         mask: NSWindowStyleMask,
     ) -> *mut Self {
-        Box::into_raw(Box::new(SetStyleMaskData { nswindow, nsview, mask }))
+        Box::into_raw(Box::new(SetStyleMaskData { ns_window, ns_view, mask }))
     }
 }
 extern fn set_style_mask_callback(context: *mut c_void) {
@@ -36,7 +36,7 @@ extern fn set_style_mask_callback(context: *mut c_void) {
         let context_ptr = context as *mut SetStyleMaskData;
         {
             let context = &*context_ptr;
-            set_style_mask(context.nswindow, context.nsview, context.mask);
+            set_style_mask(context.ns_window, context.ns_view, context.mask);
         }
         Box::from_raw(context_ptr);
     }
@@ -45,16 +45,16 @@ extern fn set_style_mask_callback(context: *mut c_void) {
 // `setStyleMask:` isn't thread-safe, so we have to use Grand Central Dispatch.
 // Otherwise, this would vomit out errors about not being on the main thread
 // and fail to do anything.
-pub unsafe fn set_style_mask_async(nswindow: id, nsview: id, mask: NSWindowStyleMask) {
-    let context = SetStyleMaskData::new_ptr(nswindow, nsview, mask);
+pub unsafe fn set_style_mask_async(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
+    let context = SetStyleMaskData::new_ptr(ns_window, ns_view, mask);
     dispatch_async_f(
         dispatch_get_main_queue(),
         context as *mut _,
         set_style_mask_callback,
     );
 }
-pub unsafe fn set_style_mask_sync(nswindow: id, nsview: id, mask: NSWindowStyleMask) {
-    let context = SetStyleMaskData::new_ptr(nswindow, nsview, mask);
+pub unsafe fn set_style_mask_sync(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
+    let context = SetStyleMaskData::new_ptr(ns_window, ns_view, mask);
     dispatch_sync_f(
         dispatch_get_main_queue(),
         context as *mut _,
@@ -63,15 +63,15 @@ pub unsafe fn set_style_mask_sync(nswindow: id, nsview: id, mask: NSWindowStyleM
 }
 
 struct SetContentSizeData {
-    nswindow: id,
+    ns_window: id,
     size: LogicalSize,
 }
 impl SetContentSizeData {
     fn new_ptr(
-        nswindow: id,
+        ns_window: id,
         size: LogicalSize,
     ) -> *mut Self {
-        Box::into_raw(Box::new(SetContentSizeData { nswindow, size }))
+        Box::into_raw(Box::new(SetContentSizeData { ns_window, size }))
     }
 }
 extern fn set_content_size_callback(context: *mut c_void) {
@@ -80,7 +80,7 @@ extern fn set_content_size_callback(context: *mut c_void) {
         {
             let context = &*context_ptr;
             NSWindow::setContentSize_(
-                context.nswindow,
+                context.ns_window,
                 NSSize::new(
                     context.size.width as CGFloat,
                     context.size.height as CGFloat,
@@ -92,8 +92,8 @@ extern fn set_content_size_callback(context: *mut c_void) {
 }
 // `setContentSize:` isn't thread-safe either, though it doesn't log any errors
 // and just fails silently. Anyway, GCD to the rescue!
-pub unsafe fn set_content_size_async(nswindow: id, size: LogicalSize) {
-    let context = SetContentSizeData::new_ptr(nswindow, size);
+pub unsafe fn set_content_size_async(ns_window: id, size: LogicalSize) {
+    let context = SetContentSizeData::new_ptr(ns_window, size);
     dispatch_async_f(
         dispatch_get_main_queue(),
         context as *mut _,
@@ -102,15 +102,15 @@ pub unsafe fn set_content_size_async(nswindow: id, size: LogicalSize) {
 }
 
 struct SetFrameTopLeftPointData {
-    nswindow: id,
+    ns_window: id,
     point: NSPoint,
 }
 impl SetFrameTopLeftPointData {
     fn new_ptr(
-        nswindow: id,
+        ns_window: id,
         point: NSPoint,
     ) -> *mut Self {
-        Box::into_raw(Box::new(SetFrameTopLeftPointData { nswindow, point }))
+        Box::into_raw(Box::new(SetFrameTopLeftPointData { ns_window, point }))
     }
 }
 extern fn set_frame_top_left_point_callback(context: *mut c_void) {
@@ -118,15 +118,15 @@ extern fn set_frame_top_left_point_callback(context: *mut c_void) {
         let context_ptr = context as *mut SetFrameTopLeftPointData;
         {
             let context = &*context_ptr;
-            NSWindow::setFrameTopLeftPoint_(context.nswindow, context.point);
+            NSWindow::setFrameTopLeftPoint_(context.ns_window, context.point);
         }
         Box::from_raw(context_ptr);
     }
 }
 // `setFrameTopLeftPoint:` isn't thread-safe, but fortunately has the courtesy
 // to log errors.
-pub unsafe fn set_frame_top_left_point_async(nswindow: id, point: NSPoint) {
-    let context = SetFrameTopLeftPointData::new_ptr(nswindow, point);
+pub unsafe fn set_frame_top_left_point_async(ns_window: id, point: NSPoint) {
+    let context = SetFrameTopLeftPointData::new_ptr(ns_window, point);
     dispatch_async_f(
         dispatch_get_main_queue(),
         context as *mut _,
@@ -135,15 +135,15 @@ pub unsafe fn set_frame_top_left_point_async(nswindow: id, point: NSPoint) {
 }
 
 struct SetLevelData {
-    nswindow: id,
+    ns_window: id,
     level: ffi::NSWindowLevel,
 }
 impl SetLevelData {
     fn new_ptr(
-        nswindow: id,
+        ns_window: id,
         level: ffi::NSWindowLevel,
     ) -> *mut Self {
-        Box::into_raw(Box::new(SetLevelData { nswindow, level }))
+        Box::into_raw(Box::new(SetLevelData { ns_window, level }))
     }
 }
 extern fn set_level_callback(context: *mut c_void) {
@@ -151,14 +151,14 @@ extern fn set_level_callback(context: *mut c_void) {
         let context_ptr = context as *mut SetLevelData;
         {
             let context = &*context_ptr;
-            context.nswindow.setLevel_(context.level as _);
+            context.ns_window.setLevel_(context.level as _);
         }
         Box::from_raw(context_ptr);
     }
 }
 // `setFrameTopLeftPoint:` isn't thread-safe, and fails silently.
-pub unsafe fn set_level_async(nswindow: id, level: ffi::NSWindowLevel) {
-    let context = SetLevelData::new_ptr(nswindow, level);
+pub unsafe fn set_level_async(ns_window: id, level: ffi::NSWindowLevel) {
+    let context = SetLevelData::new_ptr(ns_window, level);
     dispatch_async_f(
         dispatch_get_main_queue(),
         context as *mut _,
@@ -167,21 +167,21 @@ pub unsafe fn set_level_async(nswindow: id, level: ffi::NSWindowLevel) {
 }
 
 struct ToggleFullScreenData {
-    nswindow: id,
-    nsview: id,
+    ns_window: id,
+    ns_view: id,
     not_fullscreen: bool,
     shared_state: Weak<Mutex<SharedState>>,
 }
 impl ToggleFullScreenData {
     fn new_ptr(
-        nswindow: id,
-        nsview: id,
+        ns_window: id,
+        ns_view: id,
         not_fullscreen: bool,
         shared_state: Weak<Mutex<SharedState>>,
     ) -> *mut Self {
         Box::into_raw(Box::new(ToggleFullScreenData {
-            nswindow,
-            nsview,
+            ns_window,
+            ns_view,
             not_fullscreen,
             shared_state,
         }))
@@ -197,11 +197,11 @@ extern fn toggle_full_screen_callback(context: *mut c_void) {
             // set a normal style temporarily. The previous state will be
             // restored in `WindowDelegate::window_did_exit_fullscreen`.
             if context.not_fullscreen {
-                let curr_mask = context.nswindow.styleMask();
+                let curr_mask = context.ns_window.styleMask();
                 let required = NSWindowStyleMask::NSTitledWindowMask
                     | NSWindowStyleMask::NSResizableWindowMask;
                 if !curr_mask.contains(required) {
-                    set_style_mask(context.nswindow, context.nsview, required);
+                    set_style_mask(context.ns_window, context.ns_view, required);
                     if let Some(shared_state) = context.shared_state.upgrade() {
                         trace!("Locked shared state in `toggle_full_screen_callback`");
                         let mut shared_state_lock = shared_state.lock().unwrap();
@@ -211,7 +211,7 @@ extern fn toggle_full_screen_callback(context: *mut c_void) {
                 }
             }
 
-            context.nswindow.toggleFullScreen_(nil);
+            context.ns_window.toggleFullScreen_(nil);
         }
         Box::from_raw(context_ptr);
     }
@@ -219,14 +219,14 @@ extern fn toggle_full_screen_callback(context: *mut c_void) {
 // `toggleFullScreen` is thread-safe, but our additional logic to account for
 // window styles isn't.
 pub unsafe fn toggle_full_screen_async(
-    nswindow: id,
-    nsview: id,
+    ns_window: id,
+    ns_view: id,
     not_fullscreen: bool,
     shared_state: Weak<Mutex<SharedState>>,
 ) {
     let context = ToggleFullScreenData::new_ptr(
-        nswindow,
-        nsview,
+        ns_window,
+        ns_view,
         not_fullscreen,
         shared_state,
     );
@@ -238,11 +238,11 @@ pub unsafe fn toggle_full_screen_async(
 }
 
 struct OrderOutData {
-    nswindow: id,
+    ns_window: id,
 }
 impl OrderOutData {
-    fn new_ptr(nswindow: id) -> *mut Self {
-        Box::into_raw(Box::new(OrderOutData { nswindow }))
+    fn new_ptr(ns_window: id) -> *mut Self {
+        Box::into_raw(Box::new(OrderOutData { ns_window }))
     }
 }
 extern fn order_out_callback(context: *mut c_void) {
@@ -250,15 +250,15 @@ extern fn order_out_callback(context: *mut c_void) {
         let context_ptr = context as *mut OrderOutData;
         {
             let context = &*context_ptr;
-            context.nswindow.orderOut_(nil);
+            context.ns_window.orderOut_(nil);
         }
         Box::from_raw(context_ptr);
     }
 }
 // `orderOut:` isn't thread-safe. Calling it from another thread actually works,
 // but with an odd delay.
-pub unsafe fn order_out_async(nswindow: id) {
-    let context = OrderOutData::new_ptr(nswindow);
+pub unsafe fn order_out_async(ns_window: id) {
+    let context = OrderOutData::new_ptr(ns_window);
     dispatch_async_f(
         dispatch_get_main_queue(),
         context as *mut _,
@@ -267,11 +267,11 @@ pub unsafe fn order_out_async(nswindow: id) {
 }
 
 struct MakeKeyAndOrderFrontData {
-    nswindow: id,
+    ns_window: id,
 }
 impl MakeKeyAndOrderFrontData {
-    fn new_ptr(nswindow: id) -> *mut Self {
-        Box::into_raw(Box::new(MakeKeyAndOrderFrontData { nswindow }))
+    fn new_ptr(ns_window: id) -> *mut Self {
+        Box::into_raw(Box::new(MakeKeyAndOrderFrontData { ns_window }))
     }
 }
 extern fn make_key_and_order_front_callback(context: *mut c_void) {
@@ -279,15 +279,15 @@ extern fn make_key_and_order_front_callback(context: *mut c_void) {
         let context_ptr = context as *mut MakeKeyAndOrderFrontData;
         {
             let context = &*context_ptr;
-            context.nswindow.makeKeyAndOrderFront_(nil);
+            context.ns_window.makeKeyAndOrderFront_(nil);
         }
         Box::from_raw(context_ptr);
     }
 }
 // `makeKeyAndOrderFront:` isn't thread-safe. Calling it from another thread
 // actually works, but with an odd delay.
-pub unsafe fn make_key_and_order_front_async(nswindow: id) {
-    let context = MakeKeyAndOrderFrontData::new_ptr(nswindow);
+pub unsafe fn make_key_and_order_front_async(ns_window: id) {
+    let context = MakeKeyAndOrderFrontData::new_ptr(ns_window);
     dispatch_async_f(
         dispatch_get_main_queue(),
         context as *mut _,
@@ -296,11 +296,11 @@ pub unsafe fn make_key_and_order_front_async(nswindow: id) {
 }
 
 struct CloseData {
-    nswindow: id,
+    ns_window: id,
 }
 impl CloseData {
-    fn new_ptr(nswindow: id) -> *mut Self {
-        Box::into_raw(Box::new(CloseData { nswindow }))
+    fn new_ptr(ns_window: id) -> *mut Self {
+        Box::into_raw(Box::new(CloseData { ns_window }))
     }
 }
 extern fn close_callback(context: *mut c_void) {
@@ -309,7 +309,7 @@ extern fn close_callback(context: *mut c_void) {
         {
             let context = &*context_ptr;
             let pool = NSAutoreleasePool::new(nil);
-            context.nswindow.close();
+            context.ns_window.close();
             pool.drain();
         }
         Box::from_raw(context_ptr);
@@ -317,8 +317,8 @@ extern fn close_callback(context: *mut c_void) {
 }
 // `close:` is thread-safe, but we want the event to be triggered from the main
 // thread. Though, it's a good idea to look into that more...
-pub unsafe fn close_async(nswindow: id) {
-    let context = CloseData::new_ptr(nswindow);
+pub unsafe fn close_async(ns_window: id) {
+    let context = CloseData::new_ptr(ns_window);
     dispatch_async_f(
         dispatch_get_main_queue(),
         context as *mut _,

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -31,7 +31,7 @@ struct Modifiers {
 }
 
 struct ViewState {
-    nswindow: id,
+    ns_window: id,
     pub cursor: Arc<Mutex<util::Cursor>>,
     ime_spot: Option<(f64, f64)>,
     raw_characters: Option<String>,
@@ -39,11 +39,11 @@ struct ViewState {
     modifiers: Modifiers,
 }
 
-pub fn new_view(nswindow: id) -> (IdRef, Weak<Mutex<util::Cursor>>) {
+pub fn new_view(ns_window: id) -> (IdRef, Weak<Mutex<util::Cursor>>) {
     let cursor = Default::default();
     let cursor_access = Arc::downgrade(&cursor);
     let state = ViewState {
-        nswindow,
+        ns_window,
         cursor,
         ime_spot: None,
         raw_characters: None,
@@ -53,17 +53,17 @@ pub fn new_view(nswindow: id) -> (IdRef, Weak<Mutex<util::Cursor>>) {
     unsafe {
         // This is free'd in `dealloc`
         let state_ptr = Box::into_raw(Box::new(state)) as *mut c_void;
-        let nsview: id = msg_send![VIEW_CLASS.0, alloc];
-        (IdRef::new(msg_send![nsview, initWithWinit:state_ptr]), cursor_access)
+        let ns_view: id = msg_send![VIEW_CLASS.0, alloc];
+        (IdRef::new(msg_send![ns_view, initWithWinit:state_ptr]), cursor_access)
     }
 }
 
-pub unsafe fn set_ime_position(nsview: id, input_context: id, x: f64, y: f64) {
-    let state_ptr: *mut c_void = *(*nsview).get_mut_ivar("winitState");
+pub unsafe fn set_ime_position(ns_view: id, input_context: id, x: f64, y: f64) {
+    let state_ptr: *mut c_void = *(*ns_view).get_mut_ivar("winitState");
     let state = &mut *(state_ptr as *mut ViewState);
     let content_rect = NSWindow::contentRectForFrameRect_(
-        state.nswindow,
-        NSWindow::frame(state.nswindow),
+        state.ns_window,
+        NSWindow::frame(state.ns_window),
     );
     let base_x = content_rect.origin.x as f64;
     let base_y = (content_rect.origin.y + content_rect.size.height) as f64;
@@ -285,7 +285,7 @@ extern fn draw_rect(this: &Object, _sel: Sel, rect: id) {
         let state_ptr: *mut c_void = *this.get_ivar("winitState");
         let state = &mut *(state_ptr as *mut ViewState);
 
-        AppState::queue_redraw(WindowId(get_window_id(state.nswindow)));
+        AppState::queue_redraw(WindowId(get_window_id(state.ns_window)));
 
         let superclass = util::superclass(this);
         let () = msg_send![super(this, superclass), drawRect:rect];
@@ -417,8 +417,8 @@ extern fn first_rect_for_character_range(
         let state = &mut *(state_ptr as *mut ViewState);
         let (x, y) = state.ime_spot.unwrap_or_else(|| {
             let content_rect = NSWindow::contentRectForFrameRect_(
-                state.nswindow,
-                NSWindow::frame(state.nswindow),
+                state.ns_window,
+                NSWindow::frame(state.ns_window),
             );
             let x = content_rect.origin.x;
             let y = util::bottom_left_to_top_left(content_rect);
@@ -460,7 +460,7 @@ extern fn insert_text(this: &Object, _sel: Sel, string: id, _replacement_range: 
         let mut events = VecDeque::with_capacity(characters.len());
         for character in string.chars() {
             events.push_back(Event::WindowEvent {
-                window_id: WindowId(get_window_id(state.nswindow)),
+                window_id: WindowId(get_window_id(state.ns_window)),
                 event: WindowEvent::ReceivedCharacter(character),
             });
         }
@@ -484,7 +484,7 @@ extern fn do_command_by_selector(this: &Object, _sel: Sel, command: Sel) {
             // 1) as a reminder for how `doCommandBySelector` works
             // 2) to make our use of carriage return explicit
             events.push_back(Event::WindowEvent {
-                window_id: WindowId(get_window_id(state.nswindow)),
+                window_id: WindowId(get_window_id(state.ns_window)),
                 event: WindowEvent::ReceivedCharacter('\r'),
             });
         } else {
@@ -492,7 +492,7 @@ extern fn do_command_by_selector(this: &Object, _sel: Sel, command: Sel) {
             if let Some(raw_characters) = raw_characters {
                 for character in raw_characters.chars() {
                     events.push_back(Event::WindowEvent {
-                        window_id: WindowId(get_window_id(state.nswindow)),
+                        window_id: WindowId(get_window_id(state.ns_window)),
                         event: WindowEvent::ReceivedCharacter(character),
                     });
                 }
@@ -558,7 +558,7 @@ extern fn key_down(this: &Object, _sel: Sel, event: id) {
     unsafe {
         let state_ptr: *mut c_void = *this.get_ivar("winitState");
         let state = &mut *(state_ptr as *mut ViewState);
-        let window_id = WindowId(get_window_id(state.nswindow));
+        let window_id = WindowId(get_window_id(state.ns_window));
         let characters = get_characters(event, false);
 
         state.raw_characters = Some(characters.clone());
@@ -620,7 +620,7 @@ extern fn key_up(this: &Object, _sel: Sel, event: id) {
         let virtual_keycode = retrieve_keycode(event);
 
         let window_event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(state.nswindow)),
+            window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::KeyboardInput {
                 device_id: DEVICE_ID,
                 input: KeyboardInput {
@@ -683,7 +683,7 @@ extern fn flags_changed(this: &Object, _sel: Sel, event: id) {
 
         for event in events {
             AppState::queue_event(Event::WindowEvent {
-                window_id: WindowId(get_window_id(state.nswindow)),
+                window_id: WindowId(get_window_id(state.ns_window)),
                 event,
             });
         }
@@ -728,7 +728,7 @@ extern fn cancel_operation(this: &Object, _sel: Sel, _sender: id) {
         let event: id = msg_send![NSApp(), currentEvent];
 
         let window_event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(state.nswindow)),
+            window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::KeyboardInput {
                 device_id: DEVICE_ID,
                 input: KeyboardInput {
@@ -751,7 +751,7 @@ fn mouse_click(this: &Object, event: id, button: MouseButton, button_state: Elem
         let state = &mut *(state_ptr as *mut ViewState);
 
         let window_event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(state.nswindow)),
+            window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::MouseInput {
                 device_id: DEVICE_ID,
                 state: button_state,
@@ -812,7 +812,7 @@ fn mouse_motion(this: &Object, event: id) {
         let y = view_rect.size.height as f64 - view_point.y as f64;
 
         let window_event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(state.nswindow)),
+            window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::CursorMoved {
                 device_id: DEVICE_ID,
                 position: (x, y).into(),
@@ -847,7 +847,7 @@ extern fn mouse_entered(this: &Object, _sel: Sel, event: id) {
         let state = &mut *(state_ptr as *mut ViewState);
 
         let enter_event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(state.nswindow)),
+            window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::CursorEntered { device_id: DEVICE_ID },
         };
 
@@ -861,7 +861,7 @@ extern fn mouse_entered(this: &Object, _sel: Sel, event: id) {
             let x = view_point.x as f64;
             let y = (view_rect.size.height - view_point.y) as f64;
             Event::WindowEvent {
-                window_id: WindowId(get_window_id(state.nswindow)),
+                window_id: WindowId(get_window_id(state.ns_window)),
                 event: WindowEvent::CursorMoved {
                     device_id: DEVICE_ID,
                     position: (x, y).into(),
@@ -883,7 +883,7 @@ extern fn mouse_exited(this: &Object, _sel: Sel, _event: id) {
         let state = &mut *(state_ptr as *mut ViewState);
 
         let window_event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(state.nswindow)),
+            window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::CursorLeft { device_id: DEVICE_ID },
         };
 
@@ -918,7 +918,7 @@ extern fn scroll_wheel(this: &Object, _sel: Sel, event: id) {
         let state = &mut *(state_ptr as *mut ViewState);
 
         let window_event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(state.nswindow)),
+            window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::MouseWheel {
                 device_id: DEVICE_ID,
                 delta,
@@ -943,7 +943,7 @@ extern fn pressure_change_with_event(this: &Object, _sel: Sel, event: id) {
         let stage = event.stage();
 
         let window_event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(state.nswindow)),
+            window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::TouchpadPressure {
                 device_id: DEVICE_ID,
                 pressure,

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -60,26 +60,26 @@ pub struct PlatformSpecificWindowBuilderAttributes {
 
 fn create_app(activation_policy: ActivationPolicy) -> Option<id> {
     unsafe {
-        let nsapp = NSApp();
-        if nsapp == nil {
+        let ns_app = NSApp();
+        if ns_app == nil {
             None
         } else {
             use self::NSApplicationActivationPolicy::*;
-            nsapp.setActivationPolicy_(match activation_policy {
+            ns_app.setActivationPolicy_(match activation_policy {
                 ActivationPolicy::Regular => NSApplicationActivationPolicyRegular,
                 ActivationPolicy::Accessory => NSApplicationActivationPolicyAccessory,
                 ActivationPolicy::Prohibited => NSApplicationActivationPolicyProhibited,
             });
-            nsapp.finishLaunching();
-            Some(nsapp)
+            ns_app.finishLaunching();
+            Some(ns_app)
         }
     }
 }
 
-unsafe fn create_view(nswindow: id) -> Option<(IdRef, Weak<Mutex<util::Cursor>>)> {
-    let (nsview, cursor) = new_view(nswindow);
-    nsview.non_nil().map(|nsview| {
-        nsview.setWantsBestResolutionOpenGLSurface_(YES);
+unsafe fn create_view(ns_window: id) -> Option<(IdRef, Weak<Mutex<util::Cursor>>)> {
+    let (ns_view, cursor) = new_view(ns_window);
+    ns_view.non_nil().map(|ns_view| {
+        ns_view.setWantsBestResolutionOpenGLSurface_(YES);
 
         // On Mojave, views automatically become layer-backed shortly after being added to
         // a window. Changing the layer-backedness of a view breaks the association between
@@ -87,12 +87,12 @@ unsafe fn create_view(nswindow: id) -> Option<(IdRef, Weak<Mutex<util::Cursor>>)
         // explicitly make the view layer-backed up front so that AppKit doesn't do it
         // itself and break the association with its context.
         if f64::floor(appkit::NSAppKitVersionNumber) > appkit::NSAppKitVersionNumber10_12 {
-            nsview.setWantsLayer(YES);
+            ns_view.setWantsLayer(YES);
         }
 
-        nswindow.setContentView_(*nsview);
-        nswindow.makeFirstResponder_(*nsview);
-        (nsview, cursor)
+        ns_window.setContentView_(*ns_view);
+        ns_window.makeFirstResponder_(*ns_view);
+        (ns_view, cursor)
     })
 }
 
@@ -104,7 +104,7 @@ fn create_window(
         let pool = NSAutoreleasePool::new(nil);
         let screen = match attrs.fullscreen {
             Some(ref monitor_id) => {
-                let monitor_screen = monitor_id.inner.nsscreen();
+                let monitor_screen = monitor_id.inner.ns_screen();
                 Some(monitor_screen.unwrap_or(appkit::NSScreen::mainScreen(nil)))
             },
             _ => None,
@@ -144,24 +144,24 @@ fn create_window(
             masks |= NSWindowStyleMask::NSFullSizeContentViewWindowMask;
         }
 
-        let nswindow: id = msg_send![WINDOW_CLASS.0, alloc];
-        let nswindow = IdRef::new(nswindow.initWithContentRect_styleMask_backing_defer_(
+        let ns_window: id = msg_send![WINDOW_CLASS.0, alloc];
+        let ns_window = IdRef::new(ns_window.initWithContentRect_styleMask_backing_defer_(
             frame,
             masks,
             appkit::NSBackingStoreBuffered,
             NO,
         ));
-        let res = nswindow.non_nil().map(|nswindow| {
+        let res = ns_window.non_nil().map(|ns_window| {
             let title = IdRef::new(NSString::alloc(nil).init_str(&attrs.title));
-            nswindow.setReleasedWhenClosed_(NO);
-            nswindow.setTitle_(*title);
-            nswindow.setAcceptsMouseMovedEvents_(YES);
+            ns_window.setReleasedWhenClosed_(NO);
+            ns_window.setTitle_(*title);
+            ns_window.setAcceptsMouseMovedEvents_(YES);
 
             if pl_attrs.titlebar_transparent {
-                nswindow.setTitlebarAppearsTransparent_(YES);
+                ns_window.setTitlebarAppearsTransparent_(YES);
             }
             if pl_attrs.title_hidden {
-                nswindow.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
+                ns_window.setTitleVisibility_(appkit::NSWindowTitleVisibility::NSWindowTitleHidden);
             }
             if pl_attrs.titlebar_buttons_hidden {
                 for titlebar_button in &[
@@ -170,28 +170,28 @@ fn create_window(
                     NSWindowButton::NSWindowCloseButton,
                     NSWindowButton::NSWindowZoomButton,
                 ] {
-                    let button = nswindow.standardWindowButton_(*titlebar_button);
+                    let button = ns_window.standardWindowButton_(*titlebar_button);
                     let _: () = msg_send![button, setHidden:YES];
                 }
             }
             if pl_attrs.movable_by_window_background {
-                nswindow.setMovableByWindowBackground_(YES);
+                ns_window.setMovableByWindowBackground_(YES);
             }
 
             if attrs.always_on_top {
-                let _: () = msg_send![*nswindow, setLevel:ffi::NSWindowLevel::NSFloatingWindowLevel];
+                let _: () = msg_send![*ns_window, setLevel:ffi::NSWindowLevel::NSFloatingWindowLevel];
             }
 
             if let Some(increments) = pl_attrs.resize_increments {
                 let (x, y) = (increments.width, increments.height);
                 if x >= 1.0 && y >= 1.0 {
                     let size = NSSize::new(x as CGFloat, y as CGFloat);
-                    nswindow.setResizeIncrements_(size);
+                    ns_window.setResizeIncrements_(size);
                 }
             }
 
-            nswindow.center();
-            nswindow
+            ns_window.center();
+            ns_window
         });
         pool.drain();
         res
@@ -241,8 +241,8 @@ impl From<WindowAttributes> for SharedState {
 }
 
 pub struct UnownedWindow {
-    pub nswindow: IdRef, // never changes
-    pub nsview: IdRef, // never changes
+    pub ns_window: IdRef, // never changes
+    pub ns_view: IdRef, // never changes
     input_context: IdRef, // never changes
     pub shared_state: Arc<Mutex<SharedState>>,
     decorations: AtomicBool,
@@ -266,37 +266,37 @@ impl UnownedWindow {
 
         let pool = unsafe { NSAutoreleasePool::new(nil) };
 
-        let nsapp = create_app(pl_attribs.activation_policy).ok_or_else(|| {
+        let ns_app = create_app(pl_attribs.activation_policy).ok_or_else(|| {
             unsafe { pool.drain() };
             os_error!(OsError::CreationError("Couldn't create `NSApplication`"))
         })?;
 
-        let nswindow = create_window(&win_attribs, &pl_attribs).ok_or_else(|| {
+        let ns_window = create_window(&win_attribs, &pl_attribs).ok_or_else(|| {
             unsafe { pool.drain() };
             os_error!(OsError::CreationError("Couldn't create `NSWindow`"))
         })?;
 
-        let (nsview, cursor) = unsafe { create_view(*nswindow) }.ok_or_else(|| {
+        let (ns_view, cursor) = unsafe { create_view(*ns_window) }.ok_or_else(|| {
             unsafe { pool.drain() };
             os_error!(OsError::CreationError("Couldn't create `NSView`"))
         })?;
 
-        let input_context = unsafe { util::create_input_context(*nsview) };
+        let input_context = unsafe { util::create_input_context(*ns_view) };
 
         unsafe {
             if win_attribs.transparent {
-                nswindow.setOpaque_(NO);
-                nswindow.setBackgroundColor_(NSColor::clearColor(nil));
+                ns_window.setOpaque_(NO);
+                ns_window.setBackgroundColor_(NSColor::clearColor(nil));
             }
 
-            nsapp.activateIgnoringOtherApps_(YES);
+            ns_app.activateIgnoringOtherApps_(YES);
 
-            win_attribs.min_inner_size.map(|dim| set_min_inner_size(*nswindow, dim));
-            win_attribs.max_inner_size.map(|dim| set_max_inner_size(*nswindow, dim));
+            win_attribs.min_inner_size.map(|dim| set_min_inner_size(*ns_window, dim));
+            win_attribs.max_inner_size.map(|dim| set_max_inner_size(*ns_window, dim));
 
             use cocoa::foundation::NSArray;
             // register for drag and drop operations.
-            let () = msg_send![*nswindow, registerForDraggedTypes:NSArray::arrayWithObject(
+            let () = msg_send![*ns_window, registerForDraggedTypes:NSArray::arrayWithObject(
                 nil,
                 appkit::NSFilenamesPboardType,
             )];
@@ -313,8 +313,8 @@ impl UnownedWindow {
         let decorations = win_attribs.decorations;
 
         let window = Arc::new(UnownedWindow {
-            nsview,
-            nswindow,
+            ns_view,
+            ns_window,
             input_context,
             shared_state: Arc::new(Mutex::new(win_attribs.into())),
             decorations: AtomicBool::new(decorations),
@@ -341,9 +341,9 @@ impl UnownedWindow {
         // before it transitions.
         unsafe {
             if visible {
-                window.nswindow.makeKeyAndOrderFront_(nil);
+                window.ns_window.makeKeyAndOrderFront_(nil);
             } else {
-                window.nswindow.makeKeyWindow();
+                window.ns_window.makeKeyWindow();
             }
         }
 
@@ -358,35 +358,35 @@ impl UnownedWindow {
 
     fn set_style_mask_async(&self, mask: NSWindowStyleMask) {
         unsafe { util::set_style_mask_async(
-            *self.nswindow,
-            *self.nsview,
+            *self.ns_window,
+            *self.ns_view,
             mask,
         ) };
     }
 
     fn set_style_mask_sync(&self, mask: NSWindowStyleMask) {
         unsafe { util::set_style_mask_sync(
-            *self.nswindow,
-            *self.nsview,
+            *self.ns_window,
+            *self.ns_view,
             mask,
         ) };
     }
 
     pub fn id(&self) -> Id {
-        get_window_id(*self.nswindow)
+        get_window_id(*self.ns_window)
     }
 
     pub fn set_title(&self, title: &str) {
         unsafe {
             let title = IdRef::new(NSString::alloc(nil).init_str(title));
-            self.nswindow.setTitle_(*title);
+            self.ns_window.setTitle_(*title);
         }
     }
 
     pub fn set_visible(&self, visible: bool) {
         match visible {
-            true => unsafe { util::make_key_and_order_front_async(*self.nswindow) },
-            false => unsafe { util::order_out_async(*self.nswindow) },
+            true => unsafe { util::make_key_and_order_front_async(*self.ns_window) },
+            false => unsafe { util::order_out_async(*self.ns_window) },
         }
     }
 
@@ -395,7 +395,7 @@ impl UnownedWindow {
     }
 
     pub fn outer_position(&self) -> Result<LogicalPosition, NotSupportedError> {
-        let frame_rect = unsafe { NSWindow::frame(*self.nswindow) };
+        let frame_rect = unsafe { NSWindow::frame(*self.ns_window) };
         Ok((
             frame_rect.origin.x as f64,
             util::bottom_left_to_top_left(frame_rect),
@@ -405,8 +405,8 @@ impl UnownedWindow {
     pub fn inner_position(&self) -> Result<LogicalPosition, NotSupportedError> {
         let content_rect = unsafe {
             NSWindow::contentRectForFrameRect_(
-                *self.nswindow,
-                NSWindow::frame(*self.nswindow),
+                *self.ns_window,
+                NSWindow::frame(*self.ns_window),
             )
         };
         Ok((
@@ -426,40 +426,40 @@ impl UnownedWindow {
             NSSize::new(0f64, 0f64),
         );
         unsafe {
-            util::set_frame_top_left_point_async(*self.nswindow, dummy.origin);
+            util::set_frame_top_left_point_async(*self.ns_window, dummy.origin);
         }
     }
 
     #[inline]
     pub fn inner_size(&self) -> LogicalSize {
-        let view_frame = unsafe { NSView::frame(*self.nsview) };
+        let view_frame = unsafe { NSView::frame(*self.ns_view) };
         (view_frame.size.width as f64, view_frame.size.height as f64).into()
     }
 
     #[inline]
     pub fn outer_size(&self) -> LogicalSize {
-        let view_frame = unsafe { NSWindow::frame(*self.nswindow) };
+        let view_frame = unsafe { NSWindow::frame(*self.ns_window) };
         (view_frame.size.width as f64, view_frame.size.height as f64).into()
     }
 
     #[inline]
     pub fn set_inner_size(&self, size: LogicalSize) {
         unsafe {
-            util::set_content_size_async(*self.nswindow, size);
+            util::set_content_size_async(*self.ns_window, size);
         }
     }
 
     pub fn set_min_inner_size(&self, dimensions: Option<LogicalSize>) {
         unsafe {
             let dimensions = dimensions.unwrap_or_else(|| (0, 0).into());
-            set_min_inner_size(*self.nswindow, dimensions);
+            set_min_inner_size(*self.ns_window, dimensions);
         }
     }
 
     pub fn set_max_inner_size(&self, dimensions: Option<LogicalSize>) {
         unsafe {
             let dimensions = dimensions.unwrap_or_else(|| (!0, !0).into());
-            set_max_inner_size(*self.nswindow, dimensions);
+            set_max_inner_size(*self.ns_window, dimensions);
         }
     }
 
@@ -473,7 +473,7 @@ impl UnownedWindow {
             shared_state_lock.fullscreen.is_some()
         };
         if !fullscreen {
-            let mut mask = unsafe { self.nswindow.styleMask() };
+            let mut mask = unsafe { self.ns_window.styleMask() };
             if resizable {
                 mask |= NSWindowStyleMask::NSResizableWindowMask;
             } else {
@@ -489,8 +489,8 @@ impl UnownedWindow {
             *cursor_access.lock().unwrap() = cursor;
         }
         unsafe {
-            let _: () = msg_send![*self.nswindow,
-                invalidateCursorRectsForView:*self.nsview
+            let _: () = msg_send![*self.ns_window,
+                invalidateCursorRectsForView:*self.ns_view
             ];
         }
     }
@@ -519,7 +519,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn hidpi_factor(&self) -> f64 {
-        unsafe { NSWindow::backingScaleFactor(*self.nswindow) as _ }
+        unsafe { NSWindow::backingScaleFactor(*self.ns_window) as _ }
     }
 
     #[inline]
@@ -540,7 +540,7 @@ impl UnownedWindow {
     pub(crate) fn is_zoomed(&self) -> bool {
         // because `isZoomed` doesn't work if the window's borderless,
         // we make it resizable temporalily.
-        let curr_mask = unsafe { self.nswindow.styleMask() };
+        let curr_mask = unsafe { self.ns_window.styleMask() };
 
         let required = NSWindowStyleMask::NSTitledWindowMask
             | NSWindowStyleMask::NSResizableWindowMask;
@@ -549,7 +549,7 @@ impl UnownedWindow {
             self.set_style_mask_sync(required);
         }
 
-        let is_zoomed: BOOL = unsafe { msg_send![*self.nswindow, isZoomed] };
+        let is_zoomed: BOOL = unsafe { msg_send![*self.ns_window, isZoomed] };
 
         // Roll back temp styles
         if needs_temp_mask {
@@ -562,7 +562,7 @@ impl UnownedWindow {
     fn saved_style(&self, shared_state: &mut SharedState) -> NSWindowStyleMask {
         let base_mask = shared_state.saved_style
             .take()
-            .unwrap_or_else(|| unsafe { self.nswindow.styleMask() });
+            .unwrap_or_else(|| unsafe { self.ns_window.styleMask() });
         if shared_state.resizable {
             base_mask | NSWindowStyleMask::NSResizableWindowMask
         } else {
@@ -604,19 +604,19 @@ impl UnownedWindow {
         // Save the standard frame sized if it is not zoomed
         if !is_zoomed {
             unsafe {
-                shared_state_lock.standard_frame = Some(NSWindow::frame(*self.nswindow));
+                shared_state_lock.standard_frame = Some(NSWindow::frame(*self.ns_window));
             }
         }
 
         shared_state_lock.maximized = maximized;
 
-        let curr_mask = unsafe { self.nswindow.styleMask() };
+        let curr_mask = unsafe { self.ns_window.styleMask() };
         if shared_state_lock.fullscreen.is_some() {
             // Handle it in window_did_exit_fullscreen
             return;
         } else if curr_mask.contains(NSWindowStyleMask::NSResizableWindowMask) {
             // Just use the native zoom if resizable
-            unsafe { self.nswindow.zoom_(nil) };
+            unsafe { self.ns_window.zoom_(nil) };
         } else {
             // if it's not resizable, we set the frame directly
             unsafe {
@@ -627,7 +627,7 @@ impl UnownedWindow {
                     Self::saved_standard_frame(&mut *shared_state_lock)
                 };
                 // This probably isn't thread-safe!
-                self.nswindow.setFrame_display_(new_rect, 0);
+                self.ns_window.setFrame_display_(new_rect, 0);
             }
         }
 
@@ -666,8 +666,8 @@ impl UnownedWindow {
         };
 
         unsafe { util::toggle_full_screen_async(
-            *self.nswindow,
-            *self.nsview,
+            *self.ns_window,
+            *self.ns_view,
             not_fullscreen,
             Arc::downgrade(&self.shared_state),
         ) };
@@ -718,7 +718,7 @@ impl UnownedWindow {
         } else {
             ffi::NSWindowLevel::NSNormalWindowLevel
         };
-        unsafe { util::set_level_async(*self.nswindow, level) };
+        unsafe { util::set_level_async(*self.ns_window, level) };
     }
 
     #[inline]
@@ -737,7 +737,7 @@ impl UnownedWindow {
     pub fn set_ime_position(&self, logical_spot: LogicalPosition) {
         unsafe {
             view::set_ime_position(
-                *self.nsview,
+                *self.ns_view,
                 *self.input_context,
                 logical_spot.x,
                 logical_spot.y,
@@ -748,7 +748,7 @@ impl UnownedWindow {
     #[inline]
     pub fn current_monitor(&self) -> RootMonitorHandle {
         unsafe {
-            let screen: id = msg_send![*self.nswindow, screen];
+            let screen: id = msg_send![*self.ns_window, screen];
             let desc = NSScreen::deviceDescription(screen);
             let key = IdRef::new(NSString::alloc(nil).init_str("NSScreenNumber"));
             let value = NSDictionary::valueForKey_(desc, *key);
@@ -770,13 +770,13 @@ impl UnownedWindow {
 
 impl WindowExtMacOS for UnownedWindow {
     #[inline]
-    fn nswindow(&self) -> *mut c_void {
-        *self.nswindow as *mut _
+    fn ns_window(&self) -> *mut c_void {
+        *self.ns_window as *mut _
     }
 
     #[inline]
-    fn nsview(&self) -> *mut c_void {
-        *self.nsview as *mut _
+    fn ns_view(&self) -> *mut c_void {
+        *self.ns_view as *mut _
     }
 
     #[inline]
@@ -811,8 +811,8 @@ impl WindowExtMacOS for UnownedWindow {
 
             if fullscreen {
                 // Remember the original window's settings
-                shared_state_lock.standard_frame = Some(NSWindow::frame(*self.nswindow));
-                shared_state_lock.saved_style = Some(self.nswindow.styleMask());
+                shared_state_lock.standard_frame = Some(NSWindow::frame(*self.ns_window));
+                shared_state_lock.saved_style = Some(self.ns_window.styleMask());
                 shared_state_lock.save_presentation_opts = Some(app.presentationOptions_());
 
                 // Tell our window's state that we're in fullscreen
@@ -825,17 +825,17 @@ impl WindowExtMacOS for UnownedWindow {
                 app.setPresentationOptions_(presentation_options);
 
                 // Hide the titlebar
-                util::toggle_style_mask(*self.nswindow, *self.nsview, NSWindowStyleMask::NSTitledWindowMask, false);
+                util::toggle_style_mask(*self.ns_window, *self.ns_view, NSWindowStyleMask::NSTitledWindowMask, false);
 
                 // Set the window frame to the screen frame size
-                let screen = self.nswindow.screen();
+                let screen = self.ns_window.screen();
                 let screen_frame = NSScreen::frame(screen);
-                NSWindow::setFrame_display_(*self.nswindow, screen_frame, YES);
+                NSWindow::setFrame_display_(*self.ns_window, screen_frame, YES);
 
                 // Fullscreen windows can't be resized, minimized, or moved
-                util::toggle_style_mask(*self.nswindow, *self.nsview, NSWindowStyleMask::NSMiniaturizableWindowMask, false);
-                util::toggle_style_mask(*self.nswindow, *self.nsview, NSWindowStyleMask::NSResizableWindowMask, false);
-                NSWindow::setMovable_(*self.nswindow, NO);
+                util::toggle_style_mask(*self.ns_window, *self.ns_view, NSWindowStyleMask::NSMiniaturizableWindowMask, false);
+                util::toggle_style_mask(*self.ns_window, *self.ns_view, NSWindowStyleMask::NSResizableWindowMask, false);
+                NSWindow::setMovable_(*self.ns_window, NO);
 
                 true
             } else {
@@ -848,8 +848,8 @@ impl WindowExtMacOS for UnownedWindow {
                 }
 
                 let frame = Self::saved_standard_frame(&mut *shared_state_lock);
-                NSWindow::setFrame_display_(*self.nswindow, frame, YES);
-                NSWindow::setMovable_(*self.nswindow, YES);
+                NSWindow::setFrame_display_(*self.ns_window, frame, YES);
+                NSWindow::setMovable_(*self.ns_window, YES);
 
                 true
             }
@@ -861,8 +861,8 @@ impl Drop for UnownedWindow {
     fn drop(&mut self) {
         trace!("Dropping `UnownedWindow` ({:?})", self as *mut _);
         // Close the window if it has not yet been closed.
-        if *self.nswindow != nil {
-            unsafe { util::close_async(*self.nswindow) };
+        if *self.ns_window != nil {
+            unsafe { util::close_async(*self.ns_window) };
         }
     }
 }


### PR DESCRIPTION
This makes the macOS API style consistent with that of iOS. It also makes it easier to read long identifiers when they're added in the future.

----

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
