### PR TITLE
Fix invalid_value lint triggering on mem::zeroed of CFRunLoopSourceContext

### DIFF
--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -132,7 +132,7 @@ impl<T> Proxy<T> {
             // process user events through the normal OS EventLoop mechanisms.
             let rl = CFRunLoopGetMain();
             let mut context: CFRunLoopSourceContext = mem::zeroed();
-            context.perform = event_loop_proxy_handler;
+            context.perform = Some(event_loop_proxy_handler);
             let source =
                 CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::max_value() - 1, &mut context);
             CFRunLoopAddSource(rl, source, kCFRunLoopCommonModes);

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -93,14 +93,14 @@ pub enum CFRunLoopTimerContext {}
 pub struct CFRunLoopSourceContext {
     pub version: CFIndex,
     pub info: *mut c_void,
-    pub retain: extern "C" fn(*const c_void) -> *const c_void,
-    pub release: extern "C" fn(*const c_void),
-    pub copyDescription: extern "C" fn(*const c_void) -> CFStringRef,
-    pub equal: extern "C" fn(*const c_void, *const c_void) -> ffi::Boolean,
-    pub hash: extern "C" fn(*const c_void) -> CFHashCode,
-    pub schedule: extern "C" fn(*mut c_void, CFRunLoopRef, CFRunLoopMode),
-    pub cancel: extern "C" fn(*mut c_void, CFRunLoopRef, CFRunLoopMode),
-    pub perform: extern "C" fn(*mut c_void),
+    pub retain: Option<extern "C" fn(*const c_void) -> *const c_void>,
+    pub release: Option<extern "C" fn(*const c_void)>,
+    pub copyDescription: Option<extern "C" fn(*const c_void) -> CFStringRef>,
+    pub equal: Option<extern "C" fn(*const c_void, *const c_void) -> ffi::Boolean>,
+    pub hash: Option<extern "C" fn(*const c_void) -> CFHashCode>,
+    pub schedule: Option<extern "C" fn(*mut c_void, CFRunLoopRef, CFRunLoopMode)>,
+    pub cancel: Option<extern "C" fn(*mut c_void, CFRunLoopRef, CFRunLoopMode)>,
+    pub perform: Option<extern "C" fn(*mut c_void)>,
 }
 
 // begin is queued with the highest priority to ensure it is processed before other observers


### PR DESCRIPTION
Without you get 
```
warning: the type `platform_impl::platform::observer::CFRunLoopSourceContext` does not permit zero-initialization
   --> src/platform_impl/macos/event_loop.rs:134:55
    |
134 |             let mut context: CFRunLoopSourceContext = mem::zeroed();
    |                                                       ^^^^^^^^^^^^^
    |                                                       |
    |                                                       this code causes undefined behavior when executed
    |                                                       help: use `MaybeUninit<T>` instead
    |
    = note: `#[warn(invalid_value)]` on by default
note: Function pointers must be non-null (in this struct field)
   --> src/platform_impl/macos/observer.rs:96:5
    |
96  |     pub retain: extern "C" fn(*const c_void) -> *const c_void,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```


- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
    - Was that type public?
- [ ] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [ ] ~~Created or updated an example program if it would help users understand this functionality~~
- [ ] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~
