### PR TITLE
Defer window creation until `UIApplicationMain` on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On macOS, implement `run_return`.
+- On iOS 13.0, fix `NSInternalInconsistencyException` upon touching the screen.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 - On macOS, implement `run_return`.
 - On iOS 13.0, fix `NSInternalInconsistencyException` upon touching the screen.
+- On iOS, `Window::set_outer_position` is now ignored.
+- On iOS, `WindowBuilder::with_inner_size` is now ignored (to match behaviour
+  `Window::set_inner_size`, and additionally when combined with `with_fullscreen` this used to
+  result in an incorrect size for the window).
+- On iOS, `Window::inner_position` and `Window::inner_size` no longer include the safe area insets,
+  and the safe area must now be queried with `WindowExtIOS::safe_area_screen_space`.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -3,6 +3,7 @@
 use std::os::raw::c_void;
 
 use crate::{
+    dpi::{LogicalPosition, LogicalSize},
     event_loop::EventLoop,
     monitor::{MonitorHandle, VideoMode},
     window::{Window, WindowBuilder},
@@ -24,14 +25,16 @@ impl<T: 'static> EventLoopExtIOS for EventLoop<T> {
 pub trait WindowExtIOS {
     /// Returns a pointer to the [`UIWindow`] that is used by this window.
     ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
+    /// The pointer will be null before the event loop is running, and the pointer will become
+    /// invalid when the [`Window`] is destroyed.
     ///
     /// [`UIWindow`]: https://developer.apple.com/documentation/uikit/uiwindow?language=objc
     fn ui_window(&self) -> *mut c_void;
 
     /// Returns a pointer to the [`UIViewController`] that is used by this window.
     ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
+    /// The pointer will be null before the event loop is running, and the pointer will become
+    /// invalid when the [`Window`] is destroyed.
     ///
     /// [`UIViewController`]: https://developer.apple.com/documentation/uikit/uiviewcontroller?language=objc
     fn ui_view_controller(&self) -> *mut c_void;
@@ -90,6 +93,14 @@ pub trait WindowExtIOS {
     /// and then calls
     /// [`-[UIViewController setNeedsStatusBarAppearanceUpdate]`](https://developer.apple.com/documentation/uikit/uiviewcontroller/1621354-setneedsstatusbarappearanceupdat?language=objc).
     fn set_prefers_status_bar_hidden(&self, hidden: bool);
+
+    /// The safe area of a view reflects the area not covered by navigation bars, tab bars,
+    /// toolbars, and other ancestors that obscure a view controller's view.
+    ///
+    /// This may not be called before the event loop is running.
+    ///
+    /// See [`-[UIView safeAreaInsets]`](https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc).
+    fn safe_area_screen_space(&self) -> (LogicalPosition, LogicalSize);
 }
 
 impl WindowExtIOS for Window {
@@ -132,6 +143,11 @@ impl WindowExtIOS for Window {
     #[inline]
     fn set_prefers_status_bar_hidden(&self, hidden: bool) {
         self.window.set_prefers_status_bar_hidden(hidden)
+    }
+
+    #[inline]
+    fn safe_area_screen_space(&self) -> (LogicalPosition, LogicalSize) {
+        self.window.safe_area_screen_space()
     }
 }
 

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -14,9 +14,9 @@ use crate::{
 use crate::platform_impl::platform::{
     event_loop::{EventHandler, Never},
     ffi::{
-        id, kCFRunLoopCommonModes, CFAbsoluteTimeGetCurrent, CFRelease, CFRunLoopAddTimer,
+        kCFRunLoopCommonModes, CFAbsoluteTimeGetCurrent, CFRelease, CFRunLoopAddTimer,
         CFRunLoopGetMain, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
-        CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, NSUInteger,
+        CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate,
     },
     window::Inner as WindowInner,
 };
@@ -107,7 +107,6 @@ impl AppState {
             } => queued_windows.push(window),
             // `UIApplicationMain` already called, so initialize immediately
             _ => (*window).init(),
-            ref app_state => unreachable!("unexpected state: {:#?}", app_state),
         }
         drop(this);
     }

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -12,9 +12,8 @@ use crate::{
         app_state::AppState,
         event_loop,
         ffi::{
-            id, nil, CGFloat, CGPoint, CGRect, CGSize, UIEdgeInsets, UIForceTouchCapability,
-            UIInterfaceOrientationMask, UIRectEdge, UIScreenOverscanCompensation, UITouchPhase,
-            UITouchType,
+            id, nil, CGFloat, CGPoint, CGRect, UIForceTouchCapability, UIInterfaceOrientationMask,
+            UIRectEdge, UITouchPhase, UITouchType,
         },
         monitor,
         window::PlatformSpecificWindowBuilderAttributes,
@@ -337,7 +336,7 @@ unsafe fn get_window_class() -> &'static Class {
     CLASS.unwrap()
 }
 
-unsafe fn frame_from_window_attributes(window_attributes: &WindowAttributes) -> CGRect {
+pub unsafe fn frame_from_window_attributes(window_attributes: &WindowAttributes) -> CGRect {
     let screen = match window_attributes.fullscreen {
         Some(Fullscreen::Exclusive(ref video_mode)) => {
             video_mode.video_mode.monitor.ui_screen() as id
@@ -345,17 +344,7 @@ unsafe fn frame_from_window_attributes(window_attributes: &WindowAttributes) -> 
         Some(Fullscreen::Borderless(ref monitor)) => monitor.ui_screen() as id,
         None => monitor::main_uiscreen().ui_screen(),
     };
-    let screen_bounds: CGRect = msg_send![screen, bounds];
-    match window_attributes.inner_size {
-        Some(dim) => CGRect {
-            origin: screen_bounds.origin,
-            size: CGSize {
-                width: dim.width as _,
-                height: dim.height as _,
-            },
-        },
-        None => screen_bounds,
-    }
+    msg_send![screen, bounds]
 }
 
 // requires main thread


### PR DESCRIPTION
Fixes #1120 
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
