### PR TITLE
Make examples set control_flow in a more realistic way

### DIFF
--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -12,35 +12,39 @@ fn main() {
 
     let mut cursor_idx = 0;
 
-    event_loop.run(move |event, _, control_flow| match event {
-        Event::WindowEvent {
-            event:
-                WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            state: ElementState::Pressed,
-                            ..
-                        },
-                    ..
-                },
-            ..
-        } => {
-            println!("Setting cursor to \"{:?}\"", CURSORS[cursor_idx]);
-            window.set_cursor_icon(CURSORS[cursor_idx]);
-            if cursor_idx < CURSORS.len() - 1 {
-                cursor_idx += 1;
-            } else {
-                cursor_idx = 0;
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent {
+                event:
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                state: ElementState::Pressed,
+                                ..
+                            },
+                        ..
+                    },
+                ..
+            } => {
+                println!("Setting cursor to \"{:?}\"", CURSORS[cursor_idx]);
+                window.set_cursor_icon(CURSORS[cursor_idx]);
+                if cursor_idx < CURSORS.len() - 1 {
+                    cursor_idx += 1;
+                } else {
+                    cursor_idx = 0;
+                }
             }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                *control_flow = ControlFlow::Exit;
+                return;
+            }
+            _ => (),
         }
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            ..
-        } => {
-            *control_flow = ControlFlow::Exit;
-            return;
-        }
-        _ => (),
     });
 }
 

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -16,6 +16,7 @@ fn main() {
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
+
         match event {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -31,13 +31,17 @@ fn main() {
         }
     });
 
-    event_loop.run(move |event, _, control_flow| match event {
-        Event::UserEvent(event) => println!("user event: {:?}", event),
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            ..
-        } => *control_flow = ControlFlow::Exit,
-        _ => *control_flow = ControlFlow::Wait,
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::UserEvent(event) => println!("user event: {:?}", event),
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => *control_flow = ControlFlow::Exit,
+            _ => (),
+        }
     });
 }
 

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -14,6 +14,7 @@ fn main() {
     window.set_max_inner_size(Some(LogicalSize::new(800.0, 400.0)));
 
     event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
         println!("{:?}", event);
 
         match event {
@@ -21,7 +22,7 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 ..
             } => *control_flow = ControlFlow::Exit,
-            _ => *control_flow = ControlFlow::Wait,
+            _ => (),
         }
     });
 }

--- a/examples/minimize.rs
+++ b/examples/minimize.rs
@@ -12,24 +12,28 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, _, control_flow| match event {
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            ..
-        } => *control_flow = ControlFlow::Exit,
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
 
-        // Keyboard input event to handle minimize via a hotkey
-        Event::WindowEvent {
-            event: WindowEvent::KeyboardInput { input, .. },
-            window_id,
-        } => {
-            if window_id == window.id() {
-                // Pressing the 'M' key will minimize the window
-                if input.virtual_keycode == Some(VirtualKeyCode::M) {
-                    window.set_minimized(true);
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => *control_flow = ControlFlow::Exit,
+
+            // Keyboard input event to handle minimize via a hotkey
+            Event::WindowEvent {
+                event: WindowEvent::KeyboardInput { input, .. },
+                window_id,
+            } => {
+                if window_id == window.id() {
+                    // Pressing the 'M' key will minimize the window
+                    if input.virtual_keycode == Some(VirtualKeyCode::M) {
+                        window.set_minimized(true);
+                    }
                 }
             }
+            _ => (),
         }
-        _ => *control_flow = ControlFlow::Wait,
     });
 }

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -16,6 +16,7 @@ fn main() {
 
     event_loop.run(move |event, event_loop, control_flow| {
         *control_flow = ControlFlow::Wait;
+
         match event {
             Event::WindowEvent { event, window_id } => {
                 match event {

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -1,8 +1,5 @@
-use instant::Instant;
-use std::time::Duration;
-
 use winit::{
-    event::{Event, WindowEvent},
+    event::{ElementState, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     window::WindowBuilder,
 };
@@ -15,18 +12,26 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, _, control_flow| match event {
-        Event::WindowEvent {
-            event: WindowEvent::CloseRequested,
-            ..
-        } => *control_flow = ControlFlow::Exit,
-        Event::MainEventsCleared => {
-            window.request_redraw();
-            *control_flow = ControlFlow::WaitUntil(Instant::now() + Duration::new(1, 0))
+    event_loop.run(move |event, _, control_flow| {
+        println!("{:?}", event);
+
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent {
+                event,
+                ..
+            } => match event {
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::MouseInput{ state: ElementState::Released, .. } => {
+                    window.request_redraw();
+                },
+                _ => (),
+            },
+            Event::RedrawRequested(_) => {
+                println!("\nredrawing!\n");
+            }
+            _ => (),
         }
-        Event::RedrawRequested(_) => {
-            println!("{:?}", event);
-        }
-        _ => (),
     });
 }

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -18,14 +18,14 @@ fn main() {
         *control_flow = ControlFlow::Wait;
 
         match event {
-            Event::WindowEvent {
-                event,
-                ..
-            } => match event {
+            Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
-                WindowEvent::MouseInput{ state: ElementState::Released, .. } => {
+                WindowEvent::MouseInput {
+                    state: ElementState::Released,
+                    ..
+                } => {
                     window.request_redraw();
-                },
+                }
                 _ => (),
             },
             Event::RedrawRequested(_) => {

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -18,6 +18,7 @@ fn main() {
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
+
         match event {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -16,6 +16,7 @@ fn main() {
     window.set_title("A fantastic window!");
 
     event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
         println!("{:?}", event);
 
         match event {
@@ -23,7 +24,7 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 ..
             } => *control_flow = ControlFlow::Exit,
-            _ => *control_flow = ControlFlow::Wait,
+            _ => (),
         }
     });
 }

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -40,6 +40,8 @@ pub fn main() {
     }
 
     event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
         #[cfg(feature = "web-sys")]
         log::debug!("{:?}", event);
 
@@ -54,7 +56,7 @@ pub fn main() {
             Event::MainEventsCleared => {
                 window.request_redraw();
             }
-            _ => *control_flow = ControlFlow::Wait,
+            _ => (),
         }
     });
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -13,6 +13,7 @@ fn main() {
         .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
         println!("{:?}", event);
 
         match event {
@@ -23,7 +24,7 @@ fn main() {
             Event::MainEventsCleared => {
                 window.request_redraw();
             }
-            _ => *control_flow = ControlFlow::Poll,
+            _ => (),
         }
     });
 }

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -27,6 +27,7 @@ fn main() {
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
+
         if let Event::WindowEvent { event, .. } = event {
             use winit::event::WindowEvent::*;
             match event {

--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -38,7 +38,6 @@ fn main() {
                     ..
                 } => {
                     quit = true;
-                    *control_flow = ControlFlow::Exit;
                 }
                 Event::MainEventsCleared => {
                     *control_flow = ControlFlow::Exit;
@@ -48,6 +47,7 @@ fn main() {
         });
 
         // Sleep for 1/60 second to simulate rendering
+        println!("rendering");
         sleep(Duration::from_millis(16));
     }
 }


### PR DESCRIPTION
- [x] Created or updated an example program if it would help users understand this functionality

I was talking with @grovesNL in the Rust Discord, and I noticed that a lot of the examples set `control_flow` in the event matching fallthrough case. That's a bad design pattern to be encouraging, so this PR moves the `control_flow` setters to the top of the event handler closure.