### PR TITLE
On Windows, fix request_redraw() related panics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On Windows, fix minor timing issue in wait_until_time_or_msg
+- On Windows, rework handling of request_redraw() to address panics.
 - On macOS, fix `set_simple_screen` to remember frame excluding title bar.
 - On Wayland, fix coordinates in touch events when scale factor isn't 1.
 - On Wayland, fix color from `close_button_icon_color` not applying.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -632,13 +632,6 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
         }
 
         winuser::WM_NCLBUTTONDOWN => {
-            // jumpstart the modal loop
-            winuser::RedrawWindow(
-                window,
-                ptr::null(),
-                ptr::null_mut(),
-                winuser::RDW_INTERNALPAINT,
-            );
             if wparam == winuser::HTCAPTION as _ {
                 winuser::PostMessageW(window, winuser::WM_MOUSEMOVE, 0, 0);
             }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -252,7 +252,7 @@ impl<T: 'static> EventLoop<T> {
                         ptr::null_mut(),
                         winuser::WM_PAINT,
                         winuser::WM_PAINT,
-                        winuser::PM_REMOVE,
+                        winuser::PM_QS_PAINT | winuser::PM_REMOVE,
                     ) {
                         break;
                     }
@@ -1725,7 +1725,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                         ptr::null_mut(),
                         winuser::WM_PAINT,
                         winuser::WM_PAINT,
-                        winuser::PM_REMOVE,
+                        winuser::PM_QS_PAINT | winuser::PM_REMOVE,
                     ) {
                         break;
                     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -242,7 +242,6 @@ impl<T: 'static> EventLoop<T> {
                         break;
                     }
                 }
-                assert!(!unread_message_exists);
                 runner.main_events_cleared();
                 // Drain eventual WM_PAINT messages sent if user called request_redraw()
                 // during handling of MainEventsCleared.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -223,67 +223,61 @@ impl<T: 'static> EventLoop<T> {
                 runner.new_events();
                 loop {
                     if !unread_message_exists {
-                        if 0 == winuser::PeekMessageW(&mut msg, ptr::null_mut(), 0, 0, 1) {
-                            break;
-                        }
-                    }
-                    if msg.message == winuser::WM_PAINT {
-                        unread_message_exists = true;
-                        break;
-                    }
-                    winuser::TranslateMessage(&mut msg);
-                    winuser::DispatchMessageW(&mut msg);
-
-                    unread_message_exists = false;
-                }
-                runner.main_events_cleared();
-                loop {
-                    if !unread_message_exists {
                         if 0 == winuser::PeekMessageW(
                             &mut msg,
                             ptr::null_mut(),
-                            winuser::WM_PAINT,
-                            winuser::WM_PAINT,
-                            1,
+                            0,
+                            0,
+                            winuser::PM_REMOVE,
                         ) {
                             break;
                         }
                     }
-
                     winuser::TranslateMessage(&mut msg);
                     winuser::DispatchMessageW(&mut msg);
 
                     unread_message_exists = false;
-                }
-                if runner.redraw_events_cleared().events_buffered() {
-                    if runner.control_flow() == ControlFlow::Exit {
-                        break 'main;
-                    }
-                    continue;
-                }
 
-                if !unread_message_exists {
-                    let control_flow = runner.control_flow();
-                    match control_flow {
-                        ControlFlow::Exit => break 'main,
-                        ControlFlow::Wait => {
-                            if 0 == winuser::GetMessageW(&mut msg, ptr::null_mut(), 0, 0) {
-                                break 'main;
-                            }
-                            unread_message_exists = true;
-                        }
-                        ControlFlow::WaitUntil(resume_time) => {
-                            wait_until_time_or_msg(resume_time);
-                        }
-                        ControlFlow::Poll => (),
+                    if msg.message == winuser::WM_PAINT {
+                        break;
                     }
+                }
+                assert!(!unread_message_exists);
+                runner.main_events_cleared();
+                // Drain eventual WM_PAINT messages sent if user called request_redraw()
+                // during handling of MainEventsCleared.
+                loop {
+                    if 0 == winuser::PeekMessageW(
+                        &mut msg,
+                        ptr::null_mut(),
+                        winuser::WM_PAINT,
+                        winuser::WM_PAINT,
+                        winuser::PM_REMOVE,
+                    ) {
+                        break;
+                    }
+
+                    winuser::TranslateMessage(&mut msg);
+                    winuser::DispatchMessageW(&mut msg);
+                }
+                runner.redraw_events_cleared();
+                match runner.control_flow() {
+                    ControlFlow::Exit => break 'main,
+                    ControlFlow::Wait => {
+                        if 0 == winuser::GetMessageW(&mut msg, ptr::null_mut(), 0, 0) {
+                            break 'main;
+                        }
+                        unread_message_exists = true;
+                    }
+                    ControlFlow::WaitUntil(resume_time) => {
+                        wait_until_time_or_msg(resume_time);
+                    }
+                    ControlFlow::Poll => (),
                 }
             }
         }
 
