### PR TITLE
Fix web redraw requested

### DIFF
--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -4,7 +4,12 @@ use crate::event_loop as root;
 use crate::window::WindowId;
 
 use instant::{Duration, Instant};
-use std::{cell::RefCell, clone::Clone, collections::{HashSet, VecDeque}, rc::Rc};
+use std::{
+    cell::RefCell,
+    clone::Clone,
+    collections::{HashSet, VecDeque},
+    rc::Rc,
+};
 
 pub struct Shared<T>(Rc<Execution<T>>);
 
@@ -125,7 +130,13 @@ impl<T: 'static> Shared<T> {
         // Collect all of the redraw events to avoid double-locking the RefCell
         let redraw_events: Vec<WindowId> = self.0.redraw_pending.borrow_mut().drain().collect();
         for window_id in redraw_events {
-            self.handle_event(Event::WindowEvent { window_id, event: WindowEvent::RedrawRequested }, &mut control);
+            self.handle_event(
+                Event::WindowEvent {
+                    window_id,
+                    event: WindowEvent::RedrawRequested,
+                },
+                &mut control,
+            );
         }
         self.handle_event(Event::EventsCleared, &mut control);
         self.apply_control_flow(control);

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -9,7 +9,6 @@ use web_sys::{FocusEvent, HtmlCanvasElement, KeyboardEvent, PointerEvent, WheelE
 
 pub struct Canvas {
     raw: HtmlCanvasElement,
-    on_redraw: Closure<dyn Fn()>,
     on_focus: Option<Closure<dyn FnMut(FocusEvent)>>,
     on_blur: Option<Closure<dyn FnMut(FocusEvent)>>,
     on_keyboard_release: Option<Closure<dyn FnMut(KeyboardEvent)>>,
@@ -30,10 +29,7 @@ impl Drop for Canvas {
 }
 
 impl Canvas {
-    pub fn create<F>(on_redraw: F) -> Result<Self, RootOE>
-    where
-        F: 'static + Fn(),
-    {
+    pub fn create() -> Result<Self, RootOE> {
         let window =
             web_sys::window().ok_or(os_error!(OsError("Failed to obtain window".to_owned())))?;
 
@@ -57,7 +53,6 @@ impl Canvas {
 
         Ok(Canvas {
             raw: canvas,
-            on_redraw: Closure::wrap(Box::new(on_redraw) as Box<dyn Fn()>),
             on_blur: None,
             on_focus: None,
             on_keyboard_release: None,
@@ -99,13 +94,6 @@ impl Canvas {
 
     pub fn raw(&self) -> &HtmlCanvasElement {
         &self.raw
-    }
-
-    pub fn request_redraw(&self) {
-        let window = web_sys::window().expect("Failed to obtain window");
-        window
-            .request_animation_frame(&self.on_redraw.as_ref().unchecked_ref())
-            .expect("Failed to request animation frame");
     }
 
     pub fn on_blur<F>(&mut self, mut handler: F)


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

request_redraw on web would just dispatch unbounded amounts of requestAnimationFrame, which would lead to slowdowns over time. It also wasn't dispatched in the right point of the event loop.
