### PR TITLE
Handle RedrawRequested event in request_redraw example

### DIFF
--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -14,19 +14,21 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, _, control_flow| {
-        println!("{:?}", event);
-
-        match event {
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => *control_flow = ControlFlow::Exit,
-            Event::EventsCleared => {
-                window.request_redraw();
-                *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::new(1, 0))
-            }
-            _ => (),
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        } => *control_flow = ControlFlow::Exit,
+        Event::EventsCleared => {
+            window.request_redraw();
+            *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::new(1, 0))
         }
+        Event::WindowEvent {
+            event: WindowEvent::RedrawRequested,
+            ..
+        } => {
+            println!("{:?}", event);
+        }
+        _ => (),
     });
 }


### PR DESCRIPTION
- [x] `cargo fmt` has been run on this branch
- [x] Created or updated an example program if it would help users understand this functionality

The example previously didn't show how to handle redraw requests, only how to generate them.

I'm not sure why the formatting change. The only functional change here is:

```rust
Event::WindowEvent {
    event: WindowEvent::RedrawRequested,
    ..
} => {
    println!("{:?}", event);
}
```