### PR TITLE
Add ability to create Icons from embedded resources on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 - On Wayland, fix coordinates in mouse events when scale factor isn't 1
 - On Web, add the ability to provide a custom canvas
 - **Breaking:** On Wayland, the `WaylandTheme` struct has been replaced with a `Theme` trait, allowing for extra configuration
+- On Windows, add `IconExtWindows` trait which exposes creating an `Icon` from an external file or embedded resource
+- Add `BadIcon::OsError` variant for when OS icon functionality fails
 
 # 0.20.0 (2020-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - On Wayland, Hide CSD for fullscreen windows.
 - On Windows, ignore spurious mouse move messages.
 - **Breaking:** Move `ModifiersChanged` variant from `DeviceEvent` to `WindowEvent`.
+- On Windows, add `IconExtWindows` trait which exposes creating an `Icon` from an external file or embedded resource
+- Add `BadIcon::OsError` variant for when OS icon functionality fails
 
 # 0.21.0 (2020-02-04)
 
@@ -28,8 +30,6 @@
 - On Wayland, fix coordinates in mouse events when scale factor isn't 1
 - On Web, add the ability to provide a custom canvas
 - **Breaking:** On Wayland, the `WaylandTheme` struct has been replaced with a `Theme` trait, allowing for extra configuration
