### PR TITLE
Remove window resize call in timer example

### DIFF
--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,16 +1,10 @@
 extern crate winit;
 use std::time::{Duration, Instant};
-use winit::window::WindowBuilder;
 use winit::event::{Event, WindowEvent, StartCause};
 use winit::event_loop::{EventLoop, ControlFlow};
 
 fn main() {
     let event_loop = EventLoop::new();
-
-    let _window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .build(&event_loop)
-        .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         println!("{:?}", event);
@@ -21,7 +15,6 @@ fn main() {
             Event::NewEvents(StartCause::ResumeTimeReached{..}) => {
                 *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::new(1, 0));
                 println!("\nTimer\n");
-                _window.set_inner_size(winit::dpi::LogicalSize::new(300.0, 300.0));
             },
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -6,14 +6,16 @@ use winit::event_loop::{EventLoop, ControlFlow};
 fn main() {
     let event_loop = EventLoop::new();
 
+    let timer_length = Duration::new(1, 0);
+
     event_loop.run(move |event, _, control_flow| {
         println!("{:?}", event);
 
         match event {
             Event::NewEvents(StartCause::Init) =>
-                *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::new(1, 0)),
+                *control_flow = ControlFlow::WaitUntil(Instant::now() + timer_length),
             Event::NewEvents(StartCause::ResumeTimeReached{..}) => {
-                *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::new(1, 0));
+                *control_flow = ControlFlow::WaitUntil(Instant::now() + timer_length);
                 println!("\nTimer\n");
             },
             Event::WindowEvent {

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,10 +1,16 @@
 extern crate winit;
 use std::time::{Duration, Instant};
+use winit::window::WindowBuilder;
 use winit::event::{Event, WindowEvent, StartCause};
 use winit::event_loop::{EventLoop, ControlFlow};
 
 fn main() {
     let event_loop = EventLoop::new();
+
+    let _window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .build(&event_loop)
+        .unwrap();
 
     let timer_length = Duration::new(1, 0);
 


### PR DESCRIPTION
It looks like a call to `set_inner_size` snuck into the `timer` example at some point, which isn't necessary for the example. This removes that.