### PR TITLE
X11: Fix multiple RedrawRequested events per event loop iteration

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -309,19 +309,20 @@ impl<T: 'static> EventLoop<T> {
             }
             // Empty the redraw requests
             {
-                // Set of windows that have already received `RedrawRequested` this iteration
                 let mut windows = HashSet::new();
 
                 while let Ok(window_id) = self.redraw_channel.try_recv() {
-                    if windows.insert(window_id) {
-                        let window_id = crate::window::WindowId(super::WindowId::X(window_id));
-                        sticky_exit_callback(
-                            Event::RedrawRequested(window_id),
-                            &self.target,
-                            &mut control_flow,
-                            &mut callback,
-                        );
-                    }
+                    windows.insert(window_id);
+                }
+
+                for window_id in windows {
+                    let window_id = crate::window::WindowId(super::WindowId::X(window_id));
+                    sticky_exit_callback(
+                        Event::RedrawRequested(window_id),
+                        &self.target,
+                        &mut control_flow,
+                        &mut callback,
+                    );
                 }
             }
             // send RedrawEventsCleared


### PR DESCRIPTION
Fixup to #1756, which could generate multiple `RedrawRequested` events for the same window id in a single event loop iteration.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
