### PR TITLE
Fix freeze when pressing modifier keys on Windows

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -610,6 +610,9 @@ fn update_modifiers<T>(window: HWND, subclass_input: &SubclassInput<T>) {
     if window_state.modifiers_state != modifiers {
         window_state.modifiers_state = modifiers;
 
+        // Drop lock
+        drop(window_state);
+
         unsafe {
             subclass_input.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes deadlock that appears to be introduced by #1381 