### PR TITLE
[RFC] event: Unwrap user event in map_nonuser_event Err()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking:** On Web, remove the `stdweb` backend.
 - Added `Window::focus_window`to bring the window to the front and set input focus.
 - On Wayland and X11, implement `is_maximized` method on `Window`.
+- **Breaking:** `map_nonuser_event` now returns the unwrapped user event `T` in `Err()`.
 
 # 0.25.0 (2021-05-15)
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -143,10 +143,10 @@ impl<T: Clone> Clone for Event<'static, T> {
 }
 
 impl<'a, T> Event<'a, T> {
-    pub fn map_nonuser_event<U>(self) -> Result<Event<'a, U>, Event<'a, T>> {
+    pub fn map_nonuser_event<U>(self) -> Result<Event<'a, U>, T> {
         use self::Event::*;
         match self {
-            UserEvent(_) => Err(self),
+            UserEvent(user_event) => Err(user_event),
             WindowEvent { window_id, event } => Ok(WindowEvent { window_id, event }),
             DeviceEvent { device_id, event } => Ok(DeviceEvent { device_id, event }),
             NewEvents(cause) => Ok(NewEvents(cause)),


### PR DESCRIPTION
:warning:  **WARNING** :warning: : This is a _breaking_ API change!

Currently separating an `Event<T>` into a user event `T` and `Event<()>` is not ergonomic: when `map_nonuser_event` returns `Err()` the caller "knows" this can only contain `UserEvent(T)`, yet has to write additional unpacking logic to extract the event, with an unnecessary `unreachable!()`.

Solve this by returning `T` directly in the Err case, instead of `Event<'a, T>`.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed (N/A: there were no compiler warnings in the first place?)
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
  - How about introducing a user event to `multithreaded.rs`? That is the exact use case we need this for: handle user events (from the thread) in the event loop, and send nonuser events into the thread.
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
