### PR TITLE
Use `dbg!()` macro in monitor list example

### DIFF
--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -5,5 +5,7 @@ use winit::window::WindowBuilder;
 fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
-    println!("{:#?}\nPrimary: {:#?}", window.available_monitors(), window.primary_monitor());
+
+    dbg!(window.available_monitors());
+    dbg!(window.primary_monitor());
 }


### PR DESCRIPTION
Uses the [`dbg!()` macro](https://doc.rust-lang.org/std/macro.dbg.html) which was added in Rust 1.32.