### PR TITLE
Only use 'extern crate stdweb' on web targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,7 +127,7 @@ extern crate bitflags;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[macro_use]
 extern crate objc;
-#[cfg(feature = "std_web")]
+#[cfg(all(target_arch = "wasm32", feature = "std_web"))]
 extern crate std_web as stdweb;
 
 pub mod dpi;


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully

The 'extern crate' declaration shouldn't be there even if the stdweb feature is on, unless the crate is being compiled for web.
