### PR TITLE
Impl. page CSS layout-based canvas sizing (web-sys)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc", "i686-unknown-linux
 
 [features]
 default = ["x11", "wayland"]
-web-sys = ["web_sys", "wasm-bindgen", "instant/wasm-bindgen"]
+web-sys = ["web_sys", "js-sys", "wasm-bindgen", "instant/wasm-bindgen"]
 stdweb = ["std_web", "instant/stdweb"]
 x11 = ["x11-dl"]
 wayland = ["wayland-client", "smithay-client-toolkit"]
@@ -116,6 +116,10 @@ features = [
     'Window',
     'WheelEvent'
 ]
+
+[target.'cfg(target_arch = "wasm32")'.dependencies.js-sys]
+version = "0.3.22"
+optional = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
 version = "0.2.45"

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -47,6 +47,7 @@ impl WindowBuilderExtStdweb for WindowBuilder {
 #[cfg(feature = "web-sys")]
 pub trait WindowBuilderExtWebSys {
     fn with_canvas(self, canvas: Option<HtmlCanvasElement>) -> Self;
+    fn with_auto_parent_size(self) -> Self;
 }
 
 #[cfg(feature = "web-sys")]
@@ -54,6 +55,11 @@ impl WindowBuilderExtWebSys for WindowBuilder {
     fn with_canvas(mut self, canvas: Option<HtmlCanvasElement>) -> Self {
         self.platform_specific.canvas = canvas;
 
+        self
+    }
+
+    fn with_auto_parent_size(mut self) -> Self {
+        self.platform_specific.auto_parent_size = true;
         self
     }
 }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -226,14 +226,18 @@ impl<T> WindowTarget<T> {
             let logical_size = current_size.to_logical::<f64>(old_dpr);
             let new_size = logical_size.to_physical(new_dpr);
 
-            web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
-                "devicePixelRatio changed from {:?} to {:?}",
-                old_dpr, new_dpr,
-            )));
-            web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
-                "old size {:?} -> new size {:?}",
-                current_size, new_size,
-            )));
+            // TODO: Remove debugging output
+            #[cfg(feature = "web-sys")]
+            {
+                web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+                    "devicePixelRatio changed from {:?} to {:?}",
+                    old_dpr, new_dpr,
+                )));
+                web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+                    "old size {:?} -> new size {:?}",
+                    current_size, new_size,
+                )));
+            }
 
             backend::set_canvas_size(&raw, Size::Physical(new_size));
 
@@ -252,7 +256,7 @@ impl<T> WindowTarget<T> {
             });
             runner.request_redraw(WindowId(id));
             old_dpr = new_dpr;
-        })
+        });
     }
 
     pub fn available_monitors(&self) -> VecDequeIter<monitor::Handle> {

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -265,6 +265,8 @@ impl<T> WindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_size_or_scale_change(move |args| {
             if args.changed_flag == CanvasResizeChangedFlag::SizeAndDevicePixelRatioChanged {
+                // TODO: Remove debugging output
+                #[cfg(feature = "web-sys")]
                 web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
                     "devicePixelRatio changed to {:?}",
                     args.device_pixel_ratio
@@ -279,6 +281,7 @@ impl<T> WindowTarget<T> {
                     },
                 });
             }
+            #[cfg(feature = "web-sys")]
             web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(
                 &format!("canvas resized",),
             ));

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -246,6 +246,10 @@ impl<T> WindowTarget<T> {
                     new_inner_size: size,
                 },
             });
+            runner.send_event(Event::WindowEvent {
+                window_id: WindowId(id),
+                event: WindowEvent::Resized(new_size),
+            });
             runner.request_redraw(WindowId(id));
             old_dpr = new_dpr;
         })

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -46,3 +46,16 @@ pub use self::window::{
 };
 
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum CanvasResizeChangedFlag {
+    SizeChanged,
+    SizeAndDevicePixelRatioChanged,
+}
+
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub(crate) struct CanvasResizedArgs {
+    pub(crate) size: crate::dpi::PhysicalSize<u32>,
+    pub(crate) device_pixel_ratio: f64,
+    pub(crate) changed_flag: CanvasResizeChangedFlag,
+}

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -260,6 +260,13 @@ impl Canvas {
         }
     }
 
