### PR TITLE
On X11, if RANDR based scale factor is higher than 20 reset it to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - On Wayland, bump `smithay-client-toolkit` to 0.15.1.
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
+- On X11, if RANDR based scale factor is higher than 20 reset it to 1
 
 # 0.25.0 (2021-05-15)
 

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -27,7 +27,11 @@ pub fn calc_dpi_factor(
     // Quantize 1/12 step size
     let dpi_factor = ((ppmm * (12.0 * 25.4 / 96.0)).round() / 12.0).max(1.0);
     assert!(validate_scale_factor(dpi_factor));
-    dpi_factor
+    if dpi_factor <= 20. {
+        dpi_factor
+    } else {
+        1.
+    }
 }
 
 impl XConnection {


### PR DESCRIPTION
Some video drivers could set display metrics to odd values, which can result in
extra large scale factors (e.g. winit is sending 720 for 5k screen on nvidia
binary drivers), so let's just drop them to prevent clients from using them.
The value 20 was picked, because the DPR for 8k @ 5 inch is ~18.36.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


This PR is more of a proposal. The original issue was here https://github.com/alacritty/alacritty/issues/3214 , as you can see in a log, DPR from winit is 718, which is literally insane. I see 2 options on how to fix such issues.

1 - Make winit compute DPI only if a randr value in use, otherwise return just 1 all the time. Qt is probably doing something similar IIRC
2 - Just try to ignore odd values (this PR is doing it).

The proposed `1` change is a breaking change, so I guess `2` option should fix some problems right now, however I feel like we should also implement `1` at some point to be more `native`, since auto DPI adjustments aren't something common for X11.