### PR TITLE
On Wayland, fix color from `close_button_icon_color` not applying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-- On Wayland, fix coordinates in touch events when scale factor isn't 1
+- On Wayland, fix coordinates in touch events when scale factor isn't 1.
+- On Wayland, fix color from `close_button_icon_color` not applying.
 
 # 0.21.0 (2020-02-04)
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -446,7 +446,8 @@ impl<T: Theme> SCTKTheme for WaylandTheme<T> {
     }
 
     fn get_close_button_icon_color(&self, status: SCTKButtonState) -> [u8; 4] {
-        self.0.close_button_color(ButtonState::from_sctk(status))
+        self.0
+            .close_button_icon_color(ButtonState::from_sctk(status))
     }
 
     fn get_maximize_button_color(&self, status: SCTKButtonState) -> [u8; 4] {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


This change doesn't require any Wayland knowledge to review.