### PR TITLE
On Wayland, fix coordinates in touch events when scale factor isn't 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On Wayland, fix coordinates in touch events when scale factor isn't 1
+
 # 0.21.0 (2020-02-04)
 
 - On Windows, fixed "error: linking with `link.exe` failed: exit code: 1120" error on older versions of windows.
@@ -16,7 +18,6 @@
 - On Wayland, fix coordinates in mouse events when scale factor isn't 1
 - On Web, add the ability to provide a custom canvas
 - **Breaking:** On Wayland, the `WaylandTheme` struct has been replaced with a `Theme` trait, allowing for extra configuration
-- On Wayland, fix coordinates in touch events when scale factor isn't 1
 
 # 0.20.0 (2020-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - On Wayland, fix coordinates in mouse events when scale factor isn't 1
 - On Web, add the ability to provide a custom canvas
 - **Breaking:** On Wayland, the `WaylandTheme` struct has been replaced with a `Theme` trait, allowing for extra configuration
+- On Wayland, fix coordinates in touch events when scale factor isn't 1
 
 # 0.20.0 (2020-01-05)
 

--- a/src/platform_impl/linux/wayland/pointer.rs
+++ b/src/platform_impl/linux/wayland/pointer.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, Mutex};
 
-use crate::dpi::PhysicalPosition;
+use crate::dpi::LogicalPosition;
 use crate::event::{
     DeviceEvent, ElementState, ModifiersState, MouseButton, MouseScrollDelta, TouchPhase,
     WindowEvent,
@@ -78,10 +78,8 @@ pub fn implement_pointer(
                                 wid,
                             );
 
-                            let position = PhysicalPosition::new(
-                                surface_x * scale_factor,
-                                surface_y * scale_factor,
-                            );
+                            let position = LogicalPosition::new(surface_x, surface_y)
+                                .to_physical(scale_factor);
 
                             sink.send_window_event(
                                 WindowEvent::CursorMoved {
@@ -118,10 +116,8 @@ pub fn implement_pointer(
                             let wid = make_wid(surface);
 
                             let scale_factor = surface::get_dpi_factor(&surface) as f64;
-                            let position = PhysicalPosition::new(
-                                surface_x * scale_factor,
-                                surface_y * scale_factor,
-                            );
+                            let position = LogicalPosition::new(surface_x, surface_y)
+                                .to_physical(scale_factor);
 
                             sink.send_window_event(
                                 WindowEvent::CursorMoved {

--- a/src/platform_impl/linux/wayland/pointer.rs
+++ b/src/platform_impl/linux/wayland/pointer.rs
@@ -1,5 +1,6 @@
 use std::sync::{Arc, Mutex};
 
+use crate::dpi::PhysicalPosition;
 use crate::event::{
     DeviceEvent, ElementState, ModifiersState, MouseButton, MouseScrollDelta, TouchPhase,
     WindowEvent,
@@ -76,13 +77,18 @@ pub fn implement_pointer(
                                 },
                                 wid,
                             );
+
+                            let position = PhysicalPosition::new(
+                                surface_x * scale_factor,
+                                surface_y * scale_factor,
+                            );
+
                             sink.send_window_event(
                                 WindowEvent::CursorMoved {
                                     device_id: crate::event::DeviceId(
                                         crate::platform_impl::DeviceId::Wayland(DeviceId),
                                     ),
-                                    position: (surface_x * scale_factor, surface_y * scale_factor)
-                                        .into(),
+                                    position,
                                     modifiers: modifiers_tracker.lock().unwrap().clone(),
                                 },
                                 wid,
@@ -109,15 +115,20 @@ pub fn implement_pointer(
                         ..
                     } => {
                         if let Some(surface) = mouse_focus.as_ref() {
-                            let scale_factor = surface::get_dpi_factor(&surface) as f64;
                             let wid = make_wid(surface);
+
+                            let scale_factor = surface::get_dpi_factor(&surface) as f64;
+                            let position = PhysicalPosition::new(
+                                surface_x * scale_factor,
+                                surface_y * scale_factor,
+                            );
+
                             sink.send_window_event(
                                 WindowEvent::CursorMoved {
                                     device_id: crate::event::DeviceId(
                                         crate::platform_impl::DeviceId::Wayland(DeviceId),
                                     ),
-                                    position: (surface_x * scale_factor, surface_y * scale_factor)
-                                        .into(),
+                                    position,
                                     modifiers: modifiers_tracker.lock().unwrap().clone(),
                                 },
                                 wid,

--- a/src/platform_impl/linux/wayland/touch.rs
+++ b/src/platform_impl/linux/wayland/touch.rs
@@ -1,17 +1,23 @@
 use std::sync::{Arc, Mutex};
 
+use crate::dpi::PhysicalPosition;
 use crate::event::{TouchPhase, WindowEvent};
 
-use super::{event_loop::EventsSink, window::WindowStore, DeviceId, WindowId};
+use super::{event_loop::EventsSink, make_wid, window::WindowStore, DeviceId};
+
+use smithay_client_toolkit::surface;
 
 use smithay_client_toolkit::reexports::client::protocol::{
     wl_seat,
+    wl_surface::WlSurface,
     wl_touch::{Event as TouchEvent, WlTouch},
 };
 
+// location is in logical coordinates.
 struct TouchPoint {
-    wid: WindowId,
-    location: (f64, f64),
+    surface: WlSurface,
+    x: f64,
+    y: f64,
     id: i32,
 }
 
@@ -31,75 +37,90 @@ pub(crate) fn implement_touch(
                     } => {
                         let wid = store.find_wid(&surface);
                         if let Some(wid) = wid {
+                            let scale_factor = surface::get_dpi_factor(&surface) as f64;
+                            let location =
+                                PhysicalPosition::new(scale_factor * x, scale_factor * y);
+
                             sink.send_window_event(
                                 WindowEvent::Touch(crate::event::Touch {
                                     device_id: crate::event::DeviceId(
                                         crate::platform_impl::DeviceId::Wayland(DeviceId),
                                     ),
                                     phase: TouchPhase::Started,
-                                    location: (x, y).into(),
+                                    location,
                                     force: None, // TODO
                                     id: id as u64,
                                 }),
                                 wid,
                             );
-                            pending_ids.push(TouchPoint {
-                                wid,
-                                location: (x, y),
-                                id,
-                            });
+                            pending_ids.push(TouchPoint { surface, x, y, id });
                         }
                     }
                     TouchEvent::Up { id, .. } => {
                         let idx = pending_ids.iter().position(|p| p.id == id);
                         if let Some(idx) = idx {
                             let pt = pending_ids.remove(idx);
+
+                            let scale_factor = surface::get_dpi_factor(&pt.surface) as f64;
+                            let location =
+                                PhysicalPosition::new(pt.x * scale_factor, pt.y * scale_factor);
+
                             sink.send_window_event(
                                 WindowEvent::Touch(crate::event::Touch {
                                     device_id: crate::event::DeviceId(
                                         crate::platform_impl::DeviceId::Wayland(DeviceId),
                                     ),
                                     phase: TouchPhase::Ended,
-                                    location: pt.location.into(),
+                                    location,
                                     force: None, // TODO
                                     id: id as u64,
                                 }),
-                                pt.wid,
+                                make_wid(&pt.surface),
                             );
                         }
                     }
                     TouchEvent::Motion { id, x, y, .. } => {
                         let pt = pending_ids.iter_mut().find(|p| p.id == id);
                         if let Some(pt) = pt {
-                            pt.location = (x, y);
+                            pt.x = x;
+                            pt.y = y;
+
+                            let scale_factor = surface::get_dpi_factor(&pt.surface) as f64;
+                            let location =
+                                PhysicalPosition::new(x * scale_factor, y * scale_factor);
+
                             sink.send_window_event(
                                 WindowEvent::Touch(crate::event::Touch {
                                     device_id: crate::event::DeviceId(
                                         crate::platform_impl::DeviceId::Wayland(DeviceId),
                                     ),
                                     phase: TouchPhase::Moved,
-                                    location: (x, y).into(),
+                                    location,
                                     force: None, // TODO
                                     id: id as u64,
                                 }),
-                                pt.wid,
+                                make_wid(&pt.surface),
                             );
                         }
                     }
                     TouchEvent::Frame => (),
                     TouchEvent::Cancel => {
                         for pt in pending_ids.drain(..) {
+                            let scale_factor = surface::get_dpi_factor(&pt.surface) as f64;
+                            let location =
+                                PhysicalPosition::new(pt.x * scale_factor, pt.y * scale_factor);
+
                             sink.send_window_event(
                                 WindowEvent::Touch(crate::event::Touch {
                                     device_id: crate::event::DeviceId(
                                         crate::platform_impl::DeviceId::Wayland(DeviceId),
                                     ),
                                     phase: TouchPhase::Cancelled,
-                                    location: pt.location.into(),
+                                    location,
                                     force: None, // TODO
                                     id: pt.id as u64,
                                 }),
-                                pt.wid,
+                                make_wid(&pt.surface),
                             );
                         }
                     }


### PR DESCRIPTION
- [ ] Tested on all platforms changed( don't have touch screen)
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users