### PR TITLE
 Fix hovering the mouse over the active window creating an endless stream of CursorMoved events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - On Windows, fix handling of surrogate pairs when dispatching `ReceivedCharacter`.
 - On macOS 10.15, fix freeze upon exiting exclusive fullscreen mode.
 - On iOS, fix null window on initial `HiDpiFactorChanged` event.
+- On Windows, fix hovering the mouse over the active window creating an endless stream of CursorMoved events.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -141,6 +141,17 @@ pub fn set_cursor_hidden(hidden: bool) {
     }
 }
 
+pub fn get_cursor_clip() -> Result<RECT, io::Error> {
+    unsafe {
+        let mut rect: RECT = mem::zeroed();
+        win_to_err(|| winuser::GetClipCursor(&mut rect))
+            .map(|_| rect)
+    }
+}
+
+/// Sets the cursor's clip rect.
+///
+/// Note that calling this will automatically dispatch a `WM_MOUSEMOVE` event.
 pub fn set_cursor_clip(rect: Option<RECT>) -> Result<(), io::Error> {
     unsafe {
         let rect_ptr = rect
@@ -148,6 +159,19 @@ pub fn set_cursor_clip(rect: Option<RECT>) -> Result<(), io::Error> {
             .map(|r| r as *const RECT)
             .unwrap_or(ptr::null());
         win_to_err(|| winuser::ClipCursor(rect_ptr))
+    }
+}
+
+pub fn get_desktop_rect() -> RECT {
+    unsafe {
+        let left = winuser::GetSystemMetrics(winuser::SM_XVIRTUALSCREEN);
+        let top = winuser::GetSystemMetrics(winuser::SM_YVIRTUALSCREEN);
+        RECT {
+            left,
+            top,
+            right: left + winuser::GetSystemMetrics(winuser::SM_CXVIRTUALSCREEN),
+            bottom: top + winuser::GetSystemMetrics(winuser::SM_CYVIRTUALSCREEN),
+        }
     }
 }
 

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -144,8 +144,7 @@ pub fn set_cursor_hidden(hidden: bool) {
 pub fn get_cursor_clip() -> Result<RECT, io::Error> {
     unsafe {
         let mut rect: RECT = mem::zeroed();
-        win_to_err(|| winuser::GetClipCursor(&mut rect))
-            .map(|_| rect)
+        win_to_err(|| winuser::GetClipCursor(&mut rect)).map(|_| rect)
     }
 }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #1169.