### PR TITLE
Use consistent return types for available_monitors()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - On Wayland, fixed DeviceEvents for relative mouse movement is not always produced.
 - Removed `derivative` crate dependency.
 - On Wayland, add support for set_cursor_icon.
+- Use `impl Iterator<Item = MonitorHandle>` instead of `AvailableMonitorsIter` consistently.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -4,6 +4,6 @@ fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    dbg!(window.available_monitors());
+    dbg!(window.available_monitors().collect::<Vec<_>>());
     dbg!(window.primary_monitor());
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -11,11 +11,7 @@
 //! [send_event]: ./struct.EventLoopProxy.html#method.send_event
 use std::{error, fmt, ops::Deref, time::Instant};
 
-use crate::{
-    event::Event,
-    monitor::{AvailableMonitorsIter, MonitorHandle},
-    platform_impl,
-};
+use crate::{event::Event, monitor::MonitorHandle, platform_impl};
 
 /// Provides a way to retrieve events from the system and from the windows that were registered to
 /// the events loop.
@@ -150,10 +146,10 @@ impl<T> EventLoop<T> {
     /// Returns the list of all the monitors available on the system.
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
-        let data = self.event_loop.available_monitors();
-        AvailableMonitorsIter {
-            data: data.into_iter(),
-        }
+        self.event_loop
+            .available_monitors()
+            .into_iter()
+            .map(|inner| MonitorHandle { inner })
     }
 
     /// Returns the primary monitor of the system.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,13 +1,12 @@
 //! Types useful for interacting with a user's monitors.
 //!
 //! If you want to get basic information about a monitor, you can use the [`MonitorHandle`][monitor_id]
-//! type. This is retreived from an [`AvailableMonitorsIter`][monitor_iter], which can be acquired
-//! with:
+//! type. This is retreived from one of the following methods, which return an iterator of
+//! [`MonitorHandle`][monitor_id]:
 //! - [`EventLoop::available_monitors`][loop_get]
 //! - [`Window::available_monitors`][window_get].
 //!
 //! [monitor_id]: ./struct.MonitorHandle.html
-//! [monitor_iter]: ./struct.AvailableMonitorsIter.html
 //! [loop_get]: ../event_loop/struct.EventLoop.html#method.available_monitors
 //! [window_get]: ../window/struct.Window.html#method.available_monitors
 use crate::{

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -10,41 +10,10 @@
 //! [monitor_iter]: ./struct.AvailableMonitorsIter.html
 //! [loop_get]: ../event_loop/struct.EventLoop.html#method.available_monitors
 //! [window_get]: ../window/struct.Window.html#method.available_monitors
-use std::collections::vec_deque::IntoIter as VecDequeIter;
-
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     platform_impl,
 };
-
-/// An iterator over all available monitors.
-///
-/// Can be acquired with:
-/// - [`EventLoop::available_monitors`][loop_get]
-/// - [`Window::available_monitors`][window_get].
-///
-/// [loop_get]: ../event_loop/struct.EventLoop.html#method.available_monitors
-/// [window_get]: ../window/struct.Window.html#method.available_monitors
-// Implementation note: we retrieve the list once, then serve each element by one by one.
-// This may change in the future.
-#[derive(Debug)]
-pub struct AvailableMonitorsIter {
-    pub(crate) data: VecDequeIter<platform_impl::MonitorHandle>,
-}
-
-impl Iterator for AvailableMonitorsIter {
-    type Item = MonitorHandle;
-
-    #[inline]
-    fn next(&mut self) -> Option<MonitorHandle> {
-        self.data.next().map(|id| MonitorHandle { inner: id })
-    }
-
-    #[inline]
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        self.data.size_hint()
-    }
-}
 
 /// Describes a fullscreen video mode of a monitor.
 ///

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,7 +5,7 @@ use crate::{
     dpi::{LogicalPosition, LogicalSize},
     error::{ExternalError, NotSupportedError, OsError},
     event_loop::EventLoopWindowTarget,
-    monitor::{AvailableMonitorsIter, MonitorHandle, VideoMode},
+    monitor::{MonitorHandle, VideoMode},
     platform_impl,
 };
 
@@ -704,10 +704,10 @@ impl Window {
     /// **iOS:** Can only be called on the main thread.
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
-        let data = self.window.available_monitors();
-        AvailableMonitorsIter {
-            data: data.into_iter(),
-        }
+        self.window
+            .available_monitors()
+            .into_iter()
+            .map(|inner| MonitorHandle { inner })
     }
 
     /// Returns the primary monitor of the system.

--- a/src/window.rs
+++ b/src/window.rs
@@ -703,7 +703,7 @@ impl Window {
     ///
     /// **iOS:** Can only be called on the main thread.
     #[inline]
-    pub fn available_monitors(&self) -> AvailableMonitorsIter {
+    pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
         let data = self.window.available_monitors();
         AvailableMonitorsIter {
             data: data.into_iter(),


### PR DESCRIPTION
Fixes #1111 

- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This just changes the return types to be consistent between `event_loop` and `window`. This doesn't go as far as to introduce something like `MonitorHandle::available_monitors(&EventLoop)`, but that could be amended if desired. I just didn't want to introduce a breaking change so quickly