### PR TITLE
on Wayland, drop resize events equal to the current window size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   - This is because some platforms cannot run the event loop outside the main thread. Preventing this
     reduces the potential for cross-platform compatibility gotchyas.
 - On Windows and Linux X11/Wayland, add platform-specific functions for creating an `EventLoop` outside the main thread.
+- On Wayland, drop resize events identical to the current window size.
 
 # 0.20.0 Alpha 3 (2019-08-14)
 

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -673,15 +673,22 @@ impl<T> EventLoop<T> {
              wid,
              frame| {
                 if let Some(frame) = frame {
-                    if let Some((w, h)) = newsize {
-                        frame.resize(w, h);
-                        frame.refresh();
-                        let logical_size = crate::dpi::LogicalSize::new(w as f64, h as f64);
-                        sink.send_window_event(
-                            crate::event::WindowEvent::Resized(logical_size),
-                            wid,
-                        );
-                        *size = (w, h);
+                    if let Some(newsize) = newsize {
+                        // Drop resize events equaled to the current size
+                        if newsize != *size {
+                            let (w, h) = newsize;
+                            frame.resize(w, h);
+                            frame.refresh();
+                            let logical_size = crate::dpi::LogicalSize::new(w as f64, h as f64);
+                            sink.send_window_event(
+                                crate::event::WindowEvent::Resized(logical_size),
+                                wid,
+                            );
+                            *size = (w, h);
+                        } else {
+                            // Refresh csd, etc, otherwise
+                            frame.refresh();
+                        }
                     } else if frame_refresh {
                         frame.refresh();
                         if !refresh {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes: #1247