### PR TITLE
Fix run_return example build error on non-desktop platforms

### DIFF
--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -1,11 +1,21 @@
-use winit::{
-    event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
-    platform::desktop::EventLoopExtDesktop,
-    window::WindowBuilder,
-};
-
+// Limit this example to only compatible platforms.
+#[cfg(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 fn main() {
+    use winit::{
+        event::{Event, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        platform::desktop::EventLoopExtDesktop,
+        window::WindowBuilder,
+    };
+
     let mut event_loop = EventLoop::new();
 
     let window = WindowBuilder::new()
@@ -38,4 +48,9 @@ fn main() {
     });
 
     println!("Okay we're done now for real.");
+}
+
+#[cfg(any(target_os = "ios", target_os = "android", target_os = "emscripten"))]
+fn main() {
+    println!("This platform doesn't support run_return.");
 }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
    - N/A
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
    - N/A
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
    - N/A

Fixes #1064. Tested `cargo build --examples` for macOS and iOS, iOS build now works with this change. I wrote a comment explaining the platform selection because most of the other examples don't have any platform-specific code.