### PR TITLE
Fix WindowBuilder function names that missed first pass

### DIFF
--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -7,7 +7,7 @@ fn main() {
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new().with_decorations(false)
-                                                 .with_transparency(true)
+                                                 .with_transparent(true)
                                                  .build(&event_loop).unwrap();
 
     window.set_title("A fantastic window!");

--- a/src/window.rs
+++ b/src/window.rs
@@ -234,14 +234,14 @@ impl WindowBuilder {
 
     /// Sets whether the window will be initially hidden or visible.
     #[inline]
-    pub fn with_visibility(mut self, visible: bool) -> WindowBuilder {
+    pub fn with_visible(mut self, visible: bool) -> WindowBuilder {
         self.window.visible = visible;
         self
     }
 
     /// Sets whether the background of the window should be transparent.
     #[inline]
-    pub fn with_transparency(mut self, transparent: bool) -> WindowBuilder {
+    pub fn with_transparent(mut self, transparent: bool) -> WindowBuilder {
         self.window.transparent = transparent;
         self
     }


### PR DESCRIPTION
Should be fairly uncontroversial. These functions missed the first consistency pass.