### PR TITLE
On Wayland, under mutter(GNOME Wayland), fix CSD being behind the status bar, when starting window in maximized mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On Wayland, fix cursor icon updates on window borders when using CSD.
+- On Wayland, under mutter(GNOME Wayland), fix CSD being behind the status bar, when starting window in maximized mode.
 
 # # 0.20.0 Alpha 5 (2019-12-09)
 


### PR DESCRIPTION
GNOME places maximized window CSD behind the status bar, and in the same time it moves any window crossing the "bounding box"(screen edges + status bar's bottom edge on top) into it on the next resize. So the main problem is GNOME placing window in a wrong place initially.

That gif shows the behavior I'm talking about. You don't need maximize to repro it.

![jump](https://user-images.githubusercontent.com/27620401/71134761-8c7c5100-2210-11ea-9afa-90d1ba31cb5d.gif)

The question why mutter places our window in a wrong place initially is still flying in the air...

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

cc @Will-W

Fixes #1312