### PR TITLE
Fix WindowEvent::ReceivedCharacter on web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - On Wayland, fix window not being resizeable when using `with_min_inner_size` in `WindowBuilder`.
 - On Unix, fix cross-compiling to wasm32 without enabling X11 or Wayland.
 - On Windows, fix use after free crash during window destruction.
+- On Web, fix `WindowEvent::ReceivedCharacter` never being sent on key input.
 
 # 0.23.0 (2020-10-02)
 

--- a/src/platform_impl/web/stdweb/canvas.rs
+++ b/src/platform_impl/web/stdweb/canvas.rs
@@ -165,6 +165,8 @@ impl Canvas {
         // viable/compatible alternative as of now. `beforeinput` is still widely
         // unsupported.
         self.on_received_character = Some(self.add_user_event(move |event: KeyPressEvent| {
+            // Supress further handling to stop keys like the space key from scrolling the page.
+            event.prevent_default();
             handler(event::codepoint(&event));
         }));
     }

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -189,6 +189,8 @@ impl Canvas {
         self.on_received_character = Some(self.common.add_user_event(
             "keypress",
             move |event: KeyboardEvent| {
+                // Supress further handling to stop keys like the space key from scrolling the page.
+                event.prevent_default();
                 handler(event::codepoint(&event));
             },
         ));

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -157,7 +157,17 @@ impl Canvas {
         self.on_keyboard_press = Some(self.common.add_user_event(
             "keydown",
             move |event: KeyboardEvent| {
-                event.prevent_default();
+                // event.prevent_default() would suppress subsequent on_received_character() calls. That
+                // supression is correct for key sequences like Tab/Shift-Tab, Ctrl+R, PgUp/Down to
+                // scroll, etc. We should not do it for key sequences that result in meaningful character
+                // input though.
+                let event_key = &event.key();
+                let is_key_string = event_key.len() == 1 || !event_key.is_ascii();
+                let is_shortcut_modifiers =
+                    (event.ctrl_key() || event.alt_key()) && !event.get_modifier_state("AltGr");
+                if !is_key_string || is_shortcut_modifiers {
+                    event.prevent_default();
+                }
                 handler(
                     event::scan_code(&event),
                     event::virtual_key_code(&event),


### PR DESCRIPTION
The event was never sent to the application because of the unconditional
preventDefault()
call on keydown.

Fixes #1741

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
