### PR TITLE
Wayland: Switched to using a reference to relative_pointer_manager_proxy when creating SeatData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - On Windows, fix hovering the mouse over the active window creating an endless stream of CursorMoved events.
 - On X11, prevent stealing input focus when creating a new window.
   Only steal input focus when entering fullscreen mode.
+- On Wayland, DeviceEvents for relative mouse movement is not always produced
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - On Windows, fix hovering the mouse over the active window creating an endless stream of CursorMoved events.
 - On X11, prevent stealing input focus when creating a new window.
   Only steal input focus when entering fullscreen mode.
-- On Wayland, DeviceEvents for relative mouse movement is not always produced
+- On Wayland, fixed DeviceEvents for relative mouse movement is not always produced
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -148,7 +148,7 @@ impl<T: 'static> EventLoop<T> {
 
         let mut seat_manager = SeatManager {
             sink: sink.clone(),
-            relative_pointer_manager_proxy: Arc::new(Mutex::new(None)),
+            relative_pointer_manager_proxy: Rc::new(RefCell::new(None)),
             store: store.clone(),
             seats: seats.clone(),
             kbd_sender,
@@ -170,7 +170,7 @@ impl<T: 'static> EventLoop<T> {
                             })
                             .unwrap();
 
-                        *seat_manager.relative_pointer_manager_proxy.lock().unwrap() =
+                        *seat_manager.relative_pointer_manager_proxy.try_borrow_mut().unwrap() =
                             Some(relative_pointer_manager_proxy);
                     }
                     if interface == "wl_seat" {
@@ -494,7 +494,7 @@ struct SeatManager<T: 'static> {
     store: Arc<Mutex<WindowStore>>,
     seats: Arc<Mutex<Vec<(u32, wl_seat::WlSeat)>>>,
     kbd_sender: ::calloop::channel::Sender<(crate::event::WindowEvent, super::WindowId)>,
-    relative_pointer_manager_proxy: Arc<Mutex<Option<ZwpRelativePointerManagerV1>>>,
+    relative_pointer_manager_proxy: Rc<RefCell<Option<ZwpRelativePointerManagerV1>>>,
 }
 
 impl<T: 'static> SeatManager<T> {
@@ -538,7 +538,7 @@ struct SeatData<T> {
     kbd_sender: ::calloop::channel::Sender<(crate::event::WindowEvent, super::WindowId)>,
     pointer: Option<wl_pointer::WlPointer>,
     relative_pointer: Option<ZwpRelativePointerV1>,
-    relative_pointer_manager_proxy: Arc<Mutex<Option<ZwpRelativePointerManagerV1>>>,
+    relative_pointer_manager_proxy: Rc<RefCell<Option<ZwpRelativePointerManagerV1>>>,
     keyboard: Option<wl_keyboard::WlKeyboard>,
     touch: Option<wl_touch::WlTouch>,
     modifiers_tracker: Arc<Mutex<ModifiersState>>,
@@ -560,7 +560,7 @@ impl<T: 'static> SeatData<T> {
 
                     self.relative_pointer = self
                         .relative_pointer_manager_proxy
-                        .lock()
+                        .try_borrow()
                         .unwrap()
                         .as_ref()
                         .and_then(|manager| {

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -164,16 +164,14 @@ impl<T: 'static> EventLoop<T> {
                     version,
                 } => {
                     if interface == "zwp_relative_pointer_manager_v1" {
-                        let relative_pointer_manager_proxy =
-                            registry
-                                .bind(version, id, move |pointer_manager| {
-                                    pointer_manager.implement_closure(|_, _| (), ())
-                                })
-                                .unwrap();
+                        let relative_pointer_manager_proxy = registry
+                            .bind(version, id, move |pointer_manager| {
+                                pointer_manager.implement_closure(|_, _| (), ())
+                            })
+                            .unwrap();
 
-                        *seat_manager.relative_pointer_manager_proxy
-                            .lock()
-                            .unwrap() = Some(relative_pointer_manager_proxy);
+                        *seat_manager.relative_pointer_manager_proxy.lock().unwrap() =
+                            Some(relative_pointer_manager_proxy);
                     }
                     if interface == "wl_seat" {
                         seat_manager.add_seat(id, version, registry)
@@ -560,19 +558,19 @@ impl<T: 'static> SeatData<T> {
                         self.modifiers_tracker.clone(),
                     ));
 
-                    self.relative_pointer =
-                        self.relative_pointer_manager_proxy
-                            .lock()
-                            .unwrap()
-                            .as_ref()
-                            .and_then(|manager| {
-                                super::pointer::implement_relative_pointer(
-                                    self.sink.clone(),
-                                    self.pointer.as_ref().unwrap(),
-                                    manager,
-                                )
-                                .ok()
-                            })
+                    self.relative_pointer = self
+                        .relative_pointer_manager_proxy
+                        .lock()
+                        .unwrap()
+                        .as_ref()
+                        .and_then(|manager| {
+                            super::pointer::implement_relative_pointer(
+                                self.sink.clone(),
+                                self.pointer.as_ref().unwrap(),
+                                manager,
+                            )
+                            .ok()
+                        })
                 }
                 // destroy pointer if applicable
                 if !capabilities.contains(wl_seat::Capability::Pointer) {

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -170,8 +170,10 @@ impl<T: 'static> EventLoop<T> {
                             })
                             .unwrap();
 
-                        *seat_manager.relative_pointer_manager_proxy.try_borrow_mut().unwrap() =
-                            Some(relative_pointer_manager_proxy);
+                        *seat_manager
+                            .relative_pointer_manager_proxy
+                            .try_borrow_mut()
+                            .unwrap() = Some(relative_pointer_manager_proxy);
                     }
                     if interface == "wl_seat" {
                         seat_manager.add_seat(id, version, registry)


### PR DESCRIPTION
Changed SeatData to obtain a reference to the relative pointer manager proxy in SeatManager. This solves the problem that when the GlobalEvent for the "zwp_relative_pointer_manager_v1" interface comes after the "wl_seat" interfaces the SeatData still has a way to obtain the relative_pointer_manager_proxy that was created when receiving "zwp_relative_pointer_manager_v1". This is a fix for #1178 
