### PR TITLE
WIP – Android EventLoop 2.0

### DIFF
--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,8 +1,5 @@
 #![cfg(any(target_os = "android"))]
-
-use crate::{EventLoop, Window, WindowBuilder};
-use std::os::raw::c_void;
-
+/*
 /// Additional methods on `EventLoop` that are specific to Android.
 pub trait EventLoopExtAndroid {
     /// Makes it possible for glutin to register a callback when a suspend event happens on Android
@@ -31,3 +28,4 @@ impl WindowExtAndroid for Window {
 pub trait WindowBuilderExtAndroid {}
 
 impl WindowBuilderExtAndroid for WindowBuilder {}
+*/

--- a/src/platform_impl/android/ffi.rs
+++ b/src/platform_impl/android/ffi.rs
@@ -22,19 +22,25 @@ pub type AAssetManager = raw::c_void;
 pub type ANativeWindow = raw::c_void;
 
 extern "C" {
-    pub fn ANativeWindow_getHeight(window: *const ANativeWindow) -> libc::int32_t;
-    pub fn ANativeWindow_getWidth(window: *const ANativeWindow) -> libc::int32_t;
+    pub fn ANativeWindow_getHeight(window: *const ANativeWindow) -> i32;
+    pub fn ANativeWindow_getWidth(window: *const ANativeWindow) -> i32;
 }
 
 /**
  ** native_activity.h
  **/
-pub type JavaVM = ();
-pub type JNIEnv = ();
+pub type JavaVM = raw::c_void;
+pub type JNIEnv = raw::c_void;
 pub type jobject = *const libc::c_void;
 
-pub type AInputQueue = (); // FIXME: wrong
-pub type ARect = (); // FIXME: wrong
+#[repr(C)]
+pub struct AInputQueue {
+    _opaque: (),
+}
+#[repr(C)]
+pub struct ARect {
+    _opaque: (),
+}
 
 #[repr(C)]
 pub struct ANativeActivity {
@@ -44,7 +50,7 @@ pub struct ANativeActivity {
     pub clazz: jobject,
     pub internalDataPath: *const libc::c_char,
     pub externalDataPath: *const libc::c_char,
-    pub sdkVersion: libc::int32_t,
+    pub sdkVersion: i32,
     pub instance: *mut libc::c_void,
     pub assetManager: *mut AAssetManager,
     pub obbPath: *const libc::c_char,
@@ -73,7 +79,7 @@ pub struct ANativeActivityCallbacks {
 /**
  ** looper.h
  **/
-pub type ALooper = ();
+pub type ALooper = raw::c_void;
 
 #[link(name = "android")]
 extern "C" {
@@ -120,3 +126,7 @@ pub const ALOOPER_EVENT_INVALID: libc::c_int = 1 << 4;
 
 pub type ALooper_callbackFunc =
     extern "C" fn(libc::c_int, libc::c_int, *mut libc::c_void) -> libc::c_int;
+
+extern "C" {
+    pub fn pthread_exit() -> !;
+}


### PR DESCRIPTION
Depends on rust-windowing/android-rs-glue#220

Starts to help out with #948.

This implementation is not great, undocumented, unfinished, and in some cases, unsound or incorrect. It's intended just to have the overall structure down, to be able to make gradual progress as different pieces of it are switched out for actual, better implementations.

It does, however, minimally work; I am able to [log events](https://github.com/mb64/winit_event_logger) on my phone.

These are the different "sub-parts" that need work:

### The event loop

`android-rs-glue` has [known issues](https://github.com/rust-windowing/android-rs-glue/issues/172), as well as hard-to-maintain [cross-ffi](https://github.com/rust-windowing/android-rs-glue/blob/master/cargo-apk/injected-glue/lib.rs#L114-L154) [datastructures](https://github.com/rust-windowing/android-rs-glue/blob/master/glue/src/lib.rs#L20-L60) and I think a general overhaul is warranted. (Of the 
glue code – this is (mostly) independant of the [build system](https://github.com/rust-windowing/android-rs-glue/issues/212).)

Currently, `android-rs-glue` starts `main` in a separate thread, then polls events, parses them, and sends them on a mpsc channel. I would like to transition the glue code away from this, instead giving `main` direct access to the `ALooper`, likely through a nice API that wraps the FFI calls. This gives Winit the ability to parse the `AInputEvent`s directly into Winit events, avoiding intermediaries, and also removes a layer (one of many) of glue.

This might mean you can't run the event loop in threads other than the main one; I'm not certain/haven't done any tests. (iOS already sets a precedent for only allowing things in the main thread, though.)

When an activity is destroyed, Android asks it to save its state as a `&[u8]`, then gives this data back when it restarts it later. This is somewhat incompatible with the normal C entrypoint of `int main(int argc, char **argv)`.  Here's my idea to deal with this:

 * An extention trait allows users to save state, which must be a `String`.
 * On Android, the supplied "command-line arguments" are `"android"`, then the saved state.

This part is a fairly major change for `android-rs-glue`, so I'd like to discuss this and get an OK before I work on its implementation.

### Support for multi-window

Multi-window is Android's term for things like split screen and Samsung's [pop-up view](https://www.androidexplained.com/galaxy-s9-floating-window/) floating apps.  While it's a nice feature, it does make life more complicated when implementing Window stuff.  I mostly ignored it in this initial implementation.

### Multiple displays

It is possible to use multiple displays with Android phones. (For example, the Motorola Lapdock.)  This implementation assumes only one monitor.  This should be fixed.

### Hidpi, window attributes, etc.

The hardcoded hidpi factor of 1 should be replaced.  Information about display density can be found in the AConfiguration associated with the android_app, and can be mapped to hidpi factors using the table [here](https://developer.android.com/training/multiscreen/screendensities).

Currently it ignores window attributes; this needs to be implemented.

There are various other details that need attending to, such as:

 * Figure out how (if possible) to set the title
 * Legit video modes
 * I'm sure there's more that I'm forgetting

### Docs and tests

Last but not least, the documentation and tests should be updated for Android.

---

Some of these things are fairly straightforward. Hidpi support is probably the easiest of these items. If my ideas are OK'd, updating `android-rs-glue` will take some work, but seems doable.

However, I'm not at all well-versed in API's for multi-window or multiple displays.  So if there's an Android guru reading this with free time, **consider helping out**.

A couple of questions I had along the way:

 * What is `set_ime_position` supposed to do?
 * What should `run` do when the app is closed?
 * What should `run` do if the event handler sets it to `ControlFlow::Exit`?
