### PR TITLE
Make wayland or X11 optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+- On Unix, X11 and Wayland are now optional features (enabled by default)
 - On X11, fix deadlock when calling `set_fullscreen_inner`.
 - On Web, prevent the webpage from scrolling when the user is focused on a winit canvas
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,11 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc", "i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-unknown-unknown"]
 
 [features]
+default = ["x11", "wayland"]
 web-sys = ["web_sys", "wasm-bindgen", "instant/wasm-bindgen"]
 stdweb = ["std_web", "instant/stdweb"]
+x11 = ["x11-dl"]
+wayland = ["wayland-client", "smithay-client-toolkit"]
 
 [dependencies]
 instant = "0.1"
@@ -78,11 +81,11 @@ features = [
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-wayland-client = { version = "0.23.0", features = [ "dlopen", "egl", "cursor", "eventloop"] }
+wayland-client = { version = "0.23.0", features = [ "dlopen", "egl", "cursor", "eventloop"] , optional = true }
 mio = "0.6"
 mio-extras = "2.0"
-smithay-client-toolkit = "^0.6.6"
-x11-dl = "2.18.5"
+smithay-client-toolkit = { version = "^0.6.6", optional = true }
+x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = "2.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows"))'.dependencies.parking_lot]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Winit is only officially supported on the latest stable version of the Rust comp
 
 Winit provides the following features, which can be enabled in your `Cargo.toml` file:
 * `serde`: Enables serialization/deserialization of certain types with [Serde](https://crates.io/crates/serde).
+* `x11` (enabled by default): On Unix platform, compiles with the X11 backend
+* `wayland` (enabled by default): On Unix platform, compiles with the Wayland backend
 
 ### Platform-specific usage
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,21 @@
+#[cfg(all(
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd"
+    ),
+    not(feature = "x11"),
+    not(feature = "wayland")
+))]
+compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
+
+#[cfg(all(
+    target_arch = "wasm32",
+    not(feature = "web-sys"),
+    not(feature = "stdweb")
+))]
+compile_error!("Please select a feature to build for web: `web-sys`, `stdweb`");
+
+fn main() {}

--- a/build.rs
+++ b/build.rs
@@ -9,13 +9,13 @@
     not(feature = "x11"),
     not(feature = "wayland")
 ))]
-compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
+compile_error!("at least one of the \"x11\"/\"wayland\" features must be enabled");
 
 #[cfg(all(
     target_arch = "wasm32",
     not(feature = "web-sys"),
     not(feature = "stdweb")
 ))]
-compile_error!("Please select a feature to build for web: `web-sys`, `stdweb`");
+compile_error!("at least one of the \"web-sys\"/\"stdweb\" features must be enabled");
 
 fn main() {}

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -1,12 +1,10 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 
-use std::os::raw;
-
-#[cfg(feature = "x11")]
-use std::{ptr, sync::Arc};
-
 #[cfg(feature = "wayland")]
 use smithay_client_toolkit::window::{ButtonState as SCTKButtonState, Theme as SCTKTheme};
