### PR TITLE
Stop appending canvas to document in web platform

### DIFF
--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -56,7 +56,7 @@ impl Canvas {
         // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
         canvas
             .set_attribute("tabindex", "0")
-            .expect("Failed to set a tabindex");
+            .map_err(|_| os_error!(OsError("Failed to set a tabindex".to_owned())))?;
 
         Ok(Canvas {
             raw: canvas,

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -49,7 +49,11 @@ impl Canvas {
             .try_into()
             .map_err(|_| os_error!(OsError("Failed to create canvas element".to_owned())))?;
 
-        // TODO: Set up unique ids
+        // A tabindex is needed in order to capture local keyboard events.
+        // A "0" value means that the element should be focusable in
+        // sequential keyboard navigation, but its order is defined by the
+        // document's source order.
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
         canvas
             .set_attribute("tabindex", "0")
             .expect("Failed to set a tabindex");

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -49,11 +49,6 @@ impl Canvas {
             .try_into()
             .map_err(|_| os_error!(OsError("Failed to create canvas element".to_owned())))?;
 
-        document()
-            .body()
-            .ok_or_else(|| os_error!(OsError("Failed to find body node".to_owned())))?
-            .append_child(&canvas);
-
         // TODO: Set up unique ids
         canvas
             .set_attribute("tabindex", "0")

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -34,8 +34,12 @@ impl Canvas {
     where
         F: 'static + Fn(),
     {
-        let window = web_sys::window().expect("Failed to obtain window");
-        let document = window.document().expect("Failed to obtain document");
+        let window =
+            web_sys::window().ok_or(os_error!(OsError("Failed to obtain window".to_owned())))?;
+
+        let document = window
+            .document()
+            .ok_or(os_error!(OsError("Failed to obtain document".to_owned())))?;
 
         let canvas: HtmlCanvasElement = document
             .create_element("canvas")
@@ -49,7 +53,7 @@ impl Canvas {
         // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
         canvas
             .set_attribute("tabindex", "0")
-            .expect("Failed to set a tabindex");
+            .map_err(|_| os_error!(OsError("Failed to set a tabindex".to_owned())))?;
 
         Ok(Canvas {
             raw: canvas,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -42,12 +42,6 @@ impl Canvas {
             .map_err(|_| os_error!(OsError("Failed to create canvas element".to_owned())))?
             .unchecked_into();
 
-        document
-            .body()
-            .ok_or_else(|| os_error!(OsError("Failed to find body node".to_owned())))?
-            .append_child(&canvas)
-            .map_err(|_| os_error!(OsError("Failed to append canvas".to_owned())))?;
-
         // TODO: Set up unique ids
         canvas
             .set_attribute("tabindex", "0")

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -42,7 +42,11 @@ impl Canvas {
             .map_err(|_| os_error!(OsError("Failed to create canvas element".to_owned())))?
             .unchecked_into();
 
-        // TODO: Set up unique ids
+        // A tabindex is needed in order to capture local keyboard events.
+        // A "0" value means that the element should be focusable in
+        // sequential keyboard navigation, but its order is defined by the
+        // document's source order.
+        // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
         canvas
             .set_attribute("tabindex", "0")
             .expect("Failed to set a tabindex");


### PR DESCRIPTION
The changes here stop `winit` from automatically appending the window canvas to the document root in the web platform. I discussed this with @ryanisaacg on Discord and we seemed to agree.

I think this approach has multiple benefits:

  * It reduces the scope of `winit` to simply providing a canvas with the proper event listeners attached.
  * We get multiple canvas support for free, given that all the event listeners are currently local to the canvas (however, we still need to think if we should provide fullscreen support and how in #1072).
  * The user decides how to embed the canvas freely in their own web document. This allows us to leave some functionality out of `winit`'s scope, like changing the document/tab title or updating the favicon. The user is expected to implement this on top of `winit` if necessary.

Additionally, I have updated an unnecessary `TODO` comment and fixed some panics on canvas creation.