+    pub fn on_device_pixel_ratio_change<F>(&mut self, handler: F)
+    where
+        F: 'static + FnMut(),
+    {
+        // TODO: Stub, unimplemented (see web_sys for reference).
+    }
+
     fn add_event<E, F>(&self, mut handler: F) -> EventListenerHandle
     where
         E: ConcreteEvent,

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -2,7 +2,7 @@ use super::event;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
 use crate::event::{ModifiersState, MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode};
-use crate::platform_impl::{OsError, PlatformSpecificWindowBuilderAttributes};
+use crate::platform_impl::{CanvasResizedArgs, OsError, PlatformSpecificWindowBuilderAttributes};
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -263,6 +263,13 @@ impl Canvas {
     pub fn on_device_pixel_ratio_change<F>(&mut self, handler: F)
     where
         F: 'static + FnMut(),
+    {
+        // TODO: Stub, unimplemented (see web_sys for reference).
+    }
+
+    pub(crate) fn on_size_or_scale_change<F>(&mut self, handler: F)
+    where
+        F: 'static + FnMut(CanvasResizedArgs),
     {
         // TODO: Stub, unimplemented (see web_sys for reference).
     }

--- a/src/platform_impl/web/web_sys/bindings.rs
+++ b/src/platform_impl/web/web_sys/bindings.rs
@@ -1,0 +1,35 @@
+// #[cfg(feature = "ResizeObservation")]
+#[allow(non_snake_case)]
+mod gen_ResizeObservation;
+// #[cfg(feature = "ResizeObservation")]
+pub use gen_ResizeObservation::*;
+
+// #[cfg(feature = "ResizeObserver")]
+#[allow(non_snake_case)]
+mod gen_ResizeObserver;
+// #[cfg(feature = "ResizeObserver")]
+pub use gen_ResizeObserver::*;
+
+// #[cfg(feature = "ResizeObserverBoxOptions")]
+#[allow(non_snake_case)]
+mod gen_ResizeObserverBoxOptions;
+// #[cfg(feature = "ResizeObserverBoxOptions")]
+pub use gen_ResizeObserverBoxOptions::*;
+
+// #[cfg(feature = "ResizeObserverEntry")]
+#[allow(non_snake_case)]
+mod gen_ResizeObserverEntry;
+// #[cfg(feature = "ResizeObserverEntry")]
+pub use gen_ResizeObserverEntry::*;
+
+// #[cfg(feature = "ResizeObserverOptions")]
+#[allow(non_snake_case)]
+mod gen_ResizeObserverOptions;
+// #[cfg(feature = "ResizeObserverOptions")]
+pub use gen_ResizeObserverOptions::*;
+
+// #[cfg(feature = "ResizeObserverSize")]
+#[allow(non_snake_case)]
+mod gen_ResizeObserverSize;
+// #[cfg(feature = "ResizeObserverSize")]
+pub use gen_ResizeObserverSize::*;

--- a/src/platform_impl/web/web_sys/bindings/gen_ResizeObservation.rs
+++ b/src/platform_impl/web/web_sys/bindings/gen_ResizeObservation.rs
@@ -1,0 +1,38 @@
+#![allow(unused_imports)]
+use super::*;
+use wasm_bindgen::prelude::*;
+use web_sys::*;
+#[wasm_bindgen]
+extern "C" {
+    # [ wasm_bindgen ( extends = :: js_sys :: Object , js_name = ResizeObservation , typescript_type = "ResizeObservation" ) ]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `ResizeObservation` class."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObservation)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObservation`*"]
+    pub type ResizeObservation;
+    // #[cfg(feature = "Element")]
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObservation" , js_name = target ) ]
+    #[doc = "Getter for the `target` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObservation/target)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Element`, `ResizeObservation`*"]
+    pub fn target(this: &ResizeObservation) -> Element;
+    // #[cfg(feature = "ResizeObserverBoxOptions")]
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObservation" , js_name = observedBox ) ]
+    #[doc = "Getter for the `observedBox` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObservation/observedBox)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObservation`, `ResizeObserverBoxOptions`*"]
+    pub fn observed_box(this: &ResizeObservation) -> ResizeObserverBoxOptions;
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObservation" , js_name = lastReportedSizes ) ]
+    #[doc = "Getter for the `lastReportedSizes` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObservation/lastReportedSizes)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObservation`*"]
+    pub fn last_reported_sizes(this: &ResizeObservation) -> ::js_sys::Array;
+}

--- a/src/platform_impl/web/web_sys/bindings/gen_ResizeObserver.rs
+++ b/src/platform_impl/web/web_sys/bindings/gen_ResizeObserver.rs
@@ -1,0 +1,57 @@
+#![allow(unused_imports)]
+use super::*;
+use wasm_bindgen::prelude::*;
+use web_sys::*;
+#[wasm_bindgen]
+extern "C" {
+    # [ wasm_bindgen ( extends = :: js_sys :: Object , js_name = ResizeObserver , typescript_type = "ResizeObserver" ) ]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `ResizeObserver` class."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserver`*"]
+    pub type ResizeObserver;
+    #[wasm_bindgen(catch, constructor, js_class = "ResizeObserver")]
+    #[doc = "The `new ResizeObserver(..)` constructor, creating a new instance of `ResizeObserver`."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserver`*"]
+    pub fn new(callback: &::js_sys::Function) -> Result<ResizeObserver, JsValue>;
+    # [ wasm_bindgen ( method , structural , js_class = "ResizeObserver" , js_name = disconnect ) ]
+    #[doc = "The `disconnect()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/disconnect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserver`*"]
+    pub fn disconnect(this: &ResizeObserver);
+    // #[cfg(feature = "Element")]
+    # [ wasm_bindgen ( catch , method , structural , js_class = "ResizeObserver" , js_name = observe ) ]
+    #[doc = "The `observe()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Element`, `ResizeObserver`*"]
+    pub fn observe(this: &ResizeObserver, target: &Element) -> Result<(), JsValue>;
+    // #[cfg(all(feature = "Element", feature = "ResizeObserverOptions",))]
+    # [ wasm_bindgen ( catch , method , structural , js_class = "ResizeObserver" , js_name = observe ) ]
+    #[doc = "The `observe()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/observe)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Element`, `ResizeObserver`, `ResizeObserverOptions`*"]
+    pub fn observe_with_options(
+        this: &ResizeObserver,
+        target: &Element,
+        options: &ResizeObserverOptions,
+    ) -> Result<(), JsValue>;
+    // #[cfg(feature = "Element")]
+    # [ wasm_bindgen ( method , structural , js_class = "ResizeObserver" , js_name = unobserve ) ]
+    #[doc = "The `unobserve()` method."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/unobserve)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Element`, `ResizeObserver`*"]
+    pub fn unobserve(this: &ResizeObserver, target: &Element);
+}

--- a/src/platform_impl/web/web_sys/bindings/gen_ResizeObserverBoxOptions.rs
+++ b/src/platform_impl/web/web_sys/bindings/gen_ResizeObserverBoxOptions.rs
@@ -1,0 +1,12 @@
+#![allow(unused_imports)]
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+#[doc = "The `ResizeObserverBoxOptions` enum."]
+#[doc = ""]
+#[doc = "*This API requires the following crate features to be activated: `ResizeObserverBoxOptions`*"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResizeObserverBoxOptions {
+    BorderBox = "border-box",
+    ContentBox = "content-box",
+    DevicePixelContentBox = "device-pixel-content-box",
+}

--- a/src/platform_impl/web/web_sys/bindings/gen_ResizeObserverEntry.rs
+++ b/src/platform_impl/web/web_sys/bindings/gen_ResizeObserverEntry.rs
@@ -1,0 +1,52 @@
+#![allow(unused_imports)]
+use super::*;
+use wasm_bindgen::prelude::*;
+use web_sys::*;
+#[wasm_bindgen]
+extern "C" {
+    # [ wasm_bindgen ( extends = :: js_sys :: Object , js_name = ResizeObserverEntry , typescript_type = "ResizeObserverEntry" ) ]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `ResizeObserverEntry` class."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverEntry`*"]
+    pub type ResizeObserverEntry;
+    // #[cfg(feature = "Element")]
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObserverEntry" , js_name = target ) ]
+    #[doc = "Getter for the `target` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/target)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `Element`, `ResizeObserverEntry`*"]
+    pub fn target(this: &ResizeObserverEntry) -> Element;
+    // #[cfg(feature = "DomRectReadOnly")]
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObserverEntry" , js_name = contentRect ) ]
+    #[doc = "Getter for the `contentRect` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/contentRect)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `DomRectReadOnly`, `ResizeObserverEntry`*"]
+    pub fn content_rect(this: &ResizeObserverEntry) -> DomRectReadOnly;
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObserverEntry" , js_name = borderBoxSize ) ]
+    #[doc = "Getter for the `borderBoxSize` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/borderBoxSize)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverEntry`*"]
+    pub fn border_box_size(this: &ResizeObserverEntry) -> ::js_sys::Array;
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObserverEntry" , js_name = contentBoxSize ) ]
+    #[doc = "Getter for the `contentBoxSize` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/contentBoxSize)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverEntry`*"]
+    pub fn content_box_size(this: &ResizeObserverEntry) -> ::js_sys::Array;
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObserverEntry" , js_name = devicePixelContentBoxSize ) ]
+    #[doc = "Getter for the `devicePixelContentBoxSize` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverEntry/devicePixelContentBoxSize)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverEntry`*"]
+    pub fn device_pixel_content_box_size(this: &ResizeObserverEntry) -> ::js_sys::Array;
+}

