### PR TITLE
Fix use-after-free in XConnection::get_output_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Removed `derivative` crate dependency.
 - On Wayland, add support for set_cursor_icon.
 - Use `impl Iterator<Item = MonitorHandle>` instead of `AvailableMonitorsIter` consistently.
+- On X11, fix use-after-free during window creation
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -99,7 +99,8 @@ impl XConnection {
                     // video mode is returned to the user
                     monitor: None,
                 }
-            });
+            })
+            .collect();
 
         let name_slice = slice::from_raw_parts(
             (*output_info).name as *mut u8,
@@ -119,7 +120,7 @@ impl XConnection {
         };
 
         (self.xrandr.XRRFreeOutputInfo)(output_info);
-        Some((name, hidpi_factor, modes.collect()))
+        Some((name, hidpi_factor, modes))
     }
     pub fn set_crtc_config(&self, crtc_id: RRCrtc, mode_id: RRMode) -> Result<(), ()> {
         unsafe {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
