### PR TITLE
Rework Fullscreen::Borderless enum variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
 - On Web, `WindowEvent::Resized` is now emitted when `Window::set_inner_size` is called.
 - **Breaking:** `Fullscreen` enum now uses `Option<Borderless>` instead of `Borderless` to pick system preferred monitor.
 - **Breaking:** `Fullscreen` enum now uses `Borderless<Option<MonitorHandle>>` instead of `Borderless<MonitorHandle>` to pick system's preferred monitor.
+- **Breaking:** `Fullscreen` enum now uses `Borderless<Option<MonitorHandle>>` instead of `Borderless<MonitorHandle>` to allow picking the current monitor.
 
 # 0.22.2 (2020-05-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - On Web, the event handler closure passed to `EventLoop::run` now gets dropped after the event loop is destroyed.
 - **Breaking:** On Web, the canvas element associated to a `Window` is no longer removed from the DOM when the `Window` is dropped.
 - On Web, `WindowEvent::Resized` is now emitted when `Window::set_inner_size` is called.
+- **Breaking:** `Fullscreen` enum now uses `Option<Borderless>` instead of `Borderless` to pick system preferred monitor.
 
 # 0.22.2 (2020-05-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - **Breaking:** On Web, the canvas element associated to a `Window` is no longer removed from the DOM when the `Window` is dropped.
 - On Web, `WindowEvent::Resized` is now emitted when `Window::set_inner_size` is called.
 - **Breaking:** `Fullscreen` enum now uses `Option<Borderless>` instead of `Borderless` to pick system preferred monitor.
+- **Breaking:** `Fullscreen` enum now uses `Borderless<Option<MonitorHandle>>` instead of `Borderless<MonitorHandle>` to pick system's preferred monitor.
 
 # 0.22.2 (2020-05-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,7 @@
 - On Web, the event handler closure passed to `EventLoop::run` now gets dropped after the event loop is destroyed.
 - **Breaking:** On Web, the canvas element associated to a `Window` is no longer removed from the DOM when the `Window` is dropped.
 - On Web, `WindowEvent::Resized` is now emitted when `Window::set_inner_size` is called.
