### PR TITLE
Make size/position types generic over pixel type

### DIFF
--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -5,7 +5,7 @@ fn main() {
     use std::{collections::HashMap, sync::mpsc, thread, time::Duration};
 
     use winit::{
-    	dpi::{PhysicalPosition, PhysicalSize, Position, Size},
+        dpi::{PhysicalPosition, PhysicalSize, Position, Size},
         event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
         event_loop::{ControlFlow, EventLoop},
         window::{CursorIcon, Fullscreen, WindowBuilder},
@@ -116,22 +116,17 @@ fn main() {
                             Q => window.request_redraw(),
                             R => window.set_resizable(state),
                             S => window.set_inner_size(match state {
-                                true => {
-                                    PhysicalSize::new(
-                                        WINDOW_SIZE.width + 100,
-                                        WINDOW_SIZE.height + 100,
-                                    )
-                                }
+                                true => PhysicalSize::new(
+                                    WINDOW_SIZE.width + 100,
+                                    WINDOW_SIZE.height + 100,
+                                ),
                                 false => WINDOW_SIZE,
                             }),
                             W => {
                                 if let Size::Physical(size) = WINDOW_SIZE.into() {
                                     window
                                         .set_cursor_position(Position::Physical(
-                                            PhysicalPosition::new(
-                                                size.width / 2,
-                                                size.height / 2,
-                                            ),
+                                            PhysicalPosition::new(size.width / 2, size.height / 2),
                                         ))
                                         .unwrap()
                                 }

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -12,7 +12,7 @@ fn main() {
     };
 
     const WINDOW_COUNT: usize = 3;
-    const WINDOW_SIZE: PhysicalSize = PhysicalSize::new(600, 400);
+    const WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize::new(600, 400);
 
     env_logger::init();
     let event_loop = EventLoop::new();
@@ -108,9 +108,9 @@ fn main() {
                             M => window.set_maximized(state),
                             P => window.set_outer_position({
                                 let mut position = window.outer_position().unwrap();
-                                let sign = if state { 1.0 } else { -1.0 };
-                                position.x += 10.0 * sign;
-                                position.y += 10.0 * sign;
+                                let sign = if state { 1 } else { -1 };
+                                position.x += 10 * sign;
+                                position.y += 10 * sign;
                                 position
                             }),
                             Q => window.request_redraw(),
@@ -129,8 +129,8 @@ fn main() {
                                     window
                                         .set_cursor_position(Position::Physical(
                                             PhysicalPosition::new(
-                                                size.width as f64 / 2.0,
-                                                size.height as f64 / 2.0,
+                                                size.width / 2,
+                                                size.height / 2,
                                             ),
                                         ))
                                         .unwrap()

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -155,7 +155,10 @@ impl<P> LogicalPosition<P> {
 
 impl<P: Pixel> LogicalPosition<P> {
     #[inline]
-    pub fn from_physical<T: Into<PhysicalPosition<X>>, X: Pixel>(physical: T, dpi_factor: f64) -> Self {
+    pub fn from_physical<T: Into<PhysicalPosition<X>>, X: Pixel>(
+        physical: T,
+        dpi_factor: f64,
+    ) -> Self {
         physical.into().to_logical(dpi_factor)
     }
 
@@ -209,7 +212,10 @@ impl<P> PhysicalPosition<P> {
 
 impl<P: Pixel> PhysicalPosition<P> {
     #[inline]
-    pub fn from_logical<T: Into<LogicalPosition<X>>, X: Pixel>(logical: T, dpi_factor: f64) -> Self {
+    pub fn from_logical<T: Into<LogicalPosition<X>>, X: Pixel>(
+        logical: T,
+        dpi_factor: f64,
+    ) -> Self {
         logical.into().to_physical(dpi_factor)
     }
 

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -141,17 +141,19 @@ pub fn validate_hidpi_factor(dpi_factor: f64) -> bool {
 /// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LogicalPosition<P: Pixel> {
+pub struct LogicalPosition<P> {
     pub x: P,
     pub y: P,
 }
 
-impl<P: Pixel> LogicalPosition<P> {
+impl<P> LogicalPosition<P> {
     #[inline]
-    pub fn new(x: P, y: P) -> Self {
+    pub const fn new(x: P, y: P) -> Self {
         LogicalPosition { x, y }
     }
+}
 
+impl<P: Pixel> LogicalPosition<P> {
     #[inline]
     pub fn from_physical<T: Into<PhysicalPosition<X>>, X: Pixel>(physical: T, dpi_factor: f64) -> Self {
         physical.into().to_logical(dpi_factor)
@@ -193,17 +195,19 @@ impl<P: Pixel, X: Pixel> Into<(X, X)> for LogicalPosition<P> {
 /// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PhysicalPosition<P: Pixel> {
+pub struct PhysicalPosition<P> {
     pub x: P,
     pub y: P,
 }
 
-impl<P: Pixel> PhysicalPosition<P> {
+impl<P> PhysicalPosition<P> {
     #[inline]
-    pub fn new(x: P, y: P) -> Self {
+    pub const fn new(x: P, y: P) -> Self {
         PhysicalPosition { x, y }
     }
+}
 
+impl<P: Pixel> PhysicalPosition<P> {
     #[inline]
     pub fn from_logical<T: Into<LogicalPosition<X>>, X: Pixel>(logical: T, dpi_factor: f64) -> Self {
         logical.into().to_physical(dpi_factor)
@@ -245,17 +249,19 @@ impl<P: Pixel, X: Pixel> Into<(X, X)> for PhysicalPosition<P> {
 /// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LogicalSize<P: Pixel> {
+pub struct LogicalSize<P> {
     pub width: P,
     pub height: P,
 }
 
-impl<P: Pixel> LogicalSize<P> {
+impl<P> LogicalSize<P> {
     #[inline]
-    pub fn new(width: P, height: P) -> Self {
+    pub const fn new(width: P, height: P) -> Self {
         LogicalSize { width, height }
     }
+}
 
+impl<P: Pixel> LogicalSize<P> {
     #[inline]
     pub fn from_physical<T: Into<PhysicalSize<X>>, X: Pixel>(physical: T, dpi_factor: f64) -> Self {
         physical.into().to_logical(dpi_factor)
@@ -293,17 +299,19 @@ impl<P: Pixel, X: Pixel> Into<(X, X)> for LogicalSize<P> {
 /// A size represented in physical pixels.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PhysicalSize<P: Pixel> {
+pub struct PhysicalSize<P> {
     pub width: P,
     pub height: P,
 }
 
-impl<P: Pixel> PhysicalSize<P> {
+impl<P> PhysicalSize<P> {
     #[inline]
-    pub fn new(width: P, height: P) -> Self {
+    pub const fn new(width: P, height: P) -> Self {
         PhysicalSize { width, height }
     }
+}
 
+impl<P: Pixel> PhysicalSize<P> {
     #[inline]
     pub fn from_logical<T: Into<LogicalSize<X>>, X: Pixel>(logical: T, dpi_factor: f64) -> Self {
         logical.into().to_physical(dpi_factor)

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -76,6 +76,54 @@
 //! If you never received any [`HiDpiFactorChanged`](../enum.WindowEvent.html#variant.HiDpiFactorChanged) events,
 //! then your window's DPI factor is 1.
 
+pub trait Pixel: Copy + Into<f64> {
+    fn from_f64(f: f64) -> Self;
+    fn cast<P: Pixel>(self) -> P {
+        P::from_f64(self.into())
+    }
+}
+
+impl Pixel for u8 {
+    fn from_f64(f: f64) -> Self {
+        f.round() as u8
+    }
+}
+impl Pixel for u16 {
+    fn from_f64(f: f64) -> Self {
+        f.round() as u16
+    }
+}
+impl Pixel for u32 {
+    fn from_f64(f: f64) -> Self {
+        f.round() as u32
+    }
+}
+impl Pixel for i8 {
+    fn from_f64(f: f64) -> Self {
+        f.round() as i8
+    }
+}
+impl Pixel for i16 {
+    fn from_f64(f: f64) -> Self {
+        f.round() as i16
+    }
+}
+impl Pixel for i32 {
+    fn from_f64(f: f64) -> Self {
+        f.round() as i32
+    }
+}
+impl Pixel for f32 {
+    fn from_f64(f: f64) -> Self {
+        f as f32
+    }
+}
+impl Pixel for f64 {
+    fn from_f64(f: f64) -> Self {
+        f
+    }
+}
+
 /// Checks that the DPI factor is a normal positive `f64`.
 ///
 /// All functions that take a DPI factor assert that this will return `true`. If you're sourcing DPI factors from
@@ -93,57 +141,48 @@ pub fn validate_hidpi_factor(dpi_factor: f64) -> bool {
 /// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LogicalPosition {
-    pub x: f64,
-    pub y: f64,
+pub struct LogicalPosition<P: Pixel> {
+    pub x: P,
+    pub y: P,
 }
 
-impl LogicalPosition {
+impl<P: Pixel> LogicalPosition<P> {
     #[inline]
-    pub const fn new(x: f64, y: f64) -> Self {
+    pub fn new(x: P, y: P) -> Self {
         LogicalPosition { x, y }
     }
 
     #[inline]
-    pub fn from_physical<T: Into<PhysicalPosition>>(physical: T, dpi_factor: f64) -> Self {
+    pub fn from_physical<T: Into<PhysicalPosition<X>>, X: Pixel>(physical: T, dpi_factor: f64) -> Self {
         physical.into().to_logical(dpi_factor)
     }
 
     #[inline]
-    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalPosition {
+    pub fn to_physical<X: Pixel>(&self, dpi_factor: f64) -> PhysicalPosition<X> {
         assert!(validate_hidpi_factor(dpi_factor));
-        let x = self.x * dpi_factor;
-        let y = self.y * dpi_factor;
-        PhysicalPosition::new(x, y)
+        let x = self.x.into() * dpi_factor;
+        let y = self.y.into() * dpi_factor;
+        PhysicalPosition::new(x, y).cast()
+    }
+
+    #[inline]
+    pub fn cast<X: Pixel>(&self) -> LogicalPosition<X> {
+        LogicalPosition {
+            x: self.x.cast(),
+            y: self.y.cast(),
+        }
     }
 }
 
-impl From<(f64, f64)> for LogicalPosition {
-    #[inline]
-    fn from((x, y): (f64, f64)) -> Self {
-        Self::new(x, y)
+impl<P: Pixel, X: Pixel> From<(X, X)> for LogicalPosition<P> {
+    fn from((x, y): (X, X)) -> LogicalPosition<P> {
+        LogicalPosition::new(x.cast(), y.cast())
     }
 }
 
-impl From<(i32, i32)> for LogicalPosition {
-    #[inline]
-    fn from((x, y): (i32, i32)) -> Self {
-        Self::new(x as f64, y as f64)
-    }
-}
-
-impl Into<(f64, f64)> for LogicalPosition {
-    #[inline]
-    fn into(self) -> (f64, f64) {
-        (self.x, self.y)
-    }
-}
-
-impl Into<(i32, i32)> for LogicalPosition {
-    /// Note that this rounds instead of truncating.
-    #[inline]
-    fn into(self) -> (i32, i32) {
-        (self.x.round() as _, self.y.round() as _)
+impl<P: Pixel, X: Pixel> Into<(X, X)> for LogicalPosition<P> {
+    fn into(self: Self) -> (X, X) {
+        (self.x.cast(), self.y.cast())
     }
 }
 
@@ -154,57 +193,48 @@ impl Into<(i32, i32)> for LogicalPosition {
 /// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PhysicalPosition {
-    pub x: f64,
-    pub y: f64,
+pub struct PhysicalPosition<P: Pixel> {
+    pub x: P,
+    pub y: P,
 }
 
-impl PhysicalPosition {
+impl<P: Pixel> PhysicalPosition<P> {
     #[inline]
-    pub const fn new(x: f64, y: f64) -> Self {
+    pub fn new(x: P, y: P) -> Self {
         PhysicalPosition { x, y }
     }
 
     #[inline]
-    pub fn from_logical<T: Into<LogicalPosition>>(logical: T, dpi_factor: f64) -> Self {
+    pub fn from_logical<T: Into<LogicalPosition<X>>, X: Pixel>(logical: T, dpi_factor: f64) -> Self {
         logical.into().to_physical(dpi_factor)
     }
 
     #[inline]
-    pub fn to_logical(&self, dpi_factor: f64) -> LogicalPosition {
+    pub fn to_logical<X: Pixel>(&self, dpi_factor: f64) -> LogicalPosition<X> {
         assert!(validate_hidpi_factor(dpi_factor));
-        let x = self.x / dpi_factor;
-        let y = self.y / dpi_factor;
-        LogicalPosition::new(x, y)
+        let x = self.x.into() / dpi_factor;
+        let y = self.y.into() / dpi_factor;
+        LogicalPosition::new(x, y).cast()
+    }
+
+    #[inline]
+    pub fn cast<X: Pixel>(&self) -> PhysicalPosition<X> {
+        PhysicalPosition {
+            x: self.x.cast(),
+            y: self.y.cast(),
+        }
     }
 }
 
-impl From<(f64, f64)> for PhysicalPosition {
-    #[inline]
-    fn from((x, y): (f64, f64)) -> Self {
-        Self::new(x, y)
+impl<P: Pixel, X: Pixel> From<(X, X)> for PhysicalPosition<P> {
+    fn from((x, y): (X, X)) -> PhysicalPosition<P> {
+        PhysicalPosition::new(x.cast(), y.cast())
     }
 }
 
-impl From<(i32, i32)> for PhysicalPosition {
-    #[inline]
-    fn from((x, y): (i32, i32)) -> Self {
-        Self::new(x as f64, y as f64)
-    }
-}
-
-impl Into<(f64, f64)> for PhysicalPosition {
-    #[inline]
-    fn into(self) -> (f64, f64) {
-        (self.x, self.y)
-    }
-}
-
-impl Into<(i32, i32)> for PhysicalPosition {
-    /// Note that this rounds instead of truncating.
-    #[inline]
-    fn into(self) -> (i32, i32) {
-        (self.x.round() as _, self.y.round() as _)
+impl<P: Pixel, X: Pixel> Into<(X, X)> for PhysicalPosition<P> {
+    fn into(self: Self) -> (X, X) {
+        (self.x.cast(), self.y.cast())
     }
 }
 
@@ -215,108 +245,104 @@ impl Into<(i32, i32)> for PhysicalPosition {
 /// does the rounding for you.
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LogicalSize {
-    pub width: f64,
-    pub height: f64,
+pub struct LogicalSize<P: Pixel> {
+    pub width: P,
+    pub height: P,
 }
 
-impl LogicalSize {
+impl<P: Pixel> LogicalSize<P> {
     #[inline]
-    pub const fn new(width: f64, height: f64) -> Self {
+    pub fn new(width: P, height: P) -> Self {
         LogicalSize { width, height }
     }
 
     #[inline]
-    pub fn from_physical<T: Into<PhysicalSize>>(physical: T, dpi_factor: f64) -> Self {
+    pub fn from_physical<T: Into<PhysicalSize<X>>, X: Pixel>(physical: T, dpi_factor: f64) -> Self {
         physical.into().to_logical(dpi_factor)
     }
 
     #[inline]
-    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalSize {
+    pub fn to_physical<X: Pixel>(&self, dpi_factor: f64) -> PhysicalSize<X> {
         assert!(validate_hidpi_factor(dpi_factor));
-        let width = self.width * dpi_factor;
-        let height = self.height * dpi_factor;
-        PhysicalSize::new(width.round() as _, height.round() as _)
+        let width = self.width.into() * dpi_factor;
+        let height = self.height.into() * dpi_factor;
+        PhysicalSize::new(width, height).cast()
+    }
+
+    #[inline]
+    pub fn cast<X: Pixel>(&self) -> LogicalSize<X> {
+        LogicalSize {
+            width: self.width.cast(),
+            height: self.height.cast(),
+        }
     }
 }
 
-impl From<(f64, f64)> for LogicalSize {
-    #[inline]
-    fn from((width, height): (f64, f64)) -> Self {
-        Self::new(width, height)
+impl<P: Pixel, X: Pixel> From<(X, X)> for LogicalSize<P> {
+    fn from((x, y): (X, X)) -> LogicalSize<P> {
+        LogicalSize::new(x.cast(), y.cast())
     }
 }
 
-impl From<(u32, u32)> for LogicalSize {
-    #[inline]
-    fn from((width, height): (u32, u32)) -> Self {
-        Self::new(width as f64, height as f64)
-    }
-}
-
-impl Into<(f64, f64)> for LogicalSize {
-    #[inline]
-    fn into(self) -> (f64, f64) {
-        (self.width, self.height)
-    }
-}
-
-impl Into<(u32, u32)> for LogicalSize {
-    /// Note that this rounds instead of truncating.
-    #[inline]
-    fn into(self) -> (u32, u32) {
-        (self.width.round() as _, self.height.round() as _)
+impl<P: Pixel, X: Pixel> Into<(X, X)> for LogicalSize<P> {
+    fn into(self: LogicalSize<P>) -> (X, X) {
+        (self.width.cast(), self.height.cast())
     }
 }
 
 /// A size represented in physical pixels.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PhysicalSize {
-    pub width: u32,
-    pub height: u32,
+pub struct PhysicalSize<P: Pixel> {
+    pub width: P,
+    pub height: P,
 }
 
-impl PhysicalSize {
+impl<P: Pixel> PhysicalSize<P> {
     #[inline]
-    pub const fn new(width: u32, height: u32) -> Self {
+    pub fn new(width: P, height: P) -> Self {
         PhysicalSize { width, height }
     }
 
     #[inline]
-    pub fn from_logical<T: Into<LogicalSize>>(logical: T, dpi_factor: f64) -> Self {
+    pub fn from_logical<T: Into<LogicalSize<X>>, X: Pixel>(logical: T, dpi_factor: f64) -> Self {
         logical.into().to_physical(dpi_factor)
     }
 
     #[inline]
-    pub fn to_logical(&self, dpi_factor: f64) -> LogicalSize {
+    pub fn to_logical<X: Pixel>(&self, dpi_factor: f64) -> LogicalSize<X> {
         assert!(validate_hidpi_factor(dpi_factor));
-        let width = self.width as f64 / dpi_factor;
-        let height = self.height as f64 / dpi_factor;
-        LogicalSize::new(width, height)
+        let width = self.width.into() / dpi_factor;
+        let height = self.height.into() / dpi_factor;
+        LogicalSize::new(width, height).cast()
+    }
+
+    #[inline]
+    pub fn cast<X: Pixel>(&self) -> PhysicalSize<X> {
+        PhysicalSize {
+            width: self.width.cast(),
+            height: self.height.cast(),
+        }
     }
 }
 
-impl From<(u32, u32)> for PhysicalSize {
-    #[inline]
-    fn from((width, height): (u32, u32)) -> Self {
-        Self::new(width, height)
+impl<P: Pixel, X: Pixel> From<(X, X)> for PhysicalSize<P> {
+    fn from((x, y): (X, X)) -> PhysicalSize<P> {
+        PhysicalSize::new(x.cast(), y.cast())
     }
 }
 
-impl Into<(u32, u32)> for PhysicalSize {
-    /// Note that this rounds instead of truncating.
-    #[inline]
-    fn into(self) -> (u32, u32) {
-        (self.width, self.height)
+impl<P: Pixel, X: Pixel> Into<(X, X)> for PhysicalSize<P> {
+    fn into(self: Self) -> (X, X) {
+        (self.width.cast(), self.height.cast())
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Size {
-    Physical(PhysicalSize),
-    Logical(LogicalSize),
+    Physical(PhysicalSize<u32>),
+    Logical(LogicalSize<f64>),
 }
 
 impl Size {
@@ -324,40 +350,40 @@ impl Size {
         size.into()
     }
 
-    pub fn to_logical(&self, dpi_factor: f64) -> LogicalSize {
+    pub fn to_logical<P: Pixel>(&self, dpi_factor: f64) -> LogicalSize<P> {
         match *self {
             Size::Physical(size) => size.to_logical(dpi_factor),
-            Size::Logical(size) => size,
+            Size::Logical(size) => size.cast(),
         }
     }
 
-    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalSize {
+    pub fn to_physical<P: Pixel>(&self, dpi_factor: f64) -> PhysicalSize<P> {
         match *self {
-            Size::Physical(size) => size,
+            Size::Physical(size) => size.cast(),
             Size::Logical(size) => size.to_physical(dpi_factor),
         }
     }
 }
 
-impl From<PhysicalSize> for Size {
+impl<P: Pixel> From<PhysicalSize<P>> for Size {
     #[inline]
-    fn from(size: PhysicalSize) -> Size {
-        Size::Physical(size)
+    fn from(size: PhysicalSize<P>) -> Size {
+        Size::Physical(size.cast())
     }
 }
 
-impl From<LogicalSize> for Size {
+impl<P: Pixel> From<LogicalSize<P>> for Size {
     #[inline]
-    fn from(size: LogicalSize) -> Size {
-        Size::Logical(size)
+    fn from(size: LogicalSize<P>) -> Size {
+        Size::Logical(size.cast())
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Position {
-    Physical(PhysicalPosition),
-    Logical(LogicalPosition),
+    Physical(PhysicalPosition<u32>),
+    Logical(LogicalPosition<f64>),
 }
 
 impl Position {
@@ -365,31 +391,31 @@ impl Position {
         position.into()
     }
 
-    pub fn to_logical(&self, dpi_factor: f64) -> LogicalPosition {
+    pub fn to_logical<P: Pixel>(&self, dpi_factor: f64) -> LogicalPosition<P> {
         match *self {
             Position::Physical(position) => position.to_logical(dpi_factor),
-            Position::Logical(position) => position,
+            Position::Logical(position) => position.cast(),
         }
     }
 
-    pub fn to_physical(&self, dpi_factor: f64) -> PhysicalPosition {
+    pub fn to_physical<P: Pixel>(&self, dpi_factor: f64) -> PhysicalPosition<P> {
         match *self {
-            Position::Physical(position) => position,
+            Position::Physical(position) => position.cast(),
             Position::Logical(position) => position.to_physical(dpi_factor),
         }
     }
 }
 
-impl From<PhysicalPosition> for Position {
+impl<P: Pixel> From<PhysicalPosition<P>> for Position {
     #[inline]
-    fn from(position: PhysicalPosition) -> Position {
-        Position::Physical(position)
+    fn from(position: PhysicalPosition<P>) -> Position {
+        Position::Physical(position.cast())
     }
 }
 
-impl From<LogicalPosition> for Position {
+impl<P: Pixel> From<LogicalPosition<P>> for Position {
     #[inline]
-    fn from(position: LogicalPosition) -> Position {
-        Position::Logical(position)
+    fn from(position: LogicalPosition<P>) -> Position {
+        Position::Logical(position.cast())
     }
 }

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -297,7 +297,7 @@ impl<P: Pixel, X: Pixel> From<(X, X)> for LogicalSize<P> {
 }
 
 impl<P: Pixel, X: Pixel> Into<(X, X)> for LogicalSize<P> {
-    fn into(self: LogicalSize<f64><P>) -> (X, X) {
+    fn into(self: LogicalSize<P>) -> (X, X) {
         (self.width.cast(), self.height.cast())
     }
 }
@@ -388,7 +388,7 @@ impl<P: Pixel> From<PhysicalSize<P>> for Size {
 
 impl<P: Pixel> From<LogicalSize<P>> for Size {
     #[inline]
-    fn from(size: LogicalSize<f64><P>) -> Size {
+    fn from(size: LogicalSize<P>) -> Size {
         Size::Logical(size.cast())
     }
 }

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -297,7 +297,7 @@ impl<P: Pixel, X: Pixel> From<(X, X)> for LogicalSize<P> {
 }
 
 impl<P: Pixel, X: Pixel> Into<(X, X)> for LogicalSize<P> {
-    fn into(self: LogicalSize<P>) -> (X, X) {
+    fn into(self: LogicalSize<f64><P>) -> (X, X) {
         (self.width.cast(), self.height.cast())
     }
 }
@@ -388,7 +388,7 @@ impl<P: Pixel> From<PhysicalSize<P>> for Size {
 
 impl<P: Pixel> From<LogicalSize<P>> for Size {
     #[inline]
-    fn from(size: LogicalSize<P>) -> Size {
+    fn from(size: LogicalSize<f64><P>) -> Size {
         Size::Logical(size.cast())
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -109,10 +109,10 @@ pub enum StartCause {
 #[derive(Debug, PartialEq)]
 pub enum WindowEvent<'a> {
     /// The size of the window has changed. Contains the client area's new dimensions.
-    Resized(PhysicalSize),
+    Resized(PhysicalSize<u32>),
 
     /// The position of the window has changed. Contains the window's new position.
-    Moved(PhysicalPosition),
+    Moved(PhysicalPosition<u32>),
 
     /// The window has been requested to close.
     CloseRequested,
@@ -163,7 +163,7 @@ pub enum WindowEvent<'a> {
         /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range of this data is
         /// limited by the display area and it may have been transformed by the OS to implement effects such as cursor
         /// acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
-        position: PhysicalPosition,
+        position: PhysicalPosition<u32>,
         modifiers: ModifiersState,
     },
 
@@ -229,7 +229,7 @@ pub enum WindowEvent<'a> {
     /// For more information about DPI in general, see the [`dpi`](dpi/index.html) module.
     HiDpiFactorChanged {
         hidpi_factor: f64,
-        new_inner_size: &'a mut Option<PhysicalSize>,
+        new_inner_size: &'a mut Option<PhysicalSize<u32>>,
     },
 }
 
@@ -427,7 +427,7 @@ pub enum TouchPhase {
 pub struct Touch {
     pub device_id: DeviceId,
     pub phase: TouchPhase,
-    pub location: PhysicalPosition,
+    pub location: PhysicalPosition<f64>,
     /// Describes how hard the screen was pressed. May be `None` if the platform
     /// does not support pressure sensitivity.
     ///
@@ -538,7 +538,7 @@ pub enum MouseScrollDelta {
     /// Scroll events are expressed as a PixelDelta if
     /// supported by the device (eg. a touchpad) and
     /// platform.
-    PixelDelta(LogicalPosition),
+    PixelDelta(LogicalPosition<f64>),
 }
 
 /// Symbolic name for a keyboard key.

--- a/src/event.rs
+++ b/src/event.rs
@@ -163,7 +163,7 @@ pub enum WindowEvent<'a> {
         /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range of this data is
         /// limited by the display area and it may have been transformed by the OS to implement effects such as cursor
         /// acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
-        position: PhysicalPosition<u32>,
+        position: PhysicalPosition<i32>,
         modifiers: ModifiersState,
     },
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -58,7 +58,7 @@ impl Ord for VideoMode {
 impl VideoMode {
     /// Returns the resolution of this video mode.
     #[inline]
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         self.video_mode.size()
     }
 
@@ -133,7 +133,7 @@ impl MonitorHandle {
     ///
     /// - **Web:** Always returns (0,0)
     #[inline]
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         self.inner.size()
     }
 
@@ -144,7 +144,7 @@ impl MonitorHandle {
     ///
     /// - **Web:** Always returns (0,0)
     #[inline]
-    pub fn position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition<i32> {
         self.inner.position()
     }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -128,7 +128,7 @@ pub trait WindowBuilderExtMacOS {
     /// Makes the window content appear behind the titlebar.
     fn with_fullsize_content_view(self, fullsize_content_view: bool) -> WindowBuilder;
     /// Build window with `resizeIncrements` property. Values must not be 0.
-    fn with_resize_increments(self, increments: LogicalSize) -> WindowBuilder;
+    fn with_resize_increments(self, increments: LogicalSize<f64>) -> WindowBuilder;
     fn with_disallow_hidpi(self, disallow_hidpi: bool) -> WindowBuilder;
 }
 
@@ -179,7 +179,7 @@ impl WindowBuilderExtMacOS for WindowBuilder {
     }
 
     #[inline]
-    fn with_resize_increments(mut self, increments: LogicalSize) -> WindowBuilder {
+    fn with_resize_increments(mut self, increments: LogicalSize<f64>) -> WindowBuilder {
         self.platform_specific.resize_increments = Some(increments.into());
         self
     }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -380,9 +380,9 @@ pub trait WindowBuilderExtUnix {
     /// Build window with `_GTK_THEME_VARIANT` hint set to the specified value. Currently only relevant on X11.
     fn with_gtk_theme_variant(self, variant: String) -> Self;
     /// Build window with resize increment hint. Only implemented on X11.
-    fn with_resize_increments(self, increments: LogicalSize) -> Self;
+    fn with_resize_increments(self, increments: LogicalSize<f64>) -> Self;
     /// Build window with base size hint. Only implemented on X11.
-    fn with_base_size(self, base_size: LogicalSize) -> Self;
+    fn with_base_size(self, base_size: LogicalSize<f64>) -> Self;
 
     /// Build window with a given application ID. It should match the `.desktop` file distributed with
     /// your program. Only relevant on Wayland.
@@ -431,13 +431,13 @@ impl WindowBuilderExtUnix for WindowBuilder {
     }
 
     #[inline]
-    fn with_resize_increments(mut self, increments: LogicalSize) -> Self {
+    fn with_resize_increments(mut self, increments: LogicalSize<f64>) -> Self {
         self.platform_specific.resize_increments = Some(increments.into());
         self
     }
 
     #[inline]
-    fn with_base_size(mut self, base_size: LogicalSize) -> Self {
+    fn with_base_size(mut self, base_size: LogicalSize<f64>) -> Self {
         self.platform_specific.base_size = Some(base_size.into());
         self
     }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -356,7 +356,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, _position: LogicalPosition<f64>) -> Result<(), ExternalError> {
+    pub fn set_cursor_position(
+        &self,
+        _position: LogicalPosition<f64>,
+    ) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -193,8 +193,8 @@ impl fmt::Debug for MonitorHandle {
         #[derive(Debug)]
         struct MonitorHandle {
             name: Option<String>,
-            dimensions: PhysicalSize,
-            position: PhysicalPosition,
+            dimensions: PhysicalSize<u32>,
+            position: PhysicalPosition<i32>,
             hidpi_factor: f64,
         }
 
@@ -216,7 +216,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         unsafe {
             let window = android_glue::native_window();
             (
@@ -228,7 +228,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn outer_position(&self) -> PhysicalPosition {
+    pub fn outer_position(&self) -> PhysicalPosition<i32> {
         // Android assumes single screen
         (0, 0).into()
     }
@@ -295,7 +295,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_outer_position(&self, _position: LogicalPosition) {
+    pub fn set_outer_position(&self, _position: LogicalPosition<f64>) {
         // N/A
     }
 
@@ -331,7 +331,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_inner_size(&self, _size: LogicalSize) {
+    pub fn set_inner_size(&self, _size: LogicalSize<f64>) {
         // N/A
     }
 
@@ -356,7 +356,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, _position: LogicalPosition) -> Result<(), ExternalError> {
+    pub fn set_cursor_position(&self, _position: LogicalPosition<f64>) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
@@ -395,7 +395,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_position(&self, _spot: LogicalPosition) {
+    pub fn set_ime_position(&self, _spot: LogicalPosition<f64>) {
         // N/A
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -283,13 +283,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_position(&self) -> Option<LogicalPosition> {
+    pub fn outer_position(&self) -> Option<LogicalPosition<f64>> {
         // N/A
         None
     }
 
     #[inline]
-    pub fn inner_position(&self) -> Option<LogicalPosition> {
+    pub fn inner_position(&self) -> Option<LogicalPosition<f64>> {
         // N/A
         None
     }
@@ -300,12 +300,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_min_inner_size(&self, _dimensions: Option<LogicalSize>) {
+    pub fn set_min_inner_size(&self, _dimensions: Option<LogicalSize<f64>>) {
         // N/A
     }
 
     #[inline]
-    pub fn set_max_inner_size(&self, _dimensions: Option<LogicalSize>) {
+    pub fn set_max_inner_size(&self, _dimensions: Option<LogicalSize<f64>>) {
         // N/A
     }
 
@@ -315,7 +315,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn inner_size(&self) -> Option<LogicalSize> {
+    pub fn inner_size(&self) -> Option<LogicalSize<f64>> {
         if self.native_window.is_null() {
             None
         } else {
@@ -326,7 +326,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_size(&self) -> Option<LogicalSize> {
+    pub fn outer_size(&self) -> Option<LogicalSize<f64>> {
         self.inner_size()
     }
 

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -859,7 +859,7 @@ fn handle_event_proxy(
 fn handle_hidpi_proxy(
     event_handler: &mut Box<dyn EventHandler>,
     mut control_flow: ControlFlow,
-    suggested_size: LogicalSize,
+    suggested_size: LogicalSize<f64>,
     hidpi_factor: f64,
     window_id: id,
 ) {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -39,7 +39,7 @@ pub enum EventWrapper {
 pub enum EventProxy {
     HiDpiFactorChangedProxy {
         window_id: id,
-        suggested_size: LogicalSize,
+        suggested_size: LogicalSize<f64>,
         hidpi_factor: f64,
     },
 }

--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -43,7 +43,7 @@ pub struct CGSize {
 }
 
 impl CGSize {
-    pub fn new(size: LogicalSize) -> CGSize {
+    pub fn new(size: LogicalSize<f64>) -> CGSize {
         CGSize {
             width: size.width as _,
             height: size.height as _,

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -73,7 +73,7 @@ impl VideoMode {
         }
     }
 
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
     }
 
@@ -156,8 +156,8 @@ impl fmt::Debug for MonitorHandle {
         #[derive(Debug)]
         struct MonitorHandle {
             name: Option<String>,
-            size: PhysicalSize,
-            position: PhysicalPosition,
+            size: PhysicalSize<u32>,
+            position: PhysicalPosition<i32>,
             hidpi_factor: f64,
         }
 
@@ -201,14 +201,14 @@ impl Inner {
         }
     }
 
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         unsafe {
             let bounds: CGRect = msg_send![self.ui_screen(), nativeBounds];
             PhysicalSize::new(bounds.size.width as u32, bounds.size.height as u32)
         }
     }
 
-    pub fn position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition<i32> {
         unsafe {
             let bounds: CGRect = msg_send![self.ui_screen(), nativeBounds];
             (bounds.origin.x as f64, bounds.origin.y as f64).into()

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -125,8 +125,8 @@ unsafe fn get_view_class(root_view_class: &'static Class) -> &'static Class {
                     msg_send![object, convertRect:bounds toCoordinateSpace:screen_space];
                 let dpi_factor: CGFloat = msg_send![screen, scale];
                 let size = crate::dpi::LogicalSize {
-                    width: screen_frame.size.width as _,
-                    height: screen_frame.size.height as _,
+                    width: screen_frame.size.width as f64,
+                    height: screen_frame.size.height as f64,
                 }
                 .to_physical(dpi_factor.into());
                 app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -508,7 +508,9 @@ pub unsafe fn create_window(
             let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode];
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
-        Some(Fullscreen::Borderless(ref monitor)) => msg_send![window, setScreen:monitor.ui_screen()],
+        Some(Fullscreen::Borderless(ref monitor)) => {
+            msg_send![window, setScreen:monitor.ui_screen()]
+        }
         None => (),
     }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -76,7 +76,7 @@ impl Inner {
         }
     }
 
-    pub fn inner_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         unsafe {
             let safe_area = self.safe_area_screen_space();
             let position = LogicalPosition {
@@ -88,7 +88,7 @@ impl Inner {
         }
     }
 
-    pub fn outer_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         unsafe {
             let screen_frame = self.screen_frame();
             let position = LogicalPosition {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -103,7 +103,7 @@ impl Inner {
     pub fn set_outer_position(&self, physical_position: Position) {
         unsafe {
             let dpi_factor = self.hidpi_factor();
-            let position = physical_position.to_logical::<_, f64>(dpi_factor);
+            let position = physical_position.to_logical::<f64>(dpi_factor);
             let screen_frame = self.screen_frame();
             let new_screen_frame = CGRect {
                 origin: CGPoint {
@@ -352,7 +352,7 @@ impl Window {
             let frame = match window_attributes.inner_size {
                 Some(dim) => {
                     let dpi_factor = msg_send![screen, scale];
-                    let size = dim.to_logical::<_, f64>(dpi_factor);
+                    let size = dim.to_logical::<f64>(dpi_factor);
                     CGRect {
                         origin: screen_bounds.origin,
                         size: CGSize {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -80,8 +80,8 @@ impl Inner {
         unsafe {
             let safe_area = self.safe_area_screen_space();
             let position = LogicalPosition {
-                x: safe_area.origin.x as _,
-                y: safe_area.origin.y as _,
+                x: safe_area.origin.x as f64,
+                y: safe_area.origin.y as f64,
             };
             let dpi_factor = self.hidpi_factor();
             Ok(position.to_physical(dpi_factor))
@@ -92,8 +92,8 @@ impl Inner {
         unsafe {
             let screen_frame = self.screen_frame();
             let position = LogicalPosition {
-                x: screen_frame.origin.x as _,
-                y: screen_frame.origin.y as _,
+                x: screen_frame.origin.x as f64,
+                y: screen_frame.origin.y as f64,
             };
             let dpi_factor = self.hidpi_factor();
             Ok(position.to_physical(dpi_factor))
@@ -103,7 +103,7 @@ impl Inner {
     pub fn set_outer_position(&self, physical_position: Position) {
         unsafe {
             let dpi_factor = self.hidpi_factor();
-            let position = physical_position.to_logical(dpi_factor);
+            let position = physical_position.to_logical::<_, f64>(dpi_factor);
             let screen_frame = self.screen_frame();
             let new_screen_frame = CGRect {
                 origin: CGPoint {
@@ -122,8 +122,8 @@ impl Inner {
             let dpi_factor = self.hidpi_factor();
             let safe_area = self.safe_area_screen_space();
             let size = LogicalSize {
-                width: safe_area.size.width as _,
-                height: safe_area.size.height as _,
+                width: safe_area.size.width as f64,
+                height: safe_area.size.height as f64,
             };
             size.to_physical(dpi_factor)
         }
@@ -134,8 +134,8 @@ impl Inner {
             let dpi_factor = self.hidpi_factor();
             let screen_frame = self.screen_frame();
             let size = LogicalSize {
-                width: screen_frame.size.width as _,
-                height: screen_frame.size.height as _,
+                width: screen_frame.size.width as f64,
+                height: screen_frame.size.height as f64,
             };
             size.to_physical(dpi_factor)
         }
@@ -352,7 +352,7 @@ impl Window {
             let frame = match window_attributes.inner_size {
                 Some(dim) => {
                     let dpi_factor = msg_send![screen, scale];
-                    let size = dim.to_logical(dpi_factor);
+                    let size = dim.to_logical::<_, f64>(dpi_factor);
                     CGRect {
                         origin: screen_bounds.origin,
                         size: CGSize {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -117,7 +117,7 @@ impl Inner {
         }
     }
 
-    pub fn inner_size(&self) -> PhysicalSize {
+    pub fn inner_size(&self) -> PhysicalSize<u32> {
         unsafe {
             let dpi_factor = self.hidpi_factor();
             let safe_area = self.safe_area_screen_space();
@@ -129,7 +129,7 @@ impl Inner {
         }
     }
 
-    pub fn outer_size(&self) -> PhysicalSize {
+    pub fn outer_size(&self) -> PhysicalSize<u32> {
         unsafe {
             let dpi_factor = self.hidpi_factor();
             let screen_frame = self.screen_frame();

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -132,7 +132,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         match self {
             &MonitorHandle::X(ref m) => m.size(),
             &MonitorHandle::Wayland(ref m) => m.size(),
@@ -140,7 +140,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition<i32> {
         match self {
             &MonitorHandle::X(ref m) => m.position(),
             &MonitorHandle::Wayland(ref m) => m.position(),
@@ -172,7 +172,7 @@ pub enum VideoMode {
 
 impl VideoMode {
     #[inline]
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         match self {
             &VideoMode::X(ref m) => m.size(),
             &VideoMode::Wayland(ref m) => m.size(),
@@ -270,7 +270,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn inner_size(&self) -> PhysicalSize {
+    pub fn inner_size(&self) -> PhysicalSize<u32> {
         match self {
             &Window::X(ref w) => w.inner_size(),
             &Window::Wayland(ref w) => w.inner_size(),
@@ -278,7 +278,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_size(&self) -> PhysicalSize {
+    pub fn outer_size(&self) -> PhysicalSize<u32> {
         match self {
             &Window::X(ref w) => w.outer_size(),
             &Window::Wayland(ref w) => w.outer_size(),

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -246,7 +246,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         match self {
             &Window::X(ref w) => w.outer_position(),
             &Window::Wayland(ref w) => w.outer_position(),
@@ -254,7 +254,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn inner_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         match self {
             &Window::X(ref m) => m.inner_position(),
             &Window::Wayland(ref m) => m.inner_position(),

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -697,7 +697,7 @@ impl<T> EventLoop<T> {
                         });
 
                         if let Some(new_size) = new_inner_size {
-                            let (w, h) = new_size.to_logical(dpi).into();
+                            let (w, h) = new_size.to_logical::<f64>(dpi).into();
                             frame.resize(w, h);
                             *size = (w, h);
                         }

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -906,7 +906,7 @@ pub struct VideoMode {
 
 impl VideoMode {
     #[inline]
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
     }
 
@@ -966,8 +966,8 @@ impl fmt::Debug for MonitorHandle {
         struct MonitorHandle {
             name: Option<String>,
             native_identifier: u32,
-            size: PhysicalSize,
-            position: PhysicalPosition,
+            size: PhysicalSize<u32>,
+            position: PhysicalPosition<i32>,
             hidpi_factor: i32,
         }
 
@@ -995,7 +995,7 @@ impl MonitorHandle {
         self.mgr.with_info(&self.proxy, |id, _| id).unwrap_or(0)
     }
 
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         match self.mgr.with_info(&self.proxy, |_, info| {
             info.modes
                 .iter()
@@ -1008,7 +1008,7 @@ impl MonitorHandle {
         .into()
     }
 
-    pub fn position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition<i32> {
         self.mgr
             .with_info(&self.proxy, |_, info| info.location)
             .unwrap_or((0, 0))

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -685,7 +685,7 @@ impl<T> EventLoop<T> {
 
                     if let Some(dpi) = new_dpi {
                         let dpi = dpi as f64;
-                        let logical_size = LogicalSize::from(*size);
+                        let logical_size = LogicalSize::<f64>::from(*size);
                         let mut new_inner_size = Some(logical_size.to_physical(dpi));
 
                         callback(Event::WindowEvent {

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -60,7 +60,7 @@ impl Window {
         let dpi = get_dpi_factor(&surface) as f64;
         let (width, height) = attributes
             .inner_size
-            .map(|size| size.to_logical(dpi).into())
+            .map(|size| size.to_logical::<_, f64>(dpi).into())
             .unwrap_or((800, 600));
 
         // Create the window
@@ -222,7 +222,7 @@ impl Window {
 
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         let dpi = self.hidpi_factor() as f64;
-        let size = LogicalSize::from(*self.size.lock().unwrap());
+        let size = LogicalSize::<f64>::from(*self.size.lock().unwrap());
         size.to_physical(dpi)
     }
 
@@ -235,7 +235,7 @@ impl Window {
         let dpi = self.hidpi_factor() as f64;
         let (w, h) = self.size.lock().unwrap().clone();
         // let (w, h) = super::wayland_window::add_borders(w as i32, h as i32);
-        let size = LogicalSize::from((w, h));
+        let size = LogicalSize::<f64>::from((w, h));
         size.to_physical(dpi)
     }
 
@@ -243,7 +243,7 @@ impl Window {
     // NOTE: This will only resize the borders, the contents must be updated by the user
     pub fn set_inner_size(&self, size: Size) {
         let dpi = self.hidpi_factor() as f64;
-        let (w, h) = size.to_logical(dpi).into();
+        let (w, h) = size.to_logical::<_, u32>(dpi).into();
         self.frame.lock().unwrap().resize(w, h);
         *(self.size.lock().unwrap()) = (w, h);
     }
@@ -254,7 +254,7 @@ impl Window {
         self.frame
             .lock()
             .unwrap()
-            .set_min_size(dimensions.map(|dim| dim.to_logical(dpi).into()));
+            .set_min_size(dimensions.map(|dim| dim.to_logical::<_, f64>(dpi).into()));
     }
 
     #[inline]
@@ -263,7 +263,7 @@ impl Window {
         self.frame
             .lock()
             .unwrap()
-            .set_max_size(dimensions.map(|dim| dim.to_logical(dpi).into()));
+            .set_max_size(dimensions.map(|dim| dim.to_logical::<_, f64>(dpi).into()));
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -206,12 +206,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         Err(NotSupportedError::new())
     }
 
     #[inline]
-    pub fn inner_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         Err(NotSupportedError::new())
     }
 

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -60,7 +60,7 @@ impl Window {
         let dpi = get_dpi_factor(&surface) as f64;
         let (width, height) = attributes
             .inner_size
-            .map(|size| size.to_logical::<_, f64>(dpi).into())
+            .map(|size| size.to_logical::<f64>(dpi).into())
             .unwrap_or((800, 600));
 
         // Create the window
@@ -243,7 +243,7 @@ impl Window {
     // NOTE: This will only resize the borders, the contents must be updated by the user
     pub fn set_inner_size(&self, size: Size) {
         let dpi = self.hidpi_factor() as f64;
-        let (w, h) = size.to_logical::<_, u32>(dpi).into();
+        let (w, h) = size.to_logical::<u32>(dpi).into();
         self.frame.lock().unwrap().resize(w, h);
         *(self.size.lock().unwrap()) = (w, h);
     }
@@ -254,7 +254,7 @@ impl Window {
         self.frame
             .lock()
             .unwrap()
-            .set_min_size(dimensions.map(|dim| dim.to_logical::<_, f64>(dpi).into()));
+            .set_min_size(dimensions.map(|dim| dim.to_logical::<f64>(dpi).into()));
     }
 
     #[inline]
@@ -263,7 +263,7 @@ impl Window {
         self.frame
             .lock()
             .unwrap()
-            .set_max_size(dimensions.map(|dim| dim.to_logical::<_, f64>(dpi).into()));
+            .set_max_size(dimensions.map(|dim| dim.to_logical::<f64>(dpi).into()));
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -147,12 +147,12 @@ impl Window {
         frame.set_min_size(
             attributes
                 .min_inner_size
-                .map(|size| size.to_logical(dpi).into()),
+                .map(|size| size.to_logical::<f64>(dpi).into()),
         );
         frame.set_max_size(
             attributes
                 .max_inner_size
-                .map(|size| size.to_logical(dpi).into()),
+                .map(|size| size.to_logical::<f64>(dpi).into()),
         );
 
         let kill_switch = Arc::new(Mutex::new(false));

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -220,7 +220,7 @@ impl Window {
         // Not possible with wayland
     }
 
-    pub fn inner_size(&self) -> PhysicalSize {
+    pub fn inner_size(&self) -> PhysicalSize<u32> {
         let dpi = self.hidpi_factor() as f64;
         let size = LogicalSize::from(*self.size.lock().unwrap());
         size.to_physical(dpi)
@@ -231,7 +231,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_size(&self) -> PhysicalSize {
+    pub fn outer_size(&self) -> PhysicalSize<u32> {
         let dpi = self.hidpi_factor() as f64;
         let (w, h) = self.size.lock().unwrap().clone();
         // let (w, h) = super::wayland_window::add_borders(w as i32, h as i32);

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -704,7 +704,7 @@ impl<T: 'static> EventProcessor<T> {
                         });
                         if cursor_moved == Some(true) {
                             let position =
-                                PhysicalPosition::new(xev.event_x as f64, xev.event_y as f64);
+                                PhysicalPosition::new(xev.event_x as i32, xev.event_y as i32);
 
                             callback(Event::WindowEvent {
                                 window_id,
@@ -809,7 +809,7 @@ impl<T: 'static> EventProcessor<T> {
                         });
 
                         let position =
-                            PhysicalPosition::new(xev.event_x as f64, xev.event_y as f64);
+                            PhysicalPosition::new(xev.event_x as i32, xev.event_y as i32);
 
                         // The mods field on this event isn't actually populated, so query the
                         // pointer device. In the future, we can likely remove this round-trip by
@@ -888,7 +888,7 @@ impl<T: 'static> EventProcessor<T> {
                             .unwrap_or(2);
 
                         let position =
-                            PhysicalPosition::new(xev.event_x as f64, xev.event_y as f64);
+                            PhysicalPosition::new(xev.event_x as i32, xev.event_y as i32);
 
                         callback(Event::WindowEvent {
                             window_id,

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -38,7 +38,7 @@ pub struct VideoMode {
 
 impl VideoMode {
     #[inline]
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
     }
 
@@ -152,11 +152,11 @@ impl MonitorHandle {
         self.id as u32
     }
 
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         self.dimensions.into()
     }
 
-    pub fn position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition<i32> {
         self.position.into()
     }
 

--- a/src/platform_impl/linux/x11/util/geometry.rs
+++ b/src/platform_impl/linux/x11/util/geometry.rs
@@ -137,9 +137,9 @@ impl FrameExtentsHeuristic {
 
     pub fn inner_pos_to_outer_logical(
         &self,
-        mut logical: LogicalPosition,
+        mut logical: LogicalPosition<f64>,
         factor: f64,
-    ) -> LogicalPosition {
+    ) -> LogicalPosition<f64> {
         use self::FrameExtentsHeuristicPath::*;
         if self.heuristic_path != UnsupportedBordered {
             let frame_extents = self.frame_extents.as_logical(factor);
@@ -166,9 +166,9 @@ impl FrameExtentsHeuristic {
 
     pub fn inner_size_to_outer_logical(
         &self,
-        mut logical: LogicalSize,
+        mut logical: LogicalSize<f64>,
         factor: f64,
-    ) -> LogicalSize {
+    ) -> LogicalSize<f64> {
         let frame_extents = self.frame_extents.as_logical(factor);
         logical.width += frame_extents.left + frame_extents.right;
         logical.height += frame_extents.top + frame_extents.bottom;

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -126,10 +126,10 @@ impl UnownedWindow {
 
         let max_inner_size: Option<(u32, u32)> = window_attrs
             .max_inner_size
-            .map(|size| size.to_physical::<_, u32>(dpi_factor).into());
+            .map(|size| size.to_physical::<u32>(dpi_factor).into());
         let min_inner_size: Option<(u32, u32)> = window_attrs
             .min_inner_size
-            .map(|size| size.to_physical::<_, u32>(dpi_factor).into());
+            .map(|size| size.to_physical::<u32>(dpi_factor).into());
 
         let dimensions = {
             // x11 only applies constraints when the window is actively resized
@@ -954,7 +954,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_outer_position(&self, position: Position) {
-        let (x, y) = position.to_physical::<_, i32>(self.hidpi_factor()).into();
+        let (x, y) = position.to_physical::<i32>(self.hidpi_factor()).into();
         self.set_position_physical(x, y);
     }
 
@@ -1011,7 +1011,7 @@ impl UnownedWindow {
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
         let dpi_factor = self.hidpi_factor();
-        let (width, height) = size.to_physical::<_, u32>(dpi_factor).into();
+        let (width, height) = size.to_physical::<u32>(dpi_factor).into();
         self.set_inner_size_physical(width, height);
     }
 
@@ -1034,8 +1034,8 @@ impl UnownedWindow {
     #[inline]
     pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
         self.shared_state.lock().min_inner_size = dimensions;
-        let physical_dimensions = dimensions
-            .map(|dimensions| dimensions.to_physical::<_, u32>(self.hidpi_factor()).into());
+        let physical_dimensions =
+            dimensions.map(|dimensions| dimensions.to_physical::<u32>(self.hidpi_factor()).into());
         self.set_min_inner_size_physical(physical_dimensions);
     }
 
@@ -1047,8 +1047,8 @@ impl UnownedWindow {
     #[inline]
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
         self.shared_state.lock().max_inner_size = dimensions;
-        let physical_dimensions = dimensions
-            .map(|dimensions| dimensions.to_physical::<_, u32>(self.hidpi_factor()).into());
+        let physical_dimensions =
+            dimensions.map(|dimensions| dimensions.to_physical::<u32>(self.hidpi_factor()).into());
         self.set_max_inner_size_physical(physical_dimensions);
     }
 
@@ -1107,10 +1107,10 @@ impl UnownedWindow {
 
         let dpi_factor = self.hidpi_factor();
         let min_inner_size = min_size
-            .map(|size| size.to_physical::<_, u32>(dpi_factor))
+            .map(|size| size.to_physical::<u32>(dpi_factor))
             .map(Into::into);
         let max_inner_size = max_size
-            .map(|size| size.to_physical::<_, u32>(dpi_factor))
+            .map(|size| size.to_physical::<u32>(dpi_factor))
             .map(Into::into);
         self.update_normal_hints(|normal_hints| {
             normal_hints.set_min_size(min_inner_size);
@@ -1246,7 +1246,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
-        let (x, y) = position.to_physical::<_, i32>(self.hidpi_factor()).into();
+        let (x, y) = position.to_physical::<i32>(self.hidpi_factor()).into();
         self.set_cursor_position_physical(x, y)
     }
 
@@ -1259,7 +1259,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_ime_position(&self, spot: Position) {
-        let (x, y) = spot.to_physical::<_, i32>(self.hidpi_factor()).into();
+        let (x, y) = spot.to_physical::<i32>(self.hidpi_factor()).into();
         self.set_ime_position_physical(x, y);
     }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -136,7 +136,7 @@ impl UnownedWindow {
             // by the user, so we have to manually apply the initial constraints
             let mut dimensions: (u32, u32) = window_attrs
                 .inner_size
-                .map(|size| size.to_physical(dpi_factor))
+                .map(|size| size.to_physical::<u32>(dpi_factor))
                 .or_else(|| Some((800, 600).into()))
                 .map(Into::into)
                 .unwrap();
@@ -308,10 +308,10 @@ impl UnownedWindow {
             {
                 let mut min_inner_size = window_attrs
                     .min_inner_size
-                    .map(|size| size.to_physical(dpi_factor));
+                    .map(|size| size.to_physical::<u32>(dpi_factor));
                 let mut max_inner_size = window_attrs
                     .max_inner_size
-                    .map(|size| size.to_physical(dpi_factor));
+                    .map(|size| size.to_physical::<u32>(dpi_factor));
                 if !window_attrs.resizable {
                     if util::wm_name_is_one_of(&["Xfwm4"]) {
                         warn!("To avoid a WM bug, disabling resizing has no effect on Xfwm4");

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -902,7 +902,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn outer_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let extents = (*self.shared_state.lock()).frame_extents.clone();
         if let Some(extents) = extents {
             let (x, y) = self.inner_position_physical();
@@ -923,7 +923,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn inner_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         Ok(self.inner_position_physical().into())
     }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -968,7 +968,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn inner_size(&self) -> PhysicalSize {
+    pub fn inner_size(&self) -> PhysicalSize<u32> {
         self.inner_size_physical().into()
     }
 
@@ -984,7 +984,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn outer_size(&self) -> PhysicalSize {
+    pub fn outer_size(&self) -> PhysicalSize<u32> {
         let extents = self.shared_state.lock().frame_extents.clone();
         if let Some(extents) = extents {
             let (width, height) = self.inner_size_physical();

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -126,10 +126,10 @@ impl UnownedWindow {
 
         let max_inner_size: Option<(u32, u32)> = window_attrs
             .max_inner_size
-            .map(|size| size.to_physical(dpi_factor).into());
+            .map(|size| size.to_physical::<_, u32>(dpi_factor).into());
         let min_inner_size: Option<(u32, u32)> = window_attrs
             .min_inner_size
-            .map(|size| size.to_physical(dpi_factor).into());
+            .map(|size| size.to_physical::<_, u32>(dpi_factor).into());
 
         let dimensions = {
             // x11 only applies constraints when the window is actively resized
@@ -954,7 +954,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_outer_position(&self, position: Position) {
-        let (x, y) = position.to_physical(self.hidpi_factor()).into();
+        let (x, y) = position.to_physical::<_, i32>(self.hidpi_factor()).into();
         self.set_position_physical(x, y);
     }
 
@@ -1011,7 +1011,7 @@ impl UnownedWindow {
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
         let dpi_factor = self.hidpi_factor();
-        let (width, height) = size.to_physical(dpi_factor).into();
+        let (width, height) = size.to_physical::<_, u32>(dpi_factor).into();
         self.set_inner_size_physical(width, height);
     }
 
@@ -1034,8 +1034,8 @@ impl UnownedWindow {
     #[inline]
     pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
         self.shared_state.lock().min_inner_size = dimensions;
-        let physical_dimensions =
-            dimensions.map(|dimensions| dimensions.to_physical(self.hidpi_factor()).into());
+        let physical_dimensions = dimensions
+            .map(|dimensions| dimensions.to_physical::<_, u32>(self.hidpi_factor()).into());
         self.set_min_inner_size_physical(physical_dimensions);
     }
 
@@ -1047,8 +1047,8 @@ impl UnownedWindow {
     #[inline]
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
         self.shared_state.lock().max_inner_size = dimensions;
-        let physical_dimensions =
-            dimensions.map(|dimensions| dimensions.to_physical(self.hidpi_factor()).into());
+        let physical_dimensions = dimensions
+            .map(|dimensions| dimensions.to_physical::<_, u32>(self.hidpi_factor()).into());
         self.set_max_inner_size_physical(physical_dimensions);
     }
 
@@ -1107,10 +1107,10 @@ impl UnownedWindow {
 
         let dpi_factor = self.hidpi_factor();
         let min_inner_size = min_size
-            .map(|size| size.to_physical(dpi_factor))
+            .map(|size| size.to_physical::<_, u32>(dpi_factor))
             .map(Into::into);
         let max_inner_size = max_size
-            .map(|size| size.to_physical(dpi_factor))
+            .map(|size| size.to_physical::<_, u32>(dpi_factor))
             .map(Into::into);
         self.update_normal_hints(|normal_hints| {
             normal_hints.set_min_size(min_inner_size);
@@ -1246,7 +1246,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
-        let (x, y) = position.to_physical(self.hidpi_factor()).into();
+        let (x, y) = position.to_physical::<_, i32>(self.hidpi_factor()).into();
         self.set_cursor_position_physical(x, y)
     }
 
@@ -1259,7 +1259,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_ime_position(&self, spot: Position) {
-        let (x, y) = spot.to_physical(self.hidpi_factor()).into();
+        let (x, y) = spot.to_physical::<_, i32>(self.hidpi_factor()).into();
         self.set_ime_position_physical(x, y);
     }
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -184,7 +184,7 @@ impl Handler {
         &self,
         callback: &mut Box<dyn EventHandler + 'static>,
         ns_window: IdRef,
-        suggested_size: LogicalSize,
+        suggested_size: LogicalSize<f64>,
         hidpi_factor: f64,
     ) {
         let size = suggested_size.to_physical(hidpi_factor);

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -24,7 +24,7 @@ pub enum EventWrapper {
 pub enum EventProxy {
     HiDpiFactorChangedProxy {
         ns_window: IdRef,
-        suggested_size: LogicalSize,
+        suggested_size: LogicalSize<f64>,
         hidpi_factor: f64,
     },
 }

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -84,7 +84,7 @@ impl Clone for NativeDisplayMode {
 }
 
 impl VideoMode {
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
     }
 
@@ -166,8 +166,8 @@ impl fmt::Debug for MonitorHandle {
         struct MonitorHandle {
             name: Option<String>,
             native_identifier: u32,
-            size: PhysicalSize,
-            position: PhysicalPosition,
+            size: PhysicalSize<u32>,
+            position: PhysicalPosition<i32>,
             hidpi_factor: f64,
         }
 
@@ -199,7 +199,7 @@ impl MonitorHandle {
         self.0
     }
 
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         let MonitorHandle(display_id) = *self;
         let display = CGDisplay::new(display_id);
         let height = display.pixels_high();
@@ -208,7 +208,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition<i32> {
         let bounds = unsafe { CGDisplayBounds(self.native_identifier()) };
         PhysicalPosition::from_logical(
             (bounds.origin.x as f64, bounds.origin.y as f64),

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -204,13 +204,13 @@ impl MonitorHandle {
         let display = CGDisplay::new(display_id);
         let height = display.pixels_high();
         let width = display.pixels_wide();
-        PhysicalSize::from_logical((width as f64, height as f64), self.hidpi_factor())
+        PhysicalSize::from_logical::<_, f64>((width as f64, height as f64), self.hidpi_factor())
     }
 
     #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         let bounds = unsafe { CGDisplayBounds(self.native_identifier()) };
-        PhysicalPosition::from_logical(
+        PhysicalPosition::from_logical::<_, f64>(
             (bounds.origin.x as f64, bounds.origin.y as f64),
             self.hidpi_factor(),
         )

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -69,10 +69,10 @@ pub unsafe fn set_style_mask_sync(ns_window: id, ns_view: id, mask: NSWindowStyl
 
 struct SetContentSizeData {
     ns_window: id,
-    size: LogicalSize,
+    size: LogicalSize<f64>,
 }
 impl SetContentSizeData {
-    fn new_ptr(ns_window: id, size: LogicalSize) -> *mut Self {
+    fn new_ptr(ns_window: id, size: LogicalSize<f64>) -> *mut Self {
         Box::into_raw(Box::new(SetContentSizeData { ns_window, size }))
     }
 }
@@ -94,7 +94,7 @@ extern "C" fn set_content_size_callback(context: *mut c_void) {
 }
 // `setContentSize:` isn't thread-safe either, though it doesn't log any errors
 // and just fails silently. Anyway, GCD to the rescue!
-pub unsafe fn set_content_size_async(ns_window: id, size: LogicalSize) {
+pub unsafe fn set_content_size_async(ns_window: id, size: LogicalSize<f64>) {
     let context = SetContentSizeData::new_ptr(ns_window, size);
     dispatch_async_f(
         dispatch_get_main_queue(),

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -584,8 +584,8 @@ impl UnownedWindow {
     pub fn set_cursor_position(&self, cursor_position: Position) -> Result<(), ExternalError> {
         let physical_window_position = self.inner_position().unwrap();
         let dpi_factor = self.hidpi_factor();
-        let window_position = physical_window_position.to_logical::<_, CGFloat>(dpi_factor);
-        let logical_cursor_position = cursor_position.to_logical::<_, CGFloat>(dpi_factor);
+        let window_position = physical_window_position.to_logical::<CGFloat>(dpi_factor);
+        let logical_cursor_position = cursor_position.to_logical::<CGFloat>(dpi_factor);
         let point = appkit::CGPoint {
             x: logical_cursor_position.x + window_position.x,
             y: logical_cursor_position.y + window_position.y,

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -67,7 +67,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub titlebar_hidden: bool,
     pub titlebar_buttons_hidden: bool,
     pub fullsize_content_view: bool,
-    pub resize_increments: Option<LogicalSize>,
+    pub resize_increments: Option<LogicalSize<f64>>,
     pub disallow_hidpi: bool,
 }
 
@@ -292,7 +292,7 @@ pub struct UnownedWindow {
     decorations: AtomicBool,
     cursor: Weak<Mutex<util::Cursor>>,
     cursor_visible: AtomicBool,
-    pub inner_rect: Option<PhysicalSize>,
+    pub inner_rect: Option<PhysicalSize<u32>>,
 }
 
 unsafe impl Send for UnownedWindow {}
@@ -434,7 +434,7 @@ impl UnownedWindow {
         AppState::queue_redraw(RootWindowId(self.id()));
     }
 
-    pub fn outer_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let frame_rect = unsafe { NSWindow::frame(*self.ns_window) };
         let position = LogicalPosition::new(
             frame_rect.origin.x as f64,
@@ -444,7 +444,7 @@ impl UnownedWindow {
         Ok(position.to_physical(dpi_factor))
     }
 
-    pub fn inner_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let content_rect = unsafe {
             NSWindow::contentRectForFrameRect_(*self.ns_window, NSWindow::frame(*self.ns_window))
         };

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -584,11 +584,11 @@ impl UnownedWindow {
     pub fn set_cursor_position(&self, cursor_position: Position) -> Result<(), ExternalError> {
         let physical_window_position = self.inner_position().unwrap();
         let dpi_factor = self.hidpi_factor();
-        let window_position = physical_window_position.to_logical(dpi_factor);
-        let logical_cursor_position = cursor_position.to_logical(dpi_factor);
+        let window_position = physical_window_position.to_logical::<_, CGFloat>(dpi_factor);
+        let logical_cursor_position = cursor_position.to_logical::<_, CGFloat>(dpi_factor);
         let point = appkit::CGPoint {
-            x: (logical_cursor_position.x + window_position.x) as CGFloat,
-            y: (logical_cursor_position.y + window_position.y) as CGFloat,
+            x: logical_cursor_position.x + window_position.x,
+            y: logical_cursor_position.y + window_position.y,
         };
         CGDisplay::warp_mouse_cursor_position(point)
             .map_err(|e| ExternalError::Os(os_error!(OsError::CGError(e))))?;

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -474,18 +474,18 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn inner_size(&self) -> PhysicalSize {
+    pub fn inner_size(&self) -> PhysicalSize<u32> {
         let view_frame = unsafe { NSView::frame(*self.ns_view) };
-        let logical: LogicalSize =
+        let logical: LogicalSize<f64> =
             (view_frame.size.width as f64, view_frame.size.height as f64).into();
         let dpi_factor = self.hidpi_factor();
         logical.to_physical(dpi_factor)
     }
 
     #[inline]
-    pub fn outer_size(&self) -> PhysicalSize {
+    pub fn outer_size(&self) -> PhysicalSize<u32> {
         let view_frame = unsafe { NSWindow::frame(*self.ns_window) };
-        let logical: LogicalSize =
+        let logical: LogicalSize<f64> =
             (view_frame.size.width as f64, view_frame.size.height as f64).into();
         let dpi_factor = self.hidpi_factor();
         logical.to_physical(dpi_factor)
@@ -1062,7 +1062,7 @@ impl Drop for UnownedWindow {
     }
 }
 
-unsafe fn set_min_inner_size<V: NSWindow + Copy>(window: V, mut min_size: LogicalSize) {
+unsafe fn set_min_inner_size<V: NSWindow + Copy>(window: V, mut min_size: LogicalSize<f64>) {
     let mut current_rect = NSWindow::frame(window);
     let content_rect = NSWindow::contentRectForFrameRect_(window, NSWindow::frame(window));
     // Convert from client area size to window size
@@ -1086,7 +1086,7 @@ unsafe fn set_min_inner_size<V: NSWindow + Copy>(window: V, mut min_size: Logica
     }
 }
 
-unsafe fn set_max_inner_size<V: NSWindow + Copy>(window: V, mut max_size: LogicalSize) {
+unsafe fn set_max_inner_size<V: NSWindow + Copy>(window: V, mut max_size: LogicalSize<f64>) {
     let mut current_rect = NSWindow::frame(window);
     let content_rect = NSWindow::contentRectForFrameRect_(window, NSWindow::frame(window));
     // Convert from client area size to window size

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -118,7 +118,7 @@ impl WindowDelegateState {
         (unsafe { NSWindow::backingScaleFactor(*self.ns_window) }) as f64
     }
 
-    fn view_size(&self) -> LogicalSize {
+    fn view_size(&self) -> LogicalSize<f64> {
         let ns_size = unsafe { NSView::frame(*self.ns_view).size };
         LogicalSize::new(ns_size.width as f64, ns_size.height as f64)
     }

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -9,7 +9,7 @@ impl Handle {
         1.0
     }
 
-    pub fn position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition<i32> {
         PhysicalPosition { x: 0.0, y: 0.0 }
     }
 
@@ -17,7 +17,7 @@ impl Handle {
         None
     }
 
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         PhysicalSize {
             width: 0.0,
             height: 0.0,
@@ -33,7 +33,7 @@ impl Handle {
 pub struct Mode;
 
 impl Mode {
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         unimplemented!();
     }
 

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -96,7 +96,7 @@ impl Canvas {
         self.raw.height() as f64
     }
 
-    pub fn set_size(&self, size: LogicalSize) {
+    pub fn set_size(&self, size: LogicalSize<f64>) {
         self.raw.set_width(size.width as u32);
         self.raw.set_height(size.height as u32);
     }

--- a/src/platform_impl/web/stdweb/event.rs
+++ b/src/platform_impl/web/stdweb/event.rs
@@ -23,7 +23,7 @@ pub fn mouse_modifiers(event: &impl IMouseEvent) -> ModifiersState {
     }
 }
 
-pub fn mouse_position(event: &impl IMouseEvent) -> LogicalPosition {
+pub fn mouse_position(event: &impl IMouseEvent) -> LogicalPosition<f64> {
     LogicalPosition {
         x: event.offset_x() as f64,
         y: event.offset_y() as f64,

--- a/src/platform_impl/web/stdweb/mod.rs
+++ b/src/platform_impl/web/stdweb/mod.rs
@@ -33,7 +33,7 @@ impl WindowExtStdweb for Window {
     }
 }
 
-pub fn window_size() -> LogicalSize {
+pub fn window_size() -> LogicalSize<f64> {
     let window = window();
     let width = window.inner_width() as f64;
     let height = window.inner_height() as f64;

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -94,7 +94,7 @@ impl Canvas {
         self.raw.height() as f64
     }
 
-    pub fn set_size(&self, size: LogicalSize) {
+    pub fn set_size(&self, size: LogicalSize<f64>) {
         self.raw.set_width(size.width as u32);
         self.raw.set_height(size.height as u32);
     }

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -22,7 +22,7 @@ pub fn mouse_modifiers(event: &MouseEvent) -> ModifiersState {
     }
 }
 
-pub fn mouse_position(event: &MouseEvent) -> LogicalPosition {
+pub fn mouse_position(event: &MouseEvent) -> LogicalPosition<f64> {
     LogicalPosition {
         x: event.offset_x() as f64,
         y: event.offset_y() as f64,

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -40,7 +40,7 @@ impl WindowExtWebSys for Window {
     }
 }
 
-pub fn window_size() -> LogicalSize {
+pub fn window_size() -> LogicalSize<f64> {
     let window = web_sys::window().expect("Failed to obtain window");
     let width = window
         .inner_width()

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -178,7 +178,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, _position: LogicalPosition<f64>) -> Result<(), ExternalError> {
+    pub fn set_cursor_position(
+        &self,
+        _position: LogicalPosition<f64>,
+    ) -> Result<(), ExternalError> {
         // Intentionally a no-op, as the web does not support setting cursor positions
         Ok(())
     }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -82,7 +82,7 @@ impl Window {
         Ok(*self.position.borrow())
     }
 
-    pub fn set_outer_position(&self, position: LogicalPosition) {
+    pub fn set_outer_position(&self, position: LogicalPosition<f64>) {
         *self.position.borrow_mut() = position;
 
         self.canvas.set_attribute("position", "fixed");
@@ -91,7 +91,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn inner_size(&self) -> LogicalSize {
+    pub fn inner_size(&self) -> LogicalSize<f64> {
         LogicalSize {
             width: self.canvas.width() as f64,
             height: self.canvas.height() as f64,
@@ -99,7 +99,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_size(&self) -> LogicalSize {
+    pub fn outer_size(&self) -> LogicalSize<f64> {
         LogicalSize {
             width: self.canvas.width() as f64,
             height: self.canvas.height() as f64,
@@ -107,7 +107,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_inner_size(&self, size: LogicalSize) {
+    pub fn set_inner_size(&self, size: LogicalSize<f64>) {
         self.canvas.set_size(size);
     }
 
@@ -178,7 +178,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, _position: LogicalPosition) -> Result<(), ExternalError> {
+    pub fn set_cursor_position(&self, _position: LogicalPosition<f64>) -> Result<(), ExternalError> {
         // Intentionally a no-op, as the web does not support setting cursor positions
         Ok(())
     }
@@ -238,7 +238,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_position(&self, _position: LogicalPosition) {
+    pub fn set_ime_position(&self, _position: LogicalPosition<f64>) {
         // Currently a no-op as it does not seem there is good support for this on web
     }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -15,7 +15,7 @@ use std::collections::VecDeque;
 pub struct Window {
     canvas: backend::Canvas,
     previous_pointer: RefCell<&'static str>,
-    position: RefCell<LogicalPosition>,
+    position: RefCell<LogicalPosition<f64>>,
     id: Id,
     register_redraw_request: Box<dyn Fn()>,
 }
@@ -72,13 +72,13 @@ impl Window {
         (self.register_redraw_request)();
     }
 
-    pub fn outer_position(&self) -> Result<LogicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<LogicalPosition<f64>, NotSupportedError> {
         let (x, y) = self.canvas.position();
 
         Ok(LogicalPosition { x, y })
     }
 
-    pub fn inner_position(&self) -> Result<LogicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<LogicalPosition<f64>, NotSupportedError> {
         Ok(*self.position.borrow())
     }
 
@@ -112,12 +112,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_min_inner_size(&self, _dimensions: Option<LogicalSize>) {
+    pub fn set_min_inner_size(&self, _dimensions: Option<LogicalSize<f64>>) {
         // Intentionally a no-op: users can't resize canvas elements
     }
 
     #[inline]
-    pub fn set_max_inner_size(&self, _dimensions: Option<LogicalSize>) {
+    pub fn set_max_inner_size(&self, _dimensions: Option<LogicalSize<f64>>) {
         // Intentionally a no-op: users can't resize canvas elements
     }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1074,7 +1074,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
             let windowpos = lparam as *const winuser::WINDOWPOS;
             if (*windowpos).flags & winuser::SWP_NOMOVE != winuser::SWP_NOMOVE {
                 let physical_position =
-                    PhysicalPosition::new((*windowpos).x as f64, (*windowpos).y as f64);
+                    PhysicalPosition::new((*windowpos).x as u32, (*windowpos).y as u32);
                 subclass_input.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: Moved(physical_position),
@@ -1191,8 +1191,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 });
             }
 
-            let x = windowsx::GET_X_LPARAM(lparam) as f64;
-            let y = windowsx::GET_Y_LPARAM(lparam) as f64;
+            let x = windowsx::GET_X_LPARAM(lparam) as u32;
+            let y = windowsx::GET_Y_LPARAM(lparam) as u32;
             let position = PhysicalPosition::new(x, y);
 
             subclass_input.send_event(Event::WindowEvent {
@@ -1923,8 +1923,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
             // We calculate our own size because the default suggested rect doesn't do a great job
             // of preserving the window's logical size.
             let suggested_physical_inner_size = old_physical_inner_size
-                .to_logical(old_dpi_factor)
-                .to_physical(new_dpi_factor);
+                .to_logical::<f64>(old_dpi_factor)
+                .to_physical::<u32>(new_dpi_factor);
 
             // `allow_resize` prevents us from re-applying DPI adjustment to the restored size after
             // exiting fullscreen (the restored size is already DPI adjusted).

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1191,8 +1191,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 });
             }
 
-            let x = windowsx::GET_X_LPARAM(lparam) as u32;
-            let y = windowsx::GET_Y_LPARAM(lparam) as u32;
+            let x = windowsx::GET_X_LPARAM(lparam) as i32;
+            let y = windowsx::GET_Y_LPARAM(lparam) as i32;
             let position = PhysicalPosition::new(x, y);
 
             subclass_input.send_event(Event::WindowEvent {

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -62,7 +62,7 @@ impl std::fmt::Debug for VideoMode {
 }
 
 impl VideoMode {
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
     }
 
@@ -185,7 +185,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn size(&self) -> PhysicalSize {
+    pub fn size(&self) -> PhysicalSize<u32> {
         let monitor_info = get_monitor_info(self.0).unwrap();
         PhysicalSize {
             width: (monitor_info.rcMonitor.right - monitor_info.rcMonitor.left) as u32,
@@ -194,11 +194,11 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn position(&self) -> PhysicalPosition {
+    pub fn position(&self) -> PhysicalPosition<i32> {
         let monitor_info = get_monitor_info(self.0).unwrap();
         PhysicalPosition {
-            x: monitor_info.rcMonitor.left as f64,
-            y: monitor_info.rcMonitor.top as f64,
+            x: monitor_info.rcMonitor.left,
+            y: monitor_info.rcMonitor.top,
         }
     }
 

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -76,7 +76,7 @@ pub fn get_client_rect(hwnd: HWND) -> Result<RECT, io::Error> {
     }
 }
 
-pub fn adjust_size(hwnd: HWND, size: PhysicalSize) -> PhysicalSize {
+pub fn adjust_size(hwnd: HWND, size: PhysicalSize<u32>) -> PhysicalSize<u32> {
     let (width, height): (u32, u32) = size.into();
     let rect = RECT {
         left: 0,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -159,24 +159,24 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         util::get_window_rect(self.window.0)
-            .map(|rect| Ok(PhysicalPosition::new(rect.left as f64, rect.top as f64)))
+            .map(|rect| Ok(PhysicalPosition::new(rect.left as i32, rect.top as i32)))
             .expect("Unexpected GetWindowRect failure; please report this error to https://github.com/rust-windowing/winit")
     }
 
     #[inline]
-    pub fn inner_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let mut position: POINT = unsafe { mem::zeroed() };
         if unsafe { winuser::ClientToScreen(self.window.0, &mut position) } == 0 {
             panic!("Unexpected ClientToScreen failure: please report this error to https://github.com/rust-windowing/winit")
         }
-        Ok(PhysicalPosition::new(position.x as f64, position.y as f64))
+        Ok(PhysicalPosition::new(position.x as i32, position.y as i32))
     }
 
     #[inline]
     pub fn set_outer_position(&self, position: Position) {
-        let (x, y): (i32, i32) = position.to_physical(self.hidpi_factor()).into();
+        let (x, y): (i32, i32) = position.to_physical::<i32>(self.hidpi_factor()).into();
 
         let window_state = Arc::clone(&self.window_state);
         let window = self.window.clone();
@@ -201,7 +201,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn inner_size(&self) -> PhysicalSize {
+    pub fn inner_size(&self) -> PhysicalSize<u32> {
         let mut rect: RECT = unsafe { mem::zeroed() };
         if unsafe { winuser::GetClientRect(self.window.0, &mut rect) } == 0 {
             panic!("Unexpected GetClientRect failure: please report this error to https://github.com/rust-windowing/winit")
@@ -213,7 +213,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_size(&self) -> PhysicalSize {
+    pub fn outer_size(&self) -> PhysicalSize<u32> {
         util::get_window_rect(self.window.0)
             .map(|rect| {
                 PhysicalSize::new(
@@ -259,7 +259,7 @@ impl Window {
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
         let dpi_factor = self.hidpi_factor();
-        let (width, height) = size.to_physical(dpi_factor).into();
+        let (width, height) = size.to_physical::<u32>(dpi_factor).into();
 
         let window_state = Arc::clone(&self.window_state);
         let window = self.window.clone();
@@ -372,7 +372,7 @@ impl Window {
     #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
         let dpi_factor = self.hidpi_factor();
-        let (x, y) = position.to_physical(dpi_factor).into();
+        let (x, y) = position.to_physical::<i32>(dpi_factor).into();
 
         let mut point = POINT { x, y };
         unsafe {

--- a/src/window.rs
+++ b/src/window.rs
@@ -422,7 +422,7 @@ impl Window {
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     #[inline]
-    pub fn inner_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         self.window.inner_position()
     }
 
@@ -441,7 +441,7 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread. Returns the top left coordinates of the
     ///   window in the screen space coordinate system.
     #[inline]
-    pub fn outer_position(&self) -> Result<PhysicalPosition, NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         self.window.outer_position()
     }
 
@@ -470,7 +470,7 @@ impl Window {
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     #[inline]
-    pub fn inner_size(&self) -> PhysicalSize {
+    pub fn inner_size(&self) -> PhysicalSize<u32> {
         self.window.inner_size()
     }
 
@@ -498,7 +498,7 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread. Returns the `PhysicalSize` of the window in
     ///   screen space coordinates.
     #[inline]
-    pub fn outer_size(&self) -> PhysicalSize {
+    pub fn outer_size(&self) -> PhysicalSize<u32> {
         self.window.outer_size()
     }
 

--- a/tests/serde_objects.rs
+++ b/tests/serde_objects.rs
@@ -31,8 +31,9 @@ fn events_serde() {
 
 #[test]
 fn dpi_serde() {
-    needs_serde::<LogicalPosition>();
-    needs_serde::<PhysicalPosition>();
-    needs_serde::<LogicalSize>();
-    needs_serde::<PhysicalSize>();
+    needs_serde::<LogicalPosition<f64>>();
+    needs_serde::<PhysicalPosition<i32>>();
+    needs_serde::<PhysicalPosition<f64>>();
+    needs_serde::<LogicalSize<f64>>();
+    needs_serde::<PhysicalSize<u32>>();
 }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Implements the changes suggested in https://github.com/rust-windowing/winit/issues/1135#issuecomment-528543352. I haven't gotten around to updating the type signatures on non-Windows platforms but I'll go through the CI logs after they fail and update them where necessary.