### PR TITLE
Added more docs.rs targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ documentation = "https://docs.rs/winit"
 categories = ["gui"]
 
 [package.metadata.docs.rs]
-features = ["serde"]
+features = ["serde", "web-sys"]
+default-target = "x86_64-unknown-linux-gnu"
+targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc", "i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-unknown-unknown"]
 
 [features]
 web-sys = ["web_sys", "wasm-bindgen", "instant/wasm-bindgen"]


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR adds `wasm32-unknown-unknown` to docs.rs and explicitly states which targets are built for docs.rs. I tested this by doing https://github.com/rust-windowing/winit/issues/1028#issuecomment-607873122 and had mixed results with all of our targets as talked about in https://github.com/rust-windowing/winit/issues/1028#issuecomment-608645825.

`i686-unknown-linux-gnu` build is currently broken. Fix requires a PR to https://github.com/rust-lang/crates-build-env.

It doesn't look like docs.rs supports feature flag ops so I just chose `web-sys` as a default feature for all docrs targets.