### PR TITLE
Bump version to 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.22.0 (2020-03-07)
 
 - On Windows, fix minor timing issue in wait_until_time_or_msg
 - On macOS, fix `set_simple_screen` to remember frame excluding title bar.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ```toml
 [dependencies]
-winit = "0.21.0"
+winit = "0.22.0"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
There are two PRs I'm aware of that should be relatively trivial to get
merged, which would fix some issues. Other than those, I don't think it
makes sense to wait on anything.

 - Fix Windows crash: https://github.com/rust-windowing/winit/pull/1459
 - Fix macOS mouse reports: https://github.com/rust-windowing/winit/pull/1490

While #1459 seems pretty essential to actually make winit run, #1490 is
much less important and can probably be ignored if there aren't any
resources to merge it.