### PR TITLE
Fix warnings on all platforms

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -215,14 +215,10 @@ impl<T: 'static> fmt::Debug for EventLoopProxy<T> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct EventLoopClosed<T>(pub T);
 
-impl<T: fmt::Debug> fmt::Display for EventLoopClosed<T> {
+impl<T> fmt::Display for EventLoopClosed<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", error::Error::description(self))
+        f.write_str("Tried to wake up a closed `EventLoop`")
     }
 }
 
-impl<T: fmt::Debug> error::Error for EventLoopClosed<T> {
-    fn description(&self) -> &str {
-        "Tried to wake up a closed `EventLoop`"
-    }
-}
+impl<T: fmt::Debug> error::Error for EventLoopClosed<T> {}

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -49,11 +49,7 @@ impl fmt::Display for BadIcon {
 }
 
 impl Error for BadIcon {
-    fn description(&self) -> &str {
-        "A valid icon cannot be created from these arguments"
-    }
-
-    fn cause(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         Some(self)
     }
 }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -29,22 +29,21 @@ pub enum BadIcon {
 
 impl fmt::Display for BadIcon {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg = match self {
-            &BadIcon::ByteCountNotDivisibleBy4 { byte_count } => format!(
+        match self {
+            BadIcon::ByteCountNotDivisibleBy4 { byte_count } => write!(f,
                 "The length of the `rgba` argument ({:?}) isn't divisible by 4, making it impossible to interpret as 32bpp RGBA pixels.",
                 byte_count,
             ),
-            &BadIcon::DimensionsVsPixelCount {
+            BadIcon::DimensionsVsPixelCount {
                 width,
                 height,
                 width_x_height,
                 pixel_count,
-            } => format!(
+            } => write!(f,
                 "The specified dimensions ({:?}x{:?}) don't match the number of pixels supplied by the `rgba` argument ({:?}). For those dimensions, the expected pixel count is {:?}.",
                 width, height, pixel_count, width_x_height,
             ),
-        };
-        write!(f, "{}", msg)
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@
 #[allow(unused_imports)]
 #[macro_use]
 extern crate lazy_static;
+#[allow(unused_imports)]
 #[macro_use]
 extern crate log;
 #[cfg(feature = "serde")]

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -111,12 +111,7 @@ pub struct XError {
     pub minor_code: u8,
 }
 
-impl Error for XError {
-    #[inline]
-    fn description(&self) -> &str {
-        &self.description
-    }
-}
+impl Error for XError {}
 
 impl fmt::Display for XError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -144,17 +139,18 @@ impl From<ffi::OpenError> for XNotSupported {
     }
 }
 
-impl Error for XNotSupported {
-    #[inline]
-    fn description(&self) -> &str {
-        match *self {
+impl XNotSupported {
+    fn description(&self) -> &'static str {
+        match self {
             XNotSupported::LibraryOpenError(_) => "Failed to load one of xlib's shared libraries",
             XNotSupported::XOpenDisplayFailed => "Failed to open connection to X server",
         }
     }
+}
 
+impl Error for XNotSupported {
     #[inline]
-    fn cause(&self) -> Option<&dyn Error> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             XNotSupported::LibraryOpenError(ref err) => Some(err),
             _ => None,

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -287,6 +287,7 @@ pub unsafe fn modifier_event(
 
         let scancode = get_scancode(ns_event);
         let virtual_keycode = scancode_to_keycode(scancode);
+        #[allow(deprecated)]
         Some(WindowEvent::KeyboardInput {
             device_id: DEVICE_ID,
             input: KeyboardInput {

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -631,6 +631,7 @@ extern "C" fn key_down(this: &Object, _sel: Sel, event: id) {
 
         let is_repeat = msg_send![event, isARepeat];
 
+        #[allow(deprecated)]
         let window_event = Event::WindowEvent {
             window_id,
             event: WindowEvent::KeyboardInput {
@@ -683,6 +684,7 @@ extern "C" fn key_up(this: &Object, _sel: Sel, event: id) {
         let scancode = get_scancode(event) as u32;
         let virtual_keycode = retrieve_keycode(event);
 
+        #[allow(deprecated)]
         let window_event = Event::WindowEvent {
             window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::KeyboardInput {
@@ -797,6 +799,7 @@ extern "C" fn cancel_operation(this: &Object, _sel: Sel, _sender: id) {
 
         let event: id = msg_send![NSApp(), currentEvent];
 
+        #[allow(deprecated)]
         let window_event = Event::WindowEvent {
             window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::KeyboardInput {

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -57,6 +57,7 @@ impl<T> WindowTarget<T> {
 
         let runner = self.runner.clone();
         canvas.on_keyboard_press(move |scancode, virtual_keycode, modifiers| {
+            #[allow(deprecated)]
             runner.send_event(Event::WindowEvent {
                 window_id: WindowId(id),
                 event: WindowEvent::KeyboardInput {
@@ -74,6 +75,7 @@ impl<T> WindowTarget<T> {
 
         let runner = self.runner.clone();
         canvas.on_keyboard_release(move |scancode, virtual_keycode, modifiers| {
+            #[allow(deprecated)]
             runner.send_event(Event::WindowEvent {
                 window_id: WindowId(id),
                 event: WindowEvent::KeyboardInput {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -936,6 +936,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 commctrl::DefSubclassProc(window, msg, wparam, lparam)
             } else {
                 if let Some((scancode, vkey)) = process_key_params(wparam, lparam) {
+                    #[allow(deprecated)]
                     subclass_input.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: WindowEvent::KeyboardInput {
@@ -965,6 +966,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
         winuser::WM_KEYUP | winuser::WM_SYSKEYUP => {
             use crate::event::ElementState::Released;
             if let Some((scancode, vkey)) = process_key_params(wparam, lparam) {
+                #[allow(deprecated)]
                 subclass_input.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
@@ -1330,6 +1332,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::MapVirtualKeyA(windows_keycode as _, winuser::MAPVK_VK_TO_VSC);
                 let virtual_keycode = event::vkey_to_winit_vkey(windows_keycode);
 
+                #[allow(deprecated)]
                 subclass_input.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
@@ -1360,6 +1363,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::MapVirtualKeyA(windows_keycode as _, winuser::MAPVK_VK_TO_VSC);
                 let virtual_keycode = event::vkey_to_winit_vkey(windows_keycode);
 
+                #[allow(deprecated)]
                 subclass_input.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
@@ -1913,6 +1917,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                                 });
                             }
 
+                            #[allow(deprecated)]
                             subclass_input.send_event(Event::DeviceEvent {
                                 device_id,
                                 event: Key(KeyboardInput {


### PR DESCRIPTION
* Also removed an unnecessary impl trait bound that I noticed along the way

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
