### PR TITLE
macos: Fix compile on aarch64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - On Unix, fix cross-compiling to wasm32 without enabling X11 or Wayland.
 - On Windows, fix use after free crash during window destruction.
 - On Web, fix `WindowEvent::ReceivedCharacter` never being sent on key input.
+- On macOS, fix compilation when targeting aarch64
 
 # 0.23.0 (2020-10-02)
 

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -10,6 +10,7 @@ use cocoa::{
 };
 use dispatch::Queue;
 use objc::rc::autoreleasepool;
+use objc::runtime::NO;
 
 use crate::{
     dpi::LogicalSize,
@@ -167,7 +168,7 @@ pub unsafe fn set_maximized_async(
                 } else {
                     shared_state_lock.saved_standard_frame()
                 };
-                ns_window.setFrame_display_(new_rect, 0);
+                ns_window.setFrame_display_(new_rect, NO);
             }
 
             trace!("Unlocked shared state in `set_maximized`");

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -388,7 +388,7 @@ extern "C" fn has_marked_text(this: &Object, _sel: Sel) -> BOOL {
         trace!("Triggered `hasMarkedText`");
         let marked_text: id = *this.get_ivar("markedText");
         trace!("Completed `hasMarkedText`");
-        (marked_text.length() > 0) as i8
+        (marked_text.length() > 0) as BOOL
     }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -653,7 +653,7 @@ impl UnownedWindow {
             self.set_style_mask_async(curr_mask);
         }
 
-        is_zoomed != 0
+        is_zoomed != NO
     }
 
     fn saved_style(&self, shared_state: &mut SharedState) -> NSWindowStyleMask {
@@ -1168,14 +1168,14 @@ unsafe fn set_min_inner_size<V: NSWindow + Copy>(window: V, mut min_size: Logica
     // If necessary, resize the window to match constraint
     if current_rect.size.width < min_size.width {
         current_rect.size.width = min_size.width;
-        window.setFrame_display_(current_rect, 0)
+        window.setFrame_display_(current_rect, NO)
     }
     if current_rect.size.height < min_size.height {
         // The origin point of a rectangle is at its bottom left in Cocoa.
         // To ensure the window's top-left point remains the same:
         current_rect.origin.y += current_rect.size.height - min_size.height;
         current_rect.size.height = min_size.height;
-        window.setFrame_display_(current_rect, 0)
+        window.setFrame_display_(current_rect, NO)
     }
 }
 
@@ -1192,13 +1192,13 @@ unsafe fn set_max_inner_size<V: NSWindow + Copy>(window: V, mut max_size: Logica
     // If necessary, resize the window to match constraint
     if current_rect.size.width > max_size.width {
         current_rect.size.width = max_size.width;
-        window.setFrame_display_(current_rect, 0)
+        window.setFrame_display_(current_rect, NO)
     }
     if current_rect.size.height > max_size.height {
         // The origin point of a rectangle is at its bottom left in Cocoa.
         // To ensure the window's top-left point remains the same:
         current_rect.origin.y += current_rect.size.height - max_size.height;
         current_rect.size.height = max_size.height;
-        window.setFrame_display_(current_rect, 0)
+        window.setFrame_display_(current_rect, NO)
     }
 }


### PR DESCRIPTION
Fixes compilation when targeting aarch64, where `objc` crate has slightly different encoding for `BOOL` type.


