### PR TITLE
macos: fix an incorrect type signature on NSView drawRect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   hijacking `set_decorations` for this purpose.
 - On macOS and iOS, corrected the auto trait impls of `EventLoopProxy`.
 - On iOS, add touch pressure information for touch events.
+- On macOS, fix the signature of `-[NSView drawRect:]`.
 
 # 0.20.0 Alpha 2 (2019-07-09)
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -104,7 +104,7 @@ lazy_static! {
         );
         decl.add_method(
             sel!(drawRect:),
-            draw_rect as extern "C" fn(&Object, Sel, id),
+            draw_rect as extern "C" fn(&Object, Sel, NSRect),
         );
         decl.add_method(
             sel!(acceptsFirstResponder),
@@ -280,7 +280,7 @@ extern "C" fn view_did_move_to_window(this: &Object, _sel: Sel) {
     trace!("Completed `viewDidMoveToWindow`");
 }
 
-extern "C" fn draw_rect(this: &Object, _sel: Sel, rect: id) {
+extern "C" fn draw_rect(this: &Object, _sel: Sel, rect: NSRect) {
     unsafe {
         let state_ptr: *mut c_void = *this.get_ivar("winitState");
         let state = &mut *(state_ptr as *mut ViewState);


### PR DESCRIPTION
- [x] Tested on all platforms changed: macos
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

[drawRect](https://developer.apple.com/documentation/appkit/nsview/1483686-drawrect) takes an NSRect not a pointer.
