### PR TITLE
Move available_monitors and primary_monitor to EventLoopWindowTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On all platforms, `available_monitors` and `primary_monitor` are now on `EventLoopWindowTarget` rather than `EventLoop` to list monitors event in the event loop.
 - On Unix, X11 and Wayland are now optional features (enabled by default)
 - On X11, fix deadlock when calling `set_fullscreen_inner`.
 - On Web, prevent the webpage from scrolling when the user is focused on a winit canvas

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -155,11 +155,20 @@ impl<T> EventLoop<T> {
             event_loop_proxy: self.event_loop.create_proxy(),
         }
     }
+}
 
+impl<T> Deref for EventLoop<T> {
+    type Target = EventLoopWindowTarget<T>;
+    fn deref(&self) -> &EventLoopWindowTarget<T> {
+        self.event_loop.window_target()
+    }
+}
+
+impl<T> EventLoopWindowTarget<T> {
     /// Returns the list of all the monitors available on the system.
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
-        self.event_loop
+        self.p
             .available_monitors()
             .into_iter()
             .map(|inner| MonitorHandle { inner })
@@ -169,15 +178,8 @@ impl<T> EventLoop<T> {
     #[inline]
     pub fn primary_monitor(&self) -> MonitorHandle {
         MonitorHandle {
-            inner: self.event_loop.primary_monitor(),
+            inner: self.p.primary_monitor(),
         }
-    }
-}
-
-impl<T> Deref for EventLoop<T> {
-    type Target = EventLoopWindowTarget<T>;
-    fn deref(&self) -> &EventLoopWindowTarget<T> {
-        self.event_loop.window_target()
     }
 }
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,11 +3,11 @@
 //! If you want to get basic information about a monitor, you can use the [`MonitorHandle`][monitor_handle]
 //! type. This is retreived from one of the following methods, which return an iterator of
 //! [`MonitorHandle`][monitor_handle]:
-//! - [`EventLoop::available_monitors`][loop_get]
+//! - [`EventLoopWindowTarget::available_monitors`][loop_get]
 //! - [`Window::available_monitors`][window_get].
 //!
 //! [monitor_handle]: crate::monitor::MonitorHandle
-//! [loop_get]: crate::event_loop::EventLoop::available_monitors
+//! [loop_get]: crate::event_loop::EventLoopWindowTarget::available_monitors
 //! [window_get]: crate::window::Window::available_monitors
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -295,16 +295,6 @@ impl<T: 'static> EventLoop<T> {
         &self.window_target
     }
 
-    pub fn primary_monitor(&self) -> MonitorHandle {
-        MonitorHandle
-    }
-
-    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        let mut v = VecDeque::with_capacity(1);
-        v.push_back(self.primary_monitor());
-        v
-    }
-
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         EventLoopProxy {
             queue: self.user_queue.clone(),
@@ -337,6 +327,18 @@ impl<T> Clone for EventLoopProxy<T> {
 
 pub struct EventLoopWindowTarget<T: 'static> {
     _marker: std::marker::PhantomData<T>,
+}
+
+impl<T: 'static> EventLoopWindowTarget<T> {
+    pub fn primary_monitor(&self) -> MonitorHandle {
+        MonitorHandle
+    }
+
+    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
+        let mut v = VecDeque::with_capacity(1);
+        v.push_back(self.primary_monitor());
+        v
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -49,6 +49,19 @@ pub struct EventLoopWindowTarget<T: 'static> {
     sender_to_clone: Sender<T>,
 }
 
+impl<T: 'static> EventLoopWindowTarget<T> {
+    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
+        // guaranteed to be on main thread
+        unsafe { monitor::uiscreens() }
+    }
+
+    pub fn primary_monitor(&self) -> MonitorHandle {
+        // guaranteed to be on main thread
+        unsafe { monitor::main_uiscreen() }
+    }
+
+}
+
 pub struct EventLoop<T: 'static> {
     window_target: RootEventLoopWindowTarget<T>,
 }
