### PR TITLE
Add function to hide other applications on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 - On Wayland, fix deadlock when calling to `set_inner_size` from a callback.
 
+- On macOS, add `hide__other_applications` to `EventLoopWindowTarget` via existing `EventLoopWindowTargetExtMacOS` trait. `hide_other_applications` will hide other applications by calling `-[NSApplication hideOtherApplications: nil]`.
+
 # 0.22.2 (2020-05-16)
 
 - Added Clone implementation for 'static events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 - On Web, prevent the webpage from scrolling when the user is focused on a winit canvas
 
 - On Wayland, fix deadlock when calling to `set_inner_size` from a callback.
-
 - On macOS, add `hide__other_applications` to `EventLoopWindowTarget` via existing `EventLoopWindowTargetExtMacOS` trait. `hide_other_applications` will hide other applications by calling `-[NSApplication hideOtherApplications: nil]`.
 
 # 0.22.2 (2020-05-16)

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -215,6 +215,8 @@ impl MonitorHandleExtMacOS for MonitorHandle {
 pub trait EventLoopWindowTargetExtMacOS {
     /// Hide the entire application. In most applications this is typically triggered with Command-H.
     fn hide_application(&self);
+    /// Hide the other applications. In most applications this is typically triggered with Command+Option-H.
+    fn hide_other_applications(&self);
 }
 
 impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
@@ -222,5 +224,11 @@ impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
         let cls = objc::runtime::Class::get("NSApplication").unwrap();
         let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
         unsafe { msg_send![app, hide: 0] }
+    }
+
+    fn hide_other_applications(&self) {
+        let cls = objc::runtime::Class::get("NSApplication").unwrap();
+        let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
+        unsafe { msg_send![app, hideOtherApplications: 0] }
     }
 }


### PR DESCRIPTION
- [ x] Tested on all platforms changed
- [ x] Compilation warnings were addressed
- [ x] `cargo fmt` has been run on this branch
- [ x] `cargo doc` builds successfully
- [ x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ x] Created or updated an example program if it would help users understand this functionality
- [ x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Trivial addition so that downstream MacOS users can use Cmd+Option-H to hide other applications in the same way they currently use Cmd-H to hide the current one.  If approved, an issue with Alacritty [https://github.com/alacritty/alacritty/issues/3697#issue-614000377] can be easily fixed