### PR TITLE
X11: Fix `request_redraw` deadlock while handling `RedrawRequested`

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -278,8 +278,10 @@ impl<T: 'static> EventLoop<T> {
             }
             // Empty the redraw requests
             {
-                let mut guard = wt.pending_redraws.lock().unwrap();
-                for wid in guard.drain() {
+                // Release the lock to prevent deadlock
+                let windows: Vec<_> = wt.pending_redraws.lock().unwrap().drain().collect();
+
+                for wid in windows {
                     sticky_exit_callback(
                         Event::WindowEvent {
                             window_id: crate::window::WindowId(super::WindowId::X(wid)),


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