+use std::os::raw;
+#[cfg(feature = "x11")]
+use std::{ptr, sync::Arc};
 
 use crate::{
     event_loop::{EventLoop, EventLoopWindowTarget},
@@ -16,7 +14,6 @@ use crate::{
 
 #[cfg(feature = "x11")]
 use crate::dpi::Size;
-
 #[cfg(feature = "x11")]
 use crate::platform_impl::x11::{ffi::XVisualInfo, XConnection};
 use crate::platform_impl::{
@@ -28,7 +25,6 @@ use crate::platform_impl::{
 #[cfg(feature = "x11")]
 #[doc(hidden)]
 pub use crate::platform_impl::x11;
-
 #[cfg(feature = "x11")]
 pub use crate::platform_impl::{x11::util::WindowType as XWindowType, XNotSupported};
 
@@ -37,7 +33,7 @@ pub trait EventLoopWindowTargetExtUnix {
     /// True if the `EventLoopWindowTarget` uses Wayland.
     #[cfg(feature = "wayland")]
     fn is_wayland(&self) -> bool;
-    ///
+
     /// True if the `EventLoopWindowTarget` uses X11.
     #[cfg(feature = "x11")]
     fn is_x11(&self) -> bool;
@@ -300,9 +296,10 @@ impl WindowExtUnix for Window {
     #[inline]
     #[cfg(feature = "x11")]
     fn set_urgent(&self, is_urgent: bool) {
-        #[allow(irrefutable_let_patterns)]
-        if let LinuxWindow::X(ref w) = self.window {
-            w.set_urgent(is_urgent);
+        match self.window {
+            LinuxWindow::X(ref w) => w.set_urgent(is_urgent),
+            #[cfg(feature = "wayland")]
+            _ => (),
         }
     }
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -1,10 +1,11 @@
 #![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
 
-#[cfg(feature = "wayland")]
-use smithay_client_toolkit::window::{ButtonState as SCTKButtonState, Theme as SCTKTheme};
 use std::os::raw;
 #[cfg(feature = "x11")]
 use std::{ptr, sync::Arc};
+
+#[cfg(feature = "wayland")]
+use smithay_client_toolkit::window::{ButtonState as SCTKButtonState, Theme as SCTKTheme};
 
 use crate::{
     event_loop::{EventLoop, EventLoopWindowTarget},

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -383,6 +383,7 @@ pub trait WindowBuilderExtUnix {
     ///
     /// For details about application ID conventions, see the
     /// [Desktop Entry Spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id)
+    #[cfg(feature = "wayland")]
     fn with_app_id(self, app_id: String) -> Self;
 }
 
@@ -447,6 +448,7 @@ impl WindowBuilderExtUnix for WindowBuilder {
     }
 
     #[inline]
+    #[cfg(feature = "wayland")]
     fn with_app_id(mut self, app_id: String) -> Self {
         self.platform_specific.app_id = Some(app_id);
         self

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -23,8 +23,8 @@ use crate::platform_impl::{
 };
 
 // TODO: stupid hack so that glutin can do its work
-#[cfg(feature = "x11")]
 #[doc(hidden)]
+#[cfg(feature = "x11")]
 pub use crate::platform_impl::x11;
 #[cfg(feature = "x11")]
 pub use crate::platform_impl::{x11::util::WindowType as XWindowType, XNotSupported};
@@ -154,14 +154,14 @@ impl<T> EventLoopExtUnix for EventLoop<T> {
         wrap_ev(LinuxEventLoop::new_any_thread())
     }
 
-    #[cfg(feature = "x11")]
     #[inline]
+    #[cfg(feature = "x11")]
     fn new_x11_any_thread() -> Result<Self, XNotSupported> {
         LinuxEventLoop::new_x11_any_thread().map(wrap_ev)
     }
 
-    #[cfg(feature = "wayland")]
     #[inline]
+    #[cfg(feature = "wayland")]
     fn new_wayland_any_thread() -> Self {
         wrap_ev(
             LinuxEventLoop::new_wayland_any_thread()
@@ -170,14 +170,14 @@ impl<T> EventLoopExtUnix for EventLoop<T> {
         )
     }
 
-    #[cfg(feature = "x11")]
     #[inline]
+    #[cfg(feature = "x11")]
     fn new_x11() -> Result<Self, XNotSupported> {
         LinuxEventLoop::new_x11().map(wrap_ev)
     }
 
-    #[cfg(feature = "wayland")]
     #[inline]
+    #[cfg(feature = "wayland")]
     fn new_wayland() -> Self {
         wrap_ev(
             LinuxEventLoop::new_wayland()
@@ -466,8 +466,8 @@ impl MonitorHandleExtUnix for MonitorHandle {
     }
 }
 
-#[cfg(feature = "wayland")]
 /// Wrapper for implementing SCTK's theme trait.
+#[cfg(feature = "wayland")]
 struct WaylandTheme<T: Theme>(T);
 
 pub trait Theme: Send + 'static {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -112,12 +112,11 @@ pub enum OsError {
 
 impl fmt::Display for OsError {
     fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        #[cfg(not(feature = "x11"))]
-        panic!();
-        #[cfg(feature = "x11")]
-        match self {
-            OsError::XError(e) => _f.pad(&e.description),
-            OsError::XMisc(e) => _f.pad(e),
+        match *self {
+            #[cfg(feature = "x11")]
+            OsError::XError(ref e) => _f.pad(&e.description),
+            #[cfg(feature = "x11")]
+            OsError::XMisc(ref e) => _f.pad(e),
         }
     }
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -1,7 +1,13 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+#![cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 
 #[cfg(all(not(feature = "x11"), not(feature = "wayland")))]
-compile_error!("Please select a feature to build for web: `w11`, `wayland`");
+compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
 use std::{collections::VecDeque, env, fmt};
 #[cfg(feature = "x11")]
@@ -47,15 +53,21 @@ const BACKEND_PREFERENCE_ENV_VAR: &str = "WINIT_UNIX_BACKEND";
 pub struct PlatformSpecificWindowBuilderAttributes {
     #[cfg(feature = "x11")]
     pub visual_infos: Option<XVisualInfo>,
+    #[cfg(feature = "x11")]
     pub screen_id: Option<i32>,
+    #[cfg(feature = "x11")]
     pub resize_increments: Option<Size>,
+    #[cfg(feature = "x11")]
     pub base_size: Option<Size>,
+    #[cfg(feature = "x11")]
     pub class: Option<(String, String)>,
+    #[cfg(feature = "x11")]
     pub override_redirect: bool,
     #[cfg(feature = "x11")]
     pub x11_window_types: Vec<XWindowType>,
     #[cfg(feature = "x11")]
     pub gtk_theme_variant: Option<String>,
+    #[cfg(feature = "wayland")]
     pub app_id: Option<String>,
 }
 
@@ -64,15 +76,21 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
         Self {
             #[cfg(feature = "x11")]
             visual_infos: None,
+            #[cfg(feature = "x11")]
             screen_id: None,
+            #[cfg(feature = "x11")]
             resize_increments: None,
+            #[cfg(feature = "x11")]
             base_size: None,
+            #[cfg(feature = "x11")]
             class: None,
+            #[cfg(feature = "x11")]
             override_redirect: false,
             #[cfg(feature = "x11")]
             x11_window_types: vec![XWindowType::Normal],
             #[cfg(feature = "x11")]
             gtk_theme_variant: None,
+            #[cfg(feature = "wayland")]
             app_id: None,
         }
     }
@@ -85,19 +103,21 @@ lazy_static! {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub enum OsError {
     #[cfg(feature = "x11")]
     XError(XError),
+    #[cfg(feature = "x11")]
     XMisc(&'static str),
 }
 
 impl fmt::Display for OsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        #[cfg(not(feature = "x11"))]
+        panic!();
+        #[cfg(feature = "x11")]
         match self {
-            #[cfg(feature = "x11")]
-            OsError::XError(e) => f.pad(&e.description),
-            OsError::XMisc(e) => f.pad(e),
+            OsError::XError(e) => _f.pad(&e.description),
+            OsError::XMisc(e) => _f.pad(e),
         }
     }
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -1,12 +1,31 @@
-#![cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os = "openbsd"))]
+#![cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
+#![cfg_attr(
+    not(all(feature = "x11", feature = "wayland")),
+    allow(
+        unused_imports,
+        unused_variables,
+        unreachable_code,
+        dead_code,
+        unreachable_patterns
+    )
+)]
 
 use std::{collections::VecDeque, env, ffi::CStr, fmt, mem::MaybeUninit, os::raw::*, sync::Arc};
 
 use parking_lot::Mutex;
 use raw_window_handle::RawWindowHandle;
+#[cfg(feature = "wayland")]
 use smithay_client_toolkit::reexports::client::ConnectError;
 
+#[cfg(feature = "x11")]
 pub use self::x11::XNotSupported;
+#[cfg(feature = "x11")]
 use self::x11::{ffi::XVisualInfo, util::WindowType as XWindowType, XConnection, XError};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
@@ -20,7 +39,9 @@ use crate::{
 
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 
+#[cfg(feature = "wayland")]
 pub mod wayland;
+#[cfg(feature = "x11")]
 pub mod x11;
 
 /// Environment variable specifying which backend should be used on unix platform.
@@ -34,12 +55,14 @@ const BACKEND_PREFERENCE_ENV_VAR: &str = "WINIT_UNIX_BACKEND";
 
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
+    #[cfg(feature = "x11")]
     pub visual_infos: Option<XVisualInfo>,
     pub screen_id: Option<i32>,
     pub resize_increments: Option<Size>,
     pub base_size: Option<Size>,
     pub class: Option<(String, String)>,
     pub override_redirect: bool,
+    #[cfg(feature = "x11")]
     pub x11_window_types: Vec<XWindowType>,
     pub gtk_theme_variant: Option<String>,
     pub app_id: Option<String>,
@@ -48,12 +71,14 @@ pub struct PlatformSpecificWindowBuilderAttributes {
 impl Default for PlatformSpecificWindowBuilderAttributes {
     fn default() -> Self {
         Self {
+            #[cfg(feature = "x11")]
             visual_infos: None,
             screen_id: None,
             resize_increments: None,
             base_size: None,
             class: None,
             override_redirect: false,
+            #[cfg(feature = "x11")]
             x11_window_types: vec![XWindowType::Normal],
             gtk_theme_variant: None,
             app_id: None,
@@ -61,6 +86,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
     }
 }
 
+#[cfg(feature = "x11")]
 lazy_static! {
     pub static ref X11_BACKEND: Mutex<Result<Arc<XConnection>, XNotSupported>> =
         Mutex::new(XConnection::new(Some(x_error_callback)).map(Arc::new));
@@ -68,6 +94,7 @@ lazy_static! {
 
 #[derive(Debug, Clone)]
 pub enum OsError {
+    #[cfg(feature = "x11")]
     XError(XError),
     XMisc(&'static str),
 }
@@ -75,6 +102,7 @@ pub enum OsError {
 impl fmt::Display for OsError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
+            #[cfg(feature = "x11")]
             OsError::XError(e) => f.pad(&e.description),
             OsError::XMisc(e) => f.pad(e),
         }
@@ -82,127 +110,153 @@ impl fmt::Display for OsError {
 }
 
 pub enum Window {
+    #[cfg(feature = "x11")]
     X(x11::Window),
+    #[cfg(feature = "wayland")]
     Wayland(wayland::Window),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum WindowId {
+    #[cfg(feature = "x11")]
     X(x11::WindowId),
+    #[cfg(feature = "wayland")]
     Wayland(wayland::WindowId),
+    #[cfg(all(not(feature = "x11"), not(feature = "wayland")))]
+    Dummy,
 }
 
 impl WindowId {
     pub unsafe fn dummy() -> Self {
-        WindowId::Wayland(wayland::WindowId::dummy())
+        #[cfg(feature = "wayland")]
+        return WindowId::Wayland(wayland::WindowId::dummy());
+        #[cfg(all(not(feature = "wayland"), feature = "x11"))]
+        return WindowId::X(x11::WindowId::dummy());
+        #[cfg(all(not(feature = "x11"), not(feature = "wayland")))]
+        WindowId::Dummy
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceId {
+    #[cfg(feature = "x11")]
     X(x11::DeviceId),
+    #[cfg(feature = "wayland")]
     Wayland(wayland::DeviceId),
+    #[cfg(all(not(feature = "x11"), not(feature = "wayland")))]
+    Dummy,
 }
 
 impl DeviceId {
     pub unsafe fn dummy() -> Self {
-        DeviceId::Wayland(wayland::DeviceId::dummy())
+        #[cfg(feature = "wayland")]
+        return DeviceId::Wayland(wayland::DeviceId::dummy());
+        #[cfg(all(not(feature = "wayland"), feature = "x11"))]
+        return DeviceId::X(x11::DeviceId::dummy());
+        #[cfg(all(not(feature = "x11"), not(feature = "wayland")))]
+        DeviceId::Dummy
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MonitorHandle {
+    #[cfg(feature = "x11")]
     X(x11::MonitorHandle),
+    #[cfg(feature = "wayland")]
     Wayland(wayland::MonitorHandle),
+}
+
+/// `x11_or_wayland!(match expr; Enum(foo) => foo.something())`
+/// expands to the equivalent of
+/// ```ignore
+/// match self {
+///    Enum::X(foo) => foo.something(),
+///    Enum::Wayland(foo) => foo.something(),
+/// }
+/// ```
+/// The result can be converted to another enum by adding `; as AnotherEnum`
+macro_rules! x11_or_wayland {
+    (match $what:expr; $enum:ident ( $($c1:tt)* ) => $x:expr; as $enum2:ident ) => {
+        match $what {
+            #[cfg(feature = "x11")]
+            $enum::X($($c1)*) => $enum2::X($x),
+            #[cfg(feature = "wayland")]
+            $enum::Wayland($($c1)*) => $enum2::Wayland($x),
+            #[cfg(not(any(feature = "x11", feature = "wayland")))]
+            _ => panic!()
+        }
+    };
+    (match $what:expr; $enum:ident ( $($c1:tt)* ) => $x:expr) => {
+        match $what {
+            #[cfg(feature = "x11")]
+            $enum::X($($c1)*) => $x,
+            #[cfg(feature = "wayland")]
+            $enum::Wayland($($c1)*) => $x,
+            #[cfg(not(any(feature = "x11", feature = "wayland")))]
+            _ => panic!()
+        }
+    };
 }
 
 impl MonitorHandle {
     #[inline]
     pub fn name(&self) -> Option<String> {
-        match self {
-            &MonitorHandle::X(ref m) => m.name(),
-            &MonitorHandle::Wayland(ref m) => m.name(),
-        }
+        x11_or_wayland!(match self; MonitorHandle(m) => m.name())
     }
 
     #[inline]
     pub fn native_identifier(&self) -> u32 {
-        match self {
-            &MonitorHandle::X(ref m) => m.native_identifier(),
-            &MonitorHandle::Wayland(ref m) => m.native_identifier(),
-        }
+        x11_or_wayland!(match self; MonitorHandle(m) => m.native_identifier())
     }
 
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
-        match self {
-            &MonitorHandle::X(ref m) => m.size(),
-            &MonitorHandle::Wayland(ref m) => m.size(),
-        }
+        x11_or_wayland!(match self; MonitorHandle(m) => m.size())
     }
 
     #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
-        match self {
-            &MonitorHandle::X(ref m) => m.position(),
-            &MonitorHandle::Wayland(ref m) => m.position(),
-        }
+        x11_or_wayland!(match self; MonitorHandle(m) => m.position())
     }
 
     #[inline]
     pub fn scale_factor(&self) -> f64 {
-        match self {
-            &MonitorHandle::X(ref m) => m.scale_factor(),
-            &MonitorHandle::Wayland(ref m) => m.scale_factor() as f64,
-        }
+        x11_or_wayland!(match self; MonitorHandle(m) => m.scale_factor() as f64)
     }
 
     #[inline]
     pub fn video_modes(&self) -> Box<dyn Iterator<Item = RootVideoMode>> {
-        match self {
-            MonitorHandle::X(m) => Box::new(m.video_modes()),
-            MonitorHandle::Wayland(m) => Box::new(m.video_modes()),
-        }
+        x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum VideoMode {
+    #[cfg(feature = "x11")]
     X(x11::VideoMode),
+    #[cfg(feature = "wayland")]
     Wayland(wayland::VideoMode),
 }
 
 impl VideoMode {
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
-        match self {
-            &VideoMode::X(ref m) => m.size(),
-            &VideoMode::Wayland(ref m) => m.size(),
-        }
+        x11_or_wayland!(match self; VideoMode(m) => m.size())
     }
 
     #[inline]
     pub fn bit_depth(&self) -> u16 {
-        match self {
-            &VideoMode::X(ref m) => m.bit_depth(),
-            &VideoMode::Wayland(ref m) => m.bit_depth(),
-        }
+        x11_or_wayland!(match self; VideoMode(m) => m.bit_depth())
     }
 
     #[inline]
     pub fn refresh_rate(&self) -> u16 {
-        match self {
-            &VideoMode::X(ref m) => m.refresh_rate(),
-            &VideoMode::Wayland(ref m) => m.refresh_rate(),
-        }
+        x11_or_wayland!(match self; VideoMode(m) => m.refresh_rate())
     }
 
     #[inline]
     pub fn monitor(&self) -> RootMonitorHandle {
-        match self {
-            &VideoMode::X(ref m) => m.monitor(),
-            &VideoMode::Wayland(ref m) => m.monitor(),
-        }
+        x11_or_wayland!(match self; VideoMode(m) => m.monitor())
     }
 }
 
@@ -214,267 +268,206 @@ impl Window {
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
         match *window_target {
+            #[cfg(feature = "wayland")]
             EventLoopWindowTarget::Wayland(ref window_target) => {
                 wayland::Window::new(window_target, attribs, pl_attribs).map(Window::Wayland)
             }
+            #[cfg(feature = "x11")]
             EventLoopWindowTarget::X(ref window_target) => {
                 x11::Window::new(window_target, attribs, pl_attribs).map(Window::X)
             }
+            #[cfg(not(any(feature = "x11", feature = "wayland")))]
+            _ => panic!(),
         }
     }
 
     #[inline]
     pub fn id(&self) -> WindowId {
-        match self {
-            &Window::X(ref w) => WindowId::X(w.id()),
-            &Window::Wayland(ref w) => WindowId::Wayland(w.id()),
-        }
+        x11_or_wayland!(match self; Window(w) => w.id(); as WindowId)
     }
 
     #[inline]
     pub fn set_title(&self, title: &str) {
-        match self {
-            &Window::X(ref w) => w.set_title(title),
-            &Window::Wayland(ref w) => w.set_title(title),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_title(title));
     }
 
     #[inline]
     pub fn set_visible(&self, visible: bool) {
-        match self {
-            &Window::X(ref w) => w.set_visible(visible),
-            &Window::Wayland(ref w) => w.set_visible(visible),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_visible(visible))
     }
 
     #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-        match self {
-            &Window::X(ref w) => w.outer_position(),
-            &Window::Wayland(ref w) => w.outer_position(),
-        }
+        x11_or_wayland!(match self; Window(w) => w.outer_position())
     }
 
     #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-        match self {
-            &Window::X(ref m) => m.inner_position(),
-            &Window::Wayland(ref m) => m.inner_position(),
-        }
+        x11_or_wayland!(match self; Window(w) => w.inner_position())
     }
 
     #[inline]
     pub fn set_outer_position(&self, position: Position) {
-        match self {
-            &Window::X(ref w) => w.set_outer_position(position),
-            &Window::Wayland(ref w) => w.set_outer_position(position),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_outer_position(position))
     }
 
     #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
-        match self {
-            &Window::X(ref w) => w.inner_size(),
-            &Window::Wayland(ref w) => w.inner_size(),
-        }
+        x11_or_wayland!(match self; Window(w) => w.inner_size())
     }
 
     #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
-        match self {
-            &Window::X(ref w) => w.outer_size(),
-            &Window::Wayland(ref w) => w.outer_size(),
-        }
+        x11_or_wayland!(match self; Window(w) => w.outer_size())
     }
 
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
-        match self {
-            &Window::X(ref w) => w.set_inner_size(size),
-            &Window::Wayland(ref w) => w.set_inner_size(size),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_inner_size(size))
     }
 
     #[inline]
     pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
-        match self {
-            &Window::X(ref w) => w.set_min_inner_size(dimensions),
-            &Window::Wayland(ref w) => w.set_min_inner_size(dimensions),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_min_inner_size(dimensions))
     }
 
     #[inline]
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
-        match self {
-            &Window::X(ref w) => w.set_max_inner_size(dimensions),
-            &Window::Wayland(ref w) => w.set_max_inner_size(dimensions),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_max_inner_size(dimensions))
     }
 
     #[inline]
     pub fn set_resizable(&self, resizable: bool) {
-        match self {
-            &Window::X(ref w) => w.set_resizable(resizable),
-            &Window::Wayland(ref w) => w.set_resizable(resizable),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_resizable(resizable))
     }
 
     #[inline]
     pub fn set_cursor_icon(&self, cursor: CursorIcon) {
-        match self {
-            &Window::X(ref w) => w.set_cursor_icon(cursor),
-            &Window::Wayland(ref w) => w.set_cursor_icon(cursor),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_cursor_icon(cursor))
     }
 
     #[inline]
     pub fn set_cursor_grab(&self, grab: bool) -> Result<(), ExternalError> {
-        match self {
-            &Window::X(ref window) => window.set_cursor_grab(grab),
-            &Window::Wayland(ref window) => window.set_cursor_grab(grab),
-        }
+        x11_or_wayland!(match self; Window(window) => window.set_cursor_grab(grab))
     }
 
     #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
-        match self {
-            &Window::X(ref window) => window.set_cursor_visible(visible),
-            &Window::Wayland(ref window) => window.set_cursor_visible(visible),
-        }
+        x11_or_wayland!(match self; Window(window) => window.set_cursor_visible(visible))
     }
 
     #[inline]
     pub fn scale_factor(&self) -> f64 {
-        match self {
-            &Window::X(ref w) => w.scale_factor(),
-            &Window::Wayland(ref w) => w.scale_factor() as f64,
-        }
+        x11_or_wayland!(match self; Window(w) => w.scale_factor() as f64)
     }
 
     #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
-        match self {
-            &Window::X(ref w) => w.set_cursor_position(position),
-            &Window::Wayland(ref w) => w.set_cursor_position(position),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_cursor_position(position))
     }
 
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
-        match self {
-            &Window::X(ref w) => w.set_maximized(maximized),
-            &Window::Wayland(ref w) => w.set_maximized(maximized),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_maximized(maximized))
     }
 
     #[inline]
     pub fn set_minimized(&self, minimized: bool) {
-        match self {
-            &Window::X(ref w) => w.set_minimized(minimized),
-            &Window::Wayland(ref w) => w.set_minimized(minimized),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_minimized(minimized))
     }
 
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
-        match self {
-            &Window::X(ref w) => w.fullscreen(),
-            &Window::Wayland(ref w) => w.fullscreen(),
-        }
+        x11_or_wayland!(match self; Window(w) => w.fullscreen())
     }
 
     #[inline]
     pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
-        match self {
-            &Window::X(ref w) => w.set_fullscreen(monitor),
-            &Window::Wayland(ref w) => w.set_fullscreen(monitor),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_fullscreen(monitor))
     }
 
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
-        match self {
-            &Window::X(ref w) => w.set_decorations(decorations),
-            &Window::Wayland(ref w) => w.set_decorations(decorations),
-        }
+        x11_or_wayland!(match self; Window(w) => w.set_decorations(decorations))
     }
 
     #[inline]
     pub fn set_always_on_top(&self, always_on_top: bool) {
         match self {
+            #[cfg(feature = "x11")]
             &Window::X(ref w) => w.set_always_on_top(always_on_top),
-            &Window::Wayland(_) => (),
+            _ => (),
         }
     }
 
     #[inline]
     pub fn set_window_icon(&self, window_icon: Option<Icon>) {
         match self {
+            #[cfg(feature = "x11")]
             &Window::X(ref w) => w.set_window_icon(window_icon),
-            &Window::Wayland(_) => (),
+            _ => (),
         }
     }
 
     #[inline]
     pub fn set_ime_position(&self, position: Position) {
         match self {
+            #[cfg(feature = "x11")]
             &Window::X(ref w) => w.set_ime_position(position),
-            &Window::Wayland(_) => (),
+            _ => (),
         }
     }
 
     #[inline]
     pub fn request_redraw(&self) {
-        match self {
-            &Window::X(ref w) => w.request_redraw(),
-            &Window::Wayland(ref w) => w.request_redraw(),
-        }
+        x11_or_wayland!(match self; Window(w) => w.request_redraw())
     }
 
     #[inline]
     pub fn current_monitor(&self) -> RootMonitorHandle {
-        match self {
-            &Window::X(ref window) => RootMonitorHandle {
-                inner: MonitorHandle::X(window.current_monitor()),
-            },
-            &Window::Wayland(ref window) => RootMonitorHandle {
-                inner: MonitorHandle::Wayland(window.current_monitor()),
-            },
+        RootMonitorHandle {
+            inner: x11_or_wayland!(match self; Window(window) => window.current_monitor(); as MonitorHandle),
         }
     }
 
     #[inline]
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         match self {
+            #[cfg(feature = "x11")]
             &Window::X(ref window) => window
                 .available_monitors()
                 .into_iter()
                 .map(MonitorHandle::X)
                 .collect(),
+            #[cfg(feature = "wayland")]
             &Window::Wayland(ref window) => window
                 .available_monitors()
                 .into_iter()
                 .map(MonitorHandle::Wayland)
                 .collect(),
+            #[cfg(not(any(feature = "x11", feature = "wayland")))]
+            _ => panic!(),
         }
     }
 
     #[inline]
     pub fn primary_monitor(&self) -> MonitorHandle {
-        match self {
-            &Window::X(ref window) => MonitorHandle::X(window.primary_monitor()),
-            &Window::Wayland(ref window) => MonitorHandle::Wayland(window.primary_monitor()),
-        }
+        x11_or_wayland!(match self; Window(window) => window.primary_monitor(); as MonitorHandle)
     }
 
     pub fn raw_window_handle(&self) -> RawWindowHandle {
         match self {
+            #[cfg(feature = "x11")]
             &Window::X(ref window) => RawWindowHandle::Xlib(window.raw_window_handle()),
+            #[cfg(feature = "wayland")]
             &Window::Wayland(ref window) => RawWindowHandle::Wayland(window.raw_window_handle()),
+            #[cfg(not(any(feature = "x11", feature = "wayland")))]
+            _ => panic!(),
         }
     }
 }
 
+#[cfg(feature = "x11")]
 unsafe extern "C" fn x_error_callback(
     display: *mut x11::ffi::Display,
     event: *mut x11::ffi::XErrorEvent,
@@ -507,22 +500,30 @@ unsafe extern "C" fn x_error_callback(
     0
 }
 
+#[cfg(not(any(feature = "x11", feature = "wayland")))]
+pub enum Never {}
+
 pub enum EventLoop<T: 'static> {
+    #[cfg(feature = "wayland")]
     Wayland(wayland::EventLoop<T>),
+    #[cfg(feature = "x11")]
     X(x11::EventLoop<T>),
+    #[cfg(not(any(feature = "x11", feature = "wayland")))]
+    Dummy(T, Never),
 }
 
 pub enum EventLoopProxy<T: 'static> {
+    #[cfg(feature = "x11")]
     X(x11::EventLoopProxy<T>),
+    #[cfg(feature = "wayland")]
     Wayland(wayland::EventLoopProxy<T>),
+    #[cfg(not(any(feature = "x11", feature = "wayland")))]
+    Dummy(T, Never),
 }
 
 impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
-        match self {
-            EventLoopProxy::X(proxy) => EventLoopProxy::X(proxy.clone()),
-            EventLoopProxy::Wayland(proxy) => EventLoopProxy::Wayland(proxy.clone()),
-        }
+        x11_or_wayland!(match self; EventLoopProxy(proxy) => proxy.clone(); as EventLoopProxy)
     }
 }
 
@@ -538,12 +539,18 @@ impl<T: 'static> EventLoop<T> {
             match env_var.as_str() {
                 "x11" => {
                     // TODO: propagate
+                    #[cfg(feature = "x11")]
                     return EventLoop::new_x11_any_thread()
                         .expect("Failed to initialize X11 backend");
+                    #[cfg(not(feature = "x11"))]
+                    panic!("x11 feature is not enabled")
                 }
                 "wayland" => {
+                    #[cfg(feature = "wayland")]
                     return EventLoop::new_wayland_any_thread()
                         .expect("Failed to initialize Wayland backend");
+                    #[cfg(not(feature = "wayland"))]
+                    panic!("wayland feature is not enabled");
                 }
                 _ => panic!(
                     "Unknown environment variable value for {}, try one of `x11`,`wayland`",
@@ -552,15 +559,22 @@ impl<T: 'static> EventLoop<T> {
             }
         }
 
+        #[cfg(feature = "wayland")]
         let wayland_err = match EventLoop::new_wayland_any_thread() {
             Ok(event_loop) => return event_loop,
             Err(err) => err,
         };
 
+        #[cfg(feature = "x11")]
         let x11_err = match EventLoop::new_x11_any_thread() {
             Ok(event_loop) => return event_loop,
             Err(err) => err,
         };
+
+        #[cfg(not(feature = "wayland"))]
+        let wayland_err = "backend disabled";
+        #[cfg(not(feature = "x11"))]
+        let x11_err = "backend disabled";
 
         let err_string = format!(
             "Failed to initialize any backend! Wayland status: {:?} X11 status: {:?}",
@@ -569,22 +583,26 @@ impl<T: 'static> EventLoop<T> {
         panic!(err_string);
     }
 
+    #[cfg(feature = "wayland")]
     pub fn new_wayland() -> Result<EventLoop<T>, ConnectError> {
         assert_is_main_thread("new_wayland_any_thread");
 
         EventLoop::new_wayland_any_thread()
     }
 
+    #[cfg(feature = "wayland")]
     pub fn new_wayland_any_thread() -> Result<EventLoop<T>, ConnectError> {
         wayland::EventLoop::new().map(EventLoop::Wayland)
     }
 
+    #[cfg(feature = "x11")]
     pub fn new_x11() -> Result<EventLoop<T>, XNotSupported> {
         assert_is_main_thread("new_x11_any_thread");
 
         EventLoop::new_x11_any_thread()
     }
 
+    #[cfg(feature = "x11")]
     pub fn new_x11_any_thread() -> Result<EventLoop<T>, XNotSupported> {
         let xconn = match X11_BACKEND.lock().as_ref() {
             Ok(xconn) => xconn.clone(),
@@ -597,83 +615,81 @@ impl<T: 'static> EventLoop<T> {
     #[inline]
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         match *self {
+            #[cfg(feature = "wayland")]
             EventLoop::Wayland(ref evlp) => evlp
                 .available_monitors()
                 .into_iter()
                 .map(MonitorHandle::Wayland)
                 .collect(),
+            #[cfg(feature = "x11")]
             EventLoop::X(ref evlp) => evlp
                 .x_connection()
                 .available_monitors()
                 .into_iter()
                 .map(MonitorHandle::X)
                 .collect(),
+            #[cfg(not(any(feature = "x11", feature = "wayland")))]
+            _ => panic!(),
         }
     }
 
     #[inline]
     pub fn primary_monitor(&self) -> MonitorHandle {
         match *self {
+            #[cfg(feature = "wayland")]
             EventLoop::Wayland(ref evlp) => MonitorHandle::Wayland(evlp.primary_monitor()),
+            #[cfg(feature = "x11")]
             EventLoop::X(ref evlp) => MonitorHandle::X(evlp.x_connection().primary_monitor()),
+            #[cfg(not(any(feature = "x11", feature = "wayland")))]
+            _ => panic!(),
         }
     }
 
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
-        match *self {
-            EventLoop::Wayland(ref evlp) => EventLoopProxy::Wayland(evlp.create_proxy()),
-            EventLoop::X(ref evlp) => EventLoopProxy::X(evlp.create_proxy()),
-        }
+        x11_or_wayland!(match self; EventLoop(evlp) => evlp.create_proxy(); as EventLoopProxy)
     }
 
     pub fn run_return<F>(&mut self, callback: F)
     where
         F: FnMut(crate::event::Event<'_, T>, &RootELW<T>, &mut ControlFlow),
     {
-        match *self {
-            EventLoop::Wayland(ref mut evlp) => evlp.run_return(callback),
-            EventLoop::X(ref mut evlp) => evlp.run_return(callback),
-        }
+        x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_return(callback))
     }
 
     pub fn run<F>(self, callback: F) -> !
     where
         F: 'static + FnMut(crate::event::Event<'_, T>, &RootELW<T>, &mut ControlFlow),
     {
-        match self {
-            EventLoop::Wayland(evlp) => evlp.run(callback),
-            EventLoop::X(evlp) => evlp.run(callback),
-        }
+        x11_or_wayland!(match self; EventLoop(evlp) => evlp.run(callback))
     }
 
     pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget<T> {
-        match *self {
-            EventLoop::Wayland(ref evl) => evl.window_target(),
-            EventLoop::X(ref evl) => evl.window_target(),
-        }
+        x11_or_wayland!(match self; EventLoop(evl) => evl.window_target())
     }
 }
 
 impl<T: 'static> EventLoopProxy<T> {
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
-        match *self {
-            EventLoopProxy::Wayland(ref proxy) => proxy.send_event(event),
-            EventLoopProxy::X(ref proxy) => proxy.send_event(event),
-        }
+        x11_or_wayland!(match self; EventLoopProxy(proxy) => proxy.send_event(event))
     }
 }
 
 pub enum EventLoopWindowTarget<T> {
+    #[cfg(feature = "wayland")]
     Wayland(wayland::EventLoopWindowTarget<T>),
+    #[cfg(feature = "x11")]
     X(x11::EventLoopWindowTarget<T>),
+    #[cfg(not(any(feature = "x11", feature = "wayland")))]
+    Dummy(T, Never),
 }
 
 impl<T> EventLoopWindowTarget<T> {
     #[inline]
     pub fn is_wayland(&self) -> bool {
         match *self {
+            #[cfg(feature = "wayland")]
             EventLoopWindowTarget::Wayland(_) => true,
-            EventLoopWindowTarget::X(_) => false,
+            _ => false,
         }
     }
 }

