### PR TITLE
Prevent the default browser behavior of events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- On Web, prevent the webpage from scrolling when the user is focused on a winit canvas
 
 # 0.22.2 (2020-05-16)
 

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -130,6 +130,7 @@ impl Canvas {
         F: 'static + FnMut(ScanCode, Option<VirtualKeyCode>, ModifiersState),
     {
         self.on_keyboard_release = Some(self.add_user_event(move |event: KeyUpEvent| {
+            event.prevent_default();
             handler(
                 event::scan_code(&event),
                 event::virtual_key_code(&event),
@@ -143,6 +144,7 @@ impl Canvas {
         F: 'static + FnMut(ScanCode, Option<VirtualKeyCode>, ModifiersState),
     {
         self.on_keyboard_press = Some(self.add_user_event(move |event: KeyDownEvent| {
+            event.prevent_default();
             handler(
                 event::scan_code(&event),
                 event::virtual_key_code(&event),
@@ -228,6 +230,7 @@ impl Canvas {
         F: 'static + FnMut(i32, MouseScrollDelta, ModifiersState),
     {
         self.on_mouse_wheel = Some(self.add_event(move |event: MouseWheelEvent| {
+            event.prevent_default();
             if let Some(delta) = event::mouse_scroll_delta(&event) {
                 handler(0, delta, event::mouse_modifiers(&event));
             }
@@ -265,7 +268,6 @@ impl Canvas {
         self.raw.add_event_listener(move |event: E| {
             event.stop_propagation();
             event.cancel_bubble();
-            event.prevent_default();
 
             handler(event);
         })

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -10,9 +10,9 @@ use stdweb::js;
 use stdweb::traits::IPointerEvent;
 use stdweb::unstable::TryInto;
 use stdweb::web::event::{
-    BlurEvent, ConcreteEvent, FocusEvent, FullscreenChangeEvent, KeyDownEvent, KeyPressEvent,
-    KeyUpEvent, MouseWheelEvent, PointerDownEvent, PointerMoveEvent, PointerOutEvent,
-    PointerOverEvent, PointerUpEvent,
+    BlurEvent, ConcreteEvent, FocusEvent, FullscreenChangeEvent, IEvent, KeyDownEvent,
+    KeyPressEvent, KeyUpEvent, MouseWheelEvent, PointerDownEvent, PointerMoveEvent,
+    PointerOutEvent, PointerOverEvent, PointerUpEvent,
 };
 use stdweb::web::html_element::CanvasElement;
 use stdweb::web::{

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -265,6 +265,7 @@ impl Canvas {
         self.raw.add_event_listener(move |event: E| {
             event.stop_propagation();
             event.cancel_bubble();
+            event.prevent_default();
 
             handler(event);
         })

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -287,6 +287,7 @@ impl Canvas {
             {
                 let event_ref = event.as_ref();
                 event_ref.stop_propagation();
+                event_ref.prevent_default();
                 event_ref.cancel_bubble();
             }
 

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -135,6 +135,7 @@ impl Canvas {
     {
         self.on_keyboard_release =
             Some(self.add_user_event("keyup", move |event: KeyboardEvent| {
+                event.prevent_default();
                 handler(
                     event::scan_code(&event),
                     event::virtual_key_code(&event),
@@ -149,6 +150,7 @@ impl Canvas {
     {
         self.on_keyboard_press =
             Some(self.add_user_event("keydown", move |event: KeyboardEvent| {
+                event.prevent_default();
                 handler(
                     event::scan_code(&event),
                     event::virtual_key_code(&event),
@@ -242,6 +244,7 @@ impl Canvas {
         F: 'static + FnMut(i32, MouseScrollDelta, ModifiersState),
     {
         self.on_mouse_wheel = Some(self.add_event("wheel", move |event: WheelEvent| {
+            event.prevent_default();
             if let Some(delta) = event::mouse_scroll_delta(&event) {
                 handler(0, delta, event::mouse_modifiers(&event));
             }
@@ -287,7 +290,6 @@ impl Canvas {
             {
                 let event_ref = event.as_ref();
                 event_ref.stop_propagation();
-                event_ref.prevent_default();
                 event_ref.cancel_bubble();
             }
 


### PR DESCRIPTION
This stops things like page scrolling on spacebar / arrow keys

Resolves #1573 

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