--- a/src/platform_impl/web/web_sys/bindings/gen_ResizeObserverOptions.rs
+++ b/src/platform_impl/web/web_sys/bindings/gen_ResizeObserverOptions.rs
@@ -1,0 +1,36 @@
+#![allow(unused_imports)]
+use super::*;
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+extern "C" {
+    # [ wasm_bindgen ( extends = :: js_sys :: Object , js_name = ResizeObserverOptions ) ]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `ResizeObserverOptions` dictionary."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverOptions`*"]
+    pub type ResizeObserverOptions;
+}
+impl ResizeObserverOptions {
+    #[doc = "Construct a new `ResizeObserverOptions`."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverOptions`*"]
+    pub fn new() -> Self {
+        #[allow(unused_mut)]
+        let mut ret: Self = ::wasm_bindgen::JsCast::unchecked_into(::js_sys::Object::new());
+        ret
+    }
+    // #[cfg(feature = "ResizeObserverBoxOptions")]
+    #[doc = "Change the `box` field of this object."]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverBoxOptions`, `ResizeObserverOptions`*"]
+    pub fn box_(&mut self, val: ResizeObserverBoxOptions) -> &mut Self {
+        use wasm_bindgen::JsValue;
+        let r = ::js_sys::Reflect::set(self.as_ref(), &JsValue::from("box"), &JsValue::from(val));
+        debug_assert!(
+            r.is_ok(),
+            "setting properties should never fail on our dictionary objects"
+        );
+        let _ = r;
+        self
+    }
+}

--- a/src/platform_impl/web/web_sys/bindings/gen_ResizeObserverSize.rs
+++ b/src/platform_impl/web/web_sys/bindings/gen_ResizeObserverSize.rs
@@ -1,0 +1,28 @@
+#![allow(unused_imports)]
+use super::*;
+use wasm_bindgen::prelude::*;
+#[wasm_bindgen]
+extern "C" {
+    # [ wasm_bindgen ( extends = :: js_sys :: Object , js_name = ResizeObserverSize , typescript_type = "ResizeObserverSize" ) ]
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[doc = "The `ResizeObserverSize` class."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverSize)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverSize`*"]
+    pub type ResizeObserverSize;
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObserverSize" , js_name = inlineSize ) ]
+    #[doc = "Getter for the `inlineSize` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverSize/inlineSize)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverSize`*"]
+    pub fn inline_size(this: &ResizeObserverSize) -> f64;
+    # [ wasm_bindgen ( structural , method , getter , js_class = "ResizeObserverSize" , js_name = blockSize ) ]
+    #[doc = "Getter for the `blockSize` field of this object."]
+    #[doc = ""]
+    #[doc = "[MDN Documentation](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserverSize/blockSize)"]
+    #[doc = ""]
+    #[doc = "*This API requires the following crate features to be activated: `ResizeObserverSize`*"]
+    pub fn block_size(this: &ResizeObserverSize) -> f64;
+}

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -1,8 +1,14 @@
+use super::bindings::{
+    ResizeObserver, ResizeObserverBoxOptions, ResizeObserverEntry, ResizeObserverOptions,
+    ResizeObserverSize,
+};
 use super::event;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
 use crate::event::{ModifiersState, MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode};
