### PR TITLE
Added focus_window to Window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - On X11, fix `Window::request_redraw` not waking the event loop.
 - On Wayland, the keypad arrow keys are now recognized.
 - **Breaking** Rename `desktop::EventLoopExtDesktop` to `run_return::EventLoopExtRunReturn`.
+- Added `Window::focus_window`to bring the window to the front and set input focus.
 
 # 0.23.0 (2020-10-02)
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -485,6 +485,8 @@ impl Window {
 
     pub fn set_ime_position(&self, _position: Position) {}
 
+    pub fn focus_window(&self) {}
+
     pub fn set_cursor_icon(&self, _: window::CursorIcon) {}
 
     pub fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -260,6 +260,10 @@ impl Inner {
         warn!("`Window::set_ime_position` is ignored on iOS")
     }
 
+    pub fn focus_window(&self) {
+        warn!("`Window::set_focus` is ignored on iOS")
+    }
+
     // Allow directly accessing the current monitor internally without unwrapping.
     fn current_monitor_inner(&self) -> RootMonitorHandle {
         unsafe {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -419,6 +419,16 @@ impl Window {
     }
 
     #[inline]
+    pub fn focus_window(&self) {
+        match self {
+            #[cfg(feature = "x11")]
+            &Window::X(ref w) => w.focus_window(_window_icon),
+            #[cfg(feature = "wayland")]
+            _ => (),
+        }
+    }
+
+    #[inline]
     pub fn request_redraw(&self) {
         x11_or_wayland!(match self; Window(w) => w.request_redraw())
     }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -599,6 +599,9 @@ impl Window {
     }
 
     #[inline]
+    pub fn focus_window(&self) {}
+
+    #[inline]
     pub fn display(&self) -> &Display {
         &self.display
     }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1309,7 +1309,6 @@ impl UnownedWindow {
     fn set_focus_inner(&self) -> util::Flusher<'_> {
         unsafe {
             let atom = self.xconn.get_atom_unchecked(b"_NET_ACTIVE_WINDOW\0");
-            
             self.xconn.send_client_msg(
                 self.xwindow,
                 self.root,
@@ -1322,9 +1321,23 @@ impl UnownedWindow {
 
     #[inline]
     pub fn focus_window(&self) {
-        self.focus_window_inner()
-            .flush()
-            .expect("Failed to focus window");
+        let state_atom = self.xconn.get_atom_unchecked(b"WM_STATE\0");
+        let is_minimized = if let Ok(state) =
+            self.xconn
+                .get_property(self.xwindow, state_atom, state_atom)
+        {
+            state.contains(&ffi::IconicState)
+        };
+        let is_visible = match self.shared_state.lock().visibility {
+            Visibility::Yes => true,
+            Visibility::YesWait | Visibility::No => false,
+        };
+
+        if is_visible && !is_minimized {
+            self.focus_window_inner()
+                .flush()
+                .expect("Failed to focus window");
+        }
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1306,6 +1306,27 @@ impl UnownedWindow {
         self.set_ime_position_physical(x, y);
     }
 
+    fn set_focus_inner(&self) -> util::Flusher<'_> {
+        unsafe {
+            let atom = self.xconn.get_atom_unchecked(b"_NET_ACTIVE_WINDOW\0");
+            
+            self.xconn.send_client_msg(
+                self.xwindow,
+                self.root,
+                atom,
+                Some(ffi::SubstructureRedirectMask | ffi::SubstructureNotifyMask),
+                [1, ffi::CurrentTime as c_long, 0, 0, 0],
+            )
+        }
+    }
+
+    #[inline]
+    pub fn focus_window(&self) {
+        self.focus_window_inner()
+            .flush()
+            .expect("Failed to focus window");
+    }
+
     #[inline]
     pub fn id(&self) -> WindowId {
         WindowId(self.xwindow)

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -978,6 +978,14 @@ impl UnownedWindow {
     }
 
     #[inline]
+    pub fn focus_window(&self) {
+        unsafe {
+            NSApp().activateIgnoringOtherApps_(YES);
+            util::make_key_and_order_front_async(*self.ns_window);
+        }
+    }
+
+    #[inline]
     // Allow directly accessing the current monitor internally without unwrapping.
     pub(crate) fn current_monitor_inner(&self) -> RootMonitorHandle {
         unsafe {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -269,6 +269,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn focus_window(&self) {
+        // Currently a no-op as it does not seem there is good support for this on web
+    }
+
+    #[inline]
     // Allow directly accessing the current monitor internally without unwrapping.
     fn current_monitor_inner(&self) -> RootMH {
         RootMH {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -629,13 +629,15 @@ impl Window {
     #[inline]
     pub fn focus_window(&self) {
         let window = self.window.clone();
-        let minimized = self.window_state.lock().window_flags().contains(WindowFlags::MINIMIZED);
-        let foreground = window.0 == unsafe { winuser::GetForegroundWindow() };
+        let window_flags = self.window_state.lock().window_flags();
 
-        if !minimized && !foreground {
-            println!("x");
-            unsafe { force_window_active(window.0) }    
-        }       
+        let is_visible = window_flags.contains(WindowFlags::VISIBLE);
+        let is_minimized = window_flags.contains(WindowFlags::MINIMIZED);
+        let is_foreground = window.0 == unsafe { winuser::GetForegroundWindow() };
+
+        if is_visible && !is_minimized && !is_foreground {
+            unsafe { force_window_active(window.0) };
+        }
     }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -625,6 +625,18 @@ impl Window {
     pub fn is_dark_mode(&self) -> bool {
         self.window_state.lock().is_dark_mode
     }
+
+    #[inline]
+    pub fn focus_window(&self) {
+        let window = self.window.clone();
+        let minimized = self.window_state.lock().window_flags().contains(WindowFlags::MINIMIZED);
+        let foreground = window.0 == unsafe { winuser::GetForegroundWindow() };
+
+        if !minimized && !foreground {
+            println!("x");
+            unsafe { force_window_active(window.0) }    
+        }       
+    }
 }
 
 impl Drop for Window {

--- a/src/window.rs
+++ b/src/window.rs
@@ -683,7 +683,16 @@ impl Window {
         self.window.set_ime_position(position.into())
     }
 
-    /// TODO: docs
+    /// Brings the window to the front and sets input focus. Has no effect if the window is
+    /// already in focus, minimized, or not visible.
+    ///
+    /// This method steals input focus from other applications. Do not use this method unless
+    /// you are certain that's what the user wants. Focus stealing can cause an extremely disruptive
+    /// user experience.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / Wayland:** Unsupported.
     #[inline]
     pub fn focus_window(&self) {
         self.window.focus_window()

--- a/src/window.rs
+++ b/src/window.rs
@@ -682,6 +682,12 @@ impl Window {
     pub fn set_ime_position<P: Into<Position>>(&self, position: P) {
         self.window.set_ime_position(position.into())
     }
+
+    /// TODO: docs
+    #[inline]
+    pub fn focus_window(&self) {
+        self.window.focus_window()
+    }
 }
 
 /// Cursor functions.


### PR DESCRIPTION
Fixes #1750

`Window::focus_window` brings the window to the front and sets input focus to that window. As described in the documentation, this method steals focus from other applications and should be used with care. Even though this method can cause quite a disruptive user experience I do believe winit should provide the option to users of this crate as valid use cases exist. Once #1764 has been merged, documentation could be expanded to redirect users to `request_user_attention` for a less disruptive way of getting attention to a window.

Decided to call it `focus_window` but the name could be changed for more clarity. Some APIs, like `set_minimized`, have a boolean parameter for toggling the, in this case, "minimized" state. For `focus_window` I decided not to do that as "unfocusing" is quite strange, like, where does the focus go? Also deliberately made the choice to "ignore" `focus_window` on minimized and not visible windows for improved user experience.

Don't have a Linux X11 machine at my disposal so the implementation might/is probably incorrect.

- [ ] Tested on all platforms changed
Tested on Windows and macOS.
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