-- On Windows, add `IconExtWindows` trait which exposes creating an `Icon` from an external file or embedded resource
-- Add `BadIcon::OsError` variant for when OS icon functionality fails
 
 # 0.20.0 (2020-01-05)
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -22,6 +22,8 @@ use crate::{
 use raw_window_handle::{android::AndroidHandle, RawWindowHandle};
 use CreationError::OsError;
 
+pub(crate) use crate::icon::NoIcon as PlatformIcon;
+
 pub type OsError = std::io::Error;
 
 pub struct EventLoop {

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -83,6 +83,8 @@ pub use self::{
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},
 };
 
+pub(crate) use crate::icon::NoIcon as PlatformIcon;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId {
     uiscreen: ffi::id,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -18,6 +18,8 @@ use crate::{
     window::{CursorIcon, Fullscreen, WindowAttributes},
 };
 
+pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
+
 pub mod wayland;
 pub mod x11;
 

--- a/src/platform_impl/linux/x11/util/icon.rs
+++ b/src/platform_impl/linux/x11/util/icon.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::window::{Icon, Pixel, PIXEL_SIZE};
+use crate::icon::{Icon, Pixel, PIXEL_SIZE};
 
 impl Pixel {
     pub fn to_packed_argb(&self) -> Cardinal {
@@ -18,13 +18,14 @@ impl Pixel {
 
 impl Icon {
     pub(crate) fn to_cardinals(&self) -> Vec<Cardinal> {
-        assert_eq!(self.rgba.len() % PIXEL_SIZE, 0);
-        let pixel_count = self.rgba.len() / PIXEL_SIZE;
-        assert_eq!(pixel_count, (self.width * self.height) as usize);
+        let rgba_icon = &self.inner;
+        assert_eq!(rgba_icon.rgba.len() % PIXEL_SIZE, 0);
+        let pixel_count = rgba_icon.rgba.len() / PIXEL_SIZE;
+        assert_eq!(pixel_count, (rgba_icon.width * rgba_icon.height) as usize);
         let mut data = Vec::with_capacity(pixel_count);
-        data.push(self.width as Cardinal);
-        data.push(self.height as Cardinal);
-        let pixels = self.rgba.as_ptr() as *const Pixel;
+        data.push(rgba_icon.width as Cardinal);
+        data.push(rgba_icon.height as Cardinal);
+        let pixels = rgba_icon.rgba.as_ptr() as *const Pixel;
         for pixel_index in 0..pixel_count {
             let pixel = unsafe { &*pixels.offset(pixel_index as isize) };
             data.push(pixel.to_packed_argb());

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -25,6 +25,8 @@ use crate::{
     error::OsError as RootOsError, event::DeviceId as RootDeviceId, window::WindowAttributes,
 };
 
+pub(crate) use crate::icon::NoIcon as PlatformIcon;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
 

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -44,3 +44,5 @@ pub use self::window::{
     Id as WindowId, PlatformSpecificBuilderAttributes as PlatformSpecificWindowBuilderAttributes,
     Window,
 };
+
+pub(crate) use crate::icon::NoIcon as PlatformIcon;

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -1,19 +1,52 @@
-use std::{io, mem, os::windows::ffi::OsStrExt, path::Path, ptr};
+use std::{fmt, io, iter::once, mem, os::windows::ffi::OsStrExt, path::Path, ptr, sync::Arc};
 
 use winapi::{
     ctypes::{c_int, wchar_t},
     shared::{
-        minwindef::{BYTE, LPARAM, WPARAM},
+        minwindef::{BYTE, LPARAM, WORD, WPARAM},
         windef::{HICON, HWND},
     },
+    um::libloaderapi,
     um::winuser,
 };
 
-use crate::icon::{Icon, Pixel, PIXEL_SIZE};
+use crate::dpi::PhysicalSize;
+use crate::icon::*;
 
 impl Pixel {
     fn to_bgra(&mut self) {
         mem::swap(&mut self.r, &mut self.b);
+    }
+}
+
+impl RgbaIcon {
+    fn into_windows_icon(self) -> Result<WinIcon, BadIcon> {
+        let mut rgba = self.rgba;
+        let pixel_count = rgba.len() / PIXEL_SIZE;
+        let mut and_mask = Vec::with_capacity(pixel_count);
+        let pixels =
+            unsafe { std::slice::from_raw_parts_mut(rgba.as_mut_ptr() as *mut Pixel, pixel_count) };
+        for pixel in pixels {
+            and_mask.push(pixel.a.wrapping_sub(std::u8::MAX)); // invert alpha channel
+            pixel.to_bgra();
+        }
+        assert_eq!(and_mask.len(), pixel_count);
+        let handle = unsafe {
+            winuser::CreateIcon(
+                ptr::null_mut(),
+                self.width as c_int,
+                self.height as c_int,
+                1,
+                (PIXEL_SIZE * 8) as BYTE,
+                and_mask.as_ptr() as *const BYTE,
+                rgba.as_ptr() as *const BYTE,
+            ) as HICON
+        };
+        if !handle.is_null() {
+            Ok(WinIcon::from_handle(handle))
+        } else {
+            Err(BadIcon::OsError(io::Error::last_os_error()))
+        }
     }
 }
 
@@ -23,66 +56,80 @@ pub enum IconType {
     Big = winuser::ICON_BIG as isize,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
+struct RaiiIcon {
+    handle: HICON,
+}
+
+#[derive(Clone)]
 pub struct WinIcon {
-    pub handle: HICON,
+    inner: Arc<RaiiIcon>,
 }
 
 unsafe impl Send for WinIcon {}
 
 impl WinIcon {
-    #[allow(dead_code)]
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, io::Error> {
-        let wide_path: Vec<u16> = path.as_ref().as_os_str().encode_wide().collect();
+    pub fn as_raw_handle(&self) -> HICON {
+        self.inner.handle
+    }
+
+    pub fn from_path<P: AsRef<Path>>(
+        path: P,
+        size: Option<PhysicalSize<u32>>,
+    ) -> Result<Self, BadIcon> {
+        let wide_path: Vec<u16> = path
+            .as_ref()
+            .as_os_str()
+            .encode_wide()
+            .chain(once(0))
+            .collect();
+
+        // width / height of 0 along with LR_DEFAULTSIZE tells windows to load the default icon size
+        let (width, height) = size.map(Into::into).unwrap_or((0, 0));
+
         let handle = unsafe {
             winuser::LoadImageW(
                 ptr::null_mut(),
                 wide_path.as_ptr() as *const wchar_t,
                 winuser::IMAGE_ICON,
-                0, // 0 indicates that we want to use the actual width
-                0, // and height
-                winuser::LR_LOADFROMFILE,
-            ) as HICON
-        };
-        if !handle.is_null() {
-            Ok(WinIcon { handle })
-        } else {
-            Err(io::Error::last_os_error())
-        }
-    }
-
-    pub fn from_icon(icon: Icon) -> Result<Self, io::Error> {
-        Self::from_rgba(icon.rgba, icon.width, icon.height)
-    }
-
-    pub fn from_rgba(mut rgba: Vec<u8>, width: u32, height: u32) -> Result<Self, io::Error> {
-        assert_eq!(rgba.len() % PIXEL_SIZE, 0);
-        let pixel_count = rgba.len() / PIXEL_SIZE;
-        assert_eq!(pixel_count, (width * height) as usize);
-        let mut and_mask = Vec::with_capacity(pixel_count);
-        let pixels = rgba.as_mut_ptr() as *mut Pixel; // how not to write idiomatic Rust
-        for pixel_index in 0..pixel_count {
-            let pixel = unsafe { &mut *pixels.offset(pixel_index as isize) };
-            and_mask.push(pixel.a.wrapping_sub(std::u8::MAX)); // invert alpha channel
-            pixel.to_bgra();
-        }
-        assert_eq!(and_mask.len(), pixel_count);
-        let handle = unsafe {
-            winuser::CreateIcon(
-                ptr::null_mut(),
                 width as c_int,
                 height as c_int,
-                1,
-                (PIXEL_SIZE * 8) as BYTE,
-                and_mask.as_ptr() as *const BYTE,
-                rgba.as_ptr() as *const BYTE,
+                winuser::LR_DEFAULTSIZE | winuser::LR_LOADFROMFILE,
             ) as HICON
         };
         if !handle.is_null() {
-            Ok(WinIcon { handle })
+            Ok(WinIcon::from_handle(handle))
         } else {
-            Err(io::Error::last_os_error())
+            Err(BadIcon::OsError(io::Error::last_os_error()))
         }
+    }
+
+    pub fn from_resource(
+        resource_id: WORD,
+        size: Option<PhysicalSize<u32>>,
+    ) -> Result<Self, BadIcon> {
+        // width / height of 0 along with LR_DEFAULTSIZE tells windows to load the default icon size
+        let (width, height) = size.map(Into::into).unwrap_or((0, 0));
+        let handle = unsafe {
+            winuser::LoadImageW(
+                libloaderapi::GetModuleHandleW(ptr::null_mut()),
+                winuser::MAKEINTRESOURCEW(resource_id),
+                winuser::IMAGE_ICON,
+                width as c_int,
+                height as c_int,
+                winuser::LR_DEFAULTSIZE,
+            ) as HICON
+        };
+        if !handle.is_null() {
+            Ok(WinIcon::from_handle(handle))
+        } else {
+            Err(BadIcon::OsError(io::Error::last_os_error()))
+        }
+    }
+
+    pub fn from_rgba(rgba: Vec<u8>, width: u32, height: u32) -> Result<Self, BadIcon> {
+        let rgba_icon = RgbaIcon::from_rgba(rgba, width, height)?;
+        rgba_icon.into_windows_icon()
     }
 
     pub fn set_for_window(&self, hwnd: HWND, icon_type: IconType) {
@@ -91,15 +138,27 @@ impl WinIcon {
                 hwnd,
                 winuser::WM_SETICON,
                 icon_type as WPARAM,
-                self.handle as LPARAM,
+                self.as_raw_handle() as LPARAM,
             );
+        }
+    }
+
+    fn from_handle(handle: HICON) -> Self {
+        Self {
+            inner: Arc::new(RaiiIcon { handle }),
         }
     }
 }
 
-impl Drop for WinIcon {
+impl Drop for RaiiIcon {
     fn drop(&mut self) {
         unsafe { winuser::DestroyIcon(self.handle) };
+    }
+}
+
+impl fmt::Debug for WinIcon {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        (*self.inner).fmt(formatter)
     }
 }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -4,11 +4,15 @@ use winapi::{self, shared::windef::HWND};
 
 pub use self::{
     event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget},
+    icon::WinIcon,
     monitor::{MonitorHandle, VideoMode},
     window::Window,
 };
 
-use crate::{event::DeviceId as RootDeviceId, window::Icon};
+pub use self::icon::WinIcon as PlatformIcon;
+
+use crate::event::DeviceId as RootDeviceId;
+use crate::icon::Icon;
 
 #[derive(Clone, Default)]
 pub struct PlatformSpecificWindowBuilderAttributes {

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -1,7 +1,8 @@
 use crate::{
     dpi::{PhysicalPosition, Size},
     event::ModifiersState,
-    platform_impl::platform::{event_loop, icon::WinIcon, util},
+    icon::Icon,
+    platform_impl::platform::{event_loop, util},
     window::{CursorIcon, Fullscreen, WindowAttributes},
 };
 use parking_lot::MutexGuard;
@@ -15,7 +16,6 @@ use winapi::{
 };
 
 /// Contains information about states and the window that the callback is going to use.
-#[derive(Clone)]
 pub struct WindowState {
     pub mouse: MouseProperties,
 
@@ -23,8 +23,8 @@ pub struct WindowState {
     pub min_size: Option<Size>,
     pub max_size: Option<Size>,
 
-    pub window_icon: Option<WinIcon>,
-    pub taskbar_icon: Option<WinIcon>,
+    pub window_icon: Option<Icon>,
+    pub taskbar_icon: Option<Icon>,
 
     pub saved_window: Option<SavedWindow>,
     pub scale_factor: f64,
@@ -99,8 +99,7 @@ bitflags! {
 impl WindowState {
     pub fn new(
         attributes: &WindowAttributes,
-        window_icon: Option<WinIcon>,
-        taskbar_icon: Option<WinIcon>,
+        taskbar_icon: Option<Icon>,
         scale_factor: f64,
         is_dark_mode: bool,
     ) -> WindowState {
@@ -115,7 +114,7 @@ impl WindowState {
             min_size: attributes.min_inner_size,
             max_size: attributes.max_inner_size,
 
-            window_icon,
+            window_icon: attributes.window_icon.clone(),
             taskbar_icon,
 
             saved_window: None,

--- a/src/window.rs
+++ b/src/window.rs
@@ -9,7 +9,7 @@ use crate::{
     platform_impl,
 };
 
-pub use crate::icon::*;
+pub use crate::icon::{BadIcon, Icon};
 
 /// Represents a window.
 ///


### PR DESCRIPTION
To achieve this, I needed to refactor the `Icon` internals a little so that on Windows the canonical representation is the handle rather than RGBA.

I exposed this functionality as an `IconExtWindows` platform trait.

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
