### PR TITLE
Detect change of devicePixelRatio (hidpi scaling) on web target

### DIFF
--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -226,14 +226,18 @@ impl<T> WindowTarget<T> {
             let logical_size = current_size.to_logical::<f64>(old_dpr);
             let new_size = logical_size.to_physical(new_dpr);
 
-            web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
-                "devicePixelRatio changed from {:?} to {:?}",
-                old_dpr, new_dpr,
-            )));
-            web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
-                "old size {:?} -> new size {:?}",
-                current_size, new_size,
-            )));
+            // TODO: Remove debugging output
+            #[cfg(feature = "web-sys")]
+            {
+                web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+                    "devicePixelRatio changed from {:?} to {:?}",
+                    old_dpr, new_dpr,
+                )));
+                web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+                    "old size {:?} -> new size {:?}",
+                    current_size, new_size,
+                )));
+            }
 
             backend::set_canvas_size(&raw, Size::Physical(new_size));
 
@@ -252,7 +256,7 @@ impl<T> WindowTarget<T> {
             });
             runner.request_redraw(WindowId(id));
             old_dpr = new_dpr;
-        })
+        });
     }
 
     pub fn available_monitors(&self) -> VecDequeIter<monitor::Handle> {

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -246,6 +246,10 @@ impl<T> WindowTarget<T> {
                     new_inner_size: size,
                 },
             });
+            runner.send_event(Event::WindowEvent {
+                window_id: WindowId(id),
+                event: WindowEvent::Resized(new_size),
+            });
             runner.request_redraw(WindowId(id));
             old_dpr = new_dpr;
         })

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -260,6 +260,13 @@ impl Canvas {
         }
     }
 
+    pub fn on_device_pixel_ratio_change<F>(&mut self, handler: F)
+    where
+        F: 'static + FnMut(),
+    {
+        // TODO: Stub, unimplemented (see web_sys for reference).
+    }
+
     fn add_event<E, F>(&self, mut handler: F) -> EventListenerHandle
     where
         E: ConcreteEvent,


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


The WASM web target did not handle change of the `devicePixelRatio` (changing the browser zoom level also causes it to change). This results in the canvas becoming wonky.

The change of `devicePixelRatio` can be detected using a `MediaQueryList`, so this is what I used. The tricky part is that a media query can only be used to detect whether a specific `devicePixelRatio` matches, which means a new `MediaQueryList` will be needed whenever the scaling has changed. I added a helper type `DevicePixelRatioChangeDetector` to manage this.

### Outstanding issues:

- [ ] Remove `console.log` debug messages
- [ ] Properly handle the `new_inner_size` field in `WindowEvent::ScaleFactorChanged`
    I have no idea how it should be handled.
- [ ] ~~Fix issue where canvas become blurry at certain scales?
    It seems that whenever the CSS width/height in pixels is not an integer, the canvas becomes blurry in that dimension (e.g. when `devicePixelRatio == 1.3333333333333333` and the physical width is `1067`, the CSS width becomes `800.25` and the rendering is somehow not aligned to the physical pixels). I do wonder if it is more appropriate to handle this in a separate PR.  
Edit: I just realized that this is probably due to `winit` not firing `WindowEvent::Resized` events that could be causing some of the UI code to lay out things incorrectly. However I don't believe this is the only reason.~~
Edit 2: False alarm, after adding `WindowEvent::Resized` it seems to work fine.
- [ ] ~~Also make the change for `stdweb`~~
    Would be nice if someone else can do it as I really don't know if I can make the change correctly for `stdweb`. ~~Is there a possibility for this change to be implemented for `web-sys` only at first and stub out the `stdweb` side and fix it later in a separate PR?~~
- [x] Stubbed out for `stdweb`.

This change is incomplete but functionally working on `web-sys`. I would really like some comments and pointers.