### PR TITLE
Fix panic at redraw event in non redraw phase

### DIFF
--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -419,7 +419,8 @@ impl<T> EventLoopRunner<T> {
                 self.call_event_handler(event)
             }
             (RunnerState::New, Event::RedrawRequested(_))
-            | (RunnerState::Idle(..), Event::RedrawRequested(_)) => {
+            | (RunnerState::Idle(..), Event::RedrawRequested(_))
+            | (RunnerState::HandlingEvents, Event::RedrawRequested(_)) => {
                 self.new_events();
                 self.main_events_cleared();
                 self.call_event_handler(event);

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -424,11 +424,11 @@ impl<T> EventLoopRunner<T> {
                 self.call_event_handler(event);
             }
             (_, Event::RedrawRequested(_)) => {
-                panic!("redraw event in non-redraw phase");
+                panic!("redraw event in non-redraw phase: {:?}", self.runner_state);
             }
             (RunnerState::HandlingRedraw, _) => {
                 panic!(
-                    "Non-redraw event dispatched durning redraw phase: {:?}",
+                    "non-redraw event in redraw phase: {:?}",
                     event.map_nonuser_event::<()>().ok()
                 );
             }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -411,6 +411,7 @@ impl<T> EventLoopRunner<T> {
                 // that was sent after `MainEventsCleared`.
                 ControlFlow::Poll => self.call_event_handler(Event::NewEvents(StartCause::Poll)),
             }
+            self.runner_state = RunnerState::HandlingEvents;
         }
 
         match (self.runner_state, &event) {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
