### PR TITLE
doc: change remaining EventsCleared references to MainEventsCleared

### DIFF
--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -215,10 +215,10 @@ fn setup_control_flow_observers() {
 
         // Core Animation registers its `CFRunLoopObserver` that performs drawing operations in
         // `CA::Transaction::ensure_implicit` with a priority of `0x1e8480`. We set the main_end
-        // priority to be 0, in order to send EventsCleared before RedrawRequested. This value was
+        // priority to be 0, in order to send MainEventsCleared before RedrawRequested. This value was
         // chosen conservatively to guard against apple using different priorities for their redraw
         // observers in different OS's or on different devices. If it so happens that it's too
-        // conservative, the main symptom would be non-redraw events coming in after `EventsCleared`.
+        // conservative, the main symptom would be non-redraw events coming in after `MainEventsCleared`.
         //
         // The value of `0x1e8480` was determined by inspecting stack traces and the associated
         // registers for every `CFRunLoopAddObserver` call on an iPad Air 2 running iOS 11.4.

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -122,7 +122,7 @@ extern "C" fn control_flow_begin_handler(
 }
 
 // end is queued with the lowest priority to ensure it is processed after other observers
-// without that, LoopDestroyed would  get sent after EventsCleared
+// without that, LoopDestroyed would  get sent after MainEventsCleared
 extern "C" fn control_flow_end_handler(
     _: CFRunLoopObserverRef,
     activity: CFRunLoopActivity,

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -30,7 +30,7 @@ pub struct WindowState {
 
     pub fullscreen: Option<Fullscreen>,
     /// Used to supress duplicate redraw attempts when calling `request_redraw` multiple
-    /// times in `EventsCleared`.
+    /// times in `MainEventsCleared`.
     pub queued_out_of_band_redraw: bool,
     pub is_dark_mode: bool,
     pub high_surrogate: Option<u16>,

--- a/src/window.rs
+++ b/src/window.rs
@@ -392,10 +392,10 @@ impl Window {
     /// This is the **strongly encouraged** method of redrawing windows, as it can integrate with
     /// OS-requested redraws (e.g. when a window gets resized).
     ///
-    /// This function can cause `RedrawRequested` events to be emitted after `Event::EventsCleared`
+    /// This function can cause `RedrawRequested` events to be emitted after `Event::MainEventsCleared`
     /// but before `Event::NewEvents` if called in the following circumstances:
-    /// * While processing `EventsCleared`.
-    /// * While processing a `RedrawRequested` event that was sent during `EventsCleared` or any
+    /// * While processing `MainEventsCleared`.
+    /// * While processing a `RedrawRequested` event that was sent during `MainEventsCleared` or any
     ///   directly subsequent `RedrawRequested` event.
     ///
     /// ## Platform-specific


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
