### PR TITLE
Fix issues with redraw_requested when called during EventsCleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - On X11, fix sanity check which checks that a monitor's reported width and height (in millimeters) are non-zero when calculating the DPI factor.
 - On X11, implement `_NET_WM_PING` to allow desktop environment to kill unresponsive programs.
 - On Windows, when a window is initially invisible, it won't take focus from the existing visible windows.
+- On Windows, fix multiple calls to `request_redraw` during `EventsCleared` sending multiple `RedrawRequested events.`
+- On Windows, fix edge case where `RedrawRequested` could be dispatched before input events in event loop iteration.
 
 # 0.20.0 Alpha 1
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -11,6 +11,10 @@ fn main() {
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();
+    let window_1 = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .build(&event_loop)
+        .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         println!("{:?}", event);
@@ -20,6 +24,12 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 window_id,
             } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            Event::NewEvents(_) => {
+                println!("{:?}", window.id());
+                println!("{:?}", window_1.id());
+                window.request_redraw();
+                window_1.request_redraw();
+            }
             _ => *control_flow = ControlFlow::Wait,
         }
     });

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -11,10 +11,6 @@ fn main() {
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();
-    let window_1 = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .build(&event_loop)
-        .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
         println!("{:?}", event);
@@ -24,12 +20,6 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 window_id,
             } if window_id == window.id() => *control_flow = ControlFlow::Exit,
-            Event::NewEvents(_) => {
-                println!("{:?}", window.id());
-                println!("{:?}", window_1.id());
-                window.request_redraw();
-                window_1.request_redraw();
-            }
             _ => *control_flow = ControlFlow::Wait,
         }
     });

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -435,10 +435,14 @@ impl<T> EventLoopRunner<T> {
 
         self.runner_state = RunnerState::HandlingEvents;
         match (self.in_repaint, &event) {
-            (true, Event::WindowEvent{event: WindowEvent::RedrawRequested, ..}) |
-            (false, _) => {
-                self.call_event_handler(event)
-            },
+            (
+                true,
+                Event::WindowEvent {
+                    event: WindowEvent::RedrawRequested,
+                    ..
+                },
+            )
+            | (false, _) => self.call_event_handler(event),
             (true, _) => {
                 self.events_cleared();
                 self.new_events();
@@ -500,8 +504,10 @@ impl<T> EventLoopRunner<T> {
             Event::EventsCleared => self
                 .trigger_newevents_on_redraw
                 .store(false, Ordering::Relaxed),
-            Event::WindowEvent{event: WindowEvent::RedrawRequested, ..} =>
-                self.in_repaint = true,
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            } => self.in_repaint = true,
             _ => (),
         }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -893,7 +893,7 @@ unsafe extern "system" fn public_window_callback<T>(
                             ptr::null_mut(),
                             winuser::RDW_INTERNALPAINT,
                         );
-                    },
+                    }
                     _ => (),
                 }
             }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -149,7 +149,11 @@ impl Window {
                     winuser::RDW_INTERNALPAINT,
                 );
             } else {
-                winuser::PostMessageW(self.window.0, *REQUEST_REDRAW_NO_NEWEVENTS_MSG_ID, 0, 0);
+                let mut window_state = self.window_state.lock();
+                if !window_state.queued_out_of_band_redraw {
+                    window_state.queued_out_of_band_redraw = true;
+                    winuser::PostMessageW(self.window.0, *REQUEST_REDRAW_NO_NEWEVENTS_MSG_ID, 0, 0);
+                }
             }
         }
     }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -30,6 +30,9 @@ pub struct WindowState {
     pub dpi_factor: f64,
 
     pub fullscreen: Option<MonitorHandle>,
+    /// Used to supress duplicate redraw attempts when calling `request_redraw` multiple
+    /// times in `EventsCleared`.
+    pub queued_out_of_band_redraw: bool,
     window_flags: WindowFlags,
 }
 
@@ -110,6 +113,7 @@ impl WindowState {
             dpi_factor,
 
             fullscreen: None,
+            queued_out_of_band_redraw: false,
             window_flags: WindowFlags::empty(),
         }
     }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

If the user calls `request_redraw` multiple times during the `EventsCleared` handler, multiple redraw events would get dispatched. This fixes that.

Example displaying that behavior here:

```rust
use winit::{
    event::{Event, WindowEvent},
    event_loop::{ControlFlow, EventLoop},
    window::WindowBuilder,
};

fn main() {
    let event_loop = EventLoop::new();

    let window = WindowBuilder::new()
        .with_title("A fantastic window!")
        .build(&event_loop)
        .unwrap();

    event_loop.run(move |event, _, control_flow| {
        println!("{:?}", event);

        match event {
            Event::WindowEvent {
                event: WindowEvent::CloseRequested,
                window_id,
            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
            Event::EventsCleared => {
                window.request_redraw();
                window.request_redraw();
            }
            _ => *control_flow = ControlFlow::Wait,
        }
    });
}
```

All the `request_redraw` calls should be consolidated into a single event, but they weren't here.