### PR TITLE
X11: Fix window position setting ignored when fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - On X11, prevent stealing input focus when creating a new window.
   Only steal input focus when entering fullscreen mode.
 - On Wayland, fixed DeviceEvents for relative mouse movement is not always produced
+- On X11, fix `Window::set_outer_position` being ignored when called while window is fullscreen.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 


### PR DESCRIPTION
When `Window::set_outer_position` is called while a window is fullscreen,
the given position will be saved and will be assigned to the window when
it leaves fullscreen mode.

This addresses one of the issues described in #978.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
