### PR TITLE
Fix examples build by bumping simple_logger to v1.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ bitflags = "1"
 
 [dev-dependencies]
 image = "0.23"
-simple_logger = "1"
+simple_logger = "1.9"
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk = "0.1.0"


### PR DESCRIPTION
Fix regression from #1702. `simple_logger::SimpleLogger` is not public in `simple-logger` < v1.9.

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented