### PR TITLE
Implement changes to `RedrawRequested` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 - On Windows, location of `WindowEvent::Touch` are window client coordinates instead of screen coordinates.
 - On X11, fix delayed events after window redraw.
+- Changes to the `RedrawRequested` event (#1041):
+  - `RedrawRequested` has been moved from `WindowEvent` to `Event`.
+  - `EventsCleared` has been renamed to `MainEventsCleared`.
+  - `RedrawRequested` is now issued only after `MainEventsCleared`.
+  - `RedrawEventsCleared` is issued after each set of `RedrawRequested` events.
 
 # 0.20.0 Alpha 2 (2019-07-09)
 

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -19,14 +19,11 @@ fn main() {
             event: WindowEvent::CloseRequested,
             ..
         } => *control_flow = ControlFlow::Exit,
-        Event::EventsCleared => {
+        Event::MainEventsCleared => {
             window.request_redraw();
             *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::new(1, 0))
         }
-        Event::WindowEvent {
-            event: WindowEvent::RedrawRequested,
-            ..
-        } => {
+        Event::RedrawRequested(_) => {
             println!("{:?}", event);
         }
         _ => (),

--- a/src/event.rs
+++ b/src/event.rs
@@ -29,9 +29,22 @@ pub enum Event<T> {
     UserEvent(T),
     /// Emitted when new events arrive from the OS to be processed.
     NewEvents(StartCause),
-    /// Emitted when all of the event loop's events have been processed and control flow is about
-    /// to be taken away from the program.
-    EventsCleared,
+    /// Emitted when all events (except for `RedrawRequested`) have been reported.
+    ///
+    /// This event is followed by zero or more instances of `RedrawRequested`
+    /// and, finally, `RedrawEventsCleared`.
+    MainEventsCleared,
+
+    /// The OS or application has requested that a window be redrawn.
+    ///
+    /// Emitted only after `MainEventsCleared`.
+    RedrawRequested(WindowId),
+
+    /// Emitted after any `RedrawRequested` events.
+    ///
+    /// If there are no `RedrawRequested` events, it is reported immediately after
+    /// `MainEventsCleared`.
+    RedrawEventsCleared,
 
     /// Emitted when the event loop is being shut down. This is irreversable - if this event is
     /// emitted, it is guaranteed to be the last event emitted.
@@ -52,7 +65,9 @@ impl<T> Event<T> {
             WindowEvent { window_id, event } => Ok(WindowEvent { window_id, event }),
             DeviceEvent { device_id, event } => Ok(DeviceEvent { device_id, event }),
             NewEvents(cause) => Ok(NewEvents(cause)),
-            EventsCleared => Ok(EventsCleared),
+            MainEventsCleared => Ok(MainEventsCleared),
+            RedrawRequested(wid) => Ok(RedrawRequested(wid)),
+            RedrawEventsCleared => Ok(RedrawEventsCleared),
             LoopDestroyed => Ok(LoopDestroyed),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
@@ -183,9 +198,6 @@ pub enum WindowEvent {
         axis: AxisId,
         value: f64,
     },
-
-    /// The OS or application has requested that the window be redrawn.
-    RedrawRequested,
 
     /// Touch event has been received
     Touch(Touch),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,19 +48,16 @@
 //!
 //! event_loop.run(move |event, _, control_flow| {
 //!     match event {
-//!         Event::EventsCleared => {
+//!         Event::MainEventsCleared => {
 //!             // Application update code.
 //!     
 //!             // Queue a RedrawRequested event.
 //!             window.request_redraw();
 //!         },
-//!         Event::WindowEvent {
-//!             event: WindowEvent::RedrawRequested,
-//!             ..
-//!         } => {
+//!         Event::RedrawRequested(_) => {
 //!             // Redraw the application.
 //!             //
-//!             // It's preferrable to render in this event rather than in EventsCleared, since
+//!             // It's preferrable to render in this event rather than in MainEventsCleared, since
 //!             // rendering in here allows the program to gracefully handle redraws requested
 //!             // by the OS.
 //!         },

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -294,7 +294,7 @@ impl<T: 'static> EventLoop<T> {
             // send Events cleared
             {
                 sticky_exit_callback(
-                    crate::event::Event::EventsCleared,
+                    crate::event::Event::MainEventsCleared,
                     &self.window_target,
                     &mut control_flow,
                     &mut callback,
@@ -438,7 +438,8 @@ impl<T> EventLoop<T> {
                     );
                 }
                 if refresh {
-                    sink.send_window_event(crate::event::WindowEvent::RedrawRequested, wid);
+                    unimplemented!()
+                    //sink.send_window_event(crate::event::WindowEvent::RedrawRequested, wid);
                 }
                 if closed {
                     sink.send_window_event(crate::event::WindowEvent::CloseRequested, wid);

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -482,10 +482,14 @@ impl<T: 'static> EventProcessor<T> {
             ffi::Expose => {
                 let xev: &ffi::XExposeEvent = xev.as_ref();
 
-                let window = xev.window;
-                let window_id = mkwid(window);
+                // Multiple Expose events may be received for subareas of a window.
+                // We issue `RedrawRequested` only for the last event of such a series.
+                if xev.count == 0 {
+                    let window = xev.window;
+                    let window_id = mkwid(window);
 
-                callback(Event::RedrawRequested(window_id));
+                    callback(Event::RedrawRequested(window_id));
+                }
             }
 
             ffi::KeyPress | ffi::KeyRelease => {

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -485,10 +485,7 @@ impl<T: 'static> EventProcessor<T> {
                 let window = xev.window;
                 let window_id = mkwid(window);
 
-                callback(Event::WindowEvent {
-                    window_id,
-                    event: WindowEvent::RedrawRequested,
-                });
+                callback(Event::RedrawRequested(window_id));
             }
 
             ffi::KeyPress | ffi::KeyRelease => {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -37,7 +37,7 @@ use self::{
 };
 use crate::{
     error::OsError as RootOsError,
-    event::{Event, WindowEvent},
+    event::Event,
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
     platform_impl::{platform::sticky_exit_callback, PlatformSpecificWindowBuilderAttributes},
     window::WindowAttributes,
@@ -136,6 +136,8 @@ impl<T: 'static> EventLoop<T> {
 
         xconn.update_cached_wm_info(root);
 
+        let pending_redraws: Arc<Mutex<HashSet<WindowId>>> = Default::default();
+
         let target = Rc::new(RootELW {
             p: super::EventLoopWindowTarget::X(EventLoopWindowTarget {
                 ime,
@@ -146,7 +148,7 @@ impl<T: 'static> EventLoop<T> {
                 xconn,
                 wm_delete_window,
                 net_wm_ping,
-                pending_redraws: Default::default(),
+                pending_redraws: pending_redraws.clone(),
             }),
             _marker: ::std::marker::PhantomData,
         });
@@ -205,7 +207,9 @@ impl<T: 'static> EventLoop<T> {
                     if evt.readiness.is_readable() {
                         let mut processor = processor.borrow_mut();
                         let mut pending_events = pending_events.borrow_mut();
-                        drain_events(&mut processor, &mut pending_events);
+                        let mut pending_redraws = pending_redraws.lock().unwrap();
+
+                        drain_events(&mut processor, &mut pending_events, &mut pending_redraws);
                     }
                 }
             })
@@ -275,6 +279,15 @@ impl<T: 'static> EventLoop<T> {
                     );
                 }
             }
+            // send MainEventsCleared
+            {
+                sticky_exit_callback(
+                    crate::event::Event::MainEventsCleared,
+                    &self.target,
+                    &mut control_flow,
+                    &mut callback,
+                );
+            }
             // Empty the redraw requests
             {
                 // Release the lock to prevent deadlock
@@ -282,20 +295,17 @@ impl<T: 'static> EventLoop<T> {
 
                 for wid in windows {
                     sticky_exit_callback(
-                        Event::WindowEvent {
-                            window_id: crate::window::WindowId(super::WindowId::X(wid)),
-                            event: WindowEvent::RedrawRequested,
-                        },
+                        Event::RedrawRequested(crate::window::WindowId(super::WindowId::X(wid))),
                         &self.target,
                         &mut control_flow,
                         &mut callback,
                     );
                 }
             }
-            // send Events cleared
+            // send RedrawEventsCleared
             {
                 sticky_exit_callback(
-                    crate::event::Event::EventsCleared,
+                    crate::event::Event::RedrawEventsCleared,
                     &self.target,
                     &mut control_flow,
                     &mut callback,
@@ -385,17 +395,24 @@ impl<T: 'static> EventLoop<T> {
     fn drain_events(&self) {
         let mut processor = self.event_processor.borrow_mut();
         let mut pending_events = self.pending_events.borrow_mut();
+        let wt = get_xtarget(&self.target);
+        let mut pending_redraws = wt.pending_redraws.lock().unwrap();
 
-        drain_events(&mut processor, &mut pending_events);
+        drain_events(&mut processor, &mut pending_events, &mut pending_redraws);
     }
 }
 
 fn drain_events<T: 'static>(
     processor: &mut EventProcessor<T>,
     pending_events: &mut VecDeque<Event<T>>,
+    pending_redraws: &mut HashSet<WindowId>,
 ) {
     let mut callback = |event| {
-        pending_events.push_back(event);
+        if let Event::RedrawRequested(crate::window::WindowId(super::WindowId::X(wid))) = event {
+            pending_redraws.insert(wid);
+        } else {
+            pending_events.push_back(event);
+        }
     };
 
     // process all pending events


### PR DESCRIPTION
Implements the changes described in #1041 for the X11 platform and for
platform-independent public-facing code.

- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
