### PR TITLE
X11: Fix `request_redraw` not waking the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - On Windows, fix use after free crash during window destruction.
 - On Web, fix `WindowEvent::ReceivedCharacter` never being sent on key input.
 - On macOS, fix compilation when targeting aarch64
+- On X11, fix `Window::request_redraw` not waking the event loop.
 
 # 0.23.0 (2020-10-02)
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -309,9 +309,11 @@ impl<T: 'static> EventLoop<T> {
             }
             // Empty the redraw requests
             {
-                while let Ok(wid) = self.redraw_channel.try_recv() {
+                while let Ok(window_id) = self.redraw_channel.try_recv() {
                     sticky_exit_callback(
-                        Event::RedrawRequested(crate::window::WindowId(super::WindowId::X(wid))),
+                        Event::RedrawRequested(crate::window::WindowId(super::WindowId::X(
+                            window_id,
+                        ))),
                         &self.target,
                         &mut control_flow,
                         &mut callback,

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -24,7 +24,7 @@ pub use self::{
 
 use std::{
     cell::RefCell,
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     ffi::CStr,
     mem::{self, MaybeUninit},
     ops::Deref,
@@ -32,7 +32,7 @@ use std::{
     ptr,
     rc::Rc,
     slice,
-    sync::{mpsc, Arc, Mutex, Weak},
+    sync::{mpsc, Arc, Weak},
     time::{Duration, Instant},
 };
 
@@ -58,6 +58,7 @@ use crate::{
 
 const X_TOKEN: Token = Token(0);
 const USER_TOKEN: Token = Token(1);
+const REDRAW_TOKEN: Token = Token(2);
 
 pub struct EventLoopWindowTarget<T> {
     xconn: Arc<XConnection>,
@@ -67,13 +68,14 @@ pub struct EventLoopWindowTarget<T> {
     root: ffi::Window,
     ime: RefCell<Ime>,
     windows: RefCell<HashMap<WindowId, Weak<UnownedWindow>>>,
-    pending_redraws: Arc<Mutex<HashSet<WindowId>>>,
+    redraw_sender: Sender<WindowId>,
     _marker: ::std::marker::PhantomData<T>,
 }
 
 pub struct EventLoop<T: 'static> {
     poll: Poll,
     event_processor: EventProcessor<T>,
+    redraw_channel: Receiver<WindowId>,
     user_channel: Receiver<T>,
     user_sender: Sender<T>,
     target: Rc<RootELW<T>>,
@@ -174,32 +176,16 @@ impl<T: 'static> EventLoop<T> {
 
         xconn.update_cached_wm_info(root);
 
-        let pending_redraws: Arc<Mutex<HashSet<WindowId>>> = Default::default();
-
         let mut mod_keymap = ModifierKeymap::new();
         mod_keymap.reset_from_x_connection(&xconn);
-
-        let target = Rc::new(RootELW {
-            p: super::EventLoopWindowTarget::X(EventLoopWindowTarget {
-                ime,
-                root,
-                windows: Default::default(),
-                _marker: ::std::marker::PhantomData,
-                ime_sender,
-                xconn,
-                wm_delete_window,
-                net_wm_ping,
-                pending_redraws: pending_redraws.clone(),
-            }),
-            _marker: ::std::marker::PhantomData,
-        });
 
         let poll = Poll::new().unwrap();
 
         let (user_sender, user_channel) = channel();
+        let (redraw_sender, redraw_channel) = channel();
 
         poll.register(
-            &EventedFd(&get_xtarget(&target).xconn.x11_fd),
+            &EventedFd(&xconn.x11_fd),
             X_TOKEN,
             Ready::readable(),
             PollOpt::level(),
@@ -213,6 +199,29 @@ impl<T: 'static> EventLoop<T> {
             PollOpt::level(),
         )
         .unwrap();
+
+        poll.register(
+            &redraw_channel,
+            REDRAW_TOKEN,
+            Ready::readable(),
+            PollOpt::level(),
+        )
+        .unwrap();
+
+        let target = Rc::new(RootELW {
+            p: super::EventLoopWindowTarget::X(EventLoopWindowTarget {
+                ime,
+                root,
+                windows: Default::default(),
+                _marker: ::std::marker::PhantomData,
+                ime_sender,
+                xconn,
+                wm_delete_window,
+                net_wm_ping,
+                redraw_sender,
+            }),
+            _marker: ::std::marker::PhantomData,
+        });
 
         let event_processor = EventProcessor {
             target: target.clone(),
@@ -239,6 +248,7 @@ impl<T: 'static> EventLoop<T> {
 
         let result = EventLoop {
             poll,
+            redraw_channel,
             user_channel,
             user_sender,
             event_processor,
@@ -277,8 +287,6 @@ impl<T: 'static> EventLoop<T> {
             // Process all pending events
             self.drain_events(&mut callback, &mut control_flow);
 
-            let wt = get_xtarget(&self.target);
-
             // Empty the user event buffer
             {
                 while let Ok(event) = self.user_channel.try_recv() {
@@ -301,10 +309,7 @@ impl<T: 'static> EventLoop<T> {
             }
             // Empty the redraw requests
             {
-                // Release the lock to prevent deadlock
-                let windows: Vec<_> = wt.pending_redraws.lock().unwrap().drain().collect();
-
-                for wid in windows {
+                while let Ok(wid) = self.redraw_channel.try_recv() {
                     sticky_exit_callback(
                         Event::RedrawRequested(crate::window::WindowId(super::WindowId::X(wid))),
                         &self.target,
@@ -408,7 +413,7 @@ impl<T: 'static> EventLoop<T> {
                             super::WindowId::X(wid),
                         )) = event
                         {
-                            wt.pending_redraws.lock().unwrap().insert(wid);
+                            wt.redraw_sender.send(wid).unwrap();
                         } else {
                             callback(event, window_target, control_flow);
                         }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -310,10 +310,9 @@ impl<T: 'static> EventLoop<T> {
             // Empty the redraw requests
             {
                 while let Ok(window_id) = self.redraw_channel.try_recv() {
+                    let window_id = crate::window::WindowId(super::WindowId::X(window_id));
                     sticky_exit_callback(
-                        Event::RedrawRequested(crate::window::WindowId(super::WindowId::X(
-                            window_id,
-                        ))),
+                        Event::RedrawRequested(window_id),
                         &self.target,
                         &mut control_flow,
                         &mut callback,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -10,9 +10,8 @@ use std::{
 };
 
 use libc;
-use parking_lot::Mutex;
-
 use mio_extras::channel::Sender;
+use parking_lot::Mutex;
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},


### PR DESCRIPTION
Fixes #1755

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
