### PR TITLE
Replace `set_decorations` with `set_prefers_status_bar_hidden` on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - On iOS, fix a crash that occurred while acquiring a monitor's name.
 - On iOS, fix armv7-apple-ios compile target.
 - Removed the `T: Clone` requirement from the `Clone` impl of `EventLoopProxy<T>`.
+- On iOS, add `set_prefers_status_bar_hidden` extension function instead of
+  hijacking `set_decorations` for this purpose.
 
 # 0.20.0 Alpha 2 (2019-07-09)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -140,6 +140,7 @@ If your PR makes notable changes to Winit's features, please update this section
 * Setting the `UIView` hidpi factor
 * Valid orientations
 * Home indicator visibility
+* Status bar visibility
 * Deferrring system gestures
 * Support for custom `UIView` derived class
 * Getting the device idiom
@@ -164,8 +165,8 @@ Legend:
 |Window initialization            |✔️     |✔️     |▢[#5]      |✔️             |▢[#33]|▢[#33] |❓        |
 |Providing pointer to init OpenGL |✔️     |✔️     |✔️         |✔️             |✔️     |✔️    |❓        |
 |Providing pointer to init Vulkan |✔️     |✔️     |✔️         |✔️             |✔️     |❓     |**N/A**   |
-|Window decorations               |✔️     |✔️     |✔️         |▢[#306]        |**N/A**|✔️     |**N/A**   |
-|Window decorations toggle        |✔️     |✔️     |✔️         |✔️             |**N/A**|✔️     |**N/A**   |
+|Window decorations               |✔️     |✔️     |✔️         |▢[#306]        |**N/A**|**N/A**|**N/A**   |
+|Window decorations toggle        |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |
 |Window resizing                  |✔️     |▢[#219]|✔️         |▢[#306]        |**N/A**|**N/A**|❓        |
 |Window resize increments         |❌     |❌     |❌         |❌             |❌    |❌     |❌        |
 |Window transparency              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**   |

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -80,6 +80,16 @@ pub trait WindowExtIOS {
     /// and then calls
     /// [`-[UIViewController setNeedsUpdateOfScreenEdgesDeferringSystemGestures]`](https://developer.apple.com/documentation/uikit/uiviewcontroller/2887507-setneedsupdateofscreenedgesdefer?language=objc).
     fn set_preferred_screen_edges_deferring_system_gestures(&self, edges: ScreenEdge);
+
+    /// Sets whether the [`Window`] prefers the status bar hidden.
+    ///
+    /// The default is to prefer showing the status bar.
+    ///
+    /// This changes the value returned by
+    /// [`-[UIViewController prefersStatusBarHidden]`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621440-prefersstatusbarhidden?language=objc),
+    /// and then calls
+    /// [`-[UIViewController setNeedsStatusBarAppearanceUpdate]`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621354-setneedsstatusbarappearanceupdat?language=objc).
+    fn set_prefers_status_bar_hidden(&self, hidden: bool);
 }
 
 impl WindowExtIOS for Window {
@@ -117,6 +127,11 @@ impl WindowExtIOS for Window {
     fn set_preferred_screen_edges_deferring_system_gestures(&self, edges: ScreenEdge) {
         self.window
             .set_preferred_screen_edges_deferring_system_gestures(edges)
+    }
+
+    #[inline]
+    fn set_prefers_status_bar_hidden(&self, hidden: bool) {
+        self.window.set_prefers_status_bar_hidden(hidden)
     }
 }
 
@@ -163,6 +178,14 @@ pub trait WindowBuilderExtIOS {
         self,
         edges: ScreenEdge,
     ) -> WindowBuilder;
+
+    /// Sets whether the [`Window`] prefers the status bar hidden.
+    ///
+    /// The default is to prefer showing the status bar.
+    ///
+    /// This sets the initial value returned by
+    /// [`-[UIViewController prefersStatusBarHidden]`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621440-prefersstatusbarhidden?language=objc).
+    fn with_prefers_status_bar_hidden(self, hidden: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExtIOS for WindowBuilder {
@@ -197,6 +220,12 @@ impl WindowBuilderExtIOS for WindowBuilder {
     ) -> WindowBuilder {
         self.platform_specific
             .preferred_screen_edges_deferring_system_gestures = edges;
+        self
+    }
+
+    #[inline]
+    fn with_prefers_status_bar_hidden(mut self, hidden: bool) -> WindowBuilder {
+        self.platform_specific.prefers_status_bar_hidden = hidden;
         self
     }
 }

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -331,7 +331,7 @@ pub unsafe fn create_view(
 
 // requires main thread
 pub unsafe fn create_view_controller(
-    window_attributes: &WindowAttributes,
+    _window_attributes: &WindowAttributes,
     platform_attributes: &PlatformSpecificWindowBuilderAttributes,
     view: id,
 ) -> id {
@@ -347,10 +347,10 @@ pub unsafe fn create_view_controller(
         !view_controller.is_null(),
         "Failed to initialize `UIViewController` instance"
     );
-    let status_bar_hidden = if window_attributes.decorations {
-        NO
-    } else {
+    let status_bar_hidden = if platform_attributes.prefers_status_bar_hidden {
         YES
+    } else {
+        NO
     };
     let idiom = event_loop::get_idiom();
     let supported_orientations = UIInterfaceOrientationMask::from_valid_orientations_idiom(

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -206,14 +206,8 @@ impl Inner {
         }
     }
 
-    pub fn set_decorations(&self, decorations: bool) {
-        unsafe {
-            let status_bar_hidden = if decorations { NO } else { YES };
-            let () = msg_send![
-                self.view_controller,
-                setPrefersStatusBarHidden: status_bar_hidden
-            ];
-        }
+    pub fn set_decorations(&self, _decorations: bool) {
+        warn!("`Window::set_decorations` is ignored on iOS")
     }
 
     pub fn set_always_on_top(&self, _always_on_top: bool) {
@@ -406,6 +400,16 @@ impl Inner {
             ];
         }
     }
+
+    pub fn set_prefers_status_bar_hidden(&self, hidden: bool) {
+        unsafe {
+            let status_bar_hidden = if hidden { YES } else { NO };
+            let () = msg_send![
+                self.view_controller,
+                setPrefersStatusBarHidden: status_bar_hidden
+            ];
+        }
+    }
 }
 
 impl Inner {
@@ -528,6 +532,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub hidpi_factor: Option<f64>,
     pub valid_orientations: ValidOrientations,
     pub prefers_home_indicator_hidden: bool,
+    pub prefers_status_bar_hidden: bool,
     pub preferred_screen_edges_deferring_system_gestures: ScreenEdge,
 }
 
@@ -538,6 +543,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             hidpi_factor: None,
             valid_orientations: Default::default(),
             prefers_home_indicator_hidden: false,
+            prefers_status_bar_hidden: false,
             preferred_screen_edges_deferring_system_gestures: Default::default(),
         }
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -585,10 +585,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS:** Can only be called on the main thread. Controls whether the status bar is hidden
-    ///   via [`setPrefersStatusBarHidden`].
-    ///
-    /// [`setPrefersStatusBarHidden`]: https://developer.apple.com/documentation/uikit/uiviewcontroller/1621440-prefersstatusbarhidden?language=objc
+    /// - **iOS:** Has no effect.
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         self.window.set_decorations(decorations)


### PR DESCRIPTION
I don't think the semantics of `set_decorations` really match with the intent of wanting to hide the status bar. On desktop platforms for example, fullscreen windows are expected to automatically get their decorations disabled. On iOS however, all windows are fullscreen but the status bar is still enabled by default. It's also a common use case to have a regular windowed application (with decorations!) on desktop platforms, but to also hide the status bar on iOS. It looks confusing to have the `set_decorations` call be only invoked for iOS. This pull request makes `set_decorations` a no-op on iOS and adds a new extension function `set_prefers_status_bar_hidden` to `WindowExtIOS` and `with_prefers_status_bar_hidden` to `WindowBuilderExtIOS`.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented