### PR TITLE
Stop using deprecated simple_logger initialization

### DIFF
--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -1,5 +1,6 @@
 use std::{thread, time};
 
+use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, KeyboardInput, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -17,7 +18,7 @@ const WAIT_TIME: time::Duration = time::Duration::from_millis(100);
 const POLL_SLEEP_TIME: time::Duration = time::Duration::from_millis(100);
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
 
     println!("Press '1' to switch to Wait mode.");
     println!("Press '2' to switch to WaitUntil mode.");

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,3 +1,4 @@
+use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyboardInput, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -5,7 +6,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new().build(&event_loop).unwrap();

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -1,3 +1,4 @@
+use simple_logger::SimpleLogger;
 use winit::{
     event::{DeviceEvent, ElementState, Event, KeyboardInput, ModifiersState, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -5,7 +6,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new()

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -1,5 +1,6 @@
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {
+    use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
         event_loop::{ControlFlow, EventLoop},
@@ -11,7 +12,7 @@ fn main() {
         Timer,
     }
 
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::<CustomEvent>::with_user_event();
 
     let _window = WindowBuilder::new()

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,11 +1,13 @@
 use std::io::{stdin, stdout, Write};
+
+use simple_logger::SimpleLogger;
 use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::monitor::{MonitorHandle, VideoMode};
 use winit::window::{Fullscreen, WindowBuilder};
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     print!("Please choose the fullscreen mode: (1) exclusive, (2) borderless: ");

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -1,3 +1,4 @@
+use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, KeyboardInput, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -5,7 +6,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let _window = WindowBuilder::new()

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -1,3 +1,4 @@
+use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
     event::{Event, WindowEvent},
@@ -6,7 +7,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new().build(&event_loop).unwrap();

--- a/examples/minimize.rs
+++ b/examples/minimize.rs
@@ -1,11 +1,12 @@
 extern crate winit;
 
+use simple_logger::SimpleLogger;
 use winit::event::{Event, VirtualKeyCode, WindowEvent};
 use winit::event_loop::{ControlFlow, EventLoop};
 use winit::window::WindowBuilder;
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new()

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -1,7 +1,8 @@
+use simple_logger::SimpleLogger;
 use winit::{event_loop::EventLoop, window::WindowBuilder};
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -2,6 +2,7 @@
 fn main() {
     use std::{collections::HashMap, sync::mpsc, thread, time::Duration};
 
+    use simple_logger::SimpleLogger;
     use winit::{
         dpi::{PhysicalPosition, PhysicalSize, Position, Size},
         event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
@@ -12,7 +13,7 @@ fn main() {
     const WINDOW_COUNT: usize = 3;
     const WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize::new(600, 400);
 
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
     let mut window_senders = HashMap::with_capacity(WINDOW_COUNT);
     for _ in 0..WINDOW_COUNT {

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+
+use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyboardInput, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -6,7 +8,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let mut windows = HashMap::new();

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -1,3 +1,4 @@
+use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -5,7 +6,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new()

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -1,5 +1,6 @@
 use std::{thread, time};
 
+use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -7,7 +8,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new()

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,3 +1,4 @@
+use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
@@ -6,7 +7,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let mut resizable = false;

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,5 +1,7 @@
 use instant::Instant;
 use std::time::Duration;
+
+use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -7,7 +9,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let _window = WindowBuilder::new()

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,3 +1,4 @@
+use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -5,7 +6,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new()

--- a/examples/video_modes.rs
+++ b/examples/video_modes.rs
@@ -1,7 +1,8 @@
+use simple_logger::SimpleLogger;
 use winit::event_loop::EventLoop;
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
     let monitor = match event_loop.primary_monitor() {
         Some(monitor) => monitor,

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,3 +1,4 @@
+use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -5,7 +6,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new()

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -1,5 +1,6 @@
 // This example is used by developers to test various window functions.
 
+use simple_logger::SimpleLogger;
 use winit::{
     dpi::{LogicalSize, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
@@ -8,7 +9,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
     let window = WindowBuilder::new()

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -1,5 +1,7 @@
 extern crate image;
 use std::path::Path;
+
+use simple_logger::SimpleLogger;
 use winit::{
     event::Event,
     event_loop::{ControlFlow, EventLoop},
@@ -7,7 +9,7 @@ use winit::{
 };
 
 fn main() {
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
 
     // You'll have to choose an icon size at your own discretion. On X11, the desired size varies
     // by WM, and on Windows, you still have to account for screen scaling. Here we use 32px,

--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -10,6 +10,8 @@
 ))]
 fn main() {
     use std::{thread::sleep, time::Duration};
+
+    use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
         event_loop::{ControlFlow, EventLoop},
@@ -18,7 +20,7 @@ fn main() {
     };
     let mut event_loop = EventLoop::new();
 
-    simple_logger::init().unwrap();
+    SimpleLogger::new().init().unwrap();
     let _window = WindowBuilder::new()
         .with_title("A fantastic window!")
         .build(&event_loop)


### PR DESCRIPTION
This is only a change to the examples. Some `use` imports have an extra newline to prevent `std` imports from getting mixed in the middle of external crate imports.

- [ ] Tested on all platforms changed
This shouldn't be an issue since we're just using the newer initialization API of `simple_logger` 1.9.0
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
This seems internal enough, so I didn't make a changelog entry.
- [N/A] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [N/A] Created or updated an example program if it would help users understand this functionality
- [N/A] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented