### PR TITLE
Remove Option from HiDpiFactorChanged in favor of a bare PhysicalSize

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -223,13 +223,12 @@ pub enum WindowEvent<'a> {
     ///
     /// After this event callback has been processed, the window will be resized to whatever value
     /// is pointed to by the `new_inner_size` reference. By default, this will contain the size suggested
-    /// by the OS, but it can be changed to any value. If `new_inner_size` is set to `None`, no resizing
-    /// will occur.
+    /// by the OS, but it can be changed to any value.
     ///
     /// For more information about DPI in general, see the [`dpi`](dpi/index.html) module.
     HiDpiFactorChanged {
         hidpi_factor: f64,
-        new_inner_size: &'a mut Option<PhysicalSize<u32>>,
+        new_inner_size: &'a mut PhysicalSize<u32>,
     },
 }
 

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -863,7 +863,7 @@ fn handle_hidpi_proxy(
     hidpi_factor: f64,
     window_id: id,
 ) {
-    let size = suggested_size.to_physical(hidpi_factor);
+    let mut size = suggested_size.to_physical(hidpi_factor);
     let new_inner_size = &mut size;
     let event = Event::WindowEvent {
         window_id: RootWindowId(window_id.into()),

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -864,7 +864,7 @@ fn handle_hidpi_proxy(
     window_id: id,
 ) {
     let size = suggested_size.to_physical(hidpi_factor);
-    let new_inner_size = &mut Some(size);
+    let new_inner_size = &mut size;
     let event = Event::WindowEvent {
         window_id: RootWindowId(window_id.into()),
         event: WindowEvent::HiDpiFactorChanged {
@@ -874,13 +874,12 @@ fn handle_hidpi_proxy(
     };
     event_handler.handle_nonuser_event(event, &mut control_flow);
     let (view, screen_frame) = get_view_and_screen_frame(window_id);
-    if let Some(physical_size) = new_inner_size {
-        let logical_size = physical_size.to_logical(hidpi_factor);
-        let size = CGSize::new(logical_size);
-        let new_frame: CGRect = CGRect::new(screen_frame.origin, size);
-        unsafe {
-            let () = msg_send![view, setFrame: new_frame];
-        }
+    let physical_size = *new_inner_size;
+    let logical_size = physical_size.to_logical(hidpi_factor);
+    let size = CGSize::new(logical_size);
+    let new_frame: CGRect = CGRect::new(screen_frame.origin, size);
+    unsafe {
+        let () = msg_send![view, setFrame: new_frame];
     }
 }
 

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -686,7 +686,7 @@ impl<T> EventLoop<T> {
                     if let Some(dpi) = new_dpi {
                         let dpi = dpi as f64;
                         let logical_size = LogicalSize::<f64>::from(*size);
-                        let mut new_inner_size = Some(logical_size.to_physical(dpi));
+                        let mut new_inner_size = logical_size.to_physical(dpi);
 
                         callback(Event::WindowEvent {
                             window_id,
@@ -696,11 +696,9 @@ impl<T> EventLoop<T> {
                             },
                         });
 
-                        if let Some(new_size) = new_inner_size {
-                            let (w, h) = new_size.to_logical::<f64>(dpi).into();
-                            frame.resize(w, h);
-                            *size = (w, h);
-                        }
+                        let (w, h) = new_inner_size.to_logical::<f64>(dpi).into();
+                        frame.resize(w, h);
+                        *size = (w, h);
                     }
                 }
                 if refresh {

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -405,7 +405,8 @@ impl<T: 'static> EventProcessor<T> {
                                 height,
                             );
 
-                            let mut new_inner_size = Some(PhysicalSize::new(new_width, new_height));
+                            let old_inner_size = PhysicalSize::new(width, height);
+                            let mut new_inner_size = PhysicalSize::new(new_width, new_height);
 
                             callback(Event::WindowEvent {
                                 window_id,
@@ -415,9 +416,12 @@ impl<T: 'static> EventProcessor<T> {
                                 },
                             });
 
-                            if let Some(new_size) = new_inner_size {
-                                window.set_inner_size_physical(new_size.width, new_size.height);
-                                shared_state_lock.dpi_adjusted = Some(new_size.into());
+                            if new_inner_size != old_inner_size {
+                                window.set_inner_size_physical(
+                                    new_inner_size.width,
+                                    new_inner_size.height,
+                                );
+                                shared_state_lock.dpi_adjusted = Some(new_inner_size.into());
                                 // if the DPI factor changed, force a resize event to ensure the logical
                                 // size is computed with the right DPI factor
                                 resized = true;
@@ -1132,9 +1136,10 @@ impl<T: 'static> EventProcessor<T> {
                                                             *window_id,
                                                         ),
                                                     );
-                                                    let mut new_inner_size = Some(
-                                                        PhysicalSize::new(new_width, new_height),
-                                                    );
+                                                    let old_inner_size =
+                                                        PhysicalSize::new(width, height);
+                                                    let mut new_inner_size =
+                                                        PhysicalSize::new(new_width, new_height);
 
                                                     callback(Event::WindowEvent {
                                                         window_id,
@@ -1144,9 +1149,9 @@ impl<T: 'static> EventProcessor<T> {
                                                         },
                                                     });
 
-                                                    if let Some(new_size) = new_inner_size {
+                                                    if new_inner_size != old_inner_size {
                                                         let (new_width, new_height) =
-                                                            new_size.into();
+                                                            new_inner_size.into();
                                                         window.set_inner_size_physical(
                                                             new_width, new_height,
                                                         );

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -187,7 +187,7 @@ impl Handler {
         suggested_size: LogicalSize<f64>,
         hidpi_factor: f64,
     ) {
-        let size = suggested_size.to_physical(hidpi_factor);
+        let mut size = suggested_size.to_physical(hidpi_factor);
         let new_inner_size = &mut size;
         let event = Event::WindowEvent {
             window_id: WindowId(get_window_id(*ns_window)),

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -188,7 +188,7 @@ impl Handler {
         hidpi_factor: f64,
     ) {
         let size = suggested_size.to_physical(hidpi_factor);
-        let new_inner_size = &mut Some(size);
+        let new_inner_size = &mut size;
         let event = Event::WindowEvent {
             window_id: WindowId(get_window_id(*ns_window)),
             event: WindowEvent::HiDpiFactorChanged {
@@ -199,7 +199,7 @@ impl Handler {
 
         callback.handle_nonuser_event(event, &mut *self.control_flow.lock().unwrap());
 
-        let physical_size = new_inner_size.unwrap_or(size);
+        let physical_size = *new_inner_size;
         let logical_size = physical_size.to_logical(hidpi_factor);
         let size = NSSize::new(logical_size.width, logical_size.height);
         unsafe { NSWindow::setContentSize_(*ns_window, size) };

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1920,26 +1920,24 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 (old_physical_inner_rect.bottom - old_physical_inner_rect.top) as u32,
             );
 
-            // We calculate our own size because the default suggested rect doesn't do a great job
-            // of preserving the window's logical size.
-            let suggested_physical_inner_size = old_physical_inner_size
-                .to_logical::<f64>(old_dpi_factor)
-                .to_physical::<u32>(new_dpi_factor);
-
             // `allow_resize` prevents us from re-applying DPI adjustment to the restored size after
             // exiting fullscreen (the restored size is already DPI adjusted).
-            let mut new_inner_size_opt =
-                Some(suggested_physical_inner_size).filter(|_| allow_resize);
+            let mut new_physical_inner_size = match allow_resize {
+                // We calculate our own size because the default suggested rect doesn't do a great job
+                // of preserving the window's logical size.
+                true => old_physical_inner_size
+                    .to_logical::<f64>(old_dpi_factor)
+                    .to_physical::<u32>(new_dpi_factor),
+                false => old_physical_inner_size,
+            };
 
             let _ = subclass_input.send_event_unbuffered(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: HiDpiFactorChanged {
                     hidpi_factor: new_dpi_factor,
-                    new_inner_size: &mut new_inner_size_opt,
+                    new_inner_size: &mut new_physical_inner_size,
                 },
             });
-
-            let new_physical_inner_size = new_inner_size_opt.unwrap_or(old_physical_inner_size);
 
             // Unset maximized if we're changing the window's size.
             if new_physical_inner_size != old_physical_inner_size {


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

Thinking about it, the `Option` wrapper isn't really necessary - if the user doesn't want the window to resize, they can just set the size to `Window::inner_size()`.

Not 100% sure if this'll compile on macOS and iOS, but I'll update the PR if the CI fails.