### PR TITLE
Windows: Fix alt tab bordless fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On Android, calling `WindowEvent::Focused` now works properly instead of always returning false. 
+- On Windows, fix alt-tab behaviour by removing borderless fullscreen "always on top" flag.
 - On Windows, fix bug preventing windows with transparency enabled from having fully-opaque regions.
 
 # 0.23.0 (2020-10-02)

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -489,7 +489,14 @@ impl Window {
 
             // Update window style
             WindowState::set_window_flags(window_state_lock, window.0, |f| {
-                f.set(WindowFlags::MARKER_FULLSCREEN, fullscreen.is_some())
+                f.set(
+                    WindowFlags::MARKER_EXCLUSIVE_FULLSCREEN,
+                    matches!(fullscreen, Some(Fullscreen::Exclusive(_))),
+                );
+                f.set(
+                    WindowFlags::MARKER_BORDERLESS_FULLSCREEN,
+                    matches!(fullscreen, Some(Fullscreen::Borderless(_))),
+                );
             });
 
             // Update window bounds

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -71,7 +71,8 @@ bitflags! {
 
         /// Marker flag for fullscreen. Should always match `WindowState::fullscreen`, but is
         /// included here to make masking easier.
-        const MARKER_FULLSCREEN = 1 << 9;
+        const MARKER_EXCLUSIVE_FULLSCREEN = 1 << 9;
+        const MARKER_BORDERLESS_FULLSCREEN = 1 << 13;
 
         /// The `WM_SIZE` event contains some parameters that can effect the state of `WindowFlags`.
         /// In most cases, it's okay to let those parameters change the state. However, when we're
@@ -89,7 +90,7 @@ bitflags! {
             WindowFlags::RESIZABLE.bits |
             WindowFlags::MAXIMIZED.bits
         );
-        const FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits;
+        const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits;
         const NO_DECORATIONS_AND_MASK = !WindowFlags::RESIZABLE.bits;
         const INVISIBLE_AND_MASK = !WindowFlags::MAXIMIZED.bits;
     }
@@ -176,9 +177,11 @@ impl MouseProperties {
 
 impl WindowFlags {
     fn mask(mut self) -> WindowFlags {
-        if self.contains(WindowFlags::MARKER_FULLSCREEN) {
+        if self.contains(WindowFlags::MARKER_EXCLUSIVE_FULLSCREEN) {
             self &= WindowFlags::FULLSCREEN_AND_MASK;
-            self |= WindowFlags::FULLSCREEN_OR_MASK;
+            self |= WindowFlags::EXCLUSIVE_FULLSCREEN_OR_MASK;
+        } else if self.contains(WindowFlags::MARKER_BORDERLESS_FULLSCREEN) {
+            self &= WindowFlags::FULLSCREEN_AND_MASK;
         }
         if !self.contains(WindowFlags::VISIBLE) {
             self &= WindowFlags::INVISIBLE_AND_MASK;
@@ -319,7 +322,9 @@ impl WindowFlags {
                 // We generally don't want style changes here to affect window
                 // focus, but for fullscreen windows they must be activated
                 // (i.e. focused) so that they appear on top of the taskbar
-                if !new.contains(WindowFlags::MARKER_FULLSCREEN) {
+                if !new.contains(WindowFlags::MARKER_EXCLUSIVE_FULLSCREEN)
+                    && !new.contains(WindowFlags::MARKER_BORDERLESS_FULLSCREEN)
+                {
                     flags |= winuser::SWP_NOACTIVATE;
                 }
 


### PR DESCRIPTION
Like #1542 but just for borderless.

Fixes #1540
Closes #1542

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- ~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- ~Created or updated an example program if it would help users understand this functionality~
- ~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~
