### PR TITLE
Remove println! call in Android's eventloop

### DIFF
--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -175,7 +175,6 @@ impl<T: 'static> EventLoop<T> {
                 Some(EventSource::InputQueue) => {
                     if let Some(input_queue) = ndk_glue::input_queue().as_ref() {
                         while let Some(event) = input_queue.get_event() {
-                            println!("event {:?}", event);
                             if let Some(event) = input_queue.pre_dispatch(event) {
                                 let window_id = window::WindowId(WindowId);
                                 let device_id = event::DeviceId(DeviceId);


### PR DESCRIPTION
Is there a reason why this `println!()` call is in the event loop of Android? Would like it removed as it spams stdout :)
