### PR TITLE
macOS: Only check is_repeat to send ReceivedCharacter. Fixes #1488

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking:** On Web, remove the `stdweb` backend.
 - Added `Window::focus_window`to bring the window to the front and set input focus.
 - On Wayland and X11, implement `is_maximized` method on `Window`.
+- On macOS, fix issue where `ReceivedCharacter` was not being emitted during some key repeat events.
 
 # 0.25.0 (2021-05-15)
 


### PR DESCRIPTION
Checking state.is_key_down is redundant, since we are handling keyDown.
Moreover, state.is_key_down can be affected by a previous repeated key's
keyUp.

- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
