### PR TITLE
Update to 1.38.0 formatting

### DIFF
--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -500,9 +500,7 @@ pub unsafe fn create_window(
             let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode];
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
-        Some(Fullscreen::Borderless(ref monitor)) => {
-            msg_send![window, setScreen:monitor.ui_screen()]
-        }
+        Some(Fullscreen::Borderless(ref monitor)) => msg_send![window, setScreen:monitor.ui_screen()],
         None => (),
     }
 


### PR DESCRIPTION
1.38.0 changed the default formatting rules subtly for some reason.