### PR TITLE
Fix: Invisible windows steal focus from visible windows Win32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Change `Event::Suspended(true / false)` to `Event::Suspended` and `Event::Resumed`.
 - On X11, fix sanity check which checks that a monitor's reported width and height (in millimeters) are non-zero when calculating the DPI factor.
+- On Windows, when a window is initially invisible, it won't take focus from the existing visible windows.
 
 # 0.20.0 Alpha 1
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -271,7 +271,8 @@ impl Window {
                 winuser::SWP_ASYNCWINDOWPOS
                     | winuser::SWP_NOZORDER
                     | winuser::SWP_NOREPOSITION
-                    | winuser::SWP_NOMOVE,
+                    | winuser::SWP_NOMOVE
+                    | winuser::SWP_NOACTIVATE,
             );
             winuser::UpdateWindow(self.window.0);
         }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -307,7 +307,9 @@ impl WindowFlags {
                             y,
                             w,
                             h,
-                            winuser::SWP_NOZORDER | winuser::SWP_FRAMECHANGED,
+                            winuser::SWP_NOZORDER
+                                | winuser::SWP_FRAMECHANGED
+                                | winuser::SWP_NOACTIVATE,
                         );
                     }
                     None => {
@@ -322,7 +324,8 @@ impl WindowFlags {
                             winuser::SWP_NOZORDER
                                 | winuser::SWP_NOMOVE
                                 | winuser::SWP_NOSIZE
-                                | winuser::SWP_FRAMECHANGED,
+                                | winuser::SWP_FRAMECHANGED
+                                | winuser::SWP_NOACTIVATE,
                         );
                     }
                 }


### PR DESCRIPTION
Fixes: https://github.com/rust-windowing/winit/issues/936
Updated the multiwindow example adding an invisible window

- [x] Tested on all platforms changed (Windows only)
- [x] `cargo fmt` has been run on this branch (Tried running it but it modifies a lot of files...)
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created an example program if it would help users understand this functionality
