### PR TITLE
Use i32 instead of u32 for position type in WindowEvent::Moved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - On Windows, add `IconExtWindows` trait which exposes creating an `Icon` from an external file or embedded resource
 - Add `BadIcon::OsError` variant for when OS icon functionality fails
 - On Windows, fix crash at startup on systems that do not properly support Windows' Dark Mode
-- Use `i32` instead of `u32` for position type in `WindowEvent::Moved`.
+- **Breaking:** Use `i32` instead of `u32` for position type in `WindowEvent::Moved`.
 
 # 0.21.0 (2020-02-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - On Windows, add `IconExtWindows` trait which exposes creating an `Icon` from an external file or embedded resource
 - Add `BadIcon::OsError` variant for when OS icon functionality fails
 - On Windows, fix crash at startup on systems that do not properly support Windows' Dark Mode
+- Use `i32` instead of `u32` for position type in `WindowEvent::Moved`.
 
 # 0.21.0 (2020-02-04)
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -185,7 +185,7 @@ pub enum WindowEvent<'a> {
     Resized(PhysicalSize<u32>),
 
     /// The position of the window has changed. Contains the window's new position.
-    Moved(PhysicalPosition<u32>),
+    Moved(PhysicalPosition<i32>),
 
     /// The window has been requested to close.
     CloseRequested,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -736,7 +736,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
             let windowpos = lparam as *const winuser::WINDOWPOS;
             if (*windowpos).flags & winuser::SWP_NOMOVE != winuser::SWP_NOMOVE {
                 let physical_position =
-                    PhysicalPosition::new((*windowpos).x as u32, (*windowpos).y as u32);
+                    PhysicalPosition::new((*windowpos).x as i32, (*windowpos).y as i32);
                 subclass_input.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: Moved(physical_position),


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Fixes #1494. Not sure if it'll build on all the platforms yet, but we'll see where the CI takes us.
