### PR TITLE
fix: distinguish grab and grabbing cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - On iOS, fix improper `msg_send` usage that was UB and/or would break if `!` is stabilized.
 - On Windows, unset `maximized` when manually changing the window's position or size.
 - On Windows, add touch pressure information for touch events.
+- On macOS, differentiate between `CursorIcon::Grab` and `CursorIcon::Grabbing`.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/platform_impl/macos/util/cursor.rs
+++ b/src/platform_impl/macos/util/cursor.rs
@@ -15,10 +15,12 @@ pub enum Cursor {
 
 impl From<CursorIcon> for Cursor {
     fn from(cursor: CursorIcon) -> Self {
+        // See native cursors at https://developer.apple.com/documentation/appkit/nscursor?language=objc.
         match cursor {
             CursorIcon::Arrow | CursorIcon::Default => Cursor::Native("arrowCursor"),
             CursorIcon::Hand => Cursor::Native("pointingHandCursor"),
-            CursorIcon::Grabbing | CursorIcon::Grab => Cursor::Native("closedHandCursor"),
+            CursorIcon::Grab => Cursor::Native("openHandCursor"),
+            CursorIcon::Grabbing => Cursor::Native("closedHandCursor"),
             CursorIcon::Text => Cursor::Native("IBeamCursor"),
             CursorIcon::VerticalText => Cursor::Native("IBeamCursorForVerticalLayout"),
             CursorIcon::Copy => Cursor::Native("dragCopyCursor"),

--- a/src/window.rs
+++ b/src/window.rs
@@ -760,7 +760,9 @@ pub enum CursorIcon {
     Alias,
     Copy,
     NoDrop,
+    /// Indicates something can be grabbed.
     Grab,
+    /// Indicates something is grabbed.
     Grabbing,
     AllScroll,
     ZoomIn,


### PR DESCRIPTION
On MacOS, there is a difference between a "grab" cursor and a "grabbing"
cursor, where "grab" is an open-hand cursor used during a hover, and
"grabbing" is a closed-hand cursor used on a click. These, and other
native MacOS cursors, can be seen at the [NSCursor documentation](https://developer.apple.com/documentation/appkit/nscursor?language=objc).

See https://github.com/hecrj/iced/issues/9 for the motivation for this PR.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
  - N/A
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
  - N/A
