### PR TITLE
X11: Remember position setting in fullscreen

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -13,7 +13,7 @@
 use std::collections::vec_deque::IntoIter as VecDequeIter;
 
 use crate::{
-    dpi::{PhysicalPosition, PhysicalSize},
+    dpi::{LogicalPosition, PhysicalPosition, PhysicalSize},
     platform_impl,
 };
 
@@ -115,6 +115,17 @@ impl MonitorHandle {
     #[inline]
     pub fn position(&self) -> PhysicalPosition {
         self.inner.position()
+    }
+
+    #[inline]
+    pub(crate) fn relative_position(&self, position: LogicalPosition) -> PhysicalPosition {
+        let phys = self.position();
+        let dpi = self.hidpi_factor();
+
+        PhysicalPosition{
+            x: position.x + phys.x * dpi,
+            y: position.y + phys.y * dpi,
+        }
     }
 
     /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -122,7 +122,7 @@ impl MonitorHandle {
         let phys = self.position();
         let dpi = self.hidpi_factor();
 
-        PhysicalPosition{
+        PhysicalPosition {
             x: position.x + phys.x * dpi,
             y: position.y + phys.y * dpi,
         }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -214,6 +214,14 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_global_outer_position(&self, position: PhysicalPosition) {
+        match self {
+            &Window::X(ref w) => w.set_global_outer_position(position),
+            &Window::Wayland(ref w) => w.set_global_outer_position(position),
+        }
+    }
+
+    #[inline]
     pub fn inner_size(&self) -> LogicalSize {
         match self {
             &Window::X(ref w) => w.inner_size(),

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    dpi::{LogicalPosition, LogicalSize},
+    dpi::{LogicalPosition, LogicalSize, PhysicalPosition},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
     monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::{
@@ -221,6 +221,11 @@ impl Window {
 
     #[inline]
     pub fn set_outer_position(&self, _pos: LogicalPosition) {
+        // Not possible with wayland
+    }
+
+    #[inline]
+    pub fn set_global_outer_position(&self, _pos: PhysicalPosition) {
         // Not possible with wayland
     }
 

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -10,7 +10,7 @@ use super::{
     util, XConnection, XError,
 };
 use crate::{
-    dpi::{PhysicalPosition, PhysicalSize},
+    dpi::{LogicalPosition, PhysicalPosition, PhysicalSize},
     monitor::VideoMode,
 };
 
@@ -104,6 +104,17 @@ impl MonitorHandle {
     #[inline]
     pub fn hidpi_factor(&self) -> f64 {
         self.hidpi_factor
+    }
+
+    #[inline]
+    pub fn relative_position(&self, position: LogicalPosition) -> PhysicalPosition {
+        let phys = self.position();
+        let dpi = self.hidpi_factor();
+
+        PhysicalPosition{
+            x: position.x + phys.x * dpi,
+            y: position.y + phys.y * dpi,
+        }
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -111,7 +111,7 @@ impl MonitorHandle {
         let phys = self.position();
         let dpi = self.hidpi_factor();
 
-        PhysicalPosition{
+        PhysicalPosition {
             x: position.x + phys.x * dpi,
             y: position.y + phys.y * dpi,
         }

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -116,6 +116,21 @@ impl<'a> NormalHints<'a> {
         }
     }
 
+    pub fn get_position(&self) -> Option<(u32, u32)> {
+        self.getter(ffi::PPosition, &self.size_hints.x, &self.size_hints.y)
+    }
+
+    // WARNING: This hint is obsolete
+    pub fn set_position(&mut self, position: Option<(u32, u32)>) {
+        if let Some((x, y)) = position {
+            self.size_hints.flags |= ffi::PPosition;
+            self.size_hints.x = x as c_int;
+            self.size_hints.y = y as c_int;
+        } else {
+            self.size_hints.flags &= !ffi::PPosition;
+        }
+    }
+
     pub fn get_size(&self) -> Option<(u32, u32)> {
         self.getter(ffi::PSize, &self.size_hints.width, &self.size_hints.height)
     }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -830,7 +830,12 @@ impl UnownedWindow {
     #[inline]
     pub fn set_outer_position(&self, logical_position: LogicalPosition) {
         let (x, y) = logical_position.to_physical(self.hidpi_factor()).into();
-        self.set_position_physical(x, y);
+
+        if self.fullscreen().is_some() {
+            self.shared_state.lock().restore_position = Some((x, y));
+        } else {
+            self.set_position_physical(x, y);
+        }
     }
 
     pub(crate) fn inner_size_physical(&self) -> (u32, u32) {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -212,7 +212,7 @@ impl UnownedWindow {
             )
         };
 
-        let window = UnownedWindow {
+        let mut window = UnownedWindow {
             xconn: Arc::clone(xconn),
             xwindow,
             root,
@@ -404,6 +404,17 @@ impl UnownedWindow {
                 window
                     .set_fullscreen_inner(window_attrs.fullscreen.clone())
                     .queue();
+
+                let shared_state = window.shared_state.get_mut();
+
+                shared_state.fullscreen = window_attrs.fullscreen.clone();
+
+                if let Some(pos) = window_attrs.outer_position {
+                    let pos = pos.to_physical(dpi_factor).into();
+                    shared_state.restore_position = Some(pos);
+                }
+
+                window.invalidate_cached_frame_extents();
             }
             if window_attrs.always_on_top {
                 window

--- a/src/window.rs
+++ b/src/window.rs
@@ -102,6 +102,12 @@ pub struct WindowAttributes {
     /// The default is `None`.
     pub max_inner_size: Option<LogicalSize>,
 
+    /// The desired position of the window on the screen. If `None`,
+    /// the position will be determined by the platform's window system.
+    ///
+    /// The default is `None`.
+    pub outer_position: Option<LogicalPosition>,
+
     /// Whether the window is resizable or not.
     ///
     /// The default is `true`.
@@ -156,6 +162,7 @@ impl Default for WindowAttributes {
             inner_size: None,
             min_inner_size: None,
             max_inner_size: None,
+            outer_position: None,
             resizable: true,
             title: "winit window".to_owned(),
             maximized: false,
@@ -196,6 +203,17 @@ impl WindowBuilder {
     #[inline]
     pub fn with_max_inner_size(mut self, max_size: LogicalSize) -> WindowBuilder {
         self.window.max_inner_size = Some(max_size);
+        self
+    }
+
+    /// Requests the window to be placed at a position on the screen.
+    ///
+    /// ## Note
+    ///
+    /// Some platforms may ignore this hint in choosing where to place the window.
+    #[inline]
+    pub fn with_outer_position(mut self, position: LogicalPosition) -> WindowBuilder {
+        self.window.outer_position = Some(position);
         self
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -102,11 +102,11 @@ pub struct WindowAttributes {
     /// The default is `None`.
     pub max_inner_size: Option<LogicalSize>,
 
-    /// The desired position of the window on the screen. If `None`,
+    /// The desired monitor and position placement of the window. If `None`,
     /// the position will be determined by the platform's window system.
     ///
     /// The default is `None`.
-    pub outer_position: Option<LogicalPosition>,
+    pub outer_position: Option<(MonitorHandle, LogicalPosition)>,
 
     /// Whether the window is resizable or not.
     ///
@@ -206,14 +206,16 @@ impl WindowBuilder {
         self
     }
 
-    /// Requests the window to be placed at a position on the screen.
+    /// Requests the window to be placed at a position on the given monitor.
     ///
-    /// ## Note
+    /// ## Platform-specific
     ///
-    /// Some platforms may ignore this hint in choosing where to place the window.
+    /// **X11**: Some window managers may ignore this hint.
+    ///
+    /// **Wayland**: This hint has no effect.
     #[inline]
-    pub fn with_outer_position(mut self, position: LogicalPosition) -> WindowBuilder {
-        self.window.outer_position = Some(position);
+    pub fn with_outer_position(mut self, monitor: MonitorHandle, position: LogicalPosition) -> WindowBuilder {
+        self.window.outer_position = Some((monitor, position));
         self
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -214,7 +214,11 @@ impl WindowBuilder {
     ///
     /// **Wayland**: This hint has no effect.
     #[inline]
-    pub fn with_outer_position(mut self, monitor: MonitorHandle, position: LogicalPosition) -> WindowBuilder {
+    pub fn with_outer_position(
+        mut self,
+        monitor: MonitorHandle,
+        position: LogicalPosition,
+    ) -> WindowBuilder {
         self.window.outer_position = Some((monitor, position));
         self
     }


### PR DESCRIPTION
Window position that is assigned while a window is set to fullscreen
will be used as the window's position when fullscreen is disabled.

- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
