### PR TITLE
upgrades x11-dl to 2.18.5 to fix #376

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ wayland-client = { version = "0.23.0", features = [ "dlopen", "egl", "cursor", "
 mio = "0.6"
 mio-extras = "2.0"
 smithay-client-toolkit = "^0.6.6"
-x11-dl = "2.18.3"
+x11-dl = "2.18.5"
 percent-encoding = "2.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows"))'.dependencies.parking_lot]


### PR DESCRIPTION
x11-dl was using std::mem::uninitialized incorrectly and when
rustlang added MaybeUninit and intrinsic panics on UB caused
by improper use of uninitialized (see rust-lang/rust/pull/69922)
it caused issues with X11 initialization. x11-dl pr
erlepereira/x11-rs/pull/101 updated x11-dl to use MaybeUninit
correctly

fixes #376 

- [ ] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [NA] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [NA] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [NA] Created or updated an example program if it would help users understand this functionality
- [NA] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
