### PR TITLE
On Wayland, increase default font size in CSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - On X11, fix `Window::request_redraw` not waking the event loop.
 - On Wayland, the keypad arrow keys are now recognized.
 - **Breaking** Rename `desktop::EventLoopExtDesktop` to `run_return::EventLoopExtRunReturn`.
+- On Wayland, default font size in CSD increased from 11 to 17.
 
 # 0.23.0 (2020-10-02)
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -486,13 +486,13 @@ pub trait Theme: Send + 'static {
 
     /// Font name and the size for the title bar.
     ///
-    /// By default the font is `sans-serif` at the size of 11.
+    /// By default the font is `sans-serif` at the size of 17.
     ///
     /// Returning `None` means that title won't be drawn.
     fn font(&self) -> Option<(String, f32)> {
         // Not having any title isn't something desirable for the users, so setting it to
         // something generic.
-        Some((String::from("sans-serif"), 11.))
+        Some((String::from("sans-serif"), 17.))
     }
 }
 


### PR DESCRIPTION
This commit increased default font size from 11 to 17 making it
identical to the one SCTK is using under the hood, since it's more
readable.