### PR TITLE
Disable web module on other targets than wasm32

### DIFF
--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -1,3 +1,5 @@
+#![cfg(target_arch = "wasm32")]
+
 #[cfg(feature = "stdweb")]
 use stdweb::web::html_element::CanvasElement;
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation errors were addressed

Allows enabling `web-sys` or `stdweb` features and build for other targets than wasm32.