### PR TITLE
android: don't panic if ANativeWindow handle is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - On Windows, `set_ime_position` is now a no-op instead of a runtime crash.
 - On Android, `set_fullscreen` is now a no-op instead of a runtime crash.
 - On iOS and Android, `set_inner_size` is now a no-op instead of a runtime crash.
+- On Android, the native window handle returned by `raw_window_handle` might be null instead of panicking
 - **Breaking:** On Web, `set_cursor_position` and `set_cursor_grab` will now always return an error.
 - **Breaking:** `PixelDelta` scroll events now return a `PhysicalPosition`.
 


### PR DESCRIPTION
**Change:** Return null-ptr instead of panic if the ANativeWindow handle is not available when requesting the RawWindowHandle

`ash-window` provides functionality for enumerating the required extensions based on the RawWindowHandle which would be happen before Instance creation in Vulkan. At this point, usually the ANativeWindow will not be available, which causes a panic.


- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
