### PR TITLE
Add NewEvents(Init) callback to x11

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -249,6 +249,12 @@ impl<T: 'static> EventLoop<T> {
         let mut control_flow = ControlFlow::default();
         let wt = get_xtarget(&self.target);
 
+        callback(
+            crate::event::Event::NewEvents(crate::event::StartCause::Init),
+            &self.target,
+            &mut control_flow,
+        );
+
         loop {
             // Empty the event buffer
             {


### PR DESCRIPTION
On X11, `Event::NewEvents(StartCause::Init)` was not delivered as first event.

̃~~I added a test case to run on an event loop without any windows attached and check that first event is `NewEvents(Init)`, then `ControlFlow::Exit` and check that last event is `LoopDestroyed`.~~

I have ran this test on Linux/x11 platform only.
**Help wanted**: please run the new test on macos and windows.

- [ ] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
