### PR TITLE
Touch events emit screen coordinates instead of client coordinates on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and `WindowEvent::HoveredFile`.
 - On Windows, fix the trail effect happening on transparent decorated windows. Borderless (or un-decorated) windows were not affected.
 - On Windows, fix `with_maximized` not properly setting window size to entire window.
 - On macOS, change `WindowExtMacOS::request_user_attention()` to take an `enum` instead of a `bool`.
+- On Windows, location of `WindowEvent::Touch` are window client coordinates instead of screen coordinates.
 
 # 0.20.0 Alpha 1
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1457,8 +1457,8 @@ unsafe extern "system" fn public_window_callback<T>(
                         continue;
                     }
 
-                    let x = location.x as f64;
-                    let y = location.y as f64;
+                    let x = location.x as f64 + (input.x % 100) as f64 / 100f64;
+                    let y = location.y as f64 + (input.y % 100) as f64 / 100f64;
                     let location = LogicalPosition::from_physical((x, y), dpi_factor);
                     subclass_input.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1448,8 +1448,17 @@ unsafe extern "system" fn public_window_callback<T>(
             {
                 let dpi_factor = hwnd_scale_factor(window);
                 for input in &inputs {
-                    let x = (input.x as f64) / 100f64;
-                    let y = (input.y as f64) / 100f64;
+                    let mut location = POINT {
+                        x: input.x / 100,
+                        y: input.y / 100,
+                    };
+
+                    if winuser::ScreenToClient(window, &mut location as *mut _) == 0 {
+                        continue;
+                    }
+
+                    let x = location.x as f64;
+                    let y = location.y as f64;
                     let location = LogicalPosition::from_physical((x, y), dpi_factor);
                     subclass_input.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
@@ -1510,8 +1519,17 @@ unsafe extern "system" fn public_window_callback<T>(
                 // The information retrieved appears in reverse chronological order, with the most recent entry in the first
                 // row of the returned array
                 for pointer_info in pointer_infos.iter().rev() {
-                    let x = pointer_info.ptPixelLocation.x as f64;
-                    let y = pointer_info.ptPixelLocation.y as f64;
+                    let mut location = POINT {
+                        x: pointer_info.ptPixelLocation.x,
+                        y: pointer_info.ptPixelLocation.y,
+                    };
+
+                    if winuser::ScreenToClient(window, &mut location as *mut _) == 0 {
+                        continue;
+                    }
+
+                    let x = location.x as f64;
+                    let y = location.y as f64;
                     let location = LogicalPosition::from_physical((x, y), dpi_factor);
                     subclass_input.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),


### PR DESCRIPTION
Fixes #1002

I think this change should be reflected in CHANGELOG.md. Should i add it under "Unreleased"?

- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
