### PR TITLE
Mention raw-window-handle in library docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,8 +94,9 @@
 //! # Drawing on the window
 //!
 //! Winit doesn't directly provide any methods for drawing on a [`Window`]. However it allows you to
-//! retrieve the raw handle of the window (see the [`platform`] module), which in turn allows you
-//! to create an OpenGL/Vulkan/DirectX/Metal/etc. context that can be used to render graphics.
+//! retrieve the raw handle of the window (see the [`platform`] module and/or the
+//! [`raw_window_handle`] method), which in turn allows you to create an
+//! OpenGL/Vulkan/DirectX/Metal/etc. context that can be used to render graphics.
 //!
 //! [`EventLoop`]: event_loop::EventLoop
 //! [`EventLoopExtDesktop::run_return`]: ./platform/desktop/trait.EventLoopExtDesktop.html#tymethod.run_return
@@ -116,6 +117,7 @@
 //! [`UserEvent`]: event::Event::UserEvent
 //! [`LoopDestroyed`]: event::Event::LoopDestroyed
 //! [`platform`]: platform
+//! [`raw_window_handle`]: ./window/struct.Window.html#method.raw_window_handle
 
 #![deny(rust_2018_idioms)]
 #![deny(intra_doc_link_resolution_failure)]


### PR DESCRIPTION
May save people some time when building or using graphics libraries with raw-window-handle support. I didn't manage to find a way to use proper intra doc links on a foreign trait method, but this works.