-- **Breaking:** `Fullscreen` enum now uses `Option<Borderless>` instead of `Borderless` to pick system preferred monitor.
-- **Breaking:** `Fullscreen` enum now uses `Borderless<Option<MonitorHandle>>` instead of `Borderless<MonitorHandle>` to pick system's preferred monitor.
-- **Breaking:** `Fullscreen` enum now uses `Borderless<Option<MonitorHandle>>` instead of `Borderless<MonitorHandle>` to allow picking the current monitor.
+- **Breaking:** `Fullscreen` enum now uses `Borderless(Option<MonitorHandle>)` instead of `Borderless(MonitorHandle)` to allow picking the current monitor.
 
 # 0.22.2 (2020-05-16)
 

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -19,7 +19,7 @@ fn main() {
 
     let fullscreen = Some(match num {
         1 => Fullscreen::Exclusive(prompt_for_video_mode(&prompt_for_monitor(&event_loop))),
-        2 => Fullscreen::Borderless(prompt_for_monitor(&event_loop)),
+        2 => Fullscreen::Borderless(Some(prompt_for_monitor(&event_loop))),
         _ => panic!("Please enter a valid number"),
     });
 

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -83,9 +83,7 @@ fn main() {
                                 );
                             }
                             F => window.set_fullscreen(match (state, modifiers.alt()) {
-                                (true, false) => {
-                                    Some(Fullscreen::Borderless(window.current_monitor().unwrap()))
-                                }
+                                (true, false) => Some(Fullscreen::Borderless(None)),
                                 (true, true) => Some(Fullscreen::Exclusive(
                                     video_modes.iter().nth(video_mode_id).unwrap().clone(),
                                 )),

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -21,6 +21,7 @@ fn main() {
     eprintln!("debugging keys:");
     eprintln!("  (E) Enter exclusive fullscreen");
     eprintln!("  (F) Toggle borderless fullscreen");
+    eprintln!("  (P) Toggle borderless fullscreen on system's preffered monitor");
     eprintln!("  (M) Toggle minimized");
     eprintln!("  (Q) Quit event loop");
     eprintln!("  (V) Toggle visibility");
@@ -85,8 +86,15 @@ fn main() {
                         if window.fullscreen().is_some() {
                             window.set_fullscreen(None);
                         } else {
-                            let monitor = window.current_monitor().unwrap();
+                            let monitor = window.current_monitor();
                             window.set_fullscreen(Some(Fullscreen::Borderless(monitor)));
+                        }
+                    }
+                    VirtualKeyCode::P => {
+                        if window.fullscreen().is_some() {
+                            window.set_fullscreen(None);
+                        } else {
+                            window.set_fullscreen(Some(Fullscreen::Borderless(None)));
                         }
                     }
                     VirtualKeyCode::M => {

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -519,7 +519,15 @@ pub unsafe fn create_window(
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
         Some(Fullscreen::Borderless(ref monitor)) => {
-            msg_send![window, setScreen:monitor.ui_screen()]
+            let uiscreen: id = match monitor {
+                Some(ref monitor) => monitor.ui_screen() as id,
+                None => {
+                    let uiscreen: id = msg_send![window, screen];
+                    uiscreen
+                }
+            };
+
+            msg_send![window, setScreen: uiscreen]
         }
         None => (),
     }

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -519,8 +519,8 @@ pub unsafe fn create_window(
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
         Some(Fullscreen::Borderless(ref monitor)) => {
-            let uiscreen: id = match monitor {
-                Some(ref monitor) => monitor.ui_screen() as id,
+            let uiscreen: id = match &monitor {
+                Some(monitor) => monitor.ui_screen() as id,
                 None => {
                     let uiscreen: id = msg_send![window, screen];
                     uiscreen

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -196,7 +196,8 @@ impl Inner {
                     let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode];
                     uiscreen
                 }
-                Some(Fullscreen::Borderless(monitor)) => monitor.ui_screen() as id,
+                Some(Fullscreen::Borderless(Some(monitor))) => monitor.ui_screen() as id,
+                Some(Fullscreen::Borderless(None)) => self.current_monitor().ui_screen() as id,
                 None => {
                     warn!("`Window::set_fullscreen(None)` ignored on iOS");
                     return;
@@ -235,7 +236,7 @@ impl Inner {
                 && screen_space_bounds.size.width == screen_bounds.size.width
                 && screen_space_bounds.size.height == screen_bounds.size.height
             {
-                Some(Fullscreen::Borderless(monitor))
+                Some(Fullscreen::Borderless(Some(monitor)))
             } else {
                 None
             }
@@ -353,8 +354,10 @@ impl Window {
                 Some(Fullscreen::Exclusive(ref video_mode)) => {
                     video_mode.video_mode.monitor.ui_screen() as id
                 }
-                Some(Fullscreen::Borderless(ref monitor)) => monitor.ui_screen() as id,
-                None => monitor::main_uiscreen().ui_screen(),
+                Some(Fullscreen::Borderless(Some(ref monitor))) => monitor.inner.ui_screen(),
+                Some(Fullscreen::Borderless(None)) | None => {
+                    monitor::main_uiscreen().ui_screen() as id
+                }
             };
 
             let screen_bounds: CGRect = msg_send![screen, bounds];

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -196,10 +196,9 @@ impl Inner {
                     let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode];
                     uiscreen
                 }
-                Some(Fullscreen::Borderless(Some(monitor))) => monitor.ui_screen() as id,
-                Some(Fullscreen::Borderless(None)) => {
-                    self.current_monitor_inner().ui_screen() as id
-                }
+                Some(Fullscreen::Borderless(monitor)) => monitor
+                    .unwrap_or_else(|| self.current_monitor_inner())
+                    .ui_screen() as id,
                 None => {
                     warn!("`Window::set_fullscreen(None)` ignored on iOS");
                     return;

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -197,7 +197,7 @@ impl Inner {
                     uiscreen
                 }
                 Some(Fullscreen::Borderless(Some(monitor))) => monitor.ui_screen() as id,
-                Some(Fullscreen::Borderless(None)) => self.current_monitor().ui_screen() as id,
+                Some(Fullscreen::Borderless(None)) => self.current_monitor_inner().ui_screen() as id,
                 None => {
                     warn!("`Window::set_fullscreen(None)` ignored on iOS");
                     return;

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -197,7 +197,9 @@ impl Inner {
                     uiscreen
                 }
                 Some(Fullscreen::Borderless(Some(monitor))) => monitor.ui_screen() as id,
-                Some(Fullscreen::Borderless(None)) => self.current_monitor_inner().ui_screen() as id,
+                Some(Fullscreen::Borderless(None)) => {
+                    self.current_monitor_inner().ui_screen() as id
+                }
                 None => {
                     warn!("`Window::set_fullscreen(None)` ignored on iOS");
                     return;

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -155,14 +155,14 @@ impl Window {
                 panic!("Wayland doesn't support exclusive fullscreen")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor = if let Some(RootMonitorHandle {
-                    inner: PlatformMonitorHandle::Wayland(monitor),
-                }) = monitor
-                {
-                    Some(monitor.proxy)
-                } else {
-                    None
-                };
+                let monitor = monitor.map(|monitor| {
+                    let RootMonitorHandle { inner: monitor } = monitor;
+                    match monitor {
+                        PlatformMonitorHandle::Wayland(monitor) => monitor.proxy,
+                        #[cfg(feature = "x11")]
+                        PlatformMonitorHandle::X(_) => unreachable!(),
+                    }
+                });
 
                 frame.set_fullscreen(monitor.as_ref())
             }
@@ -358,14 +358,14 @@ impl Window {
                 panic!("Wayland doesn't support exclusive fullscreen")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor = if let Some(RootMonitorHandle {
-                    inner: PlatformMonitorHandle::Wayland(monitor),
-                }) = monitor
-                {
-                    Some(monitor.proxy)
-                } else {
-                    None
-                };
+                let monitor = monitor.map(|monitor| {
+                    let RootMonitorHandle { inner: monitor } = monitor;
+                    match monitor {
+                        PlatformMonitorHandle::Wayland(monitor) => monitor.proxy,
+                        #[cfg(feature = "x11")]
+                        PlatformMonitorHandle::X(_) => unreachable!(),
+                    }
+                });
 
                 self.frame.lock().unwrap().set_fullscreen(monitor.as_ref());
             }

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -155,14 +155,13 @@ impl Window {
                 panic!("Wayland doesn't support exclusive fullscreen")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor = monitor.map(|monitor| {
-                    let RootMonitorHandle { inner: monitor } = monitor;
-                    match monitor {
-                        PlatformMonitorHandle::Wayland(monitor) => monitor.proxy,
+                let monitor = monitor
+                    .map(|RootMonitorHandle { inner: monitor }| match monitor {
+                        PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
                         #[cfg(feature = "x11")]
-                        PlatformMonitorHandle::X(_) => unreachable!(),
-                    }
-                });
+                        PlatformMonitorHandle::X(_) => None,
+                    })
+                    .flatten();
 
                 frame.set_fullscreen(monitor.as_ref())
             }
@@ -358,14 +357,13 @@ impl Window {
                 panic!("Wayland doesn't support exclusive fullscreen")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor = monitor.map(|monitor| {
-                    let RootMonitorHandle { inner: monitor } = monitor;
-                    match monitor {
-                        PlatformMonitorHandle::Wayland(monitor) => monitor.proxy,
+                let monitor = monitor
+                    .map(|RootMonitorHandle { inner: monitor }| match monitor {
+                        PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
                         #[cfg(feature = "x11")]
-                        PlatformMonitorHandle::X(_) => unreachable!(),
-                    }
-                });
+                        PlatformMonitorHandle::X(_) => None,
+                    })
+                    .flatten();
 
                 self.frame.lock().unwrap().set_fullscreen(monitor.as_ref());
             }

--- a/src/platform_impl/linux/wayland/window.rs
+++ b/src/platform_impl/linux/wayland/window.rs
@@ -155,13 +155,12 @@ impl Window {
                 panic!("Wayland doesn't support exclusive fullscreen")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor = monitor
-                    .map(|RootMonitorHandle { inner: monitor }| match monitor {
+                let monitor =
+                    monitor.and_then(|RootMonitorHandle { inner: monitor }| match monitor {
                         PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
                         #[cfg(feature = "x11")]
                         PlatformMonitorHandle::X(_) => None,
-                    })
-                    .flatten();
+                    });
 
                 frame.set_fullscreen(monitor.as_ref())
             }
@@ -357,13 +356,12 @@ impl Window {
                 panic!("Wayland doesn't support exclusive fullscreen")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor = monitor
-                    .map(|RootMonitorHandle { inner: monitor }| match monitor {
+                let monitor =
+                    monitor.and_then(|RootMonitorHandle { inner: monitor }| match monitor {
                         PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
                         #[cfg(feature = "x11")]
                         PlatformMonitorHandle::X(_) => None,
-                    })
-                    .flatten();
+                    });
 
                 self.frame.lock().unwrap().set_fullscreen(monitor.as_ref());
             }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -585,16 +585,6 @@ impl UnownedWindow {
 
     fn set_fullscreen_inner(&self, fullscreen: Option<Fullscreen>) -> Option<util::Flusher<'_>> {
         let mut shared_state_lock = self.shared_state.lock();
-        // Map Borderless(`None`) to current monitor.
-        let fullscreen = match fullscreen {
-            Some(Fullscreen::Borderless(None)) => {
-                let current_monitor = Some(RootMonitorHandle {
-                    inner: PlatformMonitorHandle::X(self.current_monitor()),
-                });
-                Some(Fullscreen::Borderless(current_monitor))
-            }
-            _ => fullscreen,
-        };
 
         match shared_state_lock.visibility {
             // Setting fullscreen on a window that is not visible will generate an error.
@@ -663,8 +653,7 @@ impl UnownedWindow {
                     Fullscreen::Borderless(Some(RootMonitorHandle {
                         inner: PlatformMonitorHandle::X(monitor),
                     })) => (None, monitor),
-                    // We've mapped `None` in borderless earlier.
-                    Fullscreen::Borderless(None) => unreachable!(),
+                    Fullscreen::Borderless(None) => (None, self.current_monitor()),
                     #[cfg(feature = "wayland")]
                     _ => unreachable!(),
                 };

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -649,10 +649,11 @@ impl UnownedWindow {
                 let (video_mode, monitor) = match fullscreen {
                     Fullscreen::Exclusive(RootVideoMode {
                         video_mode: PlatformVideoMode::X(ref video_mode),
-                    }) => (Some(video_mode), video_mode.monitor.as_ref().unwrap()),
-                    Fullscreen::Borderless(RootMonitorHandle {
-                        inner: PlatformMonitorHandle::X(ref monitor),
-                    }) => (None, monitor),
+                    }) => (Some(video_mode), video_mode.monitor.clone().unwrap()),
+                    Fullscreen::Borderless(Some(RootMonitorHandle {
+                        inner: PlatformMonitorHandle::X(monitor),
+                    })) => (None, monitor),
+                    Fullscreen::Borderless(None) => (None, self.current_monitor()),
                     #[cfg(feature = "wayland")]
                     _ => unreachable!(),
                 };

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -758,7 +758,7 @@ impl UnownedWindow {
             let new_screen = match fullscreen {
                 Fullscreen::Borderless(borderless) => {
                     let RootMonitorHandle { inner: monitor } =
-                        borderless.clone().unwrap_or_else(|| self.current_monitor());
+                        borderless.clone().unwrap_or_else(|| self.current_monitor_inner());
                     monitor
                 }
                 Fullscreen::Exclusive(RootVideoMode {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -757,8 +757,9 @@ impl UnownedWindow {
         if let Some(ref fullscreen) = fullscreen {
             let new_screen = match fullscreen {
                 Fullscreen::Borderless(borderless) => {
-                    let RootMonitorHandle { inner: monitor } =
-                        borderless.clone().unwrap_or_else(|| self.current_monitor_inner());
+                    let RootMonitorHandle { inner: monitor } = borderless
+                        .clone()
+                        .unwrap_or_else(|| self.current_monitor_inner());
                     monitor
                 }
                 Fullscreen::Exclusive(RootVideoMode {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -142,13 +142,14 @@ fn create_window(
     unsafe {
         let pool = NSAutoreleasePool::new(nil);
         let screen = match attrs.fullscreen {
-            Some(Fullscreen::Borderless(RootMonitorHandle { inner: ref monitor }))
+            Some(Fullscreen::Borderless(Some(RootMonitorHandle { inner: ref monitor })))
             | Some(Fullscreen::Exclusive(RootVideoMode {
                 video_mode: VideoMode { ref monitor, .. },
             })) => {
                 let monitor_screen = monitor.ns_screen();
                 Some(monitor_screen.unwrap_or(appkit::NSScreen::mainScreen(nil)))
             }
+            Some(Fullscreen::Borderless(None)) => Some(appkit::NSScreen::mainScreen(nil)),
             None => None,
         };
         let frame = match screen {
@@ -755,10 +756,14 @@ impl UnownedWindow {
         // does not take a screen parameter, but uses the current screen)
         if let Some(ref fullscreen) = fullscreen {
             let new_screen = match fullscreen {
-                Fullscreen::Borderless(RootMonitorHandle { inner: ref monitor }) => monitor,
+                Fullscreen::Borderless(borderless) => {
+                    let RootMonitorHandle { inner: monitor } =
+                        borderless.clone().unwrap_or_else(|| self.current_monitor());
+                    monitor
+                }
                 Fullscreen::Exclusive(RootVideoMode {
                     video_mode: VideoMode { ref monitor, .. },
-                }) => monitor,
+                }) => monitor.clone(),
             }
             .ns_screen()
             .unwrap();

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -450,7 +450,8 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
                 // Otherwise, we must've reached fullscreen by the user clicking
                 // on the green fullscreen button. Update state!
                 None => {
-                    shared_state.fullscreen = Some(Fullscreen::Borderless(window.current_monitor()))
+                    let current_monitor = Some(window.current_monitor_inner());
+                    shared_state.fullscreen = Some(Fullscreen::Borderless(current_monitor))
                 }
             }
             shared_state.in_fullscreen_transition = true;

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -450,8 +450,7 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
                 // Otherwise, we must've reached fullscreen by the user clicking
                 // on the green fullscreen button. Update state!
                 None => {
-                    let current_monitor = window.current_monitor_inner();
-                    shared_state.fullscreen = Some(Fullscreen::Borderless(current_monitor))
+                    shared_state.fullscreen = Some(Fullscreen::Borderless(window.current_monitor()))
                 }
             }
             shared_state.in_fullscreen_transition = true;

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -233,7 +233,7 @@ impl Window {
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.borrow().is_fullscreen() {
-            Some(Fullscreen::Borderless(self.current_monitor_inner()))
+            Some(Fullscreen::Borderless(Some(self.current_monitor_inner())))
         } else {
             None
         }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -857,12 +857,11 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                             return 0;
                         }
 
-                        let current_monitor = fullscreen_monitor
+                        if fullscreen_monitor
                             .as_ref()
-                            .map(|monitor| monitor.inner.hmonitor())
-                            .unwrap_or(new_monitor);
-
-                        if new_monitor != current_monitor {
+                            .map(|monitor| new_monitor != monitor.inner.hmonitor())
+                            .unwrap_or(true)
+                        {
                             if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor) {
                                 let new_monitor_rect = new_monitor_info.rcMonitor;
                                 window_pos.x = new_monitor_rect.left;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -853,9 +853,16 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::MonitorFromRect(&new_rect, winuser::MONITOR_DEFAULTTONULL);
                 match fullscreen {
                     Fullscreen::Borderless(ref mut fullscreen_monitor) => {
-                        if new_monitor != ptr::null_mut()
-                            && new_monitor != fullscreen_monitor.as_ref().unwrap().inner.hmonitor()
-                        {
+                        if new_monitor == ptr::null_mut() {
+                            return 0;
+                        }
+
+                        let current_monitor = fullscreen_monitor
+                            .as_ref()
+                            .map(inner.hmonitor())
+                            .unwrap_or(new_monitor);
+
+                        if new_monitor != current_monitor {
                             if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor) {
                                 let new_monitor_rect = new_monitor_info.rcMonitor;
                                 window_pos.x = new_monitor_rect.left;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -853,7 +853,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::MonitorFromRect(&new_rect, winuser::MONITOR_DEFAULTTONULL);
                 match fullscreen {
                     Fullscreen::Borderless(ref mut fullscreen_monitor) => {
-                        if new_monitor != fullscreen_monitor.inner.hmonitor()
+                        // FIXME This should be properly implemented.
+                        if new_monitor != fullscreen_monitor.as_ref().unwrap().inner.hmonitor()
                             && new_monitor != ptr::null_mut()
                         {
                             if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor) {
@@ -863,9 +864,9 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                                 window_pos.cx = new_monitor_rect.right - new_monitor_rect.left;
                                 window_pos.cy = new_monitor_rect.bottom - new_monitor_rect.top;
                             }
-                            *fullscreen_monitor = crate::monitor::MonitorHandle {
+                            *fullscreen_monitor = Some(crate::monitor::MonitorHandle {
                                 inner: MonitorHandle::new(new_monitor),
-                            };
+                            });
                         }
                     }
                     Fullscreen::Exclusive(ref video_mode) => {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -853,15 +853,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::MonitorFromRect(&new_rect, winuser::MONITOR_DEFAULTTONULL);
                 match fullscreen {
                     Fullscreen::Borderless(ref mut fullscreen_monitor) => {
-                        if new_monitor
-                            != fullscreen_monitor
-                                .as_ref()
-                                .unwrap_or_else(|| RootMonitorHandle {
-                                    inner: monitor::current_monitor(window),
-                                })
-                                .inner
-                                .hmonitor()
-                            && new_monitor != ptr::null_mut()
+                        if new_monitor != ptr::null_mut()
+                            && new_monitor != fullscreen_monitor.as_ref().unwrap().inner.hmonitor()
                         {
                             if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor) {
                                 let new_monitor_rect = new_monitor_info.rcMonitor;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -859,7 +859,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
 
                         let current_monitor = fullscreen_monitor
                             .as_ref()
-                            .map(inner.hmonitor())
+                            .map(|monitor| monitor.inner.hmonitor())
                             .unwrap_or(new_monitor);
 
                         if new_monitor != current_monitor {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -853,14 +853,11 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::MonitorFromRect(&new_rect, winuser::MONITOR_DEFAULTTONULL);
                 match fullscreen {
                     Fullscreen::Borderless(ref mut fullscreen_monitor) => {
-                        if new_monitor == ptr::null_mut() {
-                            return 0;
-                        }
-
-                        if fullscreen_monitor
-                            .as_ref()
-                            .map(|monitor| new_monitor != monitor.inner.hmonitor())
-                            .unwrap_or(true)
+                        if new_monitor != ptr::null_mut()
+                            && fullscreen_monitor
+                                .as_ref()
+                                .map(|monitor| new_monitor != monitor.inner.hmonitor())
+                                .unwrap_or(true)
                         {
                             if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor) {
                                 let new_monitor_rect = new_monitor_info.rcMonitor;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -853,7 +853,8 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::MonitorFromRect(&new_rect, winuser::MONITOR_DEFAULTTONULL);
                 match fullscreen {
                     Fullscreen::Borderless(ref mut fullscreen_monitor) => {
-                        // FIXME This should be properly implemented.
+                        // Unwrap is safe, since we explicitly map `None` to current monitor
+                        // when we're setting fullscreen state.
                         if new_monitor != fullscreen_monitor.as_ref().unwrap().inner.hmonitor()
                             && new_monitor != ptr::null_mut()
                         {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -853,9 +853,14 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::MonitorFromRect(&new_rect, winuser::MONITOR_DEFAULTTONULL);
                 match fullscreen {
                     Fullscreen::Borderless(ref mut fullscreen_monitor) => {
-                        // Unwrap is safe, since we explicitly map `None` to current monitor
-                        // when we're setting fullscreen state.
-                        if new_monitor != fullscreen_monitor.as_ref().unwrap().inner.hmonitor()
+                        if new_monitor
+                            != fullscreen_monitor
+                                .as_ref()
+                                .unwrap_or_else(|| RootMonitorHandle {
+                                    inner: monitor::current_monitor(window),
+                                })
+                                .inner
+                                .hmonitor()
                             && new_monitor != ptr::null_mut()
                         {
                             if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor) {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -509,7 +509,7 @@ impl Window {
                     let monitor = match fullscreen {
                         Fullscreen::Exclusive(ref video_mode) => video_mode.monitor(),
                         // We explicitly map `None` eaerlier, so unwrap is safe.
-                        Fullscreen::Borderless(ref monitor) => monitor.unwrap().clone(),
+                        Fullscreen::Borderless(ref monitor) => monitor.as_ref().unwrap().clone(),
                     };
 
                     let position: (i32, i32) = monitor.position().into();

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -392,16 +392,6 @@ impl Window {
     pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         let window = self.window.clone();
         let window_state = Arc::clone(&self.window_state);
-        let fullscreen = match fullscreen {
-            Some(Fullscreen::Borderless(None)) => {
-                let current_monitor = Some(RootMonitorHandle {
-                    inner: monitor::current_monitor(window.0),
-                });
-
-                Some(Fullscreen::Borderless(current_monitor))
-            }
-            _ => fullscreen,
-        };
 
         let mut window_state_lock = window_state.lock();
         let old_fullscreen = window_state_lock.fullscreen.clone();
@@ -506,10 +496,11 @@ impl Window {
             // Update window bounds
             match &fullscreen {
                 Some(fullscreen) => {
-                    let monitor = match fullscreen {
-                        Fullscreen::Exclusive(ref video_mode) => video_mode.monitor(),
+                    let monitor = match &fullscreen {
+                        Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
                         // We explicitly map `None` eaerlier, so unwrap is safe.
-                        Fullscreen::Borderless(ref monitor) => monitor.as_ref().unwrap().clone(),
+                        Fullscreen::Borderless(Some(monitor)) => monitor.as_ref().clone(),
+                        Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
                     };
 
                     let position: (i32, i32) = monitor.position().into();

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -393,17 +393,6 @@ impl Window {
         let window = self.window.clone();
         let window_state = Arc::clone(&self.window_state);
 
-        let fullscreen = match fullscreen {
-            Some(Fullscreen::Borderless(None)) => {
-                let current_monitor = Some(RootMonitorHandle {
-                    inner: monitor::current_monitor(window.0),
-                });
-
-                Some(Fullscreen::Borderless(current_monitor))
-            }
-            _ => fullscreen,
-        };
-
         let mut window_state_lock = window_state.lock();
         let old_fullscreen = window_state_lock.fullscreen.clone();
         if window_state_lock.fullscreen == fullscreen {
@@ -509,8 +498,8 @@ impl Window {
                 Some(fullscreen) => {
                     let monitor = match &fullscreen {
                         Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
-                        // We explicitly map `None` eaerlier, so unwrap is safe.
-                        Fullscreen::Borderless(monitor) => monitor.as_ref().unwrap().clone(),
+                        Fullscreen::Borderless(Some(monitor)) => monitor.as_ref().clone(),
+                        Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
                     };
 
                     let position: (i32, i32) = monitor.position().into();

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -393,6 +393,17 @@ impl Window {
         let window = self.window.clone();
         let window_state = Arc::clone(&self.window_state);
 
+        let fullscreen = match fullscreen {
+            Some(Fullscreen::Borderless(None)) => {
+                let current_monitor = Some(RootMonitorHandle {
+                    inner: monitor::current_monitor(window.0),
+                });
+
+                Some(Fullscreen::Borderless(current_monitor))
+            }
+            _ => fullscreen,
+        };
+
         let mut window_state_lock = window_state.lock();
         let old_fullscreen = window_state_lock.fullscreen.clone();
         if window_state_lock.fullscreen == fullscreen {
@@ -499,8 +510,7 @@ impl Window {
                     let monitor = match &fullscreen {
                         Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
                         // We explicitly map `None` eaerlier, so unwrap is safe.
-                        Fullscreen::Borderless(Some(monitor)) => monitor.as_ref().clone(),
-                        Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
+                        Fullscreen::Borderless(monitor) => monitor.as_ref().unwrap().clone(),
                     };
 
                     let position: (i32, i32) = monitor.position().into();

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -498,7 +498,10 @@ impl Window {
                 Some(fullscreen) => {
                     let monitor = match fullscreen {
                         Fullscreen::Exclusive(ref video_mode) => video_mode.monitor(),
-                        Fullscreen::Borderless(ref monitor) => monitor.clone(),
+                        Fullscreen::Borderless(Some(ref monitor)) => monitor.clone(),
+                        Fullscreen::Borderless(None) => RootMonitorHandle {
+                            inner: monitor::current_monitor(window.0),
+                        },
                     };
 
                     let position: (i32, i32) = monitor.position().into();

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -498,8 +498,10 @@ impl Window {
                 Some(fullscreen) => {
                     let monitor = match &fullscreen {
                         Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
-                        Fullscreen::Borderless(Some(monitor)) => monitor.as_ref().clone(),
-                        Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
+                        Fullscreen::Borderless(Some(monitor)) => monitor.clone(),
+                        Fullscreen::Borderless(None) => RootMonitorHandle {
+                            inner: monitor::current_monitor(window.0),
+                        },
                     };
 
                     let position: (i32, i32) = monitor.position().into();

--- a/src/window.rs
+++ b/src/window.rs
@@ -624,6 +624,10 @@ impl Window {
 
     /// Gets the window's current fullscreen state.
     ///
+    /// If `None` in `Fullscreen::Borderless` was returned it means
+    /// that the window is in a `Fullscreen` state, however there's
+    /// no monitor information available.
+    ///
     /// ## Platform-specific
     ///
     /// - **iOS:** Can only be called on the main thread.
@@ -850,10 +854,15 @@ impl Default for CursorIcon {
     }
 }
 
+/// Fullscreen mode to be set on certain output.
+///
+/// Providing `None` to `Borderless` will result in fullscreen
+/// being set on a system preferred monitor. In general it'll be
+/// the current monitor.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Fullscreen {
     Exclusive(VideoMode),
-    Borderless(MonitorHandle),
+    Borderless(Option<MonitorHandle>),
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/src/window.rs
+++ b/src/window.rs
@@ -628,7 +628,7 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread.
     /// - **Android:** Will always return `None`.
-    /// - **Wayland** Can return `Borderless(None)` in some scenarios
+    /// - **Wayland:** Can return `Borderless(None)` when no monitors are presented.
     ///
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
@@ -852,13 +852,13 @@ impl Default for CursorIcon {
     }
 }
 
-/// Fullscreen mode to be set on certain output.
-///
-/// Providing `None` to `Borderless` will result in fullscreen
-/// being set on a current monitor.
+/// Fullscreen modes.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Fullscreen {
     Exclusive(VideoMode),
+
+    /// Providing `None` to `Borderless` will result in fullscreen
+    /// being set on a current monitor.
     Borderless(Option<MonitorHandle>),
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -624,14 +624,12 @@ impl Window {
 
     /// Gets the window's current fullscreen state.
     ///
-    /// If `None` in `Fullscreen::Borderless` was returned it means
-    /// that the window is in a `Fullscreen` state, however there's
-    /// no monitor information available.
-    ///
     /// ## Platform-specific
     ///
     /// - **iOS:** Can only be called on the main thread.
     /// - **Android:** Will always return `None`.
+    /// - **Wayland** Can return `Borderless(None)` in some scenarios
+    ///
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         self.window.fullscreen()
@@ -857,8 +855,7 @@ impl Default for CursorIcon {
 /// Fullscreen mode to be set on certain output.
 ///
 /// Providing `None` to `Borderless` will result in fullscreen
-/// being set on a system preferred monitor. In general it'll be
-/// the current monitor.
+/// being set on a current monitor.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Fullscreen {
     Exclusive(VideoMode),

--- a/src/window.rs
+++ b/src/window.rs
@@ -628,8 +628,7 @@ impl Window {
     ///
     /// - **iOS:** Can only be called on the main thread.
     /// - **Android:** Will always return `None`.
-    /// - **Wayland:** Can return `Borderless(None)` when no monitors are presented.
-    ///
+    /// - **Wayland:** Can return `Borderless(None)` when there are no monitors.
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         self.window.fullscreen()
@@ -857,8 +856,7 @@ impl Default for CursorIcon {
 pub enum Fullscreen {
     Exclusive(VideoMode),
 
-    /// Providing `None` to `Borderless` will result in fullscreen
-    /// being set on a current monitor.
+    /// Providing `None` to `Borderless` will fullscreen on the current monitor.
     Borderless(Option<MonitorHandle>),
 }
 


### PR DESCRIPTION
This changes `Fullscreen::Borderless` enum variant from
`Fullscreen::Borderless(MonitorHandle)` to
`Fullscreen::Borderless(Option<MonitorHandle>)`. Providing
`None` to it will result in picking system's preferred monitor.

This is an implementation of proposal from https://github.com/rust-windowing/winit/issues/793#issuecomment-676820743 . I can only speak for Wayland implementation here. So `macOS`,`ios`,`X11`, and `Windows`, implementations are interested and likely wrong or inefficient to do what this variant should do.

cc for checking implementations
@francesca64 (not sure if you're active checking macOS/ios stuff now, let me know if you don't want to take a look)
@Osspial (windows) The implementation I've provided needs fixing for sure, since I have a hard time understand how windows even works in winit.
@murarth  (X11)