### PR TITLE
In control_flow example, don't schedule a new WaitUntil if wait was c…

### DIFF
--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -100,7 +100,13 @@ fn main() {
             Event::RedrawEventsCleared => {
                 *control_flow = match mode {
                     Mode::Wait => ControlFlow::Wait,
-                    Mode::WaitUntil => ControlFlow::WaitUntil(time::Instant::now() + WAIT_TIME),
+                    Mode::WaitUntil => {
+                        if wait_cancelled {
+                            *control_flow
+                        } else {
+                            ControlFlow::WaitUntil(time::Instant::now() + WAIT_TIME)
+                        }
+                    }
                     Mode::Poll => {
                         thread::sleep(POLL_SLEEP_TIME);
                         ControlFlow::Poll


### PR DESCRIPTION
…ancelled

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
