### PR TITLE
Return physical position in `CursorMoved` on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - On Windows, fix bug where `RedrawRequested` would only get emitted every other iteration of the event loop.
 - On X11, fix deadlock on window state when handling certain window events.
 - `WindowBuilder` now implements `Default`.
+- On macOS, fix `CursorMoved` event reporting the cursor position using logical coordinates.
 
 # 0.20.0 (2020-01-05)
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -17,6 +17,7 @@ use objc::{
 };
 
 use crate::{
+    dpi::LogicalPosition,
     event::{
         DeviceEvent, ElementState, Event, KeyboardInput, ModifiersState, MouseButton,
         MouseScrollDelta, TouchPhase, VirtualKeyCode, WindowEvent,
@@ -57,6 +58,12 @@ struct ViewState {
     is_key_down: bool,
     modifiers: ModifiersState,
     tracking_rect: Option<NSInteger>,
+}
+
+impl ViewState {
+    fn get_scale_factor(&self) -> f64 {
+        (unsafe { NSWindow::backingScaleFactor(self.ns_window) }) as f64
+    }
 }
 
 pub fn new_view(ns_window: id) -> (IdRef, Weak<Mutex<CursorState>>) {
@@ -882,12 +889,13 @@ fn mouse_motion(this: &Object, event: id) {
 
         let x = view_point.x as f64;
         let y = view_rect.size.height as f64 - view_point.y as f64;
+        let logical_position = LogicalPosition::new(x, y);
 
         let window_event = Event::WindowEvent {
             window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::CursorMoved {
                 device_id: DEVICE_ID,
-                position: (x, y).into(),
+                position: logical_position.to_physical(state.get_scale_factor()),
                 modifiers: event_mods(event),
             },
         };
@@ -925,27 +933,8 @@ extern "C" fn mouse_entered(this: &Object, _sel: Sel, event: id) {
             },
         };
 
-        let move_event = {
-            let window_point = event.locationInWindow();
-            let view_point: NSPoint = msg_send![this,
-                convertPoint:window_point
-                fromView:nil // convert from window coordinates
-            ];
-            let view_rect: NSRect = msg_send![this, frame];
-            let x = view_point.x as f64;
-            let y = (view_rect.size.height - view_point.y) as f64;
-            Event::WindowEvent {
-                window_id: WindowId(get_window_id(state.ns_window)),
-                event: WindowEvent::CursorMoved {
-                    device_id: DEVICE_ID,
-                    position: (x, y).into(),
-                    modifiers: event_mods(event),
-                },
-            }
-        };
-
         AppState::queue_event(EventWrapper::StaticEvent(enter_event));
-        AppState::queue_event(EventWrapper::StaticEvent(move_event));
+        mouse_motion(this, event);
     }
     trace!("Completed `mouseEntered`");
 }


### PR DESCRIPTION
Fixes #1371.

I found the issue described in #1371 when upgrading `iced_winit`: https://github.com/hecrj/iced/pull/147

The fix takes the same approach used in `window_delegate`. I am not sure if there is a better way to obtain the cursor position using physical coordinates.

- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
