### PR TITLE
Remove assertions from Windows dark mode code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - On Wayland, Hide CSD for fullscreen windows.
 - On Windows, ignore spurious mouse move messages.
 - **Breaking:** Move `ModifiersChanged` variant from `DeviceEvent` to `WindowEvent`.
+- On Windows, fix crash at startup on systems that do not properly support Windows' Dark Mode
 
 # 0.21.0 (2020-02-04)
 

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -81,9 +81,7 @@ pub fn try_dark_mode(hwnd: HWND) -> bool {
             LIGHT_THEME_NAME.as_ptr()
         };
 
-        let status = unsafe {
-            uxtheme::SetWindowTheme(hwnd, theme_name as _, std::ptr::null())
-        };
+        let status = unsafe { uxtheme::SetWindowTheme(hwnd, theme_name as _, std::ptr::null()) };
 
         if status == 0 {
             set_dark_mode_for_window(hwnd, is_dark_mode);

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -86,7 +86,7 @@ pub fn try_dark_mode(hwnd: HWND) -> bool {
         };
 
         if status == 0 {
-            set_dark_mode_for_window(hwnd, is_dark_mode)
+            set_dark_mode_for_window(hwnd, is_dark_mode);
             is_dark_mode
         } else {
             false

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -44,9 +44,8 @@ lazy_static! {
                 };
 
                 let status = (rtl_get_version)(&mut vi as _);
-                assert!(NT_SUCCESS(status));
 
-                if vi.dwMajorVersion == 10 && vi.dwMinorVersion == 0 {
+                if NT_SUCCESS(status) && vi.dwMajorVersion == 10 && vi.dwMinorVersion == 0 {
                     Some(vi.dwBuildNumber)
                 } else {
                     None
@@ -82,16 +81,16 @@ pub fn try_dark_mode(hwnd: HWND) -> bool {
             LIGHT_THEME_NAME.as_ptr()
         };
 
-        unsafe {
-            assert_eq!(
-                0,
-                uxtheme::SetWindowTheme(hwnd, theme_name as _, std::ptr::null())
-            );
+        let status = unsafe {
+            uxtheme::SetWindowTheme(hwnd, theme_name as _, std::ptr::null())
+        };
 
+        if status == 0 {
             set_dark_mode_for_window(hwnd, is_dark_mode)
+            is_dark_mode
+        } else {
+            false
         }
-
-        is_dark_mode
     } else {
         false
     }
@@ -132,10 +131,11 @@ fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) {
                 cbData: std::mem::size_of_val(&is_dark_mode_bigbool) as _,
             };
 
-            assert_eq!(
-                1,
-                set_window_composition_attribute(hwnd, &mut data as *mut _)
-            );
+            let status = set_window_composition_attribute(hwnd, &mut data as *mut _);
+
+            if status == 0 {
+                *is_dark_mode = false;
+            }
         }
     }
 }

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -96,7 +96,7 @@ pub fn try_dark_mode(hwnd: HWND) -> bool {
     }
 }
 
-fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) {
+fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: &mut bool) {
     // Uses Windows undocumented API SetWindowCompositionAttribute,
     // as seen in win32-darkmode example linked at top of file.
 
@@ -123,11 +123,11 @@ fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) {
     if let Some(set_window_composition_attribute) = *SET_WINDOW_COMPOSITION_ATTRIBUTE {
         unsafe {
             // SetWindowCompositionAttribute needs a bigbool (i32), not bool.
-            let mut is_dark_mode_bigbool = is_dark_mode as BOOL;
+            let mut is_dark_mode_bigbool = is_dark_mode as &mut BOOL;
 
             let mut data = WINDOWCOMPOSITIONATTRIBDATA {
                 Attrib: WCA_USEDARKMODECOLORS,
-                pvData: &mut is_dark_mode_bigbool as *mut _ as _,
+                pvData: is_dark_mode_bigbool as *mut _ as _,
                 cbData: std::mem::size_of_val(&is_dark_mode_bigbool) as _,
             };
 

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -126,7 +126,7 @@ fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) -> bool {
 
             let status = set_window_composition_attribute(hwnd, &mut data as *mut _);
 
-            status == 0
+            status == 1
         }
     } else {
         false

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -126,7 +126,7 @@ fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) -> bool {
 
             let status = set_window_composition_attribute(hwnd, &mut data as *mut _);
 
-            status == 1
+            status != 0
         }
     } else {
         false

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -6,9 +6,10 @@ use std::os::windows::ffi::OsStrExt;
 use winapi::{
     shared::{
         basetsd::SIZE_T,
-        minwindef::{BOOL, DWORD, UINT, ULONG, WORD},
+        minwindef::{BOOL, DWORD, FALSE, UINT, ULONG, WORD},
         ntdef::{LPSTR, NTSTATUS, NT_SUCCESS, PVOID, WCHAR},
         windef::HWND,
+        winerror::S_OK,
     },
     um::{libloaderapi, uxtheme, winuser},
 };
@@ -83,7 +84,7 @@ pub fn try_dark_mode(hwnd: HWND) -> bool {
 
         let status = unsafe { uxtheme::SetWindowTheme(hwnd, theme_name as _, std::ptr::null()) };
 
-        status == 0 && set_dark_mode_for_window(hwnd, is_dark_mode)
+        status == S_OK && set_dark_mode_for_window(hwnd, is_dark_mode)
     } else {
         false
     }
@@ -126,7 +127,7 @@ fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) -> bool {
 
             let status = set_window_composition_attribute(hwnd, &mut data as *mut _);
 
-            status != 0
+            status != FALSE
         }
     } else {
         false
@@ -198,7 +199,7 @@ fn is_high_contrast() -> bool {
         )
     };
 
-    (ok > 0) && ((HCF_HIGHCONTRASTON & hc.dwFlags) == 1)
+    ok != FALSE && (HCF_HIGHCONTRASTON & hc.dwFlags) == 1
 }
 
 fn widestring(src: &'static str) -> Vec<u16> {


### PR DESCRIPTION
In general, winit should never assert on anything unless it means that
it is impossible to continue the execution of the program. There are
several assertions in the Windows dark mode code where this is not the
case.

Based on surface level inspection, all existing assertions could be
easily replaced with just simple conditional checks, allowing the
execution of the program to proceed with sane default values.

Fixes #1458.
Fixes #1405.
