### PR TITLE
VirtualKeyCode extensions + X11 bindings

### DIFF
--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use winit::monitor::MonitorHandle;
 use winit::{event_loop::EventLoop, window::WindowBuilder};
 
 fn main() {
@@ -8,6 +9,30 @@ fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    dbg!(window.available_monitors().collect::<Vec<_>>());
-    dbg!(window.primary_monitor());
+    for mon in window.available_monitors() {
+        print_info(mon);
+    }
+    if let Some(mon) = window.primary_monitor() {
+        print_info(mon);
+    }
+}
+
+fn print_info(monitor: MonitorHandle) {
+    if let Some(name) = monitor.name() {
+        println!("name: {name}");
+    } else {
+        println!("name: <none>");
+    }
+    println!("size: {:?}", monitor.size());
+    println!("position: {:?}", monitor.position());
+    println!("refresh_rate: {:?} mHz", monitor.refresh_rate_millihertz());
+    println!("scale_factor: {:?}", monitor.scale_factor());
+    for mode in monitor.video_modes() {
+        println!(
+            "mode: {:?}, depth = {} bits, refresh rate = {} mHz",
+            mode.size(),
+            mode.bit_depth(),
+            mode.refresh_rate_millihertz()
+        );
+    }
 }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR comes in two parts (not completely separated by commit):

1.  Fix some missing X11 key bindings
2.  Add some `VirtualKeyCode` enumerations and bindings for several common symbols (most of which don't usually appear on keys directly, but nevertheless are generated on my keyboard)

I expect this to be at least a little contentious: choices of which codes to add to `VirtualKeyCode` are arbitrary. I didn't touch any media/web keys yet (I can, and probably should, since many of these are already included in `VirtualKeyCode`); I also did not add locale-specific letters (ç, à, ä, etc.; there are *many* of these defined for X11). With some feedback I can fix this up.

Of course, these new enums deserve bindings on other platforms. Since I can't easily test on other platforms and since many X11 bindings were already missed, I feel no obligation to address this myself. Also, some of these enums may be specific to X11. I also feel no guilt about this, since I believe some of the other codes are likely platform specific (e.g. `Ax, AbntC1`).

There may be prior art in some other compilation of key symbols? Alternatively I'm half tempted to completely ignore this enumeration and use [`ReceivedCharacter`](https://docs.rs/winit/0.20.0-alpha3/winit/event/enum.WindowEvent.html#variant.ReceivedCharacter) instead, since this automatically includes all possible generated chars (although it misses media/web keys).

Useful link: [`x11-rs/src/keysym.rs`](https://github.com/erlepereira/x11-rs/blob/master/src/keysym.rs)