### PR TITLE
Fix broken links to mod DPI on various documentation pages

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -198,7 +198,7 @@ pub enum WindowEvent {
     /// * Changing the display's DPI factor (e.g. in Control Panel on Windows).
     /// * Moving the window to a display with a different DPI factor.
     ///
-    /// For more information about DPI in general, see the [`dpi`](dpi/index.html) module.
+    /// For more information about DPI in general, see the [`dpi`](../dpi/index.html) module.
     HiDpiFactorChanged(f64),
 }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -119,7 +119,7 @@ impl MonitorHandle {
 
     /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
     ///
-    /// See the [`dpi`](dpi/index.html) module for more information.
+    /// See the [`dpi`](../dpi/index.html) module for more information.
     ///
     /// ## Platform-specific
     ///

--- a/src/window.rs
+++ b/src/window.rs
@@ -329,7 +329,7 @@ impl Window {
 
     /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
     ///
-    /// See the [`dpi`](dpi/index.html) module for more information.
+    /// See the [`dpi`](../dpi/index.html) module for more information.
     ///
     /// Note that this value can change depending on user action (for example if the window is
     /// moved to another screen); as such, tracking `WindowEvent::HiDpiFactorChanged` events is


### PR DESCRIPTION
Looking around in the documentation I saw several links to mod DPI were broken. Tested and confirmed these new links work. 👍🏻

- [X] Tested on all platforms changed
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

Other tasks not relevant for this tiny docfix