### PR TITLE
iOS: convert touch positions to physical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On Windows, fix `WindowBuilder::with_maximized` being ignored.
+- On iOS, touch positions are now properly converted to physical pixels.
 
 # 0.22.1 (2020-04-16)
 


### PR DESCRIPTION
Looks like this got missed whenever the DPI revamp happened. Touch works great on iOS with this change, though! 

Tested on iPhone XR