### PR TITLE
Fix request_redraw in MainEventsCleared not dispatching immediately

### DIFF
--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -1,5 +1,3 @@
-use std::time::{Duration, Instant};
-
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -14,18 +14,21 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, _, control_flow| match event {
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            ..
-        } => *control_flow = ControlFlow::Exit,
-        Event::MainEventsCleared => {
-            window.request_redraw();
-            *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::new(1, 0))
+    event_loop.run(move |event, _, control_flow| {
+        println!("{:?}", event);
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => *control_flow = ControlFlow::Exit,
+            Event::MainEventsCleared => {
+                println!("request redraw");
+                window.request_redraw();
+            }
+            Event::RedrawRequested(_) => {
+                println!("redraw requested");
+            }
+            _ => (),
         }
-        Event::RedrawRequested(_) => {
-            println!("{:?}", event);
-        }
-        _ => (),
     });
 }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -35,9 +35,7 @@ use crate::{
     platform_impl::platform::{
         dpi::{dpi_to_scale_factor, hwnd_dpi},
         drop_handler::FileDropHandler,
-        event_loop::{
-            self, EventLoopWindowTarget, DESTROY_MSG_ID, INITIAL_DPI_MSG_ID,
-        },
+        event_loop::{self, EventLoopWindowTarget, DESTROY_MSG_ID, INITIAL_DPI_MSG_ID},
         icon::{self, IconType, WinIcon},
         monitor,
         raw_input::register_all_mice_and_keyboards_for_raw_input,


### PR DESCRIPTION
Previously, RedrawRequested would be dispatched in the next iteration of
the event loop. This fixes that.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

