### PR TITLE
Implement revamped `RedrawRequested` on macOS

### DIFF
--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -265,13 +265,11 @@ impl AppState {
             for event in HANDLER.take_events() {
                 HANDLER.handle_nonuser_event(event);
             }
+            HANDLER.handle_nonuser_event(Event::MainEventsCleared);
             for window_id in HANDLER.should_redraw() {
-                HANDLER.handle_nonuser_event(Event::WindowEvent {
-                    window_id,
-                    event: WindowEvent::RedrawRequested,
-                });
+                HANDLER.handle_nonuser_event(Event::RedrawRequested(window_id));
             }
-            HANDLER.handle_nonuser_event(Event::EventsCleared);
+            HANDLER.handle_nonuser_event(Event::RedrawEventsCleared);
             HANDLER.set_in_callback(false);
         }
         if HANDLER.should_exit() {


### PR DESCRIPTION
Related to #1082.

I have tested this with https://github.com/hecrj/iced/pull/22 and it seems to work well.

However, I am not very familiar with macOS windowing APIs, thus I am not sure if any further changes are necessary.

The PR most likely won't compile because it needs a fix that was merged to `master` recently: https://github.com/rust-windowing/winit/commit/af3ef52252dfad178d897b036876c2575c20f1f3. I will be happy to rebase the changes once `redraw-requested-2.0` catches up!

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
