### PR TITLE
Clarify ControlFlow::Poll doc for web

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -74,9 +74,11 @@ pub enum ControlFlow {
     /// When the current loop iteration finishes, immediately begin a new iteration regardless of
     /// whether or not new events are available to process.
     ///
-    /// For web, events are queued and usually sent when `requestAnimationFrame` fires but sometimes
-    /// the events in the queue may be sent before the next `requestAnimationFrame` callback, for
-    /// example when the scaling of the page has changed.
+    /// ## Platform-specific
+    /// - **Web:** Events are queued and usually sent when `requestAnimationFrame` fires but sometimes
+    ///   the events in the queue may be sent before the next `requestAnimationFrame` callback, for
+    ///   example when the scaling of the page has changed. This should be treated as an implementation
+    ///   detail which should not be relied on.
     Poll,
     /// When the current loop iteration finishes, suspend the thread until another event arrives.
     Wait,


### PR DESCRIPTION
Make it clear that ControlFlow::Poll causing events to be sent on `requestAnimationFrame` is an implementation detail which should not be relied on.

**Rationale:**
The exact behaviour of `ControlFlow::Poll` had already been changed once in #1690, and it might be changed again in the future. It also does not expose the timestamp obtained from the `requestAnimationFrame` callback so it is not very useful to users who actually want to do rendering from `requestAnimationFrame` (#1697).

- [x] `cargo doc` builds successfully

cc @ryanisaacg 