### PR TITLE
Disable caching on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: rust
 
-cache: cargo
-
 matrix:
   include:
     # Linux 32bit


### PR DESCRIPTION
Linux builds on Travis builds seem to be stalling, and from the looks of it, while trying to extract the cache. If this is indeed the issue, it can be remedied by clearing the caches by hand. However, from past experience, they fill up pretty quickly (and stay that way), so I've found it better to disable caching outright. We'd have to see how this affects build times, but it shouldn't be too bad.