@@ -113,16 +126,6 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         EventLoopProxy::new(self.window_target.p.sender_to_clone.clone())
-    }
-
-    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        // guaranteed to be on main thread
-        unsafe { monitor::uiscreens() }
-    }
-
-    pub fn primary_monitor(&self) -> MonitorHandle {
-        // guaranteed to be on main thread
-        unsafe { monitor::main_uiscreen() }
     }
 
     pub fn window_target(&self) -> &RootEventLoopWindowTarget<T> {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -59,7 +59,6 @@ impl<T: 'static> EventLoopWindowTarget<T> {
         // guaranteed to be on main thread
         unsafe { monitor::main_uiscreen() }
     }
-
 }
 
 pub struct EventLoop<T: 'static> {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -672,9 +672,13 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn primary_monitor(&self) -> MonitorHandle {
         match *self {
             #[cfg(feature = "wayland")]
-            EventLoopWindowTarget::Wayland(ref evlp) => MonitorHandle::Wayland(evlp.primary_monitor()),
+            EventLoopWindowTarget::Wayland(ref evlp) => {
+                MonitorHandle::Wayland(evlp.primary_monitor())
+            }
             #[cfg(feature = "x11")]
-            EventLoopWindowTarget::X(ref evlp) => MonitorHandle::X(evlp.x_connection().primary_monitor()),
+            EventLoopWindowTarget::X(ref evlp) => {
+                MonitorHandle::X(evlp.x_connection().primary_monitor())
+            }
         }
     }
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -602,35 +602,6 @@ impl<T: 'static> EventLoop<T> {
         Ok(EventLoop::X(x11::EventLoop::new(xconn)))
     }
 
-    #[inline]
-    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        match *self {
-            #[cfg(feature = "wayland")]
-            EventLoop::Wayland(ref evlp) => evlp
-                .available_monitors()
-                .into_iter()
-                .map(MonitorHandle::Wayland)
-                .collect(),
-            #[cfg(feature = "x11")]
-            EventLoop::X(ref evlp) => evlp
-                .x_connection()
-                .available_monitors()
-                .into_iter()
-                .map(MonitorHandle::X)
-                .collect(),
-        }
-    }
-
-    #[inline]
-    pub fn primary_monitor(&self) -> MonitorHandle {
-        match *self {
-            #[cfg(feature = "wayland")]
-            EventLoop::Wayland(ref evlp) => MonitorHandle::Wayland(evlp.primary_monitor()),
-            #[cfg(feature = "x11")]
-            EventLoop::X(ref evlp) => MonitorHandle::X(evlp.x_connection().primary_monitor()),
-        }
-    }
-
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.create_proxy(); as EventLoopProxy)
     }
@@ -675,6 +646,35 @@ impl<T> EventLoopWindowTarget<T> {
             EventLoopWindowTarget::Wayland(_) => true,
             #[cfg(feature = "x11")]
             _ => false,
+        }
+    }
+
+    #[inline]
+    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
+        match *self {
+            #[cfg(feature = "wayland")]
+            EventLoopWindowTarget::Wayland(ref evlp) => evlp
+                .available_monitors()
+                .into_iter()
+                .map(MonitorHandle::Wayland)
+                .collect(),
+            #[cfg(feature = "x11")]
+            EventLoopWindowTarget::X(ref evlp) => evlp
+                .x_connection()
+                .available_monitors()
+                .into_iter()
+                .map(MonitorHandle::X)
+                .collect(),
+        }
+    }
+
+    #[inline]
+    pub fn primary_monitor(&self) -> MonitorHandle {
+        match *self {
+            #[cfg(feature = "wayland")]
+            EventLoopWindowTarget::Wayland(ref evlp) => MonitorHandle::Wayland(evlp.primary_monitor()),
+            #[cfg(feature = "x11")]
+            EventLoopWindowTarget::X(ref evlp) => MonitorHandle::X(evlp.x_connection().primary_monitor()),
         }
     }
 }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -258,10 +258,6 @@ impl<T: 'static> EventLoop<T> {
         &self.target
     }
 
-    pub(crate) fn x_connection(&self) -> &Arc<XConnection> {
-        get_xtarget(&self.target).x_connection()
-    }
-
     pub fn run_return<F>(&mut self, mut callback: F)
     where
         F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -34,6 +34,18 @@ impl<T> Default for EventLoopWindowTarget<T> {
     }
 }
 
+impl<T: 'static> EventLoopWindowTarget<T> {
+    #[inline]
+    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
+        monitor::available_monitors()
+    }
+
+    #[inline]
+    pub fn primary_monitor(&self) -> MonitorHandle {
+        monitor::primary_monitor()
+    }
+}
+
 pub struct EventLoop<T: 'static> {
     window_target: Rc<RootWindowTarget<T>>,
     _delegate: IdRef,
