### PR TITLE
Renamed NSString to NSStringRust to support Debug View Heirarchy in Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On iOS `NSString` was renamed to `NSStringRust` to support the "Debug View Heirarchy" feature of Xcode.
 - On all platforms, `available_monitors` and `primary_monitor` are now on `EventLoopWindowTarget` rather than `EventLoop` to list monitors event in the event loop.
 - On Unix, X11 and Wayland are now optional features (enabled by default)
 - On X11, fix deadlock when calling `set_fullscreen_inner`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- On iOS `NSString` was renamed to `NSStringRust` to support the "Debug View Heirarchy" feature of Xcode.
+- On iOS, fixed support for the "Debug View Heirarchy" feature in Xcode.
 - On all platforms, `available_monitors` and `primary_monitor` are now on `EventLoopWindowTarget` rather than `EventLoop` to list monitors event in the event loop.
 - On Unix, X11 and Wayland are now optional features (enabled by default)
 - On X11, fix deadlock when calling `set_fullscreen_inner`.

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -24,7 +24,8 @@ use crate::platform_impl::platform::{
         CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddSource, CFRunLoopGetMain,
         CFRunLoopObserverCreate, CFRunLoopObserverRef, CFRunLoopSourceContext,
         CFRunLoopSourceCreate, CFRunLoopSourceInvalidate, CFRunLoopSourceRef,
-        CFRunLoopSourceSignal, CFRunLoopWakeUp, NSString, UIApplicationMain, UIUserInterfaceIdiom,
+        CFRunLoopSourceSignal, CFRunLoopWakeUp, NSStringRust, UIApplicationMain,
+        UIUserInterfaceIdiom,
     },
     monitor, view, MonitorHandle,
 };
@@ -117,7 +118,7 @@ impl<T: 'static> EventLoop<T> {
                 0,
                 ptr::null(),
                 nil,
-                NSString::alloc(nil).init_str("AppDelegate"),
+                NSStringRust::alloc(nil).init_str("AppDelegate"),
             );
             unreachable!()
         }

--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -359,6 +359,9 @@ pub struct CFRunLoopSourceContext {
     pub perform: Option<extern "C" fn(*mut c_void)>,
 }
 
+// This is named NSStringRust rather than NSString because the "Debug View Heirarchy" feature of
+// Xcode requires a non-ambiguous reference to NSString for unclear reasons. This makes Xcode happy
+// so please test if you change the name back to NSString.
 pub trait NSStringRust: Sized {
     unsafe fn alloc(_: Self) -> id {
         msg_send![class!(NSString), alloc]

--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -359,7 +359,7 @@ pub struct CFRunLoopSourceContext {
     pub perform: Option<extern "C" fn(*mut c_void)>,
 }
 
-pub trait NSString: Sized {
+pub trait NSStringRust: Sized {
     unsafe fn alloc(_: Self) -> id {
         msg_send![class!(NSString), alloc]
     }
@@ -370,7 +370,7 @@ pub trait NSString: Sized {
     unsafe fn UTF8String(self) -> *const c_char;
 }
 
-impl NSString for id {
+impl NSStringRust for id {
     unsafe fn initWithUTF8String_(self, c_string: *const c_char) -> id {
         msg_send![self, initWithUTF8String: c_string as id]
     }


### PR DESCRIPTION
Hi Friends,

I'm messing around with adding UIKit bindings to iced. Anyway, one of the things that I think myself (and others) will want is the ability to use the [Debug View Heirarchy](https://developer.apple.com/library/archive/documentation/ToolsLanguages/Conceptual/Xcode_Overview/ExaminingtheViewHierarchy.html
) feature in Xcode. Under normal conditions, when I attach to the process in Xcode and push the "Debug View Heirarchy" button I get this:

```
Error:    Unable to Capture View Hierarchy.
Details:  Log Title: Data source expression execution failure.
Log Details: error evaluating expression “(id)[[(Class)objc_getClass("DBGTargetHub") sharedHub] performRequestWithRequestInBase64:@"…"]”: error: <user expression 4>:1:89: reference to 'NSString' is ambiguous
note: candidate found by name lookup is 'NSString'

note: candidate found by name lookup is 'winit::platform_impl::platform::ffi::NSString'


Log Method: -[DBGDataSourceConnectionLibViewDebugger _executeLLDBExpression:forRequest:onPotentialThread:iteration:]_block_invoke
Method:   -[DBGViewDebugger _initiateInitialRequestWithDataSourceVersion:]_block_invoke
Environment: Xcode 11.5 (11E608c) debugging iPhone SE (2nd generation) iOS Simulator 13.5 (17F61).
Please file a bug at https://feedbackassistant.apple.com with this warning message and any useful information you can provide.
(lldb)
```

While, I could have tried to submit a bug report to Apple as the message suggested, I took a while guess that maybe the NSString symbol was the issue so I renamed `NSString` to `NSStringRust` and to my surprise it worked.

![image](https://user-images.githubusercontent.com/1163510/88437340-23b71180-cdbb-11ea-8f72-9fc6c6ee3d45.png)

There's something magic and probably bad happening on the Xcode debugging tooling side but eh.

I've got mixed feelings about `NSStringRust` but don't know what else to call it. Thoughts?

- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
