### PR TITLE
Fix crash on NetBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - On macOS, add `NSWindow.hasShadow` support.
 - **Breaking:** On Web, `set_cursor_position` and `set_cursor_grab` will now always return an error.
 - **Breaking:** `PixelDelta` scroll events now return a `PhysicalPosition`.
+- On NetBSD, fixed crash due to incorrect detection of the main thread.
 
 # 0.22.2 (2020-05-16)
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -730,7 +730,5 @@ fn is_main_thread() -> bool {
 
 #[cfg(target_os = "netbsd")]
 fn is_main_thread() -> bool {
-    use libc::_lwp_self;
-
-    unsafe { _lwp_self() == 1 }
+    std::thread::current().name() == Some("main")
 }


### PR DESCRIPTION
The `_lwp_self` function cannot be used to reliably determine the main
thread, see
https://github.com/alacritty/alacritty/issues/2631#issuecomment-676723289.

It might always be equal to the PID, but it's certainly not always 1
when the thread is the main thread.

However, Rust's built in `Thread::id` and `Thread::name` function will
always return `ThreadId(1)` and `Some("main")`. Since converting the
thread's ID to a number is not supported on stable Rust, checking that
the thread is labeled `Some("main")` seems like the most reliable
option. It should also be a good fallback in general.
