### PR TITLE
Bump parking_lot to 0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - **Breaking:** `current_monitor` now returns `Option<MonitorHandle>`.
 - **Breaking:** `primary_monitor` now returns `Option<MonitorHandle>`.
 - On macOS, updated core-* dependencies and cocoa.
+- Bump `parking_lot` to 0.11
 
 # 0.22.2 (2020-05-16)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = "2.0"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd", target_os = "windows"))'.dependencies.parking_lot]
-version = "0.10"
+version = "0.11"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web_sys]
 package = "web-sys"


### PR DESCRIPTION
- [ ] Tested on all platforms changed
Tested on Linux. The other platforms affected by this change are the BSDs and Windows. Nothing stands out in the [parking_lot changelog](https://github.com/Amanieu/parking_lot/blob/master/CHANGELOG.md#parking_lot-0110-parking_lot_core-080-lock_api-040-2020-06-23) that suggests there were any platform-specific changes however.
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [N/A] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [N/A] Created or updated an example program if it would help users understand this functionality
- [N/A] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Resolves #1657 