### PR TITLE
Implement `WindowBuilder::with_outer_position` for X11

### DIFF
--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -201,6 +201,24 @@ impl<'a> NormalHints<'a> {
         }
     }
 
+    pub fn get_position(&self) -> Option<(i32, i32)> {
+        if self.has_flag(ffi::PPosition) {
+            Some((self.size_hints.x as i32, self.size_hints.y as i32))
+        } else {
+            None
+        }
+    }
+
+    pub fn set_position(&mut self, position: Option<(i32, i32)>) {
+        if let Some((x, y)) = position {
+            self.size_hints.flags |= ffi::PPosition;
+            self.size_hints.x = x as c_int;
+            self.size_hints.y = y as c_int;
+        } else {
+            self.size_hints.flags &= !ffi::PPosition;
+        }
+    }
+
     pub fn get_size(&self) -> Option<(u32, u32)> {
         self.getter(ffi::PSize, &self.size_hints.width, &self.size_hints.height)
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -114,6 +114,12 @@ pub struct WindowAttributes {
     /// The default is `None`.
     pub max_inner_size: Option<LogicalSize>,
 
+    /// The desired position of the window. If this is `None`,
+    /// some platform-specific position will be chosen.
+    ///
+    /// The default is `None`.
+    pub outer_position: Option<LogicalPosition>,
+
     /// Whether the window is resizable or not.
     ///
     /// The default is `true`.
@@ -168,6 +174,7 @@ impl Default for WindowAttributes {
             inner_size: None,
             min_inner_size: None,
             max_inner_size: None,
+            outer_position: None,
             resizable: true,
             title: "winit window".to_owned(),
             maximized: false,
@@ -209,6 +216,17 @@ impl WindowBuilder {
     #[inline]
     pub fn with_max_inner_size(mut self, max_size: LogicalSize) -> Self {
         self.window.max_inner_size = Some(max_size);
+        self
+    }
+
+    /// Sets a desired initial position for the window
+    ///
+    /// ## Platform-specific
+    ///
+    /// **Wayland**: This has no effect.
+    #[inline]
+    pub fn with_outer_position(mut self, position: LogicalPosition) -> Self {
+        self.window.outer_position = Some(position);
         self
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -118,6 +118,10 @@ pub struct WindowAttributes {
     /// some platform-specific position will be chosen.
     ///
     /// The default is `None`.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **Wayland**: This has no effect.
     pub outer_position: Option<LogicalPosition>,
 
     /// Whether the window is resizable or not.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
