### PR TITLE
Move contributors table to wiki

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ at least a maintainer of the platform (a maintainer making a PR themselves count
 
 ## Maintainers & Testers
 
-Please refer to [this table in the Wiki](https://github.com/rust-windowing/winit/wiki/Testers-and-Contributors)
-for the list of active contributors and testers.
+The current [list of testers and contributors](https://github.com/rust-windowing/winit/wiki/Testers-and-Contributors)
+can be found on the Wiki.
 
 If you are interested in contributing or testing on a platform, please add yourself to that table!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,4 +36,4 @@ at least a maintainer of the platform (a maintainer making a PR themselves count
 
 ## Maintainers & Testers
 
-Please refer to [this table in the Wiki](TODO LINK) for the list of active contributors and testers.
+Please refer to [this table in the Wiki](https://github.com/rust-windowing/winit/wiki/Testers-and-Contributors) for the list of active contributors and testers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,4 +36,7 @@ at least a maintainer of the platform (a maintainer making a PR themselves count
 
 ## Maintainers & Testers
 
-Please refer to [this table in the Wiki](https://github.com/rust-windowing/winit/wiki/Testers-and-Contributors) for the list of active contributors and testers.
+Please refer to [this table in the Wiki](https://github.com/rust-windowing/winit/wiki/Testers-and-Contributors)
+for the list of active contributors and testers.
+
+If you are interested in contributing or testing on a platform, please add yourself to that table!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,24 +36,4 @@ at least a maintainer of the platform (a maintainer making a PR themselves count
 
 ## Maintainers & Testers
 
-Winit is managed by several people, each with their specialities, and each maintaining a subset of the
-backends of winit. As such, depending on your platform of interest, your contacts will be different.
-
-This table summarizes who can be contacted in which case, with the following legend:
-
-- `M` - Maintainer: is a main maintainer for this platform
-- `C` - Collaborator: can review code and address issues on this platform
-- `T` - Tester: has the ability of testing the platform
-- ` `: knows nothing of this platform
-
-| Platform            | Windows | macOS | X11   | Wayland | Android | iOS   | Emscripten |
-| :---                | :---:   | :---: | :---: | :---:   | :---:   | :---: | :---:      |
-| [@mitchmindtree]    | T       |       | T     | T       |         |       |            |
-| [@Osspial]          | M       |       | T     | T       | T       |       | T          |
-| [@vberger]          |         |       | T     | M       |         |       |            |
-| [@mtak-]            |         | T     |       |         | T       | M     |            |
-
-[@mitchmindtree]: https://github.com/mitchmindtree
-[@Osspial]: https://github.com/Osspial
-[@vberger]: https://github.com/vberger
-[@mtak-]: https://github.com/mtak-
+Please refer to [this table in the Wiki](TODO LINK) for the list of active contributors and testers.


### PR DESCRIPTION
The contributors table is a good idea, but it has a tendency to drift out of date since it needs a full PR to update it. My theory here is that moving the table to the Wiki (thus making the table editable by everyone and lowering the stakes for changes) will allow for easier self-reporting and make the table both more accurate and more comprehensive, though whether that is substantiated by reality is yet to be seen.

@mtak- I've re-listed you as an iOS tester on the table, since you mentioned that you weren't able to actively maintain the platform. If you'd like to be listed differently (or not listed at all) I can make that change before creating the wiki page.

@jdm You mentioned that you were able to test for MacOS in https://github.com/rust-windowing/winit/pull/922#issuecomment-502850287, so I've added you to the table. Feel free to change your listing here as you find necessary.

There are a few other people I've seen in the issues that have been helping out regularly and could definitely go on this table (<3), but I don't want to add people to this list without their explicit consent. I won't create the wiki page until we agree to move it out of `CONTRIBUTING.md` to avoid duplication of lists, but the source is visible below.

```markdown
Winit is managed by several people, each with their specialities, and each maintaining a subset of the
backends of winit. As such, depending on your platform of interest, your contacts will be different.

**If you are willing and able to test or contribute to a platform, please add yourself to this table!**
If you've added yourself and are no longer able to contribute, feel free to de-list yourself.

This table summarizes who can be contacted in which case, with the following legend:

- `M` - Maintainer: is a main maintainer for this platform
- `C` - Contributor: can review code and address issues on this platform
- `T` - Tester: can test this platform
- ` `: knows nothing of this platform

| Platform            | Windows | macOS |  X11  | Wayland | Android |  iOS  |  WASM  |
| :---                |  :---:  | :---: | :---: |  :---:  |  :---:  | :---: | :----: |
| [@Osspial]          | M       |       | T     | T       |         |       |        |
| [@vberger]          |         |       | T     | M       |         |       |        |
| [@ryanisaacg]       | T       | T     |       |         |         |       |   M    | 
| [@mitchmindtree]    | T       |       | T     | T       |         |       |        |
| [@mtak-]            |         |       |       |         |         | T     |        |
| [@jdm]              |         | T     |       |         |         |       |        |
| [@ZeGentzy]         |         |       | T     | T       |         |       |        |

[@Osspial]: https://github.com/Osspial
[@vberger]: https://github.com/vberger
[@ryanisaacg]: https://github.com/ryanisaacg
[@mitchmindtree]: https://github.com/mitchmindtree
[@jdm]: https://github.com/jdm
[@mtak-]: https://github.com/mtak-
[@ZeGentzy]: https://github.com/ZeGentzy
```