### PR TITLE
MacOS: request_user_attention(bool -> enum)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and `WindowEvent::HoveredFile`.
 - On macOS, drop unused Metal dependency.
 - On Windows, fix the trail effect happening on transparent decorated windows. Borderless (or un-decorated) windows were not affected.
 - On Windows, fix `with_maximized` not properly setting window size to entire window.
+- On macOS, change `WindowExtMacOS::request_user_attention()` to take an `enum` instead of a `bool`.
 
 # 0.20.0 Alpha 1
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -8,6 +8,26 @@ use crate::{
     window::{Window, WindowBuilder},
 };
 
+/// Corresponds to `NSRequestUserAttentionType`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum RequestUserAttentionType {
+    /// Corresponds to `NSCriticalRequest`.
+    ///
+    /// Dock icon will bounce until the application is focused.
+    Critical,
+
+    /// Corresponds to `NSInformationalRequest`.
+    ///
+    /// Dock icon will bounce once.
+    Informational,
+}
+
+impl Default for RequestUserAttentionType {
+    fn default() -> Self {
+        RequestUserAttentionType::Critical
+    }
+}
+
 /// Additional methods on `Window` that are specific to MacOS.
 pub trait WindowExtMacOS {
     /// Returns a pointer to the cocoa `NSWindow` that is used by this window.
@@ -22,11 +42,7 @@ pub trait WindowExtMacOS {
 
     /// Request user attention, causing the application's dock icon to bounce.
     /// Note that this has no effect if the application is already focused.
-    ///
-    /// The `is_critical` flag has the following effects:
-    /// - `false`: the dock icon will only bounce once.
-    /// - `true`: the dock icon will bounce until the application is focused.
-    fn request_user_attention(&self, is_critical: bool);
+    fn request_user_attention(&self, request_type: RequestUserAttentionType);
 
     /// Returns whether or not the window is in simple fullscreen mode.
     fn simple_fullscreen(&self) -> bool;
@@ -53,8 +69,8 @@ impl WindowExtMacOS for Window {
     }
 
     #[inline]
-    fn request_user_attention(&self, is_critical: bool) {
-        self.window.request_user_attention(is_critical)
+    fn request_user_attention(&self, request_type: RequestUserAttentionType) {
+        self.window.request_user_attention(request_type)
     }
 
     #[inline]

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -28,7 +28,7 @@ use crate::{
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
     icon::Icon,
     monitor::MonitorHandle as RootMonitorHandle,
-    platform::macos::{ActivationPolicy, WindowExtMacOS},
+    platform::macos::{ActivationPolicy, RequestUserAttentionType, WindowExtMacOS},
     platform_impl::platform::{
         app_state::AppState,
         ffi,
@@ -778,11 +778,13 @@ impl WindowExtMacOS for UnownedWindow {
     }
 
     #[inline]
-    fn request_user_attention(&self, is_critical: bool) {
+    fn request_user_attention(&self, request_type: RequestUserAttentionType) {
         unsafe {
-            NSApp().requestUserAttention_(match is_critical {
-                true => NSRequestUserAttentionType::NSCriticalRequest,
-                false => NSRequestUserAttentionType::NSInformationalRequest,
+            NSApp().requestUserAttention_(match request_type {
+                RequestUserAttentionType::Critical => NSRequestUserAttentionType::NSCriticalRequest,
+                RequestUserAttentionType::Informational => {
+                    NSRequestUserAttentionType::NSInformationalRequest
+                }
             });
         }
     }


### PR DESCRIPTION
- [x] Tested on all platforms changed (macOS only, `cargo t` runs fine)
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md`
- [x] Updated documentation to reflect any user-facing changes
- [x] No example changed
