### PR TITLE
macOS: Drop the closure on exit. (Fixes #1058)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+- On macOS, drop the run closure on exit.
 - On Windows, location of `WindowEvent::Touch` are window client coordinates instead of screen coordinates.
 - On X11, fix delayed events after window redraw.
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -196,6 +196,7 @@ impl AppState {
         HANDLER.set_in_callback(true);
         HANDLER.handle_nonuser_event(Event::LoopDestroyed);
         HANDLER.set_in_callback(false);
+        HANDLER.callback.lock().unwrap().take();
     }
 
     pub fn launched() {


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
