### PR TITLE
X11: Fix CursorEntered event for non-winit window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On X11, fix `CursorEntered` event being generated for non-winit windows.
+
 # # 0.20.0 Alpha 5 (2019-12-09)
 
 - On macOS, fix application termination on `ControlFlow::Exit`

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -834,14 +834,15 @@ impl<T: 'static> EventProcessor<T> {
                                 }
                             }
                         }
-                        callback(Event::WindowEvent {
-                            window_id,
-                            event: CursorEntered { device_id },
-                        });
 
                         if let Some(dpi_factor) =
                             self.with_window(xev.event, |window| window.hidpi_factor())
                         {
+                            callback(Event::WindowEvent {
+                                window_id,
+                                event: CursorEntered { device_id },
+                            });
+
                             let position = LogicalPosition::from_physical(
                                 (xev.event_x as f64, xev.event_y as f64),
                                 dpi_factor,


### PR DESCRIPTION
Closes #1319

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
