### PR TITLE
fix: remove deprecated usage of `mem::uninitialized`.

### DIFF
--- a/src/platform_impl/web/stdweb/timeout.rs
+++ b/src/platform_impl/web/stdweb/timeout.rs
@@ -3,7 +3,7 @@ use stdweb::web::{window, IWindowOrWorker, TimeoutHandle};
 
 #[derive(Debug)]
 pub struct Timeout {
-    handle: TimeoutHandle,
+    handle: Option<TimeoutHandle>,
 }
 
 impl Timeout {
@@ -12,14 +12,14 @@ impl Timeout {
         F: 'static + FnMut(),
     {
         Timeout {
-            handle: window().set_clearable_timeout(f, duration.as_millis() as u32),
+            handle: Some(window().set_clearable_timeout(f, duration.as_millis() as u32)),
         }
     }
 }
 
 impl Drop for Timeout {
     fn drop(&mut self) {
-        let handle = std::mem::replace(&mut self.handle, unsafe { std::mem::uninitialized() });
+        let handle = self.handle.take().unwrap();
         handle.clear();
     }
 }


### PR DESCRIPTION
While working on #1233, I noticed rustc complaining about a usage of `mem::uninitialized` in the stdweb backend.

Previously: we were swapping out the `TimeoutHandle` with uninitialized memory to own it, since `TimeoutHandle::clear` takes `self`. This change replaces that swap with an `Option<TimeoutHandle>`, so we can write this code without deprecated APIs. `Option` adds a trivial amount of overhead, zero-cost alternatives could be: [`mem::ManuallyDrop::take`](https://doc.rust-lang.org/beta/std/mem/struct.ManuallyDrop.html#method.take) (when it becomes stable) or `mem::MaybeUninit`. I'm happy to add a comment in `Timeout::handle` describing why it's coded this way for posterity, if desired.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
