### PR TITLE
macos: Implement run_return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- On macOs, implement `run_return`.
+- On macOS, implement `run_return`.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- On macOs, implement `run_return`
+- On macOs, implement `run_return`.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On macOs, implement `run_return`
+
 # 0.20.0 Alpha 3 (2019-08-14)
 
 - On macOS, drop the run closure on exit.

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -177,6 +177,7 @@ impl Handler {
 pub enum AppState {}
 
 impl AppState {
+    // This function extends lifetime of `callback` to 'static as its side effect
     pub unsafe fn set_callback<F, T>(callback: F, window_target: Rc<RootWindowTarget<T>>)
     where
         F: FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
@@ -184,8 +185,8 @@ impl AppState {
         *HANDLER.callback.lock().unwrap() = Some(Box::new(EventLoopHandler {
             // This transmute is always safe, in case it was reached through `run`, since our
             // lifetime will be already 'static. In other cases caller should ensure that all data
-            // he passed to callback will actually outlive it, some apps just can't move everything
-            // to event loop, so this is something that they should care about.
+            // they passed to callback will actually outlive it, some apps just can't move
+            // everything to event loop, so this is something that they should care about.
             callback: mem::transmute::<
                 Box<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>,
                 Box<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>,

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::{self, Debug},
     hint::unreachable_unchecked,
     mem,
+    rc::Rc,
     sync::{
         atomic::{AtomicBool, Ordering},
         Mutex, MutexGuard,
@@ -37,13 +38,13 @@ pub trait EventHandler: Debug {
     fn handle_user_events(&mut self, control_flow: &mut ControlFlow);
 }
 
-struct EventLoopHandler<F, T: 'static> {
-    callback: F,
+struct EventLoopHandler<T: 'static> {
+    callback: Box<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>,
     will_exit: bool,
-    window_target: RootWindowTarget<T>,
+    window_target: Rc<RootWindowTarget<T>>,
 }
 
-impl<F, T> Debug for EventLoopHandler<F, T> {
+impl<T> Debug for EventLoopHandler<T> {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
             .debug_struct("EventLoopHandler")
@@ -52,11 +53,7 @@ impl<F, T> Debug for EventLoopHandler<F, T> {
     }
 }
 
-impl<F, T> EventHandler for EventLoopHandler<F, T>
-where
-    F: 'static + FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
-    T: 'static,
-{
+impl<T> EventHandler for EventLoopHandler<T> {
     fn handle_nonuser_event(&mut self, event: Event<Never>, control_flow: &mut ControlFlow) {
         (self.callback)(event.userify(), &self.window_target, control_flow);
         self.will_exit |= *control_flow == ControlFlow::Exit;
@@ -180,13 +177,19 @@ impl Handler {
 pub enum AppState {}
 
 impl AppState {
-    pub fn set_callback<F, T>(callback: F, window_target: RootWindowTarget<T>)
+    pub unsafe fn set_callback<F, T>(callback: F, window_target: Rc<RootWindowTarget<T>>)
     where
-        F: 'static + FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
-        T: 'static,
+        F: FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         *HANDLER.callback.lock().unwrap() = Some(Box::new(EventLoopHandler {
-            callback,
+            // This transmute is always safe, in case it was reached through `run`, since our
+            // lifetime will be already 'static. In other cases caller should ensure that all data
+            // he passed to callback will actually outlive it, some apps just can't move everything
+            // to event loop, so this is something that they should care about.
+            callback: mem::transmute::<
+                Box<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>,
+                Box<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>,
+            >(Box::new(callback)),
             will_exit: false,
             window_target,
         }));
@@ -299,7 +302,7 @@ impl AppState {
         }
         HANDLER.update_start_time();
         match HANDLER.get_old_and_new_control_flow() {
-            (ControlFlow::Exit, _) | (_, ControlFlow::Exit) => unreachable!(),
+            (ControlFlow::Exit, _) | (_, ControlFlow::Exit) => (),
             (old, new) if old == new => (),
             (_, ControlFlow::Wait) => HANDLER.waker().stop(),
             (_, ControlFlow::WaitUntil(instant)) => HANDLER.waker().start_at(instant),


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

The implementation is mostly based on discussion here #1005. I'm not quite familiar with macOs internals, and probably doing something wrong, but alacritty was starting and kind of working with this implementation. window_run_return example is also working fine.

cc @chrisduerr 

Fixes: #1005