### PR TITLE
Update parking_lot and bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.19.2"
+version = "0.19.3"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]
@@ -66,5 +66,5 @@ features = [
 wayland-client = { version = "0.21", features = [ "dlopen", "egl", "cursor"] }
 smithay-client-toolkit = "0.4.3"
 x11-dl = "2.18.3"
-parking_lot = "0.8"
+parking_lot = "0.9"
 percent-encoding = "2.0"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please direct all work against `master`.
 
 ```toml
 [dependencies]
-winit = "0.19.2"
+winit = "0.19.3"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
Update parking_lot in winit-legacy so that the versions can be synced with glutin.

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