-use crate::platform_impl::{OsError, PlatformSpecificWindowBuilderAttributes};
+use crate::platform_impl::{
+    CanvasResizeChangedFlag, CanvasResizedArgs, OsError, PlatformSpecificWindowBuilderAttributes,
+};
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -16,6 +22,7 @@ use web_sys::{
 pub struct Canvas {
     /// Note: resizing the HTMLCanvasElement should go through `backend::set_canvas_size` to ensure the DPI factor is maintained.
     raw: HtmlCanvasElement,
+    pub(crate) auto_parent_size: bool,
     on_focus: Option<Closure<dyn FnMut(FocusEvent)>>,
     on_blur: Option<Closure<dyn FnMut(FocusEvent)>>,
     on_keyboard_release: Option<Closure<dyn FnMut(KeyboardEvent)>>,
@@ -37,6 +44,7 @@ pub struct Canvas {
     wants_fullscreen: Rc<RefCell<bool>>,
     on_dark_mode: Option<Closure<dyn FnMut(MediaQueryListEvent)>>,
     dpr_change_detector: Option<Rc<RefCell<DevicePixelRatioChangeDetector>>>,
+    canvas_resize_observer: Option<Rc<RefCell<CanvasResizeObserver>>>,
 }
 
 impl Drop for Canvas {
@@ -75,6 +83,7 @@ impl Canvas {
 
         Ok(Canvas {
             raw: canvas,
+            auto_parent_size: attr.auto_parent_size,
             on_blur: None,
             on_focus: None,
             on_keyboard_release: None,
@@ -95,6 +104,7 @@ impl Canvas {
             wants_fullscreen: Rc::new(RefCell::new(false)),
             on_dark_mode: None,
             dpr_change_detector: None,
+            canvas_resize_observer: None,
         })
     }
 
@@ -315,8 +325,10 @@ impl Canvas {
     where
         F: 'static + FnMut(),
     {
-        self.on_fullscreen_change =
-            Some(self.add_event("fullscreenchange", move |_: Event| handler()));
+        if !self.auto_parent_size {
+            self.on_fullscreen_change =
+                Some(self.add_event("fullscreenchange", move |_: Event| handler()));
+        }
     }
 
     pub fn on_dark_mode<F>(&mut self, mut handler: F)
@@ -345,7 +357,19 @@ impl Canvas {
     where
         F: 'static + FnMut(),
     {
-        self.dpr_change_detector = Some(DevicePixelRatioChangeDetector::new(handler));
+        if !self.auto_parent_size {
+            self.dpr_change_detector = Some(DevicePixelRatioChangeDetector::new(handler));
+        }
+    }
+
+    pub(crate) fn on_size_or_scale_change<F>(&mut self, handler: F)
+    where
+        F: 'static + FnMut(CanvasResizedArgs),
+    {
+        if self.auto_parent_size {
+            self.canvas_resize_observer =
+                Some(CanvasResizeObserver::new(&self.raw, Box::new(handler)));
+        }
     }
 
     fn add_event<E, F>(&self, event_name: &str, mut handler: F) -> Closure<dyn FnMut(E)>
@@ -502,4 +526,293 @@ impl Drop for DevicePixelRatioChangeDetector {
             _ => {}
         }
     }
+}
+
+struct CanvasResizeObserver {
+    callback: Box<dyn FnMut(CanvasResizedArgs)>,
+    canvas: HtmlCanvasElement,
+    is_device_pixel_content_box_supported: bool,
+    /// The listener closure for the `ResizeObserver`. The callback argument is
+    /// an array of `ResizeObserverList`.
+    resize_observer_listener: Option<Closure<dyn FnMut(js_sys::Array)>>,
+    /// The `ResizeObserver` for the canvas.
+    resize_observer: Option<ResizeObserver>,
+    /// The listener closure for the window resize event, in case `ResizeObserver`
+    /// or 'device-pixel-content-box' is not supported.
+    window_resize_listener: Option<Closure<dyn FnMut()>>,
+    fullscreen_change_listener: Option<Closure<dyn FnMut()>>,
+    last_width: u32,
+    last_height: u32,
+    last_dpr: f64,
+    before_fullscreen_width: u32,
+    before_fullscren_height: u32,
+}
+
+impl CanvasResizeObserver {
+    fn new(
+        canvas: &HtmlCanvasElement,
+        callback: Box<dyn FnMut(CanvasResizedArgs)>,
+    ) -> Rc<RefCell<Self>> {
+        assert!(
+            canvas
+                .matches(":only-child")
+                .expect("Fail to match selector `:only-child`"),
+            "Only supports Canvas that is the only child of its parent",
+        );
+        super::set_canvas_style_property(&canvas, "width", "100%");
+        super::set_canvas_style_property(&canvas, "height", "100%");
+        super::set_canvas_style_property(&canvas, "display", "block");
+        // super::set_canvas_style_property(&canvas, "position", "relative");
+        super::set_canvas_style_property(&canvas, "position", "absolute");
+
+        let window = web_sys::window().expect("Failed to obtain window");
+        let dpr = window.device_pixel_ratio();
+
+        // TODO: align the initial size maybe?
+        // let width = (canvas.client_width() as f64 * dpr) as u32;
+        // let height = (canvas.client_height() as f64 * dpr) as u32;
+
+        let new_self = Rc::new(RefCell::new(Self {
+            callback,
+            canvas: canvas.clone(),
+            is_device_pixel_content_box_supported: true,
+            resize_observer_listener: None,
+            resize_observer: None,
+            window_resize_listener: None,
+            fullscreen_change_listener: None,
+            // last_width: width,
+            last_width: 0,
+            // last_height: height,
+            last_height: 0,
+            last_dpr: dpr,
+            before_fullscreen_width: 0,
+            before_fullscren_height: 0,
+        }));
+
+        let cloned_self = new_self.clone();
+        // This is the handler for the `ResizeObserver`. The callback argument
+        // is an array of `ResizeObserverList`.
+        let closure = Closure::wrap(Box::new(move |entries: js_sys::Array| {
+            cloned_self.borrow_mut().resize_observer_handler(entries)
+        }) as Box<dyn FnMut(_)>);
+        let resize_observer = ResizeObserver::new(&closure.as_ref().unchecked_ref());
+        if let Ok(resize_observer) = resize_observer {
+            let canvas_parent = canvas
+                .parent_element()
+                .expect("Failed to get parent element of Canvas");
+            new_self.borrow_mut().resize_observer_listener = Some(closure);
+            let observe_result = resize_observer.observe_with_options(
+                &canvas_parent,
+                ResizeObserverOptions::new().box_(ResizeObserverBoxOptions::DevicePixelContentBox),
+            );
+            if let Err(err) = observe_result {
+                // 'device-pixel-content-box' not supported, falling back to 'border-box'.
+                new_self.borrow_mut().is_device_pixel_content_box_supported = false;
+                web_sys::console::warn_2(
+                    &wasm_bindgen::JsValue::from_str(
+                        "'device-pixel-content-box' not supported, falling back to 'border-box'.",
+                    ),
+                    &err,
+                );
+                resize_observer
+                    .observe_with_options(
+                        &canvas_parent,
+                        ResizeObserverOptions::new().box_(ResizeObserverBoxOptions::BorderBox),
+                    )
+                    .expect("Failed to observe 'border-box'");
+                // If we don't support `device-pixel-content-box`, then zooming
+                // the page will not trigger the `ResizeObserver` callback if
+                // the canvas CSS size has not changed even though the number
+                // of native pixels it covers has.
+                let cloned_self = new_self.clone();
+                let closure =
+                    Closure::wrap(
+                        Box::new(move || cloned_self.borrow_mut().window_resize_handler())
+                            as Box<dyn FnMut()>,
+                    );
+                window
+                    .add_event_listener_with_callback("resize", &closure.as_ref().unchecked_ref())
+                    .expect("Failed to add `resize` listener");
+                new_self.borrow_mut().window_resize_listener = Some(closure);
+            }
+            new_self.borrow_mut().resize_observer = Some(resize_observer);
+        } else {
+            web_sys::console::warn_1(&wasm_bindgen::JsValue::from_str(
+                "ResizeObserver not supported, falling back to only using resize event.",
+            ));
+            new_self.borrow_mut().is_device_pixel_content_box_supported = false;
+
+            let cloned_self = new_self.clone();
+            let closure =
+                Closure::wrap(
+                    Box::new(move || cloned_self.borrow_mut().window_resize_handler())
+                        as Box<dyn FnMut()>,
+                );
+            window
+                .add_event_listener_with_callback("resize", &closure.as_ref().unchecked_ref())
+                .expect("Failed to add `resize` listener");
+            new_self.borrow_mut().window_resize_listener = Some(closure);
+
+            // TODO: Should we also use setTimeout to check for size changes?
+
+            // Run the handler once to set the initial size.
+            new_self.borrow_mut().window_resize_handler()
+        }
+
+        let cloned_self = new_self.clone();
+        let closure =
+            Closure::wrap(
+                Box::new(move || cloned_self.borrow_mut().fullscreen_change_handler())
+                    as Box<dyn FnMut()>,
+            );
+        canvas
+            .add_event_listener_with_callback("fullscreenchange", &closure.as_ref().unchecked_ref())
+            .expect("Failed to add `fullscreenchange` listener");
+        new_self.borrow_mut().fullscreen_change_listener = Some(closure);
+        new_self
+    }
+
+    fn resize_observer_handler(&mut self, entries: js_sys::Array) {
+        for entry in entries.iter() {
+            let entry = entry
+                .dyn_into::<ResizeObserverEntry>()
+                .expect("Failed to get `ResizeObserverEntry`");
+            let (width, height) = if self.is_device_pixel_content_box_supported {
+                let size = entry
+                    .device_pixel_content_box_size()
+                    .get(0)
+                    .dyn_into::<ResizeObserverSize>()
+                    .expect("Failed to get ResizeObserverSize");
+                (size.inline_size() as u32, size.block_size() as u32)
+            } else {
+                snap_to_parent_pixels(&self.canvas)
+            };
+            web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+                "resized {}x{}",
+                width, height
+            )));
+            self.maybe_handle_resize(width, height, super::scale_factor());
+        }
+    }
+
+    fn window_resize_handler(&mut self) {
+        assert_eq!(self.is_device_pixel_content_box_supported, false);
+        let (width, height) = snap_to_parent_pixels(&self.canvas);
+        web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+            "resized (window) {}x{}",
+            width, height
+        )));
+        self.maybe_handle_resize(width, height, super::scale_factor());
+    }
+
+    fn fullscreen_change_handler(&mut self) {
+        web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+            "Fullscreen change"
+        )));
+        let dpr = super::scale_factor();
+        // If the canvas is marked as fullscreen, it is moving *into* fullscreen
+        // If it is not, it is moving *out of* fullscreen
+        let (width, height) = if super::is_fullscreen(&self.canvas) {
+            let size = super::window_size().to_physical(dpr);
+            (size.width, size.height)
+        } else if self.is_device_pixel_content_box_supported {
+            (self.before_fullscreen_width, self.before_fullscren_height)
+        } else {
+            snap_to_parent_pixels(&self.canvas)
+        };
+        self.maybe_handle_resize(width, height, dpr);
+    }
+
+    fn maybe_handle_resize(&mut self, width: u32, height: u32, dpr: f64) {
+        let new_size = {
+            // If the canvas is marked as fullscreen, it is moving *into* fullscreen
+            // If it is not, it is moving *out of* fullscreen
+            if super::is_fullscreen(&self.canvas) {
+                web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+                    "In fullscreen"
+                )));
+                // If we're in fullscreen, we don't care about the size of the
+                // parent element.
+                super::window_size().to_physical(dpr)
+            } else {
+                self.before_fullscreen_width = width;
+                self.before_fullscren_height = height;
+                PhysicalSize::new(width, height)
+            }
+        };
+        let width = new_size.width;
+        let height = new_size.height;
+        let maybe_changed_flag = {
+            // We do expect the devicePixelRatio to be exactly equal unless changed.
+            #[allow(clippy::float_cmp)]
+            if self.last_dpr != dpr {
+                Some(CanvasResizeChangedFlag::SizeAndDevicePixelRatioChanged)
+            } else if self.last_width != new_size.width || self.last_height != new_size.height {
+                Some(CanvasResizeChangedFlag::SizeChanged)
+            } else {
+                None
+            }
+        };
+        if let Some(changed_flag) = maybe_changed_flag {
+            self.canvas.set_width(width);
+            self.canvas.set_height(height);
+            self.last_width = width;
+            self.last_height = height;
+            self.last_dpr = dpr;
+            (self.callback)(CanvasResizedArgs {
+                size: new_size,
+                device_pixel_ratio: dpr,
+                changed_flag,
+            })
+        }
+    }
+}
+
+impl Drop for CanvasResizeObserver {
+    fn drop(&mut self) {
+        if let Some(resize_observer) = self.resize_observer.take() {
+            resize_observer.disconnect();
+        }
+        if let Some(listener) = self.window_resize_listener.take() {
+            web_sys::window().map(|window| {
+                let _ = window.remove_event_listener_with_callback(
+                    "resize",
+                    listener.as_ref().unchecked_ref(),
+                );
+            });
+        }
+        if let Some(listener) = self.fullscreen_change_listener.take() {
+            let _ = self
+                .canvas
+                .remove_event_listener_with_callback("resize", listener.as_ref().unchecked_ref());
+        }
+    }
+}
+
+/// This function attempts to snap the canvas element to the pixel grid based
+/// on its parent element. This function should *never* be used if the browser
+/// supports `device-pixel-content-box` in `ResizeObserver`.
+fn snap_to_parent_pixels(canvas: &HtmlCanvasElement) -> (u32, u32) {
+    fn client_to_device_dim(dpr: f64, dim: f64) -> f64 {
+        (dim * dpr).round()
+    }
+
+    let canvas_parent = &canvas
+        .parent_element()
+        .expect("Failed to get parent element of Canvas");
+    let client_rect = canvas_parent.get_bounding_client_rect();
+    let dpr = super::scale_factor();
+
+    web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+        "bounding client rect top/left: {} {}",
+        client_rect.top() * dpr,
+        client_rect.left() * dpr
+    )));
+    let width = client_to_device_dim(dpr, client_rect.width());
+    let height = client_to_device_dim(dpr, client_rect.height());
+
+    super::set_canvas_style_property(canvas, "width", &format!("{}px", width / dpr));
+    super::set_canvas_style_property(canvas, "height", &format!("{}px", height / dpr));
+
+    (width as u32, height as u32)
 }

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -1,5 +1,6 @@
 mod canvas;
 mod event;
