### PR TITLE
Drop platform name from extension traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
       - `Exit` aborts the event loop.
     - Takes a closure that implements `'static + FnMut(Event<T>, &EventLoop<T>, &mut ControlFlow)`.
       - `&EventLoop<T>` is provided to allow new `Window`s to be created.
-  - **Major:** `platform::desktop` module exposes `EventLoopExtDesktop` trait with `run_return` method.
+  - **Major:** `platform::desktop` module exposes `EventLoopExt` trait with `run_return` method.
     - Behaves identically to `run`, but returns control flow to the calling context and can take non-`'static` closures.
   - `EventLoop`'s `poll_events` and `run_forever` methods have been removed in favor of `run` and `run_return`.
 - Changes to events:

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -70,8 +70,8 @@ fn main() {
                         #[cfg(target_os = "macos")]
                         {
                             if macos_use_simple_fullscreen {
-                                use winit::platform::macos::WindowExtMacOS;
-                                if WindowExtMacOS::set_simple_fullscreen(&window, !is_fullscreen) {
+                                use winit::platform::macos::WindowExt;
+                                if WindowExt::set_simple_fullscreen(&window, !is_fullscreen) {
                                     is_fullscreen = !is_fullscreen;
                                 }
                                 return;
@@ -90,8 +90,8 @@ fn main() {
 
                         #[cfg(target_os = "macos")]
                         {
-                            use winit::platform::macos::WindowExtMacOS;
-                            println!("window.simple_fullscreen {:?}", WindowExtMacOS::simple_fullscreen(&window));
+                            use winit::platform::macos::WindowExt;
+                            println!("window.simple_fullscreen {:?}", WindowExt::simple_fullscreen(&window));
                         }
                     }
                     (VirtualKeyCode::M, ElementState::Pressed) => {

--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -3,7 +3,7 @@ extern crate winit;
 use winit::window::WindowBuilder;
 use winit::event::{Event, WindowEvent};
 use winit::event_loop::{EventLoop, ControlFlow};
-use winit::platform::desktop::EventLoopExtDesktop;
+use winit::platform::desktop::EventLoopExt;
 
 fn main() {
     let mut event_loop = EventLoop::new();

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -6,23 +6,23 @@ use Window;
 use WindowBuilder;
 
 /// Additional methods on `EventLoop` that are specific to Android.
-pub trait EventLoopExtAndroid {
+pub trait EventLoopExt {
     /// Makes it possible for glutin to register a callback when a suspend event happens on Android
     fn set_suspend_callback(&self, cb: Option<Box<Fn(bool) -> ()>>);
 }
 
-impl EventLoopExtAndroid for EventLoop {
+impl EventLoopExt for EventLoop {
     fn set_suspend_callback(&self, cb: Option<Box<Fn(bool) -> ()>>) {
         self.event_loop.set_suspend_callback(cb);
     }
 }
 
 /// Additional methods on `Window` that are specific to Android.
-pub trait WindowExtAndroid {
+pub trait WindowExt {
     fn native_window(&self) -> *const c_void;
 }
 
-impl WindowExtAndroid for Window {
+impl WindowExt for Window {
     #[inline]
     fn native_window(&self) -> *const c_void {
         self.window.native_window()
@@ -30,9 +30,9 @@ impl WindowExtAndroid for Window {
 }
 
 /// Additional methods on `WindowBuilder` that are specific to Android.
-pub trait WindowBuilderExtAndroid {
+pub trait WindowBuilderExt {
 
 }
 
-impl WindowBuilderExtAndroid for WindowBuilder {
+impl WindowBuilderExt for WindowBuilder {
 }

--- a/src/platform/desktop.rs
+++ b/src/platform/desktop.rs
@@ -8,7 +8,7 @@ use event::Event;
 use event_loop::{EventLoop, EventLoopWindowTarget, ControlFlow};
 
 /// Additional methods on `EventLoop` that are specific to desktop platforms.
-pub trait EventLoopExtDesktop {
+pub trait EventLoopExt {
     /// A type provided by the user that can be passed through `Event::UserEvent`.
     type UserEvent;
 
@@ -20,7 +20,7 @@ pub trait EventLoopExtDesktop {
         where F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
 }
 
-impl<T> EventLoopExtDesktop for EventLoop<T> {
+impl<T> EventLoopExt for EventLoop<T> {
     type UserEvent = T;
 
     fn run_return<F>(&mut self, event_handler: F)

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -7,19 +7,19 @@ use monitor::MonitorHandle;
 use window::{Window, WindowBuilder};
 
 /// Additional methods on `EventLoop` that are specific to iOS.
-pub trait EventLoopExtIOS {
+pub trait EventLoopExt {
     /// Returns the idiom (phone/tablet/tv/etc) for the current device.
     fn idiom(&self) -> Idiom;
 }
 
-impl<T: 'static> EventLoopExtIOS for EventLoop<T> {
+impl<T: 'static> EventLoopExt for EventLoop<T> {
     fn idiom(&self) -> Idiom {
         self.event_loop.idiom()
     }
 }
 
 /// Additional methods on `Window` that are specific to iOS.
-pub trait WindowExtIOS {
+pub trait WindowExt {
     /// Returns a pointer to the `UIWindow` that is used by this window.
     ///
     /// The pointer will become invalid when the `Window` is destroyed.
@@ -46,7 +46,7 @@ pub trait WindowExtIOS {
     fn set_valid_orientations(&self, valid_orientations: ValidOrientations);
 }
 
-impl WindowExtIOS for Window {
+impl WindowExt for Window {
     #[inline]
     fn ui_window(&self) -> *mut c_void {
         self.window.ui_window() as _
@@ -74,7 +74,7 @@ impl WindowExtIOS for Window {
 }
 
 /// Additional methods on `WindowBuilder` that are specific to iOS.
-pub trait WindowBuilderExtIOS {
+pub trait WindowBuilderExt {
     /// Sets the root view class used by the `Window`, otherwise a barebones `UIView` is provided.
     ///
     /// The class will be initialized by calling `[root_view initWithFrame:CGRect]`
@@ -90,7 +90,7 @@ pub trait WindowBuilderExtIOS {
     fn with_valid_orientations(self, valid_orientations: ValidOrientations) -> WindowBuilder;
 }
 
-impl WindowBuilderExtIOS for WindowBuilder {
+impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_root_view_class(mut self, root_view_class: *const c_void) -> WindowBuilder {
         self.platform_specific.root_view_class = unsafe { &*(root_view_class as *const _) };
@@ -111,12 +111,12 @@ impl WindowBuilderExtIOS for WindowBuilder {
 }
 
 /// Additional methods on `MonitorHandle` that are specific to iOS.
-pub trait MonitorHandleExtIOS {
+pub trait MonitorHandleExt {
     /// Returns a pointer to the `UIScreen` that is used by this monitor.
     fn ui_screen(&self) -> *mut c_void;
 }
 
-impl MonitorHandleExtIOS for MonitorHandle {
+impl MonitorHandleExt for MonitorHandle {
     #[inline]
     fn ui_screen(&self) -> *mut c_void {
         self.inner.ui_screen() as _

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -7,7 +7,7 @@ use crate::monitor::MonitorHandle;
 use crate::window::{Window, WindowBuilder};
 
 /// Additional methods on `Window` that are specific to MacOS.
-pub trait WindowExtMacOS {
+pub trait WindowExt {
     /// Returns a pointer to the cocoa `NSWindow` that is used by this window.
     ///
     /// The pointer will become invalid when the `Window` is destroyed.
@@ -39,7 +39,7 @@ pub trait WindowExtMacOS {
     fn set_simple_fullscreen(&self, fullscreen: bool) -> bool;
 }
 
-impl WindowExtMacOS for Window {
+impl WindowExt for Window {
     #[inline]
     fn nswindow(&self) -> *mut c_void {
         self.window.nswindow()
@@ -93,7 +93,7 @@ impl Default for ActivationPolicy {
 ///  - `with_titlebar_hidden`
 ///  - `with_titlebar_buttons_hidden`
 ///  - `with_fullsize_content_view`
-pub trait WindowBuilderExtMacOS {
+pub trait WindowBuilderExt {
     /// Sets the activation policy for the window being built.
     fn with_activation_policy(self, activation_policy: ActivationPolicy) -> WindowBuilder;
     /// Enables click-and-drag behavior for the entire window, not just the titlebar.
@@ -112,7 +112,7 @@ pub trait WindowBuilderExtMacOS {
     fn with_resize_increments(self, increments: LogicalSize) -> WindowBuilder;
 }
 
-impl WindowBuilderExtMacOS for WindowBuilder {
+impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_activation_policy(mut self, activation_policy: ActivationPolicy) -> WindowBuilder {
         self.platform_specific.activation_policy = activation_policy;
@@ -163,14 +163,14 @@ impl WindowBuilderExtMacOS for WindowBuilder {
 }
 
 /// Additional methods on `MonitorHandle` that are specific to MacOS.
-pub trait MonitorHandleExtMacOS {
+pub trait MonitorHandleExt {
     /// Returns the identifier of the monitor for Cocoa.
     fn native_id(&self) -> u32;
     /// Returns a pointer to the NSScreen representing this monitor.
     fn nsscreen(&self) -> Option<*mut c_void>;
 }
 
-impl MonitorHandleExtMacOS for MonitorHandle {
+impl MonitorHandleExt for MonitorHandle {
     #[inline]
     fn native_id(&self) -> u32 {
         self.inner.native_identifier()

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -94,7 +94,7 @@ impl Theme for WaylandThemeObject {
 }
 
 /// Additional methods on `EventLoop` that are specific to Unix.
-pub trait EventLoopExtUnix {
+pub trait EventLoopExt {
     /// Builds a new `EventLoops` that is forced to use X11.
     fn new_x11() -> Result<Self, XNotSupported>
         where Self: Sized;
@@ -120,7 +120,7 @@ pub trait EventLoopExtUnix {
     fn wayland_display(&self) -> Option<*mut raw::c_void>;
 }
 
-impl<T> EventLoopExtUnix for EventLoop<T> {
+impl<T> EventLoopExt for EventLoop<T> {
     #[inline]
     fn new_x11() -> Result<Self, XNotSupported> {
         LinuxEventLoop::new_x11().map(|ev|
@@ -171,7 +171,7 @@ impl<T> EventLoopExtUnix for EventLoop<T> {
 }
 
 /// Additional methods on `Window` that are specific to Unix.
-pub trait WindowExtUnix {
+pub trait WindowExt {
     /// Returns the ID of the `Window` xlib object that is used by this window.
     ///
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
@@ -226,7 +226,7 @@ pub trait WindowExtUnix {
     fn is_ready(&self) -> bool;
 }
 
-impl WindowExtUnix for Window {
+impl WindowExt for Window {
     #[inline]
     fn xlib_window(&self) -> Option<raw::c_ulong> {
         match self.window {
@@ -306,7 +306,7 @@ impl WindowExtUnix for Window {
 }
 
 /// Additional methods on `WindowBuilder` that are specific to Unix.
-pub trait WindowBuilderExtUnix {
+pub trait WindowBuilderExt {
     fn with_x11_visual<T>(self, visual_infos: *const T) -> WindowBuilder;
     fn with_x11_screen(self, screen_id: i32) -> WindowBuilder;
 
@@ -331,7 +331,7 @@ pub trait WindowBuilderExtUnix {
     fn with_app_id(self, app_id: String) -> WindowBuilder;
 }
 
-impl WindowBuilderExtUnix for WindowBuilder {
+impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_x11_visual<T>(mut self, visual_infos: *const T) -> WindowBuilder {
         self.platform_specific.visual_infos = Some(
@@ -390,12 +390,12 @@ impl WindowBuilderExtUnix for WindowBuilder {
 }
 
 /// Additional methods on `MonitorHandle` that are specific to Linux.
-pub trait MonitorHandleExtUnix {
+pub trait MonitorHandleExt {
     /// Returns the inner identifier of the monitor.
     fn native_id(&self) -> u32;
 }
 
-impl MonitorHandleExtUnix for MonitorHandle {
+impl MonitorHandleExt for MonitorHandle {
     #[inline]
     fn native_id(&self) -> u32 {
         self.inner.native_identifier()

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -12,13 +12,13 @@ use window::{Icon, Window, WindowBuilder};
 use platform_impl::EventLoop as WindowsEventLoop;
 
 /// Additional methods on `EventLoop` that are specific to Windows.
-pub trait EventLoopExtWindows {
+pub trait EventLoopExt {
     /// By default, winit on Windows will attempt to enable process-wide DPI awareness. If that's
     /// undesirable, you can create an `EventLoop` using this function instead.
     fn new_dpi_unaware() -> Self where Self: Sized;
 }
 
-impl<T> EventLoopExtWindows for EventLoop<T> {
+impl<T> EventLoopExt for EventLoop<T> {
     #[inline]
     fn new_dpi_unaware() -> Self {
         EventLoop {
@@ -29,7 +29,7 @@ impl<T> EventLoopExtWindows for EventLoop<T> {
 }
 
 /// Additional methods on `Window` that are specific to Windows.
-pub trait WindowExtWindows {
+pub trait WindowExt {
     /// Returns the native handle that is used by this window.
     ///
     /// The pointer will become invalid when the native window was destroyed.
@@ -39,7 +39,7 @@ pub trait WindowExtWindows {
     fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>);
 }
 
-impl WindowExtWindows for Window {
+impl WindowExt for Window {
     #[inline]
     fn hwnd(&self) -> *mut libc::c_void {
         self.window.hwnd() as *mut _
@@ -52,7 +52,7 @@ impl WindowExtWindows for Window {
 }
 
 /// Additional methods on `WindowBuilder` that are specific to Windows.
-pub trait WindowBuilderExtWindows {
+pub trait WindowBuilderExt {
     /// Sets a parent to the window to be created.
     fn with_parent_window(self, parent: HWND) -> WindowBuilder;
 
@@ -63,7 +63,7 @@ pub trait WindowBuilderExtWindows {
     fn with_no_redirection_bitmap(self, flag: bool) -> WindowBuilder;
 }
 
-impl WindowBuilderExtWindows for WindowBuilder {
+impl WindowBuilderExt for WindowBuilder {
     #[inline]
     fn with_parent_window(mut self, parent: HWND) -> WindowBuilder {
         self.platform_specific.parent = Some(parent);
@@ -84,7 +84,7 @@ impl WindowBuilderExtWindows for WindowBuilder {
 }
 
 /// Additional methods on `MonitorHandle` that are specific to Windows.
-pub trait MonitorHandleExtWindows {
+pub trait MonitorHandleExt {
     /// Returns the name of the monitor adapter specific to the Win32 API.
     fn native_id(&self) -> String;
 
@@ -92,7 +92,7 @@ pub trait MonitorHandleExtWindows {
     fn hmonitor(&self) -> *mut c_void;
 }
 
-impl MonitorHandleExtWindows for MonitorHandle {
+impl MonitorHandleExt for MonitorHandle {
     #[inline]
     fn native_id(&self) -> String {
         self.inner.native_identifier()
@@ -105,14 +105,14 @@ impl MonitorHandleExtWindows for MonitorHandle {
 }
 
 /// Additional methods on `DeviceId` that are specific to Windows.
-pub trait DeviceIdExtWindows {
+pub trait DeviceIdExt {
     /// Returns an identifier that persistently refers to this specific device.
     ///
     /// Will return `None` if the device is no longer available.
     fn persistent_identifier(&self) -> Option<String>;
 }
 
-impl DeviceIdExtWindows for DeviceId {
+impl DeviceIdExt for DeviceId {
     #[inline]
     fn persistent_identifier(&self) -> Option<String> {
         self.0.persistent_identifier()

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -138,7 +138,7 @@ impl<T: 'static> EventLoop<T> {
     }
 }
 
-// EventLoopExtIOS
+// EventLoopExt
 impl<T: 'static> EventLoop<T> {
     pub fn idiom(&self) -> Idiom {
         // guaranteed to be on main thread

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -136,7 +136,7 @@ impl Inner {
     }
 }
 
-// MonitorHandleExtIOS
+// MonitorHandleExt
 impl Inner {
     pub fn ui_screen(&self) -> id {
         self.uiscreen

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -10,7 +10,7 @@ use event::{
     TouchPhase,
     WindowEvent
 };
-use platform::ios::MonitorHandleExtIOS;
+use platform::ios::MonitorHandleExt;
 use window::{WindowAttributes, WindowId as RootWindowId};
 
 use platform_impl::platform::app_state::AppState;

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -9,7 +9,7 @@ use dpi::{self, LogicalPosition, LogicalSize};
 use error::{ExternalError, NotSupportedError, OsError as RootOsError};
 use icon::Icon;
 use monitor::MonitorHandle as RootMonitorHandle;
-use platform::ios::{MonitorHandleExtIOS, ValidOrientations};
+use platform::ios::{MonitorHandleExt, ValidOrientations};
 use window::{
     CursorIcon,
     WindowAttributes,
@@ -340,7 +340,7 @@ impl Window {
     }
 }
 
-// WindowExtIOS
+// WindowExt
 impl Inner {
     pub fn ui_window(&self) -> id { self.window }
     pub fn ui_view_controller(&self) -> id { self.view_controller }
@@ -348,7 +348,7 @@ impl Inner {
 
     pub fn set_hidpi_factor(&self, hidpi_factor: f64) {
         unsafe {
-            assert!(dpi::validate_hidpi_factor(hidpi_factor), "`WindowExtIOS::set_hidpi_factor` received an invalid hidpi factor");
+            assert!(dpi::validate_hidpi_factor(hidpi_factor), "`WindowExt::set_hidpi_factor` received an invalid hidpi factor");
             let hidpi_factor = hidpi_factor as CGFloat;
             let () = msg_send![self.view, setContentScaleFactor:hidpi_factor];
         }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -23,7 +23,7 @@ use {
         CursorIcon, WindowAttributes, WindowId as RootWindowId,
     },
 };
-use platform::macos::{ActivationPolicy, WindowExtMacOS};
+use platform::macos::{ActivationPolicy, WindowExt};
 use platform_impl::platform::{
     OsError,
     app_state::AppState, ffi, monitor::{self, MonitorHandle},
@@ -768,7 +768,7 @@ impl UnownedWindow {
     }
 }
 
-impl WindowExtMacOS for UnownedWindow {
+impl WindowExt for UnownedWindow {
     #[inline]
     fn nswindow(&self) -> *mut c_void {
         *self.nswindow as *mut _


### PR DESCRIPTION
As mentioned in https://github.com/rust-windowing/winit/issues/459#issuecomment-500286307, I feel as though adding the name of the platform to the `Ext` traits feels awkward and inconsistent with the Rust ecosystem. Also, these traits are already within their own modules specific to each platform.

----

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
