### PR TITLE
Set CHANGELOG.md merge style to union

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,3 +20,5 @@
 *.PDF	 diff=astextplain
 *.rtf	 diff=astextplain
 *.RTF	 diff=astextplain
+
+/CHANGELOG.md merge=union


### PR DESCRIPTION
We've had quite a few unnecessary merge conflicts due to git not knowing how to merge changes `CHANGELOG.md`. This should change the merge style on that file to just pull in all changes from everywhere, hopefully stopping that.