### PR TITLE
Add tests for X11 and Wayland features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
           - { target: i686-pc-windows-gnu,      os: windows-latest, host: -i686-pc-windows-gnu }
           - { target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: x11 }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: wayland }
           - { target: aarch64-linux-android,    os: ubuntu-latest,  cmd: 'apk --' }
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
           - { target: x86_64-apple-ios,         os: macos-latest,    }
@@ -50,6 +52,7 @@ jobs:
       RUST_BACKTRACE: 1
       CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C debuginfo=0"
+      OPTIONS: ${{ matrix.platform.options }}
       FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
       CMD: ${{ matrix.platform.cmd }}
 
@@ -82,35 +85,35 @@ jobs:
     - name: Check documentation
       shell: bash
       if: matrix.platform.target != 'wasm32-unknown-unknown'
-      run: cargo $CMD doc --no-deps --target ${{ matrix.platform.target }} --features $FEATURES
+      run: cargo $CMD doc --no-deps --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
     - name: Build
       shell: bash
-      run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} --features $FEATURES
+      run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
     - name: Build tests
       shell: bash
-      run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} --features $FEATURES
+      run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
     - name: Run tests
       shell: bash
       if: (
         !contains(matrix.platform.target, 'android') &&
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32'))
-      run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} --features $FEATURES
+      run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
 
     - name: Build with serde enabled
       shell: bash
-      run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} --features serde,$FEATURES
+      run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
 
     - name: Build tests with serde enabled
       shell: bash
-      run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} --features serde,$FEATURES
+      run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
     - name: Run tests with serde enabled
       shell: bash
       if: (
         !contains(matrix.platform.target, 'android') &&
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32'))
-      run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} --features serde,$FEATURES
+      run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES


### PR DESCRIPTION
Follow-up to #1597, adding tests to build without optional X11 and Wayland features.