### PR TITLE
Fix vertical scroll being inverted on web targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - On iOS and Android, `set_inner_size` is now a no-op instead of a runtime crash.
 - On Android, fix `ControlFlow::Poll` not polling the Android event queue.
 - On macOS, add `NSWindow.hasShadow` support.
+- On Web, fix vertical mouse wheel scrolling being inverted.
 - **Breaking:** On Web, `set_cursor_position` and `set_cursor_grab` will now always return an error.
 - **Breaking:** `PixelDelta` scroll events now return a `PhysicalPosition`.
 

--- a/src/platform_impl/web/stdweb/event.rs
+++ b/src/platform_impl/web/stdweb/event.rs
@@ -32,7 +32,7 @@ pub fn mouse_position(event: &impl IMouseEvent) -> LogicalPosition<f64> {
 
 pub fn mouse_scroll_delta(event: &MouseWheelEvent) -> Option<MouseScrollDelta> {
     let x = event.delta_x();
-    let y = event.delta_y();
+    let y = -event.delta_y();
 
     match event.delta_mode() {
         MouseWheelDeltaMode::Line => Some(MouseScrollDelta::LineDelta(x as f32, y as f32)),

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -31,7 +31,7 @@ pub fn mouse_position(event: &MouseEvent) -> LogicalPosition<f64> {
 
 pub fn mouse_scroll_delta(event: &WheelEvent) -> Option<MouseScrollDelta> {
     let x = event.delta_x();
-    let y = event.delta_y();
+    let y = -event.delta_y();
 
     match event.delta_mode() {
         WheelEvent::DOM_DELTA_LINE => Some(MouseScrollDelta::LineDelta(x as f32, y as f32)),


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Closes #1655

The code had been changed for both `stdweb` and `web-sys`, but I have only tested with `web-sys`. Though technically they both use the same web API so their behaviour should not be any different.