### PR TITLE
Bump ndk dependencies to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - **Breaking:** `primary_monitor` now returns `Option<MonitorHandle>`.
 - On macOS, updated core-* dependencies and cocoa.
 - Bump `parking_lot` to 0.11
+- Bump `ndk`, `ndk-sys` and `ndk-glue` to 0.2.0
 
 # 0.22.2 (2020-05-16)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ image = "0.23"
 simple_logger = "1.9"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = "0.1.0"
-ndk-sys = "0.1.0"
-ndk-glue = "0.1.0"
+ndk = "0.2.0"
+ndk-sys = "0.2.0"
+ndk-glue = "0.2.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
 objc = "0.2.3"

--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ crate-type = ["cdylib"]
 
 And add this to the example file to add the native activity glue:
 ```rust
-#[cfg(target_os = "android")]
-ndk_glue::ndk_glue!(main);
+#[cfg_attr(target_os = "android", ndk_glue::main(backtrace = "on"))]
+fn main() {
+  // Already existing main function
+}
 ```
 
 And run the application with `cargo apk run --example request_redraw_threaded`


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Tested on some examples and a [personal project](https://github.com/adrien-ben/vulkan-triangle-rs/commit/746979a88f590568088e0441bf01d84e187ec913) (Simple Vulkan application displaying a triangle)