### PR TITLE
CHANGELOG.md: Move entries for #805 to 0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,9 @@
 - On Windows, fix `CursorMoved(0, 0)` getting dispatched on window focus.
 - On macOS, fix command key event left and right reverse.
 - On FreeBSD, NetBSD, and OpenBSD, fix build of X11 backend.
+- On Linux, the numpad's add, subtract and divide keys are now mapped to the `Add`, `Subtract` and `Divide` virtual key codes
+- On macOS, the numpad's subtract key has been added to the `Subtract` mapping
+- On Wayland, the numpad's home, end, page up and page down keys are now mapped to the `Home`, `End`, `PageUp` and `PageDown` virtual key codes
 - On Windows, fix icon not showing up in corner of window.
 - On X11, change DPI scaling factor behavior. First, winit tries to read it from "Xft.dpi" XResource, and uses DPI calculation from xrandr dimensions as fallback behavior.
 
@@ -73,9 +76,6 @@
 - On Windows, cursor grabs used to get perpetually canceled when the grabbing window lost focus. Now, cursor grabs automatically get re-initialized when the window regains focus and the mouse moves over the client area.
 - On Windows, only vertical mouse wheel events were handled. Now, horizontal mouse wheel events are also handled.
 - On Windows, ignore the AltGr key when populating the `ModifersState` type.
-- On Linux, the numpad's add, subtract and divide keys are now mapped to the `Add`, `Subtract` and `Divide` virtual key codes
-- On macOS, the numpad's subtract key has been added to the `Subtract` mapping
-- On Wayland, the numpad's home, end, page up and page down keys are now mapped to the `Home`, `End`, `PageUp` and `PageDown` virtual key codes
 
 # Version 0.18.1 (2018-12-30)
 


### PR DESCRIPTION
This change was included in 0.19.1 ([diff](https://github.com/rust-windowing/winit/compare/e0340d52b0...cd5caf6a22#diff-4ac32a78649ca5bdd8e0ba38b7006a1e)), not in 0.19.0 ([diff](https://github.com/rust-windowing/winit/compare/ddf133dd...e0340d52b0#diff-4ac32a78649ca5bdd8e0ba38b7006a1e)).

Btw some git tags would be nice (see [api guide](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#release-notes-document-all-significant-changes-c-relnotes)):

```
git tag v0.19.0 e0340d52
git tag v0.18.1 ddf133dd
```