### PR TITLE
Remove logical pixel handling from scroll events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 - On android added support for `run_return`.
 - On MacOS, Fixed fullscreen and dialog support for `run_return`.
 - On Windows, fix bug where we'd try to emit `MainEventsCleared` events during nested win32 event loops.
+- On Windows, `set_ime_position` is now a no-op instead of a runtime crash.
+- On Android, `set_fullscreen` is now a no-op instead of a runtime crash.
+- On iOS and Android, `set_inner_size` is now a no-op instead of a runtime crash.
+- **Breaking:** On Web, `set_cursor_position` and `set_cursor_grab` will now always return an error.
+- **Breaking:** `PixelDelta` scroll events now return a `PhysicalPosition`.
 
 # 0.22.2 (2020-05-16)
 
@@ -49,10 +54,6 @@
 - on macOS, fix incorrect ReceivedCharacter events for some key combinations.
 - **Breaking:** Use `i32` instead of `u32` for position type in `WindowEvent::Moved`.
 - On macOS, a mouse motion event is now generated before every mouse click.
-- On Windows, `set_ime_position` is now a no-op instead of a runtime crash.
-- On Android, `set_fullscreen` is now a no-op instead of a runtime crash.
-- On iOS and Android, `set_inner_size` is now a no-op instead of a runtime crash.
-- **Breaking:** On Web, `set_cursor_position` and `set_cursor_grab` will now always return an error.
 
 # 0.21.0 (2020-02-04)
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -37,7 +37,7 @@ use instant::Instant;
 use std::path::PathBuf;
 
 use crate::{
-    dpi::{LogicalPosition, PhysicalPosition, PhysicalSize},
+    dpi::{PhysicalPosition, PhysicalSize},
     platform_impl,
     window::{Theme, WindowId},
 };
@@ -764,7 +764,7 @@ pub enum MouseScrollDelta {
     /// Scroll events are expressed as a PixelDelta if
     /// supported by the device (eg. a touchpad) and
     /// platform.
-    PixelDelta(LogicalPosition<f64>),
+    PixelDelta(PhysicalPosition<f64>),
 }
 
 /// Symbolic name for a keyboard key.

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -999,10 +999,14 @@ extern "C" fn scroll_wheel(this: &Object, _sel: Sel, event: id) {
     mouse_motion(this, event);
 
     unsafe {
+        let state_ptr: *mut c_void = *this.get_ivar("winitState");
+        let state = &mut *(state_ptr as *mut ViewState);
+
         let delta = {
             let (x, y) = (event.scrollingDeltaX(), event.scrollingDeltaY());
             if event.hasPreciseScrollingDeltas() == YES {
-                MouseScrollDelta::PixelDelta((x as f64, y as f64).into())
+                let delta = LogicalPosition::new(x, y).to_physical(state.get_scale_factor());
+                MouseScrollDelta::PixelDelta(delta)
             } else {
                 MouseScrollDelta::LineDelta(x as f32, y as f32)
             }

--- a/src/platform_impl/web/stdweb/event.rs
+++ b/src/platform_impl/web/stdweb/event.rs
@@ -36,7 +36,10 @@ pub fn mouse_scroll_delta(event: &MouseWheelEvent) -> Option<MouseScrollDelta> {
 
     match event.delta_mode() {
         MouseWheelDeltaMode::Line => Some(MouseScrollDelta::LineDelta(x as f32, y as f32)),
-        MouseWheelDeltaMode::Pixel => Some(MouseScrollDelta::PixelDelta(LogicalPosition { x, y })),
+        MouseWheelDeltaMode::Pixel => {
+            let delta = LogicalPosition::new(x, y).to_physical(super::scale_factor());
+            Some(MouseScrollDelta::PixelDelta(delta))
+        }
         MouseWheelDeltaMode::Page => None,
     }
 }

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -35,7 +35,10 @@ pub fn mouse_scroll_delta(event: &WheelEvent) -> Option<MouseScrollDelta> {
 
     match event.delta_mode() {
         WheelEvent::DOM_DELTA_LINE => Some(MouseScrollDelta::LineDelta(x as f32, y as f32)),
-        WheelEvent::DOM_DELTA_PIXEL => Some(MouseScrollDelta::PixelDelta(LogicalPosition { x, y })),
+        WheelEvent::DOM_DELTA_PIXEL => {
+            let delta = LogicalPosition::new(x, y).to_physical(super::scale_factor());
+            Some(MouseScrollDelta::PixelDelta(delta))
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
This removes the `LogicalPosition` from the `PixelDelta`, since all
other APIs have been switched to use `PhysicalPosition` instead too.

It also seems like `LineDelta` was using both logical and physical
sizes, depending on platform. I've changed this to explicitly take a
`PhysicalPosition` parameter to force a uniform return value.

I'm not entirely sure which platform uses which kind of pixel sizes by
default, so I've made the assumption that both the web and macOS
platforms deliver their events in LogicalPositions.

Fixes #1406.