### PR TITLE
Test all Windows targets and allow nightly Appveyor failures

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,20 +2,23 @@ environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
     CHANNEL: stable
+  - TARGET: i686-pc-windows-msvc
+    CHANNEL: stable
+  - TARGET: x86_64-pc-windows-gnu
+    CHANNEL: stable
+  - TARGET: i686-pc-windows-gnu
+    CHANNEL: stable
   - TARGET: x86_64-pc-windows-msvc
     CHANNEL: nightly
   - TARGET: i686-pc-windows-msvc
-    CHANNEL: stable
-  - TARGET: i686-pc-windows-msvc
     CHANNEL: nightly
-  - TARGET: x86_64-pc-windows-gnu
-    CHANNEL: stable
   - TARGET: x86_64-pc-windows-gnu
     CHANNEL: nightly
   - TARGET: i686-pc-windows-gnu
-    CHANNEL: stable
-  - TARGET: i686-pc-windows-gnu
     CHANNEL: nightly
+matrix:
+  allow_failures:
+    - CHANNEL: nightly
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -yv --default-toolchain %CHANNEL% --default-host %TARGET%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,19 @@
 environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    CHANNEL: nightly
+    CHANNEL: stable
   - TARGET: x86_64-pc-windows-msvc
+    CHANNEL: nightly
+  - TARGET: i686-pc-windows-msvc
     CHANNEL: stable
   - TARGET: i686-pc-windows-msvc
     CHANNEL: nightly
+  - TARGET: x86_64-pc-windows-gnu
+    CHANNEL: stable
+  - TARGET: x86_64-pc-windows-gnu
+    CHANNEL: nightly
+  - TARGET: i686-pc-windows-gnu
+    CHANNEL: stable
   - TARGET: i686-pc-windows-gnu
     CHANNEL: nightly
 install:


### PR DESCRIPTION
Expands Appveyor testing to test all combinations of `x86_64`/`i686` and `msvc`/`gnu`. Hopefully this should help narrow down why `i686-pc-windows-gnu` is failing.