### PR TITLE
WIP - Add positions to mouse click events.

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -165,6 +165,7 @@ pub enum WindowEvent {
         state: ElementState,
         button: MouseButton,
         modifiers: ModifiersState,
+        position: LogicalPosition,
     },
 
     /// Touchpad pressure event.

--- a/src/platform_impl/linux/wayland/pointer.rs
+++ b/src/platform_impl/linux/wayland/pointer.rs
@@ -46,6 +46,7 @@ pub fn implement_pointer<T: 'static>(
                 let mut sink = sink.lock().unwrap();
                 let store = store.lock().unwrap();
                 let mut cursor_manager = cursor_manager.lock().unwrap();
+                let mut cursor_pos = (0.0, 0.0).into();
                 match evt {
                     PtrEvent::Enter {
                         surface,
@@ -53,6 +54,7 @@ pub fn implement_pointer<T: 'static>(
                         surface_y,
                         ..
                     } => {
+                        cursor_pos = (surface_x, surface_y).into();
                         let wid = store.find_wid(&surface);
                         if let Some(wid) = wid {
                             mouse_focus = Some(wid);
@@ -69,7 +71,7 @@ pub fn implement_pointer<T: 'static>(
                                     device_id: crate::event::DeviceId(
                                         crate::platform_impl::DeviceId::Wayland(DeviceId),
                                     ),
-                                    position: (surface_x, surface_y).into(),
+                                    position: cursor_pos,
                                     modifiers: modifiers_tracker.lock().unwrap().clone(),
                                 },
                                 wid,
@@ -97,13 +99,14 @@ pub fn implement_pointer<T: 'static>(
                         surface_y,
                         ..
                     } => {
+                        cursor_pos = (surface_x, surface_y).into();
                         if let Some(wid) = mouse_focus {
                             sink.send_window_event(
                                 WindowEvent::CursorMoved {
                                     device_id: crate::event::DeviceId(
                                         crate::platform_impl::DeviceId::Wayland(DeviceId),
                                     ),
-                                    position: (surface_x, surface_y).into(),
+                                    position: cursor_pos,
                                     modifiers: modifiers_tracker.lock().unwrap().clone(),
                                 },
                                 wid,
@@ -131,6 +134,7 @@ pub fn implement_pointer<T: 'static>(
                                     ),
                                     state,
                                     button,
+                                    position: cursor_pos,
                                     modifiers: modifiers_tracker.lock().unwrap().clone(),
                                 },
                                 wid,

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -651,6 +651,14 @@ impl<T: 'static> EventProcessor<T> {
                         } else {
                             Released
                         };
+
+                        let dpi_factor = self
+                            .with_window(xev.event, |window| window.hidpi_factor())
+                            .unwrap_or(1.0);
+                        let position = LogicalPosition::from_physical(
+                            (xev.event_x as f64, xev.event_y as f64),
+                            dpi_factor,
+                        );
                         match xev.detail as u32 {
                             ffi::Button1 => callback(Event::WindowEvent {
                                 window_id,
@@ -659,6 +667,7 @@ impl<T: 'static> EventProcessor<T> {
                                     state,
                                     button: Left,
                                     modifiers,
+                                    position,
                                 },
                             }),
                             ffi::Button2 => callback(Event::WindowEvent {
@@ -668,6 +677,7 @@ impl<T: 'static> EventProcessor<T> {
                                     state,
                                     button: Middle,
                                     modifiers,
+                                    position,
                                 },
                             }),
                             ffi::Button3 => callback(Event::WindowEvent {
@@ -677,6 +687,7 @@ impl<T: 'static> EventProcessor<T> {
                                     state,
                                     button: Right,
                                     modifiers,
+                                    position,
                                 },
                             }),
 
@@ -710,6 +721,7 @@ impl<T: 'static> EventProcessor<T> {
                                     state,
                                     button: Other(x as u8),
                                     modifiers,
