### PR TITLE
Add error message when building for web without selecting a feature.

### DIFF
--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -16,6 +16,9 @@ mod backend;
 #[path = "stdweb/mod.rs"]
 mod backend;
 
+#[cfg(not(any(feature = "web-sys", feature = "stdweb")))]
+compile_error!("Please select a feature to build for web: `web-sys`, `stdweb`");
+
 pub use self::device::Id as DeviceId;
 pub use self::error::OsError;
 pub use self::event_loop::{


### PR DESCRIPTION
This change adds an error message when the web backend is built without specifying the web backend (stdweb/web-sys). This is a small quality of life proposal to help avoid confusion when users try building for web.

![image](https://user-images.githubusercontent.com/2287247/67924684-8d78f680-fb6e-11e9-8089-86a3d860f1dc.png)