### PR TITLE
On Windows, fix bug where we'd try to emit `MainEventsCleared` events during nested win32 event loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+
 - On Unix, X11 and Wayland are now optional features (enabled by default)
 - On X11, fix deadlock when calling `set_fullscreen_inner`.
 - On Web, prevent the webpage from scrolling when the user is focused on a winit canvas
@@ -7,6 +8,7 @@
 - On macOS, add `hide__other_applications` to `EventLoopWindowTarget` via existing `EventLoopWindowTargetExtMacOS` trait. `hide_other_applications` will hide other applications by calling `-[NSApplication hideOtherApplications: nil]`.
 - On android added support for `run_return`.
 - On MacOS, Fixed fullscreen and dialog support for `run_return`.
+- On Windows, fix bug where we'd try to emit `MainEventsCleared` events during nested win32 event loops.
 
 # 0.22.2 (2020-05-16)
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1934,6 +1934,8 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             // `RedrawEventsCleared` event.
             if subclass_input.event_loop_runner.handling_events() {
                 if subclass_input.event_loop_runner.should_buffer() {
+                    // This branch can be triggered when a nested win32 event loop is triggered
+                    // inside of the `event_handler` callback.
                     winuser::RedrawWindow(
                         window,
                         ptr::null(),

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1933,14 +1933,23 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             // events, `handling_events` will return false and we won't emit a second
             // `RedrawEventsCleared` event.
             if subclass_input.event_loop_runner.handling_events() {
-                // This WM_PAINT handler will never be re-entrant because `flush_paint_messages`
-                // doesn't call WM_PAINT for the thread event target (i.e. this window).
-                assert!(flush_paint_messages(
-                    None,
-                    &subclass_input.event_loop_runner
-                ));
-                subclass_input.event_loop_runner.redraw_events_cleared();
-                process_control_flow(&subclass_input.event_loop_runner);
+                if subclass_input.event_loop_runner.should_buffer() {
+                    winuser::RedrawWindow(
+                        window,
+                        ptr::null(),
+                        ptr::null_mut(),
+                        winuser::RDW_INTERNALPAINT,
+                    );
+                } else {
+                    // This WM_PAINT handler will never be re-entrant because `flush_paint_messages`
+                    // doesn't call WM_PAINT for the thread event target (i.e. this window).
+                    assert!(flush_paint_messages(
+                        None,
+                        &subclass_input.event_loop_runner
+                    ));
+                    subclass_input.event_loop_runner.redraw_events_cleared();
+                    process_control_flow(&subclass_input.event_loop_runner);
+                }
             }
 
             0

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -226,7 +226,7 @@ impl<T: 'static> EventLoop<T> {
         }
 
         unsafe {
-            runner.call_event_handler(Event::LoopDestroyed);
+            runner.loop_destroyed();
         }
         runner.reset_runner();
     }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -290,7 +290,9 @@ impl<T> EventLoopRunner<T> {
     /// runner state machine (e.g. `self.runner_state == HandlingMainEvents` and
     /// `new_runner_state == Idle`), the intermediate state transitions will still be executed.
     unsafe fn move_state_to(&self, new_runner_state: RunnerState) {
-        use RunnerState::{HandlingMainEvents, HandlingRedrawEvents, Idle, Uninitialized, Destroyed};
+        use RunnerState::{
+            Destroyed, HandlingMainEvents, HandlingRedrawEvents, Idle, Uninitialized,
+        };
 
         match (
             self.runner_state.replace(new_runner_state),
@@ -362,7 +364,7 @@ impl<T> EventLoopRunner<T> {
                 self.call_event_handler(Event::LoopDestroyed);
             }
 
-            (Destroyed, _)  => panic!("cannot move state from Destroyed"),
+            (Destroyed, _) => panic!("cannot move state from Destroyed"),
         }
     }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Fixes #1587 and #1602. Fixes #1611 .