### PR TITLE
Reimplement NativeDisplayMode on iOS for #1310

### DIFF
--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -38,7 +38,7 @@ impl Drop for NativeDisplayMode {
 impl Clone for NativeDisplayMode {
     fn clone(&self) -> Self {
         unsafe {
-            let () = msg_send![self.0, retain];
+            let _: id = msg_send![self.0, retain];
         }
         NativeDisplayMode(self.0)
     }

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -497,7 +497,7 @@ pub unsafe fn create_window(
     match window_attributes.fullscreen {
         Some(Fullscreen::Exclusive(ref video_mode)) => {
             let uiscreen = video_mode.monitor().ui_screen() as id;
-            let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode];
+            let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode.0];
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
         Some(Fullscreen::Borderless(ref monitor)) => {


### PR DESCRIPTION
Closes #1310.

I pretty much did exactly as https://github.com/rust-windowing/winit/issues/1310#issuecomment-561571449 said. I'm not big on the name NativeDisplayMode nor that it's nearly the exact same code from the macOS logic but I figure it's an okay first pass.
- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
