### PR TITLE
control_flow example: fix wait_cancelled logic again

### DIFF
--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -41,15 +41,9 @@ fn main() {
         println!("{:?}", event);
         match event {
             Event::NewEvents(start_cause) => {
-                wait_cancelled = mode == Mode::WaitUntil;
-                match start_cause {
-                    StartCause::ResumeTimeReached {
-                        start: _,
-                        requested_resume: _,
-                    } => {
-                        wait_cancelled = false;
-                    }
-                    _ => (),
+                wait_cancelled = match start_cause {
+                    StartCause::WaitCancelled { .. } => mode == Mode::WaitUntil,
+                    _ => false,
                 }
             }
             Event::WindowEvent { event, .. } => match event {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This fixes a minor issue when starting in WaitUntil control flow