### PR TITLE
Implement hidpi for web platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ version = "0.3.22"
 optional = true
 features = [
     'console',
+    'CssStyleDeclaration',
     'BeforeUnloadEvent',
     'Document',
     'DomRect',

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -37,7 +37,8 @@ impl<T> EventLoop<T> {
 
     pub fn run<F>(self, mut event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<T>, &root::EventLoopWindowTarget<T>, &mut root::ControlFlow),
+        F: 'static
+            + FnMut(Event<'static, T>, &root::EventLoopWindowTarget<T>, &mut root::ControlFlow),
     {
         let target = root::EventLoopWindowTarget {
             p: self.elw.p.clone(),

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -1,5 +1,5 @@
 use super::{backend, device, proxy::Proxy, runner, window};
-use crate::dpi::PhysicalSize;
+use crate::dpi::{PhysicalSize, Size};
 use crate::event::{DeviceId, ElementState, Event, KeyboardInput, TouchPhase, WindowEvent};
 use crate::event_loop::ControlFlow;
 use crate::window::WindowId;
@@ -188,9 +188,7 @@ impl<T> WindowTarget<T> {
                 intended_size
             };
 
-            // TODO set css size as well, need `&'static Canvas` (or `Rc`)?
-            raw.set_width(new_size.width as u32);
-            raw.set_height(new_size.height as u32);
+            backend::set_canvas_size(&raw, Size::Physical(new_size));
             runner.send_event(Event::WindowEvent {
                 window_id: WindowId(id),
                 event: WindowEvent::Resized(new_size),

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -28,7 +28,7 @@ impl<T> WindowTarget<T> {
         Proxy::new(self.runner.clone())
     }
 
-    pub fn run(&self, event_handler: Box<dyn FnMut(Event<T>, &mut ControlFlow)>) {
+    pub fn run(&self, event_handler: Box<dyn FnMut(Event<'static, T>, &mut ControlFlow)>) {
         self.runner.set_listener(event_handler);
     }
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -1,5 +1,5 @@
 use super::{backend, device, proxy::Proxy, runner, window};
-use crate::dpi::LogicalSize;
+use crate::dpi::PhysicalSize;
 use crate::event::{DeviceId, ElementState, Event, KeyboardInput, TouchPhase, WindowEvent};
 use crate::event_loop::ControlFlow;
 use crate::window::WindowId;
@@ -168,20 +168,22 @@ impl<T> WindowTarget<T> {
 
         let runner = self.runner.clone();
         let raw = canvas.raw().clone();
-        let mut intended_size = LogicalSize {
-            width: raw.width() as f64,
-            height: raw.height() as f64,
+        // todo
+        let mut intended_size = PhysicalSize {
+            width: raw.width() as u32,
+            height: raw.height() as u32,
         };
         canvas.on_fullscreen_change(move || {
             // If the canvas is marked as fullscreen, it is moving *into* fullscreen
             // If it is not, it is moving *out of* fullscreen
             let new_size = if backend::is_fullscreen(&raw) {
-                intended_size = LogicalSize {
-                    width: raw.width() as f64,
-                    height: raw.height() as f64,
+                // todo
+                intended_size = PhysicalSize {
+                    width: raw.width() as u32,
+                    height: raw.height() as u32,
                 };
 
-                backend::window_size()
+                backend::window_size().to_physical(backend::hidpi_factor())
             } else {
                 intended_size
             };

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -168,7 +168,8 @@ impl<T> WindowTarget<T> {
 
         let runner = self.runner.clone();
         let raw = canvas.raw().clone();
-        // todo
+
+        // The size to restore to after exiting fullscreen.
         let mut intended_size = PhysicalSize {
             width: raw.width() as u32,
             height: raw.height() as u32,
@@ -177,7 +178,6 @@ impl<T> WindowTarget<T> {
             // If the canvas is marked as fullscreen, it is moving *into* fullscreen
             // If it is not, it is moving *out of* fullscreen
             let new_size = if backend::is_fullscreen(&raw) {
-                // todo
                 intended_size = PhysicalSize {
                     width: raw.width() as u32,
                     height: raw.height() as u32,
@@ -187,6 +187,8 @@ impl<T> WindowTarget<T> {
             } else {
                 intended_size
             };
+
+            // TODO set css size as well, need `&'static Canvas` (or `Rc`)?
             raw.set_width(new_size.width as u32);
             raw.set_height(new_size.height as u32);
             runner.send_event(Event::WindowEvent {

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -10,7 +10,7 @@ impl Handle {
     }
 
     pub fn position(&self) -> PhysicalPosition<i32> {
-        PhysicalPosition { x: 0.0, y: 0.0 }
+        PhysicalPosition { x: 0, y: 0 }
     }
 
     pub fn name(&self) -> Option<String> {
@@ -19,8 +19,8 @@ impl Handle {
 
     pub fn size(&self) -> PhysicalSize<u32> {
         PhysicalSize {
-            width: 0.0,
-            height: 0.0,
+            width: 0,
+            height: 0,
         }
     }
 

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -88,17 +88,25 @@ impl Canvas {
         (bounds.get_x(), bounds.get_y())
     }
 
-    pub fn width(&self) -> f64 {
-        self.raw.width() as f64
-    }
-
-    pub fn height(&self) -> f64 {
-        self.raw.height() as f64
+    pub fn size(&self) -> LogicalSize<f64> {
+        LogicalSize {
+            width: self.raw.width() as f64,
+            height: self.raw.height() as f64,
+        }
     }
 
     pub fn set_size(&self, size: LogicalSize<f64>) {
-        self.raw.set_width(size.width as u32);
-        self.raw.set_height(size.height as u32);
+        use stdweb::*;
+
+        let physical_size = size.to_physical(super::hidpi_factor());
+
+        self.raw.set_width(physical_size.width as u32);
+        self.raw.set_height(physical_size.height as u32);
+
+        js! {
+            @{self.raw.as_ref()}.style.width = @{size.width} + "px";
+            @{self.raw.as_ref()}.style.height = @{size.height} + "px";
+        }
     }
 
     pub fn raw(&self) -> &CanvasElement {

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -1,5 +1,5 @@
 use super::event;
-use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize, Size};
+use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
 use crate::event::{ModifiersState, MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode};
 use crate::platform_impl::OsError;

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -19,6 +19,7 @@ use stdweb::web::{
 };
 
 pub struct Canvas {
+    /// Note: resizing the CanvasElement should go through `backend::set_canvas_size` to ensure the DPI factor is maintained.
     raw: CanvasElement,
     on_focus: Option<EventListenerHandle>,
     on_blur: Option<EventListenerHandle>,
@@ -95,23 +96,6 @@ impl Canvas {
         PhysicalSize {
             width: self.raw.width() as u32,
             height: self.raw.height() as u32,
-        }
-    }
-
-    pub fn set_size(&self, size: Size) {
-        use stdweb::*;
-
-        let dpi_factor = super::hidpi_factor();
-
-        let physical_size = size.to_physical::<u32>(dpi_factor);
-        let logical_size = size.to_logical::<f64>(dpi_factor);
-
-        self.raw.set_width(physical_size.width);
-        self.raw.set_height(physical_size.height);
-
-        js! {
-            @{self.raw.as_ref()}.style.width = @{logical_size.width} + "px";
-            @{self.raw.as_ref()}.style.height = @{logical_size.height} + "px";
         }
     }
 

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -202,7 +202,7 @@ impl Canvas {
         self.on_mouse_release = Some(self.add_user_event(move |event: PointerUpEvent| {
             handler(
                 event.pointer_id(),
-                event::mouse_button(&event), // todo convert to physical
+                event::mouse_button(&event),
                 event::mouse_modifiers(&event),
             );
         }));

--- a/src/platform_impl/web/stdweb/mod.rs
+++ b/src/platform_impl/web/stdweb/mod.rs
@@ -5,7 +5,7 @@ mod timeout;
 pub use self::canvas::Canvas;
 pub use self::timeout::Timeout;
 
-use crate::dpi::LogicalSize;
+use crate::dpi::{LogicalSize, Size};
 use crate::platform::web::WindowExtStdweb;
 use crate::window::Window;
 
@@ -47,6 +47,23 @@ pub fn window_size() -> LogicalSize<f64> {
 pub fn hidpi_factor() -> f64 {
     let window = window();
     window.device_pixel_ratio()
+}
+
+pub fn set_canvas_size(raw: &CanvasElement, size: Size) {
+    use stdweb::*;
+
+    let hidpi_factor = hidpi_factor();
+
+    let physical_size = size.to_physical::<u32>(hidpi_factor);
+    let logical_size = size.to_logical::<f64>(hidpi_factor);
+
+    raw.set_width(physical_size.width);
+    raw.set_height(physical_size.height);
+
+    js! {
+        @{raw.as_ref()}.style.width = @{logical_size.width} + "px";
+        @{raw.as_ref()}.style.height = @{logical_size.height} + "px";
+    }
 }
 
 pub fn is_fullscreen(canvas: &CanvasElement) -> bool {

--- a/src/platform_impl/web/stdweb/mod.rs
+++ b/src/platform_impl/web/stdweb/mod.rs
@@ -41,6 +41,14 @@ pub fn window_size() -> LogicalSize<f64> {
     LogicalSize { width, height }
 }
 
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
+// TODO: Use media queries to register changes in dpi: https://jsfiddle.net/b6zcg24u/
+// TODO: Where does winit handle DPI changes? we can resize the "backbuffer" (canvas element), but isn't that usually handled by e.g. gfx?
+pub fn hidpi_factor() -> f64 {
+    let window = window();
+    window.device_pixel_ratio()
+}
+
 pub fn is_fullscreen(canvas: &CanvasElement) -> bool {
     match document().fullscreen_element() {
         Some(elem) => {

--- a/src/platform_impl/web/stdweb/mod.rs
+++ b/src/platform_impl/web/stdweb/mod.rs
@@ -41,9 +41,6 @@ pub fn window_size() -> LogicalSize<f64> {
     LogicalSize { width, height }
 }
 
-// https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
-// TODO: Use media queries to register changes in dpi: https://jsfiddle.net/b6zcg24u/
-// TODO: Where does winit handle DPI changes? we can resize the "backbuffer" (canvas element), but isn't that usually handled by e.g. gfx?
 pub fn hidpi_factor() -> f64 {
     let window = window();
     window.device_pixel_ratio()

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -86,17 +86,22 @@ impl Canvas {
         (bounds.x(), bounds.y())
     }
 
-    pub fn width(&self) -> f64 {
-        self.raw.width() as f64
-    }
-
-    pub fn height(&self) -> f64 {
-        self.raw.height() as f64
+    pub fn size(&self) -> LogicalSize {
+        LogicalSize {
+            width: self.raw.width() as f64,
+            height: self.raw.height() as f64,
+        }
     }
 
     pub fn set_size(&self, size: LogicalSize<f64>) {
-        self.raw.set_width(size.width as u32);
-        self.raw.set_height(size.height as u32);
+        let physical_size = size.to_physical(super::hidpi_factor());
+
+        self.raw.set_width(physical_size.width as u32);
+        self.raw.set_height(physical_size.height as u32);
+
+        let style = self.raw.style();
+        let _todo = style.set_property("width", &format!("{}px", size.width));
+        let _todo = style.set_property("height", &format!("{}px", size.height));
     }
 
     pub fn raw(&self) -> &HtmlCanvasElement {

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -1,5 +1,5 @@
 use super::event;
-use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize, Size};
+use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
 use crate::event::{ModifiersState, MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode};
 use crate::platform_impl::OsError;

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::{closure::Closure, JsCast};
 use web_sys::{Event, FocusEvent, HtmlCanvasElement, KeyboardEvent, PointerEvent, WheelEvent};
 
 pub struct Canvas {
+    /// Note: resizing the HTMLCanvasElement should go through `backend::set_canvas_size` to ensure the DPI factor is maintained.
     raw: HtmlCanvasElement,
     on_focus: Option<Closure<dyn FnMut(FocusEvent)>>,
     on_blur: Option<Closure<dyn FnMut(FocusEvent)>>,
@@ -94,24 +95,6 @@ impl Canvas {
             width: self.raw.width(),
             height: self.raw.height(),
         }
-    }
-
-    pub fn set_size(&self, size: Size) {
-        let dpi_factor = super::hidpi_factor();
-
-        let physical_size = size.to_physical::<u32>(dpi_factor);
-        let logical_size = size.to_logical::<f64>(dpi_factor);
-
-        self.raw.set_width(physical_size.width);
-        self.raw.set_height(physical_size.height);
-
-        let style = self.raw.style();
-        style
-            .set_property("width", &format!("{}px", logical_size.width))
-            .unwrap();
-        style
-            .set_property("height", &format!("{}px", logical_size.height))
-            .unwrap();
     }
 
     pub fn raw(&self) -> &HtmlCanvasElement {

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -9,7 +9,7 @@ use crate::dpi::LogicalSize;
 use crate::platform::web::WindowExtWebSys;
 use crate::window::Window;
 use wasm_bindgen::{closure::Closure, JsCast};
-use web_sys::{window, BeforeUnloadEvent, HtmlCanvasElement};
+use web_sys::{window, BeforeUnloadEvent, Element, HtmlCanvasElement};
 
 pub fn throw(msg: &str) {
     wasm_bindgen::throw_str(msg);
@@ -65,10 +65,11 @@ pub fn is_fullscreen(canvas: &HtmlCanvasElement) -> bool {
     let window = window().expect("Failed to obtain window");
     let document = window.document().expect("Failed to obtain document");
 
-    canvas.is_same_node(
-        document
-            .fullscreen_element()
-            .as_ref()
-            .map(std::ops::Deref::deref),
-    )
+    match document.fullscreen_element() {
+        Some(elem) => {
+            let raw: Element = canvas.clone().into();
+            raw == elem
+        }
+        None => false,
+    }
 }

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -9,7 +9,7 @@ use crate::dpi::LogicalSize;
 use crate::platform::web::WindowExtWebSys;
 use crate::window::Window;
 use wasm_bindgen::{closure::Closure, JsCast};
-use web_sys::{window, BeforeUnloadEvent, Element, HtmlCanvasElement};
+use web_sys::{window, BeforeUnloadEvent, HtmlCanvasElement};
 
 pub fn throw(msg: &str) {
     wasm_bindgen::throw_str(msg);
@@ -56,15 +56,19 @@ pub fn window_size() -> LogicalSize<f64> {
     LogicalSize { width, height }
 }
 
+pub fn hidpi_factor() -> f64 {
+    let window = web_sys::window().expect("Failed to obtain window");
+    window.device_pixel_ratio()
+}
+
 pub fn is_fullscreen(canvas: &HtmlCanvasElement) -> bool {
     let window = window().expect("Failed to obtain window");
     let document = window.document().expect("Failed to obtain document");
 
-    match document.fullscreen_element() {
-        Some(elem) => {
-            let raw: Element = canvas.clone().into();
-            raw == elem
-        }
-        None => false,
-    }
+    canvas.is_same_node(
+        document
+            .fullscreen_element()
+            .as_ref()
+            .map(std::ops::Deref::deref),
+    )
 }

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -5,7 +5,7 @@ mod timeout;
 pub use self::canvas::Canvas;
 pub use self::timeout::Timeout;
 
-use crate::dpi::LogicalSize;
+use crate::dpi::{LogicalSize, Size};
 use crate::platform::web::WindowExtWebSys;
 use crate::window::Window;
 use wasm_bindgen::{closure::Closure, JsCast};
@@ -59,6 +59,24 @@ pub fn window_size() -> LogicalSize<f64> {
 pub fn hidpi_factor() -> f64 {
     let window = web_sys::window().expect("Failed to obtain window");
     window.device_pixel_ratio()
+}
+
+pub fn set_canvas_size(raw: &HtmlCanvasElement, size: Size) {
+    let hidpi_factor = hidpi_factor();
+
+    let physical_size = size.to_physical::<u32>(hidpi_factor);
+    let logical_size = size.to_logical::<f64>(hidpi_factor);
+
+    raw.set_width(physical_size.width);
+    raw.set_height(physical_size.height);
+
+    let style = raw.style();
+    style
+        .set_property("width", &format!("{}px", logical_size.width))
+        .expect("Failed to set canvas width");
+    style
+        .set_property("height", &format!("{}px", logical_size.height))
+        .expect("Failed to set canvas height");
 }
 
 pub fn is_fullscreen(canvas: &HtmlCanvasElement) -> bool {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -92,18 +92,12 @@ impl Window {
 
     #[inline]
     pub fn inner_size(&self) -> LogicalSize<f64> {
-        LogicalSize {
-            width: self.canvas.width() as f64,
-            height: self.canvas.height() as f64,
-        }
+        self.canvas.size()
     }
 
     #[inline]
     pub fn outer_size(&self) -> LogicalSize<f64> {
-        LogicalSize {
-            width: self.canvas.width() as f64,
-            height: self.canvas.height() as f64,
-        }
+        self.canvas.size()
     }
 
     #[inline]
@@ -128,7 +122,7 @@ impl Window {
 
     #[inline]
     pub fn hidpi_factor(&self) -> f64 {
-        1.0
+        super::backend::hidpi_factor()
     }
 
     #[inline]

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -108,7 +108,7 @@ impl Window {
 
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
-        self.canvas.set_size(size);
+        backend::set_canvas_size(self.canvas.raw(), size);
     }
 
     #[inline]

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -1,4 +1,4 @@
-use crate::dpi::{LogicalPosition, LogicalSize};
+use crate::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
 use crate::icon::Icon;
 use crate::monitor::MonitorHandle as RootMH;
@@ -44,10 +44,10 @@ impl Window {
             register_redraw_request,
         };
 
-        window.set_inner_size(attr.inner_size.unwrap_or(LogicalSize {
+        window.set_inner_size(attr.inner_size.unwrap_or(Size::Logical(LogicalSize {
             width: 1024.0,
             height: 768.0,
-        }));
+        })));
         window.set_title(&attr.title);
         window.set_maximized(attr.maximized);
         window.set_visible(attr.visible);
@@ -72,17 +72,21 @@ impl Window {
         (self.register_redraw_request)();
     }
 
-    pub fn outer_position(&self) -> Result<LogicalPosition<f64>, NotSupportedError> {
-        let (x, y) = self.canvas.position();
-
-        Ok(LogicalPosition { x, y })
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+        // todo: not supported?
+        // Ok(self.canvas.position().to_physical(self.hidpi_factor))
+        Err(NotSupportedError::new())
     }
 
-    pub fn inner_position(&self) -> Result<LogicalPosition<f64>, NotSupportedError> {
-        Ok(*self.position.borrow())
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+        // todo: not supported?
+        // Ok(*self.position.borrow())
+        Err(NotSupportedError::new())
     }
 
-    pub fn set_outer_position(&self, position: LogicalPosition<f64>) {
+    pub fn set_outer_position(&self, position: Position) {
+        let position = position.to_logical(self.hidpi_factor());
+
         *self.position.borrow_mut() = position;
 
         self.canvas.set_attribute("position", "fixed");
@@ -91,27 +95,29 @@ impl Window {
     }
 
     #[inline]
-    pub fn inner_size(&self) -> LogicalSize<f64> {
+    pub fn inner_size(&self) -> PhysicalSize<u32> {
+        // TODO
         self.canvas.size()
     }
 
     #[inline]
-    pub fn outer_size(&self) -> LogicalSize<f64> {
+    pub fn outer_size(&self) -> PhysicalSize<u32> {
+        // TODO
         self.canvas.size()
     }
 
     #[inline]
-    pub fn set_inner_size(&self, size: LogicalSize<f64>) {
+    pub fn set_inner_size(&self, size: Size) {
         self.canvas.set_size(size);
     }
 
     #[inline]
-    pub fn set_min_inner_size(&self, _dimensions: Option<LogicalSize<f64>>) {
+    pub fn set_min_inner_size(&self, _dimensions: Option<Size>) {
         // Intentionally a no-op: users can't resize canvas elements
     }
 
     #[inline]
-    pub fn set_max_inner_size(&self, _dimensions: Option<LogicalSize<f64>>) {
+    pub fn set_max_inner_size(&self, _dimensions: Option<Size>) {
         // Intentionally a no-op: users can't resize canvas elements
     }
 
@@ -172,10 +178,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(
-        &self,
-        _position: LogicalPosition<f64>,
-    ) -> Result<(), ExternalError> {
+    pub fn set_cursor_position(&self, _position: Position) -> Result<(), ExternalError> {
         // Intentionally a no-op, as the web does not support setting cursor positions
         Ok(())
     }
@@ -235,7 +238,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_position(&self, _position: LogicalPosition<f64>) {
+    pub fn set_ime_position(&self, _position: Position) {
         // Currently a no-op as it does not seem there is good support for this on web
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -419,6 +419,8 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread. Returns the top left coordinates of the
     ///   window's [safe area] in the screen space coordinate system.
+    /// - **Web:** Returns the top-left coordinates relative to the viewport. _Note: this returns the
+    ///    same value as `outer_position`._
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     #[inline]
@@ -440,7 +442,7 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread. Returns the top left coordinates of the
     ///   window in the screen space coordinate system.
-    /// - **Web:** Returns the top-left coordinates relative to the viewport. or, TODO: not supported?
+    /// - **Web:** Returns the top-left coordinates relative to the viewport.
     #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         self.window.outer_position()
@@ -455,7 +457,7 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread. Sets the top left coordinates of the
     ///   window in the screen space coordinate system.
-    /// - **Web:** Sets the top-left coordinates relative to the viewport. or, TODO: not supported?
+    /// - **Web:** Sets the top-left coordinates relative to the viewport.
     #[inline]
     pub fn set_outer_position<P: Into<Position>>(&self, position: P) {
         self.window.set_outer_position(position.into())
@@ -469,6 +471,7 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread. Returns the `PhysicalSize` of the window's
     ///   [safe area] in screen space coordinates.
+    /// - **Web:** Returns the size of the canvas element.
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     #[inline]
@@ -485,6 +488,7 @@ impl Window {
     ///
     /// - **iOS:** Unimplemented. Currently this panics, as it's not clear what `set_inner_size`
     ///   would mean for iOS.
+    /// - **Web:** Sets the size of the canvas element.
     #[inline]
     pub fn set_inner_size<S: Into<Size>>(&self, size: S) {
         self.window.set_inner_size(size.into())
@@ -499,6 +503,8 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread. Returns the `PhysicalSize` of the window in
     ///   screen space coordinates.
+    /// - **Web:** Returns the size of the canvas element. _Note: this returns the same value as
+    ///   `inner_size`._
     #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         self.window.outer_size()

--- a/src/window.rs
+++ b/src/window.rs
@@ -440,6 +440,7 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread. Returns the top left coordinates of the
     ///   window in the screen space coordinate system.
+    /// - **Web:** Returns the top-left coordinates relative to the viewport. or, TODO: not supported?
     #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         self.window.outer_position()
@@ -454,6 +455,7 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread. Sets the top left coordinates of the
     ///   window in the screen space coordinate system.
+    /// - **Web:** Sets the top-left coordinates relative to the viewport. or, TODO: not supported?
     #[inline]
     pub fn set_outer_position<P: Into<Position>>(&self, position: P) {
         self.window.set_outer_position(position.into())


### PR DESCRIPTION
I believe both backends are implemented, but I'm not sure if just the output I'm seeing from doing `cargo web start ...` indicates it's working.

This change set it based on the MDN docs for [`Window.devicePixelRatio`](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) and [this JSFiddle](https://jsfiddle.net/znuwtfca/1/).

Some points:
- Use `Window.devicePixelRatio` to get the `hidpi_factor`
- Set canvas element to the physical size and the canvas' css size to the logical size
- (not implemented yet) register an event for `hidpi_factor` changes using `matchMedia` (JSFiddle prototype here https://jsfiddle.net/b6zcg24u/)
  - Note: Changing the browser's zoom level affects the `devicePixelRatio`
- Note: `winit` needs an example that outputs graphics to test this?
- TODO: update `dpi` mod docs!

---

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
