### PR TITLE
Flush high surrogate if not followed by low surrogate

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1031,12 +1031,12 @@ unsafe extern "system" fn public_window_callback<T>(
 
         winuser::WM_CHAR => {
             use crate::event::WindowEvent::ReceivedCharacter;
-            let high_surrogate = 0xD800 <= wparam && wparam <= 0xDBFF;
-            let low_surrogate = 0xDC00 <= wparam && wparam <= 0xDFFF;
+            let is_high_surrogate = 0xD800 <= wparam && wparam <= 0xDBFF;
+            let is_low_surrogate = 0xDC00 <= wparam && wparam <= 0xDFFF;
 
-            if high_surrogate {
+            if is_high_surrogate {
                 subclass_input.window_state.lock().high_surrogate = Some(wparam as u16);
-            } else if low_surrogate {
+            } else if is_low_surrogate {
                 let mut window_state = subclass_input.window_state.lock();
                 if let Some(high_surrogate) = window_state.high_surrogate.take() {
                     let pair = [high_surrogate, wparam as u16];
@@ -1048,6 +1048,8 @@ unsafe extern "system" fn public_window_callback<T>(
                     }
                 }
             } else {
+                subclass_input.window_state.lock().high_surrogate = None;
+
                 let chr: char = mem::transmute(wparam as u32);
                 subclass_input.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),


### PR DESCRIPTION
Addresses https://github.com/rust-windowing/winit/pull/1165#issuecomment-531628475. Shouldn't have an impact on properly-formed input, but will cause us to ignore all malformed surrogate pairs.