### PR TITLE
Fix events not being emitted during modal loops on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - On Windows, fix handling of surrogate pairs when dispatching `ReceivedCharacter`.
 - On macOS 10.15, fix freeze upon exiting exclusive fullscreen mode.
 - On iOS, fix null window on initial `HiDpiFactorChanged` event.
+- On macOS, fix events not being emitted during modal loops, such as when windows are being resized
+  by the user.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -4,7 +4,6 @@ use crate::platform_impl::platform::{app_state::AppState, ffi};
 
 #[link(name = "CoreFoundation", kind = "framework")]
 extern "C" {
-    pub static kCFRunLoopDefaultMode: CFRunLoopMode;
     pub static kCFRunLoopCommonModes: CFRunLoopMode;
 
     pub fn CFRunLoopGetMain() -> CFRunLoopRef;
@@ -162,7 +161,7 @@ impl RunLoop {
             handler,
             ptr::null_mut(),
         );
-        CFRunLoopAddObserver(self.0, observer, kCFRunLoopDefaultMode);
+        CFRunLoopAddObserver(self.0, observer, kCFRunLoopCommonModes);
     }
 }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -84,11 +84,7 @@ impl WindowDelegateState {
     pub fn emit_resize_event(&mut self) {
         let rect = unsafe { NSView::frame(*self.ns_view) };
         let size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
-        let event = Event::WindowEvent {
-            window_id: WindowId(get_window_id(*self.ns_window)),
-            event: WindowEvent::Resized(size),
-        };
-        AppState::send_event_immediately(event);
+        self.emit_event(WindowEvent::Resized(size));
     }
 
     fn emit_move_event(&mut self) {


### PR DESCRIPTION
Fixes #1162
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
