### PR TITLE
🍏 iOS threading, initial work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ ndk-glue = "0.1.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 objc = "0.2.3"
+dispatch = "0.2.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.20"

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -174,7 +174,7 @@ impl MonitorHandle {
         unsafe {
             let () = msg_send![uiscreen, retain];
         }
-        
+
         MonitorHandle {
             inner: Inner { uiscreen },
         }

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -129,22 +129,12 @@ impl Deref for MonitorHandle {
     type Target = Inner;
 
     fn deref(&self) -> &Inner {
-        unsafe {
-            assert_main_thread!(
-                "`MonitorHandle` methods can only be run on the main thread on iOS"
-            );
-        }
         &self.inner
     }
 }
 
 impl DerefMut for MonitorHandle {
     fn deref_mut(&mut self) -> &mut Inner {
-        unsafe {
-            assert_main_thread!(
-                "`MonitorHandle` methods can only be run on the main thread on iOS"
-            );
-        }
         &mut self.inner
     }
 }
@@ -155,14 +145,6 @@ unsafe impl Sync for MonitorHandle {}
 impl Clone for MonitorHandle {
     fn clone(&self) -> MonitorHandle {
         MonitorHandle::retained_new(self.uiscreen)
-    }
-}
-
-impl Drop for MonitorHandle {
-    fn drop(&mut self) {
-        unsafe {
-            assert_main_thread!("`MonitorHandle` can only be dropped on the main thread on iOS");
-        }
     }
 }
 
@@ -190,9 +172,9 @@ impl fmt::Debug for MonitorHandle {
 impl MonitorHandle {
     pub fn retained_new(uiscreen: id) -> MonitorHandle {
         unsafe {
-            assert_main_thread!("`MonitorHandle` can only be cloned on the main thread on iOS");
             let () = msg_send![uiscreen, retain];
         }
+        
         MonitorHandle {
             inner: Inner { uiscreen },
         }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -315,7 +315,7 @@ impl Deref for Window {
     type Target = Inner;
 
     fn deref(&self) -> &Inner {
-       &self.inner
+        &self.inner
     }
 }
 
@@ -550,7 +550,7 @@ impl Inner {
         Queue::main().exec_sync(move || {
             let window: id = *window;
             let bounds: CGRect = msg_send![window, bounds];
-            
+
             if app_state::os_capabilities().safe_area {
                 let safe_area: UIEdgeInsets = msg_send![window, safeAreaInsets];
                 let safe_bounds = CGRect {


### PR DESCRIPTION
The way our event loop works on iOS is that we call `run` and process all the windowing events on another thread (we send them over an mpsc channel). However, on iOS a lot of things need to happen on the main thread as documented / asserted in winit.

This follows along with some of the macOS code and uses Grand Central Dispatch to move the execution of some of these code blocks back to the main thread.

This doesn't remove all the asserts, nor does it fix all the cases, however I've moved over enough for our internal use-case.

 - [x] Tested on all platforms changed
 - [x] Compilation warnings were addressed
 - [x] cargo fmt has been run on this branch
 - [x] cargo doc builds successfully
 - [ ] Added an entry to CHANGELOG.md if knowledge of this change could be valuable to users
 - [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
 - [ ] Created or updated an example program if it would help users understand this functionality
 - [ ] Updated feature matrix, if new features were added or implemented
