### PR TITLE
Disable overscan compensation for external displays on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - On iOS, fix a crash that occurred while acquiring a monitor's name.
 - On iOS, fix armv7-apple-ios compile target.
 - Removed the `T: Clone` requirement from the `Clone` impl of `EventLoopProxy<T>`.
+- On iOS, disable overscan compensation for external displays (removes black
+  bars surrounding the image).
 
 # 0.20.0 Alpha 2 (2019-07-09)
 

--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -201,6 +201,23 @@ impl Into<ScreenEdge> for UIRectEdge {
     }
 }
 
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UIScreenOverscanCompensation(NSInteger);
+
+unsafe impl Encode for UIScreenOverscanCompensation {
+    fn encode() -> Encoding {
+        NSInteger::encode()
+    }
+}
+
+#[allow(dead_code)]
+impl UIScreenOverscanCompensation {
+    pub const Scale: UIScreenOverscanCompensation = UIScreenOverscanCompensation(0);
+    pub const InsetBounds: UIScreenOverscanCompensation = UIScreenOverscanCompensation(1);
+    pub const None: UIScreenOverscanCompensation = UIScreenOverscanCompensation(2);
+}
+
 #[link(name = "UIKit", kind = "framework")]
 #[link(name = "CoreFoundation", kind = "framework")]
 extern "C" {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -16,7 +16,7 @@ use crate::{
         event_loop,
         ffi::{
             id, CGFloat, CGPoint, CGRect, CGSize, UIEdgeInsets, UIInterfaceOrientationMask,
-            UIRectEdge,
+            UIRectEdge, UIScreenOverscanCompensation,
         },
         monitor, view, EventLoopWindowTarget, MonitorHandle,
     },
@@ -175,14 +175,22 @@ impl Inner {
                 }
             };
 
-            let current: id = msg_send![self.window, screen];
-            let bounds: CGRect = msg_send![uiscreen, bounds];
-
             // this is pretty slow on iOS, so avoid doing it if we can
+            let current: id = msg_send![self.window, screen];
             if uiscreen != current {
                 let () = msg_send![self.window, setScreen: uiscreen];
             }
+
+            let bounds: CGRect = msg_send![uiscreen, bounds];
             let () = msg_send![self.window, setFrame: bounds];
+
+            // For external displays, we must disable overscan compensation or
+            // the displayed image will have giant black bars surrounding it on
+            // each side
+            let () = msg_send![
+                uiscreen,
+                setOverscanCompensation: UIScreenOverscanCompensation::None
+            ];
         }
     }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

r? @mtak- 