### PR TITLE
Added WindowHasFocus and WindowLostFocus events to Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- On Android, calling `WindowEvent::Focused` now works properly instead of always returning false. 
+
 # 0.23.0 (2020-10-02)
 
 - On iOS, fixed support for the "Debug View Heirarchy" feature in Xcode.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -148,6 +148,28 @@ impl<T: 'static> EventLoop<T> {
                             );
                         }
                     }
+                    Event::WindowHasFocus => {
+                        call_event_handler!(
+                            event_handler,
+                            self.window_target(),
+                            control_flow,
+                            event::Event::WindowEvent {
+                                window_id: window::WindowId(WindowId),
+                                event: event::WindowEvent::Focused(true),
+                            }
+                        );
+                    }
+                    Event::WindowLostFocus => {
+                        call_event_handler!(
+                            event_handler,
+                            self.window_target(),
+                            control_flow,
+                            event::Event::WindowEvent {
+                                window_id: window::WindowId(WindowId),
+                                event: event::WindowEvent::Focused(false),
+                            }
+                        );
+                    }
                     _ => {}
                 },
                 Some(EventSource::InputQueue) => {


### PR DESCRIPTION
Ran into the issue were `WindowEvent::Focused` would always return false on Android, which was caused by unhandled events  from`ndk-glue`. This is a simple PR that solves that issue, updated the changelog as well!

Tested locally on my Android device and works as expected.
