### PR TITLE
[ios] Groundwork for new Redraw API, refactoring AppState, and bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 - On iOS, add touch pressure information for touch events.
 - Implement `raw_window_handle::HasRawWindowHandle` for `Window` type on all supported platforms.
 - On macOS, fix the signature of `-[NSView drawRect:]`.
+- On iOS, fix the behavior of `ControlFlow::Poll`. It wasn't polling if that was the only mode ever used by the application.
+- On iOS, fix DPI sent out by views on creation was `0.0` - now it gives a reasonable number.
+- On iOS, RedrawRequested now works for gl/metal backed views.
+- On iOS, RedrawRequested is generally ordered after EventsCleared.
 
 # 0.20.0 Alpha 2 (2019-07-09)
 

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -1,6 +1,9 @@
+#![deny(unused_results)]
+
 use std::{
     cell::{RefCell, RefMut},
-    mem::{self, ManuallyDrop},
+    collections::HashSet,
+    mem,
     os::raw::c_void,
     ptr,
     time::Instant,
@@ -9,45 +12,85 @@ use std::{
 use objc::runtime::{BOOL, YES};
 
 use crate::{
-    event::{Event, StartCause},
+    event::{Event, StartCause, WindowEvent},
     event_loop::ControlFlow,
-};
-
-use crate::platform_impl::platform::{
-    event_loop::{EventHandler, Never},
-    ffi::{
-        id, kCFRunLoopCommonModes, CFAbsoluteTimeGetCurrent, CFRelease, CFRunLoopAddTimer,
-        CFRunLoopGetMain, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
-        CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, NSInteger, NSOperatingSystemVersion,
-        NSUInteger,
+    platform_impl::platform::{
+        event_loop::{EventHandler, Never},
+        ffi::{
+            id, kCFRunLoopCommonModes, CFAbsoluteTimeGetCurrent, CFRelease, CFRunLoopAddTimer,
+            CFRunLoopGetMain, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
+            CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, NSInteger, NSOperatingSystemVersion,
+            NSUInteger,
+        },
     },
+    window::WindowId as RootWindowId,
 };
 
 macro_rules! bug {
-    ($msg:expr) => {
-        panic!("winit iOS bug, file an issue: {}", $msg)
+    ($($msg:tt)*) => {
+        panic!("winit iOS bug, file an issue: {}", format!($($msg)*))
     };
+}
+
+macro_rules! bug_assert {
+    ($test:expr, $($msg:tt)*) => {
+        assert!($test, "winit iOS bug, file an issue: {}", format!($($msg)*))
+    };
+}
+
+enum UserCallbackTransitionResult<'a> {
+    Success {
+        event_handler: Box<dyn EventHandler>,
+        active_control_flow: ControlFlow,
+        processing_redraws: bool,
+    },
+    ReentrancyPrevented {
+        queued_events: &'a mut Vec<Event<Never>>,
+    },
+}
+
+impl Event<Never> {
+    fn is_redraw(&self) -> bool {
+        if let Event::WindowEvent {
+            window_id: _,
+            event: WindowEvent::RedrawRequested,
+        } = self
+        {
+            true
+        } else {
+            false
+        }
+    }
 }
 
 // this is the state machine for the app lifecycle
 #[derive(Debug)]
+#[must_use = "dropping `AppStateImpl` without inspecting it is probably a bug"]
 enum AppStateImpl {
     NotLaunched {
         queued_windows: Vec<id>,
         queued_events: Vec<Event<Never>>,
+        queued_gpu_redraws: HashSet<id>,
     },
     Launching {
         queued_windows: Vec<id>,
         queued_events: Vec<Event<Never>>,
         queued_event_handler: Box<dyn EventHandler>,
+        queued_gpu_redraws: HashSet<id>,
     },
     ProcessingEvents {
         event_handler: Box<dyn EventHandler>,
+        queued_gpu_redraws: HashSet<id>,
         active_control_flow: ControlFlow,
     },
     // special state to deal with reentrancy and prevent mutable aliasing.
     InUserCallback {
         queued_events: Vec<Event<Never>>,
+        queued_gpu_redraws: HashSet<id>,
+    },
+    ProcessingRedraws {
+        event_handler: Box<dyn EventHandler>,
+        active_control_flow: ControlFlow,
     },
     Waiting {
         waiting_event_handler: Box<dyn EventHandler>,
@@ -59,9 +102,16 @@ enum AppStateImpl {
     Terminated,
 }
 
-impl Drop for AppStateImpl {
+struct AppState {
+    // This should never be `None`, except for briefly during a state transition.
+    app_state: Option<AppStateImpl>,
+    control_flow: ControlFlow,
+    waker: EventLoopWaker,
+}
+
+impl Drop for AppState {
     fn drop(&mut self) {
-        match self {
+        match self.state_mut() {
             &mut AppStateImpl::NotLaunched {
                 ref mut queued_windows,
                 ..
@@ -69,20 +119,16 @@ impl Drop for AppStateImpl {
             | &mut AppStateImpl::Launching {
                 ref mut queued_windows,
                 ..
-            } => unsafe {
+            } => {
                 for &mut window in queued_windows {
-                    let () = msg_send![window, release];
+                    unsafe {
+                        let () = msg_send![window, release];
+                    }
                 }
-            },
+            }
             _ => {}
         }
     }
-}
-
-pub struct AppState {
-    app_state: AppStateImpl,
-    control_flow: ControlFlow,
-    waker: EventLoopWaker,
 }
 
 impl AppState {
@@ -98,7 +144,6 @@ impl AppState {
                 "bug in winit: `AppState::get_mut()` can only be called on the main thread"
             );
         }
-
         let mut guard = APP_STATE.borrow_mut();
         if guard.is_none() {
             #[inline(never)]
@@ -106,10 +151,11 @@ impl AppState {
             unsafe fn init_guard(guard: &mut RefMut<'static, Option<AppState>>) {
                 let waker = EventLoopWaker::new(CFRunLoopGetMain());
                 **guard = Some(AppState {
-                    app_state: AppStateImpl::NotLaunched {
+                    app_state: Some(AppStateImpl::NotLaunched {
                         queued_windows: Vec::new(),
                         queued_events: Vec::new(),
-                    },
+                        queued_gpu_redraws: HashSet::new(),
+                    }),
                     control_flow: ControlFlow::default(),
                     waker,
                 });
@@ -119,240 +165,153 @@ impl AppState {
         RefMut::map(guard, |state| state.as_mut().unwrap())
     }
 
-    // requires main thread and window is a UIWindow
-    // retains window
-    pub unsafe fn set_key_window(window: id) {
-        let mut this = AppState::get_mut();
-        match &mut this.app_state {
-            &mut AppStateImpl::NotLaunched {
-                ref mut queued_windows,
-                ..
-            } => {
-                queued_windows.push(window);
-                let _: id = msg_send![window, retain];
-                return;
-            }
-            &mut AppStateImpl::ProcessingEvents { .. } => {}
-            &mut AppStateImpl::InUserCallback { .. } => {}
-            &mut AppStateImpl::Terminated => panic!(
-                "Attempt to create a `Window` \
-                 after the app has terminated"
-            ),
-            app_state => unreachable!("unexpected state: {:#?}", app_state), /* all other cases should be impossible */
+    fn state(&self) -> &AppStateImpl {
+        match &self.app_state {
+            Some(ref state) => state,
+            None => bug!("`AppState` previously failed a state transition"),
         }
-        drop(this);
-        msg_send![window, makeKeyAndVisible]
     }
 
-    // requires main thread
-    pub unsafe fn will_launch(queued_event_handler: Box<dyn EventHandler>) {
-        let mut this = AppState::get_mut();
-        let (queued_windows, queued_events) = match &mut this.app_state {
-            &mut AppStateImpl::NotLaunched {
-                ref mut queued_windows,
-                ref mut queued_events,
-            } => {
-                let windows = ptr::read(queued_windows);
-                let events = ptr::read(queued_events);
-                (windows, events)
-            }
-            _ => panic!(
-                "winit iOS expected the app to be in a `NotLaunched` \
-                 state, but was not - please file an issue"
-            ),
+    fn state_mut(&mut self) -> &mut AppStateImpl {
+        match &mut self.app_state {
+            Some(ref mut state) => state,
+            None => bug!("`AppState` previously failed a state transition"),
+        }
+    }
+
+    fn take_state(&mut self) -> AppStateImpl {
+        match self.app_state.take() {
+            Some(state) => state,
+            None => bug!("`AppState` previously failed a state transition"),
+        }
+    }
+
+    fn set_state(&mut self, new_state: AppStateImpl) {
+        bug_assert!(
+            self.app_state.is_none(),
+            "attempted to set an `AppState` without calling `take_state` first {:?}",
+            self.app_state
+        );
+        self.app_state = Some(new_state)
+    }
+
+    fn replace_state(&mut self, new_state: AppStateImpl) -> AppStateImpl {
+        match &mut self.app_state {
+            Some(ref mut state) => mem::replace(state, new_state),
+            None => bug!("`AppState` previously failed a state transition"),
+        }
+    }
+
+    fn has_launched(&self) -> bool {
+        match self.state() {
+            &AppStateImpl::NotLaunched { .. } | &AppStateImpl::Launching { .. } => false,
+            _ => true,
+        }
+    }
+
+    fn will_launch_transition(&mut self, queued_event_handler: Box<dyn EventHandler>) {
+        let (queued_windows, queued_events, queued_gpu_redraws) = match self.take_state() {
+            AppStateImpl::NotLaunched {
+                queued_windows,
+                queued_events,
+                queued_gpu_redraws,
+            } => (queued_windows, queued_events, queued_gpu_redraws),
+            s => bug!("unexpected state {:?}", s),
         };
-        ptr::write(
-            &mut this.app_state,
+        self.set_state(AppStateImpl::Launching {
+            queued_windows,
+            queued_events,
+            queued_event_handler,
+            queued_gpu_redraws,
+        });
+    }
+
+    fn did_finish_launching_transition(&mut self) -> (Vec<id>, Vec<Event<Never>>) {
+        let (windows, events, event_handler, queued_gpu_redraws) = match self.take_state() {
             AppStateImpl::Launching {
                 queued_windows,
                 queued_events,
                 queued_event_handler,
-            },
-        );
+                queued_gpu_redraws,
+            } => (
+                queued_windows,
+                queued_events,
+                queued_event_handler,
+                queued_gpu_redraws,
+            ),
+            s => bug!("unexpected state {:?}", s),
+        };
+        self.set_state(AppStateImpl::ProcessingEvents {
+            event_handler,
+            active_control_flow: ControlFlow::Poll,
+            queued_gpu_redraws,
+        });
+        (windows, events)
     }
 
-    // requires main thread
-    pub unsafe fn did_finish_launching() {
-        let mut this = AppState::get_mut();
-        let windows = match &mut this.app_state {
-            &mut AppStateImpl::Launching {
-                ref mut queued_windows,
-                ..
-            } => mem::replace(queued_windows, Vec::new()),
-            _ => panic!(
-                "winit iOS expected the app to be in a `Launching` \
-                 state, but was not - please file an issue"
-            ),
-        };
-        // start waking up the event loop now!
-        debug_assert!(
-            this.control_flow == ControlFlow::Poll,
-            "winit iOS is unexpectedly not setup to `Poll` on launch!"
-        );
-        this.waker.start();
-
-        // have to drop RefMut because the window setup code below can trigger new events
-        drop(this);
-
-        for window in windows {
-            let count: NSUInteger = msg_send![window, retainCount];
-            // make sure the window is still referenced
-            if count > 1 {
-                // Do a little screen dance here to account for windows being created before
-                // `UIApplicationMain` is called. This fixes visual issues such as being
-                // offcenter and sized incorrectly. Additionally, to fix orientation issues, we
-                // gotta reset the `rootViewController`.
-                //
-                // relevant iOS log:
-                // ```
-                // [ApplicationLifecycle] Windows were created before application initialzation
-                // completed. This may result in incorrect visual appearance.
-                // ```
-                let screen: id = msg_send![window, screen];
-                let _: id = msg_send![screen, retain];
-                let () = msg_send![window, setScreen:0 as id];
-                let () = msg_send![window, setScreen: screen];
-                let () = msg_send![screen, release];
-                let controller: id = msg_send![window, rootViewController];
-                let () = msg_send![window, setRootViewController:ptr::null::<()>()];
-                let () = msg_send![window, setRootViewController: controller];
-                let () = msg_send![window, makeKeyAndVisible];
-            }
-            let () = msg_send![window, release];
+    fn wakeup_transition(&mut self) -> Option<Event<Never>> {
+        // before `AppState::did_finish_launching` is called, pretend there is no running
+        // event loop.
+        if !self.has_launched() {
+            return None;
         }
 
-        let mut this = AppState::get_mut();
-        let (windows, events, event_handler) = match &mut this.app_state {
-            &mut AppStateImpl::Launching {
-                ref mut queued_windows,
-                ref mut queued_events,
-                ref mut queued_event_handler,
-            } => {
-                let windows = ptr::read(queued_windows);
-                let events = ptr::read(queued_events);
-                let event_handler = ptr::read(queued_event_handler);
-                (windows, events, event_handler)
-            }
-            _ => panic!(
-                "winit iOS expected the app to be in a `Launching` \
-                 state, but was not - please file an issue"
+        let (event_handler, event) = match (self.control_flow, self.take_state()) {
+            (
+                ControlFlow::Poll,
+                AppStateImpl::PollFinished {
+                    waiting_event_handler,
+                },
+            ) => (waiting_event_handler, Event::NewEvents(StartCause::Poll)),
+            (
+                ControlFlow::Wait,
+                AppStateImpl::Waiting {
+                    waiting_event_handler,
+                    start,
+                },
+            ) => (
+                waiting_event_handler,
+                Event::NewEvents(StartCause::WaitCancelled {
+                    start,
+                    requested_resume: None,
+                }),
             ),
-        };
-        ptr::write(
-            &mut this.app_state,
-            AppStateImpl::ProcessingEvents {
-                event_handler,
-                active_control_flow: ControlFlow::Poll,
-            },
-        );
-        drop(this);
-
-        let events = std::iter::once(Event::NewEvents(StartCause::Init)).chain(events);
-        AppState::handle_nonuser_events(events);
-
-        // the above window dance hack, could possibly trigger new windows to be created.
-        // we can just set those windows up normally, as they were created after didFinishLaunching
-        for window in windows {
-            let count: NSUInteger = msg_send![window, retainCount];
-            // make sure the window is still referenced
-            if count > 1 {
-                let () = msg_send![window, makeKeyAndVisible];
-            }
-            let () = msg_send![window, release];
-        }
-    }
-
-    // requires main thread
-    // AppState::did_finish_launching handles the special transition `Init`
-    pub unsafe fn handle_wakeup_transition() {
-        let mut this = AppState::get_mut();
-        let event =
-            match this.control_flow {
-                ControlFlow::Poll => {
-                    let event_handler = match &mut this.app_state {
-                        &mut AppStateImpl::NotLaunched { .. }
-                        | &mut AppStateImpl::Launching { .. } => return,
-                        &mut AppStateImpl::PollFinished {
-                            ref mut waiting_event_handler,
-                        } => ptr::read(waiting_event_handler),
-                        _ => bug!("`EventHandler` unexpectedly started polling"),
-                    };
-                    ptr::write(
-                        &mut this.app_state,
-                        AppStateImpl::ProcessingEvents {
-                            event_handler,
-                            active_control_flow: ControlFlow::Poll,
-                        },
-                    );
-                    Event::NewEvents(StartCause::Poll)
-                }
-                ControlFlow::Wait => {
-                    let (event_handler, start) = match &mut this.app_state {
-                        &mut AppStateImpl::NotLaunched { .. }
-                        | &mut AppStateImpl::Launching { .. } => return,
-                        &mut AppStateImpl::Waiting {
-                            ref mut waiting_event_handler,
-                            ref mut start,
-                        } => (ptr::read(waiting_event_handler), *start),
-                        _ => bug!("`EventHandler` unexpectedly woke up"),
-                    };
-                    ptr::write(
-                        &mut this.app_state,
-                        AppStateImpl::ProcessingEvents {
-                            event_handler,
-                            active_control_flow: ControlFlow::Wait,
-                        },
-                    );
+            (
+                ControlFlow::WaitUntil(requested_resume),
+                AppStateImpl::Waiting {
+                    waiting_event_handler,
+                    start,
+                },
+            ) => {
+                let event = if Instant::now() >= requested_resume {
+                    Event::NewEvents(StartCause::ResumeTimeReached {
+                        start,
+                        requested_resume,
+                    })
+                } else {
                     Event::NewEvents(StartCause::WaitCancelled {
                         start,
-                        requested_resume: None,
+                        requested_resume: Some(requested_resume),
                     })
-                }
-                ControlFlow::WaitUntil(requested_resume) => {
-                    let (event_handler, start) = match &mut this.app_state {
-                        &mut AppStateImpl::NotLaunched { .. }
-                        | &mut AppStateImpl::Launching { .. } => return,
-                        &mut AppStateImpl::Waiting {
-                            ref mut waiting_event_handler,
-                            ref mut start,
-                        } => (ptr::read(waiting_event_handler), *start),
-                        _ => bug!("`EventHandler` unexpectedly woke up"),
-                    };
-                    ptr::write(
-                        &mut this.app_state,
-                        AppStateImpl::ProcessingEvents {
-                            event_handler,
-                            active_control_flow: ControlFlow::WaitUntil(requested_resume),
-                        },
-                    );
-                    if Instant::now() >= requested_resume {
-                        Event::NewEvents(StartCause::ResumeTimeReached {
-                            start,
-                            requested_resume,
-                        })
-                    } else {
-                        Event::NewEvents(StartCause::WaitCancelled {
-                            start,
-                            requested_resume: Some(requested_resume),
-                        })
-                    }
-                }
-                ControlFlow::Exit => bug!("unexpected controlflow `Exit`"),
-            };
-        drop(this);
-        AppState::handle_nonuser_event(event)
+                };
+                (waiting_event_handler, event)
+            }
+            (ControlFlow::Exit, _) => bug!("unexpected `ControlFlow` `Exit`"),
+            s => bug!("`EventHandler` unexpectedly woke up {:?}", s),
+        };
+
+        self.set_state(AppStateImpl::ProcessingEvents {
+            event_handler,
+            queued_gpu_redraws: Default::default(),
+            active_control_flow: self.control_flow,
+        });
+        Some(event)
     }
 
-    // requires main thread
-    pub unsafe fn handle_nonuser_event(event: Event<Never>) {
-        AppState::handle_nonuser_events(std::iter::once(event))
-    }
-
-    // requires main thread
-    pub unsafe fn handle_nonuser_events<I: IntoIterator<Item = Event<Never>>>(events: I) {
-        let mut this = AppState::get_mut();
-        let mut control_flow = this.control_flow;
-        let (mut event_handler, active_control_flow) = match &mut this.app_state {
+    fn try_user_callback_transition(&mut self) -> UserCallbackTransitionResult<'_> {
+        // If we're not able to process an event due to recursion or `Init` not having been sent out
+        // yet, then queue the events up.
+        match self.state_mut() {
             &mut AppStateImpl::Launching {
                 ref mut queued_events,
                 ..
@@ -365,209 +324,476 @@ impl AppState {
                 ref mut queued_events,
                 ..
             } => {
-                queued_events.extend(events);
-                return;
+                // A lifetime cast: early returns are not currently handled well with NLL, but
+                // polonius handles them well. This transmute is a safe workaround.
+                return unsafe {
+                    mem::transmute::<
+                        UserCallbackTransitionResult<'_>,
+                        UserCallbackTransitionResult<'_>,
+                    >(UserCallbackTransitionResult::ReentrancyPrevented {
+                        queued_events,
+                    })
+                };
             }
-            &mut AppStateImpl::ProcessingEvents {
-                ref mut event_handler,
-                ref mut active_control_flow,
-            } => (ptr::read(event_handler), *active_control_flow),
-            &mut AppStateImpl::PollFinished { .. }
-            | &mut AppStateImpl::Waiting { .. }
-            | &mut AppStateImpl::Terminated => bug!("unexpected attempted to process an event"),
-        };
-        ptr::write(
-            &mut this.app_state,
-            AppStateImpl::InUserCallback {
-                queued_events: Vec::new(),
-            },
-        );
-        drop(this);
 
-        for event in events {
-            event_handler.handle_nonuser_event(event, &mut control_flow)
+            &mut AppStateImpl::ProcessingEvents { .. }
+            | &mut AppStateImpl::ProcessingRedraws { .. } => {}
+
+            s @ &mut AppStateImpl::PollFinished { .. }
+            | s @ &mut AppStateImpl::Waiting { .. }
+            | s @ &mut AppStateImpl::Terminated => {
+                bug!("unexpected attempted to process an event {:?}", s)
+            }
         }
-        loop {
-            let mut this = AppState::get_mut();
-            let queued_events = match &mut this.app_state {
-                &mut AppStateImpl::InUserCallback {
-                    ref mut queued_events,
-                } => mem::replace(queued_events, Vec::new()),
-                _ => bug!("unexpected `AppStateImpl`"),
-            };
-            if queued_events.is_empty() {
-                this.app_state = AppStateImpl::ProcessingEvents {
+
+        let (event_handler, queued_gpu_redraws, active_control_flow, processing_redraws) =
+            match self.take_state() {
+                AppStateImpl::Launching { .. }
+                | AppStateImpl::NotLaunched { .. }
+                | AppStateImpl::InUserCallback { .. } => unreachable!(),
+                AppStateImpl::ProcessingEvents {
+                    event_handler,
+                    queued_gpu_redraws,
+                    active_control_flow,
+                } => (
+                    event_handler,
+                    queued_gpu_redraws,
+                    active_control_flow,
+                    false,
+                ),
+                AppStateImpl::ProcessingRedraws {
                     event_handler,
                     active_control_flow,
-                };
-                this.control_flow = control_flow;
-                break;
-            }
-            drop(this);
-            for event in queued_events {
-                event_handler.handle_nonuser_event(event, &mut control_flow)
-            }
+                } => (event_handler, Default::default(), active_control_flow, true),
+                AppStateImpl::PollFinished { .. }
+                | AppStateImpl::Waiting { .. }
+                | AppStateImpl::Terminated => unreachable!(),
+            };
+        self.set_state(AppStateImpl::InUserCallback {
+            queued_events: Vec::new(),
+            queued_gpu_redraws,
+        });
+        UserCallbackTransitionResult::Success {
+            event_handler,
+            active_control_flow,
+            processing_redraws,
         }
     }
 
-    // requires main thread
-    pub unsafe fn handle_user_events() {
-        let mut this = AppState::get_mut();
-        let mut control_flow = this.control_flow;
-        let (mut event_handler, active_control_flow) = match &mut this.app_state {
-            &mut AppStateImpl::NotLaunched { .. } | &mut AppStateImpl::Launching { .. } => return,
-            &mut AppStateImpl::ProcessingEvents {
-                ref mut event_handler,
-                ref mut active_control_flow,
-            } => (ptr::read(event_handler), *active_control_flow),
-            &mut AppStateImpl::InUserCallback { .. }
-            | &mut AppStateImpl::PollFinished { .. }
-            | &mut AppStateImpl::Waiting { .. }
-            | &mut AppStateImpl::Terminated => bug!("unexpected attempted to process an event"),
+    fn main_events_cleared_transition(&mut self) -> HashSet<id> {
+        let (event_handler, queued_gpu_redraws, active_control_flow) = match self.take_state() {
+            AppStateImpl::ProcessingEvents {
+                event_handler,
+                queued_gpu_redraws,
+                active_control_flow,
+            } => (event_handler, queued_gpu_redraws, active_control_flow),
+            s => bug!("unexpected state {:?}", s),
         };
-        ptr::write(
-            &mut this.app_state,
-            AppStateImpl::InUserCallback {
-                queued_events: Vec::new(),
-            },
-        );
-        drop(this);
-
-        event_handler.handle_user_events(&mut control_flow);
-        loop {
-            let mut this = AppState::get_mut();
-            let queued_events = match &mut this.app_state {
-                &mut AppStateImpl::InUserCallback {
-                    ref mut queued_events,
-                } => mem::replace(queued_events, Vec::new()),
-                _ => bug!("unexpected `AppStateImpl`"),
-            };
-            if queued_events.is_empty() {
-                this.app_state = AppStateImpl::ProcessingEvents {
-                    event_handler,
-                    active_control_flow,
-                };
-                this.control_flow = control_flow;
-                break;
-            }
-            drop(this);
-            for event in queued_events {
-                event_handler.handle_nonuser_event(event, &mut control_flow)
-            }
-            event_handler.handle_user_events(&mut control_flow);
-        }
+        self.set_state(AppStateImpl::ProcessingRedraws {
+            event_handler,
+            active_control_flow,
+        });
+        queued_gpu_redraws
     }
 
-    // requires main thread
-    pub unsafe fn handle_events_cleared() {
-        let mut this = AppState::get_mut();
-        match &mut this.app_state {
-            &mut AppStateImpl::NotLaunched { .. } | &mut AppStateImpl::Launching { .. } => return,
-            &mut AppStateImpl::ProcessingEvents { .. } => {}
-            _ => unreachable!(),
-        };
-        drop(this);
-
-        AppState::handle_user_events();
-        AppState::handle_nonuser_event(Event::EventsCleared);
-
-        let mut this = AppState::get_mut();
-        let (event_handler, old) = match &mut this.app_state {
-            &mut AppStateImpl::ProcessingEvents {
-                ref mut event_handler,
-                ref mut active_control_flow,
-            } => (
-                ManuallyDrop::new(ptr::read(event_handler)),
-                *active_control_flow,
-            ),
-            _ => unreachable!(),
+    fn events_cleared_transition(&mut self) {
+        if !self.has_launched() {
+            return;
+        }
+        let (waiting_event_handler, old) = match self.take_state() {
+            AppStateImpl::ProcessingRedraws {
+                event_handler,
+                active_control_flow,
+            } => (event_handler, active_control_flow),
+            s => bug!("unexpected state {:?}", s),
         };
 
-        let new = this.control_flow;
+        let new = self.control_flow;
         match (old, new) {
-            (ControlFlow::Poll, ControlFlow::Poll) => ptr::write(
-                &mut this.app_state,
-                AppStateImpl::PollFinished {
-                    waiting_event_handler: ManuallyDrop::into_inner(event_handler),
-                },
-            ),
+            (ControlFlow::Poll, ControlFlow::Poll) => self.set_state(AppStateImpl::PollFinished {
+                waiting_event_handler,
+            }),
             (ControlFlow::Wait, ControlFlow::Wait) => {
                 let start = Instant::now();
-                ptr::write(
-                    &mut this.app_state,
-                    AppStateImpl::Waiting {
-                        waiting_event_handler: ManuallyDrop::into_inner(event_handler),
-                        start,
-                    },
-                )
+                self.set_state(AppStateImpl::Waiting {
+                    waiting_event_handler,
+                    start,
+                });
             }
             (ControlFlow::WaitUntil(old_instant), ControlFlow::WaitUntil(new_instant))
                 if old_instant == new_instant =>
             {
                 let start = Instant::now();
-                ptr::write(
-                    &mut this.app_state,
-                    AppStateImpl::Waiting {
-                        waiting_event_handler: ManuallyDrop::into_inner(event_handler),
-                        start,
-                    },
-                )
+                self.set_state(AppStateImpl::Waiting {
+                    waiting_event_handler,
+                    start,
+                });
             }
             (_, ControlFlow::Wait) => {
                 let start = Instant::now();
-                ptr::write(
-                    &mut this.app_state,
-                    AppStateImpl::Waiting {
-                        waiting_event_handler: ManuallyDrop::into_inner(event_handler),
-                        start,
-                    },
-                );
-                this.waker.stop()
+                self.set_state(AppStateImpl::Waiting {
+                    waiting_event_handler,
+                    start,
+                });
+                self.waker.stop()
             }
             (_, ControlFlow::WaitUntil(new_instant)) => {
                 let start = Instant::now();
-                ptr::write(
-                    &mut this.app_state,
-                    AppStateImpl::Waiting {
-                        waiting_event_handler: ManuallyDrop::into_inner(event_handler),
-                        start,
-                    },
-                );
-                this.waker.start_at(new_instant)
+                self.set_state(AppStateImpl::Waiting {
+                    waiting_event_handler,
+                    start,
+                });
+                self.waker.start_at(new_instant)
             }
             (_, ControlFlow::Poll) => {
-                ptr::write(
-                    &mut this.app_state,
-                    AppStateImpl::PollFinished {
-                        waiting_event_handler: ManuallyDrop::into_inner(event_handler),
-                    },
-                );
-                this.waker.start()
+                self.set_state(AppStateImpl::PollFinished {
+                    waiting_event_handler,
+                });
+                self.waker.start()
             }
             (_, ControlFlow::Exit) => {
                 // https://developer.apple.com/library/archive/qa/qa1561/_index.html
                 // it is not possible to quit an iOS app gracefully and programatically
                 warn!("`ControlFlow::Exit` ignored on iOS");
-                this.control_flow = old
+                self.control_flow = old
             }
         }
     }
 
-    pub fn terminated() {
-        let mut this = unsafe { AppState::get_mut() };
-        let mut old = mem::replace(&mut this.app_state, AppStateImpl::Terminated);
-        let mut control_flow = this.control_flow;
-        if let AppStateImpl::ProcessingEvents {
-            ref mut event_handler,
-            ..
-        } = old
-        {
-            drop(this);
-            event_handler.handle_nonuser_event(Event::LoopDestroyed, &mut control_flow)
-        } else {
-            bug!("`LoopDestroyed` happened while not processing events")
+    fn terminated_transition(&mut self) -> Box<dyn EventHandler> {
+        match self.replace_state(AppStateImpl::Terminated) {
+            AppStateImpl::ProcessingRedraws { event_handler, .. } => event_handler,
+            s => bug!(
+                "`LoopDestroyed` happened while not processing events {:?}",
+                s
+            ),
         }
     }
+}
+
+// requires main thread and window is a UIWindow
+// retains window
+pub unsafe fn set_key_window(window: id) {
+    bug_assert!(
+        {
+            let is_window: BOOL = msg_send![window, isKindOfClass: class!(UIWindow)];
+            is_window == YES
+        },
+        "set_key_window called with an incorrect type"
+    );
+    let mut this = AppState::get_mut();
+    match this.state_mut() {
+        &mut AppStateImpl::NotLaunched {
+            ref mut queued_windows,
+            ..
+        } => return queued_windows.push(msg_send![window, retain]),
+        &mut AppStateImpl::ProcessingEvents { .. }
+        | &mut AppStateImpl::InUserCallback { .. }
+        | &mut AppStateImpl::ProcessingRedraws { .. } => {}
+        s @ &mut AppStateImpl::Launching { .. }
+        | s @ &mut AppStateImpl::Waiting { .. }
+        | s @ &mut AppStateImpl::PollFinished { .. } => bug!("unexpected state {:?}", s),
+        &mut AppStateImpl::Terminated => {
+            panic!("Attempt to create a `Window` after the app has terminated")
+        }
+    }
+    drop(this);
+    msg_send![window, makeKeyAndVisible]
+}
+
+// requires main thread and window is a UIWindow
+// retains window
+pub unsafe fn queue_gl_or_metal_redraw(window: id) {
+    bug_assert!(
+        {
+            let is_window: BOOL = msg_send![window, isKindOfClass: class!(UIWindow)];
+            is_window == YES
+        },
+        "set_key_window called with an incorrect type"
+    );
+    let mut this = AppState::get_mut();
+    match this.state_mut() {
+        &mut AppStateImpl::NotLaunched {
+            ref mut queued_gpu_redraws,
+            ..
+        }
+        | &mut AppStateImpl::Launching {
+            ref mut queued_gpu_redraws,
+            ..
+        }
+        | &mut AppStateImpl::ProcessingEvents {
+            ref mut queued_gpu_redraws,
+            ..
+        }
+        | &mut AppStateImpl::InUserCallback {
+            ref mut queued_gpu_redraws,
+            ..
+        } => drop(queued_gpu_redraws.insert(window)),
+        s @ &mut AppStateImpl::ProcessingRedraws { .. }
+        | s @ &mut AppStateImpl::Waiting { .. }
+        | s @ &mut AppStateImpl::PollFinished { .. } => bug!("unexpected state {:?}", s),
+        &mut AppStateImpl::Terminated => {
+            panic!("Attempt to create a `Window` after the app has terminated")
+        }
+    }
+    drop(this);
+}
+
+// requires main thread
+pub unsafe fn will_launch(queued_event_handler: Box<dyn EventHandler>) {
+    AppState::get_mut().will_launch_transition(queued_event_handler)
+}
+
+// requires main thread
+pub unsafe fn did_finish_launching() {
+    let mut this = AppState::get_mut();
+    let windows = match this.state_mut() {
+        AppStateImpl::Launching { queued_windows, .. } => mem::replace(queued_windows, Vec::new()),
+        s => bug!("unexpected state {:?}", s),
+    };
+
+    // start waking up the event loop now!
+    bug_assert!(
+        this.control_flow == ControlFlow::Poll,
+        "unexpectedly not setup to `Poll` on launch!"
+    );
+    this.waker.start();
+
+    // have to drop RefMut because the window setup code below can trigger new events
+    drop(this);
+
+    for window in windows {
+        let count: NSUInteger = msg_send![window, retainCount];
+        // make sure the window is still referenced
+        if count > 1 {
+            // Do a little screen dance here to account for windows being created before
+            // `UIApplicationMain` is called. This fixes visual issues such as being
+            // offcenter and sized incorrectly. Additionally, to fix orientation issues, we
+            // gotta reset the `rootViewController`.
+            //
+            // relevant iOS log:
+            // ```
+            // [ApplicationLifecycle] Windows were created before application initialzation
+            // completed. This may result in incorrect visual appearance.
+            // ```
+            let screen: id = msg_send![window, screen];
+            let _: id = msg_send![screen, retain];
+            let () = msg_send![window, setScreen:0 as id];
+            let () = msg_send![window, setScreen: screen];
+            let () = msg_send![screen, release];
+            let controller: id = msg_send![window, rootViewController];
+            let () = msg_send![window, setRootViewController:ptr::null::<()>()];
+            let () = msg_send![window, setRootViewController: controller];
+            let () = msg_send![window, makeKeyAndVisible];
+        }
+        let () = msg_send![window, release];
+    }
+
+    let (windows, events) = AppState::get_mut().did_finish_launching_transition();
+
+    let events = std::iter::once(Event::NewEvents(StartCause::Init)).chain(events);
+    handle_nonuser_events(events);
+
+    // the above window dance hack, could possibly trigger new windows to be created.
+    // we can just set those windows up normally, as they were created after didFinishLaunching
+    for window in windows {
+        let count: NSUInteger = msg_send![window, retainCount];
+        // make sure the window is still referenced
+        if count > 1 {
+            let () = msg_send![window, makeKeyAndVisible];
+        }
+        let () = msg_send![window, release];
+    }
+}
+
+// requires main thread
+// AppState::did_finish_launching handles the special transition `Init`
+pub unsafe fn handle_wakeup_transition() {
+    let mut this = AppState::get_mut();
+    let wakeup_event = match this.wakeup_transition() {
+        None => return,
+        Some(wakeup_event) => wakeup_event,
+    };
+    drop(this);
+
+    handle_nonuser_event(wakeup_event)
+}
+
+// requires main thread
+pub unsafe fn handle_nonuser_event(event: Event<Never>) {
+    handle_nonuser_events(std::iter::once(event))
+}
+
+// requires main thread
+pub unsafe fn handle_nonuser_events<I: IntoIterator<Item = Event<Never>>>(events: I) {
+    let mut this = AppState::get_mut();
+    let (mut event_handler, active_control_flow, processing_redraws) =
+        match this.try_user_callback_transition() {
+            UserCallbackTransitionResult::ReentrancyPrevented { queued_events } => {
+                queued_events.extend(events);
+                return;
+            }
+            UserCallbackTransitionResult::Success {
+                event_handler,
+                active_control_flow,
+                processing_redraws,
+            } => (event_handler, active_control_flow, processing_redraws),
+        };
+    let mut control_flow = this.control_flow;
+    drop(this);
+
+    for event in events {
+        if !processing_redraws && event.is_redraw() {
+            log::info!("processing `RedrawRequested` during the main event loop");
+        }
+        event_handler.handle_nonuser_event(event, &mut control_flow)
+    }
+
+    loop {
+        let mut this = AppState::get_mut();
+        let queued_events = match this.state_mut() {
+            &mut AppStateImpl::InUserCallback {
+                ref mut queued_events,
+                queued_gpu_redraws: _,
+            } => mem::replace(queued_events, Vec::new()),
+            s => bug!("unexpected state {:?}", s),
+        };
+        if queued_events.is_empty() {
+            let queued_gpu_redraws = match this.take_state() {
+                AppStateImpl::InUserCallback {
+                    queued_events: _,
+                    queued_gpu_redraws,
+                } => queued_gpu_redraws,
+                _ => unreachable!(),
+            };
+            this.app_state = Some(if processing_redraws {
+                bug_assert!(
+                    queued_gpu_redraws.is_empty(),
+                    "redraw queued while processing redraws"
+                );
+                AppStateImpl::ProcessingRedraws {
+                    event_handler,
+                    active_control_flow,
+                }
+            } else {
+                AppStateImpl::ProcessingEvents {
+                    event_handler,
+                    queued_gpu_redraws,
+                    active_control_flow,
+                }
+            });
+            this.control_flow = control_flow;
+            break;
+        }
+        drop(this);
+
+        for event in queued_events {
+            if !processing_redraws && event.is_redraw() {
+                log::info!("processing `RedrawRequested` during the main event loop");
+            }
+            event_handler.handle_nonuser_event(event, &mut control_flow)
+        }
+    }
+}
+
+// requires main thread
+unsafe fn handle_user_events() {
+    let mut this = AppState::get_mut();
+    let mut control_flow = this.control_flow;
+    let (mut event_handler, active_control_flow, processing_redraws) =
+        match this.try_user_callback_transition() {
+            UserCallbackTransitionResult::ReentrancyPrevented { .. } => {
+                bug!("unexpected attempted to process an event")
+            }
+            UserCallbackTransitionResult::Success {
+                event_handler,
+                active_control_flow,
+                processing_redraws,
+            } => (event_handler, active_control_flow, processing_redraws),
+        };
+    if processing_redraws {
+        bug!("user events attempted to be sent out while `ProcessingRedraws`");
+    }
+    drop(this);
+
+    event_handler.handle_user_events(&mut control_flow);
+
+    loop {
+        let mut this = AppState::get_mut();
+        let queued_events = match this.state_mut() {
+            &mut AppStateImpl::InUserCallback {
+                ref mut queued_events,
+                queued_gpu_redraws: _,
+            } => mem::replace(queued_events, Vec::new()),
+            s => bug!("unexpected state {:?}", s),
+        };
+        if queued_events.is_empty() {
+            let queued_gpu_redraws = match this.take_state() {
+                AppStateImpl::InUserCallback {
+                    queued_events: _,
+                    queued_gpu_redraws,
+                } => queued_gpu_redraws,
+                _ => unreachable!(),
+            };
+            this.app_state = Some(AppStateImpl::ProcessingEvents {
+                event_handler,
+                queued_gpu_redraws,
+                active_control_flow,
+            });
+            this.control_flow = control_flow;
+            break;
+        }
+        drop(this);
+
+        for event in queued_events {
+            event_handler.handle_nonuser_event(event, &mut control_flow)
+        }
+        event_handler.handle_user_events(&mut control_flow);
+    }
+}
+
+// requires main thread
+pub unsafe fn handle_main_events_cleared() {
+    let mut this = AppState::get_mut();
+    if !this.has_launched() {
+        return;
+    }
+    match this.state_mut() {
+        &mut AppStateImpl::ProcessingEvents { .. } => {}
+        _ => bug!("`ProcessingRedraws` happened unexpectedly"),
+    };
+    drop(this);
+
+    // User events are always sent out at the end of the "MainEventLoop"
+    handle_user_events();
+    handle_nonuser_event(Event::EventsCleared);
+
+    let mut this = AppState::get_mut();
+    let redraw_events = this
+        .main_events_cleared_transition()
+        .into_iter()
+        .map(|window| Event::WindowEvent {
+            window_id: RootWindowId(window.into()),
+            event: WindowEvent::RedrawRequested,
+        });
+    drop(this);
+
+    handle_nonuser_events(redraw_events);
+}
+
+// requires main thread
+pub unsafe fn handle_events_cleared() {
+    AppState::get_mut().events_cleared_transition();
+}
+
+// requires main thread
+pub unsafe fn terminated() {
+    let mut this = AppState::get_mut();
+    let mut event_handler = this.terminated_transition();
+    let mut control_flow = this.control_flow;
+    drop(this);
+
+    event_handler.handle_nonuser_event(Event::LoopDestroyed, &mut control_flow)
 }
 
 struct EventLoopWaker {

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -645,6 +645,11 @@ pub unsafe fn handle_nonuser_events<I: IntoIterator<Item = Event<Never>>>(events
     for event in events {
         if !processing_redraws && event.is_redraw() {
             log::info!("processing `RedrawRequested` during the main event loop");
+        } else if processing_redraws && !event.is_redraw() {
+            log::warn!(
+                "processing non `RedrawRequested` event after the main event loop: {:#?}",
+                event
+            );
         }
         event_handler.handle_nonuser_event(event, &mut control_flow)
     }
@@ -690,6 +695,11 @@ pub unsafe fn handle_nonuser_events<I: IntoIterator<Item = Event<Never>>>(events
         for event in queued_events {
             if !processing_redraws && event.is_redraw() {
                 log::info!("processing `RedrawRequested` during the main event loop");
+            } else if processing_redraws && !event.is_redraw() {
+                log::warn!(
+                    "processing non-`RedrawRequested` event after the main event loop: {:#?}",
+                    event
+                );
             }
             event_handler.handle_nonuser_event(event, &mut control_flow)
         }

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -184,6 +184,13 @@ impl AppState {
                  state, but was not - please file an issue"
             ),
         };
+        // start waking up the event loop now!
+        debug_assert!(
+            this.control_flow == ControlFlow::Poll,
+            "winit iOS is unexpectedly not setup to `Poll` on launch!"
+        );
+        this.waker.start();
+
         // have to drop RefMut because the window setup code below can trigger new events
         drop(this);
 

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -155,7 +155,7 @@ impl<T> EventLoopProxy<T> {
             let rl = CFRunLoopGetMain();
             // we want all the members of context to be zero/null, except one
             let mut context: CFRunLoopSourceContext = mem::zeroed();
-            context.perform = event_loop_proxy_handler;
+            context.perform = Some(event_loop_proxy_handler);
             let source =
                 CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::max_value() - 1, &mut context);
             CFRunLoopAddSource(rl, source, kCFRunLoopCommonModes);

--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -331,14 +331,14 @@ pub enum CFRunLoopTimerContext {}
 pub struct CFRunLoopSourceContext {
     pub version: CFIndex,
     pub info: *mut c_void,
-    pub retain: extern "C" fn(*const c_void) -> *const c_void,
-    pub release: extern "C" fn(*const c_void),
-    pub copyDescription: extern "C" fn(*const c_void) -> CFStringRef,
-    pub equal: extern "C" fn(*const c_void, *const c_void) -> Boolean,
-    pub hash: extern "C" fn(*const c_void) -> CFHashCode,
-    pub schedule: extern "C" fn(*mut c_void, CFRunLoopRef, CFRunLoopMode),
-    pub cancel: extern "C" fn(*mut c_void, CFRunLoopRef, CFRunLoopMode),
-    pub perform: extern "C" fn(*mut c_void),
+    pub retain: Option<extern "C" fn(*const c_void) -> *const c_void>,
+    pub release: Option<extern "C" fn(*const c_void)>,
+    pub copyDescription: Option<extern "C" fn(*const c_void) -> CFStringRef>,
+    pub equal: Option<extern "C" fn(*const c_void, *const c_void) -> Boolean>,
+    pub hash: Option<extern "C" fn(*const c_void) -> CFHashCode>,
+    pub schedule: Option<extern "C" fn(*mut c_void, CFRunLoopRef, CFRunLoopMode)>,
+    pub cancel: Option<extern "C" fn(*mut c_void, CFRunLoopRef, CFRunLoopMode)>,
+    pub perform: Option<extern "C" fn(*mut c_void)>,
 }
 
 pub trait NSString: Sized {

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -496,7 +496,9 @@ pub unsafe fn create_window(
             let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode];
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
-        Some(Fullscreen::Borderless(ref monitor)) => msg_send![window, setScreen:monitor.ui_screen()],
+        Some(Fullscreen::Borderless(ref monitor)) => {
+            msg_send![window, setScreen:monitor.ui_screen()]
+        }
         None => (),
     }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -59,6 +59,14 @@ impl Inner {
     pub fn request_redraw(&self) {
         unsafe {
             if self.gl_or_metal_backed {
+                // `setNeedsDisplay` does nothing on UIViews which are directly backed by CAEAGLLayer or CAMetalLayer.
+                // Ordinarily the OS sets up a bunch of UIKit state before calling drawRect: on a UIView, but when using
+                // raw or gl/metal for drawing this work is completely avoided.
+                //
+                // The docs for `setNeedsDisplay` don't mention `CAMetalLayer`; however, this has been confirmed via
+                // testing.
+                //
+                // https://developer.apple.com/documentation/uikit/uiview/1622437-setneedsdisplay?language=objc
                 app_state::queue_gl_or_metal_redraw(self.window);
             } else {
                 let () = msg_send![self.view, setNeedsDisplay];


### PR DESCRIPTION
Fixes #1087

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

See changelog for more info.

Mostly this PR should make implementing the new `RedrawRequested` API much simpler, and make contributing to the iOS backend more approachable.

There are definitely times where the OS requests a redraw in the middle of an event loop. This is not the common case, but it _does_ happen.

Here's an example demonstrating the OS requesting a redraw when a new `UIView` is created:
```
NewEvents(Init)
WindowEvent { window_id: WindowId(WindowId { window: 0x0 }), event: HiDpiFactorChanged(2.0) }
WindowEvent { window_id: WindowId(WindowId { window: 0x0 }), event: Resized(LogicalSize { width: 375.0, height: 667.0 }) }
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: Focused(true) }
Resumed
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: Resized(LogicalSize { width: 375.0, height: 667.0 }) }
[2019-08-29T22:18:54Z INFO  winit::platform_impl::platform::app_state] processing `RedrawRequested` during the main event loop
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: RedrawRequested }
EventsCleared
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: RedrawRequested }
```
Here's an example of the OS requesting a redraw on backgrounding (the OS caches an image of your app in order to relaunch more quickly).
```
NewEvents(WaitCancelled { start: Instant { t: 1026013331522 }, requested_resume: None })
Suspended
EventsCleared
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: RedrawRequested }
NewEvents(WaitCancelled { start: Instant { t: 1026092807505 }, requested_resume: None })
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: Resized(LogicalSize { width: 375.0, height: 667.0 }) }
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: Resized(LogicalSize { width: 375.0, height: 667.0 }) }
[2019-08-29T22:21:06Z INFO  winit::platform_impl::platform::app_state] processing `RedrawRequested` during the main event loop
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: RedrawRequested }
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: Resized(LogicalSize { width: 375.0, height: 667.0 }) }
WindowEvent { window_id: WindowId(WindowId { window: 0x105806aa0 }), event: Resized(LogicalSize { width: 375.0, height: 667.0 }) }
EventsCleared
```
EDIT: On iOS 11 iPad Air 2 the second example sends out both the `Resized` event and the `Redraw` events after `EventsCleared`.