### PR TITLE
Preserve with_maximized on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - On X11, fix `ResumeTimeReached` being fired too early.
 - On Web, replaced zero timeout for `ControlFlow::Poll` with `requestAnimationFrame`
 - On Web, fix a possible panic during event handling
+- On Windows, fix `WindowBuilder::with_maximized` being ignored.
 
 # 0.22.0 (2020-03-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Unreleased
 
+- On Windows, fix `WindowBuilder::with_maximized` being ignored.
+
 # 0.22.1 (2020-04-16)
 
 - On X11, fix `ResumeTimeReached` being fired too early.
 - On Web, replaced zero timeout for `ControlFlow::Poll` with `requestAnimationFrame`
 - On Web, fix a possible panic during event handling
-- On Windows, fix `WindowBuilder::with_maximized` being ignored.
 
 # 0.22.0 (2020-03-09)
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -728,8 +728,6 @@ unsafe fn init<T: 'static>(
         }
     }
 
-    window_flags.set(WindowFlags::MAXIMIZED, attributes.maximized);
-
     // If the system theme is dark, we need to set the window theme now
     // before we update the window flags (and possibly show the
     // window for the first time).
@@ -753,17 +751,16 @@ unsafe fn init<T: 'static>(
         thread_executor: event_loop.create_thread_executor(),
     };
 
-    // Calling `Window::set_inner_size` will unset MAXIMIZED. Explicit
-    // `inner_size` should overwrite MAXIMIZED, but we need to preserve
-    // MAXIMIZED if it was set and `inner_size` wasn't.
-    if !attributes.maximized || attributes.inner_size.is_some() {
-        let dimensions = attributes
-            .inner_size
-            .unwrap_or_else(|| PhysicalSize::new(1024, 768).into());
-        win.set_inner_size(dimensions);
-    }
-
+    let dimensions = attributes
+        .inner_size
+        .unwrap_or_else(|| PhysicalSize::new(1024, 768).into());
+    win.set_inner_size(dimensions);
     win.set_visible(attributes.visible);
+    if attributes.maximized {
+        // Need to set MAXIMIZED after setting `inner_size` as
+        // `Window::set_inner_size` changes MAXIMIZED to false.
+        win.set_maximized(true);
+    }
 
     if let Some(_) = attributes.fullscreen {
         win.set_fullscreen(attributes.fullscreen);

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -753,10 +753,16 @@ unsafe fn init<T: 'static>(
         thread_executor: event_loop.create_thread_executor(),
     };
 
-    let dimensions = attributes
-        .inner_size
-        .unwrap_or_else(|| PhysicalSize::new(1024, 768).into());
-    win.set_inner_size(dimensions);
+    // Calling `Window::set_inner_size` will unset MAXIMIZED. Explicit
+    // `inner_size` should overwrite MAXIMIZED, but we need to preserve
+    // MAXIMIZED if it was set and `inner_size` wasn't.
+    if !attributes.maximized || attributes.inner_size.is_some() {
+        let dimensions = attributes
+            .inner_size
+            .unwrap_or_else(|| PhysicalSize::new(1024, 768).into());
+        win.set_inner_size(dimensions);
+    }
+
     win.set_visible(attributes.visible);
 
     if let Some(_) = attributes.fullscreen {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -755,12 +755,12 @@ unsafe fn init<T: 'static>(
         .inner_size
         .unwrap_or_else(|| PhysicalSize::new(1024, 768).into());
     win.set_inner_size(dimensions);
-    win.set_visible(attributes.visible);
     if attributes.maximized {
         // Need to set MAXIMIZED after setting `inner_size` as
         // `Window::set_inner_size` changes MAXIMIZED to false.
         win.set_maximized(true);
     }
+    win.set_visible(attributes.visible);
 
     if let Some(_) = attributes.fullscreen {
         win.set_fullscreen(attributes.fullscreen);


### PR DESCRIPTION
Closes #1510 

~On Windows, to prevent the MAXIMIZED flag from being overwritten, this only calls `Window::set_inner_size` if not MAXIMIZED or explicit window size was provided. If both `WindowBuilder::with_maximized(true)` and `WindowBuilder::with_inner_size(...)` are provided, `inner_size` will win over MAXIMIZED.~

Update: see https://github.com/rust-windowing/winit/pull/1515#issuecomment-602501576

- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
