### PR TITLE
Rename hidpi_factor to scale_factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On macOS, fix application termination on `ControlFlow::Exit`
+- Rename `hidpi_factor` to `scale_factor`
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - On macOS, fix application termination on `ControlFlow::Exit`
 - Rename `hidpi_factor` to `scale_factor`
+- On X11, deprecate `WINIT_HIDPI_FACTOR` environment variable in favor of `WINIT_X11_SCALE_FACTOR`
 
 # 0.20.0 Alpha 4 (2019-10-18)
 

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -19,62 +19,62 @@
 //!
 //! That's a description of what happens when the button is 100x100 *physical* pixels. Instead, let's try using 100x100
 //! *logical* pixels. To map logical pixels to physical pixels, we simply multiply by the DPI (dots per inch) factor.
-//! On a "typical" desktop display, the DPI factor will be 1.0, so 100x100 logical pixels equates to 100x100 physical
-//! pixels. However, a 1440p display may have a DPI factor of 1.25, so the button is rendered as 125x125 physical pixels.
+//! On a "typical" desktop display, the scale factor will be 1.0, so 100x100 logical pixels equates to 100x100 physical
+//! pixels. However, a 1440p display may have a scale factor of 1.25, so the button is rendered as 125x125 physical pixels.
 //! Ideally, the button now has approximately the same perceived size across varying displays.
 //!
-//! Failure to account for the DPI factor can create a badly degraded user experience. Most notably, it can make users
+//! Failure to account for the scale factor can create a badly degraded user experience. Most notably, it can make users
 //! feel like they have bad eyesight, which will potentially cause them to think about growing elderly, resulting in
 //! them entering an existential panic. Once users enter that state, they will no longer be focused on your application.
 //!
-//! There are two ways to get the DPI factor:
-//! - You can track the [`HiDpiFactorChanged`](../enum.WindowEvent.html#variant.HiDpiFactorChanged) event of your
-//!   windows. This event is sent any time the DPI factor changes, either because the window moved to another monitor,
+//! There are two ways to get the scale factor:
+//! - You can track the [`DpiChanged`](../enum.WindowEvent.html#variant.DpiChanged) event of your
+//!   windows. This event is sent any time the scale factor changes, either because the window moved to another monitor,
 //!   or because the user changed the configuration of their screen.
-//! - You can also retrieve the DPI factor of a monitor by calling
+//! - You can also retrieve the scale factor of a monitor by calling
 //!   [`MonitorHandle::scale_factor`](../monitor/struct.MonitorHandle.html#method.scale_factor), or the
-//!   current DPI factor applied to a window by calling
+//!   current scale factor applied to a window by calling
 //!   [`Window::scale_factor`](../window/struct.Window.html#method.scale_factor), which is roughly equivalent
 //!   to `window.current_monitor().scale_factor()`.
 //!
-//! Depending on the platform, the window's actual DPI factor may only be known after
+//! Depending on the platform, the window's actual scale factor may only be known after
 //! the event loop has started and your window has been drawn once. To properly handle these cases,
-//! the most robust way is to monitor the [`HiDpiFactorChanged`](../enum.WindowEvent.html#variant.HiDpiFactorChanged)
-//! event and dynamically adapt your drawing logic to follow the DPI factor.
+//! the most robust way is to monitor the [`DpiChanged`](../enum.WindowEvent.html#variant.DpiChanged)
+//! event and dynamically adapt your drawing logic to follow the scale factor.
 //!
-//! Here's an overview of what sort of DPI factors you can expect, and where they come from:
+//! Here's an overview of what sort of scale factors you can expect, and where they come from:
 //! - **Windows:** On Windows 8 and 10, per-monitor scaling is readily configured by users from the display settings.
-//! While users are free to select any option they want, they're only given a selection of "nice" DPI factors, i.e.
-//! 1.0, 1.25, 1.5... on Windows 7, the DPI factor is global and changing it requires logging out.
-//! - **macOS:** The buzzword is "retina displays", which have a DPI factor of 2.0. Otherwise, the DPI factor is 1.0.
-//! Intermediate DPI factors are never used, thus 1440p displays/etc. aren't properly supported. It's possible for any
-//! display to use that 2.0 DPI factor, given the use of the command line.
-//! - **X11:** On X11, we calcuate the DPI factor based on the millimeter dimensions provided by XRandR. This can
+//! While users are free to select any option they want, they're only given a selection of "nice" scale factors, i.e.
+//! 1.0, 1.25, 1.5... on Windows 7, the scale factor is global and changing it requires logging out.
+//! - **macOS:** The buzzword is "retina displays", which have a scale factor of 2.0. Otherwise, the scale factor is 1.0.
+//! Intermediate scale factors are never used, thus 1440p displays/etc. aren't properly supported. It's possible for any
+//! display to use that 2.0 scale factor, given the use of the command line.
+//! - **X11:** On X11, we calcuate the scale factor based on the millimeter dimensions provided by XRandR. This can
 //! result in a wide range of possible values, including some interesting ones like 1.0833333333333333. This can be
 //! overridden using the `WINIT_X11_SCALE_FACTOR` environment variable, though that's not recommended.
-//! - **Wayland:** On Wayland, DPI factors are set per-screen by the server, and are always integers (most often 1 or 2).
-//! - **iOS:** DPI factors are both constant and device-specific on iOS.
-//! - **Android:** This feature isn't yet implemented on Android, so the DPI factor will always be returned as 1.0.
-//! - **Web:** DPI factors are handled by the browser and will always be 1.0 for your application.
+//! - **Wayland:** On Wayland, scale factors are set per-screen by the server, and are always integers (most often 1 or 2).
+//! - **iOS:** scale factors are both constant and device-specific on iOS.
+//! - **Android:** This feature isn't yet implemented on Android, so the scale factor will always be returned as 1.0.
+//! - **Web:** scale factors are handled by the browser and will always be 1.0 for your application.
 //!
 //! The window's logical size is conserved across DPI changes, resulting in the physical size changing instead. This
 //! may be surprising on X11, but is quite standard elsewhere. Physical size changes always produce a
 //! [`Resized`](../event/enum.WindowEvent.html#variant.Resized) event, even on platforms where no resize actually occurs,
 //! such as macOS and Wayland. As a result, it's not necessary to separately handle
-//! [`HiDpiFactorChanged`](../event/enum.WindowEvent.html#variant.HiDpiFactorChanged) if you're only listening for size.
+//! [`DpiChanged`](../event/enum.WindowEvent.html#variant.DpiChanged) if you're only listening for size.
 //!
 //! Your GPU has no awareness of the concept of logical pixels, and unless you like wasting pixel density, your
 //! framebuffer's size should be in physical pixels.
 //!
 //! `winit` will send [`Resized`](../enum.WindowEvent.html#variant.Resized) events whenever a window's logical size
-//! changes, and [`HiDpiFactorChanged`](../enum.WindowEvent.html#variant.HiDpiFactorChanged) events
-//! whenever the DPI factor changes. Receiving either of these events means that the physical size of your window has
+//! changes, and [`DpiChanged`](../enum.WindowEvent.html#variant.DpiChanged) events
+//! whenever the scale factor changes. Receiving either of these events means that the physical size of your window has
 //! changed, and you should recompute it using the latest values you received for each. If the logical size and the
-//! DPI factor change simultaneously, `winit` will send both events together; thus, it's recommended to buffer
+//! scale factor change simultaneously, `winit` will send both events together; thus, it's recommended to buffer
 //! these events and process them at the end of the queue.
 //!
-//! If you never received any [`HiDpiFactorChanged`](../enum.WindowEvent.html#variant.HiDpiFactorChanged) events,
-//! then your window's DPI factor is 1.
+//! If you never received any [`DpiChanged`](../enum.WindowEvent.html#variant.DpiChanged) events,
+//! then your window's scale factor is 1.
 
 pub trait Pixel: Copy + Into<f64> {
     fn from_f64(f: f64) -> Self;
@@ -124,9 +124,9 @@ impl Pixel for f64 {
     }
 }
 
-/// Checks that the DPI factor is a normal positive `f64`.
+/// Checks that the scale factor is a normal positive `f64`.
 ///
-/// All functions that take a DPI factor assert that this will return `true`. If you're sourcing DPI factors from
+/// All functions that take a scale factor assert that this will return `true`. If you're sourcing scale factors from
 /// anywhere other than winit, it's recommended to validate them using this function before passing them to winit;
 /// otherwise, you risk panics.
 #[inline]

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -32,10 +32,10 @@
 //!   windows. This event is sent any time the DPI factor changes, either because the window moved to another monitor,
 //!   or because the user changed the configuration of their screen.
 //! - You can also retrieve the DPI factor of a monitor by calling
