### PR TITLE
Add support for Windows Dark Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - On Windows and Linux X11/Wayland, add platform-specific functions for creating an `EventLoop` outside the main thread.
 - On Wayland, drop resize events identical to the current window size.
 - On Windows, theme the title bar according to whether the system theme is "Light" or "Dark".
+- Added `WindowEvent::ThemeChanged` variant to handle changes to the system theme. Currently only implemented on Windows.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - On macOS, fix application not to terminate on `run_return`.
 - On Wayland, fix cursor icon updates on window borders when using CSD.
 - On Wayland, under mutter(GNOME Wayland), fix CSD being behind the status bar, when starting window in maximized mode.
+- On Windows, theme the title bar according to whether the system theme is "Light" or "Dark".
+- Added `WindowEvent::ThemeChanged` variant to handle changes to the system theme. Currently only implemented on Windows.
 
 # # 0.20.0 Alpha 5 (2019-12-09)
 
@@ -68,8 +70,6 @@
     reduces the potential for cross-platform compatibility gotchyas.
 - On Windows and Linux X11/Wayland, add platform-specific functions for creating an `EventLoop` outside the main thread.
 - On Wayland, drop resize events identical to the current window size.
-- On Windows, theme the title bar according to whether the system theme is "Light" or "Dark".
-- Added `WindowEvent::ThemeChanged` variant to handle changes to the system theme. Currently only implemented on Windows.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
     reduces the potential for cross-platform compatibility gotchyas.
 - On Windows and Linux X11/Wayland, add platform-specific functions for creating an `EventLoop` outside the main thread.
 - On Wayland, drop resize events identical to the current window size.
+- On Windows, theme the title bar according to whether the system theme is "Light" or "Dark".
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -117,6 +117,7 @@ If your PR makes notable changes to Winit's features, please update this section
 * Setting the taskbar icon
 * Setting the parent window
 * `WS_EX_NOREDIRECTIONBITMAP` support
+* Theme the title bar according to Windows 10 Dark Mode setting
 
 ### macOS
 * Window activation policy

--- a/src/event.rs
+++ b/src/event.rs
@@ -215,6 +215,8 @@ pub enum WindowEvent {
     ///
     /// Applications might wish to react to this to change the theme of the content of the window
     /// when the system changes the window theme.
+    ///
+    /// At the moment this is only supported on Windows.
     ThemeChanged(Theme),
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -210,6 +210,13 @@ pub enum WindowEvent {
     ///
     /// For more information about DPI in general, see the [`dpi`](crate::dpi) module.
     HiDpiFactorChanged(f64),
+
+    /// The window theme has changed into (or out of) Dark Mode.
+    ///
+    /// The parameter is true if the window is now in a dark theme, and false if it is not.
+    /// Applications might wish to react to this to change the theme of the content of the window
+    /// when the system changes the window theme.
+    DarkModeChanged(bool),
 }
 
 /// Identifier of an input device.

--- a/src/event.rs
+++ b/src/event.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     platform_impl,
-    window::WindowId,
+    window::{Theme, WindowId},
 };
 
 /// Describes a generic event.
@@ -211,12 +211,11 @@ pub enum WindowEvent {
     /// For more information about DPI in general, see the [`dpi`](crate::dpi) module.
     HiDpiFactorChanged(f64),
 
-    /// The window theme has changed into (or out of) Dark Mode.
+    /// The system window theme has changed.
     ///
-    /// The parameter is true if the window is now in a dark theme, and false if it is not.
     /// Applications might wish to react to this to change the theme of the content of the window
     /// when the system changes the window theme.
-    DarkModeChanged(bool),
+    ThemeChanged(Theme),
 }
 
 /// Identifier of an input device.

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -77,6 +77,9 @@ pub trait WindowExtWindows {
 
     /// This sets `ICON_BIG`. A good ceiling here is 256x256.
     fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>);
