### PR TITLE
Fix Windows transparency behavior to support fully-opaque regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On Android, calling `WindowEvent::Focused` now works properly instead of always returning false. 
+- On Windows, fix bug preventing windows with transparency enabled from having fully-opaque regions.
 
 # 0.23.0 (2020-10-02)
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] `cargo doc` builds successfully
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR is primarily here to fix a downstream bug (https://github.com/alacritty/alacritty/issues/1927). Testing the transparency feature out on Windows (both via `examples/transparency.rs` and with a build of alacritty), I was unable to reproduce the issue described in the old comment in this code. I suppose it's possible that this only manifests on some configurations though (for completeness, I'm testing on a Windows 10 environment, though I cross-compiled things on a Linux box using GNU tools). To be on the safe side, it might make sense for other people with access to a Windows environment to double check that this doesn't regress anything.

In addition, I removed a couple of redundant bits in the Windows API calls (see the description below).

---
*Original commit message follows:*

This patch removes an unneeded workaround for transparent windows on the Windows platform. In addition, it simplifies a couple of related API calls:

* Remove the `CreateRectRgn` call, since we want the entire window's region to have blur behind it, and `DwnEnableBlurBehindWindow` does that by default.
* Remove the `color_key` for `SetLayeredWindowAttributes`, since it's not used (we're not passing `winuser::LWA_COLORKEY` to the flags).