### PR TITLE
Add touch pressure information for touch events on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - On X11, performance is improved when rapidly calling `Window::set_cursor_icon`.
 - On iOS, fix improper `msg_send` usage that was UB and/or would break if `!` is stabilized.
 - On Windows, unset `maximized` when manually changing the window's position or size.
+- On Windows, add touch pressure information for touch events.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -194,7 +194,7 @@ Legend:
 |Cursor grab             |✔️       |▢[#165] |▢[#242]  |❌[#306]    |**N/A**|**N/A**|✔️       |
 |Cursor icon             |✔️       |✔️      |✔️       |❌[#306]    |**N/A**|**N/A**|❌       |
 |Touch events            |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |✔️       |
-|Touch pressure          |❌       |❌      |❌       |❌          |❌     |✔️     |❌       |
+|Touch pressure          |✔️       |❌      |❌       |❌          |❌     |✔️     |❌       |
 |Multitouch              |✔️       |❌      |✔️       |✔️          |❓     |✔️     |❌       |
 |Keyboard events         |✔️       |✔️      |✔️       |✔️          |❓     |❌     |✔️       |
 |Drag & Drop             |▢[#720]  |▢[#720] |▢[#720]  |❌[#306]    |**N/A**|**N/A**|❓        |

--- a/src/event.rs
+++ b/src/event.rs
@@ -329,7 +329,7 @@ pub struct Touch {
     ///
     /// ## Platform-specific
     ///
-    /// - Only available on **iOS** 9.0+.
+    /// - Only available on **iOS** 9.0+ and **Windows** 8+.
     pub force: Option<Force>,
     /// Unique identifier of a finger.
     pub id: u64,

--- a/src/platform_impl/windows/dpi.rs
+++ b/src/platform_impl/windows/dpi.rs
@@ -1,6 +1,6 @@
 #![allow(non_snake_case, unused_unsafe)]
 
-use std::{mem, os::raw::c_void, sync::Once};
+use std::sync::Once;
 
 use winapi::{
     shared::{

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1516,7 +1516,7 @@ unsafe extern "system" fn public_window_callback<T>(
                                 continue;
                             },
                             location,
-                            force: None, // TODO
+                            force: None, // WM_TOUCH doesn't support pressure information
                             id: input.dwID as u64,
                             device_id: DEVICE_ID,
                         }),


### PR DESCRIPTION
Related to PR #1090

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
