### PR TITLE
X11: Disable maximize on non-resizable windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On X11, non-resizable windows now have maximize explicitly disabled.
 - On Windows, support paths longer than MAX_PATH (260 characters) in `WindowEvent::DroppedFile`
 and `WindowEvent::HoveredFile`.
 - On Mac, implement `DeviceEvent::Button`.

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -109,6 +109,8 @@ struct MwmHints {
 mod mwm {
     use libc::c_ulong;
 
+    // Motif WM hints are obsolete, but still widely supported.
+    // https://stackoverflow.com/a/1909708
     pub const MWM_HINTS_FUNCTIONS: c_ulong = 1 << 0;
     pub const MWM_HINTS_DECORATIONS: c_ulong = 1 << 1;
 

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -1,8 +1,7 @@
+use std::slice;
 use std::sync::Arc;
 
 use super::*;
-
-pub const MWM_HINTS_DECORATIONS: c_ulong = 2;
 
 #[derive(Debug)]
 pub enum StateOperation {
@@ -90,6 +89,90 @@ impl WindowType {
             &Normal => b"_NET_WM_WINDOW_TYPE_NORMAL\0",
         };
         unsafe { xconn.get_atom_unchecked(atom_name) }
+    }
+}
+
+pub struct MotifHints {
+    hints: MwmHints,
+}
+
+#[repr(C)]
+struct MwmHints {
+    flags: c_ulong,
+    functions: c_ulong,
+    decorations: c_ulong,
+    input_mode: c_long,
+    status: c_ulong,
+}
+
+#[allow(dead_code)]
+mod mwm {
+    use libc::c_ulong;
+
+    pub const MWM_HINTS_FUNCTIONS: c_ulong = 1 << 0;
+    pub const MWM_HINTS_DECORATIONS: c_ulong = 1 << 1;
+
+    pub const MWM_FUNC_ALL: c_ulong = 1 << 0;
+    pub const MWM_FUNC_RESIZE: c_ulong = 1 << 1;
+    pub const MWM_FUNC_MOVE: c_ulong = 1 << 2;
+    pub const MWM_FUNC_MINIMIZE: c_ulong = 1 << 3;
+    pub const MWM_FUNC_MAXIMIZE: c_ulong = 1 << 4;
+    pub const MWM_FUNC_CLOSE: c_ulong = 1 << 5;
+}
+
+impl MotifHints {
+    pub fn new() -> MotifHints {
+        MotifHints {
+            hints: MwmHints {
+                flags: 0,
+                functions: 0,
+                decorations: 0,
+                input_mode: 0,
+                status: 0,
+            },
+        }
+    }
+
+    pub fn set_decorations(&mut self, decorations: bool) {
+        self.hints.flags |= mwm::MWM_HINTS_DECORATIONS;
+        self.hints.decorations = decorations as c_ulong;
+    }
+
+    pub fn set_maximizable(&mut self, maximizable: bool) {
+        if maximizable {
+            self.add_func(mwm::MWM_FUNC_MAXIMIZE);
+        } else {
+            self.remove_func(mwm::MWM_FUNC_MAXIMIZE);
+        }
+    }
+
+    fn add_func(&mut self, func: c_ulong) {
+        if self.hints.flags & mwm::MWM_HINTS_FUNCTIONS != 0 {
+            if self.hints.functions & mwm::MWM_FUNC_ALL != 0 {
+                self.hints.functions &= !func;
+            } else {
+                self.hints.functions |= func;
+            }
+        }
+    }
+
+    fn remove_func(&mut self, func: c_ulong) {
+        if self.hints.flags & mwm::MWM_HINTS_FUNCTIONS == 0 {
+            self.hints.flags |= mwm::MWM_HINTS_FUNCTIONS;
+            self.hints.functions = mwm::MWM_FUNC_ALL;
+        }
+
+        if self.hints.functions & mwm::MWM_FUNC_ALL != 0 {
+            self.hints.functions |= func;
+        } else {
+            self.hints.functions &= !func;
+        }
+    }
+}
+
+impl MwmHints {
+    fn as_slice(&self) -> &[c_ulong] {
+        unsafe { slice::from_raw_parts(self as *const _ as *const c_ulong, 5) }
     }
 }
 
@@ -253,5 +336,33 @@ impl XConnection {
             (self.xlib.XSetWMNormalHints)(self.display, window, normal_hints.size_hints.ptr);
         }
         Flusher::new(self)
+    }
+
+    pub fn get_motif_hints(&self, window: ffi::Window) -> MotifHints {
+        let motif_hints = unsafe { self.get_atom_unchecked(b"_MOTIF_WM_HINTS\0") };
+
+        let mut hints = MotifHints::new();
+
+        if let Ok(props) = self.get_property::<c_ulong>(window, motif_hints, motif_hints) {
+            hints.hints.flags = props.get(0).cloned().unwrap_or(0);
+            hints.hints.functions = props.get(1).cloned().unwrap_or(0);
+            hints.hints.decorations = props.get(2).cloned().unwrap_or(0);
+            hints.hints.input_mode = props.get(3).cloned().unwrap_or(0) as c_long;
+            hints.hints.status = props.get(4).cloned().unwrap_or(0);
+        }
+
+        hints
+    }
+
+    pub fn set_motif_hints(&self, window: ffi::Window, hints: &MotifHints) -> Flusher<'_> {
+        let motif_hints = unsafe { self.get_atom_unchecked(b"_MOTIF_WM_HINTS\0") };
+
+        self.change_property(
+            window,
+            motif_hints,
+            motif_hints,
+            PropMode::Replace,
+            hints.hints.as_slice(),
+        )
     }
 }


### PR DESCRIPTION
Implements #947 for the X11 platform.

- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented