### PR TITLE
platform_impl/linux/x11: fix deadlock in fn set_fullscreen_inner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- On X11, fix deadlock when calling `set_fullscreen_inner`.
 - On Web, prevent the webpage from scrolling when the user is focused on a winit canvas
 
 - On Wayland, fix deadlock when calling to `set_inner_size` from a callback.

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -640,6 +640,7 @@ impl UnownedWindow {
                 let flusher = self.set_fullscreen_hint(false);
                 let mut shared_state_lock = self.shared_state.lock();
                 if let Some(position) = shared_state_lock.restore_position.take() {
+                    drop(shared_state_lock);
                     self.set_position_inner(position.0, position.1).queue();
                 }
                 Some(flusher)


### PR DESCRIPTION
This is a double-lock bug in windows.rs:
The first lock is at L641 in `set_fullscreen_inner()`:
https://github.com/rust-windowing/winit/blob/03335cef851495e0a2843db7019516988740688b/src/platform_impl/linux/x11/window.rs#L641-L643
Then `set_position_inner()` is called, where the second lock is at L988
https://github.com/rust-windowing/winit/blob/03335cef851495e0a2843db7019516988740688b/src/platform_impl/linux/x11/window.rs#L984-L988
The patch drops the MutexGuard before calling `set_position_inner()` in `set_fullscreen_inner()`.
