### PR TITLE
Send CursorMove before mouse press event and note that touch is unimplemented on web target

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -198,9 +198,9 @@ Legend:
 |Mouse set location      |✔️       |✔️      |✔️       |❓           |**N/A**|**N/A**|**N/A**|
 |Cursor grab             |✔️       |▢[#165] |▢[#242]  |✔️         |**N/A**|**N/A**|❓        |
 |Cursor icon             |✔️       |✔️      |✔️       |✔️           |**N/A**|**N/A**|✔️        |
-|Touch events            |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |✔️        |
-|Touch pressure          |✔️       |❌      |❌       |❌          |❌    |✔️     |✔️        |
-|Multitouch              |✔️       |❌      |✔️       |✔️          |❓     |✔️     |✔️        |
+|Touch events            |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |
+|Touch pressure          |✔️       |❌      |❌       |❌          |❌    |✔️     |❌        |
+|Multitouch              |✔️       |❌      |✔️       |✔️          |❓     |✔️     |❌        |
 |Keyboard events         |✔️       |✔️      |✔️       |✔️          |❓     |❌     |✔️        |
 |Drag & Drop             |▢[#720]  |▢[#720] |▢[#720]  |❌[#306]    |**N/A**|**N/A**|❓        |
 |Raw Device Events       |▢[#750]  |▢[#750] |▢[#750]  |❌          |❌    |❌     |❓        |

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -133,7 +133,18 @@ impl<T> WindowTarget<T> {
         });
 
         let runner = self.runner.clone();
-        canvas.on_mouse_press(move |pointer_id, button, modifiers| {
+        canvas.on_mouse_press(move |pointer_id, position, button, modifiers| {
+            // A mouse down event may come in without any prior CursorMoved events,
+            // therefore we should send a CursorMoved event to make sure that the
+            // user code has the correct cursor position.
+            runner.send_event(Event::WindowEvent {
+                window_id: WindowId(id),
+                event: WindowEvent::CursorMoved {
+                    device_id: DeviceId(device::Id(pointer_id)),
+                    position,
+                    modifiers,
+                },
+            });
             runner.send_event(Event::WindowEvent {
                 window_id: WindowId(id),
                 event: WindowEvent::MouseInput {

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -200,11 +200,12 @@ impl Canvas {
 
     pub fn on_mouse_press<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
     {
         self.on_mouse_press = Some(self.add_user_event(move |event: PointerDownEvent| {
             handler(
                 event.pointer_id(),
+                event::mouse_position(&event).to_physical(super::scale_factor()),
                 event::mouse_button(&event),
                 event::mouse_modifiers(&event),
             );

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -248,7 +248,7 @@ impl Canvas {
 
     pub fn on_mouse_press<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
     {
         if has_pointer_event() {
             self.on_pointer_press = Some(self.add_user_event(
@@ -256,6 +256,7 @@ impl Canvas {
                 move |event: PointerEvent| {
                     handler(
                         event.pointer_id(),
+                        event::mouse_position(&event).to_physical(super::scale_factor()),
                         event::mouse_button(&event),
                         event::mouse_modifiers(&event),
                     );
@@ -266,6 +267,7 @@ impl Canvas {
                 Some(self.add_user_event("mousedown", move |event: MouseEvent| {
                     handler(
                         0,
+                        event::mouse_position(&event).to_physical(super::scale_factor()),
                         event::mouse_button(&event),
                         event::mouse_modifiers(&event),
                     );


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

The first commit changed the web target to send CursorMove before mouse press event. On web, the `pointerdown` or `mousedown` event comes with its own coordinates and there is no guarantee that `pointermove` or `mousemove` would be provided before them, and since the `MouseInput` event in winit does not provide coordinates, the only to pass this information would be to send an extra `CursorMove` before it. This fixes a problem I have that cursor input does not work on touchscreen devices at all.

The second commit updates the feature matrix to correctly indicate that touch events are not implemented for the web target. There is absolutely zero code in the web backend that relates to touch events, so claiming to support touch would be a complete lie.

The code had been changed for both `stdweb` and `web-sys`, but I have only tested with `web-sys`. Though technically they both use the same web API so their behaviour should not be any different.