### PR TITLE
invert h-scroll direction for macos to be consistent with other platforms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - On Windows, drag and drop is now optional and must be enabled with `WindowBuilderExtWindows::with_drag_and_drop(true)`.
 - On Wayland, fix deadlock when calling to `set_inner_size` from a callback.
 - On macOS, add `hide__other_applications` to `EventLoopWindowTarget` via existing `EventLoopWindowTargetExtMacOS` trait. `hide_other_applications` will hide other applications by calling `-[NSApplication hideOtherApplications: nil]`.
-- On macOS - fix inverted horizontal scroll
+- On macOS, fix inverted horizontal scroll.
 - On android added support for `run_return`.
 - On MacOS, Fixed fullscreen and dialog support for `run_return`.
 - On Windows, fix bug where we'd try to emit `MainEventsCleared` events during nested win32 event loops.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - On Windows, drag and drop is now optional and must be enabled with `WindowBuilderExtWindows::with_drag_and_drop(true)`.
 - On Wayland, fix deadlock when calling to `set_inner_size` from a callback.
 - On macOS, add `hide__other_applications` to `EventLoopWindowTarget` via existing `EventLoopWindowTargetExtMacOS` trait. `hide_other_applications` will hide other applications by calling `-[NSApplication hideOtherApplications: nil]`.
+- On macOS - fix inverted horizontal scroll
 - On android added support for `run_return`.
 - On MacOS, Fixed fullscreen and dialog support for `run_return`.
 - On Windows, fix bug where we'd try to emit `MainEventsCleared` events during nested win32 event loops.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - On Windows, drag and drop is now optional and must be enabled with `WindowBuilderExtWindows::with_drag_and_drop(true)`.
 - On Wayland, fix deadlock when calling to `set_inner_size` from a callback.
 - On macOS, add `hide__other_applications` to `EventLoopWindowTarget` via existing `EventLoopWindowTargetExtMacOS` trait. `hide_other_applications` will hide other applications by calling `-[NSApplication hideOtherApplications: nil]`.
-- On macOS, fix inverted horizontal scroll.
 - On android added support for `run_return`.
 - On MacOS, Fixed fullscreen and dialog support for `run_return`.
 - On Windows, fix bug where we'd try to emit `MainEventsCleared` events during nested win32 event loops.
@@ -28,6 +27,7 @@
 - On NetBSD, fixed crash due to incorrect detection of the main thread.
 - **Breaking:** The virtual key code `Subtract` has been renamed to `NumpadSubtract`
 - **Breaking:** On X11, `-` key is mapped to the `Minus` virtual key code, instead of `Subtract`
+- On macOS, fix inverted horizontal scroll.
 
 # 0.22.2 (2020-05-16)
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -748,30 +748,22 @@ pub enum MouseButton {
     Other(u8),
 }
 
-/// A measured distance as the user scrolls.
-///
-/// Many modern compositors will express touchpad drags and tablet surface touches in units of
-/// `PixelDelta`, while mouse wheel rotation will be expressed in `LineDelta`. However some
-/// backends (e.g. x11) will express all scrolling as `LineDelta` — touchpad drags will simply be
-/// scaled to some presumed equivalent number of lines.
+/// Describes a difference in the mouse scroll wheel state.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MouseScrollDelta {
-    /// Amount in lines or rows to scroll in the horizontal and vertical direction.
+    /// Amount in lines or rows to scroll in the horizontal
+    /// and vertical directions.
     ///
-    /// With "Reverse" scrolling, positive values indicate upward or rightward scrolling. With
-    /// "Natural" scrolling, it's the opposite.
-    ///
-    /// Traditionally each "line" corresponds to one "click" of a scrollable mouse wheel and
-    /// indicates that the application should scroll one line of text. However, anymore "a line"
-    /// must usually be considered an abstract unit of measurement, because of things like
-    /// configurable scroll sensitivity, variable text size, and the advent of touchpads.
+    /// Positive values indicate movement forward
+    /// (away from the user) or rightwards.
     LineDelta(f32, f32),
-
-    /// Amount in pixels to scroll in the horizontal and vertical direction.
+    /// Amount in pixels to scroll in the horizontal and
+    /// vertical direction.
     ///
-    /// With "Reverse" scrolling, positive values indicate upward or rightward scrolling. With
-    /// "Natural" scrolling, it's the opposite.
+    /// Scroll events are expressed as a PixelDelta if
+    /// supported by the device (eg. a touchpad) and
+    /// platform.
     PixelDelta(PhysicalPosition<f64>),
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -748,22 +748,30 @@ pub enum MouseButton {
     Other(u8),
 }
 
-/// Describes a difference in the mouse scroll wheel state.
+/// A measured distance as the user scrolls.
+///
+/// Many modern compositors will express touchpad drags and tablet surface touches in units of
+/// `PixelDelta`, while mouse wheel rotation will be expressed in `LineDelta`. However some
+/// backends (e.g. x11) will express all scrolling as `LineDelta` — touchpad drags will simply be
+/// scaled to some presumed equivalent number of lines.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MouseScrollDelta {
-    /// Amount in lines or rows to scroll in the horizontal
-    /// and vertical directions.
+    /// Amount in lines or rows to scroll in the horizontal and vertical direction.
     ///
-    /// Positive values indicate movement forward
-    /// (away from the user) or rightwards.
+    /// With "Reverse" scrolling, positive values indicate upward or rightward scrolling. With
+    /// "Natural" scrolling, it's the opposite.
+    ///
+    /// Traditionally each "line" corresponds to one "click" of a scrollable mouse wheel and
+    /// indicates that the application should scroll one line of text. However, anymore "a line"
+    /// must usually be considered an abstract unit of measurement, because of things like
+    /// configurable scroll sensitivity, variable text size, and the advent of touchpads.
     LineDelta(f32, f32),
-    /// Amount in pixels to scroll in the horizontal and
-    /// vertical direction.
+
+    /// Amount in pixels to scroll in the horizontal and vertical direction.
     ///
-    /// Scroll events are expressed as a PixelDelta if
-    /// supported by the device (eg. a touchpad) and
-    /// platform.
+    /// With "Reverse" scrolling, positive values indicate upward or rightward scrolling. With
+    /// "Natural" scrolling, it's the opposite.
     PixelDelta(PhysicalPosition<f64>),
 }
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -1003,7 +1003,8 @@ extern "C" fn scroll_wheel(this: &Object, _sel: Sel, event: id) {
         let state = &mut *(state_ptr as *mut ViewState);
 
         let delta = {
-            let (x, y) = (event.scrollingDeltaX(), event.scrollingDeltaY());
+            // macos horizontal sign convention is the inverse of winit
+            let (x, y) = (event.scrollingDeltaX() * -1.0, event.scrollingDeltaY());
             if event.hasPreciseScrollingDeltas() == YES {
                 let delta = LogicalPosition::new(x, y).to_physical(state.get_scale_factor());
                 MouseScrollDelta::PixelDelta(delta)

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -1003,7 +1003,7 @@ extern "C" fn scroll_wheel(this: &Object, _sel: Sel, event: id) {
         let state = &mut *(state_ptr as *mut ViewState);
 
         let delta = {
-            // macos horizontal sign convention is the inverse of winit
+            // macOS horizontal sign convention is the inverse of winit.
             let (x, y) = (event.scrollingDeltaX() * -1.0, event.scrollingDeltaY());
             if event.hasPreciseScrollingDeltas() == YES {
                 let delta = LogicalPosition::new(x, y).to_physical(state.get_scale_factor());


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/1695

---

- [x] Tested on all platforms changed
- [none] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [-] Created or updated an example program if it would help users understand this functionality
- [n/a] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented