### PR TITLE
Macos fullscreen & dialog support with `run_return`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 - On Wayland, fix deadlock when calling to `set_inner_size` from a callback.
 - On macOS, add `hide__other_applications` to `EventLoopWindowTarget` via existing `EventLoopWindowTargetExtMacOS` trait. `hide_other_applications` will hide other applications by calling `-[NSApplication hideOtherApplications: nil]`.
+- On MacOS, Fixed fullscreen and dialog support for `run_return`.
 
 # 0.22.2 (2020-05-16)
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -341,15 +341,12 @@ impl AppState {
                 let app: id = NSApp();
                 let windows: id = msg_send![app, windows];
                 let window: id = msg_send![windows, objectAtIndex:0];
+                let window_count: usize = msg_send![windows, count];
                 assert_ne!(window, nil);
 
-                let result: usize = msg_send![windows, count];
-                
-                let dialog_open = if result > 1 {
-                    let ps: id = msg_send![windows, lastObject];
-                    let vis: bool = msg_send![ps, isVisible];
-
-                    vis
+                let dialog_open: bool = if window_count > 1 {
+                    let dialog: id = msg_send![windows, lastObject];
+                    msg_send![dialog, isVisible]
                 } else {
                     false
                 };

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -340,7 +340,7 @@ impl AppState {
             unsafe {
                 if !TRANSITION_FULLSCREEN_MODE.load(Ordering::SeqCst) {
                     let _: () = msg_send![NSApp(), stop: nil];
-                    
+
                     let pool = NSAutoreleasePool::new(nil);
 
                     let windows: id = msg_send![NSApp(), windows];

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -347,7 +347,7 @@ impl AppState {
 
                 let dialog_open = if window_count > 1 {
                     let dialog: id = msg_send![windows, lastObject];
-                    let is_main_window: bool =  msg_send![dialog, isMainWindow];
+                    let is_main_window: bool = msg_send![dialog, isMainWindow];
                     msg_send![dialog, isVisible] && !is_main_window
                 } else {
                     false
@@ -355,8 +355,10 @@ impl AppState {
 
                 let dialog_is_closing = HANDLER.dialog_is_closing.load(Ordering::SeqCst);
                 let pool = NSAutoreleasePool::new(nil);
-                if !INTERRUPT_EVENT_LOOP_EXIT.load(Ordering::SeqCst) && !dialog_open && !dialog_is_closing {
-
+                if !INTERRUPT_EVENT_LOOP_EXIT.load(Ordering::SeqCst)
+                    && !dialog_open
+                    && !dialog_is_closing
+                {
                     let _: () = msg_send![app, stop: nil];
 
                     let dummy_event: id = msg_send![class!(NSEvent),

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -225,9 +225,7 @@ impl Handler {
 
 pub static mut SHOULD_CLOSE: bool = false;
 
-pub enum AppState {
-    
-}
+pub enum AppState {}
 
 impl AppState {
     // This function extends lifetime of `callback` to 'static as its side effect
@@ -341,11 +339,9 @@ impl AppState {
         if HANDLER.should_exit() {
             unsafe {
                 let _: () = msg_send![NSApp(), stop: nil];
-                if SHOULD_CLOSE
-                {
-
+                if SHOULD_CLOSE {
                     let pool = NSAutoreleasePool::new(nil);
-    
+
                     let windows: id = msg_send![NSApp(), windows];
                     let window: id = msg_send![windows, objectAtIndex:0];
                     assert_ne!(window, nil);
@@ -365,7 +361,6 @@ impl AppState {
                     let _: () = msg_send![window, postEvent: dummy_event atStart: YES];
                     pool.drain(); // Already draining the pool in the run_return function.
                 }
-
             };
         }
         HANDLER.update_start_time();

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -223,7 +223,7 @@ impl Handler {
     }
 }
 
-pub static mut ENTERING_FULLSCREEN: bool = false;
+pub static mut TRANSITION_FULLSCREEN_MODE: bool = false;
 
 pub enum AppState {}
 
@@ -338,7 +338,7 @@ impl AppState {
         }
         if HANDLER.should_exit() {
             unsafe {
-                if !ENTERING_FULLSCREEN {
+                if !TRANSITION_FULLSCREEN_MODE {
                     let _: () = msg_send![NSApp(), stop: nil];
                     let pool = NSAutoreleasePool::new(nil);
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -223,7 +223,7 @@ impl Handler {
     }
 }
 
-pub static mut TRANSITION_FULLSCREEN_MODE: bool = false;
+pub static TRANSITION_FULLSCREEN_MODE: AtomicBool = AtomicBool::new(false);
 
 pub enum AppState {}
 
@@ -338,7 +338,7 @@ impl AppState {
         }
         if HANDLER.should_exit() {
             unsafe {
-                if !TRANSITION_FULLSCREEN_MODE {
+                if !TRANSITION_FULLSCREEN_MODE.load(Ordering::SeqCst) {
                     let _: () = msg_send![NSApp(), stop: nil];
                     let pool = NSAutoreleasePool::new(nil);
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -340,6 +340,7 @@ impl AppState {
             unsafe {
                 if !TRANSITION_FULLSCREEN_MODE.load(Ordering::SeqCst) {
                     let _: () = msg_send![NSApp(), stop: nil];
+                    
                     let pool = NSAutoreleasePool::new(nil);
 
                     let windows: id = msg_send![NSApp(), windows];

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -359,7 +359,8 @@ impl AppState {
                     ];
                     // To stop event loop immediately, we need to post some event here.
                     let _: () = msg_send![window, postEvent: dummy_event atStart: YES];
-                    pool.drain(); // Already draining the pool in the run_return function.
+                    
+                    pool.drain();
                 }
             };
         }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -359,7 +359,7 @@ impl AppState {
                     ];
                     // To stop event loop immediately, we need to post some event here.
                     let _: () = msg_send![window, postEvent: dummy_event atStart: YES];
-                    
+
                     pool.drain();
                 }
             };

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -223,7 +223,7 @@ impl Handler {
     }
 }
 
-pub static mut SHOULD_CLOSE: bool = false;
+pub static mut ENTERING_FULLSCREEN: bool = false;
 
 pub enum AppState {}
 
@@ -338,8 +338,8 @@ impl AppState {
         }
         if HANDLER.should_exit() {
             unsafe {
-                let _: () = msg_send![NSApp(), stop: nil];
-                if SHOULD_CLOSE {
+                if !ENTERING_FULLSCREEN {
+                    let _: () = msg_send![NSApp(), stop: nil];
                     let pool = NSAutoreleasePool::new(nil);
 
                     let windows: id = msg_send![NSApp(), windows];

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -18,8 +18,8 @@ use crate::{
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform::macos::{ActivationPolicy, RequestUserAttentionType, WindowExtMacOS},
     platform_impl::platform::{
-        app_state::ENTERING_FULLSCREEN,
         app_state::AppState,
+        app_state::TRANSITION_FULLSCREEN_MODE,
         ffi,
         monitor::{self, MonitorHandle, VideoMode},
         util::{self, IdRef},
@@ -823,9 +823,7 @@ impl UnownedWindow {
 
         match (&old_fullscreen, &fullscreen) {
             (&None, &Some(_)) => unsafe {
-                unsafe {
-                    ENTERING_FULLSCREEN = true;
-                }
+                TRANSITION_FULLSCREEN_MODE = true;
                 util::toggle_full_screen_async(
                     *self.ns_window,
                     *self.ns_view,
@@ -834,9 +832,7 @@ impl UnownedWindow {
                 );
             },
             (&Some(Fullscreen::Borderless(_)), &None) => unsafe {
-                unsafe {
-                    ENTERING_FULLSCREEN = true;
-                }
+                TRANSITION_FULLSCREEN_MODE = true;
                 // State is restored by `window_did_exit_fullscreen`
                 util::toggle_full_screen_async(
                     *self.ns_window,
@@ -846,9 +842,7 @@ impl UnownedWindow {
                 );
             },
             (&Some(Fullscreen::Exclusive(RootVideoMode { ref video_mode })), &None) => unsafe {
-                unsafe {
-                    ENTERING_FULLSCREEN = true;
-                }
+                TRANSITION_FULLSCREEN_MODE = true;
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
                 // Rest of the state is restored by `window_did_exit_fullscreen`
                 util::toggle_full_screen_async(
@@ -859,9 +853,7 @@ impl UnownedWindow {
                 );
             },
             (&Some(Fullscreen::Borderless(_)), &Some(Fullscreen::Exclusive(_))) => unsafe {
-                unsafe {
-                    ENTERING_FULLSCREEN = true;
-                }
+                TRANSITION_FULLSCREEN_MODE = true;
                 // If we're already in fullscreen mode, calling
                 // `CGDisplayCapture` will place the shielding window on top of
                 // our window, which results in a black display and is not what
@@ -876,9 +868,7 @@ impl UnownedWindow {
                 &Some(Fullscreen::Exclusive(RootVideoMode { ref video_mode })),
                 &Some(Fullscreen::Borderless(_)),
             ) => unsafe {
-                unsafe {
-                    ENTERING_FULLSCREEN = true;
-                }
+                TRANSITION_FULLSCREEN_MODE = true;
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
             },
             _ => (),

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -18,6 +18,7 @@ use crate::{
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform::macos::{ActivationPolicy, RequestUserAttentionType, WindowExtMacOS},
     platform_impl::platform::{
+        app_state::ENTERING_FULLSCREEN,
         app_state::AppState,
         ffi,
         monitor::{self, MonitorHandle, VideoMode},
@@ -822,6 +823,9 @@ impl UnownedWindow {
 
         match (&old_fullscreen, &fullscreen) {
             (&None, &Some(_)) => unsafe {
+                unsafe {
+                    ENTERING_FULLSCREEN = true;
+                }
                 util::toggle_full_screen_async(
                     *self.ns_window,
                     *self.ns_view,
@@ -830,6 +834,9 @@ impl UnownedWindow {
                 );
             },
             (&Some(Fullscreen::Borderless(_)), &None) => unsafe {
+                unsafe {
+                    ENTERING_FULLSCREEN = true;
+                }
                 // State is restored by `window_did_exit_fullscreen`
                 util::toggle_full_screen_async(
                     *self.ns_window,
@@ -839,6 +846,9 @@ impl UnownedWindow {
                 );
             },
             (&Some(Fullscreen::Exclusive(RootVideoMode { ref video_mode })), &None) => unsafe {
+                unsafe {
+                    ENTERING_FULLSCREEN = true;
+                }
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
                 // Rest of the state is restored by `window_did_exit_fullscreen`
                 util::toggle_full_screen_async(
@@ -849,6 +859,9 @@ impl UnownedWindow {
                 );
             },
             (&Some(Fullscreen::Borderless(_)), &Some(Fullscreen::Exclusive(_))) => unsafe {
+                unsafe {
+                    ENTERING_FULLSCREEN = true;
+                }
                 // If we're already in fullscreen mode, calling
                 // `CGDisplayCapture` will place the shielding window on top of
                 // our window, which results in a black display and is not what
@@ -863,6 +876,9 @@ impl UnownedWindow {
                 &Some(Fullscreen::Exclusive(RootVideoMode { ref video_mode })),
                 &Some(Fullscreen::Borderless(_)),
             ) => unsafe {
+                unsafe {
+                    ENTERING_FULLSCREEN = true;
+                }
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
             },
             _ => (),

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -19,7 +19,7 @@ use crate::{
     platform::macos::{ActivationPolicy, RequestUserAttentionType, WindowExtMacOS},
     platform_impl::platform::{
         app_state::AppState,
-        app_state::TRANSITION_FULLSCREEN_MODE,
+        app_state::INTERRUPT_EVENT_LOOP_EXIT,
         ffi,
         monitor::{self, MonitorHandle, VideoMode},
         util::{self, IdRef},
@@ -821,7 +821,7 @@ impl UnownedWindow {
         shared_state_lock.fullscreen = fullscreen.clone();
         trace!("Unlocked shared state in `set_fullscreen`");
 
-        TRANSITION_FULLSCREEN_MODE.store(true, Ordering::SeqCst);
+        INTERRUPT_EVENT_LOOP_EXIT.store(true, Ordering::SeqCst);
 
         match (&old_fullscreen, &fullscreen) {
             (&None, &Some(_)) => unsafe {
@@ -868,7 +868,7 @@ impl UnownedWindow {
             ) => unsafe {
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
             },
-            _ => TRANSITION_FULLSCREEN_MODE.store(false, Ordering::SeqCst),
+            _ => INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst),
         }
     }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use cocoa::{
-    appkit::{NSApp, self, NSApplicationPresentationOptions, NSView, NSWindow, NSEventType::NSApplicationDefined},
+    appkit::{self, NSApplicationPresentationOptions, NSView, NSWindow},
     base::{id, nil},
-    foundation::{NSAutoreleasePool, NSUInteger, NSPoint},
+    foundation::{NSAutoreleasePool, NSUInteger},
 };
 
 use objc::{
@@ -268,7 +268,7 @@ extern "C" fn window_should_close(this: &Object, _: Sel, _: id) -> BOOL {
     unsafe {
         SHOULD_CLOSE = true;
     }
-        
+
     with_state(this, |state| state.emit_event(WindowEvent::CloseRequested));
     trace!("Completed `windowShouldClose:`");
     NO

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -9,7 +9,6 @@ use cocoa::{
     base::{id, nil},
     foundation::{NSAutoreleasePool, NSUInteger},
 };
-
 use objc::{
     declare::ClassDecl,
     runtime::{Class, Object, Sel, BOOL, NO, YES},
@@ -20,7 +19,7 @@ use crate::{
     event::{Event, ModifiersState, WindowEvent},
     platform_impl::platform::{
         app_state::AppState,
-        app_state::ENTERING_FULLSCREEN,
+        app_state::TRANSITION_FULLSCREEN_MODE,
         event::{EventProxy, EventWrapper},
         util::{self, IdRef},
         view::ViewState,
@@ -264,7 +263,6 @@ extern "C" fn init_with_winit(this: &Object, _sel: Sel, state: *mut c_void) -> i
 
 extern "C" fn window_should_close(this: &Object, _: Sel, _: id) -> BOOL {
     trace!("Triggered `windowShouldClose:`");
-
     with_state(this, |state| state.emit_event(WindowEvent::CloseRequested));
     trace!("Completed `windowShouldClose:`");
     NO
@@ -290,7 +288,6 @@ extern "C" fn window_did_resize(this: &Object, _: Sel, _: id) {
         state.emit_resize_event();
         state.emit_move_event();
     });
-
     trace!("Completed `windowDidResize:`");
 }
 
@@ -435,7 +432,7 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillEnterFullscreen:`");
 
     unsafe {
-        ENTERING_FULLSCREEN = true;
+        TRANSITION_FULLSCREEN_MODE = true;
     }
 
     with_state(this, |state| {
@@ -470,7 +467,7 @@ extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillExitFullScreen:`");
 
     unsafe {
-        ENTERING_FULLSCREEN = true;
+        TRANSITION_FULLSCREEN_MODE = true;
     }
 
     with_state(this, |state| {
@@ -506,11 +503,10 @@ extern "C" fn window_will_use_fullscreen_presentation_options(
 
 /// Invoked when entered fullscreen
 extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
-
     unsafe {
-        ENTERING_FULLSCREEN = false;
+        TRANSITION_FULLSCREEN_MODE = false;
     }
-    
+
     trace!("Triggered `windowDidEnterFullscreen:`");
     with_state(this, |state| {
         state.initial_fullscreen = false;
@@ -532,7 +528,7 @@ extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
 /// Invoked when exited fullscreen
 extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: id) {
     unsafe {
-        ENTERING_FULLSCREEN = false;
+        TRANSITION_FULLSCREEN_MODE = false;
     }
 
     trace!("Triggered `windowDidExitFullscreen:`");

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -19,7 +19,7 @@ use crate::{
     event::{Event, ModifiersState, WindowEvent},
     platform_impl::platform::{
         app_state::AppState,
-        app_state::TRANSITION_FULLSCREEN_MODE,
+        app_state::INTERRUPT_EVENT_LOOP_EXIT,
         event::{EventProxy, EventWrapper},
         util::{self, IdRef},
         view::ViewState,
@@ -431,7 +431,7 @@ extern "C" fn dragging_exited(this: &Object, _: Sel, _: id) {
 extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillEnterFullscreen:`");
 
-    TRANSITION_FULLSCREEN_MODE.store(true, Ordering::SeqCst);
+    INTERRUPT_EVENT_LOOP_EXIT.store(true, Ordering::SeqCst);
 
     with_state(this, |state| {
         state.with_window(|window| {
@@ -464,7 +464,7 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
 extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillExitFullScreen:`");
 
-    TRANSITION_FULLSCREEN_MODE.store(true, Ordering::SeqCst);
+    INTERRUPT_EVENT_LOOP_EXIT.store(true, Ordering::SeqCst);
 
     with_state(this, |state| {
         state.with_window(|window| {
@@ -499,7 +499,7 @@ extern "C" fn window_will_use_fullscreen_presentation_options(
 
 /// Invoked when entered fullscreen
 extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
-    TRANSITION_FULLSCREEN_MODE.store(false, Ordering::SeqCst);
+    INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst);
 
     trace!("Triggered `windowDidEnterFullscreen:`");
     with_state(this, |state| {
@@ -521,7 +521,7 @@ extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
 
 /// Invoked when exited fullscreen
 extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: id) {
-    TRANSITION_FULLSCREEN_MODE.store(false, Ordering::SeqCst);
+    INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst);
 
     trace!("Triggered `windowDidExitFullscreen:`");
     with_state(this, |state| {

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -1,7 +1,7 @@
 use std::{
     f64,
     os::raw::c_void,
-    sync::{Arc, Weak},
+    sync::{atomic::Ordering, Arc, Weak},
 };
 
 use cocoa::{
@@ -431,9 +431,7 @@ extern "C" fn dragging_exited(this: &Object, _: Sel, _: id) {
 extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillEnterFullscreen:`");
 
-    unsafe {
-        TRANSITION_FULLSCREEN_MODE = true;
-    }
+    TRANSITION_FULLSCREEN_MODE.store(true, Ordering::SeqCst);
 
     with_state(this, |state| {
         state.with_window(|window| {
@@ -466,9 +464,7 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
 extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillExitFullScreen:`");
 
-    unsafe {
-        TRANSITION_FULLSCREEN_MODE = true;
-    }
+    TRANSITION_FULLSCREEN_MODE.store(true, Ordering::SeqCst);
 
     with_state(this, |state| {
         state.with_window(|window| {
@@ -503,9 +499,7 @@ extern "C" fn window_will_use_fullscreen_presentation_options(
 
 /// Invoked when entered fullscreen
 extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
-    unsafe {
-        TRANSITION_FULLSCREEN_MODE = false;
-    }
+    TRANSITION_FULLSCREEN_MODE.store(false, Ordering::SeqCst);
 
     trace!("Triggered `windowDidEnterFullscreen:`");
     with_state(this, |state| {
@@ -527,9 +521,7 @@ extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
 
 /// Invoked when exited fullscreen
 extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: id) {
-    unsafe {
-        TRANSITION_FULLSCREEN_MODE = false;
-    }
+    TRANSITION_FULLSCREEN_MODE.store(false, Ordering::SeqCst);
 
     trace!("Triggered `windowDidExitFullscreen:`");
     with_state(this, |state| {

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -469,6 +469,10 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
 extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillExitFullScreen:`");
 
+    unsafe {
+        ENTERING_FULLSCREEN = true;
+    }
+
     with_state(this, |state| {
         state.with_window(|window| {
             trace!("Locked shared state in `window_will_exit_fullscreen`");
@@ -527,6 +531,10 @@ extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
 
 /// Invoked when exited fullscreen
 extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: id) {
+    unsafe {
+        ENTERING_FULLSCREEN = false;
+    }
+
     trace!("Triggered `windowDidExitFullscreen:`");
     with_state(this, |state| {
         state.with_window(|window| {

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -5,10 +5,11 @@ use std::{
 };
 
 use cocoa::{
-    appkit::{self, NSApplicationPresentationOptions, NSView, NSWindow},
+    appkit::{NSApp, self, NSApplicationPresentationOptions, NSView, NSWindow, NSEventType::NSApplicationDefined},
     base::{id, nil},
-    foundation::{NSAutoreleasePool, NSUInteger},
+    foundation::{NSAutoreleasePool, NSUInteger, NSPoint},
 };
+
 use objc::{
     declare::ClassDecl,
     runtime::{Class, Object, Sel, BOOL, NO, YES},
@@ -19,6 +20,7 @@ use crate::{
     event::{Event, ModifiersState, WindowEvent},
     platform_impl::platform::{
         app_state::AppState,
+        app_state::SHOULD_CLOSE,
         event::{EventProxy, EventWrapper},
         util::{self, IdRef},
         view::ViewState,
@@ -262,6 +264,11 @@ extern "C" fn init_with_winit(this: &Object, _sel: Sel, state: *mut c_void) -> i
 
 extern "C" fn window_should_close(this: &Object, _: Sel, _: id) -> BOOL {
     trace!("Triggered `windowShouldClose:`");
+
+    unsafe {
+        SHOULD_CLOSE = true;
+    }
+        
     with_state(this, |state| state.emit_event(WindowEvent::CloseRequested));
     trace!("Completed `windowShouldClose:`");
     NO

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -20,7 +20,7 @@ use crate::{
     event::{Event, ModifiersState, WindowEvent},
     platform_impl::platform::{
         app_state::AppState,
-        app_state::SHOULD_CLOSE,
+        app_state::ENTERING_FULLSCREEN,
         event::{EventProxy, EventWrapper},
         util::{self, IdRef},
         view::ViewState,
@@ -265,10 +265,6 @@ extern "C" fn init_with_winit(this: &Object, _sel: Sel, state: *mut c_void) -> i
 extern "C" fn window_should_close(this: &Object, _: Sel, _: id) -> BOOL {
     trace!("Triggered `windowShouldClose:`");
 
-    unsafe {
-        SHOULD_CLOSE = true;
-    }
-
     with_state(this, |state| state.emit_event(WindowEvent::CloseRequested));
     trace!("Completed `windowShouldClose:`");
     NO
@@ -294,6 +290,7 @@ extern "C" fn window_did_resize(this: &Object, _: Sel, _: id) {
         state.emit_resize_event();
         state.emit_move_event();
     });
+
     trace!("Completed `windowDidResize:`");
 }
 
@@ -436,6 +433,11 @@ extern "C" fn dragging_exited(this: &Object, _: Sel, _: id) {
 /// Invoked when before enter fullscreen
 extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillEnterFullscreen:`");
+
+    unsafe {
+        ENTERING_FULLSCREEN = true;
+    }
+
     with_state(this, |state| {
         state.with_window(|window| {
             trace!("Locked shared state in `window_will_enter_fullscreen`");
@@ -466,6 +468,7 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
 /// Invoked when before exit fullscreen
 extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
     trace!("Triggered `windowWillExitFullScreen:`");
+
     with_state(this, |state| {
         state.with_window(|window| {
             trace!("Locked shared state in `window_will_exit_fullscreen`");
@@ -499,6 +502,11 @@ extern "C" fn window_will_use_fullscreen_presentation_options(
 
 /// Invoked when entered fullscreen
 extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
+
+    unsafe {
+        ENTERING_FULLSCREEN = false;
+    }
+    
     trace!("Triggered `windowDidEnterFullscreen:`");
     with_state(this, |state| {
         state.initial_fullscreen = false;


### PR DESCRIPTION
Previously the `run_return` example would freeze if you switch to fullscreen. This fixes it.
It is not a clean solution but if anybody knows more about mac than I do let me know if there is a better way.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