-//!   [`MonitorHandle::hidpi_factor`](../monitor/struct.MonitorHandle.html#method.hidpi_factor), or the
+//!   [`MonitorHandle::scale_factor`](../monitor/struct.MonitorHandle.html#method.scale_factor), or the
 //!   current DPI factor applied to a window by calling
-//!   [`Window::hidpi_factor`](../window/struct.Window.html#method.hidpi_factor), which is roughly equivalent
-//!   to `window.current_monitor().hidpi_factor()`.
+//!   [`Window::scale_factor`](../window/struct.Window.html#method.scale_factor), which is roughly equivalent
+//!   to `window.current_monitor().scale_factor()`.
 //!
 //! Depending on the platform, the window's actual DPI factor may only be known after
 //! the event loop has started and your window has been drawn once. To properly handle these cases,
@@ -130,7 +130,7 @@ impl Pixel for f64 {
 /// anywhere other than winit, it's recommended to validate them using this function before passing them to winit;
 /// otherwise, you risk panics.
 #[inline]
-pub fn validate_hidpi_factor(dpi_factor: f64) -> bool {
+pub fn validate_scale_factor(dpi_factor: f64) -> bool {
     dpi_factor.is_sign_positive() && dpi_factor.is_normal()
 }
 
@@ -164,7 +164,7 @@ impl<P: Pixel> LogicalPosition<P> {
 
     #[inline]
     pub fn to_physical<X: Pixel>(&self, dpi_factor: f64) -> PhysicalPosition<X> {
-        assert!(validate_hidpi_factor(dpi_factor));
+        assert!(validate_scale_factor(dpi_factor));
         let x = self.x.into() * dpi_factor;
         let y = self.y.into() * dpi_factor;
         PhysicalPosition::new(x, y).cast()
@@ -233,7 +233,7 @@ impl<P: Pixel> PhysicalPosition<P> {
 
     #[inline]
     pub fn to_logical<X: Pixel>(&self, dpi_factor: f64) -> LogicalPosition<X> {
-        assert!(validate_hidpi_factor(dpi_factor));
+        assert!(validate_scale_factor(dpi_factor));
         let x = self.x.into() / dpi_factor;
         let y = self.y.into() / dpi_factor;
         LogicalPosition::new(x, y).cast()
@@ -299,7 +299,7 @@ impl<P: Pixel> LogicalSize<P> {
 
     #[inline]
     pub fn to_physical<X: Pixel>(&self, dpi_factor: f64) -> PhysicalSize<X> {
-        assert!(validate_hidpi_factor(dpi_factor));
+        assert!(validate_scale_factor(dpi_factor));
         let width = self.width.into() * dpi_factor;
         let height = self.height.into() * dpi_factor;
         PhysicalSize::new(width, height).cast()
@@ -361,7 +361,7 @@ impl<P: Pixel> PhysicalSize<P> {
 
     #[inline]
     pub fn to_logical<X: Pixel>(&self, dpi_factor: f64) -> LogicalSize<X> {
-        assert!(validate_hidpi_factor(dpi_factor));
+        assert!(validate_scale_factor(dpi_factor));
         let width = self.width.into() / dpi_factor;
         let height = self.height.into() / dpi_factor;
         LogicalSize::new(width, height).cast()

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -51,7 +51,7 @@
 //! display to use that 2.0 DPI factor, given the use of the command line.
 //! - **X11:** On X11, we calcuate the DPI factor based on the millimeter dimensions provided by XRandR. This can
 //! result in a wide range of possible values, including some interesting ones like 1.0833333333333333. This can be
-//! overridden using the `WINIT_HIDPI_FACTOR` environment variable, though that's not recommended.
+//! overridden using the `WINIT_X11_SCALE_FACTOR` environment variable, though that's not recommended.
 //! - **Wayland:** On Wayland, DPI factors are set per-screen by the server, and are always integers (most often 1 or 2).
 //! - **iOS:** DPI factors are both constant and device-specific on iOS.
 //! - **Android:** This feature isn't yet implemented on Android, so the DPI factor will always be returned as 1.0.

--- a/src/event.rs
+++ b/src/event.rs
@@ -213,13 +213,13 @@ pub enum WindowEvent<'a> {
     /// Touch event has been received
     Touch(Touch),
 
-    /// The DPI factor of the window has changed.
+    /// The window's scale factor has changed.
     ///
     /// The following user actions can cause DPI changes:
     ///
     /// * Changing the display's resolution.
-    /// * Changing the display's DPI factor (e.g. in Control Panel on Windows).
-    /// * Moving the window to a display with a different DPI factor.
+    /// * Changing the display's scale factor (e.g. in Control Panel on Windows).
+    /// * Moving the window to a display with a different scale factor.
     ///
     /// After this event callback has been processed, the window will be resized to whatever value
     /// is pointed to by the `new_inner_size` reference. By default, this will contain the size suggested
@@ -227,7 +227,7 @@ pub enum WindowEvent<'a> {
     /// will occur.
     ///
     /// For more information about DPI in general, see the [`dpi`](dpi/index.html) module.
-    HiDpiFactorChanged {
+    DpiChanged {
         scale_factor: f64,
         new_inner_size: &'a mut Option<PhysicalSize<u32>>,
     },
@@ -301,7 +301,7 @@ impl<'a> WindowEvent<'a> {
             }),
             RedrawRequested => Some(RedrawRequested),
             Touch(touch) => Some(Touch(touch)),
-            HiDpiFactorChanged { .. } => None,
+            DpiChanged { .. } => None,
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -228,7 +228,7 @@ pub enum WindowEvent<'a> {
     ///
     /// For more information about DPI in general, see the [`dpi`](dpi/index.html) module.
     HiDpiFactorChanged {
-        hidpi_factor: f64,
+        scale_factor: f64,
         new_inner_size: &'a mut Option<PhysicalSize<u32>>,
     },
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -158,8 +158,8 @@ impl MonitorHandle {
     /// - **Android:** Always returns 1.0.
     /// - **Web:** Always returns 1.0
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
-        self.inner.hidpi_factor()
+    pub fn scale_factor(&self) -> f64 {
+        self.inner.scale_factor()
     }
 
     /// Returns all fullscreen video modes supported by this monitor.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -148,7 +148,7 @@ impl MonitorHandle {
         self.inner.position()
     }
 
-    /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
+    /// Returns the scale factor that can be used to map logical pixels to physical pixels, and vice versa.
     ///
     /// See the [`dpi`](../dpi/index.html) module for more information.
     ///

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -154,7 +154,7 @@ impl MonitorHandle {
     ///
     /// ## Platform-specific
     ///
-    /// - **X11:** Can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
+    /// - **X11:** Can be overridden using the `WINIT_X11_SCALE_FACTOR` environment variable.
     /// - **Android:** Always returns 1.0.
     /// - **Web:** Always returns 1.0
     #[inline]

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -43,14 +43,14 @@ pub trait WindowExtIOS {
     /// [`UIView`]: https://developer.apple.com/documentation/uikit/uiview?language=objc
     fn ui_view(&self) -> *mut c_void;
 
-    /// Sets the [`contentScaleFactor`] of the underlying [`UIWindow`] to `hidpi_factor`.
+    /// Sets the [`contentScaleFactor`] of the underlying [`UIWindow`] to `scale_factor`.
     ///
     /// The default value is device dependent, and it's recommended GLES or Metal applications set
-    /// this to [`MonitorHandle::hidpi_factor()`].
+    /// this to [`MonitorHandle::scale_factor()`].
     ///
     /// [`UIWindow`]: https://developer.apple.com/documentation/uikit/uiwindow?language=objc
     /// [`contentScaleFactor`]: https://developer.apple.com/documentation/uikit/uiview/1622657-contentscalefactor?language=objc
-    fn set_hidpi_factor(&self, hidpi_factor: f64);
+    fn set_scale_factor(&self, scale_factor: f64);
 
     /// Sets the valid orientations for the [`Window`].
     ///
@@ -113,8 +113,8 @@ impl WindowExtIOS for Window {
     }
 
     #[inline]
-    fn set_hidpi_factor(&self, hidpi_factor: f64) {
-        self.window.set_hidpi_factor(hidpi_factor)
+    fn set_scale_factor(&self, scale_factor: f64) {
+        self.window.set_scale_factor(scale_factor)
     }
 
     #[inline]
@@ -148,14 +148,14 @@ pub trait WindowBuilderExtIOS {
     /// [`UIView`]: https://developer.apple.com/documentation/uikit/uiview?language=objc
     fn with_root_view_class(self, root_view_class: *const c_void) -> WindowBuilder;
 
-    /// Sets the [`contentScaleFactor`] of the underlying [`UIWindow`] to `hidpi_factor`.
+    /// Sets the [`contentScaleFactor`] of the underlying [`UIWindow`] to `scale_factor`.
     ///
     /// The default value is device dependent, and it's recommended GLES or Metal applications set
-    /// this to [`MonitorHandle::hidpi_factor()`].
+    /// this to [`MonitorHandle::scale_factor()`].
     ///
     /// [`UIWindow`]: https://developer.apple.com/documentation/uikit/uiwindow?language=objc
     /// [`contentScaleFactor`]: https://developer.apple.com/documentation/uikit/uiview/1622657-contentscalefactor?language=objc
-    fn with_hidpi_factor(self, hidpi_factor: f64) -> WindowBuilder;
+    fn with_scale_factor(self, scale_factor: f64) -> WindowBuilder;
 
     /// Sets the valid orientations for the [`Window`].
     ///
@@ -204,8 +204,8 @@ impl WindowBuilderExtIOS for WindowBuilder {
     }
 
     #[inline]
-    fn with_hidpi_factor(mut self, hidpi_factor: f64) -> WindowBuilder {
-        self.platform_specific.hidpi_factor = Some(hidpi_factor);
+    fn with_scale_factor(mut self, scale_factor: f64) -> WindowBuilder {
+        self.platform_specific.scale_factor = Some(scale_factor);
         self
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -61,7 +61,7 @@ impl EventLoop {
         while let Ok(event) = self.event_rx.try_recv() {
             let e = match event {
                 android_glue::Event::EventMotion(motion) => {
-                    let dpi_factor = MonitorHandle.hidpi_factor();
+                    let dpi_factor = MonitorHandle.scale_factor();
                     let location = LogicalPosition::from_physical(
                         (motion.x as f64, motion.y as f64),
                         dpi_factor,
@@ -102,7 +102,7 @@ impl EventLoop {
                     if native_window.is_null() {
                         None
                     } else {
-                        let dpi_factor = MonitorHandle.hidpi_factor();
+                        let dpi_factor = MonitorHandle.scale_factor();
                         let physical_size = MonitorHandle.size();
                         let size = LogicalSize::from_physical(physical_size, dpi_factor);
                         Some(Event::WindowEvent {
@@ -195,14 +195,14 @@ impl fmt::Debug for MonitorHandle {
             name: Option<String>,
             dimensions: PhysicalSize<u32>,
             position: PhysicalPosition<i32>,
-            hidpi_factor: f64,
+            scale_factor: f64,
         }
 
         let monitor_id_proxy = MonitorHandle {
             name: self.name(),
             dimensions: self.size(),
             position: self.outer_position(),
-            hidpi_factor: self.hidpi_factor(),
+            scale_factor: self.scale_factor(),
         };
 
         monitor_id_proxy.fmt(f)
@@ -234,7 +234,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         1.0
     }
 }
@@ -319,7 +319,7 @@ impl Window {
         if self.native_window.is_null() {
             None
         } else {
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             let physical_size = self.current_monitor().size();
             Some(LogicalSize::from_physical(physical_size, dpi_factor))
         }
@@ -336,8 +336,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
-        self.current_monitor().hidpi_factor()
+    pub fn scale_factor(&self) -> f64 {
+        self.current_monitor().scale_factor()
     }
 
     #[inline]

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -842,7 +842,7 @@ fn handle_event_proxy(
     proxy: EventProxy,
 ) {
     match proxy {
-        EventProxy::HiDpiFactorChangedProxy {
+        EventProxy::DpiChangedProxy {
             suggested_size,
             scale_factor,
             window_id,
@@ -867,7 +867,7 @@ fn handle_hidpi_proxy(
     let new_inner_size = &mut Some(size);
     let event = Event::WindowEvent {
         window_id: RootWindowId(window_id.into()),
-        event: WindowEvent::HiDpiFactorChanged {
+        event: WindowEvent::DpiChanged {
             scale_factor,
             new_inner_size,
         },

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -863,7 +863,7 @@ fn handle_hidpi_proxy(
     scale_factor: f64,
     window_id: id,
 ) {
-    let mut size = suggested_size.to_physical(hidpi_factor);
+    let mut size = suggested_size.to_physical(scale_factor);
     let new_inner_size = &mut size;
     let event = Event::WindowEvent {
         window_id: RootWindowId(window_id.into()),
@@ -875,7 +875,7 @@ fn handle_hidpi_proxy(
     event_handler.handle_nonuser_event(event, &mut control_flow);
     let (view, screen_frame) = get_view_and_screen_frame(window_id);
     let physical_size = *new_inner_size;
-    let logical_size = physical_size.to_logical(hidpi_factor);
+    let logical_size = physical_size.to_logical(scale_factor);
     let size = CGSize::new(logical_size);
     let new_frame: CGRect = CGRect::new(screen_frame.origin, size);
     unsafe {

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -844,13 +844,13 @@ fn handle_event_proxy(
     match proxy {
         EventProxy::HiDpiFactorChangedProxy {
             suggested_size,
-            hidpi_factor,
+            scale_factor,
             window_id,
         } => handle_hidpi_proxy(
             event_handler,
             control_flow,
             suggested_size,
-            hidpi_factor,
+            scale_factor,
             window_id,
         ),
     }
@@ -860,22 +860,22 @@ fn handle_hidpi_proxy(
     event_handler: &mut Box<dyn EventHandler>,
     mut control_flow: ControlFlow,
     suggested_size: LogicalSize<f64>,
-    hidpi_factor: f64,
+    scale_factor: f64,
     window_id: id,
 ) {
-    let size = suggested_size.to_physical(hidpi_factor);
+    let size = suggested_size.to_physical(scale_factor);
     let new_inner_size = &mut Some(size);
     let event = Event::WindowEvent {
         window_id: RootWindowId(window_id.into()),
         event: WindowEvent::HiDpiFactorChanged {
-            hidpi_factor,
+            scale_factor,
             new_inner_size,
         },
     };
     event_handler.handle_nonuser_event(event, &mut control_flow);
     let (view, screen_frame) = get_view_and_screen_frame(window_id);
     if let Some(physical_size) = new_inner_size {
-        let logical_size = physical_size.to_logical(hidpi_factor);
+        let logical_size = physical_size.to_logical(scale_factor);
         let size = CGSize::new(logical_size);
         let new_frame: CGRect = CGRect::new(screen_frame.origin, size);
         unsafe {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -37,7 +37,7 @@ pub enum EventWrapper {
 
 #[derive(Debug, PartialEq)]
 pub enum EventProxy {
-    HiDpiFactorChangedProxy {
+    DpiChangedProxy {
         window_id: id,
         suggested_size: LogicalSize<f64>,
         scale_factor: f64,

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -40,7 +40,7 @@ pub enum EventProxy {
     HiDpiFactorChangedProxy {
         window_id: id,
         suggested_size: LogicalSize<f64>,
-        hidpi_factor: f64,
+        scale_factor: f64,
     },
 }
 

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -158,14 +158,14 @@ impl fmt::Debug for MonitorHandle {
             name: Option<String>,
             size: PhysicalSize<u32>,
             position: PhysicalPosition<i32>,
-            hidpi_factor: f64,
+            scale_factor: f64,
         }
 
         let monitor_id_proxy = MonitorHandle {
             name: self.name(),
             size: self.size(),
             position: self.position(),
-            hidpi_factor: self.hidpi_factor(),
+            scale_factor: self.scale_factor(),
         };
 
         monitor_id_proxy.fmt(f)
@@ -215,7 +215,7 @@ impl Inner {
         }
     }
 
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         unsafe {
             let scale: CGFloat = msg_send![self.ui_screen(), nativeScale];
             scale as f64

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -177,13 +177,11 @@ unsafe fn get_view_class(root_view_class: &'static Class) -> &'static Class {
                     height: screen_frame.size.height as _,
                 };
                 app_state::handle_nonuser_events(
-                    std::iter::once(EventWrapper::EventProxy(
-                        EventProxy::DpiChangedProxy {
-                            window_id: window,
-                            scale_factor,
-                            suggested_size: size,
-                        },
-                    ))
+                    std::iter::once(EventWrapper::EventProxy(EventProxy::DpiChangedProxy {
+                        window_id: window,
+                        scale_factor,
+                        suggested_size: size,
+                    }))
                     .chain(std::iter::once(EventWrapper::StaticEvent(
                         Event::WindowEvent {
                             window_id: RootWindowId(window.into()),

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -178,7 +178,7 @@ unsafe fn get_view_class(root_view_class: &'static Class) -> &'static Class {
                 };
                 app_state::handle_nonuser_events(
                     std::iter::once(EventWrapper::EventProxy(
-                        EventProxy::HiDpiFactorChangedProxy {
+                        EventProxy::DpiChangedProxy {
                             window_id: window,
                             scale_factor,
                             suggested_size: size,

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -139,13 +139,13 @@ unsafe fn get_view_class(root_view_class: &'static Class) -> &'static Class {
         extern "C" fn set_content_scale_factor(
             object: &mut Object,
             _: Sel,
-            untrusted_hidpi_factor: CGFloat,
+            untrusted_scale_factor: CGFloat,
         ) {
             unsafe {
                 let superclass: &'static Class = msg_send![object, superclass];
                 let () = msg_send![
                     super(object, superclass),
-                    setContentScaleFactor: untrusted_hidpi_factor
+                    setContentScaleFactor: untrusted_scale_factor
                 ];
 
                 let window: id = msg_send![object, window];
@@ -164,9 +164,9 @@ unsafe fn get_view_class(root_view_class: &'static Class) -> &'static Class {
                         && dpi_factor.is_finite()
                         && dpi_factor.is_sign_positive()
                         && dpi_factor > 0.0,
-                    "invalid hidpi_factor set on UIView",
+                    "invalid scale_factor set on UIView",
                 );
-                let hidpi_factor: f64 = dpi_factor.into();
+                let scale_factor: f64 = dpi_factor.into();
                 let bounds: CGRect = msg_send![object, bounds];
                 let screen: id = msg_send![window, screen];
                 let screen_space: id = msg_send![screen, coordinateSpace];
@@ -180,14 +180,14 @@ unsafe fn get_view_class(root_view_class: &'static Class) -> &'static Class {
                     std::iter::once(EventWrapper::EventProxy(
                         EventProxy::HiDpiFactorChangedProxy {
                             window_id: window,
-                            hidpi_factor,
+                            scale_factor,
                             suggested_size: size,
                         },
                     ))
                     .chain(std::iter::once(EventWrapper::StaticEvent(
                         Event::WindowEvent {
                             window_id: RootWindowId(window.into()),
-                            event: WindowEvent::Resized(size.to_physical(hidpi_factor)),
+                            event: WindowEvent::Resized(size.to_physical(scale_factor)),
                         },
                     ))),
                 );
@@ -422,8 +422,8 @@ pub unsafe fn create_view(
     let view: id = msg_send![view, initWithFrame: frame];
     assert!(!view.is_null(), "Failed to initialize `UIView` instance");
     let () = msg_send![view, setMultipleTouchEnabled: YES];
-    if let Some(hidpi_factor) = platform_attributes.hidpi_factor {
-        let () = msg_send![view, setContentScaleFactor: hidpi_factor as CGFloat];
+    if let Some(scale_factor) = platform_attributes.scale_factor {
+        let () = msg_send![view, setContentScaleFactor: scale_factor as CGFloat];
     }
 
     view

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -409,13 +409,11 @@ impl Window {
                     height: screen_frame.size.height as _,
                 };
                 app_state::handle_nonuser_events(
-                    std::iter::once(EventWrapper::EventProxy(
-                        EventProxy::DpiChangedProxy {
-                            window_id: window,
-                            scale_factor,
-                            suggested_size: size,
-                        },
-                    ))
+                    std::iter::once(EventWrapper::EventProxy(EventProxy::DpiChangedProxy {
+                        window_id: window,
+                        scale_factor,
+                        suggested_size: size,
+                    }))
                     .chain(std::iter::once(EventWrapper::StaticEvent(
                         Event::WindowEvent {
                             window_id: RootWindowId(window.into()),

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -83,7 +83,7 @@ impl Inner {
                 x: safe_area.origin.x as f64,
                 y: safe_area.origin.y as f64,
             };
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             Ok(position.to_physical(dpi_factor))
         }
     }
@@ -95,14 +95,14 @@ impl Inner {
                 x: screen_frame.origin.x as f64,
                 y: screen_frame.origin.y as f64,
             };
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             Ok(position.to_physical(dpi_factor))
         }
     }
 
     pub fn set_outer_position(&self, physical_position: Position) {
         unsafe {
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             let position = physical_position.to_logical::<f64>(dpi_factor);
             let screen_frame = self.screen_frame();
             let new_screen_frame = CGRect {
@@ -119,7 +119,7 @@ impl Inner {
 
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         unsafe {
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             let safe_area = self.safe_area_screen_space();
             let size = LogicalSize {
                 width: safe_area.size.width as f64,
@@ -131,7 +131,7 @@ impl Inner {
 
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         unsafe {
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             let screen_frame = self.screen_frame();
             let size = LogicalSize {
                 width: screen_frame.size.width as f64,
@@ -157,7 +157,7 @@ impl Inner {
         warn!("`Window::set_resizable` is ignored on iOS")
     }
 
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         unsafe {
             let hidpi: CGFloat = msg_send![self.view, contentScaleFactor];
             hidpi as _
@@ -397,8 +397,8 @@ impl Window {
             // Like the Windows and macOS backends, we send a `HiDpiFactorChanged` and `Resized`
             // event on window creation if the DPI factor != 1.0
             let dpi_factor: CGFloat = msg_send![view, contentScaleFactor];
-            let hidpi_factor: f64 = dpi_factor.into();
-            if hidpi_factor != 1.0 {
+            let scale_factor: f64 = dpi_factor.into();
+            if scale_factor != 1.0 {
                 let bounds: CGRect = msg_send![view, bounds];
                 let screen: id = msg_send![window, screen];
                 let screen_space: id = msg_send![screen, coordinateSpace];
@@ -412,14 +412,14 @@ impl Window {
                     std::iter::once(EventWrapper::EventProxy(
                         EventProxy::HiDpiFactorChangedProxy {
                             window_id: window,
-                            hidpi_factor,
+                            scale_factor,
                             suggested_size: size,
                         },
                     ))
                     .chain(std::iter::once(EventWrapper::StaticEvent(
                         Event::WindowEvent {
                             window_id: RootWindowId(window.into()),
-                            event: WindowEvent::Resized(size.to_physical(hidpi_factor)),
+                            event: WindowEvent::Resized(size.to_physical(scale_factor)),
                         },
                     ))),
                 );
@@ -442,14 +442,14 @@ impl Inner {
         self.view
     }
 
-    pub fn set_hidpi_factor(&self, hidpi_factor: f64) {
+    pub fn set_scale_factor(&self, scale_factor: f64) {
         unsafe {
             assert!(
-                dpi::validate_hidpi_factor(hidpi_factor),
-                "`WindowExtIOS::set_hidpi_factor` received an invalid hidpi factor"
+                dpi::validate_scale_factor(scale_factor),
+                "`WindowExtIOS::set_scale_factor` received an invalid hidpi factor"
             );
-            let hidpi_factor = hidpi_factor as CGFloat;
-            let () = msg_send![self.view, setContentScaleFactor: hidpi_factor];
+            let scale_factor = scale_factor as CGFloat;
+            let () = msg_send![self.view, setContentScaleFactor: scale_factor];
         }
     }
 
@@ -615,7 +615,7 @@ impl From<id> for WindowId {
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub root_view_class: &'static Class,
-    pub hidpi_factor: Option<f64>,
+    pub scale_factor: Option<f64>,
     pub valid_orientations: ValidOrientations,
     pub prefers_home_indicator_hidden: bool,
     pub prefers_status_bar_hidden: bool,
@@ -626,7 +626,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
     fn default() -> PlatformSpecificWindowBuilderAttributes {
         PlatformSpecificWindowBuilderAttributes {
             root_view_class: class!(UIView),
-            hidpi_factor: None,
+            scale_factor: None,
             valid_orientations: Default::default(),
             prefers_home_indicator_hidden: false,
             prefers_status_bar_hidden: false,

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -394,7 +394,7 @@ impl Window {
             };
             app_state::set_key_window(window);
 
-            // Like the Windows and macOS backends, we send a `HiDpiFactorChanged` and `Resized`
+            // Like the Windows and macOS backends, we send a `DpiChanged` and `Resized`
             // event on window creation if the DPI factor != 1.0
             let dpi_factor: CGFloat = msg_send![view, contentScaleFactor];
             let scale_factor: f64 = dpi_factor.into();
@@ -410,7 +410,7 @@ impl Window {
                 };
                 app_state::handle_nonuser_events(
                     std::iter::once(EventWrapper::EventProxy(
-                        EventProxy::HiDpiFactorChangedProxy {
+                        EventProxy::DpiChangedProxy {
                             window_id: window,
                             scale_factor,
                             suggested_size: size,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -148,10 +148,10 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         match self {
-            &MonitorHandle::X(ref m) => m.hidpi_factor(),
-            &MonitorHandle::Wayland(ref m) => m.hidpi_factor() as f64,
+            &MonitorHandle::X(ref m) => m.scale_factor(),
+            &MonitorHandle::Wayland(ref m) => m.scale_factor() as f64,
         }
     }
 
@@ -342,10 +342,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         match self {
-            &Window::X(ref w) => w.hidpi_factor(),
-            &Window::Wayland(ref w) => w.hidpi_factor() as f64,
+            &Window::X(ref w) => w.scale_factor(),
+            &Window::Wayland(ref w) => w.scale_factor() as f64,
         }
     }
 

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -690,7 +690,7 @@ impl<T> EventLoop<T> {
 
                         callback(Event::WindowEvent {
                             window_id,
-                            event: WindowEvent::HiDpiFactorChanged {
+                            event: WindowEvent::DpiChanged {
                                 scale_factor: dpi,
                                 new_inner_size: &mut new_inner_size,
                             },

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -691,7 +691,7 @@ impl<T> EventLoop<T> {
                         callback(Event::WindowEvent {
                             window_id,
                             event: WindowEvent::HiDpiFactorChanged {
-                                hidpi_factor: dpi,
+                                scale_factor: dpi,
                                 new_inner_size: &mut new_inner_size,
                             },
                         });
@@ -968,7 +968,7 @@ impl fmt::Debug for MonitorHandle {
             native_identifier: u32,
             size: PhysicalSize<u32>,
             position: PhysicalPosition<i32>,
-            hidpi_factor: i32,
+            scale_factor: i32,
         }
 
         let monitor_id_proxy = MonitorHandle {
@@ -976,7 +976,7 @@ impl fmt::Debug for MonitorHandle {
             native_identifier: self.native_identifier(),
             size: self.size(),
             position: self.position(),
-            hidpi_factor: self.hidpi_factor(),
+            scale_factor: self.scale_factor(),
         };
 
         monitor_id_proxy.fmt(f)
@@ -1016,7 +1016,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> i32 {
+    pub fn scale_factor(&self) -> i32 {
         self.mgr
             .with_info(&self.proxy, |_, info| info.scale_factor)
             .unwrap_or(1)

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -221,7 +221,7 @@ impl Window {
     }
 
     pub fn inner_size(&self) -> PhysicalSize<u32> {
-        let dpi = self.hidpi_factor() as f64;
+        let dpi = self.scale_factor() as f64;
         let size = LogicalSize::<f64>::from(*self.size.lock().unwrap());
         size.to_physical(dpi)
     }
@@ -232,7 +232,7 @@ impl Window {
 
     #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
-        let dpi = self.hidpi_factor() as f64;
+        let dpi = self.scale_factor() as f64;
         let (w, h) = self.size.lock().unwrap().clone();
         // let (w, h) = super::wayland_window::add_borders(w as i32, h as i32);
         let size = LogicalSize::<f64>::from((w, h));
@@ -242,7 +242,7 @@ impl Window {
     #[inline]
     // NOTE: This will only resize the borders, the contents must be updated by the user
     pub fn set_inner_size(&self, size: Size) {
-        let dpi = self.hidpi_factor() as f64;
+        let dpi = self.scale_factor() as f64;
         let (w, h) = size.to_logical::<u32>(dpi).into();
         self.frame.lock().unwrap().resize(w, h);
         *(self.size.lock().unwrap()) = (w, h);
@@ -250,7 +250,7 @@ impl Window {
 
     #[inline]
     pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
-        let dpi = self.hidpi_factor() as f64;
+        let dpi = self.scale_factor() as f64;
         self.frame
             .lock()
             .unwrap()
@@ -259,7 +259,7 @@ impl Window {
 
     #[inline]
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
-        let dpi = self.hidpi_factor() as f64;
+        let dpi = self.scale_factor() as f64;
         self.frame
             .lock()
             .unwrap()
@@ -272,7 +272,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> i32 {
+    pub fn scale_factor(&self) -> i32 {
         get_dpi_factor(&self.surface)
     }
 

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -378,29 +378,29 @@ impl<T: 'static> EventProcessor<T> {
                         let (width, height) = shared_state_lock
                             .dpi_adjusted
                             .unwrap_or_else(|| (xev.width as u32, xev.height as u32));
-                        let last_hidpi_factor =
+                        let last_scale_factor =
                             shared_state_lock.guessed_dpi.take().unwrap_or_else(|| {
                                 shared_state_lock
                                     .last_monitor
                                     .as_ref()
-                                    .map(|last_monitor| last_monitor.hidpi_factor)
+                                    .map(|last_monitor| last_monitor.scale_factor)
                                     .unwrap_or(1.0)
                             });
-                        let new_hidpi_factor = {
+                        let new_scale_factor = {
                             let window_rect = util::AaRect::new(new_outer_position, new_inner_size);
                             let monitor = wt.xconn.get_monitor_for_window(Some(window_rect));
-                            let new_hidpi_factor = monitor.hidpi_factor;
+                            let new_scale_factor = monitor.scale_factor;
 
                             // Avoid caching an invalid dummy monitor handle
                             if monitor.id != 0 {
                                 shared_state_lock.last_monitor = Some(monitor.clone());
                             }
-                            new_hidpi_factor
+                            new_scale_factor
                         };
-                        if last_hidpi_factor != new_hidpi_factor {
+                        if last_scale_factor != new_scale_factor {
                             let (new_width, new_height) = window.adjust_for_dpi(
-                                last_hidpi_factor,
-                                new_hidpi_factor,
+                                last_scale_factor,
+                                new_scale_factor,
                                 width,
                                 height,
                             );
@@ -410,7 +410,7 @@ impl<T: 'static> EventProcessor<T> {
                             callback(Event::WindowEvent {
                                 window_id,
                                 event: WindowEvent::HiDpiFactorChanged {
-                                    hidpi_factor: new_hidpi_factor,
+                                    scale_factor: new_scale_factor,
                                     new_inner_size: &mut new_inner_size,
                                 },
                             });
@@ -1111,7 +1111,7 @@ impl<T: 'static> EventProcessor<T> {
                                 .iter()
                                 .find(|prev_monitor| prev_monitor.name == new_monitor.name)
                                 .map(|prev_monitor| {
-                                    if new_monitor.hidpi_factor != prev_monitor.hidpi_factor {
+                                    if new_monitor.scale_factor != prev_monitor.scale_factor {
                                         for (window_id, window) in wt.windows.borrow().iter() {
                                             if let Some(window) = window.upgrade() {
                                                 // Check if the window is on this monitor
@@ -1121,8 +1121,8 @@ impl<T: 'static> EventProcessor<T> {
                                                         window.inner_size_physical();
                                                     let (new_width, new_height) = window
                                                         .adjust_for_dpi(
-                                                            prev_monitor.hidpi_factor,
-                                                            new_monitor.hidpi_factor,
+                                                            prev_monitor.scale_factor,
+                                                            new_monitor.scale_factor,
                                                             width,
                                                             height,
                                                         );
@@ -1139,7 +1139,7 @@ impl<T: 'static> EventProcessor<T> {
                                                     callback(Event::WindowEvent {
                                                         window_id,
                                                         event: WindowEvent::HiDpiFactorChanged {
-                                                            hidpi_factor: new_monitor.hidpi_factor,
+                                                            scale_factor: new_monitor.scale_factor,
                                                             new_inner_size: &mut new_inner_size,
                                                         },
                                                     });

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -409,7 +409,7 @@ impl<T: 'static> EventProcessor<T> {
 
                             callback(Event::WindowEvent {
                                 window_id,
-                                event: WindowEvent::HiDpiFactorChanged {
+                                event: WindowEvent::DpiChanged {
                                     scale_factor: new_scale_factor,
                                     new_inner_size: &mut new_inner_size,
                                 },
@@ -1138,7 +1138,7 @@ impl<T: 'static> EventProcessor<T> {
 
                                                     callback(Event::WindowEvent {
                                                         window_id,
-                                                        event: WindowEvent::HiDpiFactorChanged {
+                                                        event: WindowEvent::DpiChanged {
                                                             scale_factor: new_monitor.scale_factor,
                                                             new_inner_size: &mut new_inner_size,
                                                         },

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -73,7 +73,7 @@ pub struct MonitorHandle {
     /// If the monitor is the primary one
     primary: bool,
     /// The DPI scale factor
-    pub(crate) hidpi_factor: f64,
+    pub(crate) scale_factor: f64,
     /// Used to determine which windows are on this monitor
     pub(crate) rect: util::AaRect,
     /// Supported video modes on this monitor
@@ -114,14 +114,14 @@ impl MonitorHandle {
         crtc: *mut XRRCrtcInfo,
         primary: bool,
     ) -> Option<Self> {
-        let (name, hidpi_factor, video_modes) = unsafe { xconn.get_output_info(resources, crtc)? };
+        let (name, scale_factor, video_modes) = unsafe { xconn.get_output_info(resources, crtc)? };
         let dimensions = unsafe { ((*crtc).width as u32, (*crtc).height as u32) };
         let position = unsafe { ((*crtc).x as i32, (*crtc).y as i32) };
         let rect = util::AaRect::new(position, dimensions);
         Some(MonitorHandle {
             id,
             name,
-            hidpi_factor,
+            scale_factor,
             dimensions,
             position,
             primary,
@@ -134,7 +134,7 @@ impl MonitorHandle {
         MonitorHandle {
             id: 0,
             name: "<dummy monitor>".into(),
-            hidpi_factor: 1.0,
+            scale_factor: 1.0,
             dimensions: (1, 1),
             position: (0, 0),
             primary: true,
@@ -161,8 +161,8 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
-        self.hidpi_factor
+    pub fn scale_factor(&self) -> f64 {
+        self.scale_factor
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -24,7 +24,7 @@ pub fn calc_dpi_factor(
     if let Some(dpi_override) = dpi_override {
         if !validate_scale_factor(dpi_override) {
             panic!(
-                "`WINIT_HIDPI_FACTOR` invalid; DPI factors must be normal floats greater than 0. Got `{}`",
+                "`WINIT_X11_SCALE_FACTOR` invalid; scale factors must be normal floats greater than 0. Got `{}`",
                 dpi_override,
             );
         }

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -10,9 +10,16 @@ pub fn calc_dpi_factor(
     (width_px, height_px): (u32, u32),
     (width_mm, height_mm): (u64, u64),
 ) -> f64 {
-    // Override DPI if `WINIT_HIDPI_FACTOR` variable is set
-    let dpi_override = env::var("WINIT_HIDPI_FACTOR")
+    // Override DPI if `WINIT_X11_SCALE_FACTOR` variable is set
+    let deprecated_dpi_override = env::var("WINIT_HIDPI_FACTOR").ok();
+    if deprecated_dpi_override.is_some() {
+        warn!(
+            "The WINIT_HIDPI_FACTOR environment variable is deprecated; use WINIT_X11_SCALE_FACTOR"
+        )
+    }
+    let dpi_override = env::var("WINIT_X11_SCALE_FACTOR")
         .ok()
+        .or(deprecated_dpi_override)
         .and_then(|var| f64::from_str(&var).ok());
     if let Some(dpi_override) = dpi_override {
         if !validate_scale_factor(dpi_override) {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -122,7 +122,7 @@ impl UnownedWindow {
             1.0
         };
 
-        info!("Guessed window DPI factor: {}", dpi_factor);
+        info!("Guessed window scale factor: {}", dpi_factor);
 
         let max_inner_size: Option<(u32, u32)> = window_attrs
             .max_inner_size

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -95,9 +95,9 @@ impl UnownedWindow {
 
         let monitors = xconn.available_monitors();
         let dpi_factor = if !monitors.is_empty() {
-            let mut dpi_factor = Some(monitors[0].hidpi_factor());
+            let mut dpi_factor = Some(monitors[0].scale_factor());
             for monitor in &monitors {
-                if Some(monitor.hidpi_factor()) != dpi_factor {
+                if Some(monitor.scale_factor()) != dpi_factor {
                     dpi_factor = None;
                 }
             }
@@ -110,7 +110,7 @@ impl UnownedWindow {
                         let mut dpi_factor = None;
                         for monitor in &monitors {
                             if monitor.rect.contains_point(x, y) {
-                                dpi_factor = Some(monitor.hidpi_factor());
+                                dpi_factor = Some(monitor.scale_factor());
                                 break;
                             }
                         }
@@ -954,7 +954,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_outer_position(&self, position: Position) {
-        let (x, y) = position.to_physical::<i32>(self.hidpi_factor()).into();
+        let (x, y) = position.to_physical::<i32>(self.scale_factor()).into();
         self.set_position_physical(x, y);
     }
 
@@ -1010,7 +1010,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         let (width, height) = size.to_physical::<u32>(dpi_factor).into();
         self.set_inner_size_physical(width, height);
     }
@@ -1035,7 +1035,7 @@ impl UnownedWindow {
     pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
         self.shared_state.lock().min_inner_size = dimensions;
         let physical_dimensions =
-            dimensions.map(|dimensions| dimensions.to_physical::<u32>(self.hidpi_factor()).into());
+            dimensions.map(|dimensions| dimensions.to_physical::<u32>(self.scale_factor()).into());
         self.set_min_inner_size_physical(physical_dimensions);
     }
 
@@ -1048,7 +1048,7 @@ impl UnownedWindow {
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
         self.shared_state.lock().max_inner_size = dimensions;
         let physical_dimensions =
-            dimensions.map(|dimensions| dimensions.to_physical::<u32>(self.hidpi_factor()).into());
+            dimensions.map(|dimensions| dimensions.to_physical::<u32>(self.scale_factor()).into());
         self.set_max_inner_size_physical(physical_dimensions);
     }
 
@@ -1105,7 +1105,7 @@ impl UnownedWindow {
 
         self.set_maximizable_inner(resizable).queue();
 
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         let min_inner_size = min_size
             .map(|size| size.to_physical::<u32>(dpi_factor))
             .map(Into::into);
@@ -1231,8 +1231,8 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
-        self.current_monitor().hidpi_factor
+    pub fn scale_factor(&self) -> f64 {
+        self.current_monitor().scale_factor
     }
 
     pub fn set_cursor_position_physical(&self, x: i32, y: i32) -> Result<(), ExternalError> {
@@ -1246,7 +1246,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
-        let (x, y) = position.to_physical::<i32>(self.hidpi_factor()).into();
+        let (x, y) = position.to_physical::<i32>(self.scale_factor()).into();
         self.set_cursor_position_physical(x, y)
     }
 
@@ -1259,7 +1259,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_ime_position(&self, spot: Position) {
-        let (x, y) = spot.to_physical::<i32>(self.hidpi_factor()).into();
+        let (x, y) = spot.to_physical::<i32>(self.scale_factor()).into();
         self.set_ime_position_physical(x, y);
     }
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -189,7 +189,7 @@ impl Handler {
     ) {
         let size = suggested_size.to_physical(scale_factor);
         let new_inner_size = &mut Some(size);
-        let mut size = suggested_size.to_physical(hidpi_factor);
+        let mut size = suggested_size.to_physical(scale_factor);
         let new_inner_size = &mut size;
         let event = Event::WindowEvent {
             window_id: WindowId(get_window_id(*ns_window)),
@@ -202,7 +202,7 @@ impl Handler {
         callback.handle_nonuser_event(event, &mut *self.control_flow.lock().unwrap());
 
         let physical_size = *new_inner_size;
-        let logical_size = physical_size.to_logical(hidpi_factor);
+        let logical_size = physical_size.to_logical(scale_factor);
         let size = NSSize::new(logical_size.width, logical_size.height);
         unsafe { NSWindow::setContentSize_(*ns_window, size) };
     }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -191,7 +191,7 @@ impl Handler {
         let new_inner_size = &mut Some(size);
         let event = Event::WindowEvent {
             window_id: WindowId(get_window_id(*ns_window)),
-            event: WindowEvent::HiDpiFactorChanged {
+            event: WindowEvent::DpiChanged {
                 scale_factor,
                 new_inner_size,
             },
@@ -207,7 +207,7 @@ impl Handler {
 
     fn handle_proxy(&self, proxy: EventProxy, callback: &mut Box<dyn EventHandler + 'static>) {
         match proxy {
-            EventProxy::HiDpiFactorChangedProxy {
+            EventProxy::DpiChangedProxy {
                 ns_window,
                 suggested_size,
                 scale_factor,

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -180,19 +180,19 @@ impl Handler {
         }
     }
 
-    fn handle_hidpi_factor_changed_event(
+    fn handle_scale_factor_changed_event(
         &self,
         callback: &mut Box<dyn EventHandler + 'static>,
         ns_window: IdRef,
         suggested_size: LogicalSize<f64>,
-        hidpi_factor: f64,
+        scale_factor: f64,
     ) {
-        let size = suggested_size.to_physical(hidpi_factor);
+        let size = suggested_size.to_physical(scale_factor);
         let new_inner_size = &mut Some(size);
         let event = Event::WindowEvent {
             window_id: WindowId(get_window_id(*ns_window)),
             event: WindowEvent::HiDpiFactorChanged {
-                hidpi_factor,
+                scale_factor,
                 new_inner_size,
             },
         };
@@ -200,7 +200,7 @@ impl Handler {
         callback.handle_nonuser_event(event, &mut *self.control_flow.lock().unwrap());
 
         let physical_size = new_inner_size.unwrap_or(size);
-        let logical_size = physical_size.to_logical(hidpi_factor);
+        let logical_size = physical_size.to_logical(scale_factor);
         let size = NSSize::new(logical_size.width, logical_size.height);
         unsafe { NSWindow::setContentSize_(*ns_window, size) };
     }
@@ -210,12 +210,12 @@ impl Handler {
             EventProxy::HiDpiFactorChangedProxy {
                 ns_window,
                 suggested_size,
-                hidpi_factor,
-            } => self.handle_hidpi_factor_changed_event(
+                scale_factor,
+            } => self.handle_scale_factor_changed_event(
                 callback,
                 ns_window,
                 suggested_size,
-                hidpi_factor,
+                scale_factor,
             ),
         }
     }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -187,8 +187,6 @@ impl Handler {
         suggested_size: LogicalSize<f64>,
         scale_factor: f64,
     ) {
-        let size = suggested_size.to_physical(scale_factor);
-        let new_inner_size = &mut Some(size);
         let mut size = suggested_size.to_physical(scale_factor);
         let new_inner_size = &mut size;
         let event = Event::WindowEvent {

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -25,7 +25,7 @@ pub enum EventProxy {
     HiDpiFactorChangedProxy {
         ns_window: IdRef,
         suggested_size: LogicalSize<f64>,
-        hidpi_factor: f64,
+        scale_factor: f64,
     },
 }
 

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -22,7 +22,7 @@ pub enum EventWrapper {
 
 #[derive(Debug, PartialEq)]
 pub enum EventProxy {
-    HiDpiFactorChangedProxy {
+    DpiChangedProxy {
         ns_window: IdRef,
         suggested_size: LogicalSize<f64>,
         scale_factor: f64,

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -168,7 +168,7 @@ impl fmt::Debug for MonitorHandle {
             native_identifier: u32,
             size: PhysicalSize<u32>,
             position: PhysicalPosition<i32>,
-            hidpi_factor: f64,
+            scale_factor: f64,
         }
 
         let monitor_id_proxy = MonitorHandle {
@@ -176,7 +176,7 @@ impl fmt::Debug for MonitorHandle {
             native_identifier: self.native_identifier(),
             size: self.size(),
             position: self.position(),
-            hidpi_factor: self.hidpi_factor(),
+            scale_factor: self.scale_factor(),
         };
 
         monitor_id_proxy.fmt(f)
@@ -204,7 +204,7 @@ impl MonitorHandle {
         let display = CGDisplay::new(display_id);
         let height = display.pixels_high();
         let width = display.pixels_wide();
-        PhysicalSize::from_logical::<_, f64>((width as f64, height as f64), self.hidpi_factor())
+        PhysicalSize::from_logical::<_, f64>((width as f64, height as f64), self.scale_factor())
     }
 
     #[inline]
@@ -212,11 +212,11 @@ impl MonitorHandle {
         let bounds = unsafe { CGDisplayBounds(self.native_identifier()) };
         PhysicalPosition::from_logical::<_, f64>(
             (bounds.origin.x as f64, bounds.origin.y as f64),
-            self.hidpi_factor(),
+            self.scale_factor(),
         )
     }
 
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         let screen = match self.ns_screen() {
             Some(screen) => screen,
             None => return 1.0, // default to 1.0 when we can't find the screen

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -134,10 +134,10 @@ fn create_window(
             Some(screen) => NSScreen::frame(screen),
             None => {
                 let screen = NSScreen::mainScreen(nil);
-                let hidpi_factor = NSScreen::backingScaleFactor(screen) as f64;
+                let scale_factor = NSScreen::backingScaleFactor(screen) as f64;
                 let (width, height) = match attrs.inner_size {
                     Some(size) => {
-                        let logical = size.to_logical(hidpi_factor);
+                        let logical = size.to_logical(scale_factor);
                         (logical.width, logical.height)
                     }
                     None => (800.0, 600.0),
@@ -440,7 +440,7 @@ impl UnownedWindow {
             frame_rect.origin.x as f64,
             util::bottom_left_to_top_left(frame_rect),
         );
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         Ok(position.to_physical(dpi_factor))
     }
 
@@ -452,12 +452,12 @@ impl UnownedWindow {
             content_rect.origin.x as f64,
             util::bottom_left_to_top_left(content_rect),
         );
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         Ok(position.to_physical(dpi_factor))
     }
 
     pub fn set_outer_position(&self, position: Position) {
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         let position = position.to_logical(dpi_factor);
         let dummy = NSRect::new(
             NSPoint::new(
@@ -478,7 +478,7 @@ impl UnownedWindow {
         let view_frame = unsafe { NSView::frame(*self.ns_view) };
         let logical: LogicalSize<f64> =
             (view_frame.size.width as f64, view_frame.size.height as f64).into();
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         logical.to_physical(dpi_factor)
     }
 
@@ -487,14 +487,14 @@ impl UnownedWindow {
         let view_frame = unsafe { NSWindow::frame(*self.ns_window) };
         let logical: LogicalSize<f64> =
             (view_frame.size.width as f64, view_frame.size.height as f64).into();
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         logical.to_physical(dpi_factor)
     }
 
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
         unsafe {
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             util::set_content_size_async(*self.ns_window, size.to_logical(dpi_factor));
         }
     }
@@ -505,7 +505,7 @@ impl UnownedWindow {
                 width: 0.0,
                 height: 0.0,
             }));
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             set_min_inner_size(*self.ns_window, dimensions.to_logical(dpi_factor));
         }
     }
@@ -516,7 +516,7 @@ impl UnownedWindow {
                 width: std::f32::MAX as f64,
                 height: std::f32::MAX as f64,
             }));
-            let dpi_factor = self.hidpi_factor();
+            let dpi_factor = self.scale_factor();
             set_max_inner_size(*self.ns_window, dimensions.to_logical(dpi_factor));
         }
     }
@@ -576,14 +576,14 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         unsafe { NSWindow::backingScaleFactor(*self.ns_window) as _ }
     }
 
     #[inline]
     pub fn set_cursor_position(&self, cursor_position: Position) -> Result<(), ExternalError> {
         let physical_window_position = self.inner_position().unwrap();
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         let window_position = physical_window_position.to_logical::<CGFloat>(dpi_factor);
         let logical_cursor_position = cursor_position.to_logical::<CGFloat>(dpi_factor);
         let point = appkit::CGPoint {
@@ -896,7 +896,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn set_ime_position(&self, spot: Position) {
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         let logical_spot = spot.to_logical(dpi_factor);
         unsafe {
             view::set_ime_position(

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -48,18 +48,18 @@ pub struct WindowDelegateState {
 
 impl WindowDelegateState {
     pub fn new(window: &Arc<UnownedWindow>, initial_fullscreen: bool) -> Self {
-        let hidpi_factor = window.hidpi_factor();
+        let scale_factor = window.scale_factor();
         let mut delegate_state = WindowDelegateState {
             ns_window: window.ns_window.clone(),
             ns_view: window.ns_view.clone(),
             window: Arc::downgrade(&window),
             initial_fullscreen,
             previous_position: None,
-            previous_dpi_factor: hidpi_factor,
+            previous_dpi_factor: scale_factor,
         };
 
-        if hidpi_factor != 1.0 {
-            delegate_state.emit_static_hidpi_factor_changed_event();
+        if scale_factor != 1.0 {
+            delegate_state.emit_static_scale_factor_changed_event();
         }
 
         delegate_state
@@ -80,26 +80,26 @@ impl WindowDelegateState {
         AppState::queue_event(EventWrapper::StaticEvent(event));
     }
 
-    pub fn emit_static_hidpi_factor_changed_event(&mut self) {
-        let hidpi_factor = self.get_hidpi_factor();
-        if hidpi_factor == self.previous_dpi_factor {
+    pub fn emit_static_scale_factor_changed_event(&mut self) {
+        let scale_factor = self.get_scale_factor();
+        if scale_factor == self.previous_dpi_factor {
             return ();
         };
 
-        self.previous_dpi_factor = hidpi_factor;
+        self.previous_dpi_factor = scale_factor;
         let wrapper = EventWrapper::EventProxy(EventProxy::HiDpiFactorChangedProxy {
             ns_window: IdRef::retain(*self.ns_window),
             suggested_size: self.view_size(),
-            hidpi_factor,
+            scale_factor,
         });
         AppState::queue_event(wrapper);
     }
 
     pub fn emit_resize_event(&mut self) {
         let rect = unsafe { NSView::frame(*self.ns_view) };
-        let hidpi_factor = self.get_hidpi_factor();
+        let scale_factor = self.get_scale_factor();
         let logical_size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
-        let size = logical_size.to_physical(hidpi_factor);
+        let size = logical_size.to_physical(scale_factor);
         self.emit_event(WindowEvent::Resized(size));
     }
 
@@ -114,7 +114,7 @@ impl WindowDelegateState {
         }
     }
 
-    fn get_hidpi_factor(&self) -> f64 {
+    fn get_scale_factor(&self) -> f64 {
         (unsafe { NSWindow::backingScaleFactor(*self.ns_window) }) as f64
     }
 
@@ -297,7 +297,7 @@ extern "C" fn window_did_move(this: &Object, _: Sel, _: id) {
 extern "C" fn window_did_change_backing_properties(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowDidChangeBackingProperties:`");
     with_state(this, |state| {
-        state.emit_static_hidpi_factor_changed_event();
+        state.emit_static_scale_factor_changed_event();
     });
     trace!("Completed `windowDidChangeBackingProperties:`");
 }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -87,7 +87,7 @@ impl WindowDelegateState {
         };
 
         self.previous_dpi_factor = scale_factor;
-        let wrapper = EventWrapper::EventProxy(EventProxy::HiDpiFactorChangedProxy {
+        let wrapper = EventWrapper::EventProxy(EventProxy::DpiChangedProxy {
             ns_window: IdRef::retain(*self.ns_window),
             suggested_size: self.view_size(),
             scale_factor,

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -183,7 +183,7 @@ impl<T> WindowTarget<T> {
                     height: raw.height() as u32,
                 };
 
-                backend::window_size().to_physical(backend::hidpi_factor())
+                backend::window_size().to_physical(backend::scale_factor())
             } else {
                 intended_size
             };

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -5,7 +5,7 @@ use crate::monitor::{MonitorHandle, VideoMode};
 pub struct Handle;
 
 impl Handle {
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         1.0
     }
 

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -213,7 +213,7 @@ impl Canvas {
         self.on_cursor_move = Some(self.add_event(move |event: PointerMoveEvent| {
             handler(
                 event.pointer_id(),
-                event::mouse_position(&event).to_physical(super::hidpi_factor()),
+                event::mouse_position(&event).to_physical(super::scale_factor()),
                 event::mouse_modifiers(&event),
             );
         }));

--- a/src/platform_impl/web/stdweb/mod.rs
+++ b/src/platform_impl/web/stdweb/mod.rs
@@ -41,7 +41,7 @@ pub fn window_size() -> LogicalSize<f64> {
     LogicalSize { width, height }
 }
 
-pub fn hidpi_factor() -> f64 {
+pub fn scale_factor() -> f64 {
     let window = window();
     window.device_pixel_ratio()
 }
@@ -49,10 +49,10 @@ pub fn hidpi_factor() -> f64 {
 pub fn set_canvas_size(raw: &CanvasElement, size: Size) {
     use stdweb::*;
 
-    let hidpi_factor = hidpi_factor();
+    let scale_factor = scale_factor();
 
-    let physical_size = size.to_physical::<u32>(hidpi_factor);
-    let logical_size = size.to_logical::<f64>(hidpi_factor);
+    let physical_size = size.to_physical::<u32>(scale_factor);
+    let logical_size = size.to_logical::<f64>(scale_factor);
 
     raw.set_width(physical_size.width);
     raw.set_height(physical_size.height);

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -221,7 +221,7 @@ impl Canvas {
         self.on_cursor_move = Some(self.add_event("pointermove", move |event: PointerEvent| {
             handler(
                 event.pointer_id(),
-                event::mouse_position(&event).to_physical(super::hidpi_factor()),
+                event::mouse_position(&event).to_physical(super::scale_factor()),
                 event::mouse_modifiers(&event),
             );
         }));

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -56,16 +56,16 @@ pub fn window_size() -> LogicalSize<f64> {
     LogicalSize { width, height }
 }
 
-pub fn hidpi_factor() -> f64 {
+pub fn scale_factor() -> f64 {
     let window = web_sys::window().expect("Failed to obtain window");
     window.device_pixel_ratio()
 }
 
 pub fn set_canvas_size(raw: &HtmlCanvasElement, size: Size) {
-    let hidpi_factor = hidpi_factor();
+    let scale_factor = scale_factor();
 
-    let physical_size = size.to_physical::<u32>(hidpi_factor);
-    let logical_size = size.to_logical::<f64>(hidpi_factor);
+    let physical_size = size.to_physical::<u32>(scale_factor);
+    let logical_size = size.to_logical::<f64>(scale_factor);
 
     raw.set_width(physical_size.width);
     raw.set_height(physical_size.height);

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -71,7 +71,7 @@ impl Window {
     }
 
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-        Ok(self.canvas.position().to_physical(self.hidpi_factor()))
+        Ok(self.canvas.position().to_physical(self.scale_factor()))
     }
 
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
@@ -80,7 +80,7 @@ impl Window {
     }
 
     pub fn set_outer_position(&self, position: Position) {
-        let position = position.to_logical::<f64>(self.hidpi_factor());
+        let position = position.to_logical::<f64>(self.scale_factor());
 
         self.canvas.set_attribute("position", "fixed");
         self.canvas.set_attribute("left", &position.x.to_string());
@@ -119,8 +119,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
-        super::backend::hidpi_factor()
+    pub fn scale_factor(&self) -> f64 {
+        super::backend::scale_factor()
     }
 
     #[inline]

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1849,7 +1849,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
         // Only sent on Windows 8.1 or newer. On Windows 7 and older user has to log out to change
         // DPI, therefore all applications are closed while DPI is changing.
         winuser::WM_DPICHANGED => {
-            use crate::event::WindowEvent::HiDpiFactorChanged;
+            use crate::event::WindowEvent::DpiChanged;
 
             // This message actually provides two DPI values - x and y. However MSDN says that
             // "you only need to use either the X-axis or the Y-axis value when scaling your
@@ -1933,7 +1933,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
 
             let _ = subclass_input.send_event_unbuffered(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
-                event: HiDpiFactorChanged {
+                event: DpiChanged {
                     scale_factor: new_dpi_factor,
                     new_inner_size: &mut new_inner_size_opt,
                 },

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1934,7 +1934,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
             let _ = subclass_input.send_event_unbuffered(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: HiDpiFactorChanged {
-                    hidpi_factor: new_dpi_factor,
+                    scale_factor: new_dpi_factor,
                     new_inner_size: &mut new_inner_size_opt,
                 },
             });

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -203,7 +203,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         dpi_to_scale_factor(get_monitor_dpi(self.0).unwrap_or(96))
     }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -176,7 +176,7 @@ impl Window {
 
     #[inline]
     pub fn set_outer_position(&self, position: Position) {
-        let (x, y): (i32, i32) = position.to_physical::<i32>(self.hidpi_factor()).into();
+        let (x, y): (i32, i32) = position.to_physical::<i32>(self.scale_factor()).into();
 
         let window_state = Arc::clone(&self.window_state);
         let window = self.window.clone();
@@ -258,7 +258,7 @@ impl Window {
 
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         let (width, height) = size.to_physical::<u32>(dpi_factor).into();
 
         let window_state = Arc::clone(&self.window_state);
@@ -365,13 +365,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f64 {
         self.window_state.lock().dpi_factor
     }
 
     #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
-        let dpi_factor = self.hidpi_factor();
+        let dpi_factor = self.scale_factor();
         let (x, y) = position.to_physical::<i32>(dpi_factor).into();
 
         let mut point = POINT { x, y };

--- a/src/window.rs
+++ b/src/window.rs
@@ -376,7 +376,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **X11:** This respects Xft.dpi, and can be overridden using the `WINIT_HIDPI_FACTOR` environment variable.
+    /// - **X11:** This respects Xft.dpi, and can be overridden using the `WINIT_X11_SCALE_FACTOR` environment variable.
     /// - **Android:** Always returns 1.0.
     /// - **iOS:** Can only be called on the main thread. Returns the underlying `UIView`'s
     ///   [`contentScaleFactor`].

--- a/src/window.rs
+++ b/src/window.rs
@@ -383,8 +383,8 @@ impl Window {
     ///
     /// [`contentScaleFactor`]: https://developer.apple.com/documentation/uikit/uiview/1622657-contentscalefactor?language=objc
     #[inline]
-    pub fn hidpi_factor(&self) -> f64 {
-        self.window.hidpi_factor()
+    pub fn scale_factor(&self) -> f64 {
+        self.window.scale_factor()
     }
 
     /// Emits a `WindowEvent::RedrawRequested` event in the associated event loop after all OS

--- a/src/window.rs
+++ b/src/window.rs
@@ -366,12 +366,12 @@ impl Window {
         WindowId(self.window.id())
     }
 
-    /// Returns the DPI factor that can be used to map logical pixels to physical pixels, and vice versa.
+    /// Returns the scale factor that can be used to map logical pixels to physical pixels, and vice versa.
     ///
     /// See the [`dpi`](../dpi/index.html) module for more information.
     ///
     /// Note that this value can change depending on user action (for example if the window is
-    /// moved to another screen); as such, tracking `WindowEvent::HiDpiFactorChanged` events is
+    /// moved to another screen); as such, tracking `WindowEvent::DpiChanged` events is
     /// the most robust way to track the DPI you need to use to draw.
     ///
     /// ## Platform-specific


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

As suggested in https://github.com/rust-windowing/winit/issues/939#issuecomment-556757862. This PR also deprecates X11's `WINIT_HIDPI_FACTOR` environment variable in favor of `WINIT_X11_SCALE_FACTOR`, although `WINIT_HIDPI_FACTOR` will continue to work at present. I've checked that the X11 changes compile on my WSL system, but someone should verify that they work as intended.