### PR TITLE
macOS: Don't change fullscreen state during fullscreen transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On macOS, fix error when `set_fullscreen` is called during fullscreen transition.
 - On X11, fix `CursorEntered` event being generated for non-winit windows.
 - On macOS, fix crash when starting maximized without decorations.
 - On macOS, fix application not to terminate on `run_return`.

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -196,6 +196,10 @@ lazy_static! {
             window_did_exit_fullscreen as extern "C" fn(&Object, Sel, id),
         );
         decl.add_method(
+            sel!(windowWillExitFullScreen:),
+            window_will_exit_fullscreen as extern "C" fn(&Object, Sel, id),
+        );
+        decl.add_method(
             sel!(windowDidFailToEnterFullScreen:),
             window_did_fail_to_enter_fullscreen as extern "C" fn(&Object, Sel, id),
         );
@@ -424,6 +428,12 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
         })
     });
     trace!("Completed `windowWillEnterFullscreen:`");
+}
+
+/// Invoked when before exit fullscreen
+extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
+    trace!("Triggered `windowWillExitFullScreen:`");
+    trace!("Completed `windowWillExitFullScreen:`");
 }
 
 extern "C" fn window_will_use_fullscreen_presentation_options(


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR fixes #1269 
On macOS, we must not change fullscreen state during fullscreen transition animation.
This PR saves target fullscreen state if `set_fullscreen` is called during fullscreen transition and call `set_fullscreen` again after fullscreen transition has end.