### PR TITLE
Fix run_return in MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On macOS, fix application not to terminate on `run_return`.
+
 # # 0.20.0 Alpha 5 (2019-12-09)
 
 - On macOS, fix application termination on `ControlFlow::Exit`
@@ -17,7 +19,6 @@
 - On X11, generate synthetic key events for keys held when a window gains or loses focus.
 - On X11, issue a `CursorMoved` event when a `Touch` event occurs,
   as X11 implicitly moves the cursor for such events.
-- On macOS, fix application not to terminate on `run_return`
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - On X11, generate synthetic key events for keys held when a window gains or loses focus.
 - On X11, issue a `CursorMoved` event when a `Touch` event occurs,
   as X11 implicitly moves the cursor for such events.
+- On macOS, fix application not to terminate on `run_return`
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -279,10 +279,11 @@ impl AppState {
             unsafe {
                 let _: () = msg_send![NSApp(), stop: nil];
 
-                let main_window: *const Object = msg_send![NSApp(), mainWindow];
-                assert_ne!(main_window, nil);
+                let windows: *const Object = msg_send![NSApp(), windows];
+                let window: *const Object = msg_send![windows, objectAtIndex:0];
+                assert_ne!(window, nil);
 
-                let title: *const Object = msg_send![main_window, title];
+                let title: *const Object = msg_send![window, title];
                 assert_ne!(title, nil);
                 let postfix = NSString::alloc(nil).init_str("*");
                 let some_unique_title: *const Object =
@@ -290,9 +291,9 @@ impl AppState {
                 assert_ne!(some_unique_title, nil);
 
                 // To stop event loop immediately, we need to send some UI event here.
-                let _: () = msg_send![main_window, setTitle: some_unique_title];
+                let _: () = msg_send![window, setTitle: some_unique_title];
                 // And restore it.
-                let _: () = msg_send![main_window, setTitle: title];
+                let _: () = msg_send![window, setTitle: title];
             };
         }
         HANDLER.update_start_time();


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR fixes #1242 while keeping #1117 fixed.

According to https://stackoverflow.com/questions/48041279/stopping-the-nsapplication-main-event-loop a UI event must be happening to stop event loop actually.

So  I chose to modify the main window's title to activate `stop`.