### PR TITLE
[#963] Change XRandR display size check to also take height into account

### DIFF
--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -22,7 +22,7 @@ pub fn calc_dpi_factor(
     }
 
     // See http://xpra.org/trac/ticket/728 for more information.
-    if width_mm == 0 || width_mm == 0 {
+    if width_mm == 0 || height_mm == 0 {
         warn!("XRandR reported that the display's 0mm in size, which is certifiably insane");
         return 1.0;
     }


### PR DESCRIPTION
I won't tick any checkboxes as this is a bug, not a feature, so there is no documentation involved. 
Also it only impacts X11 and the fix is trivial.
