### PR TITLE
Fix missing ModifiersChanged event from start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 - On Wayland, disable maximize button for non-resizable window.
 - On Wayland, added support for `set_ime_position`.
 - On Wayland, fix crash on startup since GNOME 3.37.90.
+- On X11, fix incorrect modifiers state on startup.
 
 # 0.22.2 (2020-05-16)
 

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -923,7 +923,7 @@ impl<T: 'static> EventProcessor<T> {
                                 },
                             });
 
-                            // Issue key press events for all pressed keys.
+                            // Issue key press events for all pressed keys
                             Self::handle_pressed_keys(
                                 &wt,
                                 window_id,

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1243,7 +1243,12 @@ impl<T: 'static> EventProcessor<T> {
         let modifiers = device_mod_state.modifiers();
 
         // Update modifiers state and emit key events based on which keys are currently pressed.
-        for keycode in wt.xconn.query_keymap().into_iter().filter(|k| *k >= KEYCODE_OFFSET) {
+        for keycode in wt
+            .xconn
+            .query_keymap()
+            .into_iter()
+            .filter(|k| *k >= KEYCODE_OFFSET)
+        {
             let scancode = (keycode - KEYCODE_OFFSET) as u32;
             let keysym = wt.xconn.keycode_to_keysym(keycode);
             let virtual_keycode = events::keysym_to_element(keysym as c_uint);

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1242,8 +1242,7 @@ impl<T: 'static> EventProcessor<T> {
         let device_id = mkdid(util::VIRTUAL_CORE_KEYBOARD);
         let modifiers = device_mod_state.modifiers();
 
-        // Get the set of keys currently pressed and apply Key events to each and also updating
-        // the pressed modifiers.
+        // Update modifiers state and emit key events based on which keys are currently pressed.
         for keycode in wt.xconn.query_keymap().into_iter().filter(|k| *k >= KEYCODE_OFFSET) {
             let scancode = (keycode - KEYCODE_OFFSET) as u32;
             let keysym = wt.xconn.keycode_to_keysym(keycode);


### PR DESCRIPTION
This patch updates the X11 `FocusIn` and `FocusOut` event processor to properly track the synthetic events produced.

fixes #1563