+mod bindings;
 mod timeout;
 
 pub use self::canvas::Canvas;

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -100,7 +100,9 @@ impl Window {
 
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
-        backend::set_canvas_size(self.canvas.raw(), size);
+        if !self.canvas.auto_parent_size {
+            backend::set_canvas_size(self.canvas.raw(), size);
+        }
     }
 
     #[inline]
@@ -281,4 +283,5 @@ impl Id {
 #[derive(Default, Clone)]
 pub struct PlatformSpecificBuilderAttributes {
     pub(crate) canvas: Option<backend::RawCanvasType>,
+    pub(crate) auto_parent_size: bool,
 }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Here is a POC implementation for #1661.

I referred to the code in https://github.com/KhronosGroup/WebGL/issues/2460#issuecomment-625045885 and implemented it with `web-sys`. It basically supports three modes (listed in order of preference):

- Use `ResizeObserver` with `device-pixel-content-box` to get the real device pixel dimensions (supported in Chrome 84 or above only)
- Use `ResizeObserver` to detect change in size with window resize event for backup, accompanied with some code to attempt to snap the canvas to device pixel (works on most recent browsers)
- Use window resize event only to check for change in size (would fail if the page layout changed without a window resize)

I have tested extensively on Chrome 85 beta and Firefox 80 beta on Windows and was able to get a crisp rendering (using a render of 1px lines, I can share the code if anyone wants to see but it's mostly similar to the test code on the linked WebGL issue thread) on different zoom levels and high-dpi display scaling. The canvas reacts to layout changes nicely (I tested with flexbox). I also tested that the fallback without `ResizeObserver` is functional.

### Technical details

- Since `web-sys` does not yet have the binding to `ResizeObserver`, I followed [these instructions](https://rustwasm.github.io/wasm-bindgen/contributing/web-sys/supporting-more-web-apis.html?highlight=webidl#supporting-more-web-apis-in-web-sys) to generate the bindings from the webidl and included them in a commit.
- Since there are multiple events that could cause the canvas to be resized and to also keep track of the scaling change, I made a `CanvasResizeObserver` struct to handle and emit the events corresponding to canvas size and scaling changes. this struct is currently quite a mess due to the need to handle multiple fallbacks and event listeners. I hope that a bit of refactoring will make it nicer.
- I am currently assuming that a change in scale factor will always come together with a size change.
- This PR builds upon PR #1659, but this PR doesn't really depend on its changes.
- To make this work, the canvas must be wrapped in a `<div>` element which must have a non-default CSS `position` (`position: relative` works). This parent element can be laid out normally.
- I added a `with_auto_parent_size` builder method. When used, the canvas will not be resizeable with user code.