### PR TITLE
Update example in README.md and add move prefix to window.rs example closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,27 @@ another library.
 
 ```rust
 extern crate winit;
+use winit::window::WindowBuilder;
+use winit::event::{Event, WindowEvent};
+use winit::event_loop::{EventLoop, ControlFlow};
 
 fn main() {
-    let mut event_loop = winit::EventLoop::new();
-    let window = winit::Window::new(&event_loop).unwrap();
+    let event_loop = EventLoop::new();
 
-    event_loop.run(|event| {
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .build(&event_loop)
+        .unwrap();
+
+    event_loop.run(move |event, _, control_flow| {
+        println!("{:?}", event);
+
         match event {
-            winit::Event::WindowEvent {
-              event: winit::WindowEvent::CloseRequested,
-              ..
-            } => winit::ControlFlow::Break,
-            _ => winit::ControlFlow::Continue,
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => *control_flow = ControlFlow::Exit,
+            _ => *control_flow = ControlFlow::Wait,
         }
     });
 }

--- a/README.md
+++ b/README.md
@@ -38,15 +38,9 @@ use winit::event_loop::{EventLoop, ControlFlow};
 
 fn main() {
     let event_loop = EventLoop::new();
-
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .build(&event_loop)
-        .unwrap();
+    let window = WindowBuilder::new().build(&event_loop).unwrap();
 
     event_loop.run(move |event, _, control_flow| {
-        println!("{:?}", event);
-
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ fn main() {
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
-                ..
-            } => *control_flow = ControlFlow::Exit,
+                window_id,
+            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
             _ => *control_flow = ControlFlow::Wait,
         }
     });

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -11,7 +11,7 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(|event, _, control_flow| {
+    event_loop.run(move |event, _, control_flow| {
         println!("{:?}", event);
 
         match event {

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -6,7 +6,7 @@ use winit::event_loop::{EventLoop, ControlFlow};
 fn main() {
     let event_loop = EventLoop::new();
 
-    let _window = WindowBuilder::new()
+    let window = WindowBuilder::new()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();
@@ -17,8 +17,8 @@ fn main() {
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
-                ..
-            } => *control_flow = ControlFlow::Exit,
+                window_id,
+            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
             _ => *control_flow = ControlFlow::Wait,
         }
     });


### PR DESCRIPTION
I just realized that the example in `README.md` was still using the old API! Wouldn't have wanted to let that slip through...

This also makes the event closure in `window.rs` a `move` closure. That change isn't *technically* necessary, but most practical modifications to `window.rs` are going to require it, so I figure we might as well add it in to reduce friction for new users using it as a base.