### PR TITLE
Implement WindowEvent ModifiersChanged for X11 and Wayland

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -133,6 +133,12 @@ pub enum WindowEvent {
         input: KeyboardInput,
     },
 
+    /// Keyboard modifiers have changed
+    ModifiersChanged {
+        device_id: DeviceId,
+        modifiers: ModifiersState,
+    },
+
     /// The cursor has moved on the window.
     CursorMoved {
         device_id: DeviceId,

--- a/src/event.rs
+++ b/src/event.rs
@@ -135,7 +135,6 @@ pub enum WindowEvent {
 
     /// Keyboard modifiers have changed
     ModifiersChanged {
-        device_id: DeviceId,
         modifiers: ModifiersState,
     },
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -134,9 +134,7 @@ pub enum WindowEvent {
     },
 
     /// Keyboard modifiers have changed
-    ModifiersChanged {
-        modifiers: ModifiersState,
-    },
+    ModifiersChanged { modifiers: ModifiersState },
 
     /// The cursor has moved on the window.
     CursorMoved {

--- a/src/platform_impl/linux/wayland/keyboard.rs
+++ b/src/platform_impl/linux/wayland/keyboard.rs
@@ -90,12 +90,7 @@ pub fn init_keyboard(
 
                     if let Some(wid) = *target.lock().unwrap() {
                         my_sink
-                            .send((
-                                WindowEvent::ModifiersChanged {
-                                    modifiers,
-                                },
-                                wid,
-                            ))
+                            .send((WindowEvent::ModifiersChanged { modifiers }, wid))
                             .unwrap();
                     }
                 }

--- a/src/platform_impl/linux/wayland/keyboard.rs
+++ b/src/platform_impl/linux/wayland/keyboard.rs
@@ -92,9 +92,6 @@ pub fn init_keyboard(
                         my_sink
                             .send((
                                 WindowEvent::ModifiersChanged {
-                                    device_id: crate::event::DeviceId(
-                                        crate::platform_impl::DeviceId::Wayland(DeviceId),
-                                    ),
                                     modifiers,
                                 },
                                 wid,

--- a/src/platform_impl/linux/wayland/keyboard.rs
+++ b/src/platform_impl/linux/wayland/keyboard.rs
@@ -83,7 +83,25 @@ pub fn init_keyboard(
                 KbEvent::RepeatInfo { .. } => { /* Handled by smithay client toolkit */ }
                 KbEvent::Modifiers {
                     modifiers: event_modifiers,
-                } => *modifiers_tracker.lock().unwrap() = event_modifiers.into(),
+                } => {
+                    let modifiers = event_modifiers.into();
+
+                    *modifiers_tracker.lock().unwrap() = modifiers;
+
+                    if let Some(wid) = *target.lock().unwrap() {
+                        my_sink
+                            .send((
+                                WindowEvent::ModifiersChanged {
+                                    device_id: crate::event::DeviceId(
+                                        crate::platform_impl::DeviceId::Wayland(DeviceId),
+                                    ),
+                                    modifiers,
+                                },
+                                wid,
+                            ))
+                            .unwrap();
+                    }
+                }
             }
         },
         move |repeat_event: KeyRepeatEvent, _| {

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -561,8 +561,11 @@ impl<T: 'static> EventProcessor<T> {
                     if let Some(modifier) =
                         self.mod_keymap.get_modifier(xkev.keycode as ffi::KeyCode)
                     {
-                        self.window_mod_state
-                            .key_event(state, xkev.keycode as ffi::KeyCode, modifier);
+                        self.window_mod_state.key_event(
+                            state,
+                            xkev.keycode as ffi::KeyCode,
+                            modifier,
+                        );
 
                         let new_modifiers = self.window_mod_state.modifiers();
 
@@ -898,9 +901,7 @@ impl<T: 'static> EventProcessor<T> {
 
                             callback(Event::WindowEvent {
                                 window_id,
-                                event: WindowEvent::ModifiersChanged {
-                                    modifiers,
-                                },
+                                event: WindowEvent::ModifiersChanged { modifiers },
                             });
                         }
 
@@ -1083,8 +1084,14 @@ impl<T: 'static> EventProcessor<T> {
 
                         let virtual_keycode = events::keysym_to_element(keysym as c_uint);
 
-                        if let Some(modifier) = self.mod_keymap.get_modifier(keycode as ffi::KeyCode) {
-                            self.device_mod_state.key_event(state, keycode as ffi::KeyCode, modifier);
+                        if let Some(modifier) =
+                            self.mod_keymap.get_modifier(keycode as ffi::KeyCode)
+                        {
+                            self.device_mod_state.key_event(
+                                state,
+                                keycode as ffi::KeyCode,
+                                modifier,
+                            );
                         }
 
                         let modifiers = self.device_mod_state.modifiers();

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -34,6 +34,7 @@ use self::{
     dnd::{Dnd, DndState},
     event_processor::EventProcessor,
     ime::{Ime, ImeCreationError, ImeReceiver, ImeSender},
+    util::modifiers::ModifierKeymap,
 };
 use crate::{
     error::OsError as RootOsError,
@@ -143,6 +144,9 @@ impl<T: 'static> EventLoop<T> {
 
         xconn.update_cached_wm_info(root);
 
+        let mut mod_keymap = ModifierKeymap::new();
+        mod_keymap.reset_from_x_connection(&xconn);
+
         let target = Rc::new(RootELW {
             p: super::EventLoopWindowTarget::X(EventLoopWindowTarget {
                 ime,
@@ -186,6 +190,8 @@ impl<T: 'static> EventLoop<T> {
             randr_event_offset,
             ime_receiver,
             xi2ext,
+            mod_keymap,
+            mod_key_state: Default::default(),
         };
 
         // Register for device hotplug events

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -191,7 +191,8 @@ impl<T: 'static> EventLoop<T> {
             ime_receiver,
             xi2ext,
             mod_keymap,
-            mod_key_state: Default::default(),
+            device_mod_state: Default::default(),
+            window_mod_state: Default::default(),
         };
 
         // Register for device hotplug events

--- a/src/platform_impl/linux/x11/util/mod.rs
+++ b/src/platform_impl/linux/x11/util/mod.rs
@@ -10,6 +10,7 @@ mod hint;
 mod icon;
 mod input;
 mod memory;
+pub mod modifiers;
 mod randr;
 mod window_property;
 mod wm;

--- a/src/platform_impl/linux/x11/util/modifiers.rs
+++ b/src/platform_impl/linux/x11/util/modifiers.rs
@@ -1,0 +1,141 @@
+use std::{collections::HashMap, slice};
+
+use super::*;
+
+use crate::event::{ElementState, ModifiersState};
+
+// Offsets within XModifierKeymap to each set of keycodes.
+// We are only interested in Shift, Control, Alt, and Logo.
+//
+// There are 8 sets total. The order of keycode sets is:
+//     Shift, Lock, Control, Mod1 (Alt), Mod2, Mod3, Mod4 (Logo), Mod5
+//
+// https://tronche.com/gui/x/xlib/input/XSetModifierMapping.html
+const SHIFT_OFFSET: usize = 0;
+const CONTROL_OFFSET: usize = 2;
+const ALT_OFFSET: usize = 3;
+const LOGO_OFFSET: usize = 6;
+const NUM_MODS: usize = 8;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum Modifier {
+    Alt,
+    Ctrl,
+    Shift,
+    Logo,
+}
+
+#[derive(Debug, Default)]
+pub struct ModifierKeymap {
+    // Maps keycodes to modifiers
+    keys: HashMap<ffi::KeyCode, Modifier>,
+}
+
+#[derive(Debug, Default)]
+pub struct ModifierKeyState {
+    // Contains currently pressed modifier keys and their corresponding modifiers
+    keys: HashMap<ffi::KeyCode, Modifier>,
+}
+
+impl ModifierKeymap {
+    pub fn new() -> ModifierKeymap {
+        ModifierKeymap::default()
+    }
+
+    pub fn get_modifier(&self, keycode: ffi::KeyCode) -> Option<Modifier> {
+        self.keys.get(&keycode).cloned()
+    }
+
+    pub fn reset_from_x_connection(&mut self, xconn: &XConnection) {
+        unsafe {
+            let keymap = (xconn.xlib.XGetModifierMapping)(xconn.display);
+
+            if keymap.is_null() {
+                panic!("failed to allocate XModifierKeymap");
+            }
+
+            self.reset_from_x_keymap(&*keymap);
+
+            (xconn.xlib.XFreeModifiermap)(keymap);
+        }
+    }
+
+    pub fn reset_from_x_keymap(&mut self, keymap: &ffi::XModifierKeymap) {
+        let keys_per_mod = keymap.max_keypermod as usize;
+
+        let keys = unsafe {
+            slice::from_raw_parts(keymap.modifiermap as *const _, keys_per_mod * NUM_MODS)
+        };
+
+        self.keys.clear();
+
+        self.read_x_keys(keys, SHIFT_OFFSET, keys_per_mod, Modifier::Shift);
+        self.read_x_keys(keys, CONTROL_OFFSET, keys_per_mod, Modifier::Ctrl);
+        self.read_x_keys(keys, ALT_OFFSET, keys_per_mod, Modifier::Alt);
+        self.read_x_keys(keys, LOGO_OFFSET, keys_per_mod, Modifier::Logo);
+    }
+
+    fn read_x_keys(
+        &mut self,
+        keys: &[ffi::KeyCode],
+        offset: usize,
+        keys_per_mod: usize,
+        modifier: Modifier,
+    ) {
+        let start = offset * keys_per_mod;
+        let end = start + keys_per_mod;
+
+        for &keycode in &keys[start..end] {
+            if keycode != 0 {
+                self.keys.insert(keycode, modifier);
+            }
+        }
+    }
+}
+
+impl ModifierKeyState {
+    pub fn update(&mut self, mods: &ModifierKeymap) {
+        self.keys.retain(|k, v| {
+            if let Some(m) = mods.get_modifier(*k) {
+                *v = m;
+                true
+            } else {
+                false
+            }
+        });
+    }
+
+    pub fn modifiers(&self) -> ModifiersState {
+        let mut state = ModifiersState::default();
+
+        for &m in self.keys.values() {
+            set_modifier(&mut state, m);
+        }
+
+        state
+    }
+
+    pub fn key_event(&mut self, state: ElementState, keycode: ffi::KeyCode, modifier: Modifier) {
+        match state {
+            ElementState::Pressed => self.key_press(keycode, modifier),
+            ElementState::Released => self.key_release(keycode),
+        }
+    }
+
+    pub fn key_press(&mut self, keycode: ffi::KeyCode, modifier: Modifier) {
+        self.keys.insert(keycode, modifier);
+    }
+
+    pub fn key_release(&mut self, keycode: ffi::KeyCode) {
+        self.keys.remove(&keycode);
+    }
+}
+
+fn set_modifier(state: &mut ModifiersState, modifier: Modifier) {
+    match modifier {
+        Modifier::Alt => state.alt = true,
+        Modifier::Ctrl => state.ctrl = true,
+        Modifier::Shift => state.shift = true,
+        Modifier::Logo => state.logo = true,
+    }
+}

--- a/src/platform_impl/linux/x11/util/modifiers.rs
+++ b/src/platform_impl/linux/x11/util/modifiers.rs
@@ -31,7 +31,7 @@ pub struct ModifierKeymap {
     keys: HashMap<ffi::KeyCode, Modifier>,
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ModifierKeyState {
     // Contains currently pressed modifier keys and their corresponding modifiers
     keys: HashMap<ffi::KeyCode, Modifier>,
@@ -94,6 +94,14 @@ impl ModifierKeymap {
 }
 
 impl ModifierKeyState {
+    pub fn clear(&mut self) {
+        self.keys.clear();
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.keys.is_empty()
+    }
+
     pub fn update(&mut self, mods: &ModifierKeymap) {
         self.keys.retain(|k, v| {
             if let Some(m) = mods.get_modifier(*k) {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
