### PR TITLE
On macOS, Fix `set_simple_screen` to remember frame excluding title bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On macOS, fix `set_simple_screen` to remember frame excluding title bar.
 - On macOS, fix set_minimized(true) works only with decorations.
 - On macOS, add `hide_application` to `EventLoopWindowTarget` via a new `EventLoopWindowTargetExtMacOS` trait. `hide_application` will hide the entire application by calling `-[NSApplication hide: nil]`.
 - On macOS, fix not sending ReceivedCharacter event for specific keys combinations.

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1028,7 +1028,11 @@ impl WindowExtMacOS for UnownedWindow {
 
             if fullscreen {
                 // Remember the original window's settings
-                shared_state_lock.standard_frame = Some(NSWindow::frame(*self.ns_window));
+                // Exclude title bar
+                shared_state_lock.standard_frame = Some(NSWindow::contentRectForFrameRect_(
+                    *self.ns_window,
+                    NSWindow::frame(*self.ns_window),
+                ));
                 shared_state_lock.saved_style = Some(self.ns_window.styleMask());
                 shared_state_lock.save_presentation_opts = Some(app.presentationOptions_());
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR fixes #1420 

The window size that restored from simple_fullscreen become bit larger because when become simple_fullscreen, it remembers the frame which contains title bar and restore it by `NSWindow::setFrame_display_` which assumes the argment does not contains title bar.

This PR fix it by remember the frame which does not contains title bar.