### PR TITLE
Add GUI tests

### DIFF
--- a/gui_tests/Cargo.toml
+++ b/gui_tests/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gui_tests"
+version = "0.1.0"
+authors = ["Artur Kovacs <kovacs.artur.barnabas@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+winit = { path = ".." }
+enigo = "0.0.14"
+scopeguard = "1.1.0"

--- a/gui_tests/rustfmt.toml
+++ b/gui_tests/rustfmt.toml
@@ -1,0 +1,3 @@
+force_explicit_abi=true
+use_field_init_shorthand=true
+# merge_imports=true

--- a/gui_tests/src/bin/basic_mouse.rs
+++ b/gui_tests/src/bin/basic_mouse.rs
@@ -1,0 +1,120 @@
+
+use enigo::{Enigo, MouseButton, MouseControllable, KeyboardControllable, Key};
+use std::thread;
+use std::time::Duration;
+use std::f32::consts::PI;
+use std::collections::VecDeque;
+use std::sync::{mpsc::channel, atomic::{AtomicIsize, Ordering}};
+
+use winit::{
+    event::{Event, WindowEvent, ElementState, VirtualKeyCode, KeyboardInput},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+    dpi::PhysicalPosition,
+};
+
+fn main() {
+    let (sender, receiver) = channel::<Event::<'static, ()>>();
+    let window_pos = PhysicalPosition::<i32>::new(200, 200);
+    let create_enigo_thread = move | client_pos_x: i32, client_pos_y: i32 | {
+        thread::spawn(move || {
+            let cursor_x = 20;
+            let cursor_y = 20;
+            let pause_time = Duration::from_millis(500);
+            let mut enigo = Enigo::new();
+            enigo.mouse_move_to(client_pos_x-1, client_pos_y-1);
+            thread::sleep(pause_time);
+            enigo.mouse_move_to(client_pos_x + cursor_x + 1, client_pos_y + cursor_y + 1);
+            thread::sleep(pause_time);
+            enigo.key_click(Key::Escape);
+            thread::sleep(pause_time);
+
+            let mut relevant_events = VecDeque::new();
+            while let Ok(event) = receiver.recv_timeout(Duration::from_millis(200)) {
+                match event {
+                    event @ Event::WindowEvent { .. } => relevant_events.push_back(event),
+                    _ => {} // ignore the rest
+                }
+            }
+            match relevant_events.pop_front() {
+                Some(Event::WindowEvent { event: WindowEvent::Moved(pos), .. })
+                if pos.x as i32 == window_pos.x && pos.y as i32 == window_pos.y => {}
+                _ => unreachable!(),
+            }
+            match relevant_events.pop_front() {
+                Some(Event::WindowEvent { event: WindowEvent::CursorEntered{..}, .. }) => {}
+                _ => unreachable!(),
+            }
+            match relevant_events.pop_front() {
+                Some(Event::WindowEvent { event: WindowEvent::CursorMoved{
+                    position: PhysicalPosition { x, y }, ..}, ..
+                }) if x as i32 == cursor_x && y as i32 == cursor_y => {
+                },
+                _ => unreachable!(),
+            }
+            // match relevant_events.pop_front() {
+            //     Some(Event::WindowEvent {
+            //         event: WindowEvent::KeyboardInput {
+            //             input: KeyboardInput {
+            //                 state,
+            //                 virtual_keycode,
+            //                 ..
+            //             }, ..
+            //         }, ..
+            //     }) if state == ElementState::Pressed && virtual_keycode == Some(VirtualKeyCode::Escape) => {},
+            //     event @ _ => {
+            //         println!("Unexpected event: {:?}", event);
+            //         unreachable!()
+            //     },
+            // }
+        })
+    };
+
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_inner_size(winit::dpi::LogicalSize::new(256.0, 256.0))
+        .build(&event_loop)
+        .unwrap();
+
+    window.set_outer_position(window_pos);
+    let inner_pos = window.inner_position().unwrap();
+    let mut enigo_handle = Some(create_enigo_thread(inner_pos.x as i32, inner_pos.y as i32));
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+        println!("{:?}", event);
+
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            Event::WindowEvent {
+                event: WindowEvent::KeyboardInput {
+                    input:
+                        KeyboardInput {
+                            virtual_keycode: Some(VirtualKeyCode::Escape),
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                },
+                window_id,
+            } => *control_flow = ControlFlow::Exit,
+            Event::MainEventsCleared => {
+                window.request_redraw();
+            }
+            _ => (),
+        }
+        if enigo_handle.is_some() {
+            if let Some(event) = event.to_static() {
+                sender.send(event).unwrap();
+            }
+        }
+        if *control_flow  == ControlFlow::Exit {
+            enigo_handle.take().unwrap().join().unwrap();
+        }
+    });
+}

