### PR TITLE
X11: Fix incorrect DPI factor when waking from suspend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - On X11, fix key modifiers being incorrectly reported.
 - On X11, fix window creation hanging when another window is fullscreen.
 - On Windows, fix focusing unfocused windows when switching from fullscreen to windowed.
+- On X11, fix reporting incorrect DPI factor when waking from suspend.
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -406,14 +406,16 @@ impl<T: 'static> EventProcessor<T> {
                         let last_hidpi_factor = shared_state_lock.last_monitor.hidpi_factor;
                         let new_hidpi_factor = {
                             let window_rect = util::AaRect::new(new_outer_position, new_inner_size);
-                            monitor = wt.xconn.get_monitor_for_window(Some(window_rect));
-                            let new_hidpi_factor = monitor.hidpi_factor;
+                            let new_monitor = wt.xconn.get_monitor_for_window(Some(window_rect));
 
-                            // Avoid caching an invalid dummy monitor handle
-                            if monitor.id != 0 {
+                            if new_monitor.is_dummy() {
+                                // Avoid updating monitor using a dummy monitor handle
+                                last_hidpi_factor
+                            } else {
+                                monitor = new_monitor;
                                 shared_state_lock.last_monitor = monitor.clone();
+                                monitor.hidpi_factor
                             }
-                            new_hidpi_factor
                         };
                         if last_hidpi_factor != new_hidpi_factor {
                             events.dpi_changed =

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -143,6 +143,11 @@ impl MonitorHandle {
         }
     }
 
+    pub(crate) fn is_dummy(&self) -> bool {
+        // Zero is an invalid XID value; no real monitor will have it
+        self.id == 0
+    }
+
     pub fn name(&self) -> Option<String> {
         Some(self.name.clone())
     }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -651,7 +651,7 @@ impl UnownedWindow {
                 };
 
                 // Don't set fullscreen on an invalid dummy monitor handle
-                if monitor.id == 0 {
+                if monitor.is_dummy() {
                     return None;
                 }
 


### PR DESCRIPTION
Closes #1302

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
