### PR TITLE
Forward porting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,4 +3,4 @@
 - [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
 - [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
 - [ ] Created an example program if it would help users understand this functionality
-- [ ] Updated [feature matrix](https://github.com/tomaka/winit/blob/master/FEATURES.md), if new features were added or implemented
+- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/apk-builder"]
 	path = deps/apk-builder
-	url = https://github.com/tomaka/android-rs-glue
+	url = https://github.com/rust-windowing/android-rs-glue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - Change `Event::Suspended(true / false)` to `Event::Suspended` and `Event::Resumed`.
+- On X11, fix sanity check which checks that a monitor's reported width and height (in millimeters) are non-zero when calculating the DPI factor.
 
 # 0.20.0 Alpha 1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 keywords = ["windowing"]
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/tomaka/winit"
+repository = "https://github.com/rust-windowing/winit"
 documentation = "https://docs.rs/winit"
 categories = ["gui"]
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -194,18 +194,18 @@ Changes in the API that have been agreed upon but aren't implemented across all 
 |Feature                             |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |Emscripten|
 |------------------------------      | ----- | ---- | ------- | ----------- | ----- | ----- | -------- |
 
-[#165]: https://github.com/tomaka/winit/issues/165
-[#219]: https://github.com/tomaka/winit/issues/219
-[#242]: https://github.com/tomaka/winit/issues/242
-[#306]: https://github.com/tomaka/winit/issues/306
-[#315]: https://github.com/tomaka/winit/issues/315
-[#319]: https://github.com/tomaka/winit/issues/319
-[#33]: https://github.com/tomaka/winit/issues/33
-[#459]: https://github.com/tomaka/winit/issues/459
-[#5]: https://github.com/tomaka/winit/issues/5
-[#63]: https://github.com/tomaka/winit/issues/63
-[#720]: https://github.com/tomaka/winit/issues/720
-[#721]: https://github.com/tomaka/winit/issues/721
-[#750]: https://github.com/tomaka/winit/issues/750
-[#804]: https://github.com/tomaka/winit/issues/804
-[#812]: https://github.com/tomaka/winit/issues/812
+[#165]: https://github.com/rust-windowing/winit/issues/165
+[#219]: https://github.com/rust-windowing/winit/issues/219
+[#242]: https://github.com/rust-windowing/winit/issues/242
+[#306]: https://github.com/rust-windowing/winit/issues/306
+[#315]: https://github.com/rust-windowing/winit/issues/315
+[#319]: https://github.com/rust-windowing/winit/issues/319
+[#33]: https://github.com/rust-windowing/winit/issues/33
+[#459]: https://github.com/rust-windowing/winit/issues/459
+[#5]: https://github.com/rust-windowing/winit/issues/5
+[#63]: https://github.com/rust-windowing/winit/issues/63
+[#720]: https://github.com/rust-windowing/winit/issues/720
+[#721]: https://github.com/rust-windowing/winit/issues/721
+[#750]: https://github.com/rust-windowing/winit/issues/750
+[#804]: https://github.com/rust-windowing/winit/issues/804
+[#812]: https://github.com/rust-windowing/winit/issues/812

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ winit = "0.20.0-alpha1"
 
 ## [Documentation](https://docs.rs/winit)
 
+For features _within_ the scope of winit, see [FEATURES.md](FEATURES.md).
+
+For features _outside_ the scope of winit, see [Missing features provided by other crates](https://github.com/rust-windowing/winit/wiki/Missing-features-provided-by-other-crates) in the wiki.
+
 ## Contact Us
 
 Join us in any of these:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # winit - Cross-platform window creation and management in Rust
 
-[![](http://meritbadge.herokuapp.com/winit)](https://crates.io/crates/winit)
+[![Crates.io](https://img.shields.io/crates/v/winit.svg)](https://crates.io/crates/winit)
 [![Docs.rs](https://docs.rs/winit/badge.svg)](https://docs.rs/winit)
 [![Build Status](https://travis-ci.org/rust-windowing/winit.svg?branch=master)](https://travis-ci.org/rust-windowing/winit)
 [![Build status](https://ci.appveyor.com/api/projects/status/hr89but4x1n3dphq/branch/master?svg=true)](https://ci.appveyor.com/project/Osspial/winit/branch/master)


### PR DESCRIPTION
This should gather the remaining pieces of the winit-legacy branch that are not yet in master.

I did not dig too deep into the mega commits, so can't guarantee that there aren't any funny surprises lurking there, but over all, this has been easier than expected and only a few things came up.

Apart from the commits that had already been ported over, and the commits included here, these are not included because they have been forward-ported in some other way:

- PR #861 (legacy) => PR #963 (master).
  PR #861 was originally merged as 594cd18. Missing commit message included in this PR in a separate commit.

- PR #879 (legacy) => #880 (master).
  Equivalent: Both remove warnings on Linux.

- PR #880 (legacy) => #882 + #884 (master).

- PR #897 + #903 + [the last commit updating README.md](https://github.com/rust-windowing/winit/commit/744913d482a9139b71eac8477abc6085bff106bc) are legacy only.

---

No checkboxes to tick. All changes included only concern documentation files and are simply missing in master.

Closes #961.