### PR TITLE
On Windows, make AdjustRect calls DPI-aware when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Change `Event::Suspended(true / false)` to `Event::Suspended` and `Event::Resumed`.
 - On X11, fix sanity check which checks that a monitor's reported width and height (in millimeters) are non-zero when calculating the DPI factor.
+- On Windows, fix window rectangle not getting set correctly on high-DPI systems.
 
 # 0.20.0 Alpha 1
 

--- a/src/platform_impl/windows/dpi.rs
+++ b/src/platform_impl/windows/dpi.rs
@@ -1,12 +1,14 @@
 #![allow(non_snake_case, unused_unsafe)]
 
-use std::{
-    sync::{Once, ONCE_INIT},
-};
+use std::sync::{Once, ONCE_INIT};
 
+use crate::platform_impl::platform::util::{
+    ENABLE_NON_CLIENT_DPI_SCALING, GET_DPI_FOR_MONITOR, GET_DPI_FOR_WINDOW, SET_PROCESS_DPI_AWARE,
+    SET_PROCESS_DPI_AWARENESS, SET_PROCESS_DPI_AWARENESS_CONTEXT,
+};
 use winapi::{
     shared::{
-        minwindef::{FALSE},
+        minwindef::FALSE,
         windef::{DPI_AWARENESS_CONTEXT, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE, HMONITOR, HWND},
         winerror::S_OK,
     },
@@ -16,7 +18,6 @@ use winapi::{
         winuser::{self, MONITOR_DEFAULTTONEAREST},
     },
 };
-use crate::platform_impl::platform::util::{GET_DPI_FOR_MONITOR, GET_DPI_FOR_WINDOW, ENABLE_NON_CLIENT_DPI_SCALING, SET_PROCESS_DPI_AWARENESS_CONTEXT, SET_PROCESS_DPI_AWARENESS, SET_PROCESS_DPI_AWARE};
 
 const DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2: DPI_AWARENESS_CONTEXT = -4isize as _;
 
