### PR TITLE
Run cargo fmt on Rust stable 1.39.0

### DIFF
--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -500,7 +500,9 @@ pub unsafe fn create_window(
             let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode];
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
-        Some(Fullscreen::Borderless(ref monitor)) => msg_send![window, setScreen:monitor.ui_screen()],
+        Some(Fullscreen::Borderless(ref monitor)) => {
+            msg_send![window, setScreen:monitor.ui_screen()]
+        }
         None => (),
     }
 


### PR DESCRIPTION
- [x] `cargo fmt` has been run on this branch