### PR TITLE
fix broken / missing `raw-window-handle` implementation on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# Version 0.19.5 (2019-11-04)
+
+- On Android, fix the missing `raw-window-handle` support
+
 # Version 0.19.4 (2019-10-16)
 
 - Add support for `raw-window-handle` 0.3.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.19.4"
+version = "0.19.5"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 keywords = ["windowing"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please direct all work against `master`.
 
 ```toml
 [dependencies]
-winit = "0.19.4"
+winit = "0.19.5"
 ```
 
 ## [Documentation](https://docs.rs/winit)

--- a/src/platform/android/mod.rs
+++ b/src/platform/android/mod.rs
@@ -4,6 +4,7 @@ extern crate android_glue;
 
 mod ffi;
 
+use raw_window_handle::{android::AndroidHandle, RawWindowHandle};
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt;
@@ -421,6 +422,14 @@ impl Window {
     #[inline]
     pub fn id(&self) -> WindowId {
         WindowId
+    }
+
+    pub fn raw_window_handle(&self) -> RawWindowHandle {
+        let handle = AndroidHandle {
+            a_native_window: self.native_window as _,
+            ..AndroidHandle::empty()
+        };
+        RawWindowHandle::Android(handle)
     }
 }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
  - build check was performed and passed (`cargo build --target=aarch64-linux-android`). on a side note, should build checks like these be added to travis? Testing on mobile is hard but making sure something builds isn't very tricky.
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
