### PR TITLE
[Draft] Per-window event handling and enable creation of windows without an event loop for embedded windows

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     error::{ExternalError, NotSupportedError, OsError},
+    event::Event,
     event_loop::EventLoopWindowTarget,
     monitor::{AvailableMonitorsIter, MonitorHandle},
     platform_impl,
@@ -295,6 +296,20 @@ impl WindowBuilder {
         platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)
             .map(|window| Window { window })
     }
+
+    /// Builds the window without an event loop.
+    ///
+    /// Intended for use with embedded windows where external code controls the main event loop.
+    /// Embedded windows should be created with `WindowBuilderExtWindows.with_parent_window` or
+    /// other similar platform-specific functions.
+    ///
+    /// Call `Window.set_event_handler` to set an event handler for the window.
+    ///
+    /// Possible causes of error include denied permission, incompatible system, and lack of memory.
+    #[inline]
+    pub fn build_without_event_loop(self) -> Result<Window, OsError> {
+        unimplemented!();
+    }
 }
 
 /// Base Window functions.
@@ -356,6 +371,23 @@ impl Window {
     #[inline]
     pub fn request_redraw(&self) {
         self.window.request_redraw()
+    }
+
+    /// Sets the event handler for a window and returns any previously set event handler.
+    ///
+    /// If an event handler is set, the handler is called for events with `window_id == window.id()`.
+    ///
+    /// This function is mainly intended for embedded windows with an external parent window such as
+    /// when using `WindowBuilderExtWindows.with_parent_window` where external code controls the main
+    /// event loop. However, it can also be used with `EventLoop.run` for per-window event handling.
+    /// In such cases, the event handler is called before the main event handler passed to
+    /// `EventLoop.run` is called.
+    #[inline]
+    pub fn set_event_handler<T: 'static>(
+        &self,
+        _event_handler: Option<Box<dyn FnMut(Event<T>) -> bool>>,
+    ) -> Option<Box<dyn FnMut(Event<T>) -> bool>> {
+        unimplemented!();
     }
 }
 


### PR DESCRIPTION
While creating child windows has become possible with platform-specific APIs (https://github.com/rust-windowing/winit/issues/93), use of winit for embedded windows such as plugin windows where external code provides a container window (see https://github.com/rust-windowing/winit/issues/159) remains blocked by the fact that such applications control the main event loop in external code, therefore `winit::EventLoop` cannot be used in such cases.

Therefore, I suggest adding `WindowBuilder.build_without_event_loop` (no equivalent `Window.new_without_event_loop` as this only really makes sense when also using `WindowBuilderExtWindows.with_parent_window` or other similar platform-specific functions). Furthermore, as lack of an event loop prevents calling the event handler passed to `EventLoop.run`, I suggest adding `Window.set_event_handler` to set an optional per-window event handler. This should make it possible to remain compatible with the existing API while gaining the ability to support embedded windows.
An added benefit is that it should make the handling of multi-window applications easier, as the user wouldn't have to perform his own event forwarding depending on `window_id`.

Currently, this PR is a suggestion for a possible API extension without an implementation. Suggestions for improvements to the API and ideas on how this could be implemented are very welcome.

- [ ] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
