### PR TITLE
Update SCTK to 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 - **Breaking:** On Wayland, `Theme` trait was reworked.
 - On Wayland, disable maximize button for non-resizable window.
 - On Wayland, added support for `set_ime_position`.
+- On Wayland, fix crash on startup since GNOME 3.37.90.
 
 # 0.22.2 (2020-05-16)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,8 @@ features = [
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-wayland-client = { version = "0.27", features = [ "dlopen"] , optional = true }
-sctk = { package = "smithay-client-toolkit", version = "0.11", optional = true }
+wayland-client = { version = "0.28", features = [ "dlopen"] , optional = true }
+sctk = { package = "smithay-client-toolkit", version = "0.12", optional = true }
 mio = "0.6"
 mio-extras = "2.0"
 x11-dl = { version = "2.18.5", optional = true }

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -99,11 +99,7 @@ impl<T: 'static> EventLoop<T> {
         let display_proxy = display.attach(event_queue.token());
 
         // Setup environment.
-        let env = Environment::init(&display_proxy, WinitEnv::new());
-
-        // Issue 2 sync roundtrips to initialize environment.
-        event_queue.sync_roundtrip(&mut (), |_, _, _| unreachable!())?;
-        event_queue.sync_roundtrip(&mut (), |_, _, _| unreachable!())?;
+        let env = Environment::new(&display_proxy, &mut event_queue, WinitEnv::new())?;
 
         // Create event loop.
         let event_loop = calloop::EventLoop::<WinitState>::new()?;


### PR DESCRIPTION
SCTK was a bit behind on Wayland protocol version, and so this release
brings it up to date. It also cleans up 'Environment'.