### PR TITLE
Add option to blur background on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On macOS, added `with_blurred_background` to make the window semi-transparent and blur the background.
 - On iOS, fixed support for the "Debug View Heirarchy" feature in Xcode.
 - On all platforms, `available_monitors` and `primary_monitor` are now on `EventLoopWindowTarget` rather than `EventLoop` to list monitors event in the event loop.
 - On Unix, X11 and Wayland are now optional features (enabled by default)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -126,6 +126,7 @@ If your PR makes notable changes to Winit's features, please update this section
 * Hidden titlebar
 * Hidden titlebar buttons
 * Full-size content view
+* Blurred background
 
 ### Unix
 * Window urgency

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -148,6 +148,8 @@ pub trait WindowBuilderExtMacOS {
     fn with_resize_increments(self, increments: LogicalSize<f64>) -> WindowBuilder;
     fn with_disallow_hidpi(self, disallow_hidpi: bool) -> WindowBuilder;
     fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
+    /// Blurs the background.
+    fn with_blurred_background(self, blurred_background: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExtMacOS for WindowBuilder {
@@ -211,6 +213,12 @@ impl WindowBuilderExtMacOS for WindowBuilder {
     #[inline]
     fn with_has_shadow(mut self, has_shadow: bool) -> WindowBuilder {
         self.platform_specific.has_shadow = has_shadow;
+        self
+    }
+
+    #[inline]
+    fn with_blurred_background(mut self, blurred_background: bool) -> WindowBuilder {
+        self.platform_specific.blurred_background = blurred_background;
         self
     }
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -390,7 +390,7 @@ impl UnownedWindow {
                     let _: () = msg_send![blurred_view, setState:0];
                     let _: () = msg_send![*ns_view, addSubview: blurred_view positioned:    NSWindowOrderingMode::NSWindowBelow relativeTo: 0];
                 }
-            }    
+            }
 
             ns_app.activateIgnoringOtherApps_(YES);
             win_attribs.min_inner_size.map(|dim| {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -41,8 +41,8 @@ use cocoa::{
 };
 use core_graphics::display::{CGDisplay, CGDisplayMode};
 use objc::{
-    rc::StrongPtr,
     declare::ClassDecl,
+    rc::StrongPtr,
     runtime::{Class, Object, Sel, BOOL, NO, YES},
 };
 


### PR DESCRIPTION
Related to #538 

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR adds `with_blurred_background` to `WindowBuilderExtMacOS` which makes the view semi-transparent and blurs the background of the window using a `NSVisualEffectView`.

I think this feature could conflict with other cross-platform implementations, but as there is no standard for blurred backgrounds on Wayland or the web, these features would need to be platform-gated anyway.