### PR TITLE
Change linking of CGDisplayCreateUUIDFromDisplayID on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,13 @@ fn main() {
 ```
 
 And run the application with `cargo apk run --example request_redraw_threaded`
+
+#### MacOS
+
+To ensure compatibility with older MacOS systems, winit links to
+CGDisplayCreateUUIDFromDisplayID through the CoreGraphics framework.
+However, under certain setups this function is only available to be linked
+through the newer ColorSync framework. So, winit provides the
+`WINIT_LINK_COLORSYNC` environment variable which can be set to `1` or `true` 
+while compiling to enable linking via ColorSync.
+

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    // If building for macos and WINIT_LINK_COLORSYNC is set to true
+    // use CGDisplayCreateUUIDFromDisplayID from ColorSync instead of CoreGraphics
+    if std::env::var("CARGO_CFG_TARGET_OS").map_or(false, |os| os == "macos")
+        && std::env::var("WINIT_LINK_COLORSYNC")
+            .map_or(false, |v| v == "1" || v.eq_ignore_ascii_case("true"))
+    {
+        println!("cargo:rustc-cfg=use_colorsync_cgdisplaycreateuuidfromdisplayid");
+    }
+}

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -161,6 +161,11 @@ pub const IO8BitOverlayPixels: &str = "O8";
 pub type CGWindowLevel = i32;
 pub type CGDisplayModeRef = *mut libc::c_void;
 
+#[link(name = "ColorSync", kind = "framework")]
+extern "C" {
+    pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
+}
+
 #[link(name = "CoreGraphics", kind = "framework")]
 extern "C" {
     pub fn CGRestorePermanentDisplayConfiguration();
@@ -189,7 +194,6 @@ extern "C" {
         synchronous: Boolean,
     ) -> CGError;
     pub fn CGReleaseDisplayFadeReservation(token: CGDisplayFadeReservationToken) -> CGError;
-    pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
     pub fn CGShieldingWindowLevel() -> CGWindowLevel;
     pub fn CGDisplaySetDisplayMode(
         display: CGDirectDisplayID,

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -161,7 +161,14 @@ pub const IO8BitOverlayPixels: &str = "O8";
 pub type CGWindowLevel = i32;
 pub type CGDisplayModeRef = *mut libc::c_void;
 
-#[link(name = "ColorSync", kind = "framework")]
+#[cfg_attr(
+    not(use_colorsync_cgdisplaycreateuuidfromdisplayid),
+    link(name = "CoreGraphics", kind = "framework")
+)]
+#[cfg_attr(
+    use_colorsync_cgdisplaycreateuuidfromdisplayid,
+    link(name = "ColorSync", kind = "framework")
+)]
 extern "C" {
     pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
 }


### PR DESCRIPTION
This fixes an issue where cross compilation to macos was failing in our CI.

the error we were getting is
```
error: linking with `/dockercache/osxcross/target/bin/x86_64-apple-darwin17-clang` failed: exit code: 1
  |
  = note: "/dockercache/osxcross/target/bin/x86_64-apple-darwin17-clang" "-m64" "-L" "/root/.rustup/toolchains/nightly-2020-06-22-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-apple-darwin/lib" "-L" "/root/.rustup/toolchains/nightly-2020-06-22-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-apple-darwin/lib/self-contained" "/builds/veloren/veloren/target/x86_64-apple-darwin/release/deps/veloren_voxygen.veloren_voxygen.7quxxn1k-cgu.4.rcgu.o" "-o" "/builds/veloren/veloren/target/x86_64-apple-darwin/release/deps/veloren_voxygen" "-Wl,-dead_strip" "-nodefaultlibs" "-L" "/builds/veloren/veloren/target/x86_64-apple-darwin/release/deps" "-L" "/builds/veloren/veloren/target/release/deps" "-L" "/builds/veloren/veloren/target/x86_64-apple-darwin/release/build/ring-2aacac616f7faeea/out" "-L" "/builds/veloren/veloren/target/x86_64-apple-darwin/release/build/libsqlite3-sys-1d15bda449b01580/out" "-L" "/root/.rustup/toolchains/nightly-2020-06-22-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-apple-darwin/lib" "/tmp/rustcfFquQR/liblibsqlite3_sys-82177fd657bac30b.rlib" "/tmp/rustcfFquQR/libring-72c42f30f281984c.rlib" "/tmp/rustcfFquQR/libbacktrace_sys-63abd5899e0d7e6b.rlib" "/root/.rustup/toolchains/nightly-2020-06-22-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-apple-darwin/lib/libcompiler_builtins-e166c2d904273814.rlib" "-framework" "AppKit" "-framework" "AppKit" "-framework" "Foundation" "-framework" "Foundation" "-framework" "QuartzCore" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-lSystem" "-framework" "OpenGL" "-framework" "Security" "-framework" "CoreGraphics" "-framework" "CoreFoundation" "-lSystem" "-framework" "CoreVideo" "-framework" "AppKit" "-framework" "AppKit" "-framework" "Foundation" "-framework" "Foundation" "-framework" "QuartzCore" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreGraphics" "-framework" "CoreFoundation" "-framework" "IOKit" "-framework" "CoreFoundation" "-framework" "AudioUnit" "-framework" "CoreAudio" "-framework" "Security" "-framework" "CoreServices" "-framework" "CoreServices" "-framework" "AppKit" "-framework" "Foundation" "-lSystem" "-lobjc" "-lSystem" "-lresolv" "-lc" "-lm"
  = note: ld: warning: directory not found for option '-L/root/.rustup/toolchains/nightly-2020-06-22-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-apple-darwin/lib/self-contained'
          Undefined symbols for architecture x86_64:
            "_CGDisplayCreateUUIDFromDisplayID", referenced from:
                winit::window::Window::set_fullscreen::h0862d839c2379539 in veloren_voxygen.veloren_voxygen.7quxxn1k-cgu.4.rcgu.o
                winit::platform_impl::platform::window::UnownedWindow::new::hd640451e51837ba2 in veloren_voxygen.veloren_voxygen.7quxxn1k-cgu.4.rcgu.o
                _$LT$winit..window..Window$u20$as$u20$core..ops..drop..Drop$GT$::drop::h502664d3c6f4fdff in veloren_voxygen.veloren_voxygen.7quxxn1k-cgu.4.rcgu.o
                winit::platform_impl::platform::window::UnownedWindow::set_fullscreen::hd2d38c24de2b5e7d in veloren_voxygen.veloren_voxygen.7quxxn1k-cgu.4.rcgu.o
                winit::platform_impl::platform::monitor::MonitorHandle::ns_screen::h33221360728abfd3 in veloren_voxygen.veloren_voxygen.7quxxn1k-cgu.4.rcgu.o
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
The CI is setup using `10.13` from https://github.com/phracker/MacOSX-SDKs
The relevant docker file is here https://gitlab.com/veloren/veloren-docker-ci/-/blob/master/base/Dockerfile
The cross compilation was setup using this guide https://wapl.es/rust/2019/02/17/rust-cross-compile-linux-to-macos.html

I don't know enough to tell whether this change will impact regular users. However, we have had two macos users able to build with this change without any issues.

Please let me know if there is a better way to fix this :slightly_smiling_face:

- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
