### PR TITLE
add composition event support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ wayland-client = { version = "0.23.0", features = [ "dlopen", "egl", "cursor", "
 mio = "0.6"
 mio-extras = "2.0"
 smithay-client-toolkit = "^0.6.6"
-x11-dl = "2.18.4"
+x11-dl = "2.18.5"
 percent-encoding = "2.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows"))'.dependencies.parking_lot]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ wayland-client = { version = "0.23.0", features = [ "dlopen", "egl", "cursor", "
 mio = "0.6"
 mio-extras = "2.0"
 smithay-client-toolkit = "^0.6.6"
-x11-dl = "2.18.3"
+x11-dl = "2.18.4"
 percent-encoding = "2.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows"))'.dependencies.parking_lot]

--- a/src/event.rs
+++ b/src/event.rs
@@ -235,6 +235,11 @@ pub enum WindowEvent<'a> {
         is_synthetic: bool,
     },
 
+    /// An event from IME
+    Composition {
+        event: CompositionEvent,
+    },
+
     /// The cursor has moved on the window.
     CursorMoved {
         device_id: DeviceId,
@@ -504,6 +509,14 @@ pub struct KeyboardInput {
     /// this device are not being delivered to the application, e.g. due to keyboard focus being elsewhere.
     #[deprecated = "Deprecated in favor of DeviceEvent::ModifiersChanged"]
     pub modifiers: ModifiersState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum CompositionEvent {
+    CompositionStart(String),
+    CompositionUpdate(String),
+    CompositionEnd(String),
 }
 
 /// Describes touch-screen input state.

--- a/src/event.rs
+++ b/src/event.rs
@@ -513,9 +513,9 @@ pub struct KeyboardInput {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CompositionEvent {
-    CompositionStart,
+    CompositionStart(String),
     CompositionUpdate(String, usize),
-    CompositionEnd,
+    CompositionEnd(String),
 }
 
 /// Describes touch-screen input state.

--- a/src/event.rs
+++ b/src/event.rs
@@ -236,9 +236,7 @@ pub enum WindowEvent<'a> {
     },
 
     /// An event from IME
-    Composition {
-        event: CompositionEvent,
-    },
+    Composition { event: CompositionEvent },
 
     /// The cursor has moved on the window.
     CursorMoved {

--- a/src/event.rs
+++ b/src/event.rs
@@ -344,6 +344,7 @@ impl<'a> WindowEvent<'a> {
                 input,
                 is_synthetic,
             }),
+            Composition { event } => Some(Composition { event }),
             #[allow(deprecated)]
             CursorMoved {
                 device_id,

--- a/src/event.rs
+++ b/src/event.rs
@@ -514,9 +514,9 @@ pub struct KeyboardInput {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CompositionEvent {
-    CompositionStart(String),
-    CompositionUpdate(String),
-    CompositionEnd(String),
+    CompositionStart(),
+    CompositionUpdate(String, usize),
+    CompositionEnd(),
 }
 
 /// Describes touch-screen input state.

--- a/src/event.rs
+++ b/src/event.rs
@@ -236,7 +236,7 @@ pub enum WindowEvent<'a> {
     },
 
     /// An event from IME
-    Composition { event: CompositionEvent },
+    Composition(CompositionEvent),
 
     /// The cursor has moved on the window.
     CursorMoved {
@@ -344,7 +344,7 @@ impl<'a> WindowEvent<'a> {
                 input,
                 is_synthetic,
             }),
-            Composition { event } => Some(Composition { event }),
+            Composition(event) => Some(Composition(event)),
             #[allow(deprecated)]
             CursorMoved {
                 device_id,
@@ -513,9 +513,9 @@ pub struct KeyboardInput {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum CompositionEvent {
-    CompositionStart(),
+    CompositionStart,
     CompositionUpdate(String, usize),
-    CompositionEnd(),
+    CompositionEnd,
 }
 
 /// Describes touch-screen input state.

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1195,7 +1195,7 @@ impl<T: 'static> EventProcessor<T> {
                 debug!("get composition event");
                 callback(Event::WindowEvent {
                     window_id: mkwid(window),
-                    event: WindowEvent::Composition { event },
+                    event: WindowEvent::Composition(event),
                 });
             }
             Err(_) => (),

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -12,6 +12,7 @@ use super::{
 
 use util::modifiers::{ModifierKeyState, ModifierKeymap};
 
+use crate::platform_impl::platform::x11::ime::ImeEventReceiver;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{
@@ -19,7 +20,6 @@ use crate::{
     },
     event_loop::EventLoopWindowTarget as RootELW,
 };
-use crate::platform_impl::platform::x11::ime::ImeEventReceiver;
 
 pub(super) struct EventProcessor<T: 'static> {
     pub(super) dnd: Dnd,

--- a/src/platform_impl/linux/x11/ime/callbacks.rs
+++ b/src/platform_impl/linux/x11/ime/callbacks.rs
@@ -108,7 +108,7 @@ unsafe fn replace_im(inner: *mut ImeInner) -> Result<(), ReplaceImError> {
     for (window, old_context) in (*inner).contexts.iter() {
         let spot = old_context.as_ref().map(|old_context| old_context.ic_spot);
         let new_context = {
-            let result = ImeContext::new(xconn, new_im.im, *window, spot);
+            let result = ImeContext::new(xconn, new_im.im, *window, spot, (*inner).event_sender.clone());
             if result.is_err() {
                 let _ = close_im(xconn, new_im.im);
             }

--- a/src/platform_impl/linux/x11/ime/callbacks.rs
+++ b/src/platform_impl/linux/x11/ime/callbacks.rs
@@ -108,7 +108,13 @@ unsafe fn replace_im(inner: *mut ImeInner) -> Result<(), ReplaceImError> {
     for (window, old_context) in (*inner).contexts.iter() {
         let spot = old_context.as_ref().map(|old_context| old_context.ic_spot);
         let new_context = {
-            let result = ImeContext::new(xconn, new_im.im, *window, spot, (*inner).event_sender.clone());
+            let result = ImeContext::new(
+                xconn,
+                new_im.im,
+                *window,
+                spot,
+                (*inner).event_sender.clone(),
+            );
             if result.is_err() {
                 let _ = close_im(xconn, new_im.im);
             }

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -265,7 +265,6 @@ impl ImeContext {
             pre_edit_attr.ptr,
             ptr::null_mut::<()>(),
         );
-        println!("set preedit call back");
         if ic.is_null() {
             None
         } else {
@@ -291,7 +290,6 @@ impl ImeContext {
             pre_edit_attr.ptr,
             ptr::null_mut::<()>(),
         );
-        println!("set preedit call back 2");
         if ic.is_null() {
             None
         } else {

--- a/src/platform_impl/linux/x11/ime/inner.rs
+++ b/src/platform_impl/linux/x11/ime/inner.rs
@@ -3,6 +3,7 @@ use std::{collections::HashMap, mem, ptr, sync::Arc};
 use super::{ffi, XConnection, XError};
 
 use super::{context::ImeContext, input_method::PotentialInputMethods};
+use crate::platform_impl::platform::x11::ime::ImeEventSender;
 
 pub unsafe fn close_im(xconn: &Arc<XConnection>, im: ffi::XIM) -> Result<(), XError> {
     (xconn.xlib.XCloseIM)(im);
@@ -22,6 +23,7 @@ pub struct ImeInner {
     pub contexts: HashMap<ffi::Window, Option<ImeContext>>,
     // WARNING: this is initially zeroed!
     pub destroy_callback: ffi::XIMCallback,
+    pub event_sender: ImeEventSender,
     // Indicates whether or not the the input method was destroyed on the server end
     // (i.e. if ibus/fcitx/etc. was terminated/restarted)
     pub is_destroyed: bool,
@@ -29,13 +31,14 @@ pub struct ImeInner {
 }
 
 impl ImeInner {
-    pub fn new(xconn: Arc<XConnection>, potential_input_methods: PotentialInputMethods) -> Self {
+    pub fn new(xconn: Arc<XConnection>, potential_input_methods: PotentialInputMethods, event_sender: ImeEventSender) -> Self {
         ImeInner {
             xconn,
             im: ptr::null_mut(),
             potential_input_methods,
             contexts: HashMap::new(),
             destroy_callback: unsafe { mem::zeroed() },
+            event_sender,
             is_destroyed: false,
             is_fallback: false,
         }

--- a/src/platform_impl/linux/x11/ime/inner.rs
+++ b/src/platform_impl/linux/x11/ime/inner.rs
@@ -31,7 +31,11 @@ pub struct ImeInner {
 }
 
 impl ImeInner {
-    pub fn new(xconn: Arc<XConnection>, potential_input_methods: PotentialInputMethods, event_sender: ImeEventSender) -> Self {
+    pub fn new(
+        xconn: Arc<XConnection>,
+        potential_input_methods: PotentialInputMethods,
+        event_sender: ImeEventSender,
+    ) -> Self {
         ImeInner {
             xconn,
             im: ptr::null_mut(),

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -19,12 +19,18 @@ use self::{
     inner::{close_im, ImeInner},
     input_method::PotentialInputMethods,
 };
-use crate::event::CompositionEvent;
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ImeEvent {
+    Start,
+    Update(String, usize),
+    End,
+}
 
 pub type ImeReceiver = Receiver<(ffi::Window, i16, i16)>;
 pub type ImeSender = Sender<(ffi::Window, i16, i16)>;
-pub type ImeEventReceiver = Receiver<(ffi::Window, CompositionEvent)>;
-pub type ImeEventSender = Sender<(ffi::Window, CompositionEvent)>;
+pub type ImeEventReceiver = Receiver<(ffi::Window, ImeEvent)>;
+pub type ImeEventSender = Sender<(ffi::Window, ImeEvent)>;
 
 #[derive(Debug)]
 pub enum ImeCreationError {

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -20,7 +20,6 @@ use self::{
     input_method::PotentialInputMethods,
 };
 use crate::event::CompositionEvent;
-use crate::platform_impl::platform::x11::ime::context::ImeContextClientData;
 
 pub type ImeReceiver = Receiver<(ffi::Window, i16, i16)>;
 pub type ImeSender = Sender<(ffi::Window, i16, i16)>;

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -20,6 +20,7 @@ use self::{
     input_method::PotentialInputMethods,
 };
 use crate::event::CompositionEvent;
+use crate::platform_impl::platform::x11::ime::context::ImeContextClientData;
 
 pub type ImeReceiver = Receiver<(ffi::Window, i16, i16)>;
 pub type ImeSender = Sender<(ffi::Window, i16, i16)>;

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -41,7 +41,10 @@ pub struct Ime {
 }
 
 impl Ime {
-    pub fn new(xconn: Arc<XConnection>, event_sender: ImeEventSender) -> Result<Self, ImeCreationError> {
+    pub fn new(
+        xconn: Arc<XConnection>,
+        event_sender: ImeEventSender,
+    ) -> Result<Self, ImeCreationError> {
         let potential_input_methods = PotentialInputMethods::new(&xconn);
 
         let (mut inner, client_data) = {
@@ -97,7 +100,15 @@ impl Ime {
             // Create empty entry in map, so that when IME is rebuilt, this window has a context.
             None
         } else {
-            Some(unsafe { ImeContext::new(&self.inner.xconn, self.inner.im, window, None, self.inner.event_sender.clone()) }?)
+            Some(unsafe {
+                ImeContext::new(
+                    &self.inner.xconn,
+                    self.inner.im,
+                    window,
+                    None,
+                    self.inner.event_sender.clone(),
+                )
+            }?)
         };
         self.inner.contexts.insert(window, context);
         Ok(!self.is_destroyed())

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -55,6 +55,7 @@ use crate::{
     platform_impl::{platform::sticky_exit_callback, PlatformSpecificWindowBuilderAttributes},
     window::WindowAttributes,
 };
+use crate::platform_impl::platform::x11::ime::ImeEventSender;
 
 const X_TOKEN: Token = Token(0);
 const USER_TOKEN: Token = Token(1);
@@ -103,6 +104,7 @@ impl<T: 'static> EventLoop<T> {
             .expect("Failed to call XInternAtoms when initializing drag and drop");
 
         let (ime_sender, ime_receiver) = mpsc::channel();
+        let (ime_event_sender, ime_event_receiver) = mpsc::channel();
         // Input methods will open successfully without setting the locale, but it won't be
         // possible to actually commit pre-edit sequences.
         unsafe {
@@ -127,7 +129,7 @@ impl<T: 'static> EventLoop<T> {
             }
         }
         let ime = RefCell::new({
-            let result = Ime::new(Arc::clone(&xconn));
+            let result = Ime::new(Arc::clone(&xconn), ime_event_sender);
             if let Err(ImeCreationError::OpenFailure(ref state)) = result {
                 panic!(format!("Failed to open input method: {:#?}", state));
             }
@@ -220,6 +222,7 @@ impl<T: 'static> EventLoop<T> {
             devices: Default::default(),
             randr_event_offset,
             ime_receiver,
+            ime_event_receiver,
             xi2ext,
             mod_keymap,
             device_mod_state: Default::default(),

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -48,7 +48,6 @@ use self::{
     ime::{Ime, ImeCreationError, ImeReceiver, ImeSender},
     util::modifiers::ModifierKeymap,
 };
-use crate::platform_impl::platform::x11::ime::ImeEventSender;
 use crate::{
     error::OsError as RootOsError,
     event::{Event, StartCause},

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -227,6 +227,8 @@ impl<T: 'static> EventLoop<T> {
             device_mod_state: Default::default(),
             num_touch: 0,
             first_touch: None,
+            is_composing: false,
+            composed_text: None,
         };
 
         // Register for device hotplug events

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -48,6 +48,7 @@ use self::{
     ime::{Ime, ImeCreationError, ImeReceiver, ImeSender},
     util::modifiers::ModifierKeymap,
 };
+use crate::platform_impl::platform::x11::ime::ImeEventSender;
 use crate::{
     error::OsError as RootOsError,
     event::{Event, StartCause},
@@ -55,7 +56,6 @@ use crate::{
     platform_impl::{platform::sticky_exit_callback, PlatformSpecificWindowBuilderAttributes},
     window::WindowAttributes,
 };
-use crate::platform_impl::platform::x11::ime::ImeEventSender;
 
 const X_TOKEN: Token = Token(0);
 const USER_TOKEN: Token = Token(1);


### PR DESCRIPTION
Fix #1293

Added new window events to get information about preedit status in IME: `CompositionStart`, `CompositionUpdate`, `CompositionEnd`.

This change requires x11-dl crate. I've already send a pull request for it (https://github.com/erlepereira/x11-rs/pull/107)

TODO:
- I'm not sure `ImeContextClientData` could be accessed at the same time. It might need to be wrapped with `Mutex`
- This feature only available in X11. I don't have other platform, so need to help implementing this feature for other platforms.
- We also need to provide a way to disable this feature, since some people don't want to receive these new events.


- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
