### PR TITLE
Handle WM_POINTER* events in favor of WM_TOUCH

### DIFF
--- a/src/platform_impl/windows/dpi.rs
+++ b/src/platform_impl/windows/dpi.rs
@@ -9,13 +9,12 @@ use winapi::{
         winerror::S_OK,
     },
     um::{
-        libloaderapi::{GetProcAddress, LoadLibraryA},
         shellscalingapi::{
             MDT_EFFECTIVE_DPI, MONITOR_DPI_TYPE, PROCESS_DPI_AWARENESS,
             PROCESS_PER_MONITOR_DPI_AWARE,
         },
         wingdi::{GetDeviceCaps, LOGPIXELSX},
-        winnt::{HRESULT, LPCSTR},
+        winnt::HRESULT,
         winuser::{self, MONITOR_DEFAULTTONEAREST},
     },
 };
@@ -34,33 +33,6 @@ type GetDpiForMonitor = unsafe extern "system" fn(
     dpi_y: *mut UINT,
 ) -> HRESULT;
 type EnableNonClientDpiScaling = unsafe extern "system" fn(hwnd: HWND) -> BOOL;
-
-// Helper function to dynamically load function pointer.
-// `library` and `function` must be zero-terminated.
-fn get_function_impl(library: &str, function: &str) -> Option<*const c_void> {
-    assert_eq!(library.chars().last(), Some('\0'));
-    assert_eq!(function.chars().last(), Some('\0'));
-
-    // Library names we will use are ASCII so we can use the A version to avoid string conversion.
-    let module = unsafe { LoadLibraryA(library.as_ptr() as LPCSTR) };
-    if module.is_null() {
-        return None;
-    }
-
-    let function_ptr = unsafe { GetProcAddress(module, function.as_ptr() as LPCSTR) };
-    if function_ptr.is_null() {
-        return None;
-    }
-
-    Some(function_ptr as _)
-}
-
-macro_rules! get_function {
-    ($lib:expr, $func:ident) => {
-        get_function_impl(concat!($lib, '\0'), concat!(stringify!($func), '\0'))
-            .map(|f| unsafe { mem::transmute::<*const _, $func>(f) })
-    };
-}
 
 lazy_static! {
     static ref GET_DPI_FOR_WINDOW: Option<GetDpiForWindow> =

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1457,6 +1457,64 @@ unsafe extern "system" fn public_window_callback<T>(
             0
         }
 
+        winuser::WM_POINTERDOWN | winuser::WM_POINTERUPDATE | winuser::WM_POINTERUP => {
+            let pointer_id = LOWORD(wparam as DWORD) as UINT;
+            let mut entries_count = 0 as UINT;
+            let mut pointers_count = 0 as UINT;
+            if winuser::GetPointerFrameInfoHistory(
+                pointer_id,
+                &mut entries_count as *mut _,
+                &mut pointers_count as *mut _,
+                std::ptr::null_mut(),
+            ) == 0
+            {
+                return 0;
+            }
+
+            let pointer_info_count = (entries_count * pointers_count) as usize;
+            let mut pointer_infos = Vec::with_capacity(pointer_info_count);
+            pointer_infos.set_len(pointer_info_count);
+            if winuser::GetPointerFrameInfoHistory(
+                pointer_id,
+                &mut entries_count as *mut _,
+                &mut pointers_count as *mut _,
+                pointer_infos.as_mut_ptr(),
+            ) == 0
+            {
+                return 0;
+            }
+
+            let dpi_factor = hwnd_scale_factor(window);
+            // https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getpointerframeinfohistory
+            // The information retrieved appears in reverse chronological order, with the most recent entry in the first
+            // row of the returned array
+            for pointer_info in pointer_infos.iter().rev() {
+                let x = pointer_info.ptPixelLocation.x as f64;
+                let y = pointer_info.ptPixelLocation.y as f64;
+                let location = LogicalPosition::from_physical((x, y), dpi_factor);
+                subclass_input.send_event(Event::WindowEvent {
+                    window_id: RootWindowId(WindowId(window)),
+                    event: WindowEvent::Touch(Touch {
+                        phase: if pointer_info.pointerFlags & winuser::POINTER_FLAG_DOWN != 0 {
+                            TouchPhase::Started
+                        } else if pointer_info.pointerFlags & winuser::POINTER_FLAG_UP != 0 {
+                            TouchPhase::Ended
+                        } else if pointer_info.pointerFlags & winuser::POINTER_FLAG_UPDATE != 0 {
+                            TouchPhase::Moved
+                        } else {
+                            continue;
+                        },
+                        location,
+                        id: pointer_info.pointerId as u64,
+                        device_id: DEVICE_ID,
+                    }),
+                });
+            }
+
+            winuser::SkipPointerFrameMessages(pointer_id);
+            0
+        }
+
         winuser::WM_SETFOCUS => {
             use crate::event::WindowEvent::Focused;
             subclass_input.send_event(Event::WindowEvent {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 //! An events loop on Win32 is a background thread.
 //!
 //! Creating an events loop spawns a thread and blocks it in a permanent Win32 events loop.
@@ -61,6 +62,22 @@ use crate::{
     },
     window::WindowId as RootWindowId,
 };
+
+type GetPointerFrameInfoHistory = unsafe extern "system" fn(
+    pointerId: UINT,
+    entriesCount: *mut UINT,
+    pointerCount: *mut UINT,
+    pointerInfo: *mut winuser::POINTER_INFO,
+) -> BOOL;
+
+type SkipPointerFrameMessages = unsafe extern "system" fn(pointerId: UINT) -> BOOL;
+
+lazy_static! {
+    static ref GET_POINTER_FRAME_INFO_HISTORY: Option<GetPointerFrameInfoHistory> =
+        get_function!("user32.dll", GetPointerFrameInfoHistory);
+    static ref SKIP_POINTER_FRAME_MESSAGES: Option<SkipPointerFrameMessages> =
+        get_function!("user32.dll", SkipPointerFrameMessages);
+}
 
 pub(crate) struct SubclassInput<T> {
     pub window_state: Arc<Mutex<WindowState>>,
@@ -1458,60 +1475,66 @@ unsafe extern "system" fn public_window_callback<T>(
         }
 
         winuser::WM_POINTERDOWN | winuser::WM_POINTERUPDATE | winuser::WM_POINTERUP => {
-            let pointer_id = LOWORD(wparam as DWORD) as UINT;
-            let mut entries_count = 0 as UINT;
-            let mut pointers_count = 0 as UINT;
-            if winuser::GetPointerFrameInfoHistory(
-                pointer_id,
-                &mut entries_count as *mut _,
-                &mut pointers_count as *mut _,
-                std::ptr::null_mut(),
-            ) == 0
-            {
-                return 0;
-            }
+            if let (Some(GetPointerFrameInfoHistory), Some(SkipPointerFrameMessages)) = (
+                *GET_POINTER_FRAME_INFO_HISTORY,
+                *SKIP_POINTER_FRAME_MESSAGES,
+            ) {
+                let pointer_id = LOWORD(wparam as DWORD) as UINT;
+                let mut entries_count = 0 as UINT;
+                let mut pointers_count = 0 as UINT;
+                if GetPointerFrameInfoHistory(
+                    pointer_id,
+                    &mut entries_count as *mut _,
+                    &mut pointers_count as *mut _,
+                    std::ptr::null_mut(),
+                ) == 0
+                {
+                    return 0;
+                }
 
-            let pointer_info_count = (entries_count * pointers_count) as usize;
-            let mut pointer_infos = Vec::with_capacity(pointer_info_count);
-            pointer_infos.set_len(pointer_info_count);
-            if winuser::GetPointerFrameInfoHistory(
-                pointer_id,
-                &mut entries_count as *mut _,
-                &mut pointers_count as *mut _,
-                pointer_infos.as_mut_ptr(),
-            ) == 0
-            {
-                return 0;
-            }
+                let pointer_info_count = (entries_count * pointers_count) as usize;
+                let mut pointer_infos = Vec::with_capacity(pointer_info_count);
+                pointer_infos.set_len(pointer_info_count);
+                if GetPointerFrameInfoHistory(
+                    pointer_id,
+                    &mut entries_count as *mut _,
+                    &mut pointers_count as *mut _,
+                    pointer_infos.as_mut_ptr(),
+                ) == 0
+                {
+                    return 0;
+                }
 
-            let dpi_factor = hwnd_scale_factor(window);
-            // https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getpointerframeinfohistory
-            // The information retrieved appears in reverse chronological order, with the most recent entry in the first
-            // row of the returned array
-            for pointer_info in pointer_infos.iter().rev() {
-                let x = pointer_info.ptPixelLocation.x as f64;
-                let y = pointer_info.ptPixelLocation.y as f64;
-                let location = LogicalPosition::from_physical((x, y), dpi_factor);
-                subclass_input.send_event(Event::WindowEvent {
-                    window_id: RootWindowId(WindowId(window)),
-                    event: WindowEvent::Touch(Touch {
-                        phase: if pointer_info.pointerFlags & winuser::POINTER_FLAG_DOWN != 0 {
-                            TouchPhase::Started
-                        } else if pointer_info.pointerFlags & winuser::POINTER_FLAG_UP != 0 {
-                            TouchPhase::Ended
-                        } else if pointer_info.pointerFlags & winuser::POINTER_FLAG_UPDATE != 0 {
-                            TouchPhase::Moved
-                        } else {
-                            continue;
-                        },
-                        location,
-                        id: pointer_info.pointerId as u64,
-                        device_id: DEVICE_ID,
-                    }),
-                });
-            }
+                let dpi_factor = hwnd_scale_factor(window);
+                // https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getpointerframeinfohistory
+                // The information retrieved appears in reverse chronological order, with the most recent entry in the first
+                // row of the returned array
+                for pointer_info in pointer_infos.iter().rev() {
+                    let x = pointer_info.ptPixelLocation.x as f64;
+                    let y = pointer_info.ptPixelLocation.y as f64;
+                    let location = LogicalPosition::from_physical((x, y), dpi_factor);
+                    subclass_input.send_event(Event::WindowEvent {
+                        window_id: RootWindowId(WindowId(window)),
+                        event: WindowEvent::Touch(Touch {
+                            phase: if pointer_info.pointerFlags & winuser::POINTER_FLAG_DOWN != 0 {
+                                TouchPhase::Started
+                            } else if pointer_info.pointerFlags & winuser::POINTER_FLAG_UP != 0 {
+                                TouchPhase::Ended
+                            } else if pointer_info.pointerFlags & winuser::POINTER_FLAG_UPDATE != 0
+                            {
+                                TouchPhase::Moved
+                            } else {
+                                continue;
+                            },
+                            location,
+                            id: pointer_info.pointerId as u64,
+                            device_id: DEVICE_ID,
+                        }),
+                    });
+                }
 
-            winuser::SkipPointerFrameMessages(pointer_id);
+                SkipPointerFrameMessages(pointer_id);
+            }
             0
         }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -67,6 +67,8 @@ impl WindowId {
     }
 }
 
+#[macro_use]
+mod util;
 mod dpi;
 mod drop_handler;
 mod event;
@@ -74,6 +76,5 @@ mod event_loop;
 mod icon;
 mod monitor;
 mod raw_input;
-mod util;
 mod window;
 mod window_state;


### PR DESCRIPTION
Fixes #975 

Haven't tested on Windows 7, but it should work, since the POINTER events are only fired on Windows 8 or higher. It should be tested anyway because GetPointerFrameInfoHistory and SkipPointerFrameMessages doesn't exist in User32.dll on pre-Windows 8.

- [ ] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
