### PR TITLE
Fix: deadlock when requesting redraw on X11

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -395,7 +395,6 @@ impl<T: 'static> EventLoop<T> {
         let mut xev = MaybeUninit::uninit();
 
         let wt = get_xtarget(&self.target);
-        let mut pending_redraws = wt.pending_redraws.lock().unwrap();
 
         while unsafe { self.event_processor.poll_one_event(xev.as_mut_ptr()) } {
             let mut xev = unsafe { xev.assume_init() };
@@ -409,7 +408,7 @@ impl<T: 'static> EventLoop<T> {
                             super::WindowId::X(wid),
                         )) = event
                         {
-                            pending_redraws.insert(wid);
+                            wt.pending_redraws.lock().unwrap().insert(wid);
                         } else {
                             callback(event, window_target, control_flow);
                         }


### PR DESCRIPTION
Fixes #1407.

Can I ask why this wasn't caught before the release? It should be obvious from any app that requests redraws on X11.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
