### PR TITLE
X11: Fix deadlock when an error occurs during startup

### DIFF
--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -584,13 +584,12 @@ impl<T: 'static> EventLoop<T> {
     }
 
     pub fn new_x11_any_thread() -> Result<EventLoop<T>, XNotSupported> {
-        X11_BACKEND
-            .lock()
-            .as_ref()
-            .map(Arc::clone)
-            .map(x11::EventLoop::new)
-            .map(EventLoop::X)
-            .map_err(|err| err.clone())
+        let xconn = match X11_BACKEND.lock().as_ref() {
+            Ok(xconn) => xconn.clone(),
+            Err(err) => return Err(err.clone()),
+        };
+
+        Ok(EventLoop::X(x11::EventLoop::new(xconn)))
     }
 
     #[inline]


### PR DESCRIPTION
Related to, but does not necessarily entirely address #1474

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
