### PR TITLE
Windows: Delayed Message Boxes Fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Windows, fix bug causing message boxes to appear delayed.
 - On Android, calling `WindowEvent::Focused` now works properly instead of always returning false. 
 - On Windows, fix alt-tab behaviour by removing borderless fullscreen "always on top" flag.
 - On Windows, fix bug preventing windows with transparency enabled from having fully-opaque regions.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1974,7 +1974,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             }
 
             // Default WM_PAINT behaviour. This makes sure modals and popups are shown immediatly when opening them.
-            let mut ps: winuser::PAINTSTRUCT = std::mem::zeroed();
+            let mut ps = std::mem::MaybeUninit::<winuser::PAINTSTRUCT>::zeroed().assume_init();
             winuser::BeginPaint(window, &mut ps as *mut _);
             winuser::EndPaint(window, &mut ps as *mut _);
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1974,11 +1974,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             }
 
             // Default WM_PAINT behaviour. This makes sure modals and popups are shown immediatly when opening them.
-            let mut ps = std::mem::MaybeUninit::<winuser::PAINTSTRUCT>::zeroed().assume_init();
-            winuser::BeginPaint(window, &mut ps as *mut _);
-            winuser::EndPaint(window, &mut ps as *mut _);
-
-            0
+            commctrl::DefSubclassProc(window, msg, wparam, lparam)
         }
 
         winuser::WM_INPUT_DEVICE_CHANGE => {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -821,7 +821,6 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
 
         winuser::WM_PAINT => {
             if subclass_input.event_loop_runner.should_buffer() {
-                println!("buffer");
                 // this branch can happen in response to `UpdateWindow`, if win32 decides to
                 // redraw the window outside the normal flow of the event loop.
                 winuser::RedrawWindow(
@@ -831,7 +830,6 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::RDW_INTERNALPAINT,
                 );
             } else {
-                println!("no buffer");
                 let managing_redraw =
                     flush_paint_messages(Some(window), &subclass_input.event_loop_runner);
                 subclass_input.send_event(Event::RedrawRequested(RootWindowId(WindowId(window))));
@@ -1949,10 +1947,10 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         // Because WM_PAINT comes after all other messages, we use it during modal loops to detect
         // when the event queue has been emptied. See `process_event` for more details.
         winuser::WM_PAINT => {
+            winuser::ValidateRect(window, ptr::null());
             // If the WM_PAINT handler in `public_window_callback` has already flushed the redraw
             // events, `handling_events` will return false and we won't emit a second
             // `RedrawEventsCleared` event.
-            winuser::ValidateRect(window, ptr::null());
             if subclass_input.event_loop_runner.handling_events() {
                 if subclass_input.event_loop_runner.should_buffer() {
                     // This branch can be triggered when a nested win32 event loop is triggered

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1964,10 +1964,10 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                 } else {
                     // This WM_PAINT handler will never be re-entrant because `flush_paint_messages`
                     // doesn't call WM_PAINT for the thread event target (i.e. this window).
-                    /*assert!(flush_paint_messages(
+                    assert!(flush_paint_messages(
                         None,
                         &subclass_input.event_loop_runner
-                    ));*/
+                    ));
                     subclass_input.event_loop_runner.redraw_events_cleared();
                     process_control_flow(&subclass_input.event_loop_runner);
                 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -821,6 +821,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
 
         winuser::WM_PAINT => {
             if subclass_input.event_loop_runner.should_buffer() {
+                println!("buffer");
                 // this branch can happen in response to `UpdateWindow`, if win32 decides to
                 // redraw the window outside the normal flow of the event loop.
                 winuser::RedrawWindow(
@@ -830,6 +831,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                     winuser::RDW_INTERNALPAINT,
                 );
             } else {
+                println!("no buffer");
                 let managing_redraw =
                     flush_paint_messages(Some(window), &subclass_input.event_loop_runner);
                 subclass_input.send_event(Event::RedrawRequested(RootWindowId(WindowId(window))));
@@ -1947,10 +1949,10 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         // Because WM_PAINT comes after all other messages, we use it during modal loops to detect
         // when the event queue has been emptied. See `process_event` for more details.
         winuser::WM_PAINT => {
-            winuser::ValidateRect(window, ptr::null());
             // If the WM_PAINT handler in `public_window_callback` has already flushed the redraw
             // events, `handling_events` will return false and we won't emit a second
             // `RedrawEventsCleared` event.
+            winuser::ValidateRect(window, ptr::null());
             if subclass_input.event_loop_runner.handling_events() {
                 if subclass_input.event_loop_runner.should_buffer() {
                     // This branch can be triggered when a nested win32 event loop is triggered
@@ -1964,14 +1966,19 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                 } else {
                     // This WM_PAINT handler will never be re-entrant because `flush_paint_messages`
                     // doesn't call WM_PAINT for the thread event target (i.e. this window).
-                    assert!(flush_paint_messages(
+                    /*assert!(flush_paint_messages(
                         None,
                         &subclass_input.event_loop_runner
-                    ));
+                    ));*/
                     subclass_input.event_loop_runner.redraw_events_cleared();
                     process_control_flow(&subclass_input.event_loop_runner);
                 }
             }
+
+            // Default WM_PAINT behaviour. This makes sure modals and popups are shown immediatly when opening them.
+            let mut ps: winuser::PAINTSTRUCT = std::mem::zeroed();
+            winuser::BeginPaint(window, &mut ps as *mut _);
+            winuser::EndPaint(window, &mut ps as *mut _);
 
             0
         }


### PR DESCRIPTION
Message boxes did not appear when opening them. The sound did play but they never were made visible unless the system triggers a redraw (for example when you press `alt`). The solution to this is to add the default `WM_PAINT` behavior back in. (`DefWindowProc` does this if you don't override `WM_PAINT`)

(This issue appeard in #1615)

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
