### PR TITLE
Implement `requestAnimationFrame` for web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On X11, fix `ResumeTimeReached` being fired too early.
+- On Web, replaced zero timeout for `ControlFlow::Poll` with `requestAnimationFrame`
 
 # 0.22.0 (2020-03-09)
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -72,7 +72,8 @@ impl<T> fmt::Debug for EventLoopWindowTarget<T> {
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ControlFlow {
     /// When the current loop iteration finishes, immediately begin a new iteration regardless of
-    /// whether or not new events are available to process.
+    /// whether or not new events are available to process. For web, events are sent when
+    /// `requestAnimationFrame` fires.
     Poll,
     /// When the current loop iteration finishes, suspend the thread until another event arrives.
     Wait,

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -227,8 +227,7 @@ impl<T: 'static> Shared<T> {
         // If the runner doesn't exist and this method recurses, it will recurse infinitely
         if !is_closed && self.0.runner.borrow().is_some() {
             // Take an event out of the queue and handle it
-            let event = { self.0.events.borrow_mut().pop_front() };
-            if let Some(event) = event {
+            if let Some(event) = self.0.events.borrow_mut().pop_front() {
                 self.handle_event(event, control);
             }
         }

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -227,7 +227,8 @@ impl<T: 'static> Shared<T> {
         // If the runner doesn't exist and this method recurses, it will recurse infinitely
         if !is_closed && self.0.runner.borrow().is_some() {
             // Take an event out of the queue and handle it
-            if let Some(event) = self.0.events.borrow_mut().pop_front() {
+            let event = { self.0.events.borrow_mut().pop_front() };
+            if let Some(event) = event {
                 self.handle_event(event, control);
             }
         }
@@ -240,7 +241,7 @@ impl<T: 'static> Shared<T> {
             root::ControlFlow::Poll => {
                 let cloned = self.clone();
                 State::Poll {
-                    timeout: backend::Timeout::new(move || cloned.poll(), Duration::from_millis(0)),
+                    request: backend::AnimationFrameRequest::new(move || cloned.poll()),
                 }
             }
             root::ControlFlow::Wait => State::Wait {

--- a/src/platform_impl/web/event_loop/state.rs
+++ b/src/platform_impl/web/event_loop/state.rs
@@ -15,7 +15,7 @@ pub enum State {
         start: Instant,
     },
     Poll {
-        timeout: backend::Timeout,
+        request: backend::AnimationFrameRequest,
     },
     Exit,
 }

--- a/src/platform_impl/web/stdweb/mod.rs
+++ b/src/platform_impl/web/stdweb/mod.rs
@@ -3,7 +3,7 @@ mod event;
 mod timeout;
 
 pub use self::canvas::Canvas;
-pub use self::timeout::Timeout;
+pub use self::timeout::{AnimationFrameRequest, Timeout};
 
 use crate::dpi::{LogicalSize, Size};
 use crate::platform::web::WindowExtStdweb;

--- a/src/platform_impl/web/stdweb/timeout.rs
+++ b/src/platform_impl/web/stdweb/timeout.rs
@@ -1,5 +1,7 @@
+use std::cell::Cell;
+use std::rc::Rc;
 use std::time::Duration;
-use stdweb::web::{window, IWindowOrWorker, TimeoutHandle};
+use stdweb::web::{window, IWindowOrWorker, RequestAnimationFrameHandle, TimeoutHandle};
 
 #[derive(Debug)]
 pub struct Timeout {
@@ -21,5 +23,41 @@ impl Drop for Timeout {
     fn drop(&mut self) {
         let handle = self.handle.take().unwrap();
         handle.clear();
+    }
+}
+
+#[derive(Debug)]
+pub struct AnimationFrameRequest {
+    handle: Option<RequestAnimationFrameHandle>,
+    // track callback state, because `cancelAnimationFrame` is slow
+    fired: Rc<Cell<bool>>,
+}
+
+impl AnimationFrameRequest {
+    pub fn new<F>(mut f: F) -> AnimationFrameRequest
+    where
+        F: 'static + FnMut(),
+    {
+        let fired = Rc::new(Cell::new(false));
+        let c_fired = fired.clone();
+        let handle = window().request_animation_frame(move |_| {
+            (*c_fired).set(true);
+            f();
+        });
+
+        AnimationFrameRequest {
+            handle: Some(handle),
+            fired,
+        }
+    }
+}
+
+impl Drop for AnimationFrameRequest {
+    fn drop(&mut self) {
+        if !(*self.fired).get() {
+            if let Some(handle) = self.handle.take() {
+                handle.cancel();
+            }
+        }
     }
 }

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -3,10 +3,7 @@ mod event;
 mod timeout;
 
 pub use self::canvas::Canvas;
-pub use self::timeout::{
-    Timeout,
-    AnimationFrameRequest,
-};
+pub use self::timeout::{AnimationFrameRequest, Timeout};
 
 use crate::dpi::{LogicalSize, Size};
 use crate::platform::web::WindowExtWebSys;

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -3,7 +3,10 @@ mod event;
 mod timeout;
 
 pub use self::canvas::Canvas;
-pub use self::timeout::Timeout;
+pub use self::timeout::{
+    Timeout,
+    AnimationFrameRequest,
+};
 
 use crate::dpi::{LogicalSize, Size};
 use crate::platform::web::WindowExtWebSys;

--- a/src/platform_impl/web/web_sys/timeout.rs
+++ b/src/platform_impl/web/web_sys/timeout.rs
@@ -1,4 +1,6 @@
 use std::time::Duration;
+use std::rc::Rc;
+use std::cell::Cell;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
@@ -36,5 +38,48 @@ impl Drop for Timeout {
         let window = web_sys::window().expect("Failed to obtain window");
 
         window.clear_timeout_with_handle(self.handle);
+    }
+}
+
+#[derive(Debug)]
+pub struct AnimationFrameRequest {
+    handle: i32,
+    // track callback state, because cancel_animation_frame is expensive
+    fired: Rc<Cell<bool>>,
+    _closure: Closure<dyn FnMut()>,
+}
+
+impl AnimationFrameRequest {
+    pub fn new<F>(mut f: F) -> AnimationFrameRequest
+    where
+        F: 'static + FnMut(),
+    {
+        let window = web_sys::window().expect("Failed to obtain window");
+
+        let fired = Rc::new(Cell::new(false));
+        let c_fired = fired.clone();
+        let closure = Closure::wrap(Box::new(move || {
+            (*c_fired).set(true);
+            f();
+        }) as Box<dyn FnMut()>);
+
+        let handle = window
+            .request_animation_frame(&closure.as_ref().unchecked_ref())
+            .expect("Failed to request animation frame");
+
+        AnimationFrameRequest {
+            handle,
+            fired,
+            _closure: closure
+        }
+    }
+}
+
+impl Drop for AnimationFrameRequest {
+    fn drop(&mut self) {
+        if !(*self.fired).get() {
+            let window = web_sys::window().expect("Failed to obtain window");
+            window.cancel_animation_frame(self.handle);
+        }
     }
 }

--- a/src/platform_impl/web/web_sys/timeout.rs
+++ b/src/platform_impl/web/web_sys/timeout.rs
@@ -1,6 +1,6 @@
-use std::time::Duration;
-use std::rc::Rc;
 use std::cell::Cell;
+use std::rc::Rc;
+use std::time::Duration;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
@@ -44,7 +44,7 @@ impl Drop for Timeout {
 #[derive(Debug)]
 pub struct AnimationFrameRequest {
     handle: i32,
-    // track callback state, because cancel_animation_frame is expensive
+    // track callback state, because `cancelAnimationFrame` is slow
     fired: Rc<Cell<bool>>,
     _closure: Closure<dyn FnMut()>,
 }
@@ -70,7 +70,7 @@ impl AnimationFrameRequest {
         AnimationFrameRequest {
             handle,
             fired,
-            _closure: closure
+            _closure: closure,
         }
     }
 }
@@ -79,7 +79,9 @@ impl Drop for AnimationFrameRequest {
     fn drop(&mut self) {
         if !(*self.fired).get() {
             let window = web_sys::window().expect("Failed to obtain window");
-            window.cancel_animation_frame(self.handle);
+            window
+                .cancel_animation_frame(self.handle)
+                .expect("Failed to cancel animation frame");
         }
     }
 }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Implementation based on discussion in #1493. I did not implement `requestPostAnimationFrame` because it's not documented properly yet and does not exist in `stdweb` or `web_sys` either.
