### PR TITLE
Always dispatch a RedrawRequested event after creating a new window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - On macOS 10.15, fix freeze upon exiting exclusive fullscreen mode.
 - On iOS, fix null window on initial `HiDpiFactorChanged` event.
 - On Windows, fix hovering the mouse over the active window creating an endless stream of CursorMoved events.
+- Always dispatch a `RedrawRequested` event after creating a new window.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -307,8 +307,12 @@ impl WindowBuilder {
         self,
         window_target: &EventLoopWindowTarget<T>,
     ) -> Result<Window, OsError> {
-        platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)
-            .map(|window| Window { window })
+        platform_impl::Window::new(&window_target.p, self.window, self.platform_specific).map(
+            |window| {
+                window.request_redraw();
+                Window { window }
+            },
+        )
     }
 }
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Should fix #1012. Needs to be tested on the following platforms, but I don't see there being many problems:
- [ ] MacOS
- [ ] X11
- [ ] Wayland
- [ ] iOS