### PR TITLE
Convert location to physical on Mac when `emit_move_event`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - **Breaking:** On Web, the canvas element associated to a `Window` is no longer removed from the DOM when the `Window` is dropped.
 - On Web, `WindowEvent::Resized` is now emitted when `Window::set_inner_size` is called.
 - **Breaking:** `Fullscreen` enum now uses `Borderless(Option<MonitorHandle>)` instead of `Borderless(MonitorHandle)` to allow picking the current monitor.
-- On MacOS, convert location to physical unit in `emit_move_event`.
+- On MacOS, fix `WindowEvent::Moved` ignoring the scale factor.
 
 # 0.22.2 (2020-05-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - **Breaking:** On Web, the canvas element associated to a `Window` is no longer removed from the DOM when the `Window` is dropped.
 - On Web, `WindowEvent::Resized` is now emitted when `Window::set_inner_size` is called.
 - **Breaking:** `Fullscreen` enum now uses `Borderless(Option<MonitorHandle>)` instead of `Borderless(MonitorHandle)` to allow picking the current monitor.
+- On MacOS, convert location to physical unit in `emit_move_event`.
 
 # 0.22.2 (2020-05-16)
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -15,7 +15,7 @@ use objc::{
 };
 
 use crate::{
-    dpi::LogicalSize,
+    dpi::{LogicalPosition, LogicalSize},
     event::{Event, ModifiersState, WindowEvent},
     platform_impl::platform::{
         app_state::AppState,
@@ -112,7 +112,9 @@ impl WindowDelegateState {
         let moved = self.previous_position != Some((x, y));
         if moved {
             self.previous_position = Some((x, y));
-            self.emit_event(WindowEvent::Moved((x, y).into()));
+            let scale_factor = self.get_scale_factor();
+            let physical_pos = LogicalPosition::<f64>::from((x, y)).to_physical(scale_factor);
+            self.emit_event(WindowEvent::Moved(physical_pos));
         }
     }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
