### PR TITLE
X11: Fix incorrect modifiers when events are missed

### DIFF
--- a/src/platform_impl/linux/wayland/keyboard.rs
+++ b/src/platform_impl/linux/wayland/keyboard.rs
@@ -97,7 +97,7 @@ pub fn init_keyboard(
                 KbEvent::Modifiers {
                     modifiers: event_modifiers,
                 } => {
-                    let modifiers = event_modifiers.into();
+                    let modifiers = ModifiersState::from_wayland(event_modifiers);
 
                     *modifiers_tracker.lock().unwrap() = modifiers;
 
@@ -399,8 +399,8 @@ fn keysym_to_vkey(keysym: u32) -> Option<VirtualKeyCode> {
     }
 }
 
-impl From<keyboard::ModifiersState> for ModifiersState {
-    fn from(mods: keyboard::ModifiersState) -> ModifiersState {
+impl ModifiersState {
+    pub(crate) fn from_wayland(mods: keyboard::ModifiersState) -> ModifiersState {
         ModifiersState {
             shift: mods.shift,
             ctrl: mods.ctrl,

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -11,14 +11,17 @@ pub const VIRTUAL_CORE_KEYBOARD: c_int = 3;
 // To test if `lookup_utf8` works correctly, set this to 1.
 const TEXT_BUFFER_SIZE: usize = 1024;
 
-impl From<ffi::XIModifierState> for ModifiersState {
-    fn from(mods: ffi::XIModifierState) -> Self {
-        let state = mods.effective as c_uint;
+impl ModifiersState {
+    pub(crate) fn from_x11(state: &ffi::XIModifierState) -> Self {
+        ModifiersState::from_x11_mask(state.effective as c_uint)
+    }
+
+    pub(crate) fn from_x11_mask(mask: c_uint) -> Self {
         ModifiersState {
-            alt: state & ffi::Mod1Mask != 0,
-            shift: state & ffi::ShiftMask != 0,
-            ctrl: state & ffi::ControlMask != 0,
-            logo: state & ffi::Mod4Mask != 0,
+            alt: mask & ffi::Mod1Mask != 0,
+            shift: mask & ffi::ShiftMask != 0,
+            ctrl: mask & ffi::ControlMask != 0,
+            logo: mask & ffi::Mod4Mask != 0,
         }
     }
 }
@@ -40,7 +43,7 @@ pub struct PointerState<'a> {
 
 impl<'a> PointerState<'a> {
     pub fn get_modifier_state(&self) -> ModifiersState {
-        self.modifiers.into()
+        ModifiersState::from_x11(&self.modifiers)
     }
 }
 


### PR DESCRIPTION
* Syncs modifier state with state data in X key/button/motion events.
* Fixes modifier state in XWayland, as xinput2 raw input events will
  not be received when a window does not have focus.
* Removes `impl From<_> for ModifiersState` on X11/Wayland API types,
  replacing them with `pub(crate)` methods.

Addresses an issue brought up in #1259

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
