### PR TITLE
Don't discard high-precision cursor position data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - On Windows, fix bug where `RedrawRequested` would only get emitted every other iteration of the event loop.
 - On X11, fix deadlock on window state when handling certain window events.
 - `WindowBuilder` now implements `Default`.
-- `WindowEvent::CursorMoved` changed to `f64` units, preserving high-precision data supplied by most backends
+- **Breaking:** `WindowEvent::CursorMoved` changed to `f64` units, preserving high-precision data supplied by most backends
 
 # 0.20.0 (2020-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - On Windows, fix bug where `RedrawRequested` would only get emitted every other iteration of the event loop.
 - On X11, fix deadlock on window state when handling certain window events.
 - `WindowBuilder` now implements `Default`.
+- `WindowEvent::CursorMoved` changed to `f64` units, preserving high-precision data supplied by most backends
 
 # 0.20.0 (2020-01-05)
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -242,7 +242,7 @@ pub enum WindowEvent<'a> {
         /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range of this data is
         /// limited by the display area and it may have been transformed by the OS to implement effects such as cursor
         /// acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
-        position: PhysicalPosition<i32>,
+        position: PhysicalPosition<f64>,
         #[deprecated = "Deprecated in favor of DeviceEvent::ModifiersChanged"]
         modifiers: ModifiersState,
     },

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -723,8 +723,7 @@ impl<T: 'static> EventProcessor<T> {
                             util::maybe_change(&mut shared_state_lock.cursor_pos, new_cursor_pos)
                         });
                         if cursor_moved == Some(true) {
-                            let position =
-                                PhysicalPosition::new(xev.event_x as i32, xev.event_y as i32);
+                            let position = PhysicalPosition::new(xev.event_x, xev.event_y);
 
                             callback(Event::WindowEvent {
                                 window_id,
@@ -830,8 +829,7 @@ impl<T: 'static> EventProcessor<T> {
                                 event: CursorEntered { device_id },
                             });
 
-                            let position =
-                                PhysicalPosition::new(xev.event_x as i32, xev.event_y as i32);
+                            let position = PhysicalPosition::new(xev.event_x, xev.event_y);
 
                             // The mods field on this event isn't actually populated, so query the
                             // pointer device. In the future, we can likely remove this round-trip by
@@ -899,8 +897,7 @@ impl<T: 'static> EventProcessor<T> {
                             .map(|device| device.attachment)
                             .unwrap_or(2);
 
-                        let position =
-                            PhysicalPosition::new(xev.event_x as i32, xev.event_y as i32);
+                        let position = PhysicalPosition::new(xev.event_x, xev.event_y);
 
                         callback(Event::WindowEvent {
                             window_id,

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -207,7 +207,7 @@ impl Canvas {
 
     pub fn on_cursor_move<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<i32>, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, ModifiersState),
     {
         // todo
         self.on_cursor_move = Some(self.add_event(move |event: PointerMoveEvent| {

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -216,7 +216,7 @@ impl Canvas {
 
     pub fn on_cursor_move<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<i32>, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, ModifiersState),
     {
         self.on_cursor_move = Some(self.add_event("pointermove", move |event: PointerEvent| {
             handler(

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -855,8 +855,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 });
             }
 
-            let x = windowsx::GET_X_LPARAM(lparam) as i32;
-            let y = windowsx::GET_Y_LPARAM(lparam) as i32;
+            let x = windowsx::GET_X_LPARAM(lparam) as f64;
+            let y = windowsx::GET_Y_LPARAM(lparam) as f64;
             let position = PhysicalPosition::new(x, y);
 
             subclass_input.send_event(Event::WindowEvent {


### PR DESCRIPTION
Most platforms (X11, wayland, macos, stdweb, ...) provide physical positions in f64 units, which can contain meaningful fractional data. For example, this can be empirically observed on modern X11 using a typical laptop touchpad. This is useful for e.g. content creation tools, where cursor motion might map to brush strokes on a canvas with higher-than-screen resolution, or positioning of an object in a vector space.

I have not audited other uses of `PhysicalPosition`. IMO there's a strong case for making it non-generic; it was difficult to trace the types of all uses even for this one event, and 64 bits ought to be enough for anyone.

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
