### PR TITLE
Make `log` an optional default dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 - Removed `serde` implementations from `ControlFlow`.
 - Rename several functions to improve both internal consistency and compliance with Rust API guidelines.
 - Remove `WindowBuilder::multitouch` field, since it was only implemented on a few platforms. Multitouch is always enabled now.
+- **Breaking:** Make `log` an optional default dependency
 
 # Version 0.19.1 (2019-04-08)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ features = ["serde"]
 [dependencies]
 lazy_static = "1"
 libc = "0.2"
-log = "0.4"
+log = { version = "0.4", optional = true }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]
@@ -72,3 +72,6 @@ percent-encoding = "1.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows"))'.dependencies.parking_lot]
 version = "0.8"
+
+[features]
+default = ["log"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@
 #[macro_use]
 extern crate lazy_static;
 extern crate libc;
+#[cfg(feature = "log")]
 #[macro_use]
 extern crate log;
 #[cfg(feature = "serde")]
@@ -118,6 +119,8 @@ pub mod error;
 pub mod event;
 pub mod event_loop;
 mod icon;
+#[macro_use]
+mod macros;
 mod platform_impl;
 pub mod window;
 pub mod monitor;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,33 @@
+/// Allows for using `log` macros when the feature is disabled.
+#[allow(unused)]
+#[cfg(not(feature = "log"))]
+#[macro_use]
+mod log {
+    macro_rules! debug {
+        ($($t:tt)*) => {}
+    }
+
+    macro_rules! error {
+        ($($t:tt)*) => {}
+    }
+
+    macro_rules! info {
+        ($($t:tt)*) => {}
+    }
+
+    macro_rules! log {
+        ($($t:tt)*) => {}
+    }
+
+    macro_rules! log_enabled {
+        ($($t:tt)*) => { false }
+    }
+
+    macro_rules! trace {
+        ($($t:tt)*) => {}
+    }
+
+    macro_rules! warn {
+        ($($t:tt)*) => {}
+    }
+}


### PR DESCRIPTION
Not all users of `winit` intend on logging events via `log`. This allows for opting out of the dependency.

----

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
