### PR TITLE
On X11, make `WINIT_HIDPI_FACTOR` dominate `Xft.dpi` in some cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - Add `DeviceEvent::ModifiersChanged`.
   - Deprecate `modifiers` fields in other events in favor of `ModifiersChanged`.
 - On X11, `WINIT_HIDPI_FACTOR` now dominates `Xft.dpi` when picking DPI factor for output.
-- On X11, add special value `0` for `WINIT_HIDPI_FACTOR` to make winit use self computed DPI factor instead of the one from `Xft.dpi`.
+- On X11, add special value `randr` for `WINIT_HIDPI_FACTOR` to make winit use self computed DPI factor instead of the one from `Xft.dpi`.
 
 # 0.20.0 Alpha 5 (2019-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 - On Windows, fix `Window::set_visible` not setting internal flags correctly. This resulted in some weird behavior.
 - Add `DeviceEvent::ModifiersChanged`.
   - Deprecate `modifiers` fields in other events in favor of `ModifiersChanged`.
+- On X11, `WINIT_HIDPI_FACTOR` now dominates `Xft.dpi` when picking DPI factor for output.
+- On X11, add special value `0` for `WINIT_HIDPI_FACTOR` to make winit use self computed DPI factor instead of the one from `Xft.dpi`.
 
 # 0.20.0 Alpha 5 (2019-12-09)
 

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -109,7 +109,10 @@ impl XConnection {
                 } else if let Ok(dpi) = f64::from_str(&var) {
                     EnvVarDPI::Scale(dpi)
                 } else {
-                    EnvVarDPI::NotSet
+                    panic!(
+                        "`WINIT_HIDPI_FACTOR` invalid; DPI factors must be either normal floats greater than 0, or `randr`. Got `{}`",
+                        var
+                    );
                 }
             },
         );
@@ -125,7 +128,7 @@ impl XConnection {
             EnvVarDPI::Scale(dpi_override) => {
                 if !validate_hidpi_factor(dpi_override) {
                     panic!(
-                        "`WINIT_HIDPI_FACTOR` invalid; DPI factors must be either normal floats greater then 0 or `randr` string. Got `{}`",
+                        "`WINIT_HIDPI_FACTOR` invalid; DPI factors must be either normal floats greater than 0, or `randr`. Got `{}`",
                         dpi_override,
                     );
                 }

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -108,6 +108,8 @@ impl XConnection {
                     EnvVarDPI::Randr
                 } else if let Ok(dpi) = f64::from_str(&var) {
                     EnvVarDPI::Scale(dpi)
+                } else if var.is_empty() {
+                    EnvVarDPI::NotSet
                 } else {
                     panic!(
                         "`WINIT_HIDPI_FACTOR` invalid; DPI factors must be either normal floats greater than 0, or `randr`. Got `{}`",


### PR DESCRIPTION
This commit makes `WINIT_HIDPI_FACTOR` dominate `Xft.dpi` in general and
adds a special value `0` for `WINIT_HIDPI_FACTOR` to use winit computed
DPI factor with randr over Xft.dpi.

We agreed with @Osspial [here](https://github.com/rust-windowing/winit/pull/1349#discussion_r362718880) that the proposed [solution](https://github.com/rust-windowing/winit/issues/836#issuecomment-562912905) for #836 makes sense and also that `WINIT_DPI_FACTOR` should dominate `Xft.dpi`.

However I'm wondering whether I should send this PR to dpi-overhaul branch instead?


- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #836 #1141

cc @chrisduerr 