### PR TITLE
Have EventLoopClosed contain the original event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - On X11, fix window creation hanging when another window is fullscreen.
 - On Windows, fix focusing unfocused windows when switching from fullscreen to windowed.
 - On X11, fix reporting incorrect DPI factor when waking from suspend.
-- Change `EventLoopClosed` to optionally contain the original event.
+- Change `EventLoopClosed` to contain the original event.
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - On X11, fix window creation hanging when another window is fullscreen.
 - On Windows, fix focusing unfocused windows when switching from fullscreen to windowed.
 - On X11, fix reporting incorrect DPI factor when waking from suspend.
+- Change `EventLoopClosed` to optionally contain the original event.
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -199,7 +199,7 @@ impl<T: 'static> EventLoopProxy<T> {
     /// function.
     ///
     /// Returns an `Err` if the associated `EventLoop` no longer exists.
-    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
         self.event_loop_proxy.send_event(event)
     }
 }
@@ -211,17 +211,17 @@ impl<T: 'static> fmt::Debug for EventLoopProxy<T> {
 }
 
 /// The error that is returned when an `EventLoopProxy` attempts to wake up an `EventLoop` that
-/// no longer exists.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct EventLoopClosed;
+/// no longer exists. Contains the original event given to `send_event`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct EventLoopClosed<T>(pub T);
 
-impl fmt::Display for EventLoopClosed {
+impl<T: fmt::Debug> fmt::Display for EventLoopClosed<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", error::Error::description(self))
     }
 }
 
-impl error::Error for EventLoopClosed {
+impl<T: fmt::Debug> error::Error for EventLoopClosed<T> {
     fn description(&self) -> &str {
         "Tried to wake up a closed `EventLoop`"
     }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -157,7 +157,7 @@ impl EventLoop {
 }
 
 impl EventLoopProxy {
-    pub fn wakeup(&self) -> Result<(), ::EventLoopClosed> {
+    pub fn wakeup(&self) -> Result<(), ::EventLoopClosed<()>> {
         android_glue::wake_event_loop();
         Ok(())
     }

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -165,8 +165,10 @@ impl<T> EventLoopProxy<T> {
         }
     }
 
-    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
-        self.sender.send(event).map_err(|_| EventLoopClosed)?;
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
+        self.sender
+            .send(event)
+            .map_err(|::std::sync::mpsc::SendError(x)| EventLoopClosed(x))?;
         unsafe {
             // let the main thread know there's a new event
             CFRunLoopSourceSignal(self.source);

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -650,7 +650,7 @@ impl<T: 'static> EventLoop<T> {
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
         match *self {
             EventLoopProxy::Wayland(ref proxy) => proxy.send_event(event),
             EventLoopProxy::X(ref proxy) => proxy.send_event(event),

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -282,8 +282,14 @@ impl<T: 'static> Clone for EventLoopProxy<T> {
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
-        self.user_sender.send(event).map_err(|_| EventLoopClosed)
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
+        self.user_sender.send(event).map_err(|e| {
+            EventLoopClosed(if let ::calloop::channel::SendError::Disconnected(x) = e {
+                x
+            } else {
+                unreachable!()
+            })
+        })
     }
 }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -1,4 +1,10 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+#![cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 
 mod dnd;
 mod event_processor;
@@ -425,8 +431,14 @@ impl<T> EventLoopWindowTarget<T> {
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
-        self.user_sender.send(event).map_err(|_| EventLoopClosed)
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
+        self.user_sender.send(event).map_err(|e| {
+            EventLoopClosed(if let ::calloop::channel::SendError::Disconnected(x) = e {
+                x
+            } else {
+                unreachable!()
+            })
+        })
     }
 }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -142,8 +142,10 @@ impl<T> Proxy<T> {
         }
     }
 
-    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
-        self.sender.send(event).map_err(|_| EventLoopClosed)?;
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
+        self.sender
+            .send(event)
+            .map_err(|mpsc::SendError(x)| EventLoopClosed(x))?;
         unsafe {
             // let the main thread know there's a new event
             CFRunLoopSourceSignal(self.source);

--- a/src/platform_impl/web/event_loop/proxy.rs
+++ b/src/platform_impl/web/event_loop/proxy.rs
@@ -11,7 +11,7 @@ impl<T: 'static> Proxy<T> {
         Proxy { runner }
     }
 
-    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
         self.runner.send_event(Event::UserEvent(event));
         Ok(())
     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -742,13 +742,13 @@ impl<T: 'static> Clone for EventLoopProxy<T> {
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed> {
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
         unsafe {
             if winuser::PostMessageW(self.target_window, *USER_EVENT_MSG_ID, 0, 0) != 0 {
                 self.event_send.send(event).ok();
                 Ok(())
             } else {
-                Err(EventLoopClosed)
+                Err(EventLoopClosed(event))
             }
         }
     }


### PR DESCRIPTION
- [X] Tested on all platforms changed
      (via CI, shouldn't change behavoir of user code except involved types when using `EventLoopProxy`, because the return value of `EventLoopProxy::send_event` changed)
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- Created or updated an example program if it would help users understand this functionality
      (appropriate example to modify would be `examples/custom_events.rs`, but I'm unsure which modification would be appropriate.)
- Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
      (no appropriate section found, where this should be added)

Fixes #1292.