### PR TITLE
Fix failing assertion on start-up with Safari

### DIFF
--- a/src/platform_impl/web/web_sys/scaling.rs
+++ b/src/platform_impl/web/web_sys/scaling.rs
@@ -59,9 +59,9 @@ impl ScaleChangeDetectorInternal {
         // We add 0.0001 to the lower and upper bounds such that it won't fail
         // due to floating point precision limitations.
         let media_query = format!(
-            "(min-resolution: {:.4}dppx) and (max-resolution: {:.4}dppx)",
-            current_scale - 0.0001,
-            current_scale + 0.0001,
+            "(min-resolution: {min_scale:.4}dppx) and (max-resolution: {max_scale:.4}dppx),
+             (-webkit-min-device-pixel-ratio: {min_scale:.4}) and (-webkit-max-device-pixel-ratio: {max_scale:.4})",
+            min_scale = current_scale - 0.0001, max_scale= current_scale + 0.0001,
         );
         let mql = MediaQueryListHandle::new(&media_query, closure);
         if let Some(mql) = &mql {


### PR DESCRIPTION
The initial media query that's used to watch for device pixel ratio
changes should match. Unfortunately it doesn't with Safari and the
corresponding assertion fails. This is because resolution is not a
supported support property for queries. As a workaround, this patch
extends the query to optionally match for the webkit specific DPR
property directly.

This fixes #1734

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