@@ -66,16 +78,6 @@ impl<T> EventLoop<T> {
             }),
             _delegate: delegate,
         }
-    }
-
-    #[inline]
-    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        monitor::available_monitors()
-    }
-
-    #[inline]
-    pub fn primary_monitor(&self) -> MonitorHandle {
-        monitor::primary_monitor()
     }
 
     pub fn window_target(&self) -> &RootWindowTarget<T> {

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -27,14 +27,6 @@ impl<T> EventLoop<T> {
         }
     }
 
-    pub fn available_monitors(&self) -> VecDequeIter<monitor::Handle> {
-        VecDeque::new().into_iter()
-    }
-
-    pub fn primary_monitor(&self) -> monitor::Handle {
-        monitor::Handle
-    }
-
     pub fn run<F>(self, mut event_handler: F) -> !
     where
         F: 'static

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -213,4 +213,12 @@ impl<T> WindowTarget<T> {
             });
         });
     }
+
+    pub fn available_monitors(&self) -> VecDequeIter<monitor::Handle> {
+        VecDeque::new().into_iter()
+    }
+
+    pub fn primary_monitor(&self) -> monitor::Handle {
+        monitor::Handle
+    }
 }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -1,9 +1,10 @@
-use super::{backend, device, proxy::Proxy, runner, window};
+use super::{backend, device, proxy::Proxy, runner, window, super::monitor};
 use crate::dpi::{PhysicalSize, Size};
 use crate::event::{DeviceId, ElementState, Event, KeyboardInput, TouchPhase, WindowEvent};
 use crate::event_loop::ControlFlow;
 use crate::window::{Theme, WindowId};
 use std::clone::Clone;
+use std::collections::{vec_deque::IntoIter as VecDequeIter, VecDeque};
 
 pub struct WindowTarget<T: 'static> {
     pub(crate) runner: runner::Shared<T>,

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -1,4 +1,4 @@
-use super::{backend, device, proxy::Proxy, runner, window, super::monitor};
+use super::{super::monitor, backend, device, proxy::Proxy, runner, window};
 use crate::dpi::{PhysicalSize, Size};
 use crate::event::{DeviceId, ElementState, Event, KeyboardInput, TouchPhase, WindowEvent};
 use crate::event_loop::ControlFlow;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -247,6 +247,15 @@ impl<T> EventLoopWindowTarget<T> {
             target_window: self.thread_msg_target,
         }
     }
+
+    // TODO: Investigate opportunities for caching
+    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
+        available_monitors()
+    }
+
+    pub fn primary_monitor(&self) -> MonitorHandle {
+        primary_monitor()
+    }
 }
 
 fn main_thread_id() -> DWORD {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -13,6 +13,7 @@ use std::{
     },
     thread,
     time::{Duration, Instant},
+    collections::VecDeque,
 };
 use winapi::shared::basetsd::{DWORD_PTR, UINT_PTR};
 
@@ -43,6 +44,7 @@ use crate::{
         wrap_device_id, WindowId, DEVICE_ID,
     },
     window::{Fullscreen, WindowId as RootWindowId},
+    monitor::MonitorHandle,
 };
 use runner::{EventLoopRunner, EventLoopRunnerShared};
 
@@ -859,8 +861,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                                 window_pos.cx = new_monitor_rect.right - new_monitor_rect.left;
                                 window_pos.cy = new_monitor_rect.bottom - new_monitor_rect.top;
                             }
-                            *fullscreen_monitor = crate::monitor::MonitorHandle {
-                                inner: monitor::MonitorHandle::new(new_monitor),
+                            *fullscreen_monitor = MonitorHandle {
+                                inner: MonitorHandle::new(new_monitor),
                             };
                         }
                     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -252,11 +252,11 @@ impl<T> EventLoopWindowTarget<T> {
 
     // TODO: Investigate opportunities for caching
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        available_monitors()
+        monitor::available_monitors()
     }
 
     pub fn primary_monitor(&self) -> MonitorHandle {
-        primary_monitor()
+        monitor::primary_monitor()
     }
 }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -4,6 +4,7 @@ mod runner;
 
 use parking_lot::Mutex;
 use std::{
+    collections::VecDeque,
     marker::PhantomData,
     mem, panic, ptr,
     rc::Rc,
@@ -13,7 +14,6 @@ use std::{
     },
     thread,
     time::{Duration, Instant},
-    collections::VecDeque,
 };
 use winapi::shared::basetsd::{DWORD_PTR, UINT_PTR};
 
