### PR TITLE
Mark Event, WindowEvent, DeviceEvent, and VirtualKeyCode as non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **Breaking**: Change `ModifiersState` to a `bitflags` struct.
 - On Windows, implement `VirtualKeyCode` translation for `LWin` and `RWin`.
 - On Windows, fix closing the last opened window causing `DeviceEvent`s to stop getting emitted.
+- **Breaking**: Mark `Event`, `WindowEvent`, `DeviceEvent`, and `VirtualKeyCode` as `non_exhaustive`.
 - On Windows, fix `Window::set_visible` not setting internal flags correctly. This resulted in some weird behavior.
 - Add `DeviceEvent::ModifiersChanged`.
   - Deprecate `modifiers` fields in other events in favor of `ModifiersChanged`.

--- a/src/event.rs
+++ b/src/event.rs
@@ -15,6 +15,7 @@ use crate::{
 
 /// Describes a generic event.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum Event<T> {
     /// Emitted when the OS sends an event to a winit window.
     WindowEvent {
@@ -104,6 +105,7 @@ pub enum StartCause {
 
 /// Describes an event from a `Window`.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum WindowEvent {
     /// The size of the window has changed. Contains the client area's new dimensions.
     Resized(LogicalSize),
@@ -264,6 +266,7 @@ impl DeviceId {
 ///
 /// Note that these events are delivered regardless of input focus.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum DeviceEvent {
     Added,
     Removed,
@@ -488,6 +491,7 @@ pub enum MouseScrollDelta {
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy)]
 #[repr(u32)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum VirtualKeyCode {
     /// The '1' key over the letters.
     Key1,


### PR DESCRIPTION
This will allow us to add new events and keycodes without introducing breaking changes. It's been a couple weeks since Rust 1.40 came out and added this attribute, so I feel like it's been a part of the ecosystem for long enough that it's okay for us to depend on it.