### PR TITLE
on MacOS, Fix not sending ReceivedCharacter event for some key combination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On X11, fix `ModifiersChanged` emitting incorrect modifier change events
+- On macOS, fix not sending ReceivedCharacter event for specific keys combinations.
 
 # 0.20.0 Alpha 6 (2020-01-03)
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -377,8 +377,6 @@ extern "C" fn reset_cursor_rects(this: &Object, _sel: Sel) {
 }
 
 extern "C" fn has_marked_text(_this: &Object, _sel: Sel) -> BOOL {
-    trace!("Triggered `hasMarkedText`");
-    trace!("Completed `hasMarkedText`");
     YES
 }
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -376,13 +376,10 @@ extern "C" fn reset_cursor_rects(this: &Object, _sel: Sel) {
     }
 }
 
-extern "C" fn has_marked_text(this: &Object, _sel: Sel) -> BOOL {
-    unsafe {
-        trace!("Triggered `hasMarkedText`");
-        let marked_text: id = *this.get_ivar("markedText");
-        trace!("Completed `hasMarkedText`");
-        (marked_text.length() > 0) as i8
-    }
+extern "C" fn has_marked_text(_this: &Object, _sel: Sel) -> BOOL {
+    trace!("Triggered `hasMarkedText`");
+    trace!("Completed `hasMarkedText`");
+    YES
 }
 
 extern "C" fn marked_range(this: &Object, _sel: Sel) -> NSRange {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR fixes #1267 
It seems that Ctrl+Q is some prefix key when `hasMarkedText` returns `NO`.
For example, it emits '\u{1e}' when input Ctrl+Q and Arrow-up key.
So I modified `hasMarkedText` to returns YES always.
I'm not 100% sure about the mean of this change, but I think it's OK because `hasMarkedText` returns always `YES` after inputting Option+N in previous implementation.

A key with Command no longer emits ReceivedCharacter event by this change.