### PR TITLE
Stop refocusing window when switching from fullscreen to windowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - On X11, fix misreporting DPI factor at startup.
 - On X11, fix events not being reported when using `run_return`.
 - On X11, fix key modifiers being incorrectly reported.
+- On Windows, fix focusing unfocused windows when switching from fullscreen to windowed.
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -202,7 +202,10 @@ impl Window {
                 y as c_int,
                 0,
                 0,
-                winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOZORDER | winuser::SWP_NOSIZE,
+                winuser::SWP_ASYNCWINDOWPOS
+                    | winuser::SWP_NOZORDER
+                    | winuser::SWP_NOSIZE
+                    | winuser::SWP_NOACTIVATE,
             );
             winuser::UpdateWindow(self.window.0);
         }
@@ -615,7 +618,9 @@ impl Window {
                                 client_rect.top,
                                 client_rect.right - client_rect.left,
                                 client_rect.bottom - client_rect.top,
-                                winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOZORDER,
+                                winuser::SWP_ASYNCWINDOWPOS
+                                    | winuser::SWP_NOZORDER
+                                    | winuser::SWP_NOACTIVATE,
                             );
                             winuser::UpdateWindow(window.0);
                         }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -255,7 +255,10 @@ impl WindowFlags {
                     0,
                     0,
                     0,
-                    winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOMOVE | winuser::SWP_NOSIZE,
+                    winuser::SWP_ASYNCWINDOWPOS
+                        | winuser::SWP_NOMOVE
+                        | winuser::SWP_NOSIZE
+                        | winuser::SWP_NOACTIVATE,
                 );
                 winuser::UpdateWindow(window);
             }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This should stop some functionality on unfocused windows to automatically focus them.
This affects for example switching from fullscreen to windowed or changing the outer position of windows.

Fixes #1284.