### PR TITLE
Bump version to 0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.22.1 (2020-04-16)
+
 - On X11, fix `ResumeTimeReached` being fired too early.
 - On Web, replaced zero timeout for `ControlFlow::Poll` with `requestAnimationFrame`
 - On Web, fix a possible panic during event handling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.22.0"
+version = "0.22.1"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-winit = "0.22.0"
+winit = "0.22.1"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
There are a few relatively important bugfixes with no API impact in the
master branch. We might as well release this as a non-breaking change.