+                                    position,
                                 },
                             }),
                         }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -128,7 +128,7 @@ impl<T> WindowTarget<T> {
         });
 
         let runner = self.runner.clone();
-        canvas.on_mouse_press(move |pointer_id, button, modifiers| {
+        canvas.on_mouse_press(move |pointer_id, button, modifiers, position| {
             runner.send_event(Event::WindowEvent {
                 window_id: WindowId(id),
                 event: WindowEvent::MouseInput {
@@ -136,12 +136,13 @@ impl<T> WindowTarget<T> {
                     state: ElementState::Pressed,
                     button,
                     modifiers,
+                    position,
                 },
             });
         });
 
         let runner = self.runner.clone();
-        canvas.on_mouse_release(move |pointer_id, button, modifiers| {
+        canvas.on_mouse_release(move |pointer_id, button, modifiers, position| {
             runner.send_event(Event::WindowEvent {
                 window_id: WindowId(id),
                 event: WindowEvent::MouseInput {
@@ -149,6 +150,7 @@ impl<T> WindowTarget<T> {
                     state: ElementState::Released,
                     button,
                     modifiers,
+                    position,
                 },
             });
         });

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -183,26 +183,28 @@ impl Canvas {
 
     pub fn on_mouse_release<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, MouseButton, ModifiersState, LogicalPosition),
     {
         self.on_mouse_release = Some(self.add_user_event(move |event: PointerUpEvent| {
             handler(
                 event.pointer_id(),
                 event::mouse_button(&event),
                 event::mouse_modifiers(&event),
+                event::mouse_position(&event),
             );
         }));
     }
 
     pub fn on_mouse_press<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, MouseButton, ModifiersState, LogicalPosition),
     {
         self.on_mouse_press = Some(self.add_user_event(move |event: PointerDownEvent| {
             handler(
                 event.pointer_id(),
                 event::mouse_button(&event),
                 event::mouse_modifiers(&event),
+                event::mouse_position(&event),
             );
         }));
     }

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -186,7 +186,7 @@ impl Canvas {
 
     pub fn on_mouse_release<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, MouseButton, ModifiersState, LogicalPosition),
     {
         self.on_mouse_release = Some(self.add_user_event(
             "pointerup",
@@ -195,6 +195,7 @@ impl Canvas {
                     event.pointer_id(),
                     event::mouse_button(&event),
                     event::mouse_modifiers(&event),
+                    event::mouse_position(&event),
                 );
             },
         ));
@@ -202,7 +203,7 @@ impl Canvas {
 
     pub fn on_mouse_press<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, MouseButton, ModifiersState, LogicalPosition),
     {
         self.on_mouse_press = Some(self.add_user_event(
             "pointerdown",
@@ -211,6 +212,7 @@ impl Canvas {
                     event.pointer_id(),
                     event::mouse_button(&event),
                     event::mouse_modifiers(&event),
+                    event::mouse_position(&event),
                 );
             },
         ));

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -907,6 +907,13 @@ fn normalize_pointer_pressure(pressure: u32) -> Option<Force> {
     }
 }
 
+fn event_position(window: HWND, lparam: LPARAM) -> LogicalPosition {
+    let x = windowsx::GET_X_LPARAM(lparam) as f64;
+    let y = windowsx::GET_Y_LPARAM(lparam) as f64;
+    let dpi_factor = hwnd_scale_factor(window);
+    LogicalPosition::from_physical((x, y), dpi_factor)
+}
+
 /// Any window whose callback is configured to this function will have its events propagated
 /// through the events loop of the thread the window was created in.
 //
@@ -1321,6 +1328,7 @@ unsafe extern "system" fn public_window_callback<T>(
             use crate::event::{ElementState::Pressed, MouseButton::Left, WindowEvent::MouseInput};
 
             capture_mouse(window, &mut *subclass_input.window_state.lock());
+            let position = event_position(window, lparam);
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
@@ -1329,6 +1337,7 @@ unsafe extern "system" fn public_window_callback<T>(
                     state: Pressed,
                     button: Left,
                     modifiers: event::get_key_mods(),
+                    position,
                 },
             });
             0
@@ -1340,6 +1349,7 @@ unsafe extern "system" fn public_window_callback<T>(
             };
 
             release_mouse(&mut *subclass_input.window_state.lock());
+            let position = event_position(window, lparam);
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
@@ -1348,6 +1358,7 @@ unsafe extern "system" fn public_window_callback<T>(
                     state: Released,
                     button: Left,
                     modifiers: event::get_key_mods(),
+                    position,
                 },
             });
             0
@@ -1359,6 +1370,7 @@ unsafe extern "system" fn public_window_callback<T>(
             };
 
             capture_mouse(window, &mut *subclass_input.window_state.lock());
+            let position = event_position(window, lparam);
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
@@ -1367,6 +1379,7 @@ unsafe extern "system" fn public_window_callback<T>(
                     state: Pressed,
                     button: Right,
                     modifiers: event::get_key_mods(),
+                    position,
                 },
             });
             0
@@ -1378,6 +1391,7 @@ unsafe extern "system" fn public_window_callback<T>(
             };
 
             release_mouse(&mut *subclass_input.window_state.lock());
+            let position = event_position(window, lparam);
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
@@ -1386,6 +1400,7 @@ unsafe extern "system" fn public_window_callback<T>(
                     state: Released,
                     button: Right,
                     modifiers: event::get_key_mods(),
+                    position,
                 },
             });
             0
@@ -1397,6 +1412,7 @@ unsafe extern "system" fn public_window_callback<T>(
             };
 
             capture_mouse(window, &mut *subclass_input.window_state.lock());
+            let position = event_position(window, lparam);
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
@@ -1405,6 +1421,7 @@ unsafe extern "system" fn public_window_callback<T>(
                     state: Pressed,
                     button: Middle,
                     modifiers: event::get_key_mods(),
+                    position,
                 },
             });
             0
@@ -1416,6 +1433,7 @@ unsafe extern "system" fn public_window_callback<T>(
             };
 
             release_mouse(&mut *subclass_input.window_state.lock());
+            let position = event_position(window, lparam);
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
@@ -1424,6 +1442,7 @@ unsafe extern "system" fn public_window_callback<T>(
                     state: Released,
                     button: Middle,
                     modifiers: event::get_key_mods(),
+                    position,
                 },
             });
             0
@@ -1436,6 +1455,7 @@ unsafe extern "system" fn public_window_callback<T>(
             let xbutton = winuser::GET_XBUTTON_WPARAM(wparam);
 
             capture_mouse(window, &mut *subclass_input.window_state.lock());
+            let position = event_position(window, lparam);
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
@@ -1444,6 +1464,7 @@ unsafe extern "system" fn public_window_callback<T>(
                     state: Pressed,
                     button: Other(xbutton as u8),
                     modifiers: event::get_key_mods(),
+                    position,
                 },
             });
             0
@@ -1456,6 +1477,7 @@ unsafe extern "system" fn public_window_callback<T>(
             let xbutton = winuser::GET_XBUTTON_WPARAM(wparam);
 
             release_mouse(&mut *subclass_input.window_state.lock());
+            let position = event_position(window, lparam);
 
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
@@ -1464,6 +1486,7 @@ unsafe extern "system" fn public_window_callback<T>(
                     state: Released,
                     button: Other(xbutton as u8),
                     modifiers: event::get_key_mods(),
+                    position,
                 },
             });
             0


### PR DESCRIPTION
For the sake of argument.  And catharsis.  Addresses issue #883 for some platforms, so I can see how much work it actually takes.  Not implemented for macos 'cause I don't have a way to test it.

- [ ] Tested on all platforms changed -- Haven't tested on Windows yet.
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
