### PR TITLE
Fix inverted parameter in `set_prefers_home_indicator_hidden` on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On macOS, implement `run_return`.
+- On iOS, fix inverted parameter in `set_prefers_home_indicator_hidden`.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -402,7 +402,7 @@ impl Inner {
 
     pub fn set_prefers_home_indicator_hidden(&self, hidden: bool) {
         unsafe {
-            let prefers_home_indicator_hidden = if hidden { NO } else { YES };
+            let prefers_home_indicator_hidden = if hidden { YES } else { NO };
             let () = msg_send![
                 self.view_controller,
                 setPrefersHomeIndicatorAutoHidden: prefers_home_indicator_hidden


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