@@ -27,8 +28,7 @@ pub fn become_dpi_aware(enable: bool) {
     static ENABLE_DPI_AWARENESS: Once = ONCE_INIT;
     ENABLE_DPI_AWARENESS.call_once(|| {
         unsafe {
-            if let Some(SetProcessDpiAwarenessContext) = *SET_PROCESS_DPI_AWARENESS_CONTEXT
-            {
+            if let Some(SetProcessDpiAwarenessContext) = *SET_PROCESS_DPI_AWARENESS_CONTEXT {
                 // We are on Windows 10 Anniversary Update (1607) or later.
                 if SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
                     == FALSE
@@ -37,12 +37,10 @@ pub fn become_dpi_aware(enable: bool) {
                     // V1 if we can't set V2.
                     SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
                 }
-            } else if let Some(SetProcessDpiAwareness) = *SET_PROCESS_DPI_AWARENESS
-            {
+            } else if let Some(SetProcessDpiAwareness) = *SET_PROCESS_DPI_AWARENESS {
                 // We are on Windows 8.1 or later.
                 SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE);
-            } else if let Some(SetProcessDPIAware) = *SET_PROCESS_DPI_AWARE
-            {
+            } else if let Some(SetProcessDPIAware) = *SET_PROCESS_DPI_AWARE {
                 // We are on Vista or later.
                 SetProcessDPIAware();
             }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -52,7 +52,6 @@ use crate::{
         event::{self, handle_extended_keys, process_key_params, vkey_to_winit_vkey},
         raw_input::{get_raw_input_data, get_raw_mouse_button_state},
         util,
-        window::adjust_size,
         window_state::{CursorFlags, WindowFlags, WindowState},
         wrap_device_id, WindowId, DEVICE_ID,
     },
@@ -1486,11 +1485,9 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
             let window_state = subclass_input.window_state.lock();
 
             if window_state.min_size.is_some() || window_state.max_size.is_some() {
-                let style = winuser::GetWindowLongA(window, winuser::GWL_STYLE) as DWORD;
-                let ex_style = winuser::GetWindowLongA(window, winuser::GWL_EXSTYLE) as DWORD;
                 if let Some(min_size) = window_state.min_size {
                     let min_size = min_size.to_physical(window_state.dpi_factor);
-                    let (width, height) = adjust_size(min_size, style, ex_style);
+                    let (width, height): (u32, u32) = util::adjust_size(window, min_size).into();
                     (*mmi).ptMinTrackSize = POINT {
                         x: width as i32,
                         y: height as i32,
@@ -1498,7 +1495,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 }
                 if let Some(max_size) = window_state.max_size {
                     let max_size = max_size.to_physical(window_state.dpi_factor);
-                    let (width, height) = adjust_size(max_size, style, ex_style);
+                    let (width, height): (u32, u32) = util::adjust_size(window, max_size).into();
                     (*mmi).ptMaxTrackSize = POINT {
                         x: width as i32,
                         y: height as i32,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1517,10 +1517,11 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
             // https://msdn.microsoft.com/en-us/library/windows/desktop/dn312083(v=vs.85).aspx
             let new_dpi_x = u32::from(LOWORD(wparam as DWORD));
             let new_dpi_factor = dpi_to_scale_factor(new_dpi_x);
+            let old_dpi_factor: f64;
 
             let allow_resize = {
                 let mut window_state = subclass_input.window_state.lock();
-                let old_dpi_factor = window_state.dpi_factor;
+                old_dpi_factor = window_state.dpi_factor;
                 window_state.dpi_factor = new_dpi_factor;
 
                 new_dpi_factor != old_dpi_factor && window_state.fullscreen.is_none()
@@ -1557,10 +1558,24 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 margins_vertical = (margin_bottom + margin_top) as u32;
             }
 
-            let physical_inner_rect = PhysicalSize::new(
-                (rect.right - rect.left) as u32 - margins_horizontal,
-                (rect.bottom - rect.top) as u32 - margins_vertical,
-            );
+            // Use the rect suggested by Windows
+            // let physical_inner_rect = PhysicalSize::new(
+            //     (rect.right - rect.left) as u32 - margins_horizontal,
+            //     (rect.bottom - rect.top) as u32 - margins_vertical,
+            // );
+
+            // We calculate our own rect because the default suggested rect doesn't do a great job
+            // of preserving the window's logical size.
+            let physical_inner_rect = {
+                let mut current_rect = mem::zeroed();
+                winuser::GetClientRect(window, &mut current_rect);
+
+                let client_rect = PhysicalSize::new(
+                    (current_rect.right - current_rect.left) as u32,
+                    (current_rect.bottom - current_rect.top) as u32,
+                );
+                client_rect.to_logical(old_dpi_factor).to_physical(new_dpi_factor)
+            };
 
             // `allow_resize` prevents us from re-applying DPI adjustment to the restored size after
             // exiting fullscreen (the restored size is already DPI adjusted).

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1574,7 +1574,9 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     (current_rect.right - current_rect.left) as u32,
                     (current_rect.bottom - current_rect.top) as u32,
                 );
-                client_rect.to_logical(old_dpi_factor).to_physical(new_dpi_factor)
+                client_rect
+                    .to_logical(old_dpi_factor)
+                    .to_physical(new_dpi_factor)
             };
 
             // `allow_resize` prevents us from re-applying DPI adjustment to the restored size after

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -6,22 +6,19 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use crate::{
-    dpi::PhysicalSize,
-    window::CursorIcon,
-};
+use crate::{dpi::PhysicalSize, window::CursorIcon};
 use winapi::{
     ctypes::wchar_t,
     shared::{
         minwindef::{BOOL, DWORD, UINT},
-        windef::{DPI_AWARENESS_CONTEXT, HMONITOR, HWND, RECT, LPRECT},
+        windef::{DPI_AWARENESS_CONTEXT, HMONITOR, HWND, LPRECT, RECT},
     },
     um::{
         libloaderapi::{GetProcAddress, LoadLibraryA},
         shellscalingapi::{MONITOR_DPI_TYPE, PROCESS_DPI_AWARENESS},
         winbase::lstrlenW,
-        winuser,
         winnt::{HRESULT, LONG, LPCSTR},
+        winuser,
     },
 };
 
@@ -88,10 +85,7 @@ pub fn adjust_size(hwnd: HWND, size: PhysicalSize) -> PhysicalSize {
         bottom: height as LONG,
     };
     let rect = adjust_window_rect(hwnd, rect).unwrap_or(rect);
-    PhysicalSize::new(
-        (rect.right - rect.left) as _,
-        (rect.bottom - rect.top) as _
-    )
+    PhysicalSize::new((rect.right - rect.left) as _, (rect.bottom - rect.top) as _)
 }
 
 pub fn adjust_window_rect(hwnd: HWND, rect: RECT) -> Option<RECT> {
@@ -113,7 +107,9 @@ pub fn adjust_window_rect_with_styles(
             *r = rect;
 
             let b_menu = !winuser::GetMenu(hwnd).is_null() as BOOL;
-            if let (Some(get_dpi_for_window), Some(adjust_window_rect_ex_for_dpi)) = (*GET_DPI_FOR_WINDOW, *ADJUST_WINDOW_RECT_EX_FOR_DPI) {
+            if let (Some(get_dpi_for_window), Some(adjust_window_rect_ex_for_dpi)) =
+                (*GET_DPI_FOR_WINDOW, *ADJUST_WINDOW_RECT_EX_FOR_DPI)
+            {
                 let dpi = get_dpi_for_window(hwnd);
                 adjust_window_rect_ex_for_dpi(r, style as _, b_menu, style_ex as _, dpi)
             } else {
@@ -206,7 +202,8 @@ macro_rules! get_function {
 }
 
 pub type SetProcessDPIAware = unsafe extern "system" fn() -> BOOL;
-pub type SetProcessDpiAwareness = unsafe extern "system" fn(value: PROCESS_DPI_AWARENESS) -> HRESULT;
+pub type SetProcessDpiAwareness =
+    unsafe extern "system" fn(value: PROCESS_DPI_AWARENESS) -> HRESULT;
 pub type SetProcessDpiAwarenessContext =
     unsafe extern "system" fn(value: DPI_AWARENESS_CONTEXT) -> BOOL;
 pub type GetDpiForWindow = unsafe extern "system" fn(hwnd: HWND) -> UINT;
@@ -217,7 +214,13 @@ pub type GetDpiForMonitor = unsafe extern "system" fn(
     dpi_y: *mut UINT,
 ) -> HRESULT;
 pub type EnableNonClientDpiScaling = unsafe extern "system" fn(hwnd: HWND) -> BOOL;
-pub type AdjustWindowRectExForDpi = unsafe extern "system" fn(rect: LPRECT, dwStyle: DWORD, bMenu: BOOL, dwExStyle: DWORD, dpi: UINT) -> BOOL;
+pub type AdjustWindowRectExForDpi = unsafe extern "system" fn(
+    rect: LPRECT,
+    dwStyle: DWORD,
+    bMenu: BOOL,
+    dwExStyle: DWORD,
+    dpi: UINT,
+) -> BOOL;
 
 lazy_static! {
     pub static ref GET_DPI_FOR_WINDOW: Option<GetDpiForWindow> =

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -1,18 +1,28 @@
 use std::{
     io, mem,
     ops::BitAnd,
+    os::raw::c_void,
     ptr, slice,
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use crate::window::CursorIcon;
+use crate::{
+    dpi::PhysicalSize,
+    window::CursorIcon,
+};
 use winapi::{
     ctypes::wchar_t,
     shared::{
-        minwindef::{BOOL, DWORD},
-        windef::{HWND, RECT},
+        minwindef::{BOOL, DWORD, UINT},
+        windef::{DPI_AWARENESS_CONTEXT, HMONITOR, HWND, RECT, LPRECT},
     },
-    um::{winbase::lstrlenW, winuser},
+    um::{
+        libloaderapi::{GetProcAddress, LoadLibraryA},
+        shellscalingapi::{MONITOR_DPI_TYPE, PROCESS_DPI_AWARENESS},
+        winbase::lstrlenW,
+        winuser,
+        winnt::{HRESULT, LONG, LPCSTR},
+    },
 };
 
 pub fn has_flag<T>(bitset: T, flag: T) -> bool
@@ -69,6 +79,21 @@ pub fn get_client_rect(hwnd: HWND) -> Result<RECT, io::Error> {
     }
 }
 
+pub fn adjust_size(hwnd: HWND, size: PhysicalSize) -> PhysicalSize {
+    let (width, height): (u32, u32) = size.into();
+    let rect = RECT {
+        left: 0,
+        right: width as LONG,
+        top: 0,
+        bottom: height as LONG,
+    };
+    let rect = adjust_window_rect(hwnd, rect).unwrap_or(rect);
+    PhysicalSize::new(
+        (rect.right - rect.left) as _,
+        (rect.bottom - rect.top) as _
+    )
+}
+
 pub fn adjust_window_rect(hwnd: HWND, rect: RECT) -> Option<RECT> {
     unsafe {
         let style = winuser::GetWindowLongW(hwnd, winuser::GWL_STYLE);
@@ -88,7 +113,12 @@ pub fn adjust_window_rect_with_styles(
             *r = rect;
 
             let b_menu = !winuser::GetMenu(hwnd).is_null() as BOOL;
-            winuser::AdjustWindowRectEx(r, style as _, b_menu, style_ex as _)
+            if let (Some(get_dpi_for_window), Some(adjust_window_rect_ex_for_dpi)) = (*GET_DPI_FOR_WINDOW, *ADJUST_WINDOW_RECT_EX_FOR_DPI) {
+                let dpi = get_dpi_for_window(hwnd);
+                adjust_window_rect_ex_for_dpi(r, style as _, b_menu, style_ex as _, dpi)
+            } else {
+                winuser::AdjustWindowRectEx(r, style as _, b_menu, style_ex as _)
+            }
         })
     }
 }
@@ -146,4 +176,62 @@ impl CursorIcon {
             _ => winuser::IDC_ARROW, // use arrow for the missing cases.
         }
     }
+}
+
+// Helper function to dynamically load function pointer.
+// `library` and `function` must be zero-terminated.
+fn get_function_impl(library: &str, function: &str) -> Option<*const c_void> {
+    assert_eq!(library.chars().last(), Some('\0'));
+    assert_eq!(function.chars().last(), Some('\0'));
+
+    // Library names we will use are ASCII so we can use the A version to avoid string conversion.
+    let module = unsafe { LoadLibraryA(library.as_ptr() as LPCSTR) };
+    if module.is_null() {
+        return None;
+    }
+
+    let function_ptr = unsafe { GetProcAddress(module, function.as_ptr() as LPCSTR) };
+    if function_ptr.is_null() {
+        return None;
+    }
+
+    Some(function_ptr as _)
+}
+
+macro_rules! get_function {
+    ($lib:expr, $func:ident) => {
+        get_function_impl(concat!($lib, '\0'), concat!(stringify!($func), '\0'))
+            .map(|f| unsafe { mem::transmute::<*const _, $func>(f) })
+    };
+}
+
+pub type SetProcessDPIAware = unsafe extern "system" fn() -> BOOL;
+pub type SetProcessDpiAwareness = unsafe extern "system" fn(value: PROCESS_DPI_AWARENESS) -> HRESULT;
+pub type SetProcessDpiAwarenessContext =
+    unsafe extern "system" fn(value: DPI_AWARENESS_CONTEXT) -> BOOL;
+pub type GetDpiForWindow = unsafe extern "system" fn(hwnd: HWND) -> UINT;
+pub type GetDpiForMonitor = unsafe extern "system" fn(
+    hmonitor: HMONITOR,
+    dpi_type: MONITOR_DPI_TYPE,
+    dpi_x: *mut UINT,
+    dpi_y: *mut UINT,
+) -> HRESULT;
+pub type EnableNonClientDpiScaling = unsafe extern "system" fn(hwnd: HWND) -> BOOL;
+pub type AdjustWindowRectExForDpi = unsafe extern "system" fn(rect: LPRECT, dwStyle: DWORD, bMenu: BOOL, dwExStyle: DWORD, dpi: UINT) -> BOOL;
+
+lazy_static! {
+    pub static ref GET_DPI_FOR_WINDOW: Option<GetDpiForWindow> =
+        get_function!("user32.dll", GetDpiForWindow);
+    pub static ref ADJUST_WINDOW_RECT_EX_FOR_DPI: Option<AdjustWindowRectExForDpi> =
+        get_function!("user32.dll", AdjustWindowRectExForDpi);
+    pub static ref GET_DPI_FOR_MONITOR: Option<GetDpiForMonitor> =
+        get_function!("shcore.dll", GetDpiForMonitor);
+    pub static ref ENABLE_NON_CLIENT_DPI_SCALING: Option<EnableNonClientDpiScaling> =
+        get_function!("user32.dll", EnableNonClientDpiScaling);
+    pub static ref SET_PROCESS_DPI_AWARENESS_CONTEXT: Option<SetProcessDpiAwarenessContext> =
+        get_function!("user32.dll", SetProcessDpiAwarenessContext);
+    pub static ref SET_PROCESS_DPI_AWARENESS: Option<SetProcessDpiAwareness> =
+        get_function!("shcore.dll", SetProcessDpiAwareness);
+    pub static ref SET_PROCESS_DPI_AWARE: Option<SetProcessDPIAware> =
+        get_function!("user32.dll", SetProcessDPIAware);
 }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -13,7 +13,7 @@ use std::{
 use winapi::{
     ctypes::c_int,
     shared::{
-        minwindef::{DWORD, UINT},
+        minwindef::UINT,
         windef::{HWND, POINT, RECT},
     },
     um::{
@@ -520,22 +520,6 @@ pub struct WindowWrapper(HWND);
 // https://github.com/retep998/winapi-rs/issues/396
 unsafe impl Sync for WindowWrapper {}
 unsafe impl Send for WindowWrapper {}
-
-pub unsafe fn adjust_size(
-    physical_size: PhysicalSize,
-    style: DWORD,
-    ex_style: DWORD,
-) -> (LONG, LONG) {
-    let (width, height): (u32, u32) = physical_size.into();
-    let mut rect = RECT {
-        left: 0,
-        right: width as LONG,
-        top: 0,
-        bottom: height as LONG,
-    };
-    winuser::AdjustWindowRectEx(&mut rect, style, 0, ex_style);
-    (rect.right - rect.left, rect.bottom - rect.top)
-}
 
 unsafe fn init<T: 'static>(
     mut attributes: WindowAttributes,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Fixes #923.