### PR TITLE
Make docs set control_flow in a more realistic way

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,14 @@ fn main() {
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
     event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
             } if window_id == window.id() => *control_flow = ControlFlow::Exit,
-            _ => *control_flow = ControlFlow::Wait,
+            _ => (),
         }
     });
 }

--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -28,6 +28,8 @@ fn main() {
 
     while !quit {
         event_loop.run_return(|event, _, control_flow| {
+            *control_flow = ControlFlow::Wait;
+
             if let Event::WindowEvent { event, .. } = &event {
                 // Print only Window events to reduce noise
                 println!("{:?}", event);
@@ -43,7 +45,7 @@ fn main() {
                 Event::MainEventsCleared => {
                     *control_flow = ControlFlow::Exit;
                 }
-                _ => *control_flow = ControlFlow::Wait,
+                _ => (),
             }
         });
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -26,12 +26,14 @@ pub use crate::icon::*;
 /// let window = Window::new(&event_loop).unwrap();
 ///
 /// event_loop.run(move |event, _, control_flow| {
+///     *control_flow = ControlFlow::Wait;
+///
 ///     match event {
 ///         Event::WindowEvent {
 ///             event: WindowEvent::CloseRequested,
 ///             ..
 ///         } => *control_flow = ControlFlow::Exit,
-///         _ => *control_flow = ControlFlow::Wait,
+///         _ => (),
 ///     }
 /// });
 /// ```


### PR DESCRIPTION
Finishing the job of #1363. I noticed that README.md still used the old style.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
