### PR TITLE
Fix ReceivedCharacter not working with Alt held on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On macOS, fix application termination on `ControlFlow::Exit`
+- On Windows, fix missing `ReceivedCharacter` events when Alt is held.
 - On X11, fix misreporting DPI factor at startup.
 - On X11, fix events not being reported when using `run_return`.
 - On X11, fix key modifiers being incorrectly reported.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1112,7 +1112,7 @@ unsafe extern "system" fn public_window_callback<T>(
             0
         }
 
-        winuser::WM_CHAR => {
+        winuser::WM_CHAR | winuser::WM_SYSCHAR => {
             use crate::event::WindowEvent::ReceivedCharacter;
             use std::char;
             let is_high_surrogate = 0xD800 <= wparam && wparam <= 0xDBFF;
@@ -1144,12 +1144,6 @@ unsafe extern "system" fn public_window_callback<T>(
             }
             0
         }
-
-        // Prevents default windows menu hotkeys playing unwanted
-        // "ding" sounds. Alternatively could check for WM_SYSCOMMAND
-        // with wparam being SC_KEYMENU, but this may prevent some
-        // other unwanted default hotkeys as well.
-        winuser::WM_SYSCHAR => 0,
 
         winuser::WM_SYSCOMMAND => {
             if wparam == winuser::SC_SCREENSAVE {


### PR DESCRIPTION
This pull requests processes WM_SYSCHAR events along with WM_CHAR events rather than ignoring them. We can combine these because they are encoded identically. See relevant docs for [WM_CHAR](https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-char) and [WM_SYSCHAR](https://docs.microsoft.com/en-us/windows/win32/menurc/wm-syschar).

Fixes #1280

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
