### PR TITLE
Windows: Survive a OleInitialize failure. Fixes #1255

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - On X11, fix misreporting DPI factor at startup.
 - On X11, fix events not being reported when using `run_return`.
 - On X11, fix key modifiers being incorrectly reported.
+- On Windows, don't panic if CoInitialize has been called with COINIT_MULTITHREADED. Instead just lose drag/drop support.
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -100,7 +100,7 @@ lazy_static! {
 pub(crate) struct SubclassInput<T> {
     pub window_state: Arc<Mutex<WindowState>>,
     pub event_loop_runner: EventLoopRunnerShared<T>,
-    pub file_drop_handler: FileDropHandler,
+    pub file_drop_handler: Option<FileDropHandler>,
 }
 
 impl<T> SubclassInput<T> {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -83,6 +83,7 @@ impl Window {
                         // OleInitialize failed because someone is using COINIT_MULTITHREADED, which
                         // OLE is not compatible with, but there's no reason we can't stumble along
                         // without drag/drop support.
+                        warn!("OleInitialize failed due to CoInitializeEx having been called with COINIT_MULTITHREADED! Disabled drag/drop.");
                         None
                     }
                     _ => {


### PR DESCRIPTION
The new file drag/drop code uses OLE.

OleInitialize fails if CoInitialize(COINIT_MULTITHREADED) has previously been called on the current thread, and currently winit panics when this happens (see #1255).

There are many reasons that CoInitialize(COINIT_MULTITHREADED) might have been called before winit is initialized, for example [cpal might be in use](https://github.com/RustAudio/cpal/pull/348). OLE drag/drop requires COINIT_APARTMENTTHREADED but if you don't care about drag/drop, that might not be a concern.

So let's survive OleInitialize failing. Should probably warn about the lost drag/drop functionality in the log somehow - what would be the appropriate way?

- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

Not sure which documentation to update?