### PR TITLE
Revert "on MacOS, Fix not sending ReceivedCharacter event for some key combination (#1347)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - On Windows, ignore spurious mouse move messages.
 - **Breaking:** Move `ModifiersChanged` variant from `DeviceEvent` to `WindowEvent`.
 - On Windows, fix crash at startup on systems that do not properly support Windows' Dark Mode
+- Revert On macOS, fix not sending ReceivedCharacter event for specific keys combinations.
+- on macOS, fix incorrect ReceivedCharacter events for some key combinations.
 
 # 0.21.0 (2020-02-04)
 
@@ -34,7 +36,6 @@
 # 0.20.0 (2020-01-05)
 
 - On X11, fix `ModifiersChanged` emitting incorrect modifier change events
-
 - **Breaking**: Overhaul how Winit handles DPI:
   + Window functions and events now return `PhysicalSize` instead of `LogicalSize`.
   + Functions that take `Size` or `Position` types can now take either `Logical` or `Physical` types.

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -383,8 +383,13 @@ extern "C" fn reset_cursor_rects(this: &Object, _sel: Sel) {
     }
 }
 
-extern "C" fn has_marked_text(_this: &Object, _sel: Sel) -> BOOL {
-    YES
+extern "C" fn has_marked_text(this: &Object, _sel: Sel) -> BOOL {
+    unsafe {
+        trace!("Triggered `hasMarkedText`");
+        let marked_text: id = *this.get_ivar("markedText");
+        trace!("Completed `hasMarkedText`");
+        (marked_text.length() > 0) as i8
+    }
 }
 
 extern "C" fn marked_range(this: &Object, _sel: Sel) -> NSRange {


### PR DESCRIPTION
This reverts commit 9daa0738a9aeb60768d9b7d19f4e3deddd55958b.

This commit introduced other bug #1453 with likely much more common bindings,
so reverting it for now.

Fixes #1453.