### PR TITLE
Send a LoopDestroyed event when the browser is closed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ version = "0.3.22"
 optional = true
 features = [
     'console',
+    'BeforeUnloadEvent',
     'Document',
     'DomRect',
     'Element',

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -48,6 +48,9 @@ impl<T: 'static> Shared<T> {
     pub fn set_listener(&self, event_handler: Box<dyn FnMut(Event<T>, &mut root::ControlFlow)>) {
         self.0.runner.replace(Some(Runner::new(event_handler)));
         self.send_event(Event::NewEvents(StartCause::Init));
+
+        let close_instance = self.clone();
+        backend::on_unload(move || close_instance.handle_unload());
     }
 
     // Add an event to the event loop runner
@@ -109,6 +112,8 @@ impl<T: 'static> Shared<T> {
             self.handle_event(Event::LoopDestroyed, &mut control);
         }
     }
+
+    fn handle_unload(&self) {}
 
     // handle_event takes in events and either queues them or applies a callback
     //

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -113,7 +113,11 @@ impl<T: 'static> Shared<T> {
         }
     }
 
-    fn handle_unload(&self) {}
+    fn handle_unload(&self) {
+        self.apply_control_flow(root::ControlFlow::Exit);
+        let mut control = self.current_control_flow();
+        self.handle_event(Event::LoopDestroyed, &mut control);
+    }
 
     // handle_event takes in events and either queues them or applies a callback
     //

--- a/src/platform_impl/web/stdweb/mod.rs
+++ b/src/platform_impl/web/stdweb/mod.rs
@@ -9,10 +9,17 @@ use crate::platform::web::WindowExtStdweb;
 use crate::window::Window;
 
 use stdweb::js;
+use stdweb::web::event::BeforeUnloadEvent;
 use stdweb::web::html_element::CanvasElement;
+use stdweb::web::window;
+use stdweb::web::IEventTarget;
 
 pub fn throw(msg: &str) {
     js! { throw @{msg} }
+}
+
+pub fn on_unload(mut handler: impl FnMut() + 'static) {
+    window().add_event_listener(move |_: BeforeUnloadEvent| handler());
 }
 
 impl WindowExtStdweb for Window {

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -7,10 +7,23 @@ pub use self::timeout::Timeout;
 
 use crate::platform::web::WindowExtWebSys;
 use crate::window::Window;
-use web_sys::HtmlCanvasElement;
+use wasm_bindgen::{closure::Closure, JsCast};
+use web_sys::{BeforeUnloadEvent, HtmlCanvasElement};
 
 pub fn throw(msg: &str) {
     wasm_bindgen::throw_str(msg);
+}
+
+pub fn on_unload(mut handler: impl FnMut() + 'static) {
+    let window = web_sys::window().expect("Failed to obtain window");
+
+    let closure = Closure::wrap(
+        Box::new(move |_: BeforeUnloadEvent| handler()) as Box<dyn FnMut(BeforeUnloadEvent)>
+    );
+
+    window
+        .add_event_listener_with_callback("beforeunload", &closure.as_ref().unchecked_ref())
+        .expect("Failed to add close listener");
 }
 
 impl WindowExtWebSys for Window {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
