### PR TITLE
Windows: Changed thread_event_target_callback's WM_DESTROY to WM_NCDESTROY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Windows, fix applications not exiting gracefully.
 - On Android, calling `WindowEvent::Focused` now works properly instead of always returning false. 
 - On Windows, fix alt-tab behaviour by removing borderless fullscreen "always on top" flag.
 - On Windows, fix bug preventing windows with transparency enabled from having fully-opaque regions.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1939,7 +1939,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     // the closure to catch_unwind directly so that the match body indendation wouldn't change and
     // the git blame and history would be preserved.
     let callback = || match msg {
-        winuser::WM_DESTROY => {
+        winuser::WM_NCDESTROY => {
             Box::from_raw(subclass_input);
             drop(subclass_input);
             0


### PR DESCRIPTION
Our application was not exiting gracefully but crashed on `platform_impl/windows/event_loop.rs:1927`. 
`WM_DESTROY` destroys `subclass_input` but `WM_NCDESTOY` is send after `WM_DESTROY` ([See MS docs](https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-ncdestroy)) which causes `subclass_input.event_loop_runner.clone();` to fail.

Examples don't repro, are the they just lucky that the memory didn't change?
Creating a minimal test case from our project would be quite a lot of work.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
