### PR TITLE
Map `UserEvent` properly in `Event::to_static`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - On Wayland, fix color from `close_button_icon_color` not applying.
 - Ignore locale if unsupported by X11 backend
 - On Wayland, Add HiDPI cursor support
+- Fix `Event::to_static` returning `None` for user events.
 
 # 0.21.0 (2020-02-04)
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -139,7 +139,7 @@ impl<'a, T> Event<'a, T> {
             WindowEvent { window_id, event } => event
                 .to_static()
                 .map(|event| WindowEvent { window_id, event }),
-            UserEvent(_) => None,
+            UserEvent(event) => Some(UserEvent(event)),
             DeviceEvent { device_id, event } => Some(DeviceEvent { device_id, event }),
             NewEvents(cause) => Some(NewEvents(cause)),
             MainEventsCleared => Some(MainEventsCleared),


### PR DESCRIPTION
The current `Event::to_static` returns `None` for user events. This PR makes it return the proper event instead.

This fixes an issue reported in https://github.com/hecrj/iced/issues/188, caused by a panic here:

https://github.com/rust-windowing/winit/blob/ad7d4939a8be2e0d9436d43d0351e2f7599a4237/src/platform_impl/windows/event_loop/runner.rs#L62