--- a/src/platform_impl/linux/wayland/event_loop.rs
+++ b/src/platform_impl/linux/wayland/event_loop.rs
@@ -554,6 +554,7 @@ impl<T: 'static> EventLoop<T> {
             let instant_wakeup = {
                 let window_target = match self.window_target.p {
                     crate::platform_impl::EventLoopWindowTarget::Wayland(ref wt) => wt,
+                    #[cfg(feature = "x11")]
                     _ => unreachable!(),
                 };
                 let dispatched = window_target
@@ -662,6 +663,7 @@ impl<T> EventLoop<T> {
     {
         let window_target = match self.window_target.p {
             crate::platform_impl::EventLoopWindowTarget::Wayland(ref wt) => wt,
+            #[cfg(feature = "x11")]
             _ => unreachable!(),
         };
         window_target.store.lock().unwrap().for_each_redraw_trigger(
@@ -689,6 +691,7 @@ impl<T> EventLoop<T> {
     {
         let window_target = match self.window_target.p {
             crate::platform_impl::EventLoopWindowTarget::Wayland(ref wt) => wt,
+            #[cfg(feature = "x11")]
             _ => unreachable!(),
         };
 
@@ -803,6 +806,7 @@ impl<T> EventLoop<T> {
 fn get_target<T>(target: &RootELW<T>) -> &EventLoopWindowTarget<T> {
     match target.p {
         crate::platform_impl::EventLoopWindowTarget::Wayland(ref wt) => wt,
+        #[cfg(feature = "x11")]
         _ => unreachable!(),
     }
 }

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -158,6 +158,7 @@ impl Window {
             Some(Fullscreen::Borderless(RootMonitorHandle {
                 inner: PlatformMonitorHandle::Wayland(ref monitor_id),
             })) => frame.set_fullscreen(Some(&monitor_id.proxy)),
+            #[cfg(feature = "x11")]
             Some(Fullscreen::Borderless(_)) => unreachable!(),
             None => {
                 if attributes.maximized {
@@ -354,6 +355,7 @@ impl Window {
                     .unwrap()
                     .set_fullscreen(Some(&monitor_id.proxy));
             }
+            #[cfg(feature = "x11")]
             Some(Fullscreen::Borderless(_)) => unreachable!(),
             None => self.frame.lock().unwrap().unset_fullscreen(),
         }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -426,6 +426,7 @@ impl<T: 'static> EventLoop<T> {
 pub(crate) fn get_xtarget<T>(target: &RootELW<T>) -> &EventLoopWindowTarget<T> {
     match target.p {
         super::EventLoopWindowTarget::X(ref target) => target,
+        #[cfg(feature = "wayland")]
         _ => unreachable!(),
     }
 }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -493,8 +493,20 @@ impl<'a> Deref for DeviceInfo<'a> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(ffi::Window);
 
+impl WindowId {
+    pub unsafe fn dummy() -> Self {
+        WindowId(0)
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId(c_int);
+
+impl DeviceId {
+    pub unsafe fn dummy() -> Self {
+        DeviceId(0)
+    }
+}
 
 pub struct Window(Arc<UnownedWindow>);
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -653,6 +653,7 @@ impl UnownedWindow {
                     Fullscreen::Borderless(RootMonitorHandle {
                         inner: PlatformMonitorHandle::X(ref monitor),
                     }) => (None, monitor),
+                    #[cfg(feature = "wayland")]
                     _ => unreachable!(),
                 };
 


### PR DESCRIPTION
As suggested in https://github.com/rust-windowing/winit/issues/774
Wayland adds lots of dependencies when building 

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I only tested on Linux/X11.  I also checked it compiles with wayland alone