### PR TITLE
On Wayland, fix 'with_min_inner_size' disabling resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - On Windows, fix alt-tab behaviour by removing borderless fullscreen "always on top" flag.
 - On Windows, fix bug preventing windows with transparency enabled from having fully-opaque regions.
 - **Breaking:** On Windows, include prefix byte in scancodes.
+- On Wayland, fix window not being resizeable when using `with_min_inner_size` in `WindowBuilder`.
 
 # 0.23.0 (2020-10-02)
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -145,7 +145,7 @@ impl Window {
 
         // Max dimensions.
         let max_size = attributes
-            .min_inner_size
+            .max_inner_size
             .map(|size| size.to_logical::<f64>(scale_factor as f64).into());
         window.set_max_size(max_size);
 


### PR DESCRIPTION
Building window with 'set_min_inner_size' was setting 'max_inner_size'
under the hood, thus completely disabling window resize, since
the window isn't resizeable on Wayland when its minimum size
is equal to its maximum size.