### PR TITLE
Hide `ModifiersChanged` from the docs.

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -134,6 +134,7 @@ pub enum WindowEvent {
     },
 
     /// Keyboard modifiers have changed
+    #[doc(hidden)]
     ModifiersChanged { modifiers: ModifiersState },
 
     /// The cursor has moved on the window.


### PR DESCRIPTION
We wouldn't want users stumbling on it until all platforms implement it.

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
