### PR TITLE
Fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+- On Windows, location of `WindowEvent::Touch` are window client coordinates instead of screen coordinates.
+- On X11, fix delayed events after window redraw.
+
 # 0.20.0 Alpha 2 (2019-07-09)
 
 - On X11, non-resizable windows now have maximize explicitly disabled.
@@ -18,8 +21,6 @@ and `WindowEvent::HoveredFile`.
 - On Windows, fix the trail effect happening on transparent decorated windows. Borderless (or un-decorated) windows were not affected.
 - On Windows, fix `with_maximized` not properly setting window size to entire window.
 - On macOS, change `WindowExtMacOS::request_user_attention()` to take an `enum` instead of a `bool`.
-- On Windows, location of `WindowEvent::Touch` are window client coordinates instead of screen coordinates.
-- On X11, fix delayed events after window redraw.
 
 # 0.20.0 Alpha 1 (2019-06-21)
 


### PR DESCRIPTION
A couple of PRs added changelog entries to the alpha2 section, but were merged after the alpha2 release was made. This PR moves those entries to the "Unreleased" section.

- [ ] Tested on all platforms changed
- [ ] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
