### PR TITLE
On Wayland, fix cursor icon updates on window borders when using CSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On Wayland, fix cursor icon updates on window borders when using CSD.
+
 # # 0.20.0 Alpha 5 (2019-12-09)
 
 - On macOS, fix application termination on `ControlFlow::Exit`
@@ -17,7 +19,6 @@
 - On X11, generate synthetic key events for keys held when a window gains or loses focus.
 - On X11, issue a `CursorMoved` event when a `Touch` event occurs,
   as X11 implicitly moves the cursor for such events.
-- On Wayland, fix cursor icon updates on window borders when using CSD.
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - On X11, generate synthetic key events for keys held when a window gains or loses focus.
 - On X11, issue a `CursorMoved` event when a `Touch` event occurs,
   as X11 implicitly moves the cursor for such events.
+- On Wayland, fix cursor icon updates on window borders when using CSD.
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/src/platform_impl/linux/wayland/pointer.rs
+++ b/src/platform_impl/linux/wayland/pointer.rs
@@ -56,6 +56,13 @@ pub fn implement_pointer<T: 'static>(
                         let wid = store.find_wid(&surface);
                         if let Some(wid) = wid {
                             mouse_focus = Some(wid);
+
+                            // Reload cursor style only when we enter winit's surface. Calling
+                            // this function every time on `PtrEvent::Enter` could interfere with
+                            // SCTK CSD handling, since it changes cursor icons when you hover
+                            // cursor over the window borders.
+                            cursor_manager.reload_cursor_style();
+
                             sink.send_window_event(
                                 WindowEvent::CursorEntered {
                                     device_id: crate::event::DeviceId(
@@ -75,8 +82,6 @@ pub fn implement_pointer<T: 'static>(
                                 wid,
                             );
                         }
-
-                        cursor_manager.reload_cursor_style();
                     }
                     PtrEvent::Leave { surface, .. } => {
                         mouse_focus = None;


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch

fixes #1236 