-        unsafe {
-            runner.call_event_handler(Event::LoopDestroyed);
-        }
+        runner.destroy_loop();
         runner.destroy_runner();
     }
 
@@ -674,7 +668,6 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
         }
 
         winuser::WM_PAINT => {
-            subclass_input.event_loop_runner.main_events_cleared();
             subclass_input.send_event(Event::RedrawRequested(RootWindowId(WindowId(window))));
             commctrl::DefSubclassProc(window, msg, wparam, lparam)
         }
@@ -1728,50 +1721,39 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             };
             let in_modal_loop = subclass_input.event_loop_runner.in_modal_loop();
             if in_modal_loop {
+                let runner = &subclass_input.event_loop_runner;
+                runner.main_events_cleared();
+                // Drain eventual WM_PAINT messages sent if user called request_redraw()
+                // during handling of MainEventsCleared.
                 let mut msg = mem::zeroed();
-                if 0 == winuser::PeekMessageW(&mut msg, ptr::null_mut(), 0, 0, 0) {
-                    if msg.message != 0 && msg.message != winuser::WM_PAINT {
-                        queue_call_again();
-                        return 0;
+                loop {
+                    if 0 == winuser::PeekMessageW(
+                        &mut msg,
+                        ptr::null_mut(),
+                        winuser::WM_PAINT,
+                        winuser::WM_PAINT,
+                        winuser::PM_REMOVE,
+                    ) {
+                        break;
                     }
 
-                    subclass_input.event_loop_runner.main_events_cleared();
-                    loop {
-                        if 0 == winuser::PeekMessageW(
-                            &mut msg,
-                            ptr::null_mut(),
-                            winuser::WM_PAINT,
-                            winuser::WM_PAINT,
-                            1,
-                        ) {
-                            break;
-                        }
-
-                        if msg.hwnd != window {
-                            winuser::TranslateMessage(&mut msg);
-                            winuser::DispatchMessageW(&mut msg);
-                        }
+                    if msg.hwnd != window {
+                        winuser::TranslateMessage(&mut msg);
+                        winuser::DispatchMessageW(&mut msg);
                     }
                 }
-
-                // we don't borrow until here because TODO SAFETY
-                let runner = &subclass_input.event_loop_runner;
-                if runner.redraw_events_cleared().events_buffered() {
-                    queue_call_again();
-                    runner.new_events();
-                } else {
-                    match runner.control_flow() {
-                        // Waiting is handled by the modal loop.
-                        ControlFlow::Exit | ControlFlow::Wait => runner.new_events(),
-                        ControlFlow::WaitUntil(resume_time) => {
-                            wait_until_time_or_msg(resume_time);
-                            runner.new_events();
-                            queue_call_again();
-                        }
-                        ControlFlow::Poll => {
-                            runner.new_events();
-                            queue_call_again();
-                        }
+                runner.redraw_events_cleared();
+                match runner.control_flow() {
+                    // Waiting is handled by the modal loop.
+                    ControlFlow::Exit | ControlFlow::Wait => runner.new_events(),
+                    ControlFlow::WaitUntil(resume_time) => {
+                        wait_until_time_or_msg(resume_time);
+                        runner.new_events();
+                        queue_call_again();
+                    }
+                    ControlFlow::Poll => {
+                        runner.new_events();
+                        queue_call_again();
                     }
                 }
             }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -239,9 +239,15 @@ impl<T: 'static> EventLoop<T> {
                     unread_message_exists = false;
 
                     if msg.message == winuser::WM_PAINT {
+                        // An "external" redraw was requested.
+                        // Note that the WM_PAINT has been dispatched and
+                        // has caused the event loop to emit the MainEventsCleared event.
+                        // See EventLoopRunner::process_event().
+                        // The call to main_events_cleared() below will do nothing.
                         break;
                     }
                 }
+                // Make sure we emit the MainEventsCleared event if no WM_PAINT message was received.
                 runner.main_events_cleared();
                 // Drain eventual WM_PAINT messages sent if user called request_redraw()
                 // during handling of MainEventsCleared.

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -6,7 +6,7 @@ use crate::{
     dpi::PhysicalSize,
     event::{Event, StartCause, WindowEvent},
     event_loop::ControlFlow,
-    platform_impl::platform::{event_loop::EventLoop, util},
+    platform_impl::platform::event_loop::{util, EventLoop},
     window::WindowId,
 };
 
@@ -14,8 +14,8 @@ pub(crate) type EventLoopRunnerShared<T> = Rc<ELRShared<T>>;
 pub(crate) struct ELRShared<T: 'static> {
     runner: RefCell<Option<EventLoopRunner<T>>>,
     buffer: RefCell<VecDeque<BufferedEvent<T>>>,
-    redraw_buffer: Rc<RefCell<VecDeque<WindowId>>>,
 }
+
 struct EventLoopRunner<T: 'static> {
     control_flow: ControlFlow,
     runner_state: RunnerState,
@@ -23,29 +23,13 @@ struct EventLoopRunner<T: 'static> {
     in_modal_loop: bool,
     event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
     panic_error: Option<PanicError>,
-    redraw_buffer: Rc<RefCell<VecDeque<WindowId>>>,
 }
+
 pub type PanicError = Box<dyn Any + Send + 'static>;
 
 pub enum BufferedEvent<T: 'static> {
     Event(Event<'static, T>),
     ScaleFactorChanged(WindowId, f64, PhysicalSize<u32>),
-}
-
-#[must_use]
-#[derive(Debug, Clone, Copy)]
-pub enum AreEventsBuffered {
-    EventsBuffered,
-    ReadyToSleep,
-}
-
-impl AreEventsBuffered {
-    pub fn events_buffered(&self) -> bool {
-        match self {
-            Self::EventsBuffered => true,
-            Self::ReadyToSleep => false,
-        }
-    }
 }
 
 impl<T> BufferedEvent<T> {
@@ -89,7 +73,6 @@ impl<T> ELRShared<T> {
         ELRShared {
             runner: RefCell::new(None),
             buffer: RefCell::new(VecDeque::new()),
-            redraw_buffer: Default::default(),
         }
     }
 
@@ -97,16 +80,11 @@ impl<T> ELRShared<T> {
     where
         F: FnMut(Event<'_, T>, &mut ControlFlow),
     {
-        let mut runner = EventLoopRunner::new(event_loop, self.redraw_buffer.clone(), f);
+        let mut runner = EventLoopRunner::new(event_loop, f);
         {
             let mut runner_ref = self.runner.borrow_mut();
-            loop {
-                let event = self.buffer.borrow_mut().pop_front();
-                match event {
-                    Some(e) => e.dispatch_event(|e| runner.process_event(e)),
-                    None => break,
-                }
-            }
+            // Dispatch any events that were buffered during the creation of the window
+            self.dispatch_buffered_events(&mut runner);
             *runner_ref = Some(runner);
         }
     }
@@ -119,80 +97,43 @@ impl<T> ELRShared<T> {
         let mut runner_ref = self.runner.borrow_mut();
         if let Some(ref mut runner) = *runner_ref {
             runner.new_events();
-            loop {
-                let buffered_event_opt = self.buffer.borrow_mut().pop_front();
-                match buffered_event_opt {
-                    Some(e) => e.dispatch_event(|e| runner.process_event(e)),
-                    None => break,
-                }
-            }
+            // Dispatch any events that were buffered during the call `new_events`
+            self.dispatch_buffered_events(runner);
         }
     }
 
-    pub(crate) unsafe fn send_event(&self, event: Event<'_, T>) {
-        let handling_redraw = self
-            .runner
-            .borrow()
-            .as_ref()
-            .map(|r| RunnerState::HandlingRedraw == r.runner_state)
-            .unwrap_or(false);
-        let mut send = None;
-        if handling_redraw {
-            if let Event::RedrawRequested(_) = event {
-                send = Some(event);
-            } else {
-                self.buffer_event(event);
-            }
-        } else {
-            send = Some(event);
-        }
-        if let Some(event) = send {
-            if let Err(event) = self.send_event_unbuffered(event) {
-                // If the runner is already borrowed, we're in the middle of an event loop invocation. Add
-                // the event to a buffer to be processed later.
-                self.buffer_event(event);
-            }
+    pub(crate) fn send_event(&self, event: Event<'_, T>) {
+        if let Err(event) = self.send_event_unbuffered(event) {
+            // If the runner is already borrowed, we're in the middle of an event loop invocation.
+            // Add the event to a buffer to be processed later.
+            self.buffer
+                .borrow_mut()
+                .push_back(BufferedEvent::from_event(event));
         }
     }
 
-    unsafe fn send_event_unbuffered<'e>(&self, event: Event<'e, T>) -> Result<(), Event<'e, T>> {
+    fn send_event_unbuffered<'e>(&self, event: Event<'e, T>) -> Result<(), Event<'e, T>> {
         if let Ok(mut runner_ref) = self.runner.try_borrow_mut() {
             if let Some(ref mut runner) = *runner_ref {
                 runner.process_event(event);
-
-                let handling_redraw = if let RunnerState::HandlingRedraw = runner.runner_state {
-                    true
-                } else {
-                    false
-                };
-
-                if !handling_redraw {
-                    // Dispatch any events that were buffered during the call to `process_event`.
-                    loop {
-                        // We do this instead of using a `while let` loop because if we use a `while let`
-                        // loop the reference returned `borrow_mut()` doesn't get dropped until the end
-                        // of the loop's body and attempts to add events to the event buffer while in
-                        // `process_event` will fail.
-                        let buffered_event_opt = self.buffer.borrow_mut().pop_front();
-                        match buffered_event_opt {
-                            Some(e) => e.dispatch_event(|e| runner.process_event(e)),
-                            None => break,
-                        }
-                    }
-                }
-
+                // Dispatch any events that were buffered during the call to `process_event`.
+                self.dispatch_buffered_events(runner);
                 return Ok(());
             }
         }
-
         Err(event)
     }
 
-    pub(crate) unsafe fn call_event_handler(&self, event: Event<'static, T>) {
-        if let Ok(mut runner_ref) = self.runner.try_borrow_mut() {
-            if let Some(ref mut runner) = *runner_ref {
-                runner.call_event_handler(event);
-                return;
+    fn dispatch_buffered_events(&self, runner: &mut EventLoopRunner<T>) {
+        // We do this instead of using a `while let` loop because if we use a `while let`
+        // loop the reference returned `borrow_mut()` doesn't get dropped until the end
+        // of the loop's body and attempts to add events to the event buffer while in
+        // `process_event` will fail.
+        loop {
+            let buffered_event_opt = self.buffer.borrow_mut().pop_front();
+            match buffered_event_opt {
+                Some(e) => e.dispatch_event(|e| runner.process_event(e)),
+                None => break,
             }
         }
     }
@@ -201,17 +142,23 @@ impl<T> ELRShared<T> {
         let mut runner_ref = self.runner.borrow_mut();
         if let Some(ref mut runner) = *runner_ref {
             runner.main_events_cleared();
+            assert!(self.buffer.borrow().is_empty());
         }
     }
 
-    pub(crate) fn redraw_events_cleared(&self) -> AreEventsBuffered {
+    pub(crate) fn redraw_events_cleared(&self) {
         let mut runner_ref = self.runner.borrow_mut();
         if let Some(ref mut runner) = *runner_ref {
             runner.redraw_events_cleared();
+            assert!(self.buffer.borrow().is_empty());
         }
-        match self.buffer.borrow().len() {
-            0 => AreEventsBuffered::ReadyToSleep,
-            _ => AreEventsBuffered::EventsBuffered,
+    }
+
+    pub(crate) fn destroy_loop(&self) {
+        if let Ok(mut runner_ref) = self.runner.try_borrow_mut() {
+            if let Some(ref mut runner) = *runner_ref {
+                runner.call_event_handler(Event::LoopDestroyed);
+            }
         }
     }
 
@@ -248,18 +195,6 @@ impl<T> ELRShared<T> {
             ControlFlow::Exit
         }
     }
-
-    fn buffer_event(&self, event: Event<'_, T>) {
-        match event {
-            Event::RedrawRequested(window_id) => {
-                self.redraw_buffer.borrow_mut().push_back(window_id)
-            }
-            _ => self
-                .buffer
-                .borrow_mut()
-                .push_back(BufferedEvent::from_event(event)),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -275,15 +210,13 @@ enum RunnerState {
     /// The event loop is handling the OS's events and sending them to the user's callback.
     /// `NewEvents` has been sent, and `MainEventsCleared` hasn't.
     HandlingEvents,
+    /// The event loop is handling the redraw events and sending them to the user's callback.
+    /// `MainEventsCleared` has been sent, and `RedrawEventsCleared` hasn't.
     HandlingRedraw,
 }
 
 impl<T> EventLoopRunner<T> {
-    unsafe fn new<F>(
-        event_loop: &EventLoop<T>,
-        redraw_buffer: Rc<RefCell<VecDeque<WindowId>>>,
-        f: F,
-    ) -> EventLoopRunner<T>
+    unsafe fn new<F>(event_loop: &EventLoop<T>, f: F) -> EventLoopRunner<T>
     where
         F: FnMut(Event<'_, T>, &mut ControlFlow),
     {
@@ -297,7 +230,6 @@ impl<T> EventLoopRunner<T> {
                 Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
             >(Box::new(f)),
             panic_error: None,
-            redraw_buffer,
         }
     }
 
@@ -323,6 +255,8 @@ impl<T> EventLoopRunner<T> {
             }
 
             // When `NewEvents` gets sent after an idle depends on the control flow...
+            // Some `NewEvents` are deferred because not all Windows messages trigger an event_loop event.
+            // So we defer the `NewEvents` to when we actually process an event.
             RunnerState::Idle(wait_start) => {
                 match self.control_flow {
                     // If we're polling, send `NewEvents` and immediately move into event processing.
@@ -411,40 +345,27 @@ impl<T> EventLoopRunner<T> {
                 // that was sent after `MainEventsCleared`.
                 ControlFlow::Poll => self.call_event_handler(Event::NewEvents(StartCause::Poll)),
             }
+            self.runner_state = RunnerState::HandlingEvents;
         }
 
         match (self.runner_state, &event) {
-            (RunnerState::HandlingRedraw, Event::RedrawRequested(_)) => {
-                self.call_event_handler(event)
+            (RunnerState::HandlingEvents, Event::RedrawRequested(window_id)) => {
+                self.call_event_handler(Event::MainEventsCleared);
+                self.runner_state = RunnerState::HandlingRedraw;
+                self.call_event_handler(Event::RedrawRequested(*window_id));
             }
-            (RunnerState::New, Event::RedrawRequested(_))
-            | (RunnerState::Idle(..), Event::RedrawRequested(_)) => {
-                self.new_events();
-                self.main_events_cleared();
-                self.call_event_handler(event);
-            }
-            (_, Event::RedrawRequested(_)) => {
-                panic!("redraw event in non-redraw phase");
+            (RunnerState::HandlingRedraw, Event::RedrawRequested(window_id)) => {
+                self.call_event_handler(Event::RedrawRequested(*window_id));
             }
             (RunnerState::HandlingRedraw, _) => {
                 panic!(
-                    "Non-redraw event dispatched durning redraw phase: {:?}",
+                    "non-redraw event in redraw phase: {:?}",
                     event.map_nonuser_event::<()>().ok()
                 );
             }
             (_, _) => {
                 self.runner_state = RunnerState::HandlingEvents;
                 self.call_event_handler(event);
-            }
-        }
-    }
-
-    fn flush_redraws(&mut self) {
-        loop {
-            let redraw_window_opt = self.redraw_buffer.borrow_mut().pop_front();
-            match redraw_window_opt {
-                Some(window_id) => self.process_event(Event::RedrawRequested(window_id)),
-                None => break,
             }
         }
     }
@@ -457,7 +378,8 @@ impl<T> EventLoopRunner<T> {
                 self.runner_state = RunnerState::HandlingRedraw;
             }
 
-            RunnerState::HandlingRedraw => (),
+            // we already cleared the main events, we don't have to do anything.
+            RunnerState::HandlingRedraw => {}
 
             // If we *weren't* handling events, we don't have to do anything.
             RunnerState::New | RunnerState::Idle(..) => (),
@@ -469,6 +391,7 @@ impl<T> EventLoopRunner<T> {
                     // If we had deferred a Poll, send the Poll NewEvents and MainEventsCleared.
                     ControlFlow::Poll => {
                         self.call_event_handler(Event::NewEvents(StartCause::Poll));
+                        self.runner_state = RunnerState::HandlingEvents;
                         self.call_event_handler(Event::MainEventsCleared);
                         self.runner_state = RunnerState::HandlingRedraw;
                     }
@@ -482,6 +405,7 @@ impl<T> EventLoopRunner<T> {
                                     requested_resume: resume_time,
                                 },
                             ));
+                            self.runner_state = RunnerState::HandlingEvents;
                             self.call_event_handler(Event::MainEventsCleared);
                             self.runner_state = RunnerState::HandlingRedraw;
                         }
@@ -496,57 +420,14 @@ impl<T> EventLoopRunner<T> {
 
     fn redraw_events_cleared(&mut self) {
         match self.runner_state {
-            // If we were handling events, send the MainEventsCleared message.
-            RunnerState::HandlingEvents => {
-                self.call_event_handler(Event::MainEventsCleared);
-                self.runner_state = RunnerState::HandlingRedraw;
-                self.flush_redraws();
-                self.call_event_handler(Event::RedrawEventsCleared);
-                self.runner_state = RunnerState::Idle(Instant::now());
-            }
-
+            // If we were handling redraws, send the RedrawEventsCleared message.
             RunnerState::HandlingRedraw => {
-                self.flush_redraws();
                 self.call_event_handler(Event::RedrawEventsCleared);
                 self.runner_state = RunnerState::Idle(Instant::now());
             }
 
-            // If we *weren't* handling events, we don't have to do anything.
-            RunnerState::New | RunnerState::Idle(..) => (),
-
-            // Some control flows require a NewEvents call even if no events were received. This
-            // branch handles those.
-            RunnerState::DeferredNewEvents(wait_start) => {
-                match self.control_flow {
-                    // If we had deferred a Poll, send the Poll NewEvents and MainEventsCleared.
-                    ControlFlow::Poll => {
-                        self.call_event_handler(Event::NewEvents(StartCause::Poll));
-                        self.call_event_handler(Event::MainEventsCleared);
-                        self.flush_redraws();
-                        self.call_event_handler(Event::RedrawEventsCleared);
-                    }
-                    // If we had deferred a WaitUntil and the resume time has since been reached,
-                    // send the resume notification and MainEventsCleared event.
-                    ControlFlow::WaitUntil(resume_time) => {
-                        if Instant::now() >= resume_time {
-                            self.call_event_handler(Event::NewEvents(
-                                StartCause::ResumeTimeReached {
-                                    start: wait_start,
-                                    requested_resume: resume_time,
-                                },
-                            ));
-                            self.call_event_handler(Event::MainEventsCleared);
-                            self.flush_redraws();
-                            self.call_event_handler(Event::RedrawEventsCleared);
-                        }
-                    }
-                    // If we deferred a wait and no events were received, the user doesn't have to
-                    // get an event.
-                    ControlFlow::Wait | ControlFlow::Exit => (),
-                }
-                // Mark that we've entered an idle state.
-                self.runner_state = RunnerState::Idle(wait_start)
-            }
+            // If we *weren't* handling redraws, we don't have to do anything.
+            _ => (),
         }
     }
 

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -106,7 +106,7 @@ impl<T> ELRShared<T> {
         if let Err(event) = self.send_event_unbuffered(event) {
             // If the runner is already borrowed, we're in the middle of an event loop invocation.
             // Add the event to a buffer to be processed later.
-            if let Event::RedrawRequested(_) = event  {
+            if let Event::RedrawRequested(_) = event {
                 panic!("buffering RedrawRequested event");
             }
             self.buffer
@@ -178,6 +178,17 @@ impl<T> ELRShared<T> {
         let mut runner_ref = self.runner.borrow_mut();
         if let Some(ref mut runner) = *runner_ref {
             runner.in_modal_loop = in_modal_loop;
+            if in_modal_loop {
+                // jumpstart the modal loop
+                unsafe {
+                    winuser::RedrawWindow(
+                        runner.modal_redraw_window,
+                        ptr::null(),
+                        ptr::null_mut(),
+                        winuser::RDW_INTERNALPAINT,
+                    );
+                }
+            }
         }
     }
 

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -106,6 +106,9 @@ impl<T> ELRShared<T> {
         if let Err(event) = self.send_event_unbuffered(event) {
             // If the runner is already borrowed, we're in the middle of an event loop invocation.
             // Add the event to a buffer to be processed later.
+            if let Event::RedrawRequested(_) = event  {
+                panic!("buffering RedrawRequested event");
+            }
             self.buffer
                 .borrow_mut()
                 .push_back(BufferedEvent::from_event(event));

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -396,7 +396,8 @@ impl<T> EventLoopRunner<T> {
                 self.runner_state = RunnerState::HandlingRedraw;
             }
 
-            // we already cleared the main events, we don't have to do anything.
+            // We already cleared the main events, we don't have to do anything.
+            // This happens when process_events() processed a RedrawRequested event.
             RunnerState::HandlingRedraw => {}
 
             // If we *weren't* handling events, we don't have to do anything.
@@ -443,9 +444,13 @@ impl<T> EventLoopRunner<T> {
                 self.call_event_handler(Event::RedrawEventsCleared);
                 self.runner_state = RunnerState::Idle(Instant::now());
             }
-
-            // If we *weren't* handling redraws, we don't have to do anything.
-            _ => (),
+            // No event was processed, we don't have to do anything.
+            RunnerState::DeferredNewEvents(_) => (),
+            // Should not happen.
+            _ => warn!(
+                "unexpected state in redraw_events_cleared: {:?}",
+                self.runner_state
+            ),
         }
     }
 

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -145,7 +145,9 @@ impl<T> ELRShared<T> {
         let mut runner_ref = self.runner.borrow_mut();
         if let Some(ref mut runner) = *runner_ref {
             runner.main_events_cleared();
-            assert!(self.buffer.borrow().is_empty());
+            if !self.buffer.borrow().is_empty() {
+                warn!("Buffered events while dispatching MainEventsCleared");
+            }
         }
     }
 
@@ -153,7 +155,9 @@ impl<T> ELRShared<T> {
         let mut runner_ref = self.runner.borrow_mut();
         if let Some(ref mut runner) = *runner_ref {
             runner.redraw_events_cleared();
-            assert!(self.buffer.borrow().is_empty());
+            if !self.buffer.borrow().is_empty() {
+                warn!("Buffered events while dispatching RedrawEventsCleared");
+            }
         }
     }
 
@@ -372,7 +376,7 @@ impl<T> EventLoopRunner<T> {
                 self.call_event_handler(Event::RedrawRequested(*window_id));
             }
             (RunnerState::HandlingRedraw, _) => {
-                panic!(
+                warn!(
                     "non-redraw event in redraw phase: {:?}",
                     event.map_nonuser_event::<()>().ok()
                 );

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -116,7 +116,7 @@ pub(crate) fn set_inner_size_physical(window: HWND, x: u32, y: u32) {
                 | winuser::SWP_NOMOVE
                 | winuser::SWP_NOACTIVATE,
         );
-        winuser::UpdateWindow(window);
+        winuser::InvalidateRgn(window, ptr::null_mut(), 0);
     }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -187,7 +187,7 @@ impl Window {
                     | winuser::SWP_NOSIZE
                     | winuser::SWP_NOACTIVATE,
             );
-            winuser::UpdateWindow(self.window.0);
+            winuser::InvalidateRgn(self.window.0, ptr::null_mut(), 0);
         }
     }
 
@@ -506,7 +506,7 @@ impl Window {
                             size.1 as i32,
                             winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOZORDER,
                         );
-                        winuser::UpdateWindow(window.0);
+                        winuser::InvalidateRgn(window.0, ptr::null_mut(), 0);
                     }
                 }
                 None => {
@@ -532,7 +532,7 @@ impl Window {
                                     | winuser::SWP_NOZORDER
                                     | winuser::SWP_NOACTIVATE,
                             );
-                            winuser::UpdateWindow(window.0);
+                            winuser::InvalidateRgn(window.0, ptr::null_mut(), 0);
                         }
                     }
                 }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -29,9 +29,6 @@ pub struct WindowState {
     pub scale_factor: f64,
 
     pub fullscreen: Option<Fullscreen>,
-    /// Used to supress duplicate redraw attempts when calling `request_redraw` multiple
-    /// times in `MainEventsCleared`.
-    pub queued_out_of_band_redraw: bool,
     pub is_dark_mode: bool,
     pub high_surrogate: Option<u16>,
     window_flags: WindowFlags,
@@ -120,7 +117,6 @@ impl WindowState {
             scale_factor,
 
             fullscreen: None,
-            queued_out_of_band_redraw: false,
             is_dark_mode,
             high_surrogate: None,
             window_flags: WindowFlags::empty(),

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -266,7 +266,7 @@ impl WindowFlags {
                         | winuser::SWP_NOSIZE
                         | winuser::SWP_NOACTIVATE,
                 );
-                winuser::UpdateWindow(window);
+                winuser::InvalidateRgn(window, ptr::null_mut(), 0);
             }
         }
 


### PR DESCRIPTION
~~Simplifies the message loops and event handling considerably~~
~~Strongly inspired from the X11 platform~~

~~Partially reverts https://github.com/rust-windowing/winit/commit/6a330a2894873d29fbbfdeebfc1a215577213996~~

 These panics were introduced by https://github.com/rust-windowing/winit/commit/6a330a2894873d29fbbfdeebfc1a215577213996

Fixes https://github.com/rust-windowing/winit/issues/1391
Fixes https://github.com/rust-windowing/winit/issues/1400
Fixes https://github.com/rust-windowing/winit/issues/1466
Fixes #1469
Probably fixes other related issues

The commit mentioned above introduced a few critical regressions.
I did quite a bit of forensic (looking at 0.19.1, 0.20.0-alpha1) to understand what was going on around the handling of request_redraw(). I also looked at how other platforms handle it.

~~I tried really hard to fix the issues using the current approach of posting WM_PAINT messages but got nowhere. Too many corner cases.
In the end I decided to go for the X11 approach of using a HashSet to keep track of windows requiring a redraw and things got much simpler.~~

This PR does not fundamentally change how request_redraw() is handled.
It still calls `RedrawWindow` which sends a `WM_PAINT` message. Which means that:
- multiple `WM_PAINT` messages are coalesced (for example when calling request_redraw while resizing or calling request_redraw multiple times),
- `RedrawRequested` events are always sent when handling a `WM_PAINT` message.

I tried to be very thorough in testing:
- tested all control flow modes (Poll, Wait and WaitUntill) in both the non-modal and modal loops
- made sure that redraw requests are properly coalesced (in particular when resizing)
- tested multi window and fullscreen

There are a few untested corner cases. See https://github.com/rust-windowing/winit/issues/1429 for more details.

And always kept the specs in a corner of my mind:
- https://docs.rs/winit/0.21.0/winit/window/struct.Window.html#method.request_redraw
- https://docs.rs/winit/0.21.0/winit/event/index.html

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
