### PR TITLE
[MacOS] Fix memory management

### DIFF
--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -11,7 +11,11 @@ use std::{
     time::Instant,
 };
 
-use cocoa::{appkit::NSApp, base::nil, foundation::NSString};
+use cocoa::{
+    appkit::NSApp,
+    base::nil,
+    foundation::{NSAutoreleasePool, NSString},
+};
 
 use crate::{
     event::{Event, StartCause, WindowEvent},
@@ -277,6 +281,8 @@ impl AppState {
             unsafe {
                 let _: () = msg_send![NSApp(), stop: nil];
 
+                let pool = NSAutoreleasePool::new(nil);
+
                 let windows: *const Object = msg_send![NSApp(), windows];
                 let window: *const Object = msg_send![windows, objectAtIndex:0];
                 assert_ne!(window, nil);
@@ -292,6 +298,8 @@ impl AppState {
                 let _: () = msg_send![window, setTitle: some_unique_title];
                 // And restore it.
                 let _: () = msg_send![window, setTitle: title];
+
+                pool.drain();
             };
         }
         HANDLER.update_start_time();

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -95,12 +95,13 @@ impl<T> EventLoop<T> {
         F: FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         unsafe {
-            let _pool = NSAutoreleasePool::new(nil);
+            let pool = NSAutoreleasePool::new(nil);
             let app = NSApp();
             assert_ne!(app, nil);
             AppState::set_callback(callback, Rc::clone(&self.window_target));
             let _: () = msg_send![app, run];
             AppState::exit();
+            pool.drain();
         }
     }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I'm completely newbie about Cocoa's memory management.
Please review this carefully.

This PR contains 2 changes.
1. Fix memory leak on `run_return`
I noticed that `leaks` command shows some leaks of `NSAutoreleasePool` object when run `window_run_return` example.
I fixed it by inserting `pool.drain();` to end.
src/platform_impl/macos/event_loop.rs
2. Reduce memory usage on  `run_return`
I noticed that memory usage of `window_run_return` example is very higher than `window` example.
I fixed it by using `NSAutoreleasePool`.
src/platform_impl/macos/app_state.rs