### PR TITLE
On Windows, fix `with_maximized` not properly setting window size to entire monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and `WindowEvent::HoveredFile`.
 - On Windows, fix edge case where `RedrawRequested` could be dispatched before input events in event loop iteration.
 - On Windows, fix timing issue that could cause events to be improperly dispatched after `RedrawRequested` but before `EventsCleared`.
 - On macOS, drop unused Metal dependency.
+- On Windows, fix `with_maximized` not properly setting window size to entire window.
 
 # 0.20.0 Alpha 1
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -291,16 +291,6 @@ impl WindowBuilder {
         mut self,
         window_target: &EventLoopWindowTarget<T>,
     ) -> Result<Window, OsError> {
-        self.window.inner_size = Some(self.window.inner_size.unwrap_or_else(|| {
-            if let Some(ref monitor) = self.window.fullscreen {
-                // resizing the window to the dimensions of the monitor when fullscreen
-                LogicalSize::from_physical(monitor.size(), monitor.hidpi_factor()) // DPI factor applies here since this is a borderless window and not real fullscreen
-            } else {
-                // default dimensions
-                (1024, 768).into()
-            }
-        }));
-
         // building
         platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)
             .map(|window| Window { window })


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

We do this by removing the global dimension default. This may be a somewhat controversial change, but it's caused a good amount of pain in the window creation system (at least on the Windows backend) and I don't think it's worth keeping.

Fixes #1009
