### PR TITLE
Implement DeviceEvent::Button on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Mac, implement `DeviceEvent::Button`.
 - Change `Event::Suspended(true / false)` to `Event::Suspended` and `Event::Resumed`.
 - On X11, fix sanity check which checks that a monitor's reported width and height (in millimeters) are non-zero when calculating the DPI factor.
 

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -1,5 +1,5 @@
 use winit::{
-    event::{ElementState, Event, KeyboardInput, WindowEvent},
+    event::{DeviceEvent, ElementState, Event, KeyboardInput, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     window::WindowBuilder,
 };
@@ -14,8 +14,8 @@ fn main() {
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
-        if let Event::WindowEvent { event, .. } = event {
-            match event {
+        match event {
+            Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 WindowEvent::KeyboardInput {
                     input:
@@ -36,7 +36,16 @@ fn main() {
                     }
                 }
                 _ => (),
-            }
+            },
+            Event::DeviceEvent { event, .. } => match event {
+                DeviceEvent::MouseMotion { delta } => println!("mouse moved: {:?}", delta),
+                DeviceEvent::Button { button, state } => match state {
+                    ElementState::Pressed => println!("mouse button {} pressed", button),
+                    ElementState::Released => println!("mouse button {} released", button),
+                },
+                _ => (),
+            },
+            _ => (),
         }
     });
 }

--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -10,7 +10,7 @@ use objc::{
 };
 
 use crate::{
-    event::{DeviceEvent, Event},
+    event::{DeviceEvent, ElementState, Event},
     platform_impl::platform::{app_state::AppState, util, DEVICE_ID},
 };
 
@@ -98,6 +98,32 @@ unsafe fn maybe_dispatch_device_event(event: id) {
                     },
                 });
             }
+
+            AppState::queue_events(events);
+        }
+        appkit::NSLeftMouseDown | appkit::NSRightMouseDown | appkit::NSOtherMouseDown => {
+            let mut events = VecDeque::with_capacity(1);
+
+            events.push_back(Event::DeviceEvent {
+                device_id: DEVICE_ID,
+                event: DeviceEvent::Button {
+                    button: event.buttonNumber() as u32,
+                    state: ElementState::Pressed,
+                },
+            });
+
+            AppState::queue_events(events);
+        }
+        appkit::NSLeftMouseUp | appkit::NSRightMouseUp | appkit::NSOtherMouseUp => {
+            let mut events = VecDeque::with_capacity(1);
+
+            events.push_back(Event::DeviceEvent {
+                device_id: DEVICE_ID,
+                event: DeviceEvent::Button {
+                    button: event.buttonNumber() as u32,
+                    state: ElementState::Released,
+                },
+            });
 
             AppState::queue_events(events);
         }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/tomaka/winit/blob/master/FEATURES.md), if new features were added or implemented

Addresses #955.

This should do the trick, but I don't have a solid test case handy, since my application is still on 0.19.1 (via glium/glutin), and this code has all been refactored since that version.