+
+    /// Whether the system theme is currently Windows 10's "Dark Mode".
+    fn is_dark_mode(&self) -> bool;
 }
 
 impl WindowExtWindows for Window {
@@ -93,6 +96,11 @@ impl WindowExtWindows for Window {
     #[inline]
     fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {
         self.window.set_taskbar_icon(taskbar_icon)
+    }
+
+    #[inline]
+    fn is_dark_mode(&self) -> bool {
+        self.window.is_dark_mode()
     }
 }
 

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -73,7 +73,7 @@ lazy_static! {
         // We won't try to do anything for windows versions < 17763
         // (Windows 10 October 2018 update)
         match *WIN10_BUILD_VERSION {
-            Some(v) => v > 18362,
+            Some(v) => v >= 17763,
             None => false
         }
     };

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -124,7 +124,7 @@ fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) {
     if let Some(set_window_composition_attribute) = *SET_WINDOW_COMPOSITION_ATTRIBUTE {
         unsafe {
             // SetWindowCompositionAttribute needs a bigbool (i32), not bool.
-            let mut is_dark_mode_bigbool: BOOL = is_dark_mode.into();
+            let mut is_dark_mode_bigbool = is_dark_mode as BOOL;
 
             let mut data = WINDOWCOMPOSITIONATTRIBDATA {
                 Attrib: WCA_USEDARKMODECOLORS,

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -1,0 +1,116 @@
+/// This is a simple implementation of support for Windows Dark Mode,
+/// which is a more or less straight translation of the implemenation
+/// in Windows Terminal (which was originally in C++).
+use std::ffi::OsStr;
+use std::os::windows::ffi::OsStrExt;
+
+use winapi::{
+    shared::{
+        minwindef::{BOOL, DWORD, UINT, WORD},
+        ntdef::LPSTR,
+        windef::HWND,
+    },
+    um::{dwmapi, libloaderapi, uxtheme, winuser},
+};
+
+const DWMWA_USE_IMMERSIVE_DARK_MODE: DWORD = 19;
+const UXTHEME_DLL_NAME: &'static str = "uxtheme.dll";
+const UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL: WORD = 132;
+
+type ShouldAppsUseDarkMode = unsafe extern "system" fn() -> bool;
+
+lazy_static! {
+    static ref SHOULD_APPS_USE_DARK_MODE: ShouldAppsUseDarkMode = {
+        unsafe {
+            let module = libloaderapi::LoadLibraryExW(
+                widestring(UXTHEME_DLL_NAME).as_ptr(),
+                std::ptr::null_mut(),
+                libloaderapi::LOAD_LIBRARY_SEARCH_SYSTEM32,
+            );
+
+            let handle = libloaderapi::GetProcAddress(
+                module,
+                winuser::MAKEINTRESOURCEA(UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL),
+            );
+
+            if handle.is_null() {
+                unsafe extern "system" fn always_false() -> bool {
+                    false
+                }
+                always_false
+            } else {
+                std::mem::transmute(handle)
+            }
+        }
+    };
+}
+
+pub fn try_dark_mode(hwnd: HWND) {
+    let theme_name: Vec<_> = widestring("DarkMode_Explorer");
+
+    // According to Windows Terminal source, should be BOOL (32-bit int)
+    // to be appropriately sized as a parameter for DwmSetWindowAttribute
+    let is_dark_mode: BOOL = should_use_dark_mode() as _;
+
+    unsafe {
+        assert_eq!(
+            0,
+            uxtheme::SetWindowTheme(hwnd, theme_name.as_ptr() as _, std::ptr::null())
+        );
+
+        assert_eq!(
+            0,
+            dwmapi::DwmSetWindowAttribute(
+                hwnd,
+                DWMWA_USE_IMMERSIVE_DARK_MODE,
+                &is_dark_mode as *const _ as _,
+                std::mem::size_of_val(&is_dark_mode) as _
+            )
+        );
+    }
+}
+
+fn should_use_dark_mode() -> bool {
+    should_apps_use_dark_mode() && !is_high_contrast()
+}
+
+fn should_apps_use_dark_mode() -> bool {
+    unsafe { SHOULD_APPS_USE_DARK_MODE() }
+}
+
+// FIXME: This definition is missing from winapi
+#[repr(C)]
+#[allow(non_snake_case)]
+struct HIGHCONTRASTA {
+    cbSize: UINT,
+    dwFlags: DWORD,
+    lpszDefaultScheme: LPSTR,
+}
+
+const HCF_HIGHCONTRASTON: DWORD = 1;
+
+fn is_high_contrast() -> bool {
+    let mut hc = HIGHCONTRASTA {
+        cbSize: 0,
+        dwFlags: 0,
+        lpszDefaultScheme: std::ptr::null_mut(),
+    };
+
+    let ok = unsafe {
+        winuser::SystemParametersInfoA(
+            winuser::SPI_GETHIGHCONTRAST,
+            std::mem::size_of_val(&hc) as _,
+            &mut hc as *mut _ as _,
+            0,
+        )
+    };
+
+    (ok > 0) && ((HCF_HIGHCONTRASTON & hc.dwFlags) == 1)
+}
+
+fn widestring(src: &'static str) -> Vec<u16> {
+    OsStr::new(src)
+        .encode_wide()
+        .chain(Some(0).into_iter())
+        .collect()
+}

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -1,48 +1,19 @@
 /// This is a simple implementation of support for Windows Dark Mode,
-/// which is a more or less straight translation of the implemenation
-/// in Windows Terminal (which was originally in C++).
+/// which is inspired by the solution in https://github.com/ysc3839/win32-darkmode
 use std::ffi::OsStr;
 use std::os::windows::ffi::OsStrExt;
 
 use winapi::{
     shared::{
+        basetsd::SIZE_T,
         minwindef::{BOOL, DWORD, UINT, ULONG, WORD},
-        ntdef::{LPSTR, WCHAR},
+        ntdef::{LPSTR, PVOID, WCHAR},
         windef::HWND,
     },
-    um::{dwmapi, libloaderapi, uxtheme, winuser},
+    um::{libloaderapi, uxtheme, winuser},
 };
 
-const UXTHEME_DLL_NAME: &'static str = "uxtheme.dll";
-const UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL: WORD = 132;
-
-type ShouldAppsUseDarkMode = unsafe extern "system" fn() -> bool;
-
 lazy_static! {
-    static ref SHOULD_APPS_USE_DARK_MODE: ShouldAppsUseDarkMode = {
-        unsafe {
-            let module = libloaderapi::LoadLibraryExW(
-                widestring(UXTHEME_DLL_NAME).as_ptr(),
-                std::ptr::null_mut(),
-                libloaderapi::LOAD_LIBRARY_SEARCH_SYSTEM32,
-            );
-
-            let handle = libloaderapi::GetProcAddress(
-                module,
-                winuser::MAKEINTRESOURCEA(UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL),
-            );
-
-            if handle.is_null() {
-                unsafe extern "system" fn always_false() -> bool {
-                    false
-                }
-                always_false
-            } else {
-                std::mem::transmute(handle)
-            }
-        }
-    };
-
     static ref WIN10_BUILD_VERSION: Option<DWORD> = {
         unsafe {
             let module = libloaderapi::LoadLibraryExW(
@@ -98,24 +69,12 @@ lazy_static! {
         }
     };
 
-    // The DWMA_USE_IMMERSIVE_DARK_MODE attribute is undocumented, and
-    // unfortunately hasn't remained stable despite usage inside the
-    // public source of the Windows Terminal project.
-    //
-    // This mapping may need to be updated in the future if the
-    // attribute changes again.
-    static ref DWMWA_USE_IMMERSIVE_DARK_MODE: Option<DWORD> = {
-        match &*WIN10_BUILD_VERSION {
-            &Some(build_version) => {
-                if build_version >= 17763 && build_version <= 18362  {
-                    Some(19)
-                } else if build_version > 18362 {
-                    Some(20)
-                } else {
-                    None
-                }
-            },
-            None => None
+    static ref DARK_MODE_SUPPORTED: bool = {
+        // We won't try to do anything for windows versions < 17763
+        // (Windows 10 October 2018 update)
+        match *WIN10_BUILD_VERSION {
+            Some(v) => v > 18362,
+            None => false
         }
     };
 
@@ -126,11 +85,8 @@ lazy_static! {
 /// Attempt to set dark mode on a window, if necessary.
 /// Returns true if dark mode was set, false if not.
 pub fn try_dark_mode(hwnd: HWND) -> bool {
-    if let &Some(attribute) = &*DWMWA_USE_IMMERSIVE_DARK_MODE {
-        // According to Windows Terminal source, should be BOOL (32-bit int)
-        // to be appropriately sized as a parameter for DwmSetWindowAttribute
+    if *DARK_MODE_SUPPORTED {
         let is_dark_mode = should_use_dark_mode();
-        let is_dark_mode_bigbool = is_dark_mode as BOOL;
 
         let theme_name = if is_dark_mode {
             DARK_THEME_NAME.as_ptr()
@@ -144,15 +100,7 @@ pub fn try_dark_mode(hwnd: HWND) -> bool {
                 uxtheme::SetWindowTheme(hwnd, theme_name as _, std::ptr::null())
             );
 
-            assert_eq!(
-                0,
-                dwmapi::DwmSetWindowAttribute(
-                    hwnd,
-                    attribute,
-                    &is_dark_mode_bigbool as *const _ as _,
-                    std::mem::size_of_val(&is_dark_mode_bigbool) as _
-                )
-            );
+            set_dark_mode_for_window(hwnd, is_dark_mode)
         }
 
         is_dark_mode
@@ -161,11 +109,111 @@ pub fn try_dark_mode(hwnd: HWND) -> bool {
     }
 }
 
+fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) {
+    // Uses Windows undocumented API SetWindowCompositionAttribute,
+    // as seen in win32-darkmode example linked at top of file.
+
+    type SetWindowCompositionAttribute =
+        unsafe extern "system" fn(HWND, *mut WINDOWCOMPOSITIONATTRIBDATA) -> BOOL;
+
+    #[allow(non_snake_case)]
+    type WINDOWCOMPOSITIONATTRIB = u32;
+    const WCA_USEDARKMODECOLORS: WINDOWCOMPOSITIONATTRIB = 26;
+
+    #[allow(non_snake_case)]
+    #[repr(C)]
+    struct WINDOWCOMPOSITIONATTRIBDATA
+    {
+        Attrib: WINDOWCOMPOSITIONATTRIB,
+        pvData: PVOID,
+        cbData: SIZE_T
+    }
+
+    lazy_static! {
+        static ref SET_WINDOW_COMPOSITION_ATTRIBUTE:
+        SetWindowCompositionAttribute = {
+            unsafe {
+                let module = libloaderapi::LoadLibraryExW(
+                    widestring("user32.dll").as_ptr(),
+                    std::ptr::null_mut(),
+                    libloaderapi::LOAD_LIBRARY_SEARCH_SYSTEM32,
+                );
+
+                let handle = libloaderapi::GetProcAddress(
+                    module,
+                    "SetWindowCompositionAttribute\0".as_ptr() as _,
+                );
+
+                if handle.is_null() {
+                    unsafe extern "system" fn always_false(
+                        _: HWND,
+                        _: *mut WINDOWCOMPOSITIONATTRIBDATA
+                    ) -> BOOL {
+                        false.into()
+                    }
+                    always_false
+                } else {
+                    std::mem::transmute(handle)
+                }
+            }
+        };
+    }
+
+    unsafe {
+        // SetWindowCompositionAttribute needs a bigbool (i32), not bool.
+        let mut is_dark_mode_bigbool = is_dark_mode as BOOL;
+
+        let mut data = WINDOWCOMPOSITIONATTRIBDATA {
+            Attrib: WCA_USEDARKMODECOLORS,
+            pvData: &mut is_dark_mode_bigbool as *mut _ as _,
+            cbData: std::mem::size_of_val(&is_dark_mode_bigbool) as _
+        };
+
+        assert_eq!(
+            1,
+            SET_WINDOW_COMPOSITION_ATTRIBUTE(
+                hwnd,
+                &mut data as *mut _
+            )
+        );
+    }
+}
+
 fn should_use_dark_mode() -> bool {
     should_apps_use_dark_mode() && !is_high_contrast()
 }
 
 fn should_apps_use_dark_mode() -> bool {
+    type ShouldAppsUseDarkMode = unsafe extern "system" fn() -> bool;
+    lazy_static! {
+        static ref SHOULD_APPS_USE_DARK_MODE: ShouldAppsUseDarkMode = {
+            unsafe {
+
+                const UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL: WORD = 132;
+
+                let module = libloaderapi::LoadLibraryExW(
+                    widestring("uxtheme.dll").as_ptr(),
+                    std::ptr::null_mut(),
+                    libloaderapi::LOAD_LIBRARY_SEARCH_SYSTEM32,
+                );
+
+                let handle = libloaderapi::GetProcAddress(
+                    module,
+                    winuser::MAKEINTRESOURCEA(UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL),
+                );
+
+                if handle.is_null() {
+                    unsafe extern "system" fn always_false() -> bool {
+                        false
+                    }
+                    always_false
+                } else {
+                    std::mem::transmute(handle)
+                }
+            }
+        };
+    }
+
     unsafe { SHOULD_APPS_USE_DARK_MODE() }
 }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -49,6 +49,7 @@ use crate::{
     event::{DeviceEvent, Event, Force, KeyboardInput, StartCause, Touch, TouchPhase, WindowEvent},
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
     platform_impl::platform::{
+        dark_mode::try_dark_mode,
         dpi::{
             become_dpi_aware, dpi_to_scale_factor, enable_non_client_dpi_scaling, hwnd_scale_factor,
         },
@@ -1900,6 +1901,11 @@ unsafe extern "system" fn public_window_callback<T>(
             });
 
             0
+        }
+
+        winuser::WM_SETTINGCHANGE => {
+            try_dark_mode(window);
+            commctrl::DefSubclassProc(window, msg, wparam, lparam)
         }
 
         _ => {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1915,6 +1915,7 @@ unsafe extern "system" fn public_window_callback<T>(
                 let theme = if is_dark_mode { Dark } else { Light };
 
                 window_state.is_dark_mode = is_dark_mode;
+                mem::drop(window_state);
                 subclass_input.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: ThemeChanged(theme),

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1904,17 +1904,20 @@ unsafe extern "system" fn public_window_callback<T>(
         }
 
         winuser::WM_SETTINGCHANGE => {
-            use crate::event::WindowEvent::DarkModeChanged;
+            use crate::event::WindowEvent::ThemeChanged;
 
             let is_dark_mode = try_dark_mode(window);
             let mut window_state = subclass_input.window_state.lock();
             let changed = window_state.is_dark_mode != is_dark_mode;
 
             if changed {
+                use crate::window::Theme::*;
+                let theme = if is_dark_mode { Dark } else { Light };
+
                 window_state.is_dark_mode = is_dark_mode;
                 subclass_input.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
-                    event: DarkModeChanged(is_dark_mode),
+                    event: ThemeChanged(theme),
                 });
             }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1904,7 +1904,7 @@ unsafe extern "system" fn public_window_callback<T>(
         }
 
         winuser::WM_SETTINGCHANGE => {
-            try_dark_mode(window);
+            subclass_input.window_state.lock().is_dark_mode = try_dark_mode(window);
             commctrl::DefSubclassProc(window, msg, wparam, lparam)
         }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -69,6 +69,7 @@ impl WindowId {
 
 #[macro_use]
 mod util;
+mod dark_mode;
 mod dpi;
 mod drop_handler;
 mod event;

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -34,6 +34,7 @@ use crate::{
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
     monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
+        dark_mode::try_dark_mode,
         dpi::{dpi_to_scale_factor, hwnd_dpi},
         drop_handler::FileDropHandler,
         event_loop::{
@@ -913,6 +914,11 @@ unsafe fn init<T: 'static>(
 
     window_flags.set(WindowFlags::VISIBLE, attributes.visible);
     window_flags.set(WindowFlags::MAXIMIZED, attributes.maximized);
+
+    // If the system theme is dark, we need to set the window theme now
+    // before we update the window flags (and possibly show the
+    // window for the first time).
+    try_dark_mode(real_window.0);
 
     let window_state = {
         let window_state = WindowState::new(&attributes, window_icon, taskbar_icon, dpi_factor);

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -708,6 +708,11 @@ impl Window {
     pub fn set_ime_position(&self, _logical_spot: LogicalPosition) {
         unimplemented!();
     }
+
+    #[inline]
+    pub fn is_dark_mode(&self) -> bool {
+        self.window_state.lock().is_dark_mode
+    }
 }
 
 impl Drop for Window {
@@ -918,10 +923,16 @@ unsafe fn init<T: 'static>(
     // If the system theme is dark, we need to set the window theme now
     // before we update the window flags (and possibly show the
     // window for the first time).
-    try_dark_mode(real_window.0);
+    let dark_mode = try_dark_mode(real_window.0);
 
     let window_state = {
-        let window_state = WindowState::new(&attributes, window_icon, taskbar_icon, dpi_factor);
+        let window_state = WindowState::new(
+            &attributes,
+            window_icon,
+            taskbar_icon,
+            dpi_factor,
+            dark_mode,
+        );
         let window_state = Arc::new(Mutex::new(window_state));
         WindowState::set_window_flags(window_state.lock(), real_window.0, |f| *f = window_flags);
         window_state

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -32,6 +32,7 @@ pub struct WindowState {
     /// Used to supress duplicate redraw attempts when calling `request_redraw` multiple
     /// times in `EventsCleared`.
     pub queued_out_of_band_redraw: bool,
+    pub is_dark_mode: bool,
     pub high_surrogate: Option<u16>,
     window_flags: WindowFlags,
 }
@@ -98,6 +99,7 @@ impl WindowState {
         window_icon: Option<WinIcon>,
         taskbar_icon: Option<WinIcon>,
         dpi_factor: f64,
+        is_dark_mode: bool,
     ) -> WindowState {
         WindowState {
             mouse: MouseProperties {
@@ -117,6 +119,7 @@ impl WindowState {
 
             fullscreen: None,
             queued_out_of_band_redraw: false,
+            is_dark_mode,
             high_surrogate: None,
             window_flags: WindowFlags::empty(),
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -857,3 +857,9 @@ pub enum Fullscreen {
     Exclusive(VideoMode),
     Borderless(MonitorHandle),
 }
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum Theme {
+    Light,
+    Dark,
+}


### PR DESCRIPTION
I had a go at adding simple support for Windows 10's "Dark Mode". The moment the title bar will set to light / dark automatically according to system theme. I did not add an option for users of `winit` to disable this behaviour, as I felt it's likely desirable for most use cases. I can change that if you prefer otherwise!

Please advise on any documentation you'd like me to update.

The "window" example when Dark Mode is enabled:

![image](https://user-images.githubusercontent.com/1939362/66387870-cd5c1c00-e9bc-11e9-942c-9f22ddb780d3.png)

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Closes #1193 