### PR TITLE
X11: Fix window creation hangs when another application is fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On macOS, fix application termination on `ControlFlow::Exit`
+- On X11, fix window creation hanging when another window is fullscreen.
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -1,0 +1,121 @@
+// This example is used by developers to test various window functions.
+
+use winit::{
+    dpi::{LogicalSize, PhysicalSize},
+    event::{DeviceEvent, ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::{Fullscreen, WindowBuilder},
+};
+
+fn main() {
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_inner_size(LogicalSize::from((100, 100)))
+        .build(&event_loop)
+        .unwrap();
+
+    eprintln!("debugging keys:");
+    eprintln!("  (E) Enter exclusive fullscreen");
+    eprintln!("  (F) Toggle borderless fullscreen");
+    #[cfg(waiting_for_set_minimized)]
+    eprintln!("  (M) Toggle minimized");
+    eprintln!("  (Q) Quit event loop");
+    eprintln!("  (V) Toggle visibility");
+    eprintln!("  (X) Toggle maximized");
+
+    #[cfg(waiting_for_set_minimized)]
+    let mut minimized = false;
+    let mut maximized = false;
+    let mut visible = true;
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::DeviceEvent {
+                event:
+                    DeviceEvent::Key(KeyboardInput {
+                        virtual_keycode: Some(key),
+                        state: ElementState::Pressed,
+                        ..
+                    }),
+                ..
+            } => match key {
+                #[cfg(waiting_for_set_minimized)]
+                VirtualKeyCode::M => {
+                    if minimized {
+                        minimized = !minimized;
+                        window.set_minimized(minimized);
+                    }
+                }
+                VirtualKeyCode::V => {
+                    if !visible {
+                        visible = !visible;
+                        window.set_visible(visible);
+                    }
+                }
+                _ => (),
+            },
+            Event::WindowEvent {
+                event: WindowEvent::KeyboardInput { input, .. },
+                ..
+            } => match input {
+                KeyboardInput {
+                    virtual_keycode: Some(key),
+                    state: ElementState::Pressed,
+                    ..
+                } => match key {
+                    VirtualKeyCode::E => {
+                        fn area(size: PhysicalSize) -> f64 {
+                            size.width * size.height
+                        }
+
+                        let monitor = window.current_monitor();
+                        if let Some(mode) = monitor.video_modes().max_by(|a, b| {
+                            area(a.size())
+                                .partial_cmp(&area(b.size()))
+                                .expect("NaN in video mode size")
+                        }) {
+                            window.set_fullscreen(Some(Fullscreen::Exclusive(mode)));
+                        } else {
+                            eprintln!("no video modes available");
+                        }
+                    }
+                    VirtualKeyCode::F => {
+                        if window.fullscreen().is_some() {
+                            window.set_fullscreen(None);
+                        } else {
+                            let monitor = window.current_monitor();
+                            window.set_fullscreen(Some(Fullscreen::Borderless(monitor)));
+                        }
+                    }
+                    #[cfg(waiting_for_set_minimized)]
+                    VirtualKeyCode::M => {
+                        minimized = !minimized;
+                        window.set_minimized(minimized);
+                    }
+                    VirtualKeyCode::Q => {
+                        *control_flow = ControlFlow::Exit;
+                    }
+                    VirtualKeyCode::V => {
+                        visible = !visible;
+                        window.set_visible(visible);
+                    }
+                    VirtualKeyCode::X => {
+                        maximized = !maximized;
+                        window.set_maximized(maximized);
+                    }
+                    _ => (),
+                },
+                _ => (),
+            },
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            _ => (),
+        }
+    });
+}

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -498,6 +498,13 @@ impl<T: 'static> EventProcessor<T> {
                 });
             }
 
+            ffi::VisibilityNotify => {
+                let xev: &ffi::XVisibilityEvent = xev.as_ref();
+                let xwindow = xev.window;
+
+                self.with_window(xwindow, |window| window.visibility_notify());
+            }
+
             ffi::Expose => {
                 let xev: &ffi::XExposeEvent = xev.as_ref();
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -718,12 +718,20 @@ impl UnownedWindow {
     pub(crate) fn visibility_notify(&self) {
         let mut shared_state = self.shared_state.lock();
 
-        if let Visibility::YesWait = shared_state.visibility {
-            shared_state.visibility = Visibility::Yes;
+        match shared_state.visibility {
+            Visibility::No => {
+                unsafe {
+                    (self.xconn.xlib.XUnmapWindow)(self.xconn.display, self.xwindow);
+                }
+            }
+            Visibility::Yes => (),
+            Visibility::YesWait => {
+                shared_state.visibility = Visibility::Yes;
 
-            if let Some(fullscreen) = shared_state.desired_fullscreen.take() {
-                drop(shared_state);
-                self.set_fullscreen(fullscreen);
+                if let Some(fullscreen) = shared_state.desired_fullscreen.take() {
+                    drop(shared_state);
+                    self.set_fullscreen(fullscreen);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #1210

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
