### PR TITLE
X11: Fix `ResumeTimeReached` being fired early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - On Windows, add `IconExtWindows` trait which exposes creating an `Icon` from an external file or embedded resource
 - Add `BadIcon::OsError` variant for when OS icon functionality fails
 - On Windows, fix crash at startup on systems that do not properly support Windows' Dark Mode
+- On X11, fix `ResumeTimeReached` being fired too early.
 
 # 0.21.0 (2020-02-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On X11, fix `ResumeTimeReached` being fired too early.
+
 # 0.22.0 (2020-03-09)
 
 - On Windows, fix minor timing issue in wait_until_time_or_msg
@@ -20,7 +22,6 @@
 - Revert On macOS, fix not sending ReceivedCharacter event for specific keys combinations.
 - on macOS, fix incorrect ReceivedCharacter events for some key combinations.
 - **Breaking:** Use `i32` instead of `u32` for position type in `WindowEvent::Moved`.
-- On X11, fix `ResumeTimeReached` being fired too early.
 
 # 0.21.0 (2020-02-04)
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -268,14 +268,16 @@ impl<T: 'static> EventLoop<T> {
     {
         let mut control_flow = ControlFlow::default();
         let mut events = Events::with_capacity(8);
-
-        callback(
-            crate::event::Event::NewEvents(crate::event::StartCause::Init),
-            &self.target,
-            &mut control_flow,
-        );
+        let mut cause = StartCause::Init;
 
         loop {
+            sticky_exit_callback(
+                crate::event::Event::NewEvents(cause),
+                &self.target,
+                &mut control_flow,
+                &mut callback,
+            );
+
             // Process all pending events
             self.drain_events(&mut callback, &mut control_flow);
 
@@ -326,7 +328,7 @@ impl<T: 'static> EventLoop<T> {
             }
 
             let start = Instant::now();
-            let (mut cause, deadline, timeout);
+            let (deadline, timeout);
 
             match control_flow {
                 ControlFlow::Exit => break,
@@ -357,38 +359,20 @@ impl<T: 'static> EventLoop<T> {
                 }
             }
 
-            if self.event_processor.poll() {
-                // If the XConnection already contains buffered events, we don't
-                // need to wait for data on the socket.
-                // However, we still need to check for user events.
-                self.poll
-                    .poll(&mut events, Some(Duration::from_millis(0)))
-                    .unwrap();
-                events.clear();
-
-                callback(
-                    crate::event::Event::NewEvents(cause),
-                    &self.target,
-                    &mut control_flow,
-                );
-            } else {
+            // If the XConnection already contains buffered events, we don't
+            // need to wait for data on the socket.
+            if !self.event_processor.poll() {
                 self.poll.poll(&mut events, timeout).unwrap();
                 events.clear();
+            }
 
-                let wait_cancelled = deadline.map_or(false, |deadline| Instant::now() < deadline);
+            let wait_cancelled = deadline.map_or(false, |deadline| Instant::now() < deadline);
 
-                if wait_cancelled {
-                    cause = StartCause::WaitCancelled {
-                        start,
-                        requested_resume: deadline,
-                    };
-                }
-
-                callback(
-                    crate::event::Event::NewEvents(cause),
-                    &self.target,
-                    &mut control_flow,
-                );
+            if wait_cancelled {
+                cause = StartCause::WaitCancelled {
+                    start,
+                    requested_resume: deadline,
+                };
             }
         }
 


### PR DESCRIPTION
Fixes #1504

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