--- a/gui_tests/src/bin/common.rs
+++ b/gui_tests/src/bin/common.rs
@@ -1,7 +1,7 @@
-use enigo::{Enigo, MouseButton, MouseControllable, KeyboardControllable, Key};
+use enigo::{Enigo, Key, KeyboardControllable, MouseButton, MouseControllable};
+use std::f32::consts::PI;
 use std::thread;
 use std::time::Duration;
-use std::f32::consts::PI;
 
 pub fn move_in_circle(enigo: &mut Enigo, pos_x: i32, pos_y: i32, r: f32) {
     let mut angle = 0.0;
@@ -14,15 +14,22 @@ pub fn move_in_circle(enigo: &mut Enigo, pos_x: i32, pos_y: i32, r: f32) {
     }
 }
 
-pub fn move_slowly_to(enigo: &mut Enigo, pos_x: f32, pos_y: f32, target_x: f32, target_y: f32, duration: Duration) {
+pub fn move_slowly_to(
+    enigo: &mut Enigo,
+    pos_x: f32,
+    pos_y: f32,
+    target_x: f32,
+    target_y: f32,
+    duration: Duration,
+) {
     let step_delay = Duration::from_millis(1);
     let steps = (duration.as_secs_f32() / step_delay.as_secs_f32()) as i32;
     for i in 0..steps {
         thread::sleep(step_delay);
-        let ratio = (i+1) as f32 / steps as f32;
+        let ratio = (i + 1) as f32 / steps as f32;
         enigo.mouse_move_to(
-            ((1.0-ratio) * pos_x + ratio * target_x) as i32,
-            ((1.0-ratio) * pos_y + ratio * target_y) as i32,
+            ((1.0 - ratio) * pos_x + ratio * target_x) as i32,
+            ((1.0 - ratio) * pos_y + ratio * target_y) as i32,
         );
     }
 }

--- a/gui_tests/src/bin/common.rs
+++ b/gui_tests/src/bin/common.rs
@@ -1,0 +1,28 @@
+use enigo::{Enigo, MouseButton, MouseControllable, KeyboardControllable, Key};
+use std::thread;
+use std::time::Duration;
+use std::f32::consts::PI;
+
+pub fn move_in_circle(enigo: &mut Enigo, pos_x: i32, pos_y: i32, r: f32) {
+    let mut angle = 0.0;
+    while angle < 2.0 * PI {
+        thread::sleep(Duration::from_millis(1));
+        let x = (angle.cos() * r) as i32;
+        let y = (angle.sin() * r) as i32;
+        enigo.mouse_move_to(pos_x + x, pos_y + y);
+        angle += 0.02;
+    }
+}
+
+pub fn move_slowly_to(enigo: &mut Enigo, pos_x: f32, pos_y: f32, target_x: f32, target_y: f32, duration: Duration) {
+    let step_delay = Duration::from_millis(1);
+    let steps = (duration.as_secs_f32() / step_delay.as_secs_f32()) as i32;
+    for i in 0..steps {
+        thread::sleep(step_delay);
+        let ratio = (i+1) as f32 / steps as f32;
+        enigo.mouse_move_to(
+            ((1.0-ratio) * pos_x + ratio * target_x) as i32,
+            ((1.0-ratio) * pos_y + ratio * target_y) as i32,
+        );
+    }
+}

--- a/gui_tests/src/bin/resize.rs
+++ b/gui_tests/src/bin/resize.rs
@@ -1,47 +1,49 @@
-
 //! This test was designed to reproduce a bug that caused a panic on Windows with winit 0.21.0
 
+use enigo::{Enigo, Key, KeyboardControllable, MouseButton, MouseControllable};
+use scopeguard::defer;
+use std::collections::VecDeque;
+use std::sync::mpsc::channel;
 use std::thread;
 use std::time::Duration;
-use std::collections::VecDeque;
-use std::sync::{mpsc::channel};
-use enigo::{Enigo, MouseButton, MouseControllable, KeyboardControllable, Key};
-use scopeguard::defer;
 
 use winit::{
-    event::{Event, WindowEvent, ElementState, VirtualKeyCode, KeyboardInput},
+    dpi::{PhysicalPosition, PhysicalSize},
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     window::WindowBuilder,
-    dpi::{PhysicalPosition, PhysicalSize},
 };
 
 fn main() {
     let event_loop = EventLoop::new();
     let el_proxy = event_loop.create_proxy();
-    let (sender, receiver) = channel::<Event::<'static, ()>>();
+    let (sender, receiver) = channel::<Event<'static, ()>>();
     // Just as in general winit terminology, `outer_pos` refers to the position of the top-left
     // corner of the window decorations. Whereas `inner_pos` refers to the area of the window
     // that's drawn by the application itself.
     let outer_pos = PhysicalPosition::<i32>::new(200, 200);
     let inner_size = PhysicalSize::new(512, 512);
-    let create_enigo_thread = move | inner_pos_x: i32, inner_pos_y: i32 | {
+    let create_enigo_thread = move |inner_pos_x: i32, inner_pos_y: i32| {
         thread::spawn(move || {
             // Defer shutdown request.
             defer!(el_proxy.send_event(()).unwrap());
             let pause_time = Duration::from_millis(250);
             let mut enigo = Enigo::new();
-            enigo.mouse_move_to(inner_pos_x + inner_size.width + 2, inner_pos_y + inner_size.height + 2);
+            enigo.mouse_move_to(
+                inner_pos_x + inner_size.width + 2,
+                inner_pos_y + inner_size.height + 2,
+            );
             thread::sleep(pause_time);
             enigo.mouse_down(MouseButton::Left);
             let mut width_offset = 0;
             let mut height_offset = 0;
             for i in 0..50 {
                 thread::sleep(Duration::from_millis(1));
-                width_offset = i*2;
+                width_offset = i * 2;
                 height_offset = i;
                 enigo.mouse_move_to(
                     inner_pos_x + inner_size.width + 2 + width_offset,
-                    inner_pos_y + inner_size.height + 2 + height_offset
+                    inner_pos_y + inner_size.height + 2 + height_offset,
                 );
             }
             thread::sleep(Duration::from_millis(1));
@@ -61,15 +63,22 @@ fn main() {
             let mut relevant_events = VecDeque::new();
             while let Ok(event) = receiver.try_recv() {
                 match event {
-                    event @ Event::WindowEvent { event: WindowEvent::Resized(_), .. } => relevant_events.push_back(event),
+                    event
+                    @
+                    Event::WindowEvent {
+                        event: WindowEvent::Resized(_),
+                        ..
+                    } => relevant_events.push_back(event),
                     _ => {} // ignore the rest
                 }
             }
             let new_width = inner_size.width + width_offset;
             let new_height = inner_size.height + height_offset - 1;
             match relevant_events.pop_back() {
-                Some(Event::WindowEvent { event: WindowEvent::Resized(size), .. })
-                if size.width as i32 == new_width && size.height as i32 == new_height => {}
+                Some(Event::WindowEvent {
+                    event: WindowEvent::Resized(size),
+                    ..
+                }) if size.width as i32 == new_width && size.height as i32 == new_height => {}
                 _ => panic!("Unexpected size at the end."),
             }
         })
@@ -84,7 +93,9 @@ fn main() {
 
     // For some reason the window doesn't have focus when it's ran from the main module (gui_tests)
     // so we are switching to fullscreen and back just to bring the window to the top
-    window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(window.current_monitor())));
+    window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(
+        window.current_monitor(),
+    )));
     thread::sleep(Duration::from_millis(500));
     window.set_fullscreen(None);
     thread::sleep(Duration::from_millis(500));
@@ -101,18 +112,20 @@ fn main() {
                 window_id,
             } if window_id == window.id() => *control_flow = ControlFlow::Exit,
             Event::WindowEvent {
-                event: WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            virtual_keycode: Some(VirtualKeyCode::Escape),
-                            state: ElementState::Pressed,
-                            ..
-                        },
-                    ..
-                },
+                event:
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                virtual_keycode: Some(VirtualKeyCode::Escape),
+                                state: ElementState::Pressed,
+                                ..
+                            },
+                        ..
+                    },
                 ..
             } => *control_flow = ControlFlow::Exit,
