### PR TITLE
Make drag and drop optional (fixes OleInitialize failure #1255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - On Unix, X11 and Wayland are now optional features (enabled by default)
 - On X11, fix deadlock when calling `set_fullscreen_inner`.
 - On Web, prevent the webpage from scrolling when the user is focused on a winit canvas
-
+- On Windows, drag and drop is now optional and must be enabled with `WindowBuilderExtWindows::with_drag_and_drop(true)`.
 - On Wayland, fix deadlock when calling to `set_inner_size` from a callback.
 - On macOS, add `hide__other_applications` to `EventLoopWindowTarget` via existing `EventLoopWindowTargetExtMacOS` trait. `hide_other_applications` will hide other applications by calling `-[NSApplication hideOtherApplications: nil]`.
 - On android added support for `run_return`.
@@ -23,7 +23,6 @@
 - On Web, replaced zero timeout for `ControlFlow::Poll` with `requestAnimationFrame`
 - On Web, fix a possible panic during event handling
 - On macOS, fix `EventLoopProxy` leaking memory for every instance.
-- On Windows, drag and drop is now optional and must be enabled with `WindowBuilderExtWindows::with_drag_and_drop(true)`.
 - On Windows, drag and drop can now be disabled with `WindowBuilderExtWindows::with_drag_and_drop(false)`.
 
 # 0.22.0 (2020-03-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - On Web, fix a possible panic during event handling
 - On macOS, fix `EventLoopProxy` leaking memory for every instance.
 - On Windows, drag and drop is now optional and must be enabled with `WindowBuilderExtWindows::with_drag_and_drop(true)`.
+- On Windows, drag and drop can now be disabled with `WindowBuilderExtWindows::with_drag_and_drop(false)`.
 
 # 0.22.0 (2020-03-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - On Web, replaced zero timeout for `ControlFlow::Poll` with `requestAnimationFrame`
 - On Web, fix a possible panic during event handling
 - On macOS, fix `EventLoopProxy` leaking memory for every instance.
+- On Windows, drag and drop is now optional and must be enabled with `WindowBuilderExtWindows::with_drag_and_drop(true)`.
 
 # 0.22.0 (2020-03-09)
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -117,6 +117,9 @@ pub trait WindowBuilderExtWindows {
 
     /// This sets `WS_EX_NOREDIRECTIONBITMAP`.
     fn with_no_redirection_bitmap(self, flag: bool) -> WindowBuilder;
+
+    /// Enables drag and drop support. Will interfere with other crates that use multi-threaded COM API on the same thread.
+    fn with_drag_and_drop(self, flag: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExtWindows for WindowBuilder {
@@ -135,6 +138,12 @@ impl WindowBuilderExtWindows for WindowBuilder {
     #[inline]
     fn with_no_redirection_bitmap(mut self, flag: bool) -> WindowBuilder {
         self.platform_specific.no_redirection_bitmap = flag;
+        self
+    }
+
+    #[inline]
+    fn with_drag_and_drop(mut self, flag: bool) -> WindowBuilder {
+        self.platform_specific.drag_and_drop = flag;
         self
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -120,7 +120,9 @@ pub trait WindowBuilderExtWindows {
 
     /// Enables or disables drag and drop support (enabled by default). Will interfere with other crates
     /// that use multi-threaded COM API (`CoInitializeEx` with `COINIT_MULTITHREADED` instead of
-    /// `COINIT_APARTMENTTHREADED`) on the same thread.
+    /// `COINIT_APARTMENTTHREADED`) on the same thread. Note that winit may still attempt to initialize
+    /// COM API regardless of this option. Currently only fullscreen mode does that, but there may be more in the future.
+    /// If you need COM API with `COINIT_MULTITHREADED` you must initialize it before calling any winit functions.
     /// See https://docs.microsoft.com/en-us/windows/win32/api/objbase/nf-objbase-coinitialize#remarks for more information.
     fn with_drag_and_drop(self, flag: bool) -> WindowBuilder;
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -118,7 +118,10 @@ pub trait WindowBuilderExtWindows {
     /// This sets `WS_EX_NOREDIRECTIONBITMAP`.
     fn with_no_redirection_bitmap(self, flag: bool) -> WindowBuilder;
 
-    /// Enables drag and drop support. Will interfere with other crates that use multi-threaded COM API on the same thread.
+    /// Enables or disables drag and drop support (enabled by default). Will interfere with other crates
+    /// that use multi-threaded COM API (`CoInitializeEx` with `COINIT_MULTITHREADED` instead of
+    /// `COINIT_APARTMENTTHREADED`) on the same thread.
+    /// See https://docs.microsoft.com/en-us/windows/win32/api/objbase/nf-objbase-coinitialize#remarks for more information.
     fn with_drag_and_drop(self, flag: bool) -> WindowBuilder;
 }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -82,7 +82,7 @@ lazy_static! {
 pub(crate) struct SubclassInput<T: 'static> {
     pub window_state: Arc<Mutex<WindowState>>,
     pub event_loop_runner: EventLoopRunnerShared<T>,
-    pub file_drop_handler: FileDropHandler,
+    pub file_drop_handler: Option<FileDropHandler>,
 }
 
 impl<T> SubclassInput<T> {

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -14,12 +14,23 @@ pub use self::icon::WinIcon as PlatformIcon;
 use crate::event::DeviceId as RootDeviceId;
 use crate::icon::Icon;
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub parent: Option<HWND>,
     pub taskbar_icon: Option<Icon>,
     pub no_redirection_bitmap: bool,
     pub drag_and_drop: bool,
+}
+
+impl Default for PlatformSpecificWindowBuilderAttributes {
+    fn default() -> Self {
+        Self {
+            parent: None,
+            taskbar_icon: None,
+            no_redirection_bitmap: false,
+            drag_and_drop: true,
+        }
+    }
 }
 
 unsafe impl Send for PlatformSpecificWindowBuilderAttributes {}

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -19,6 +19,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub parent: Option<HWND>,
     pub taskbar_icon: Option<Icon>,
     pub no_redirection_bitmap: bool,
+    pub drag_and_drop: bool,
 }
 
 unsafe impl Send for PlatformSpecificWindowBuilderAttributes {}


### PR DESCRIPTION
Since #1260 is stalled and based on discussion there I suggest an alternative fix for the `OleInitialize` problem (#1255). This makes drag and drop optional and allows `winit` to be used together with libraries like `cpal` without drag and drop functionality. I also improved the panic message as previous was really not informative.

- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
