### PR TITLE
Always use `f` as the argument name for `&mut std::fmt::Formatter`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -48,8 +48,8 @@ macro_rules! os_error {
 }
 
 impl fmt::Display for OsError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        formatter.pad(&format!(
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.pad(&format!(
             "os error at {}:{}: {}",
             self.file, self.line, self.error
         ))
@@ -57,23 +57,23 @@ impl fmt::Display for OsError {
 }
 
 impl fmt::Display for ExternalError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            ExternalError::NotSupported(e) => e.fmt(formatter),
-            ExternalError::Os(e) => e.fmt(formatter),
+            ExternalError::NotSupported(e) => e.fmt(f),
+            ExternalError::Os(e) => e.fmt(f),
         }
     }
 }
 
 impl fmt::Debug for NotSupportedError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        formatter.debug_struct("NotSupportedError").finish()
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.debug_struct("NotSupportedError").finish()
     }
 }
 
 impl fmt::Display for NotSupportedError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        formatter.pad("the requested operation is not supported by Winit")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        f.pad("the requested operation is not supported by Winit")
     }
 }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -46,14 +46,14 @@ pub struct EventLoopWindowTarget<T: 'static> {
 }
 
 impl<T> fmt::Debug for EventLoop<T> {
-    fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmtr.pad("EventLoop { .. }")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("EventLoop { .. }")
     }
 }
 
 impl<T> fmt::Debug for EventLoopWindowTarget<T> {
-    fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmtr.pad("EventLoopWindowTarget { .. }")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("EventLoopWindowTarget { .. }")
     }
 }
 
@@ -189,8 +189,8 @@ impl<T: 'static> EventLoopProxy<T> {
 }
 
 impl<T: 'static> fmt::Debug for EventLoopProxy<T> {
-    fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmtr.pad("EventLoopProxy { .. }")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("EventLoopProxy { .. }")
     }
 }
 

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -28,7 +28,7 @@ pub enum BadIcon {
 }
 
 impl fmt::Display for BadIcon {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self {
             &BadIcon::ByteCountNotDivisibleBy4 { byte_count } => format!(
                 "The length of the `rgba` argument ({:?}) isn't divisible by 4, making it impossible to interpret as 32bpp RGBA pixels.",
@@ -44,7 +44,7 @@ impl fmt::Display for BadIcon {
                 width, height, pixel_count, width_x_height,
             ),
         };
-        write!(formatter, "{}", msg)
+        write!(f, "{}", msg)
     }
 }
 

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -264,9 +264,8 @@ struct EventLoopHandler<F, T: 'static> {
 }
 
 impl<F, T: 'static> Debug for EventLoopHandler<F, T> {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter
-            .debug_struct("EventLoopHandler")
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EventLoopHandler")
             .field("event_loop", &self.event_loop)
             .finish()
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -55,10 +55,10 @@ pub enum OsError {
 }
 
 impl fmt::Display for OsError {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            OsError::XError(e) => formatter.pad(&e.description),
-            OsError::XMisc(e) => formatter.pad(e),
+            OsError::XError(e) => f.pad(&e.description),
+            OsError::XMisc(e) => f.pad(e),
         }
     }
 }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch