### PR TITLE
Simplify code by switching to higher-level dispatch APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ objc = "0.2.3"
 cocoa = "0.19.1"
 core-foundation = "0.6"
 core-graphics = "0.17.3"
-dispatch = "0.1.4"
+dispatch = "0.2.0"
 objc = "0.2.6"
 
 [target.'cfg(target_os = "macos")'.dependencies.core-video-sys]

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -6,9 +6,10 @@ use std::{
 use cocoa::{
     appkit::{CGFloat, NSScreen, NSWindow, NSWindowStyleMask},
     base::{id, nil},
-    foundation::{NSAutoreleasePool, NSPoint, NSSize, NSString},
+    foundation::{NSPoint, NSSize, NSString},
 };
 use dispatch::Queue;
+use objc::rc::autoreleasepool;
 
 use crate::{
     dpi::LogicalSize,
@@ -208,8 +209,8 @@ pub unsafe fn set_title_async(ns_window: id, title: String) {
 pub unsafe fn close_async(ns_window: id) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        let pool = NSAutoreleasePool::new(nil);
-        ns_window.close();
-        pool.drain();
+        autoreleasepool(move || {
+            ns_window.close();
+        });
     });
 }

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -1,5 +1,5 @@
 use std::{
-    os::raw::c_void,
+    ops::Deref,
     sync::{Mutex, Weak},
 };
 
@@ -8,12 +8,27 @@ use cocoa::{
     base::{id, nil},
     foundation::{NSAutoreleasePool, NSPoint, NSSize, NSString},
 };
-use dispatch::ffi::{dispatch_async_f, dispatch_get_main_queue, dispatch_sync_f};
+use dispatch::Queue;
 
 use crate::{
     dpi::LogicalSize,
     platform_impl::platform::{ffi, util::IdRef, window::SharedState},
 };
+
+// Unsafe wrapper type that allows us to dispatch things that aren't Send.
+// This should *only* be used to dispatch to the main queue.
+// While it is indeed not guaranteed that these types can safely be sent to
+// other threads, we know that they're safe to use on the main thread.
+struct MainThreadSafe<T>(T);
+
+unsafe impl<T> Send for MainThreadSafe<T> {}
+
+impl<T> Deref for MainThreadSafe<T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
 
 unsafe fn set_style_mask(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
     ns_window.setStyleMask_(mask);
@@ -22,187 +37,86 @@ unsafe fn set_style_mask(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
     ns_window.makeFirstResponder_(ns_view);
 }
 
-struct SetStyleMaskData {
-    ns_window: id,
-    ns_view: id,
-    mask: NSWindowStyleMask,
-}
-impl SetStyleMaskData {
-    fn new_ptr(ns_window: id, ns_view: id, mask: NSWindowStyleMask) -> *mut Self {
-        Box::into_raw(Box::new(SetStyleMaskData {
-            ns_window,
-            ns_view,
-            mask,
-        }))
-    }
-}
-extern "C" fn set_style_mask_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut SetStyleMaskData;
-        {
-            let context = &*context_ptr;
-            set_style_mask(context.ns_window, context.ns_view, context.mask);
-        }
-        Box::from_raw(context_ptr);
-    }
-}
 // Always use this function instead of trying to modify `styleMask` directly!
 // `setStyleMask:` isn't thread-safe, so we have to use Grand Central Dispatch.
 // Otherwise, this would vomit out errors about not being on the main thread
 // and fail to do anything.
 pub unsafe fn set_style_mask_async(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
-    let context = SetStyleMaskData::new_ptr(ns_window, ns_view, mask);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        set_style_mask_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    let ns_view = MainThreadSafe(ns_view);
+    Queue::main().exec_async(move || {
+        set_style_mask(*ns_window, *ns_view, mask);
+    });
 }
 pub unsafe fn set_style_mask_sync(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
-    let context = SetStyleMaskData::new_ptr(ns_window, ns_view, mask);
     if msg_send![class!(NSThread), isMainThread] {
-        set_style_mask_callback(context as *mut _);
+        set_style_mask(ns_window, ns_view, mask);
     } else {
-        dispatch_sync_f(
-            dispatch_get_main_queue(),
-            context as *mut _,
-            set_style_mask_callback,
-        );
+        let ns_window = MainThreadSafe(ns_window);
+        let ns_view = MainThreadSafe(ns_view);
+        Queue::main().exec_sync(move || {
+            set_style_mask(*ns_window, *ns_view, mask);
+        })
     }
 }
 
-struct SetContentSizeData {
-    ns_window: id,
-    size: LogicalSize<f64>,
-}
-impl SetContentSizeData {
-    fn new_ptr(ns_window: id, size: LogicalSize<f64>) -> *mut Self {
-        Box::into_raw(Box::new(SetContentSizeData { ns_window, size }))
-    }
-}
-extern "C" fn set_content_size_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut SetContentSizeData;
-        {
-            let context = &*context_ptr;
+unsafe fn set_content_size(ns_window: id, size: LogicalSize<f64>) {
             NSWindow::setContentSize_(
-                context.ns_window,
+                ns_window,
                 NSSize::new(
-                    context.size.width as CGFloat,
-                    context.size.height as CGFloat,
+                    size.width as CGFloat,
+                    size.height as CGFloat,
                 ),
             );
-        }
-        Box::from_raw(context_ptr);
-    }
 }
 // `setContentSize:` isn't thread-safe either, though it doesn't log any errors
 // and just fails silently. Anyway, GCD to the rescue!
 pub unsafe fn set_content_size_async(ns_window: id, size: LogicalSize<f64>) {
-    let context = SetContentSizeData::new_ptr(ns_window, size);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        set_content_size_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_async(move || {
+        set_content_size(*ns_window, size);
+    });
 }
 
-struct SetFrameTopLeftPointData {
-    ns_window: id,
-    point: NSPoint,
-}
-impl SetFrameTopLeftPointData {
-    fn new_ptr(ns_window: id, point: NSPoint) -> *mut Self {
-        Box::into_raw(Box::new(SetFrameTopLeftPointData { ns_window, point }))
-    }
-}
-extern "C" fn set_frame_top_left_point_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut SetFrameTopLeftPointData;
-        {
-            let context = &*context_ptr;
-            NSWindow::setFrameTopLeftPoint_(context.ns_window, context.point);
-        }
-        Box::from_raw(context_ptr);
-    }
+unsafe fn set_frame_top_left_point(ns_window: id, point: NSPoint) {
+            NSWindow::setFrameTopLeftPoint_(ns_window, point);
 }
 // `setFrameTopLeftPoint:` isn't thread-safe, but fortunately has the courtesy
 // to log errors.
 pub unsafe fn set_frame_top_left_point_async(ns_window: id, point: NSPoint) {
-    let context = SetFrameTopLeftPointData::new_ptr(ns_window, point);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        set_frame_top_left_point_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_async(move || {
+        set_frame_top_left_point(*ns_window, point);
+    });
 }
 
-struct SetLevelData {
-    ns_window: id,
-    level: ffi::NSWindowLevel,
-}
-impl SetLevelData {
-    fn new_ptr(ns_window: id, level: ffi::NSWindowLevel) -> *mut Self {
-        Box::into_raw(Box::new(SetLevelData { ns_window, level }))
-    }
-}
-extern "C" fn set_level_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut SetLevelData;
-        {
-            let context = &*context_ptr;
-            context.ns_window.setLevel_(context.level as _);
-        }
-        Box::from_raw(context_ptr);
-    }
+unsafe fn set_level(ns_window: id, level: ffi::NSWindowLevel) {
+            ns_window.setLevel_(level as _);
 }
 // `setFrameTopLeftPoint:` isn't thread-safe, and fails silently.
 pub unsafe fn set_level_async(ns_window: id, level: ffi::NSWindowLevel) {
-    let context = SetLevelData::new_ptr(ns_window, level);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        set_level_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_async(move || {
+        set_level(*ns_window, level);
+    });
 }
 
-struct ToggleFullScreenData {
+unsafe fn toggle_full_screen(
     ns_window: id,
     ns_view: id,
     not_fullscreen: bool,
     shared_state: Weak<Mutex<SharedState>>,
-}
-impl ToggleFullScreenData {
-    fn new_ptr(
-        ns_window: id,
-        ns_view: id,
-        not_fullscreen: bool,
-        shared_state: Weak<Mutex<SharedState>>,
-    ) -> *mut Self {
-        Box::into_raw(Box::new(ToggleFullScreenData {
-            ns_window,
-            ns_view,
-            not_fullscreen,
-            shared_state,
-        }))
-    }
-}
-extern "C" fn toggle_full_screen_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut ToggleFullScreenData;
-        {
-            let context = &*context_ptr;
-
+) {
             // `toggleFullScreen` doesn't work if the `StyleMask` is none, so we
             // set a normal style temporarily. The previous state will be
             // restored in `WindowDelegate::window_did_exit_fullscreen`.
-            if context.not_fullscreen {
-                let curr_mask = context.ns_window.styleMask();
+            if not_fullscreen {
+                let curr_mask = ns_window.styleMask();
                 let required = NSWindowStyleMask::NSTitledWindowMask
                     | NSWindowStyleMask::NSResizableWindowMask;
                 if !curr_mask.contains(required) {
-                    set_style_mask(context.ns_window, context.ns_view, required);
-                    if let Some(shared_state) = context.shared_state.upgrade() {
+                    set_style_mask(ns_window, ns_view, required);
+                    if let Some(shared_state) = shared_state.upgrade() {
                         trace!("Locked shared state in `toggle_full_screen_callback`");
                         let mut shared_state_lock = shared_state.lock().unwrap();
                         (*shared_state_lock).saved_style = Some(curr_mask);
@@ -213,11 +127,8 @@ extern "C" fn toggle_full_screen_callback(context: *mut c_void) {
             // Window level must be restored from `CGShieldingWindowLevel()
             // + 1` back to normal in order for `toggleFullScreen` to do
             // anything
-            context.ns_window.setLevel_(0);
-            context.ns_window.toggleFullScreen_(nil);
-        }
-        Box::from_raw(context_ptr);
-    }
+            ns_window.setLevel_(0);
+            ns_window.toggleFullScreen_(nil);
 }
 // `toggleFullScreen` is thread-safe, but our additional logic to account for
 // window styles isn't.
@@ -227,90 +138,61 @@ pub unsafe fn toggle_full_screen_async(
     not_fullscreen: bool,
     shared_state: Weak<Mutex<SharedState>>,
 ) {
-    let context = ToggleFullScreenData::new_ptr(ns_window, ns_view, not_fullscreen, shared_state);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        toggle_full_screen_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    let ns_view = MainThreadSafe(ns_view);
+    let shared_state = MainThreadSafe(shared_state);
+    Queue::main().exec_async(move || {
+        toggle_full_screen(*ns_window, *ns_view, not_fullscreen, shared_state.0);
+    });
 }
 
-extern "C" fn restore_display_mode_callback(screen: *mut c_void) {
-    unsafe {
-        let screen = Box::from_raw(screen as *mut u32);
+unsafe fn restore_display_mode(ns_screen: u32) {
         ffi::CGRestorePermanentDisplayConfiguration();
-        assert_eq!(ffi::CGDisplayRelease(*screen), ffi::kCGErrorSuccess);
-    }
+        assert_eq!(ffi::CGDisplayRelease(ns_screen), ffi::kCGErrorSuccess);
 }
 pub unsafe fn restore_display_mode_async(ns_screen: u32) {
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        Box::into_raw(Box::new(ns_screen)) as *mut _,
-        restore_display_mode_callback,
-    );
+    Queue::main().exec_async(move || {
+        restore_display_mode(ns_screen);
+    });
 }
 
-struct SetMaximizedData {
+unsafe fn set_maximized(
     ns_window: id,
     is_zoomed: bool,
     maximized: bool,
     shared_state: Weak<Mutex<SharedState>>,
-}
-impl SetMaximizedData {
-    fn new_ptr(
-        ns_window: id,
-        is_zoomed: bool,
-        maximized: bool,
-        shared_state: Weak<Mutex<SharedState>>,
-    ) -> *mut Self {
-        Box::into_raw(Box::new(SetMaximizedData {
-            ns_window,
-            is_zoomed,
-            maximized,
-            shared_state,
-        }))
-    }
-}
-extern "C" fn set_maximized_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut SetMaximizedData;
-        {
-            let context = &*context_ptr;
-
-            if let Some(shared_state) = context.shared_state.upgrade() {
+) {
+            if let Some(shared_state) = shared_state.upgrade() {
                 trace!("Locked shared state in `set_maximized`");
                 let mut shared_state_lock = shared_state.lock().unwrap();
 
                 // Save the standard frame sized if it is not zoomed
-                if !context.is_zoomed {
-                    shared_state_lock.standard_frame = Some(NSWindow::frame(context.ns_window));
+                if !is_zoomed {
+                    shared_state_lock.standard_frame = Some(NSWindow::frame(ns_window));
                 }
 
-                shared_state_lock.maximized = context.maximized;
+                shared_state_lock.maximized = maximized;
 
-                let curr_mask = context.ns_window.styleMask();
+                let curr_mask = ns_window.styleMask();
                 if shared_state_lock.fullscreen.is_some() {
                     // Handle it in window_did_exit_fullscreen
                     return;
                 } else if curr_mask.contains(NSWindowStyleMask::NSResizableWindowMask) {
                     // Just use the native zoom if resizable
-                    context.ns_window.zoom_(nil);
+                    ns_window.zoom_(nil);
                 } else {
                     // if it's not resizable, we set the frame directly
-                    let new_rect = if context.maximized {
+                    let new_rect = if maximized {
                         let screen = NSScreen::mainScreen(nil);
                         NSScreen::visibleFrame(screen)
                     } else {
                         shared_state_lock.saved_standard_frame()
                     };
-                    context.ns_window.setFrame_display_(new_rect, 0);
+                    ns_window.setFrame_display_(new_rect, 0);
                 }
 
                 trace!("Unlocked shared state in `set_maximized`");
             }
-        }
-        Box::from_raw(context_ptr);
-    }
 }
 // `setMaximized` is not thread-safe
 pub unsafe fn set_maximized_async(
@@ -319,127 +201,61 @@ pub unsafe fn set_maximized_async(
     maximized: bool,
     shared_state: Weak<Mutex<SharedState>>,
 ) {
-    let context = SetMaximizedData::new_ptr(ns_window, is_zoomed, maximized, shared_state);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        set_maximized_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    let shared_state = MainThreadSafe(shared_state);
+    Queue::main().exec_async(move || {
+        set_maximized(*ns_window, is_zoomed, maximized, shared_state.0);
+    });
 }
 
-struct OrderOutData {
-    ns_window: id,
-}
-impl OrderOutData {
-    fn new_ptr(ns_window: id) -> *mut Self {
-        Box::into_raw(Box::new(OrderOutData { ns_window }))
-    }
-}
-extern "C" fn order_out_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut OrderOutData;
-        {
-            let context = &*context_ptr;
-            context.ns_window.orderOut_(nil);
-        }
-        Box::from_raw(context_ptr);
-    }
+unsafe fn order_out(ns_window: id) {
+            ns_window.orderOut_(nil);
 }
 // `orderOut:` isn't thread-safe. Calling it from another thread actually works,
 // but with an odd delay.
 pub unsafe fn order_out_async(ns_window: id) {
-    let context = OrderOutData::new_ptr(ns_window);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        order_out_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_async(move || {
+        order_out(*ns_window);
+    });
 }
 
-struct MakeKeyAndOrderFrontData {
-    ns_window: id,
-}
-impl MakeKeyAndOrderFrontData {
-    fn new_ptr(ns_window: id) -> *mut Self {
-        Box::into_raw(Box::new(MakeKeyAndOrderFrontData { ns_window }))
-    }
-}
-extern "C" fn make_key_and_order_front_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut MakeKeyAndOrderFrontData;
-        {
-            let context = &*context_ptr;
-            context.ns_window.makeKeyAndOrderFront_(nil);
-        }
-        Box::from_raw(context_ptr);
-    }
+unsafe fn make_key_and_order_front(ns_window: id) {
+            ns_window.makeKeyAndOrderFront_(nil);
 }
 // `makeKeyAndOrderFront:` isn't thread-safe. Calling it from another thread
 // actually works, but with an odd delay.
 pub unsafe fn make_key_and_order_front_async(ns_window: id) {
-    let context = MakeKeyAndOrderFrontData::new_ptr(ns_window);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        make_key_and_order_front_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_async(move || {
+        make_key_and_order_front(*ns_window);
+    });
 }
 
-struct SetTitleData {
-    ns_window: id,
-    title: String,
-}
-impl SetTitleData {
-    fn new_ptr(ns_window: id, title: String) -> *mut Self {
-        Box::into_raw(Box::new(SetTitleData { ns_window, title }))
-    }
-}
-extern "C" fn set_title_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut SetTitleData;
-        {
-            let context = &*context_ptr;
-            let title = IdRef::new(NSString::alloc(nil).init_str(&context.title));
-            context.ns_window.setTitle_(*title);
-        }
-        Box::from_raw(context_ptr);
-    }
+unsafe fn set_title(ns_window: id, title: String) {
+            let title = IdRef::new(NSString::alloc(nil).init_str(&title));
+            ns_window.setTitle_(*title);
 }
 // `setTitle:` isn't thread-safe. Calling it from another thread invalidates the
 // window drag regions, which throws an exception when not done in the main
 // thread
 pub unsafe fn set_title_async(ns_window: id, title: String) {
-    let context = SetTitleData::new_ptr(ns_window, title);
-    dispatch_async_f(
-        dispatch_get_main_queue(),
-        context as *mut _,
-        set_title_callback,
-    );
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_async(move || {
+        set_title(*ns_window, title);
+    });
 }
 
-struct CloseData {
-    ns_window: id,
-}
-impl CloseData {
-    fn new_ptr(ns_window: id) -> *mut Self {
-        Box::into_raw(Box::new(CloseData { ns_window }))
-    }
-}
-extern "C" fn close_callback(context: *mut c_void) {
-    unsafe {
-        let context_ptr = context as *mut CloseData;
-        {
-            let context = &*context_ptr;
+unsafe fn close(ns_window: id) {
             let pool = NSAutoreleasePool::new(nil);
-            context.ns_window.close();
+            ns_window.close();
             pool.drain();
-        }
-        Box::from_raw(context_ptr);
-    }
 }
 // `close:` is thread-safe, but we want the event to be triggered from the main
 // thread. Though, it's a good idea to look into that more...
 pub unsafe fn close_async(ns_window: id) {
-    let context = CloseData::new_ptr(ns_window);
-    dispatch_async_f(dispatch_get_main_queue(), context as *mut _, close_callback);
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_async(move || {
+        close(*ns_window);
+    });
 }

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -60,76 +60,32 @@ pub unsafe fn set_style_mask_sync(ns_window: id, ns_view: id, mask: NSWindowStyl
     }
 }
 
-unsafe fn set_content_size(ns_window: id, size: LogicalSize<f64>) {
-            NSWindow::setContentSize_(
-                ns_window,
-                NSSize::new(
-                    size.width as CGFloat,
-                    size.height as CGFloat,
-                ),
-            );
-}
 // `setContentSize:` isn't thread-safe either, though it doesn't log any errors
 // and just fails silently. Anyway, GCD to the rescue!
 pub unsafe fn set_content_size_async(ns_window: id, size: LogicalSize<f64>) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        set_content_size(*ns_window, size);
+        ns_window.setContentSize_(NSSize::new(size.width as CGFloat, size.height as CGFloat));
     });
 }
 
-unsafe fn set_frame_top_left_point(ns_window: id, point: NSPoint) {
-            NSWindow::setFrameTopLeftPoint_(ns_window, point);
-}
 // `setFrameTopLeftPoint:` isn't thread-safe, but fortunately has the courtesy
 // to log errors.
 pub unsafe fn set_frame_top_left_point_async(ns_window: id, point: NSPoint) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        set_frame_top_left_point(*ns_window, point);
+        ns_window.setFrameTopLeftPoint_(point);
     });
 }
 
