### PR TITLE
android: fix event loop polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - On Windows, `set_ime_position` is now a no-op instead of a runtime crash.
 - On Android, `set_fullscreen` is now a no-op instead of a runtime crash.
 - On iOS and Android, `set_inner_size` is now a no-op instead of a runtime crash.
+- On Android, fix `ControlFlow::Poll` not polling the Android event queue.
 - **Breaking:** On Web, `set_cursor_position` and `set_cursor_grab` will now always return an error.
 - **Breaking:** `PixelDelta` scroll events now return a `PhysicalPosition`.
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -211,9 +211,7 @@ impl<T: 'static> EventLoop<T> {
                         );
                     }
                 }
-                None => {
-                    control_flow = ControlFlow::Exit;
-                }
+                None => {}
             }
 
             call_event_handler!(
@@ -258,6 +256,11 @@ impl<T: 'static> EventLoop<T> {
                     break 'event_loop;
                 }
                 ControlFlow::Poll => {
+                    self.first_event = poll(
+                        self.looper
+                            .poll_all_timeout(Duration::from_millis(0))
+                            .unwrap(),
+                    );
                     self.start_cause = event::StartCause::Poll;
                 }
                 ControlFlow::Wait => {


### PR DESCRIPTION
- Poll looper for `ControlFlow::Poll`, currently it won't progress in this case
- Don't exit the EventLoop when no new event has been polled from the Looper, which causes the program to instantly exit

fixes https://github.com/rust-windowing/winit/issues/1636

cc @VZout 

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
