### PR TITLE
FIX Crash on macOS when starting maximized without decorations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- on macOS, fix crash when starting maximized without decorations
+
 # # 0.20.0 Alpha 5 (2019-12-09)
 
 - On macOS, fix application termination on `ControlFlow::Exit`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- on macOS, fix crash when starting maximized without decorations
+- On macOS, fix crash when starting maximized without decorations.
 - On Wayland, fix cursor icon updates on window borders when using CSD.
 
 # # 0.20.0 Alpha 5 (2019-12-09)

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -60,11 +60,15 @@ pub unsafe fn set_style_mask_async(ns_window: id, ns_view: id, mask: NSWindowSty
 }
 pub unsafe fn set_style_mask_sync(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
     let context = SetStyleMaskData::new_ptr(ns_window, ns_view, mask);
-    dispatch_sync_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        set_style_mask_callback,
-    );
+    if msg_send![class!(NSThread), isMainThread] {
+        set_style_mask_callback(context as *mut _);
+    } else {
+        dispatch_sync_f(
+            dispatch_get_main_queue(),
+            context as *mut _,
+            set_style_mask_callback,
+        );
+    }
 }
 
 struct SetContentSizeData {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR fixes #1288 
It was crashed in `set_style_mask_sync`.
As far as I investigated, `dispatch_sync_f` must not be called in the main thread, so I added `if` clause to detect the main thread and call callback directly then.