### PR TITLE
macOS/iOS: Fix auto trait impls of `EventLoopProxy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - On iOS, add support for hiding the home indicator.
 - On iOS, add support for deferring system gestures.
 - On iOS, fix a crash that occurred while acquiring a monitor's name.
+- On macOS and iOS, corrected the auto trait impls of `EventLoopProxy`.
 
 # 0.20.0 Alpha 2 (2019-07-09)
 

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -142,8 +142,7 @@ pub struct EventLoopProxy<T> {
     source: CFRunLoopSourceRef,
 }
 
-unsafe impl<T> Send for EventLoopProxy<T> {}
-unsafe impl<T> Sync for EventLoopProxy<T> {}
+unsafe impl<T: Send> Send for EventLoopProxy<T> {}
 
 impl<T> Clone for EventLoopProxy<T> {
     fn clone(&self) -> EventLoopProxy<T> {

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -114,8 +114,7 @@ pub struct Proxy<T> {
     source: CFRunLoopSourceRef,
 }
 
-unsafe impl<T> Send for Proxy<T> {}
-unsafe impl<T> Sync for Proxy<T> {}
+unsafe impl<T: Send> Send for Proxy<T> {}
 
 impl<T> Proxy<T> {
     fn new(sender: mpsc::Sender<T>) -> Self {


### PR DESCRIPTION
This pull request fixes `EventLoopProxy<T>`'s auto trait implementations.

- `EventLoopProxy<T>: Send` *only if* `T: Send`, because otherwise it would allow sending unsendable objects.
- `EventLoopProxy<T>: !Sync` because of `std::sync::mpsc::Sender` used under the hood. This restriction is congruent with other platforms' `EventLoopProxy`.

----------------------

- [ ] Tested on all platforms changed
    - [x] macOS
    - [ ] iOS — No experience with running Rust code on iOS whatsoever, can someone please test this?
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