-            Event::UserEvent(_) => { // Shutdown request.
+            Event::UserEvent(_) => {
+                // Shutdown request.
                 *control_flow = ControlFlow::Exit;
             }
             Event::MainEventsCleared => {

--- a/gui_tests/src/bin/resize.rs
+++ b/gui_tests/src/bin/resize.rs
@@ -73,7 +73,7 @@ fn main() {
                 }
             }
             let new_width = inner_size.width + width_offset;
-            let new_height = inner_size.height + height_offset - 1;
+            let new_height = inner_size.height + height_offset;
             match relevant_events.pop_back() {
                 Some(Event::WindowEvent {
                     event: WindowEvent::Resized(size),

--- a/gui_tests/src/bin/resize.rs
+++ b/gui_tests/src/bin/resize.rs
@@ -1,0 +1,132 @@
+
+//! This test was designed to reproduce a bug that caused a panic on Windows with winit 0.21.0
+
+use std::thread;
+use std::time::Duration;
+use std::collections::VecDeque;
+use std::sync::{mpsc::channel};
+use enigo::{Enigo, MouseButton, MouseControllable, KeyboardControllable, Key};
+use scopeguard::defer;
+
+use winit::{
+    event::{Event, WindowEvent, ElementState, VirtualKeyCode, KeyboardInput},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+    dpi::{PhysicalPosition, PhysicalSize},
+};
+
+fn main() {
+    let event_loop = EventLoop::new();
+    let el_proxy = event_loop.create_proxy();
+    let (sender, receiver) = channel::<Event::<'static, ()>>();
+    // Just as in general winit terminology, `outer_pos` refers to the position of the top-left
+    // corner of the window decorations. Whereas `inner_pos` refers to the area of the window
+    // that's drawn by the application itself.
+    let outer_pos = PhysicalPosition::<i32>::new(200, 200);
+    let inner_size = PhysicalSize::new(512, 512);
+    let create_enigo_thread = move | inner_pos_x: i32, inner_pos_y: i32 | {
+        thread::spawn(move || {
+            // Defer shutdown request.
+            defer!(el_proxy.send_event(()).unwrap());
+            let pause_time = Duration::from_millis(250);
+            let mut enigo = Enigo::new();
+            enigo.mouse_move_to(inner_pos_x + inner_size.width + 2, inner_pos_y + inner_size.height + 2);
+            thread::sleep(pause_time);
+            enigo.mouse_down(MouseButton::Left);
+            let mut width_offset = 0;
+            let mut height_offset = 0;
+            for i in 0..50 {
+                thread::sleep(Duration::from_millis(1));
+                width_offset = i*2;
+                height_offset = i;
+                enigo.mouse_move_to(
+                    inner_pos_x + inner_size.width + 2 + width_offset,
+                    inner_pos_y + inner_size.height + 2 + height_offset
+                );
+            }
+            thread::sleep(Duration::from_millis(1));
+            enigo.mouse_up(MouseButton::Left);
+            thread::sleep(pause_time);
+            enigo.mouse_move_to(inner_pos_x + inner_size.width / 2, inner_pos_y - 2);
+            enigo.mouse_down(MouseButton::Left);
+            for i in 0..50 {
+                thread::sleep(Duration::from_millis(1));
+                enigo.mouse_move_to(inner_pos_x + inner_size.width / 2 + i, inner_pos_y - 2 + i);
+            }
+            thread::sleep(Duration::from_millis(1));
+            enigo.mouse_move_to(inner_pos_x + inner_size.width / 2, inner_pos_y - 2);
+            enigo.mouse_up(MouseButton::Left);
+            thread::sleep(pause_time);
+
+            let mut relevant_events = VecDeque::new();
+            while let Ok(event) = receiver.try_recv() {
+                match event {
+                    event @ Event::WindowEvent { event: WindowEvent::Resized(_), .. } => relevant_events.push_back(event),
+                    _ => {} // ignore the rest
+                }
+            }
+            let new_width = inner_size.width + width_offset;
+            let new_height = inner_size.height + height_offset - 1;
+            match relevant_events.pop_back() {
+                Some(Event::WindowEvent { event: WindowEvent::Resized(size), .. })
+                if size.width as i32 == new_width && size.height as i32 == new_height => {}
+                _ => panic!("Unexpected size at the end."),
+            }
+        })
+    };
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_inner_size(inner_size)
+        .with_resizable(true)
+        .build(&event_loop)
+        .unwrap();
+
+    // For some reason the window doesn't have focus when it's ran from the main module (gui_tests)
+    // so we are switching to fullscreen and back just to bring the window to the top
+    window.set_fullscreen(Some(winit::window::Fullscreen::Borderless(window.current_monitor())));
+    thread::sleep(Duration::from_millis(500));
+    window.set_fullscreen(None);
+    thread::sleep(Duration::from_millis(500));
+
+    window.set_outer_position(outer_pos);
+    let inner_pos = window.inner_position().unwrap();
+    let mut enigo_handle = Some(create_enigo_thread(inner_pos.x as i32, inner_pos.y as i32));
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            Event::WindowEvent {
+                event: WindowEvent::KeyboardInput {
+                    input:
+                        KeyboardInput {
+                            virtual_keycode: Some(VirtualKeyCode::Escape),
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                },
+                ..
+            } => *control_flow = ControlFlow::Exit,
+            Event::UserEvent(_) => { // Shutdown request.
+                *control_flow = ControlFlow::Exit;
+            }
+            Event::MainEventsCleared => {
+                window.request_redraw();
+            }
+            _ => (),
+        }
+        if enigo_handle.is_some() {
+            if let Some(event) = event.to_static() {
+                sender.send(event).unwrap();
+            }
+        }
+        if *control_flow == ControlFlow::Exit {
+            enigo_handle.take().unwrap().join().unwrap();
+        }
+    });
+}

--- a/gui_tests/src/main.rs
+++ b/gui_tests/src/main.rs
@@ -1,4 +1,3 @@
-
 //! This is the entry point for the test executables.
 //!
 //! Run by `cargo run --bin gui_tests`
@@ -10,7 +9,8 @@ fn run_test(name: &str) -> bool {
     let output = Command::new("cargo")
         .env("RUST_BACKTRACE", "1")
         .args(&["run", "--bin", name])
-        .output().unwrap();
+        .output()
+        .unwrap();
     if output.status.success() {
         println!("Success");
         true
@@ -29,10 +29,7 @@ fn run_test(name: &str) -> bool {
 }
 
 fn main() {
-    let tests = [
-        "basic_mouse",
-        "resize"
-    ];
+    let tests = ["basic_mouse", "resize"];
     let mut failed = 0;
     println!("Running {} tests", tests.len());
     for test_name in &tests {
@@ -40,7 +37,12 @@ fn main() {
             failed += 1;
         }
     }
-    println!("Finished running {} tests. {} failed, {} succeeded.", tests.len(), failed, tests.len() - failed);
+    println!(
+        "Finished running {} tests. {} failed, {} succeeded.",
+        tests.len(),
+        failed,
+        tests.len() - failed
+    );
     if failed > 0 {
         std::process::exit(1);
     }

--- a/gui_tests/src/main.rs
+++ b/gui_tests/src/main.rs
@@ -1,0 +1,47 @@
+
+//! This is the entry point for the test executables.
+//!
+//! Run by `cargo run --bin gui_tests`
+
+use std::process::{Command, ExitStatus};
+
+fn run_test(name: &str) -> bool {
+    println!("Running {}", name);
+    let output = Command::new("cargo")
+        .env("RUST_BACKTRACE", "1")
+        .args(&["run", "--bin", name])
+        .output().unwrap();
+    if output.status.success() {
+        println!("Success");
+        true
+    } else {
+        match output.status.code() {
+            Some(exit_code) => println!("FAILED, exit code was {}", exit_code),
+            None => println!("FAILED, terminated by signal."),
+        }
+        println!("Stdout from {}:", name);
+        println!("{}", String::from_utf8_lossy(&output.stdout));
+        println!();
+        println!("Stderr from {}:", name);
+        println!("{}", String::from_utf8_lossy(&output.stderr));
+        false
+    }
+}
+
+fn main() {
+    let tests = [
+        "basic_mouse",
+        "resize"
+    ];
+    let mut failed = 0;
+    println!("Running {} tests", tests.len());
+    for test_name in &tests {
+        if !run_test(test_name) {
+            failed += 1;
+        }
+    }
+    println!("Finished running {} tests. {} failed, {} succeeded.", tests.len(), failed, tests.len() - failed);
+    if failed > 0 {
+        std::process::exit(1);
+    }
+}

--- a/gui_tests/video-modes.txt
+++ b/gui_tests/video-modes.txt
@@ -1,0 +1,19 @@
+## Windows
+MonitorHandle { inner: MonitorHandle(0x10001) }
+1920x1080 @ 64 Hz (32 bpp)
+1680x1050 @ 64 Hz (32 bpp)
+1600x1200 @ 64 Hz (32 bpp)
+1600x900 @ 64 Hz (32 bpp)
+1440x900 @ 64 Hz (32 bpp)
+1366x768 @ 64 Hz (32 bpp)
+1280x1024 @ 64 Hz (32 bpp)
+1280x800 @ 64 Hz (32 bpp)
+1280x720 @ 64 Hz (32 bpp)
+1152x864 @ 64 Hz (32 bpp)
+1024x768 @ 64 Hz (32 bpp)
+800x600 @ 64 Hz (32 bpp)
+640x480 @ 64 Hz (32 bpp)
+
+## MacOS
+MonitorHandle { inner: MonitorHandle { name: Some("Monitor #1815"), native_identifier: 1535231424, size: PhysicalSize { width: 1176, height: 853 }, position: PhysicalPosition { x: 0, y: 0 }, scale_factor: 1.0 } }
+1176x853 @ 60 Hz (32 bpp)

--- a/tests/window.rs
+++ b/tests/window.rs
@@ -1,0 +1,33 @@
+use winit::{
+    event::{Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+};
+
+#[test]
+fn window() {
+    simple_logger::init().unwrap();
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
+        .build(&event_loop)
+        .unwrap();
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            Event::MainEventsCleared => {
+                //panic!("WAAAA");
+                window.request_redraw();
+            }
+            _ => (),
+        }
+    });
+}


### PR DESCRIPTION
This PR intends to address #1495 for the Windows platform. 

About the initial commit. It is possible to simply place the window creation and the event loop into a test function. This even executes, apparently without a panic when the tests are ran using 
```
cargo test -- --test-threads=1
``` 
But the test output is strange, i.e. it doesn't print a summary of the tests for that executable. (See `test window ...    Doc-tests winit`)

```
     Running target\debug\deps\sync_object-0ea4231252f1a8f8.exe

running 1 test
test window_sync ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

     Running target\debug\deps\window-b24e781a0d4cb2f7.exe

running 1 test
test window ...    Doc-tests winit

running 4 tests
test src\event.rs - event (line 9) ... ignored
test src\lib.rs -  (line 44) ... ok
test src\lib.rs -  (line 8) ... ok
test src\window.rs - window::Window (line 18) ... ok

test result: ok. 3 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
```
I guess it's because the event loop takes over the main thread and never returns. The exit code for cargo is 0 when the test is successful so I don't know if this is of concern for us but in any case I wanted to separate the test process and the tester framework for that reason. To do that I created a new crate inside the `gui_tests` folder where invoking cargo according to the following will run all the tests.
```
cd gui_tests
cargo run --bin gui_tests
```

However I'm not really happy with this current setup. It seems a bit messy but I'm not sure how it can be improved so I'd like to get some input on that before writing more tests.

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
