### PR TITLE
Use send_events instead of send_event in web backend

### DIFF
--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -137,23 +137,25 @@ impl<T> WindowTarget<T> {
             // A mouse down event may come in without any prior CursorMoved events,
             // therefore we should send a CursorMoved event to make sure that the
             // user code has the correct cursor position.
-            runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
-                event: WindowEvent::CursorMoved {
-                    device_id: DeviceId(device::Id(pointer_id)),
-                    position,
-                    modifiers,
-                },
-            });
-            runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
-                event: WindowEvent::MouseInput {
-                    device_id: DeviceId(device::Id(pointer_id)),
-                    state: ElementState::Pressed,
-                    button,
-                    modifiers,
-                },
-            });
+            runner.send_events(
+                std::iter::once(Event::WindowEvent {
+                    window_id: WindowId(id),
+                    event: WindowEvent::CursorMoved {
+                        device_id: DeviceId(device::Id(pointer_id)),
+                        position,
+                        modifiers,
+                    },
+                })
+                .chain(std::iter::once(Event::WindowEvent {
+                    window_id: WindowId(id),
+                    event: WindowEvent::MouseInput {
+                        device_id: DeviceId(device::Id(pointer_id)),
+                        state: ElementState::Pressed,
+                        button,
+                        modifiers,
+                    },
+                })),
+            );
         });
 
         let runner = self.runner.clone();


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Didn't notice that `send_events` is supposed to be used to send multiple events at once.