@@ -34,6 +34,7 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{DeviceEvent, Event, Force, KeyboardInput, Touch, TouchPhase, WindowEvent},
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
+    monitor::MonitorHandle,
     platform_impl::platform::{
         dark_mode::try_dark_mode,
         dpi::{become_dpi_aware, dpi_to_scale_factor, enable_non_client_dpi_scaling},
@@ -44,7 +45,6 @@ use crate::{
         wrap_device_id, WindowId, DEVICE_ID,
     },
     window::{Fullscreen, WindowId as RootWindowId},
-    monitor::MonitorHandle,
 };
 use runner::{EventLoopRunner, EventLoopRunnerShared};
 
@@ -862,7 +862,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                                 window_pos.cy = new_monitor_rect.bottom - new_monitor_rect.top;
                             }
                             *fullscreen_monitor = MonitorHandle {
-                                inner: MonitorHandle::new(new_monitor),
+                                inner: monitor::MonitorHandle::new(new_monitor),
                             };
                         }
                     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -34,13 +34,13 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{DeviceEvent, Event, Force, KeyboardInput, Touch, TouchPhase, WindowEvent},
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
-    monitor::MonitorHandle,
     platform_impl::platform::{
         dark_mode::try_dark_mode,
         dpi::{become_dpi_aware, dpi_to_scale_factor, enable_non_client_dpi_scaling},
         drop_handler::FileDropHandler,
         event::{self, handle_extended_keys, process_key_params, vkey_to_winit_vkey},
-        monitor, raw_input, util,
+        monitor::{self, MonitorHandle},
+        raw_input, util,
         window_state::{CursorFlags, WindowFlags, WindowState},
         wrap_device_id, WindowId, DEVICE_ID,
     },
@@ -861,8 +861,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                                 window_pos.cx = new_monitor_rect.right - new_monitor_rect.left;
                                 window_pos.cy = new_monitor_rect.bottom - new_monitor_rect.top;
                             }
-                            *fullscreen_monitor = MonitorHandle {
-                                inner: monitor::MonitorHandle::new(new_monitor),
+                            *fullscreen_monitor = crate::monitor::MonitorHandle {
+                                inner: MonitorHandle::new(new_monitor),
                             };
                         }
                     }

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -127,14 +127,6 @@ pub fn current_monitor(hwnd: HWND) -> MonitorHandle {
 }
 
 impl<T> EventLoop<T> {
-    // TODO: Investigate opportunities for caching
-    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        available_monitors()
-    }
-
-    pub fn primary_monitor(&self) -> MonitorHandle {
-        primary_monitor()
-    }
 }
 
 impl Window {

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -126,9 +126,6 @@ pub fn current_monitor(hwnd: HWND) -> MonitorHandle {
     MonitorHandle::new(hmonitor)
 }
 
-impl<T> EventLoop<T> {
-}
-
 impl Window {
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         available_monitors()

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -11,7 +11,7 @@ use std::{
     io, mem, ptr,
 };
 
-use super::{util, EventLoop};
+use super::util;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},

--- a/src/window.rs
+++ b/src/window.rs
@@ -758,7 +758,7 @@ impl Window {
 
     /// Returns the list of all the monitors available on the system.
     ///
-    /// This is the same as `EventLoop::available_monitors`, and is provided for convenience.
+    /// This is the same as `EventLoopWindowTarget::available_monitors`, and is provided for convenience.
     ///
     /// ## Platform-specific
     ///
@@ -773,7 +773,7 @@ impl Window {
 
     /// Returns the primary monitor of the system.
     ///
-    /// This is the same as `EventLoop::primary_monitor`, and is provided for convenience.
+    /// This is the same as `EventLoopWindowTarget::primary_monitor`, and is provided for convenience.
     ///
     /// ## Platform-specific
     ///


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I only have Linux machines, so the other platforms where not tested. This should not change behaviour though.

Fix #1566 
