### PR TITLE
macOS: Support click-dragging out of a window

### DIFF
--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -910,13 +910,12 @@ fn mouse_motion(this: &Object, event: id) {
         let view_point = view.convertPoint_fromView_(window_point, nil);
         let view_rect = NSView::frame(view);
 
-        let mouse_buttons_down: NSInteger = msg_send![class!(NSEvent), pressedMouseButtons];
-
         if view_point.x.is_sign_negative()
             || view_point.y.is_sign_negative()
             || view_point.x > view_rect.size.width
             || view_point.y > view_rect.size.height
         {
+            let mouse_buttons_down: NSInteger = msg_send![class!(NSEvent), pressedMouseButtons];
             if mouse_buttons_down == 0 {
                 // Point is outside of the client area (view) and no buttons are pressed
                 return;


### PR DESCRIPTION
This is my naive attempt to fix #1599. It seems to work, though I've only checked on a remote macOS machine.

Fixes #1599 (_"[macos] Click-dragging out of a window doesn't work on macOS"_) 
Related to #292 (_"Add mouse event capturing when click-dragging out of a win32 window"_) 