-unsafe fn set_level(ns_window: id, level: ffi::NSWindowLevel) {
-            ns_window.setLevel_(level as _);
-}
 // `setFrameTopLeftPoint:` isn't thread-safe, and fails silently.
 pub unsafe fn set_level_async(ns_window: id, level: ffi::NSWindowLevel) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        set_level(*ns_window, level);
+        ns_window.setLevel_(level as _);
     });
 }
 
-unsafe fn toggle_full_screen(
-    ns_window: id,
-    ns_view: id,
-    not_fullscreen: bool,
-    shared_state: Weak<Mutex<SharedState>>,
-) {
-            // `toggleFullScreen` doesn't work if the `StyleMask` is none, so we
-            // set a normal style temporarily. The previous state will be
-            // restored in `WindowDelegate::window_did_exit_fullscreen`.
-            if not_fullscreen {
-                let curr_mask = ns_window.styleMask();
-                let required = NSWindowStyleMask::NSTitledWindowMask
-                    | NSWindowStyleMask::NSResizableWindowMask;
-                if !curr_mask.contains(required) {
-                    set_style_mask(ns_window, ns_view, required);
-                    if let Some(shared_state) = shared_state.upgrade() {
-                        trace!("Locked shared state in `toggle_full_screen_callback`");
-                        let mut shared_state_lock = shared_state.lock().unwrap();
-                        (*shared_state_lock).saved_style = Some(curr_mask);
-                        trace!("Unlocked shared state in `toggle_full_screen_callback`");
-                    }
-                }
-            }
-            // Window level must be restored from `CGShieldingWindowLevel()
-            // + 1` back to normal in order for `toggleFullScreen` to do
-            // anything
-            ns_window.setLevel_(0);
-            ns_window.toggleFullScreen_(nil);
-}
 // `toggleFullScreen` is thread-safe, but our additional logic to account for
 // window styles isn't.
 pub unsafe fn toggle_full_screen_async(
@@ -142,58 +98,38 @@ pub unsafe fn toggle_full_screen_async(
     let ns_view = MainThreadSafe(ns_view);
     let shared_state = MainThreadSafe(shared_state);
     Queue::main().exec_async(move || {
-        toggle_full_screen(*ns_window, *ns_view, not_fullscreen, shared_state.0);
+        // `toggleFullScreen` doesn't work if the `StyleMask` is none, so we
+        // set a normal style temporarily. The previous state will be
+        // restored in `WindowDelegate::window_did_exit_fullscreen`.
+        if not_fullscreen {
+            let curr_mask = ns_window.styleMask();
+            let required =
+                NSWindowStyleMask::NSTitledWindowMask | NSWindowStyleMask::NSResizableWindowMask;
+            if !curr_mask.contains(required) {
+                set_style_mask(*ns_window, *ns_view, required);
+                if let Some(shared_state) = shared_state.upgrade() {
+                    trace!("Locked shared state in `toggle_full_screen_callback`");
+                    let mut shared_state_lock = shared_state.lock().unwrap();
+                    (*shared_state_lock).saved_style = Some(curr_mask);
+                    trace!("Unlocked shared state in `toggle_full_screen_callback`");
+                }
+            }
+        }
+        // Window level must be restored from `CGShieldingWindowLevel()
+        // + 1` back to normal in order for `toggleFullScreen` to do
+        // anything
+        ns_window.setLevel_(0);
+        ns_window.toggleFullScreen_(nil);
     });
 }
 
-unsafe fn restore_display_mode(ns_screen: u32) {
-        ffi::CGRestorePermanentDisplayConfiguration();
-        assert_eq!(ffi::CGDisplayRelease(ns_screen), ffi::kCGErrorSuccess);
-}
 pub unsafe fn restore_display_mode_async(ns_screen: u32) {
     Queue::main().exec_async(move || {
-        restore_display_mode(ns_screen);
+        ffi::CGRestorePermanentDisplayConfiguration();
+        assert_eq!(ffi::CGDisplayRelease(ns_screen), ffi::kCGErrorSuccess);
     });
 }
 
-unsafe fn set_maximized(
-    ns_window: id,
-    is_zoomed: bool,
-    maximized: bool,
-    shared_state: Weak<Mutex<SharedState>>,
-) {
-            if let Some(shared_state) = shared_state.upgrade() {
-                trace!("Locked shared state in `set_maximized`");
-                let mut shared_state_lock = shared_state.lock().unwrap();
-
-                // Save the standard frame sized if it is not zoomed
-                if !is_zoomed {
-                    shared_state_lock.standard_frame = Some(NSWindow::frame(ns_window));
-                }
-
-                shared_state_lock.maximized = maximized;
-
-                let curr_mask = ns_window.styleMask();
-                if shared_state_lock.fullscreen.is_some() {
-                    // Handle it in window_did_exit_fullscreen
-                    return;
-                } else if curr_mask.contains(NSWindowStyleMask::NSResizableWindowMask) {
-                    // Just use the native zoom if resizable
-                    ns_window.zoom_(nil);
-                } else {
-                    // if it's not resizable, we set the frame directly
-                    let new_rect = if maximized {
-                        let screen = NSScreen::mainScreen(nil);
-                        NSScreen::visibleFrame(screen)
-                    } else {
-                        shared_state_lock.saved_standard_frame()
-                    };
-                    ns_window.setFrame_display_(new_rect, 0);
-                }
-
-                trace!("Unlocked shared state in `set_maximized`");
-            }
-}
 // `setMaximized` is not thread-safe
 pub unsafe fn set_maximized_async(
     ns_window: id,
@@ -204,58 +140,76 @@ pub unsafe fn set_maximized_async(
     let ns_window = MainThreadSafe(ns_window);
     let shared_state = MainThreadSafe(shared_state);
     Queue::main().exec_async(move || {
-        set_maximized(*ns_window, is_zoomed, maximized, shared_state.0);
+        if let Some(shared_state) = shared_state.upgrade() {
+            trace!("Locked shared state in `set_maximized`");
+            let mut shared_state_lock = shared_state.lock().unwrap();
+
+            // Save the standard frame sized if it is not zoomed
+            if !is_zoomed {
+                shared_state_lock.standard_frame = Some(NSWindow::frame(*ns_window));
+            }
+
+            shared_state_lock.maximized = maximized;
+
+            let curr_mask = ns_window.styleMask();
+            if shared_state_lock.fullscreen.is_some() {
+                // Handle it in window_did_exit_fullscreen
+                return;
+            } else if curr_mask.contains(NSWindowStyleMask::NSResizableWindowMask) {
+                // Just use the native zoom if resizable
+                ns_window.zoom_(nil);
+            } else {
+                // if it's not resizable, we set the frame directly
+                let new_rect = if maximized {
+                    let screen = NSScreen::mainScreen(nil);
+                    NSScreen::visibleFrame(screen)
+                } else {
+                    shared_state_lock.saved_standard_frame()
+                };
+                ns_window.setFrame_display_(new_rect, 0);
+            }
+
+            trace!("Unlocked shared state in `set_maximized`");
+        }
     });
 }
 
-unsafe fn order_out(ns_window: id) {
-            ns_window.orderOut_(nil);
-}
 // `orderOut:` isn't thread-safe. Calling it from another thread actually works,
 // but with an odd delay.
 pub unsafe fn order_out_async(ns_window: id) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        order_out(*ns_window);
+        ns_window.orderOut_(nil);
     });
 }
 
