### PR TITLE
Fix deadlock of Window::request_redraw in x11

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -284,7 +284,10 @@ impl<T: 'static> EventLoop<T> {
             // Empty the redraw requests
             {
                 // Release the lock to prevent deadlock
-                let windows: Vec<_> = wt.pending_redraws.lock().unwrap().drain().collect();
+                let windows: Vec<_> = {
+                    let mut set = wt.pending_redraws.lock().unwrap();
+                    set.drain().collect()
+                };
 
                 for wid in windows {
                     sticky_exit_callback(


### PR DESCRIPTION
Really ensure Rust does not keep the MutexGuard around.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
