### PR TITLE
Remove `XFlush` call in event loop

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -291,11 +291,6 @@ impl<T: 'static> EventLoop<T> {
                 );
             }
 
-            // flush the X11 connection
-            unsafe {
-                (wt.xconn.xlib.XFlush)(wt.xconn.display);
-            }
-
             match control_flow {
                 ControlFlow::Exit => break,
                 ControlFlow::Poll => {


### PR DESCRIPTION
Internally, `XFlush` calls `_XSend` to write data. It then calls
`XEventsQueued(display, QueuedAfterReading)`, which reads data from the
X server connection. This prevents the event loop source callback from
being run, as there is no longer data waiting on the socket.

Ideally, we would want to call `_XSend` directly to ensure that no
output is buffered by Xlib. However, this function is not exported as
part of Xlib's public API.

Testing with the `XFlush` call removed does not appear to adversely
affect the performance of an application. If any bugs should eventually
arise from this change, perhaps another function may be used in place of
`XFlush`, such as `XPending`, which writes buffered output but does not
so aggressively read from the X server connection.

Closes #865

- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented