### PR TITLE
Fix several crashes on Windows by heavily simplifying the event loop code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On Windows, fix window intermittently hanging when `ControlFlow` was set to `Poll`.
+
 # 0.22.1 (2020-04-16)
 
 - On X11, fix `ResumeTimeReached` being fired too early.

--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -30,10 +30,10 @@ fn main() {
         event_loop.run_return(|event, _, control_flow| {
             *control_flow = ControlFlow::Wait;
 
-            // if let Event::WindowEvent { event, .. } = &event {
-            //     // Print only Window events to reduce noise
+            if let Event::WindowEvent { event, .. } = &event {
+                // Print only Window events to reduce noise
                 println!("{:?}", event);
-            // }
+            }
 
             match event {
                 Event::WindowEvent {

--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -30,10 +30,10 @@ fn main() {
         event_loop.run_return(|event, _, control_flow| {
             *control_flow = ControlFlow::Wait;
 
-            if let Event::WindowEvent { event, .. } = &event {
-                // Print only Window events to reduce noise
+            // if let Event::WindowEvent { event, .. } = &event {
+            //     // Print only Window events to reduce noise
                 println!("{:?}", event);
-            }
+            // }
 
             match event {
                 Event::WindowEvent {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -777,14 +777,15 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
 
         winuser::WM_PAINT => {
             if subclass_input.event_loop_runner.should_buffer() {
-                // this branch can happen in response to `UpdateWindow`, if win32 decides to
-                // redraw the window outside the normal flow of the event loop.
-                winuser::RedrawWindow(
-                    window,
-                    ptr::null(),
-                    ptr::null_mut(),
-                    winuser::RDW_INTERNALPAINT,
-                );
+                panic!("InvalidateRgn should be used instead of UpdateWindow");
+                // // this branch can happen in response to `UpdateWindow`, if win32 decides to
+                // // redraw the window outside the normal flow of the event loop.
+                // winuser::RedrawWindow(
+                //     window,
+                //     ptr::null(),
+                //     ptr::null_mut(),
+                //     winuser::RDW_INTERNALPAINT,
+                // );
             } else {
                 let managing_redraw =
                     flush_paint_messages(Some(window), &subclass_input.event_loop_runner);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -805,15 +805,14 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
 
         winuser::WM_PAINT => {
             if subclass_input.event_loop_runner.should_buffer() {
-                panic!("InvalidateRgn should be used instead of UpdateWindow");
-            // // this branch can happen in response to `UpdateWindow`, if win32 decides to
-            // // redraw the window outside the normal flow of the event loop.
-            // winuser::RedrawWindow(
-            //     window,
-            //     ptr::null(),
-            //     ptr::null_mut(),
-            //     winuser::RDW_INTERNALPAINT,
-            // );
+                // this branch can happen in response to `UpdateWindow`, if win32 decides to
+                // redraw the window outside the normal flow of the event loop.
+                winuser::RedrawWindow(
+                    window,
+                    ptr::null(),
+                    ptr::null_mut(),
+                    winuser::RDW_INTERNALPAINT,
+                );
             } else {
                 let managing_redraw =
                     flush_paint_messages(Some(window), &subclass_input.event_loop_runner);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -654,7 +654,7 @@ unsafe fn flush_paint_messages<T: 'static>(except: Option<HWND>, runner: &ELRSha
                 redraw_window,
                 winuser::WM_PAINT,
                 winuser::WM_PAINT,
-                winuser::PM_REMOVE | winuser::QS_PAINT,
+                winuser::PM_REMOVE | winuser::PM_QS_PAINT,
             ) {
                 return;
             }
@@ -1882,8 +1882,6 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         // Because WM_PAINT comes after all other messages, we use it during modal loops to detect
         // when the event queue has been emptied. See `process_event` for more details.
         winuser::WM_PAINT => {
-            winuser::ValidateRect(window, ptr::null());
-
             // If the WM_PAINT handler in `public_window_callback` has already flushed the redraw
             // events, `handling_events` will return false and we won't emit a second
             // `RedrawEventsCleared` event.
@@ -1898,7 +1896,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                 process_control_flow(&subclass_input.event_loop_runner);
             }
 
-            0
+            commctrl::DefSubclassProc(window, msg, wparam, lparam)
         }
 
         winuser::WM_INPUT_DEVICE_CHANGE => {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1,17 +1,4 @@
 #![allow(non_snake_case)]
-//! An events loop on Win32 is a background thread.
-//!
-//! Creating an events loop spawns a thread and blocks it in a permanent Win32 events loop.
-//! Destroying the events loop stops the thread.
-//!
-//! You can use the `execute_in_thread` method to execute some code in the background thread.
-//! Since Win32 requires you to create a window in the right thread, you must use this method
-//! to create a window.
-//!
-//! If you create a window whose class is set to `callback`, the window's events will be
-//! propagated with `run_forever` and `poll_events`.
-//! The closure passed to the `execute_in_thread` method takes an `Inserter` that you can use to
-//! add a `WindowState` entry to a list of window to be used by the callback.
 
 mod runner;
 
@@ -24,6 +11,7 @@ use std::{
         mpsc::{self, Receiver, Sender},
         Arc,
     },
+    thread,
     time::{Duration, Instant},
 };
 use winapi::shared::basetsd::{DWORD_PTR, UINT_PTR};
@@ -41,7 +29,6 @@ use winapi::{
     },
 };
 
-use self::runner::{ELRShared, EventLoopRunnerShared};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{DeviceEvent, Event, Force, KeyboardInput, Touch, TouchPhase, WindowEvent},
@@ -57,6 +44,7 @@ use crate::{
     },
     window::{Fullscreen, WindowId as RootWindowId},
 };
+use runner::{EventLoopRunnerShared, ELRShared};
 
 type GetPointerFrameInfoHistory = unsafe extern "system" fn(
     pointerId: UINT,
@@ -160,9 +148,16 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn new_dpi_unaware_any_thread() -> EventLoop<T> {
         let thread_id = unsafe { processthreadsapi::GetCurrentThreadId() };
-        let runner_shared = Rc::new(ELRShared::new());
-        let (thread_msg_target, thread_msg_sender) =
-            thread_event_target_window(runner_shared.clone());
+
+        let thread_msg_target = create_event_target_window();
+
+        let send_thread_msg_target = thread_msg_target as usize;
+        thread::spawn(move || wait_thread(thread_id, send_thread_msg_target as HWND));
+        let wait_thread_id = get_wait_thread_id();
+
+        let runner_shared = Rc::new(ELRShared::new(thread_msg_target, wait_thread_id));
+
+        let thread_msg_sender = subclass_event_target_window(thread_msg_target, runner_shared.clone());
         raw_input::register_all_mice_and_keyboards_for_raw_input(thread_msg_target);
 
         EventLoop {
@@ -200,87 +195,39 @@ impl<T: 'static> EventLoop<T> {
             self.window_target
                 .p
                 .runner_shared
-                .set_runner(self, move |event, control_flow| {
+                .set_event_handler(move |event, control_flow| {
                     event_handler(event, event_loop_windows_ref, control_flow)
-                })
+                });
         }
 
         let runner = &self.window_target.p.runner_shared;
 
         unsafe {
             let mut msg = mem::zeroed();
-            let mut unread_message_exists = false;
 
+            runner.poll();
             'main: loop {
+                if 0 == winuser::GetMessageW(&mut msg, ptr::null_mut(), 0, 0) {
+                    break 'main;
+                }
+                winuser::TranslateMessage(&mut msg);
+                winuser::DispatchMessageW(&mut msg);
+
                 if let Err(payload) = runner.take_panic_error() {
-                    runner.destroy_runner();
+                    runner.reset_runner();
                     panic::resume_unwind(payload);
                 }
 
-                runner.new_events();
-                loop {
-                    if !unread_message_exists {
-                        if 0 == winuser::PeekMessageW(
-                            &mut msg,
-                            ptr::null_mut(),
-                            0,
-                            0,
-                            winuser::PM_REMOVE,
-                        ) {
-                            break;
-                        }
-                    }
-                    winuser::TranslateMessage(&mut msg);
-                    winuser::DispatchMessageW(&mut msg);
-
-                    unread_message_exists = false;
-
-                    if msg.message == winuser::WM_PAINT {
-                        // An "external" redraw was requested.
-                        // Note that the WM_PAINT has been dispatched and
-                        // has caused the event loop to emit the MainEventsCleared event.
-                        // See EventLoopRunner::process_event().
-                        // The call to main_events_cleared() below will do nothing.
-                        break;
-                    }
-                }
-                // Make sure we emit the MainEventsCleared event if no WM_PAINT message was received.
-                runner.main_events_cleared();
-                // Drain eventual WM_PAINT messages sent if user called request_redraw()
-                // during handling of MainEventsCleared.
-                loop {
-                    if 0 == winuser::PeekMessageW(
-                        &mut msg,
-                        ptr::null_mut(),
-                        winuser::WM_PAINT,
-                        winuser::WM_PAINT,
-                        winuser::PM_QS_PAINT | winuser::PM_REMOVE,
-                    ) {
-                        break;
-                    }
-
-                    winuser::TranslateMessage(&mut msg);
-                    winuser::DispatchMessageW(&mut msg);
-                }
-                runner.redraw_events_cleared();
-                match runner.control_flow() {
-                    ControlFlow::Exit => break 'main,
-                    ControlFlow::Wait => {
-                        if 0 == winuser::GetMessageW(&mut msg, ptr::null_mut(), 0, 0) {
-                            break 'main;
-                        }
-                        unread_message_exists = true;
-                    }
-                    ControlFlow::WaitUntil(resume_time) => {
-                        wait_until_time_or_msg(resume_time);
-                    }
-                    ControlFlow::Poll => (),
+                if runner.control_flow() == ControlFlow::Exit && !runner.handling_events() {
+                    break 'main;
                 }
             }
         }
 
-        runner.destroy_loop();
-        runner.destroy_runner();
+        unsafe {
+            runner.call_event_handler(Event::LoopDestroyed);
+        }
+        runner.reset_runner();
     }
 
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
@@ -316,24 +263,84 @@ fn main_thread_id() -> DWORD {
     unsafe { MAIN_THREAD_ID }
 }
 
-unsafe fn wait_until_time_or_msg(wait_until: Instant) {
-    let now = Instant::now();
-    if now < wait_until {
-        // MsgWaitForMultipleObjects tends to overshoot just a little bit. We subtract 1 millisecond
-        // from the requested time and spinlock for the remainder to compensate for that.
-        let resume_reason = winuser::MsgWaitForMultipleObjectsEx(
+fn get_wait_thread_id() -> DWORD {
+    unsafe {
+        let mut msg = mem::zeroed();
+        let result = winuser::GetMessageW(
+            &mut msg,
+            -1 as _,
+            *SEND_WAIT_THREAD_ID_MSG_ID,
+            *SEND_WAIT_THREAD_ID_MSG_ID
+        );
+        assert_eq!(
+            msg.message,
+            *SEND_WAIT_THREAD_ID_MSG_ID,
+            "this shouldn't be possible. please open an issue with Winit. error code: {}",
+            result
+        );
+        msg.lParam as DWORD
+    }
+}
+
+fn wait_thread(parent_thread_id: DWORD, msg_window_id: HWND) {
+    unsafe {
+        let mut msg = mem::zeroed();
+
+        let cur_thread_id = processthreadsapi::GetCurrentThreadId();
+        winuser::PostThreadMessageW(
+            parent_thread_id,
+            *SEND_WAIT_THREAD_ID_MSG_ID,
             0,
-            ptr::null(),
-            dur2timeout(wait_until - now).saturating_sub(1),
-            winuser::QS_ALLEVENTS,
-            winuser::MWMO_INPUTAVAILABLE,
+            cur_thread_id as LPARAM,
         );
 
-        if resume_reason == winerror::WAIT_TIMEOUT {
-            let mut msg = mem::zeroed();
-            while Instant::now() < wait_until {
-                if 0 != winuser::PeekMessageW(&mut msg, ptr::null_mut(), 0, 0, 0) {
-                    break;
+        let mut wait_until_opt = None;
+        'main: loop {
+            if 0 == winuser::GetMessageW(&mut msg, ptr::null_mut(), 0, 0) {
+                break 'main;
+            }
+
+            winuser::TranslateMessage(&mut msg);
+            winuser::DispatchMessageW(&mut msg);
+
+            if msg.message == *WAIT_UNTIL_MSG_ID {
+                wait_until_opt = Some(*WaitUntilInstantBox::from_raw(msg.lParam as *mut _));
+            } else if msg.message == *CANCEL_WAIT_UNTIL_MSG_ID {
+                wait_until_opt = None;
+            }
+
+            if let Some(wait_until) = wait_until_opt {
+                let now = Instant::now();
+                if now < wait_until {
+                    // MsgWaitForMultipleObjects tends to overshoot just a little bit. We subtract
+                    // 1 millisecond from the requested time and spinlock for the remainder to
+                    // compensate for that.
+                    let resume_reason = winuser::MsgWaitForMultipleObjectsEx(
+                        0,
+                        ptr::null(),
+                        dur2timeout(wait_until - now).saturating_sub(1),
+                        winuser::QS_ALLEVENTS,
+                        winuser::MWMO_INPUTAVAILABLE,
+                    );
+                    if resume_reason == winerror::WAIT_TIMEOUT {
+                        winuser::PostMessageW(
+                            msg_window_id,
+                            *PROCESS_NEW_EVENTS_MSG_ID,
+                            0,
+                            0,
+                        );
+                        wait_until_opt = None;
+                    }
+
+                    // TODO: SPINLOCK ON MAIN THREAD
+                    // if resume_reason == winerror::WAIT_TIMEOUT {
+                    //     let mut msg = mem::zeroed();
+                    //     while Instant::now() < wait_until {
+                    //         if 0 != winuser::PeekMessageW(&mut msg, ptr::null_mut(), 0, 0, 0) {
+                    //             break;
+                    //         }
+                    //     }
+                    // }
                 }
             }
         }
@@ -461,6 +468,8 @@ impl<T: 'static> EventLoopProxy<T> {
     }
 }
 
+type WaitUntilInstantBox = Box<Instant>;
+
 lazy_static! {
     // Message sent by the `EventLoopProxy` when we want to wake up the thread.
     // WPARAM and LPARAM are unused.
@@ -475,6 +484,29 @@ lazy_static! {
     static ref EXEC_MSG_ID: u32 = {
         unsafe {
             winuser::RegisterWindowMessageA("Winit::ExecMsg\0".as_ptr() as *const i8)
+        }
+    };
+    static ref PROCESS_NEW_EVENTS_MSG_ID: u32 = {
+        unsafe {
+            winuser::RegisterWindowMessageA("Winit::ProcessNewEvents\0".as_ptr() as *const i8)
+        }
+    };
+    /// lparam is the wait thread's message id.
+    static ref SEND_WAIT_THREAD_ID_MSG_ID: u32 = {
+        unsafe {
+            winuser::RegisterWindowMessageA("Winit::SendWaitThreadId\0".as_ptr() as *const i8)
+        }
+    };
+    /// lparam points to a `Box<Instant>` signifying the time `PROCESS_NEW_EVENTS_MSG_ID` should
+    /// be sent.
+    static ref WAIT_UNTIL_MSG_ID: u32 = {
+        unsafe {
+            winuser::RegisterWindowMessageA("Winit::WaitUntil\0".as_ptr() as *const i8)
+        }
+    };
+    static ref CANCEL_WAIT_UNTIL_MSG_ID: u32 = {
+        unsafe {
+            winuser::RegisterWindowMessageA("Winit::CancelWaitUntil\0".as_ptr() as *const i8)
         }
     };
     // Message sent by a `Window` when it wants to be destroyed by the main thread.
@@ -519,7 +551,7 @@ lazy_static! {
     };
 }
 
-fn thread_event_target_window<T>(event_loop_runner: EventLoopRunnerShared<T>) -> (HWND, Sender<T>) {
+fn create_event_target_window() -> HWND {
     unsafe {
         let window = winuser::CreateWindowExW(
             winuser::WS_EX_NOACTIVATE | winuser::WS_EX_TRANSPARENT | winuser::WS_EX_LAYERED,
@@ -543,7 +575,12 @@ fn thread_event_target_window<T>(event_loop_runner: EventLoopRunnerShared<T>) ->
             // the LAYERED style.
             (winuser::WS_VISIBLE | winuser::WS_POPUP) as _,
         );
+        window
+    }
+}
 
+fn subclass_event_target_window<T>(window: HWND, event_loop_runner: EventLoopRunnerShared<T>) -> Sender<T> {
+    unsafe {
         let (tx, rx) = mpsc::channel();
 
         let subclass_input = ThreadMsgTargetSubclassInput {
@@ -559,7 +596,7 @@ fn thread_event_target_window<T>(event_loop_runner: EventLoopRunnerShared<T>) ->
         );
         assert_eq!(subclass_result, 1);
 
-        (window, tx)
+        tx
     }
 }
 
@@ -582,6 +619,7 @@ unsafe fn release_mouse(window_state: &mut WindowState) {
 const WINDOW_SUBCLASS_ID: UINT_PTR = 0;
 const THREAD_EVENT_TARGET_SUBCLASS_ID: UINT_PTR = 1;
 pub(crate) fn subclass_window<T>(window: HWND, subclass_input: SubclassInput<T>) {
+    subclass_input.event_loop_runner.register_window(window);
     let input_ptr = Box::into_raw(Box::new(subclass_input));
     let subclass_result = unsafe {
         commctrl::SetWindowSubclass(
@@ -598,6 +636,56 @@ fn normalize_pointer_pressure(pressure: u32) -> Option<Force> {
     match pressure {
         1..=1024 => Some(Force::Normalized(pressure as f64 / 1024.0)),
         _ => None,
+    }
+}
+
+unsafe fn flush_paint_messages<T: 'static>(except: Option<HWND>, runner: &ELRShared<T>) -> bool {
+    if !runner.redrawing() {
+        runner.main_events_cleared();
+        let mut msg = mem::zeroed();
+        runner.owned_windows(|redraw_window| {
+            if Some(redraw_window) == except {
+                return;
+            }
+
+            if 0 == winuser::PeekMessageW(
+                &mut msg,
+                redraw_window,
+                winuser::WM_PAINT,
+                winuser::WM_PAINT,
+                winuser::PM_REMOVE,
+            ) {
+                return;
+            }
+
+            winuser::TranslateMessage(&mut msg);
+            winuser::DispatchMessageW(&mut msg);
+        });
+        true
+    } else {
+        false
+    }
+}
+
+unsafe fn process_control_flow<T: 'static>(runner: &ELRShared<T>) {
+    match runner.control_flow() {
+        ControlFlow::Poll => {
+            winuser::PostMessageW(
+                runner.thread_msg_target(),
+                *PROCESS_NEW_EVENTS_MSG_ID,
+                0, 0
+            );
+        },
+        ControlFlow::Wait => (),
+        ControlFlow::WaitUntil(until) => {
+            winuser::PostThreadMessageW(
+                runner.wait_thread_id(),
+                *WAIT_UNTIL_MSG_ID,
+                0,
+                Box::into_raw(WaitUntilInstantBox::new(until)) as LPARAM
+            );
+        },
+        ControlFlow::Exit => (),
     }
 }
 
@@ -641,18 +729,19 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
 
     match msg {
         winuser::WM_ENTERSIZEMOVE => {
-            subclass_input.event_loop_runner.set_modal_loop(true);
+            subclass_input.window_state.lock().set_window_flags_in_place(|f| f.insert(WindowFlags::MARKER_IN_SIZE_MOVE));
             0
-        }
+        },
+
         winuser::WM_EXITSIZEMOVE => {
-            subclass_input.event_loop_runner.set_modal_loop(false);
+            subclass_input.window_state.lock().set_window_flags_in_place(|f| f.remove(WindowFlags::MARKER_IN_SIZE_MOVE));
             0
-        }
+        },
+
         winuser::WM_NCCREATE => {
             enable_non_client_dpi_scaling(window);
             commctrl::DefSubclassProc(window, msg, wparam, lparam)
         }
-
         winuser::WM_NCLBUTTONDOWN => {
             if wparam == winuser::HTCAPTION as _ {
                 winuser::PostMessageW(window, winuser::WM_MOUSEMOVE, 0, 0);
@@ -676,6 +765,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 window_id: RootWindowId(WindowId(window)),
                 event: Destroyed,
             });
+            subclass_input.event_loop_runner.remove_window(window);
 
             drop(subclass_input);
             Box::from_raw(subclass_input_ptr as *mut SubclassInput<T>);
@@ -683,9 +773,27 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
         }
 
         winuser::WM_PAINT => {
-            subclass_input.send_event(Event::RedrawRequested(RootWindowId(WindowId(window))));
+            if subclass_input.event_loop_runner.should_buffer() {
+                // this branch can happen in response to `UpdateWindow`, if Windows decides to
+                // redraw the window outside the normal flow of the event loop.
+                winuser::RedrawWindow(
+                    window,
+                    ptr::null(),
+                    ptr::null_mut(),
+                    winuser::RDW_INTERNALPAINT,
+                );
+
+            } else {
+                let managing_redraw =  flush_paint_messages(Some(window), &subclass_input.event_loop_runner);
+                subclass_input.send_event(Event::RedrawRequested(RootWindowId(WindowId(window))));
+                if managing_redraw {
+                    subclass_input.event_loop_runner.redraw_events_cleared();
+                    process_control_flow(&subclass_input.event_loop_runner);
+                }
+            }
+
             commctrl::DefSubclassProc(window, msg, wparam, lparam)
-        }
+        },
 
         winuser::WM_WINDOWPOSCHANGING => {
             let mut window_state = subclass_input.window_state.lock();
@@ -1583,11 +1691,17 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 },
             });
 
-            // Unset maximized if we're changing the window's size.
-            if new_physical_inner_size != old_physical_inner_size {
-                WindowState::set_window_flags(subclass_input.window_state.lock(), window, |f| {
-                    f.set(WindowFlags::MAXIMIZED, false)
-                });
+            let dragging_window: bool;
+
+            {
+                let window_state = subclass_input.window_state.lock();
+                dragging_window = window_state.window_flags().contains(WindowFlags::MARKER_IN_SIZE_MOVE);
+                // Unset maximized if we're changing the window's size.
+                if new_physical_inner_size != old_physical_inner_size {
+                    WindowState::set_window_flags(window_state, window, |f| {
+                        f.set(WindowFlags::MAXIMIZED, false)
+                    });
+                }
             }
 
             let new_outer_rect: RECT;
@@ -1612,9 +1726,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 )
                 .unwrap_or(conservative_rect);
 
-                // If we're not dragging the window, offset the window so that the cursor's
+                // If we're dragging the window, offset the window so that the cursor's
                 // relative horizontal position in the title bar is preserved.
-                let dragging_window = subclass_input.event_loop_runner.in_modal_loop();
                 if dragging_window {
                     let bias = {
                         let cursor_pos = {
@@ -1764,52 +1877,11 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         // when the event queue has been emptied. See `process_event` for more details.
         winuser::WM_PAINT => {
             winuser::ValidateRect(window, ptr::null());
-            let queue_call_again = || {
-                winuser::RedrawWindow(
-                    window,
-                    ptr::null(),
-                    ptr::null_mut(),
-                    winuser::RDW_INTERNALPAINT,
-                );
-            };
-            let in_modal_loop = subclass_input.event_loop_runner.in_modal_loop();
-            if in_modal_loop {
-                let runner = &subclass_input.event_loop_runner;
-                runner.main_events_cleared();
-                // Drain eventual WM_PAINT messages sent if user called request_redraw()
-                // during handling of MainEventsCleared.
-                let mut msg = mem::zeroed();
-                loop {
-                    if 0 == winuser::PeekMessageW(
-                        &mut msg,
-                        ptr::null_mut(),
-                        winuser::WM_PAINT,
-                        winuser::WM_PAINT,
-                        winuser::PM_QS_PAINT | winuser::PM_REMOVE,
-                    ) {
-                        break;
-                    }
 
-                    if msg.hwnd != window {
-                        winuser::TranslateMessage(&mut msg);
-                        winuser::DispatchMessageW(&mut msg);
-                    }
-                }
-                runner.redraw_events_cleared();
-                match runner.control_flow() {
-                    // Waiting is handled by the modal loop.
-                    ControlFlow::Exit | ControlFlow::Wait => runner.new_events(),
-                    ControlFlow::WaitUntil(resume_time) => {
-                        wait_until_time_or_msg(resume_time);
-                        runner.new_events();
-                        queue_call_again();
-                    }
-                    ControlFlow::Poll => {
-                        runner.new_events();
-                        queue_call_again();
-                    }
-                }
-            }
+            flush_paint_messages(None, &subclass_input.event_loop_runner);
+            subclass_input.event_loop_runner.redraw_events_cleared();
+            process_control_flow(&subclass_input.event_loop_runner);
+
             0
         }
 
@@ -1938,6 +2010,15 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         _ if msg == *EXEC_MSG_ID => {
             let mut function: ThreadExecFn = Box::from_raw(wparam as usize as *mut _);
             function();
+            0
+        }
+        _ if msg == *PROCESS_NEW_EVENTS_MSG_ID => {
+            winuser::PostThreadMessageW(
+                subclass_input.event_loop_runner.wait_thread_id(),
+                *CANCEL_WAIT_UNTIL_MSG_ID,
+                0, 0
+            );
+            subclass_input.event_loop_runner.poll();
             0
         }
         _ => commctrl::DefSubclassProc(window, msg, wparam, lparam),

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -727,6 +727,13 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
 ) -> LRESULT {
     let subclass_input = &*(subclass_input_ptr as *const SubclassInput<T>);
 
+    winuser::RedrawWindow(
+        subclass_input.event_loop_runner.thread_msg_target(),
+        ptr::null(),
+        ptr::null_mut(),
+        winuser::RDW_INTERNALPAINT,
+    );
+
     // I decided to bind the closure to `callback` and pass it to catch_unwind rather than passing
     // the closure to catch_unwind directly so that the match body indendation wouldn't change and
     // the git blame and history would be preserved.
@@ -1885,6 +1892,15 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
 ) -> LRESULT {
     let subclass_input = &mut *(subclass_input_ptr as *mut ThreadMsgTargetSubclassInput<T>);
     let runner = subclass_input.event_loop_runner.clone();
+
+    if msg != winuser::WM_PAINT {
+        winuser::RedrawWindow(
+            window,
+            ptr::null(),
+            ptr::null_mut(),
+            winuser::RDW_INTERNALPAINT,
+        );
+    }
 
     // I decided to bind the closure to `callback` and pass it to catch_unwind rather than passing
     // the closure to catch_unwind directly so that the match body indendation wouldn't change and

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -315,7 +315,6 @@ fn wait_thread(parent_thread_id: DWORD, msg_window_id: HWND) {
                 }
             }
 
-
             if msg.message == *WAIT_UNTIL_MSG_ID {
                 wait_until_opt = Some(*WaitUntilInstantBox::from_raw(msg.lParam as *mut _));
             } else if msg.message == *CANCEL_WAIT_UNTIL_MSG_ID {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -778,14 +778,14 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
         winuser::WM_PAINT => {
             if subclass_input.event_loop_runner.should_buffer() {
                 panic!("InvalidateRgn should be used instead of UpdateWindow");
-                // // this branch can happen in response to `UpdateWindow`, if win32 decides to
-                // // redraw the window outside the normal flow of the event loop.
-                // winuser::RedrawWindow(
-                //     window,
-                //     ptr::null(),
-                //     ptr::null_mut(),
-                //     winuser::RDW_INTERNALPAINT,
-                // );
+            // // this branch can happen in response to `UpdateWindow`, if win32 decides to
+            // // redraw the window outside the normal flow of the event loop.
+            // winuser::RedrawWindow(
+            //     window,
+            //     ptr::null(),
+            //     ptr::null_mut(),
+            //     winuser::RDW_INTERNALPAINT,
+            // );
             } else {
                 let managing_redraw =
                     flush_paint_messages(Some(window), &subclass_input.event_loop_runner);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -640,7 +640,10 @@ fn normalize_pointer_pressure(pressure: u32) -> Option<Force> {
 /// Returns `true` if this invocation flushed all the redraw events. If this function is re-entrant,
 /// it won't flush the redraw events and will return `false`.
 #[must_use]
-unsafe fn flush_paint_messages<T: 'static>(except: Option<HWND>, runner: &EventLoopRunner<T>) -> bool {
+unsafe fn flush_paint_messages<T: 'static>(
+    except: Option<HWND>,
+    runner: &EventLoopRunner<T>,
+) -> bool {
     if !runner.redrawing() {
         runner.main_events_cleared();
         let mut msg = mem::zeroed();

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2056,7 +2056,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                 let mut msg = mem::zeroed();
                 while Instant::now() < wait_until {
                     if 0 != winuser::PeekMessageW(&mut msg, ptr::null_mut(), 0, 0, 0) {
-                        // This works around a bug in PeekMessageW. If the message PeekMessageW
+                        // This works around a "feature" in PeekMessageW. If the message PeekMessageW
                         // gets is a WM_PAINT message that had RDW_INTERNALPAINT set (i.e. doesn't
                         // have an update region), PeekMessageW will remove that window from the
                         // redraw queue even though we told it not to remove messages from the

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -1,33 +1,39 @@
-use std::{any::Any, cell::RefCell, collections::VecDeque, mem, panic, ptr, rc::Rc, time::Instant};
+use std::{any::Any, cell::{Cell, RefCell}, collections::{HashSet, VecDeque}, mem, ptr, panic, rc::Rc, time::Instant};
 
-use winapi::{shared::windef::HWND, um::winuser};
+use winapi::{um::winuser, shared::{minwindef::DWORD, windef::HWND}};
 
 use crate::{
     dpi::PhysicalSize,
     event::{Event, StartCause, WindowEvent},
     event_loop::ControlFlow,
-    platform_impl::platform::event_loop::{util, EventLoop},
+    platform_impl::platform::util,
     window::WindowId,
 };
 
 pub(crate) type EventLoopRunnerShared<T> = Rc<ELRShared<T>>;
 pub(crate) struct ELRShared<T: 'static> {
-    runner: RefCell<Option<EventLoopRunner<T>>>,
-    buffer: RefCell<VecDeque<BufferedEvent<T>>>,
-}
-
-struct EventLoopRunner<T: 'static> {
-    control_flow: ControlFlow,
-    runner_state: RunnerState,
-    modal_redraw_window: HWND,
-    in_modal_loop: bool,
-    event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
-    panic_error: Option<PanicError>,
+    thread_msg_target: HWND,
+    wait_thread_id: DWORD,
+    processing_events: Cell<ProcessingEvents>,
+    panic_error: Cell<Option<PanicError>>,
+    control_flow: Cell<ControlFlow>,
+    last_events_cleared: Cell<Instant>,
+    event_handler: Cell<Option<Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>>>,
+    event_buffer: RefCell<VecDeque<BufferedEvent<T>>>,
+    owned_windows: Cell<HashSet<HWND>>,
 }
 
 pub type PanicError = Box<dyn Any + Send + 'static>;
 
-pub enum BufferedEvent<T: 'static> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ProcessingEvents {
+    Uninitialized,
+    NoEvents,
+    MainEvents,
+    RedrawEvents,
+}
+
+enum BufferedEvent<T: 'static> {
     Event(Event<'static, T>),
     ScaleFactorChanged(WindowId, f64, PhysicalSize<u32>),
 }
@@ -69,407 +75,237 @@ impl<T> BufferedEvent<T> {
 }
 
 impl<T> ELRShared<T> {
-    pub(crate) fn new() -> ELRShared<T> {
+    pub(crate) fn new(thread_msg_target: HWND, wait_thread_id: DWORD) -> ELRShared<T> {
         ELRShared {
-            runner: RefCell::new(None),
-            buffer: RefCell::new(VecDeque::new()),
+            thread_msg_target,
+            wait_thread_id,
+            processing_events: Cell::new(ProcessingEvents::Uninitialized),
+            control_flow: Cell::new(ControlFlow::Poll),
+            panic_error: Cell::new(None),
+            last_events_cleared: Cell::new(Instant::now()),
+            event_handler: Cell::new(None),
+            event_buffer: RefCell::new(VecDeque::new()),
+            owned_windows: Cell::new(HashSet::new())
         }
     }
 
-    pub(crate) unsafe fn set_runner<F>(&self, event_loop: &EventLoop<T>, f: F)
+    pub fn thread_msg_target(&self) -> HWND {
+        self.thread_msg_target
+    }
+
+    pub fn wait_thread_id(&self) -> DWORD {
+        self.wait_thread_id
+    }
+
+    pub(crate) unsafe fn set_event_handler<F>(&self, f: F)
     where
         F: FnMut(Event<'_, T>, &mut ControlFlow),
     {
-        let mut runner = EventLoopRunner::new(event_loop, f);
-        {
-            let mut runner_ref = self.runner.borrow_mut();
-            // Dispatch any events that were buffered during the creation of the window
-            self.dispatch_buffered_events(&mut runner);
-            *runner_ref = Some(runner);
-        }
+        let old_event_handler = self.event_handler.replace(
+            mem::transmute::<
+                Option<Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>>,
+                Option<Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>>,
+            >(Some(Box::new(f))),
+        );
+        assert!(old_event_handler.is_none());
     }
 
-    pub(crate) fn destroy_runner(&self) {
-        *self.runner.borrow_mut() = None;
+    pub(crate) fn reset_runner(&self) {
+        let ELRShared {
+            thread_msg_target: _,
+            wait_thread_id: _,
+            processing_events,
+            panic_error,
+            control_flow,
+            last_events_cleared: _,
+            event_handler,
+            event_buffer: _,
+            owned_windows: _,
+        } = self;
+        processing_events.set(ProcessingEvents::Uninitialized);
+        panic_error.set(None);
+        control_flow.set(ControlFlow::Poll);
+        event_handler.set(None);
     }
 
-    pub(crate) fn new_events(&self) {
-        let mut runner_ref = self.runner.borrow_mut();
-        if let Some(ref mut runner) = *runner_ref {
-            runner.new_events();
-            // Dispatch any events that were buffered during the call `new_events`
-            self.dispatch_buffered_events(runner);
-        }
+    pub(crate) unsafe fn poll(&self) {
+        self.move_state_to(ProcessingEvents::MainEvents);
     }
 
-    pub(crate) fn send_event(&self, event: Event<'_, T>) {
-        if let Err(event) = self.send_event_unbuffered(event) {
-            // If the runner is already borrowed, we're in the middle of an event loop invocation.
-            // Add the event to a buffer to be processed later.
-            if let Event::RedrawRequested(_) = event {
-                panic!("buffering RedrawRequested event");
-            }
-            self.buffer
-                .borrow_mut()
-                .push_back(BufferedEvent::from_event(event));
-        }
-    }
-
-    fn send_event_unbuffered<'e>(&self, event: Event<'e, T>) -> Result<(), Event<'e, T>> {
-        if let Ok(mut runner_ref) = self.runner.try_borrow_mut() {
-            if let Some(ref mut runner) = *runner_ref {
-                runner.process_event(event);
-                // Dispatch any events that were buffered during the call to `process_event`.
-                self.dispatch_buffered_events(runner);
-                return Ok(());
-            }
-        }
-        Err(event)
-    }
-
-    fn dispatch_buffered_events(&self, runner: &mut EventLoopRunner<T>) {
-        // We do this instead of using a `while let` loop because if we use a `while let`
-        // loop the reference returned `borrow_mut()` doesn't get dropped until the end
-        // of the loop's body and attempts to add events to the event buffer while in
-        // `process_event` will fail.
-        loop {
-            let buffered_event_opt = self.buffer.borrow_mut().pop_front();
-            match buffered_event_opt {
-                Some(e) => e.dispatch_event(|e| runner.process_event(e)),
-                None => break,
+    pub(crate) unsafe fn send_event(&self, event: Event<'_, T>) {
+        if let Event::RedrawRequested(_) = event {
+            self.move_state_to(ProcessingEvents::RedrawEvents);
+            self.call_event_handler(event);
+        } else {
+            if self.should_buffer() {
+                // If the runner is already borrowed, we're in the middle of an event loop invocation. Add
+                // the event to a buffer to be processed later.
+                self.event_buffer
+                    .borrow_mut()
+                    .push_back(BufferedEvent::from_event(event))
+            } else {
+                self.move_state_to(ProcessingEvents::MainEvents);
+                self.call_event_handler(event);
+                self.dispatch_buffered_events();
             }
         }
     }
 
-    pub(crate) fn main_events_cleared(&self) {
-        let mut runner_ref = self.runner.borrow_mut();
-        if let Some(ref mut runner) = *runner_ref {
-            runner.main_events_cleared();
-            if !self.buffer.borrow().is_empty() {
-                warn!("Buffered events while dispatching MainEventsCleared");
-            }
-        }
+    pub(crate) unsafe fn main_events_cleared(&self) {
+        self.move_state_to(ProcessingEvents::RedrawEvents);
     }
 
-    pub(crate) fn redraw_events_cleared(&self) {
-        let mut runner_ref = self.runner.borrow_mut();
-        if let Some(ref mut runner) = *runner_ref {
-            runner.redraw_events_cleared();
-            if !self.buffer.borrow().is_empty() {
-                warn!("Buffered events while dispatching RedrawEventsCleared");
-            }
-        }
+    pub(crate) unsafe fn redraw_events_cleared(&self) {
+        self.move_state_to(ProcessingEvents::NoEvents);
     }
 
-    pub(crate) fn destroy_loop(&self) {
-        if let Ok(mut runner_ref) = self.runner.try_borrow_mut() {
-            if let Some(ref mut runner) = *runner_ref {
-                runner.call_event_handler(Event::LoopDestroyed);
-            }
+    pub fn redrawing(&self) -> bool {
+        self.processing_events.get() == ProcessingEvents::RedrawEvents
+    }
+
+    pub(crate) unsafe fn call_event_handler(&self, event: Event<'_, T>) {
+        let mut panic_error = self.panic_error.take();
+        if panic_error.is_none() {
+            let mut control_flow = self.control_flow.take();
+            let mut event_handler = self.event_handler.take()
+                .expect("either event handler is re-entrant (likely), or no event handler is registered (very unlikely)");
+
+            panic_error = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+                if control_flow != ControlFlow::Exit {
+                    event_handler(event, &mut control_flow);
+                } else {
+                    event_handler(event, &mut ControlFlow::Exit);
+                }
+            })).err();
+
+            assert!(self.event_handler.replace(Some(event_handler)).is_none());
+            self.control_flow.set(control_flow);
         }
+        self.panic_error.set(panic_error);
     }
 
     pub(crate) fn take_panic_error(&self) -> Result<(), PanicError> {
-        let mut runner_ref = self.runner.borrow_mut();
-        if let Some(ref mut runner) = *runner_ref {
-            runner.take_panic_error()
-        } else {
-            Ok(())
-        }
-    }
-
-    pub(crate) fn set_modal_loop(&self, in_modal_loop: bool) {
-        let mut runner_ref = self.runner.borrow_mut();
-        if let Some(ref mut runner) = *runner_ref {
-            runner.in_modal_loop = in_modal_loop;
-            if in_modal_loop {
-                // jumpstart the modal loop
-                unsafe {
-                    winuser::RedrawWindow(
-                        runner.modal_redraw_window,
-                        ptr::null(),
-                        ptr::null_mut(),
-                        winuser::RDW_INTERNALPAINT,
-                    );
-                }
-            }
-        }
-    }
-
-    pub(crate) fn in_modal_loop(&self) -> bool {
-        let runner = self.runner.borrow();
-        if let Some(ref runner) = *runner {
-            runner.in_modal_loop
-        } else {
-            false
-        }
-    }
-
-    pub fn control_flow(&self) -> ControlFlow {
-        let runner_ref = self.runner.borrow();
-        if let Some(ref runner) = *runner_ref {
-            runner.control_flow
-        } else {
-            ControlFlow::Exit
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum RunnerState {
-    /// The event loop has just been created, and an `Init` event must be sent.
-    New,
-    /// The event loop is idling, and began idling at the given instant.
-    Idle(Instant),
-    /// The event loop has received a signal from the OS that the loop may resume, but no winit
-    /// events have been generated yet. We're waiting for an event to be processed or the events
-    /// to be marked as cleared to send `NewEvents`, depending on the current `ControlFlow`.
-    DeferredNewEvents(Instant),
-    /// The event loop is handling the OS's events and sending them to the user's callback.
-    /// `NewEvents` has been sent, and `MainEventsCleared` hasn't.
-    HandlingEvents,
-    /// The event loop is handling the redraw events and sending them to the user's callback.
-    /// `MainEventsCleared` has been sent, and `RedrawEventsCleared` hasn't.
-    HandlingRedraw,
-}
-
-impl<T> EventLoopRunner<T> {
-    unsafe fn new<F>(event_loop: &EventLoop<T>, f: F) -> EventLoopRunner<T>
-    where
-        F: FnMut(Event<'_, T>, &mut ControlFlow),
-    {
-        EventLoopRunner {
-            control_flow: ControlFlow::default(),
-            runner_state: RunnerState::New,
-            in_modal_loop: false,
-            modal_redraw_window: event_loop.window_target.p.thread_msg_target,
-            event_handler: mem::transmute::<
-                Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
-                Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
-            >(Box::new(f)),
-            panic_error: None,
-        }
-    }
-
-    fn take_panic_error(&mut self) -> Result<(), PanicError> {
         match self.panic_error.take() {
             Some(err) => Err(err),
             None => Ok(()),
         }
     }
 
-    fn new_events(&mut self) {
-        self.runner_state = match self.runner_state {
-            // If we're already handling events or have deferred `NewEvents`, we don't need to do
-            // do any processing.
-            RunnerState::HandlingEvents
-            | RunnerState::HandlingRedraw
-            | RunnerState::DeferredNewEvents(..) => self.runner_state,
+    pub fn register_window(&self, window: HWND) {
+        let mut owned_windows = self.owned_windows.take();
+        owned_windows.insert(window);
+        self.owned_windows.set(owned_windows);
+    }
 
-            // Send the `Init` `NewEvents` and immediately move into event processing.
-            RunnerState::New => {
+    pub fn remove_window(&self, window: HWND) {
+        let mut owned_windows = self.owned_windows.take();
+        owned_windows.remove(&window);
+        self.owned_windows.set(owned_windows);
+    }
+
+    pub fn control_flow(&self) -> ControlFlow {
+        self.control_flow.get()
+    }
+
+    pub fn handling_events(&self) -> bool {
+        self.processing_events.get() != ProcessingEvents::NoEvents
+    }
+
+    pub fn owned_windows(&self, mut f: impl FnMut(HWND)) {
+        let mut owned_windows = self.owned_windows.take();
+        for hwnd in &owned_windows {
+            f(*hwnd);
+        }
+        let new_owned_windows = self.owned_windows.take();
+        owned_windows.extend(&new_owned_windows);
+        self.owned_windows.set(owned_windows);
+    }
+
+    pub fn should_buffer(&self) -> bool {
+        let handler = self.event_handler.take();
+        let should_buffer = handler.is_none();
+        self.event_handler.set(handler);
+        should_buffer
+    }
+
+    unsafe fn dispatch_buffered_events(&self) {
+        loop {
+            // We do this instead of using a `while let` loop because if we use a `while let`
+            // loop the reference returned `borrow_mut()` doesn't get dropped until the end
+            // of the loop's body and attempts to add events to the event buffer while in
+            // `process_event` will fail.
+            let buffered_event_opt = self.event_buffer.borrow_mut().pop_front();
+            match buffered_event_opt {
+                Some(e) => e.dispatch_event(|e| self.call_event_handler(e)),
+                None => break,
+            }
+        }
+    }
+
+    unsafe fn move_state_to(&self, processing_events: ProcessingEvents) {
+        use ProcessingEvents::{Uninitialized, NoEvents, MainEvents, RedrawEvents};
+
+        let probably_wrong = || warn!("Given winit's current design, the fact that this branch is getting hit \
+                                       is probably indicates a bug. Please open an issue at \
+                                       https://github.com/rust-windowing/winit");
+
+        match (self.processing_events.replace(processing_events), processing_events) {
+            (Uninitialized, Uninitialized) |
+            (NoEvents, NoEvents) |
+            (MainEvents, MainEvents) |
+            (RedrawEvents, RedrawEvents) => (),
+
+            (Uninitialized, MainEvents) => {
+                self.call_new_events(true);
                 self.call_event_handler(Event::NewEvents(StartCause::Init));
-                RunnerState::HandlingEvents
-            }
-
-            // When `NewEvents` gets sent after an idle depends on the control flow...
-            // Some `NewEvents` are deferred because not all Windows messages trigger an event_loop event.
-            // So we defer the `NewEvents` to when we actually process an event.
-            RunnerState::Idle(wait_start) => {
-                match self.control_flow {
-                    // If we're polling, send `NewEvents` and immediately move into event processing.
-                    ControlFlow::Poll => {
-                        self.call_event_handler(Event::NewEvents(StartCause::Poll));
-                        RunnerState::HandlingEvents
-                    },
-                    // If the user was waiting until a specific time, the `NewEvents` call gets sent
-                    // at varying times depending on the current time.
-                    ControlFlow::WaitUntil(resume_time) => {
-                        match Instant::now() >= resume_time {
-                            // If the current time is later than the requested resume time, we can tell the
-                            // user that the resume time has been reached with `NewEvents` and immdiately move
-                            // into event processing.
-                            true => {
-                                self.call_event_handler(Event::NewEvents(StartCause::ResumeTimeReached {
-                                    start: wait_start,
-                                    requested_resume: resume_time,
-                                }));
-                                RunnerState::HandlingEvents
-                            },
-                            // However, if the current time is EARLIER than the requested resume time, we
-                            // don't want to send the `WaitCancelled` event until we know an event is being
-                            // sent. Defer.
-                            false => RunnerState::DeferredNewEvents(wait_start)
-                        }
-                    },
-                    // If we're waiting, `NewEvents` doesn't get sent until winit gets an event, so
-                    // we defer.
-                    ControlFlow::Wait |
-                    // `Exit` shouldn't really ever get sent here, but if it does do something somewhat sane.
-                    ControlFlow::Exit => RunnerState::DeferredNewEvents(wait_start),
-                }
-            }
-        };
-    }
-
-    fn process_event(&mut self, event: Event<'_, T>) {
-        // If we're in the modal loop, we need to have some mechanism for finding when the event
-        // queue has been cleared so we can call `events_cleared`. Windows doesn't give any utilities
-        // for doing this, but it DOES guarantee that WM_PAINT will only occur after input events have
-        // been processed. So, we send WM_PAINT to a dummy window which calls `events_cleared` when
-        // the events queue has been emptied.
-        if self.in_modal_loop {
-            unsafe {
-                winuser::RedrawWindow(
-                    self.modal_redraw_window,
-                    ptr::null(),
-                    ptr::null_mut(),
-                    winuser::RDW_INTERNALPAINT,
-                );
-            }
-        }
-
-        // If new event processing has to be done (i.e. call NewEvents or defer), do it. If we're
-        // already in processing nothing happens with this call.
-        self.new_events();
-
-        // Now that an event has been received, we have to send any `NewEvents` calls that were
-        // deferred.
-        if let RunnerState::DeferredNewEvents(wait_start) = self.runner_state {
-            match self.control_flow {
-                ControlFlow::Exit | ControlFlow::Wait => {
-                    self.call_event_handler(Event::NewEvents(StartCause::WaitCancelled {
-                        start: wait_start,
-                        requested_resume: None,
-                    }))
-                }
-                ControlFlow::WaitUntil(resume_time) => {
-                    let start_cause = match Instant::now() >= resume_time {
-                        // If the current time is later than the requested resume time, the resume time
-                        // has been reached.
-                        true => StartCause::ResumeTimeReached {
-                            start: wait_start,
-                            requested_resume: resume_time,
-                        },
-                        // Otherwise, the requested resume time HASN'T been reached and we send a WaitCancelled.
-                        false => StartCause::WaitCancelled {
-                            start: wait_start,
-                            requested_resume: Some(resume_time),
-                        },
-                    };
-                    self.call_event_handler(Event::NewEvents(start_cause));
-                }
-                // This can be reached if the control flow is changed to poll during a `RedrawRequested`
-                // that was sent after `MainEventsCleared`.
-                ControlFlow::Poll => self.call_event_handler(Event::NewEvents(StartCause::Poll)),
-            }
-            self.runner_state = RunnerState::HandlingEvents;
-        }
-
-        match (self.runner_state, &event) {
-            (RunnerState::HandlingEvents, Event::RedrawRequested(window_id)) => {
+            },
+            (Uninitialized, RedrawEvents) => {
+                self.call_new_events(true);
                 self.call_event_handler(Event::MainEventsCleared);
-                self.runner_state = RunnerState::HandlingRedraw;
-                self.call_event_handler(Event::RedrawRequested(*window_id));
-            }
-            (RunnerState::HandlingRedraw, Event::RedrawRequested(window_id)) => {
-                self.call_event_handler(Event::RedrawRequested(*window_id));
-            }
-            (RunnerState::HandlingRedraw, _) => {
-                warn!(
-                    "non-redraw event in redraw phase: {:?}",
-                    event.map_nonuser_event::<()>().ok()
-                );
-            }
-            (_, _) => {
-                self.runner_state = RunnerState::HandlingEvents;
-                self.call_event_handler(event);
-            }
-        }
-    }
-
-    fn main_events_cleared(&mut self) {
-        match self.runner_state {
-            // If we were handling events, send the MainEventsCleared message.
-            RunnerState::HandlingEvents => {
+            },
+            (Uninitialized, NoEvents) => {
+                self.call_new_events(true);
                 self.call_event_handler(Event::MainEventsCleared);
-                self.runner_state = RunnerState::HandlingRedraw;
-            }
-
-            // We already cleared the main events, we don't have to do anything.
-            // This happens when process_events() processed a RedrawRequested event.
-            RunnerState::HandlingRedraw => {}
-
-            // If we *weren't* handling events, we don't have to do anything.
-            RunnerState::New | RunnerState::Idle(..) => (),
-
-            // Some control flows require a NewEvents call even if no events were received. This
-            // branch handles those.
-            RunnerState::DeferredNewEvents(wait_start) => {
-                match self.control_flow {
-                    // If we had deferred a Poll, send the Poll NewEvents and MainEventsCleared.
-                    ControlFlow::Poll => {
-                        self.call_event_handler(Event::NewEvents(StartCause::Poll));
-                        self.runner_state = RunnerState::HandlingEvents;
-                        self.call_event_handler(Event::MainEventsCleared);
-                        self.runner_state = RunnerState::HandlingRedraw;
-                    }
-                    // If we had deferred a WaitUntil and the resume time has since been reached,
-                    // send the resume notification and MainEventsCleared event.
-                    ControlFlow::WaitUntil(resume_time) => {
-                        if Instant::now() >= resume_time {
-                            self.call_event_handler(Event::NewEvents(
-                                StartCause::ResumeTimeReached {
-                                    start: wait_start,
-                                    requested_resume: resume_time,
-                                },
-                            ));
-                            self.runner_state = RunnerState::HandlingEvents;
-                            self.call_event_handler(Event::MainEventsCleared);
-                            self.runner_state = RunnerState::HandlingRedraw;
-                        }
-                    }
-                    // If we deferred a wait and no events were received, the user doesn't have to
-                    // get an event.
-                    ControlFlow::Wait | ControlFlow::Exit => (),
-                }
-            }
-        }
-    }
-
-    fn redraw_events_cleared(&mut self) {
-        match self.runner_state {
-            // If we were handling redraws, send the RedrawEventsCleared message.
-            RunnerState::HandlingRedraw => {
                 self.call_event_handler(Event::RedrawEventsCleared);
-                self.runner_state = RunnerState::Idle(Instant::now());
+            },
+            (_, Uninitialized) => panic!("cannot move state to Uninitialized"),
+
+            (NoEvents, MainEvents) => {
+                self.call_new_events(false);
+            },
+            (NoEvents, RedrawEvents) => {
+                self.call_new_events(false);
+                self.call_event_handler(Event::MainEventsCleared);
+            },
+            (MainEvents, RedrawEvents) => {
+                self.call_event_handler(Event::MainEventsCleared);
+            },
+            (MainEvents, NoEvents) => {
+                probably_wrong();
+                self.call_event_handler(Event::MainEventsCleared);
+                self.call_event_handler(Event::RedrawEventsCleared);
+            },
+            (RedrawEvents, NoEvents) => {
+                self.call_event_handler(Event::RedrawEventsCleared);
+            },
+            (RedrawEvents, MainEvents) => {
+                probably_wrong();
+                self.call_event_handler(Event::RedrawEventsCleared);
+                self.call_new_events(false);
             }
-            // No event was processed, we don't have to do anything.
-            RunnerState::DeferredNewEvents(_) => (),
-            // Should not happen.
-            _ => warn!(
-                "unexpected state in redraw_events_cleared: {:?}",
-                self.runner_state
-            ),
         }
     }
 
-    fn call_event_handler(&mut self, event: Event<'_, T>) {
-        if self.panic_error.is_none() {
-            let EventLoopRunner {
-                ref mut panic_error,
-                ref mut event_handler,
-                ref mut control_flow,
-                ..
-            } = self;
-            *panic_error = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-                if *control_flow != ControlFlow::Exit {
-                    (*event_handler)(event, control_flow);
-                } else {
-                    (*event_handler)(event, &mut ControlFlow::Exit);
-                }
-            }))
-            .err();
-        }
+    unsafe fn call_new_events(&self, init: bool) {
+        let start_cause = match (init, self.control_flow()) {
+            (true, _) => StartCause::Init,
+            (false, ControlFlow::Poll) => StartCause::Poll,
+            (false, ControlFlow::Exit) |
+            (false, ControlFlow::Wait) => StartCause::WaitCancelled{ requested_resume: None, start: self.last_events_cleared.get() },
+            (false, ControlFlow::WaitUntil(requested_resume)) => StartCause::WaitCancelled{ requested_resume: Some(requested_resume), start: self.last_events_cleared.get() },
+        };
+        self.call_event_handler(Event::NewEvents(start_cause));
+        self.dispatch_buffered_events();
+        winuser::RedrawWindow(self.thread_msg_target, ptr::null(), ptr::null_mut(), winuser::RDW_INTERNALPAINT);
     }
 }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -20,8 +20,8 @@ use crate::{
     window::WindowId,
 };
 
-pub(crate) type EventLoopRunnerShared<T> = Rc<ELRShared<T>>;
-pub(crate) struct ELRShared<T: 'static> {
+pub(crate) type EventLoopRunnerShared<T> = Rc<EventLoopRunner<T>>;
+pub(crate) struct EventLoopRunner<T: 'static> {
     // The event loop's win32 handles
     thread_msg_target: HWND,
     wait_thread_id: DWORD,
@@ -60,9 +60,9 @@ enum BufferedEvent<T: 'static> {
     ScaleFactorChanged(WindowId, f64, PhysicalSize<u32>),
 }
 
-impl<T> ELRShared<T> {
-    pub(crate) fn new(thread_msg_target: HWND, wait_thread_id: DWORD) -> ELRShared<T> {
-        ELRShared {
+impl<T> EventLoopRunner<T> {
+    pub(crate) fn new(thread_msg_target: HWND, wait_thread_id: DWORD) -> EventLoopRunner<T> {
+        EventLoopRunner {
             thread_msg_target,
             wait_thread_id,
             runner_state: Cell::new(RunnerState::Uninitialized),
@@ -87,7 +87,7 @@ impl<T> ELRShared<T> {
     }
 
     pub(crate) fn reset_runner(&self) {
-        let ELRShared {
+        let EventLoopRunner {
             thread_msg_target: _,
             wait_thread_id: _,
             runner_state,
@@ -106,7 +106,7 @@ impl<T> ELRShared<T> {
 }
 
 /// State retrieval functions.
-impl<T> ELRShared<T> {
+impl<T> EventLoopRunner<T> {
     pub fn thread_msg_target(&self) -> HWND {
         self.thread_msg_target
     }
@@ -143,7 +143,7 @@ impl<T> ELRShared<T> {
 }
 
 /// Misc. functions
-impl<T> ELRShared<T> {
+impl<T> EventLoopRunner<T> {
     pub fn catch_unwind<R>(&self, f: impl FnOnce() -> R) -> Option<R> {
         let panic_error = self.panic_error.take();
         if panic_error.is_none() {
@@ -194,7 +194,7 @@ impl<T> ELRShared<T> {
 }
 
 /// Event dispatch functions.
-impl<T> ELRShared<T> {
+impl<T> EventLoopRunner<T> {
     pub(crate) unsafe fn poll(&self) {
         self.move_state_to(RunnerState::HandlingMainEvents);
     }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -254,14 +254,6 @@ impl<T> ELRShared<T> {
     unsafe fn move_state_to(&self, processing_events: ProcessingEvents) {
         use ProcessingEvents::{MainEvents, NoEvents, RedrawEvents, Uninitialized};
 
-        let probably_wrong = || {
-            warn!(
-                "Given winit's current design, the fact that this branch is getting hit \
-                 is probably indicates a bug. Please open an issue at \
-                 https://github.com/rust-windowing/winit"
-            )
-        };
-
         match (
             self.processing_events.replace(processing_events),
             processing_events,
@@ -297,7 +289,7 @@ impl<T> ELRShared<T> {
                 self.call_event_handler(Event::MainEventsCleared);
             }
             (MainEvents, NoEvents) => {
-                probably_wrong();
+                warn!("RedrawEventsCleared emitted without explicit MainEventsCleared");
                 self.call_event_handler(Event::MainEventsCleared);
                 self.call_event_handler(Event::RedrawEventsCleared);
             }
@@ -305,7 +297,7 @@ impl<T> ELRShared<T> {
                 self.call_event_handler(Event::RedrawEventsCleared);
             }
             (RedrawEvents, MainEvents) => {
-                probably_wrong();
+                warn!("NewEvents emitted without explicit RedrawEventsCleared");
                 self.call_event_handler(Event::RedrawEventsCleared);
                 self.call_new_events(false);
             }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -80,7 +80,9 @@ bitflags! {
         /// window's state to match our stored state. This controls whether to accept those changes.
         const MARKER_RETAIN_STATE_ON_SIZE = 1 << 10;
 
-        const MINIMIZED = 1 << 11;
+        const MARKER_IN_SIZE_MOVE = 1 << 11;
+
+        const MINIMIZED = 1 << 12;
 
         const FULLSCREEN_AND_MASK = !(
             WindowFlags::DECORATIONS.bits |


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

I'll do a more detailed writeup on the rationale behind these changes when I'm more awake, but the TL;DR is that it drastically simplifies Winit's event loop model by always using the modal event loop. This PR's fixes are an alternate approach to the problems described in #1429 that simplifies the event model more than #1461 does, but it could not exist in its current form without @filnet's work and feedback in those threads.

Fixes #1477, fixes #1496.