### PR TITLE
Fix warnings on macos

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_void;
 
 use crate::{
     dpi::LogicalSize,
-    event_loop::{EventLoop, EventLoopWindowTarget},
+    event_loop::EventLoopWindowTarget,
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
