### PR TITLE
Fix Window::set_visible not setting internal flags correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   - `RedrawEventsCleared` is issued after each set of `RedrawRequested` events.
 - Implement synthetic window focus key events on Windows.
 - **Breaking**: Change `ModifiersState` to a `bitflags` struct.
+- On Windows, fix `Window::set_visible` not setting internal flags correctly. This resulted in some weird behavior.
 
 # 0.20.0 Alpha 5 (2019-12-09)
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -127,14 +127,13 @@ impl Window {
 
     #[inline]
     pub fn set_visible(&self, visible: bool) {
-        match visible {
-            true => unsafe {
-                winuser::ShowWindow(self.window.0, winuser::SW_SHOW);
-            },
-            false => unsafe {
-                winuser::ShowWindow(self.window.0, winuser::SW_HIDE);
-            },
-        }
+        let window_state = Arc::clone(&self.window_state);
+        let window = self.window.clone();
+        self.thread_executor.execute_in_thread(move || {
+            WindowState::set_window_flags(window_state.lock(), window.0, |f| {
+                f.set(WindowFlags::VISIBLE, visible)
+            });
+        });
     }
 
     #[inline]


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

The changes in #898, updated for the modern age.
