### PR TITLE
Implement `Drop` for `Proxy` on macOS platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - On X11, fix `ResumeTimeReached` being fired too early.
 - On Web, replaced zero timeout for `ControlFlow::Poll` with `requestAnimationFrame`
 - On Web, fix a possible panic during event handling
+- On macOS, fix `EventLoopProxy` leaking memory for every instance.
 
 # 0.22.0 (2020-03-09)
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -117,6 +117,14 @@ pub struct Proxy<T> {
 
 unsafe impl<T: Send> Send for Proxy<T> {}
 
+impl<T> Drop for Proxy<T> {
+    fn drop(&mut self) {
+        unsafe {
+            CFRelease(self.source as _);
+        }
+    }
+}
+
 impl<T> Clone for Proxy<T> {
     fn clone(&self) -> Self {
         Proxy::new(self.sender.clone())


### PR DESCRIPTION
Fixes #1525.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented