### PR TITLE
Fix so the compiler can infer msg_send! return types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "0.2"
 objc = "0.2.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.18.4"
+cocoa = "0.19.1"
 core-foundation = "0.6"
 core-graphics = "0.17.3"
 dispatch = "0.1.4"

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -786,7 +786,7 @@ impl UnownedWindow {
                 // of the menu bar, and this looks broken, so we must make sure
                 // that the menu bar is disabled. This is done in the window
                 // delegate in `window:willUseFullScreenPresentationOptions:`.
-                msg_send![*self.ns_window, setLevel: ffi::CGShieldingWindowLevel() + 1];
+                let () = msg_send![*self.ns_window, setLevel: ffi::CGShieldingWindowLevel() + 1];
             },
             (
                 &Some(Fullscreen::Exclusive(RootVideoMode { ref video_mode })),


### PR DESCRIPTION
Currently, due to a quirk in Rust's type inference interacting with the structure of the `msg_send!` macro, a `()` return type will be inferred when the compiler cannot otherwise determine the return type. This behavior is expected to change, and in the future could resolve to a `!` return type, which results in undefined behavior.

Linting has previously been added for this in rust-lang/rust#39216, but it did not catch these cases due to SSheldon/rust-objc#62. An upcoming version of objc will be fixed to stop hiding these errors, at which point they will become compile errors.

This change fixes these errors and allows winit to compile with the fixed version of objc. It also bumps cocoa to ensure users of winit are on a version that has addressed those issues.

- [ ] Tested on all platforms changed
  - I ran `cargo test` on macos, close enough?
- [ ] Compilation warnings were addressed
  - No compilation warnings added by this change!
- [ ] `cargo fmt` has been run on this branch
  - No, it's such a li'l change and I don't have rustfmt installed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
  - Probably not valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
  - No user-facing changes!
- [ ] Created or updated an example program if it would help users understand this functionality
  - No functionality change!
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
  - No new features!
