### PR TITLE
Process WM_SYSCOMMAND to forbid screen savers in fullscreen mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - On macOS, drop the run closure on exit.
 - On Windows, location of `WindowEvent::Touch` are window client coordinates instead of screen coordinates.
 - On X11, fix delayed events after window redraw.
+- On Windows, screen saver won't start if the window is in fullscreen mode.
 
 # 0.20.0 Alpha 2 (2019-07-09)
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1020,6 +1020,17 @@ unsafe extern "system" fn public_window_callback<T>(
         // other unwanted default hotkeys as well.
         winuser::WM_SYSCHAR => 0,
 
+        winuser::WM_SYSCOMMAND => {
+            if wparam == winuser::SC_SCREENSAVE {
+                let window_state = subclass_input.window_state.lock();
+                if window_state.fullscreen.is_some() {
+                    return 0;
+                }
+            }
+
+            winuser::DefWindowProcW(window, msg, wparam, lparam)
+        }
+
         winuser::WM_MOUSEMOVE => {
             use crate::event::WindowEvent::{CursorEntered, CursorMoved};
             let mouse_was_outside_window = {

--- a/src/window.rs
+++ b/src/window.rs
@@ -538,6 +538,7 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS:** Can only be called on the main thread.
+    /// - **Windows:** Screen saver is disabled in fullscreen mode.
     #[inline]
     pub fn set_fullscreen(&self, monitor: Option<MonitorHandle>) {
         self.window.set_fullscreen(monitor)

--- a/src/window.rs
+++ b/src/window.rs
@@ -224,6 +224,10 @@ impl WindowBuilder {
 
     /// Sets the window fullscreen state. None means a normal window, Some(MonitorHandle)
     /// means a fullscreen window on that specific monitor
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Windows:** Screen saver is disabled in fullscreen mode.
     #[inline]
     pub fn with_fullscreen(mut self, monitor: Option<MonitorHandle>) -> WindowBuilder {
         self.window.fullscreen = monitor;


### PR DESCRIPTION
Fixes #1047

Tested only on Windows 10, but should work on previous version.

- [ ] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
