### PR TITLE
Replace `std::mem::uninitialized` with `MaybeUninit`

### DIFF
--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -1,6 +1,6 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 
-use std::{collections::VecDeque, env, ffi::CStr, fmt, mem, os::raw::*, sync::Arc};
+use std::{collections::VecDeque, env, ffi::CStr, fmt, mem::MaybeUninit, os::raw::*, sync::Arc};
 
 use parking_lot::Mutex;
 use smithay_client_toolkit::reexports::client::ConnectError;
@@ -410,7 +410,7 @@ unsafe extern "C" fn x_error_callback(
 ) -> c_int {
     let xconn_lock = X11_BACKEND.lock();
     if let Ok(ref xconn) = *xconn_lock {
-        let mut buf: [c_char; 1024] = mem::uninitialized();
+        let mut buf: [c_char; 1024] = MaybeUninit::uninit().assume_init();
         (xconn.xlib.XGetErrorText)(
             display,
             (*event).error_code as c_int,

--- a/src/platform_impl/linux/x11/util/client_msg.rs
+++ b/src/platform_impl/linux/x11/util/client_msg.rs
@@ -30,7 +30,7 @@ impl XConnection {
         event_mask: Option<c_long>,
         data: ClientMsgPayload,
     ) -> Flusher<'_> {
-        let mut event: ffi::XClientMessageEvent = unsafe { mem::uninitialized() };
+        let mut event: ffi::XClientMessageEvent = unsafe { MaybeUninit::uninit().assume_init() };
         event.type_ = ffi::ClientMessage;
         event.display = self.display;
         event.window = window;
@@ -54,7 +54,7 @@ impl XConnection {
         let format = T::FORMAT;
         let size_of_t = mem::size_of::<T>();
         debug_assert_eq!(size_of_t, format.get_actual_size());
-        let mut event: ffi::XClientMessageEvent = unsafe { mem::uninitialized() };
+        let mut event: ffi::XClientMessageEvent = unsafe { MaybeUninit::uninit().assume_init() };
         event.type_ = ffi::ClientMessage;
         event.display = self.display;
         event.window = window;

--- a/src/platform_impl/linux/x11/util/client_msg.rs
+++ b/src/platform_impl/linux/x11/util/client_msg.rs
@@ -30,13 +30,17 @@ impl XConnection {
         event_mask: Option<c_long>,
         data: ClientMsgPayload,
     ) -> Flusher<'_> {
-        let mut event: ffi::XClientMessageEvent = unsafe { MaybeUninit::uninit().assume_init() };
-        event.type_ = ffi::ClientMessage;
-        event.display = self.display;
-        event.window = window;
-        event.message_type = message_type;
-        event.format = c_long::FORMAT as c_int;
-        event.data = unsafe { mem::transmute(data) };
+        let event = ffi::XClientMessageEvent {
+            type_: ffi::ClientMessage,
+            display: self.display,
+            window,
+            message_type,
+            format: c_long::FORMAT as c_int,
+            data: unsafe { mem::transmute(data) },
+            // These fields are ignored by `XSendEvent`
+            serial: 0,
+            send_event: 0,
+        };
         self.send_event(target_window, event_mask, event)
     }
 
@@ -54,12 +58,17 @@ impl XConnection {
         let format = T::FORMAT;
         let size_of_t = mem::size_of::<T>();
         debug_assert_eq!(size_of_t, format.get_actual_size());
-        let mut event: ffi::XClientMessageEvent = unsafe { MaybeUninit::uninit().assume_init() };
-        event.type_ = ffi::ClientMessage;
-        event.display = self.display;
-        event.window = window;
-        event.message_type = message_type;
-        event.format = format as c_int;
+        let mut event = ffi::XClientMessageEvent {
+            type_: ffi::ClientMessage,
+            display: self.display,
+            window,
+            message_type,
+            format: format as c_int,
+            data: ffi::ClientMessageData::new(),
+            // These fields are ignored by `XSendEvent`
+            serial: 0,
+            send_event: 0,
+        };
 
         let t_per_payload = format.get_payload_size() / size_of_t;
         assert!(t_per_payload > 0);

--- a/src/platform_impl/linux/x11/util/geometry.rs
+++ b/src/platform_impl/linux/x11/util/geometry.rs
@@ -183,9 +183,7 @@ impl XConnection {
         window: ffi::Window,
         root: ffi::Window,
     ) -> Result<TranslatedCoords, XError> {
-        let mut x_rel_root = MaybeUninit::uninit();
-        let mut y_rel_root = MaybeUninit::uninit();
-        let mut child = MaybeUninit::uninit();
+        let mut coords: TranslatedCoords = unsafe { MaybeUninit::zeroed().assume_init() };
 
         unsafe {
             (self.xlib.XTranslateCoordinates)(
@@ -194,60 +192,36 @@ impl XConnection {
                 root,
                 0,
                 0,
-                x_rel_root.as_mut_ptr(),
-                y_rel_root.as_mut_ptr(),
-                child.as_mut_ptr(),
+                &mut coords.x_rel_root,
+                &mut coords.y_rel_root,
+                &mut coords.child,
             );
         }
 
         self.check_errors()?;
-
-        unsafe {
-            Ok(TranslatedCoords {
-                x_rel_root: x_rel_root.assume_init(),
-                y_rel_root: y_rel_root.assume_init(),
-                child: child.assume_init(),
-            })
-        }
+        Ok(coords)
     }
 
     // This is adequate for inner_size
     pub fn get_geometry(&self, window: ffi::Window) -> Result<Geometry, XError> {
-        let mut root = MaybeUninit::uninit();
-        let mut x_rel_parent = MaybeUninit::uninit();
-        let mut y_rel_parent = MaybeUninit::uninit();
-        let mut width = MaybeUninit::uninit();
-        let mut height = MaybeUninit::uninit();
-        let mut border = MaybeUninit::uninit();
-        let mut depth = MaybeUninit::uninit();
+        let mut geometry: Geometry = unsafe { MaybeUninit::zeroed().assume_init() };
 
         let _status = unsafe {
             (self.xlib.XGetGeometry)(
                 self.display,
                 window,
-                root.as_mut_ptr(),
-                x_rel_parent.as_mut_ptr(),
-                y_rel_parent.as_mut_ptr(),
-                width.as_mut_ptr(),
-                height.as_mut_ptr(),
-                border.as_mut_ptr(),
-                depth.as_mut_ptr(),
+                &mut geometry.root,
+                &mut geometry.x_rel_parent,
+                &mut geometry.y_rel_parent,
+                &mut geometry.width,
+                &mut geometry.height,
+                &mut geometry.border,
+                &mut geometry.depth,
             )
         };
 
         self.check_errors()?;
-
-        unsafe {
-            Ok(Geometry {
-                root: root.assume_init(),
-                x_rel_parent: x_rel_parent.assume_init(),
-                y_rel_parent: y_rel_parent.assume_init(),
-                width: width.assume_init(),
-                height: height.assume_init(),
-                border: border.assume_init(),
-                depth: depth.assume_init(),
-            })
-        }
+        Ok(geometry)
     }
 
     fn get_frame_extents(&self, window: ffi::Window) -> Option<FrameExtents> {

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -317,13 +317,13 @@ impl XConnection {
 
     pub fn get_normal_hints(&self, window: ffi::Window) -> Result<NormalHints<'_>, XError> {
         let size_hints = self.alloc_size_hints();
-        let mut supplied_by_user: c_long = unsafe { mem::uninitialized() };
+        let mut supplied_by_user = MaybeUninit::uninit();
         unsafe {
             (self.xlib.XGetWMNormalHints)(
                 self.display,
                 window,
                 size_hints.ptr,
-                &mut supplied_by_user,
+                supplied_by_user.as_mut_ptr(),
             );
         }
         self.check_errors().map(|_| NormalHints { size_hints })

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -93,7 +93,7 @@ impl XConnection {
         device_id: c_int,
     ) -> Result<PointerState<'_>, XError> {
         unsafe {
-            let mut pointer_state: PointerState<'_> = mem::uninitialized();
+            let mut pointer_state: PointerState<'_> = MaybeUninit::uninit().assume_init();
             pointer_state.xconn = self;
             pointer_state.relative_to_window = (self.xinput2.XIQueryPointer)(
                 self.display,
@@ -141,7 +141,7 @@ impl XConnection {
     }
 
     pub fn lookup_utf8(&self, ic: ffi::XIC, key_event: &mut ffi::XKeyEvent) -> String {
-        let mut buffer: [u8; TEXT_BUFFER_SIZE] = unsafe { mem::uninitialized() };
+        let mut buffer: [u8; TEXT_BUFFER_SIZE] = unsafe { MaybeUninit::uninit().assume_init() };
         let (_, status, count) = self.lookup_utf8_inner(ic, key_event, &mut buffer);
         // The buffer overflowed, so we'll make a new one on the heap.
         if status == ffi::XBufferOverflow {

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -94,44 +94,44 @@ impl XConnection {
         device_id: c_int,
     ) -> Result<PointerState<'_>, XError> {
         unsafe {
-            let mut root = MaybeUninit::uninit();
-            let mut child = MaybeUninit::uninit();
-            let mut root_x = MaybeUninit::uninit();
-            let mut root_y = MaybeUninit::uninit();
-            let mut win_x = MaybeUninit::uninit();
-            let mut win_y = MaybeUninit::uninit();
-            let mut buttons = MaybeUninit::uninit();
-            let mut modifiers = MaybeUninit::uninit();
-            let mut group = MaybeUninit::uninit();
+            let mut root = 0;
+            let mut child = 0;
+            let mut root_x = 0.0;
+            let mut root_y = 0.0;
+            let mut win_x = 0.0;
+            let mut win_y = 0.0;
+            let mut buttons = MaybeUninit::zeroed().assume_init();
+            let mut modifiers = MaybeUninit::zeroed().assume_init();
+            let mut group = MaybeUninit::zeroed().assume_init();
 
             let relative_to_window = (self.xinput2.XIQueryPointer)(
                 self.display,
                 device_id,
                 window,
-                root.as_mut_ptr(),
-                child.as_mut_ptr(),
-                root_x.as_mut_ptr(),
-                root_y.as_mut_ptr(),
-                win_x.as_mut_ptr(),
-                win_y.as_mut_ptr(),
-                buttons.as_mut_ptr(),
-                modifiers.as_mut_ptr(),
-                group.as_mut_ptr(),
+                &mut root,
+                &mut child,
+                &mut root_x,
+                &mut root_y,
+                &mut win_x,
+                &mut win_y,
+                &mut buttons,
+                &mut modifiers,
+                &mut group,
             ) == ffi::True;
 
             self.check_errors()?;
 
             Ok(PointerState {
                 xconn: self,
-                root: root.assume_init(),
-                child: child.assume_init(),
-                root_x: root_x.assume_init(),
-                root_y: root_y.assume_init(),
-                win_x: win_x.assume_init(),
-                win_y: win_y.assume_init(),
-                buttons: buttons.assume_init(),
-                modifiers: modifiers.assume_init(),
-                group: group.assume_init(),
+                root,
+                child,
+                root_x,
+                root_y,
+                win_x,
+                win_y,
+                buttons,
+                modifiers,
+                group,
                 relative_to_window,
             })
         }

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -23,18 +23,19 @@ impl From<ffi::XIModifierState> for ModifiersState {
     }
 }
 
+// NOTE: Some of these fields are not used, but may be of use in the future.
 pub struct PointerState<'a> {
     xconn: &'a XConnection,
-    //root: ffi::Window,
-    //child: ffi::Window,
+    pub root: ffi::Window,
+    pub child: ffi::Window,
     pub root_x: c_double,
     pub root_y: c_double,
-    //win_x: c_double,
-    //win_y: c_double,
+    pub win_x: c_double,
+    pub win_y: c_double,
     buttons: ffi::XIButtonState,
     modifiers: ffi::XIModifierState,
-    //group: ffi::XIGroupState,
-    //relative_to_window: bool,
+    pub group: ffi::XIGroupState,
+    pub relative_to_window: bool,
 }
 
 impl<'a> PointerState<'a> {
@@ -103,7 +104,7 @@ impl XConnection {
             let mut modifiers = MaybeUninit::uninit();
             let mut group = MaybeUninit::uninit();
 
-            let _relative_to_window = (self.xinput2.XIQueryPointer)(
+            let relative_to_window = (self.xinput2.XIQueryPointer)(
                 self.display,
                 device_id,
                 window,
@@ -122,16 +123,16 @@ impl XConnection {
 
             Ok(PointerState {
                 xconn: self,
-                //root: root.assume_init(),
-                //child: child.assume_init(),
+                root: root.assume_init(),
+                child: child.assume_init(),
                 root_x: root_x.assume_init(),
                 root_y: root_y.assume_init(),
-                //win_x: win_x.assume_init(),
-                //win_y: win_y.assume_init(),
+                win_x: win_x.assume_init(),
+                win_y: win_y.assume_init(),
                 buttons: buttons.assume_init(),
                 modifiers: modifiers.assume_init(),
-                //group: group.assume_init(),
-                //relative_to_window,
+                group: group.assume_init(),
+                relative_to_window,
             })
         }
     }

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -100,9 +100,9 @@ impl XConnection {
             let mut root_y = 0.0;
             let mut win_x = 0.0;
             let mut win_y = 0.0;
-            let mut buttons = MaybeUninit::zeroed().assume_init();
-            let mut modifiers = MaybeUninit::zeroed().assume_init();
-            let mut group = MaybeUninit::zeroed().assume_init();
+            let mut buttons = Default::default();
+            let mut modifiers = Default::default();
+            let mut group = Default::default();
 
             let relative_to_window = (self.xinput2.XIQueryPointer)(
                 self.display,

--- a/src/platform_impl/linux/x11/util/mod.rs
+++ b/src/platform_impl/linux/x11/util/mod.rs
@@ -18,7 +18,12 @@ pub use self::{
     randr::*, window_property::*, wm::*,
 };
 
-use std::{mem, ops::BitAnd, os::raw::*, ptr};
+use std::{
+    mem::{self, MaybeUninit},
+    ops::BitAnd,
+    os::raw::*,
+    ptr,
+};
 
 use super::{ffi, XConnection, XError};
 

--- a/src/platform_impl/linux/x11/util/window_property.rs
+++ b/src/platform_impl/linux/x11/util/window_property.rs
@@ -45,10 +45,10 @@ impl XConnection {
         let mut done = false;
         while !done {
             unsafe {
-                let mut actual_type: ffi::Atom = mem::uninitialized();
-                let mut actual_format: c_int = mem::uninitialized();
-                let mut quantity_returned: c_ulong = mem::uninitialized();
-                let mut bytes_after: c_ulong = mem::uninitialized();
+                let mut actual_type: ffi::Atom = MaybeUninit::uninit().assume_init();
+                let mut actual_format: c_int = MaybeUninit::uninit().assume_init();
+                let mut quantity_returned: c_ulong = MaybeUninit::uninit().assume_init();
+                let mut bytes_after: c_ulong = MaybeUninit::uninit().assume_init();
                 let mut buf: *mut c_uchar = ptr::null_mut();
                 (self.xlib.XGetWindowProperty)(
                     self.display,


### PR DESCRIPTION
Closes #1025

- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
