### PR TITLE
Update macOS dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - On macOS, fix `CursorMoved` event reporting the cursor position using logical coordinates.
 - On macOS, fix issue where unbundled applications would sometimes open without being focused.
 - On macOS, fix `run_return` does not return unless it receives a message.
+- On macOS, updated core-* dependencies and cocoa
 - On Windows, fix bug where `RedrawRequested` would only get emitted every other iteration of the event loop.
 - On X11, fix deadlock on window state when handling certain window events.
 - `WindowBuilder` now implements `Default`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,14 +38,14 @@ version = "0.2"
 objc = "0.2.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.19.1"
-core-foundation = "0.6"
-core-graphics = "0.17.3"
+cocoa = ">=0.20"
+core-foundation = ">=0.7.0"
+core-graphics = ">=0.19"
 dispatch = "0.2.0"
 objc = "0.2.6"
 
 [target.'cfg(target_os = "macos")'.dependencies.core-video-sys]
-version = "0.1.3"
+git = "https://github.com/LuoZijun/rust-core-video-sys"
 default_features = false
 features = ["display_link"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ version = "0.2"
 objc = "0.2.3"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = ">=0.20"
-core-foundation = ">=0.7.0"
-core-graphics = ">=0.19"
+cocoa = "0.20"
+core-foundation = "0.7"
+core-graphics = "0.19"
 dispatch = "0.2.0"
 objc = "0.2.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dispatch = "0.2.0"
 objc = "0.2.6"
 
 [target.'cfg(target_os = "macos")'.dependencies.core-video-sys]
-git = "https://github.com/LuoZijun/rust-core-video-sys"
+version = "0.1.4"
 default_features = false
 features = ["display_link"]
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_void;
 
 use crate::{
     dpi::LogicalSize,
-    event_loop::{EventLoop, EventLoopWindowTarget},
+    event_loop::EventLoopWindowTarget,
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };


### PR DESCRIPTION
Addresses https://github.com/servo/core-foundation-rs/pull/357

- [x ] Tested on all platforms changed (only affects macos)
- [x ] Compilation warnings were addressed
- [x ] `cargo fmt` has been run on this branch
- [ x] `cargo doc` builds successfully
- [ x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [NA ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [NA ] Created or updated an example program if it would help users understand this functionality
- [NA ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
