### PR TITLE
Do not require `T: Clone` for `EventLoopProxy<T>: Clone`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - On iOS, add support for hiding the home indicator.
 - On iOS, add support for deferring system gestures.
 - On iOS, fix a crash that occurred while acquiring a monitor's name.
+- Removed the `T: Clone` requirement from the `Clone` impl of `EventLoopProxy<T>`.
 
 # 0.20.0 Alpha 2 (2019-07-09)
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -173,9 +173,16 @@ impl<T> Deref for EventLoop<T> {
 }
 
 /// Used to send custom events to `EventLoop`.
-#[derive(Clone)]
 pub struct EventLoopProxy<T: 'static> {
     event_loop_proxy: platform_impl::EventLoopProxy<T>,
+}
+
+impl<T: 'static> Clone for EventLoopProxy<T> {
+    fn clone(&self) -> Self {
+        Self {
+            event_loop_proxy: self.event_loop_proxy.clone(),
+        }
+    }
 }
 
 impl<T: 'static> EventLoopProxy<T> {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -487,8 +487,8 @@ pub enum EventLoopProxy<T: 'static> {
 impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
         match self {
-            X(proxy) => EventLoopProxy::X(proxy.clone()),
-            Wayland(proxy) => EventLoopProxy::Wayland(proxy.clone()),
+            EventLoopProxy::X(proxy) => EventLoopProxy::X(proxy.clone()),
+            EventLoopProxy::Wayland(proxy) => EventLoopProxy::Wayland(proxy.clone()),
         }
     }
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -479,7 +479,6 @@ pub enum EventLoop<T: 'static> {
     X(x11::EventLoop<T>),
 }
 
-#[derive(Clone)]
 pub enum EventLoopProxy<T: 'static> {
     X(x11::EventLoopProxy<T>),
     Wayland(wayland::EventLoopProxy<T>),

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -485,6 +485,15 @@ pub enum EventLoopProxy<T: 'static> {
     Wayland(wayland::EventLoopProxy<T>),
 }
 
+impl<T: 'static> Clone for EventLoopProxy<T> {
+    fn clone(&self) -> Self {
+        match self {
+            X(proxy) => EventLoopProxy::X(proxy.clone()),
+            Wayland(proxy) => EventLoopProxy::Wayland(proxy.clone()),
+        }
+    }
+}
+
 impl<T: 'static> EventLoop<T> {
     pub fn new() -> EventLoop<T> {
         if let Ok(env_var) = env::var(BACKEND_PREFERENCE_ENV_VAR) {

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -111,6 +111,14 @@ pub struct EventLoopWindowTarget<T> {
     _marker: ::std::marker::PhantomData<T>,
 }
 
+impl<T: 'static> Clone for EventLoopProxy<T> {
+    fn clone(&self) -> Self {
+        EventLoopProxy {
+            user_sender: self.user_sender.clone(),
+        }
+    }
+}
+
 impl<T: 'static> EventLoopProxy<T> {
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
         self.user_sender.send(event).map_err(|_| EventLoopClosed)

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -90,7 +90,6 @@ pub struct EventLoop<T: 'static> {
 // A handle that can be sent across threads and used to wake up the `EventLoop`.
 //
 // We should only try and wake up the `EventLoop` if it still exists, so we hold Weak ptrs.
-#[derive(Clone)]
 pub struct EventLoopProxy<T: 'static> {
     user_sender: ::calloop::channel::Sender<T>,
 }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -66,9 +66,16 @@ pub struct EventLoop<T: 'static> {
     target: Rc<RootELW<T>>,
 }
 
-#[derive(Clone)]
 pub struct EventLoopProxy<T: 'static> {
     user_sender: ::calloop::channel::Sender<T>,
+}
+
+impl<T: 'static> Clone for EventLoopProxy<T> {
+    fn clone(&self) -> Self {
+        EventLoopProxy {
+            user_sender: self.user_sender.clone(),
+        }
+    }
 }
 
 impl<T: 'static> EventLoop<T> {

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -108,7 +108,6 @@ impl<T> EventLoop<T> {
     }
 }
 
-#[derive(Clone)]
 pub struct Proxy<T> {
     sender: mpsc::Sender<T>,
     source: CFRunLoopSourceRef,
@@ -116,6 +115,12 @@ pub struct Proxy<T> {
 
 unsafe impl<T> Send for Proxy<T> {}
 unsafe impl<T> Sync for Proxy<T> {}
+
+impl<T> Clone for Proxy<T> {
+    fn clone(&self) -> Self {
+        Proxy::new(self.sender.clone())
+    }
+}
 
 impl<T> Proxy<T> {
     fn new(sender: mpsc::Sender<T>) -> Self {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -678,7 +678,6 @@ impl EventLoopThreadExecutor {
 
 type ThreadExecFn = Box<Box<dyn FnMut()>>;
 
-#[derive(Clone)]
 pub struct EventLoopProxy<T: 'static> {
     target_window: HWND,
     event_send: Sender<T>,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -685,6 +685,15 @@ pub struct EventLoopProxy<T: 'static> {
 }
 unsafe impl<T: Send + 'static> Send for EventLoopProxy<T> {}
 
+impl<T: 'static> Clone for EventLoopProxy<T> {
+    fn clone(&self) -> Self {
+        Self {
+            target_window: self.target_window,
+            event_send: self.event_send.clone(),
+        }
+    }
+}
+
 impl<T: 'static> EventLoopProxy<T> {
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
         unsafe {


### PR DESCRIPTION
This pull request removes the `T: Clone` restriction from the `Clone` impl of `EventLoopProxy<T>`.

----------------------------------

- [x] Tested on all platforms changed
    - [x] X11
    - [x] Wayland
    - [x] macOS
    - [x] Windows
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented