### PR TITLE
iOS: Add view for created window

### DIFF
--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -388,6 +388,8 @@ impl Window {
                 view_controller,
             );
 
+            let () = msg_send![window, addSubview: view];
+
             let result = Window {
                 inner: Inner {
                     window,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Now it's possible to get window from created UIView.