-unsafe fn make_key_and_order_front(ns_window: id) {
-            ns_window.makeKeyAndOrderFront_(nil);
-}
 // `makeKeyAndOrderFront:` isn't thread-safe. Calling it from another thread
 // actually works, but with an odd delay.
 pub unsafe fn make_key_and_order_front_async(ns_window: id) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        make_key_and_order_front(*ns_window);
+        ns_window.makeKeyAndOrderFront_(nil);
     });
 }
 
-unsafe fn set_title(ns_window: id, title: String) {
-            let title = IdRef::new(NSString::alloc(nil).init_str(&title));
-            ns_window.setTitle_(*title);
-}
 // `setTitle:` isn't thread-safe. Calling it from another thread invalidates the
 // window drag regions, which throws an exception when not done in the main
 // thread
 pub unsafe fn set_title_async(ns_window: id, title: String) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        set_title(*ns_window, title);
+        let title = IdRef::new(NSString::alloc(nil).init_str(&title));
+        ns_window.setTitle_(*title);
     });
 }
 
-unsafe fn close(ns_window: id) {
-            let pool = NSAutoreleasePool::new(nil);
-            ns_window.close();
-            pool.drain();
-}
 // `close:` is thread-safe, but we want the event to be triggered from the main
 // thread. Though, it's a good idea to look into that more...
 pub unsafe fn close_async(ns_window: id) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        close(*ns_window);
+        let pool = NSAutoreleasePool::new(nil);
+        ns_window.close();
+        pool.drain();
     });
 }


### PR DESCRIPTION
In addition to the `ffi` module, `dispatch` provides higher-level APIs to convert Rust closures into a format that can be used with GCD. The current implementation does not use them, instead going through a complex process of creating custom context structs and turning them into pointers to be passed to and converted by hand-written extern functions.

Perhaps the previous author attempted to use the high level APIs but was stopped because pointers do not implement `Send`. I've worked around this with a `MainThreadSafe` wrapper type that can be used to mark things as `Send`.

This also updates `dispatch` to 0.2, which plays better with Rust 2018.

This diff is a bit harder to compare than I'd like, but I've included some intermediate commits which are easier to compare.

- [x] Tested on macos
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
