### PR TITLE
Fix initial dimensions of a fullscreen window on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - **Breaking:** On macOS, change `ns` identifiers to use snake_case for consistency with iOS's `ui` identifiers.
 - Add `MonitorHandle::video_modes` method for retrieving supported video modes for the given monitor.
 - On Wayland, the window now exists even if nothing has been drawn.
+- On Windows, fix initial dimensions of a fullscreen window.
 
 # Version 0.19.1 (2019-04-08)
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -287,7 +287,7 @@ impl WindowBuilder {
         self.window.inner_size = Some(self.window.inner_size.unwrap_or_else(|| {
             if let Some(ref monitor) = self.window.fullscreen {
                 // resizing the window to the dimensions of the monitor when fullscreen
-                LogicalSize::from_physical(monitor.size(), 1.0)
+                LogicalSize::from_physical(monitor.size(), monitor.hidpi_factor()) // DPI factor applies here since this is a borderless window and not real fullscreen
             } else {
                 // default dimensions
                 (1024, 768).into()


### PR DESCRIPTION
Previously, creating a fullscreen window on Windows would result in the window spanning more than a single monitor since the DPI factor was not taken into account. A workaround was to manually specify the size for the window, but this is no longer necessary.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
