### PR TITLE
Android: Improved multi-touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - **Breaking:** On X11, removed `WindowExt::set_urgent`, use `Window::request_user_attention`. 
 - On Wayland, default font size in CSD increased from 11 to 17.
 - On Windows, fix bug causing message boxes to appear delayed.
-- On Android, support multi-touch with proper implemenation for every input state in `event::TouchPhase`
+- On Android, support multi-touch.
 
 # 0.23.0 (2020-10-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - **Breaking:** On X11, removed `WindowExt::set_urgent`, use `Window::request_user_attention`. 
 - On Wayland, default font size in CSD increased from 11 to 17.
 - On Windows, fix bug causing message boxes to appear delayed.
-- On Android, support multi-touch.
+- On Android, support multi-touch with proper implemenation for every input state in `event::TouchPhase`
 
 # 0.23.0 (2020-10-02)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -166,61 +166,61 @@ Legend:
 - ❓: Unknown status
 
 ### Windowing
-|Feature                          |Windows|MacOS   |Linux x11   |Linux Wayland  |Android|iOS    |WASM      |
-|-------------------------------- | ----- | ----   | -------    | -----------   | ----- | ----- | -------- |
-|Window initialization            |✔️     |✔️     |▢[#5]      |✔️             |▢[#33]|▢[#33] |✔️        |
-|Providing pointer to init OpenGL |✔️     |✔️     |✔️         |✔️             |✔️     |✔️    |**N/A**|
-|Providing pointer to init Vulkan |✔️     |✔️     |✔️         |✔️             |✔️     |❓     |**N/A**|
-|Window decorations               |✔️     |✔️     |✔️         |▢[#306]        |**N/A**|**N/A**|**N/A**|
-|Window decorations toggle        |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
-|Window resizing                  |✔️     |▢[#219]|✔️         |▢[#306]        |**N/A**|**N/A**|✔️        |
-|Window resize increments         |❌     |❌     |❌         |❌             |❌    |❌     |**N/A**|
-|Window transparency              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|N/A        |
-|Window maximization              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
-|Window maximization toggle       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
-|Window minimization              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
-|Fullscreen                       |✔️     |✔️     |✔️         |✔️             |**N/A**|✔️     |✔️        |
-|Fullscreen toggle                |✔️     |✔️     |✔️         |✔️             |**N/A**|✔️     |✔️        |
-|Exclusive fullscreen             |✔️     |✔️     |✔️         |**N/A**         |❌    |✔️     |**N/A**|
-|HiDPI support                    |✔️     |✔️     |✔️         |✔️             |▢[#721]|✔️    |✔️ \*1|
-|Popup windows                    |❌     |❌     |❌         |❌             |❌    |❌     |**N/A**|
+| Feature                          | Windows | MacOS   | Linux x11 | Linux Wayland | Android | iOS     | WASM    |
+| -------------------------------- | ------- | ------- | --------- | ------------- | ------- | ------- | ------- |
+| Window initialization            | ✔️       | ✔️       | ▢[#5]     | ✔️             | ▢[#33]  | ▢[#33]  | ✔️       |
+| Providing pointer to init OpenGL | ✔️       | ✔️       | ✔️         | ✔️             | ✔️       | ✔️       | **N/A** |
+| Providing pointer to init Vulkan | ✔️       | ✔️       | ✔️         | ✔️             | ✔️       | ❓       | **N/A** |
+| Window decorations               | ✔️       | ✔️       | ✔️         | ▢[#306]       | **N/A** | **N/A** | **N/A** |
+| Window decorations toggle        | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | **N/A** |
+| Window resizing                  | ✔️       | ▢[#219] | ✔️         | ▢[#306]       | **N/A** | **N/A** | ✔️       |
+| Window resize increments         | ❌       | ❌       | ❌         | ❌             | ❌       | ❌       | **N/A** |
+| Window transparency              | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | N/A     |
+| Window maximization              | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | **N/A** |
+| Window maximization toggle       | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | **N/A** |
+| Window minimization              | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | **N/A** |
+| Fullscreen                       | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | ✔️       | ✔️       |
+| Fullscreen toggle                | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | ✔️       | ✔️       |
+| Exclusive fullscreen             | ✔️       | ✔️       | ✔️         | **N/A**       | ❌       | ✔️       | **N/A** |
+| HiDPI support                    | ✔️       | ✔️       | ✔️         | ✔️             | ▢[#721] | ✔️       | ✔️ \*1   |
+| Popup windows                    | ❌       | ❌       | ❌         | ❌             | ❌       | ❌       | **N/A** |
 
 \*1: `WindowEvent::ScaleFactorChanged` is not sent on `stdweb` backend.
 
 ### System information
-|Feature          |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS      |WASM      |
-|---------------- | ----- | ---- | ------- | ----------- | ----- | ------- | -------- |
-|Monitor list     |✔️    |✔️    |✔️       |✔️          |**N/A**|✔️       |**N/A**|
-|Video mode query |✔️    |✔️    |✔️       |✔️          |❌     |✔️      |**N/A**|
+| Feature          | Windows | MacOS | Linux x11 | Linux Wayland | Android | iOS | WASM    |
+| ---------------- | ------- | ----- | --------- | ------------- | ------- | --- | ------- |
+| Monitor list     | ✔️       | ✔️     | ✔️         | ✔️             | **N/A** | ✔️   | **N/A** |
+| Video mode query | ✔️       | ✔️     | ✔️         | ✔️             | ❌       | ✔️   | **N/A** |
 
 ### Input handling
-|Feature                 |Windows   |MacOS   |Linux x11|Linux Wayland|Android|iOS    |WASM      |
-|----------------------- | -----    | ----   | ------- | ----------- | ----- | ----- | -------- |
-|Mouse events            |✔️       |▢[#63]  |✔️       |✔️          |**N/A**|**N/A**|✔️        |
-|Mouse set location      |✔️       |✔️      |✔️       |❓           |**N/A**|**N/A**|**N/A**|
-|Cursor grab             |✔️       |▢[#165] |▢[#242]  |✔️         |**N/A**|**N/A**|❓        |
-|Cursor icon             |✔️       |✔️      |✔️       |✔️           |**N/A**|**N/A**|✔️        |
-|Touch events            |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |
-|Touch pressure          |✔️       |❌      |❌       |❌          |❌    |✔️     |❌        |
-|Multitouch              |✔️       |❌      |✔️       |✔️          |❓     |✔️     |❌        |
-|Keyboard events         |✔️       |✔️      |✔️       |✔️          |❓     |❌     |✔️        |
-|Drag & Drop             |▢[#720]  |▢[#720] |▢[#720]  |❌[#306]    |**N/A**|**N/A**|❓        |
-|Raw Device Events       |▢[#750]  |▢[#750] |▢[#750]  |❌          |❌    |❌     |❓        |
-|Gamepad/Joystick events |❌[#804] |❌      |❌       |❌          |❌    |❌     |❓        |
-|Device movement events  |❓        |❓       |❓       |❓           |❌    |❌     |❓        |
+| Feature                 | Windows | MacOS   | Linux x11 | Linux Wayland | Android | iOS     | WASM    |
+| ----------------------- | ------- | ------- | --------- | ------------- | ------- | ------- | ------- |
+| Mouse events            | ✔️       | ▢[#63]  | ✔️         | ✔️             | **N/A** | **N/A** | ✔️       |
+| Mouse set location      | ✔️       | ✔️       | ✔️         | ❓             | **N/A** | **N/A** | **N/A** |
+| Cursor grab             | ✔️       | ▢[#165] | ▢[#242]   | ✔️             | **N/A** | **N/A** | ❓       |
+| Cursor icon             | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | ✔️       |
+| Touch events            | ✔️       | ❌       | ✔️         | ✔️             | ✔️       | ✔️       | ❌       |
+| Touch pressure          | ✔️       | ❌       | ❌         | ❌             | ❌       | ✔️       | ❌       |
+| Multitouch              | ✔️       | ❌       | ✔️         | ✔️             | ✔️       | ✔️       | ❌       |
+| Keyboard events         | ✔️       | ✔️       | ✔️         | ✔️             | ❓       | ❌       | ✔️       |
+| Drag & Drop             | ▢[#720] | ▢[#720] | ▢[#720]   | ❌[#306]       | **N/A** | **N/A** | ❓       |
+| Raw Device Events       | ▢[#750] | ▢[#750] | ▢[#750]   | ❌             | ❌       | ❌       | ❓       |
+| Gamepad/Joystick events | ❌[#804] | ❌       | ❌         | ❌             | ❌       | ❌       | ❓       |
+| Device movement events  | ❓       | ❓       | ❓         | ❓             | ❌       | ❌       | ❓       |
 
 ### Pending API Reworks
 Changes in the API that have been agreed upon but aren't implemented across all platforms.
 
-|Feature                             |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |WASM      |
-|------------------------------      | ----- | ---- | ------- | ----------- | ----- | ----- | -------- |
-|New API for HiDPI ([#315] [#319])   |✔️    |✔️    |✔️       |✔️          |▢[#721]|✔️    |❓        |
-|Event Loop 2.0 ([#459])             |✔️    |✔️    |❌       |✔️          |❌     |✔️    |❓        |
-|Keyboard Input ([#812])             |❌    |❌    |❌       |❌          |❌     |❌    |❓        |
+| Feature                           | Windows | MacOS | Linux x11 | Linux Wayland | Android | iOS | WASM |
+| --------------------------------- | ------- | ----- | --------- | ------------- | ------- | --- | ---- |
+| New API for HiDPI ([#315] [#319]) | ✔️       | ✔️     | ✔️         | ✔️             | ▢[#721] | ✔️   | ❓    |
+| Event Loop 2.0 ([#459])           | ✔️       | ✔️     | ❌         | ✔️             | ❌       | ✔️   | ❓    |
+| Keyboard Input ([#812])           | ❌       | ❌     | ❌         | ❌             | ❌       | ❌   | ❓    |
 
 ### Completed API Reworks
-|Feature                             |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |WASM      |
-|------------------------------      | ----- | ---- | ------- | ----------- | ----- | ----- | -------- |
+| Feature | Windows | MacOS | Linux x11 | Linux Wayland | Android | iOS | WASM |
+| ------- | ------- | ----- | --------- | ------------- | ------- | --- | ---- |
 
 [#165]: https://github.com/rust-windowing/winit/issues/165
 [#219]: https://github.com/rust-windowing/winit/issues/219

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -166,61 +166,61 @@ Legend:
 - ❓: Unknown status
 
 ### Windowing
-| Feature                          | Windows | MacOS   | Linux x11 | Linux Wayland | Android | iOS     | WASM    |
-| -------------------------------- | ------- | ------- | --------- | ------------- | ------- | ------- | ------- |
-| Window initialization            | ✔️       | ✔️       | ▢[#5]     | ✔️             | ▢[#33]  | ▢[#33]  | ✔️       |
-| Providing pointer to init OpenGL | ✔️       | ✔️       | ✔️         | ✔️             | ✔️       | ✔️       | **N/A** |
-| Providing pointer to init Vulkan | ✔️       | ✔️       | ✔️         | ✔️             | ✔️       | ❓       | **N/A** |
-| Window decorations               | ✔️       | ✔️       | ✔️         | ▢[#306]       | **N/A** | **N/A** | **N/A** |
-| Window decorations toggle        | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | **N/A** |
-| Window resizing                  | ✔️       | ▢[#219] | ✔️         | ▢[#306]       | **N/A** | **N/A** | ✔️       |
-| Window resize increments         | ❌       | ❌       | ❌         | ❌             | ❌       | ❌       | **N/A** |
-| Window transparency              | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | N/A     |
-| Window maximization              | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | **N/A** |
-| Window maximization toggle       | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | **N/A** |
-| Window minimization              | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | **N/A** |
-| Fullscreen                       | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | ✔️       | ✔️       |
-| Fullscreen toggle                | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | ✔️       | ✔️       |
-| Exclusive fullscreen             | ✔️       | ✔️       | ✔️         | **N/A**       | ❌       | ✔️       | **N/A** |
-| HiDPI support                    | ✔️       | ✔️       | ✔️         | ✔️             | ▢[#721] | ✔️       | ✔️ \*1   |
-| Popup windows                    | ❌       | ❌       | ❌         | ❌             | ❌       | ❌       | **N/A** |
+|Feature                          |Windows|MacOS   |Linux x11   |Linux Wayland  |Android|iOS    |WASM      |
+|-------------------------------- | ----- | ----   | -------    | -----------   | ----- | ----- | -------- |
+|Window initialization            |✔️     |✔️     |▢[#5]      |✔️             |▢[#33]|▢[#33] |✔️        |
+|Providing pointer to init OpenGL |✔️     |✔️     |✔️         |✔️             |✔️     |✔️    |**N/A**|
+|Providing pointer to init Vulkan |✔️     |✔️     |✔️         |✔️             |✔️     |❓     |**N/A**|
+|Window decorations               |✔️     |✔️     |✔️         |▢[#306]        |**N/A**|**N/A**|**N/A**|
+|Window decorations toggle        |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
+|Window resizing                  |✔️     |▢[#219]|✔️         |▢[#306]        |**N/A**|**N/A**|✔️        |
+|Window resize increments         |❌     |❌     |❌         |❌             |❌    |❌     |**N/A**|
+|Window transparency              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|N/A        |
+|Window maximization              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
+|Window maximization toggle       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
+|Window minimization              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
+|Fullscreen                       |✔️     |✔️     |✔️         |✔️             |**N/A**|✔️     |✔️        |
+|Fullscreen toggle                |✔️     |✔️     |✔️         |✔️             |**N/A**|✔️     |✔️        |
+|Exclusive fullscreen             |✔️     |✔️     |✔️         |**N/A**         |❌    |✔️     |**N/A**|
+|HiDPI support                    |✔️     |✔️     |✔️         |✔️             |▢[#721]|✔️    |✔️ \*1|
+|Popup windows                    |❌     |❌     |❌         |❌             |❌    |❌     |**N/A**|
 
 \*1: `WindowEvent::ScaleFactorChanged` is not sent on `stdweb` backend.
 
 ### System information
-| Feature          | Windows | MacOS | Linux x11 | Linux Wayland | Android | iOS | WASM    |
-| ---------------- | ------- | ----- | --------- | ------------- | ------- | --- | ------- |
-| Monitor list     | ✔️       | ✔️     | ✔️         | ✔️             | **N/A** | ✔️   | **N/A** |
-| Video mode query | ✔️       | ✔️     | ✔️         | ✔️             | ❌       | ✔️   | **N/A** |
+|Feature          |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS      |WASM      |
+|---------------- | ----- | ---- | ------- | ----------- | ----- | ------- | -------- |
+|Monitor list     |✔️    |✔️    |✔️       |✔️          |**N/A**|✔️       |**N/A**|
+|Video mode query |✔️    |✔️    |✔️       |✔️          |❌     |✔️      |**N/A**|
 
 ### Input handling
-| Feature                 | Windows | MacOS   | Linux x11 | Linux Wayland | Android | iOS     | WASM    |
-| ----------------------- | ------- | ------- | --------- | ------------- | ------- | ------- | ------- |
-| Mouse events            | ✔️       | ▢[#63]  | ✔️         | ✔️             | **N/A** | **N/A** | ✔️       |
-| Mouse set location      | ✔️       | ✔️       | ✔️         | ❓             | **N/A** | **N/A** | **N/A** |
-| Cursor grab             | ✔️       | ▢[#165] | ▢[#242]   | ✔️             | **N/A** | **N/A** | ❓       |
-| Cursor icon             | ✔️       | ✔️       | ✔️         | ✔️             | **N/A** | **N/A** | ✔️       |
-| Touch events            | ✔️       | ❌       | ✔️         | ✔️             | ✔️       | ✔️       | ❌       |
-| Touch pressure          | ✔️       | ❌       | ❌         | ❌             | ❌       | ✔️       | ❌       |
-| Multitouch              | ✔️       | ❌       | ✔️         | ✔️             | ✔️       | ✔️       | ❌       |
-| Keyboard events         | ✔️       | ✔️       | ✔️         | ✔️             | ❓       | ❌       | ✔️       |
-| Drag & Drop             | ▢[#720] | ▢[#720] | ▢[#720]   | ❌[#306]       | **N/A** | **N/A** | ❓       |
-| Raw Device Events       | ▢[#750] | ▢[#750] | ▢[#750]   | ❌             | ❌       | ❌       | ❓       |
-| Gamepad/Joystick events | ❌[#804] | ❌       | ❌         | ❌             | ❌       | ❌       | ❓       |
-| Device movement events  | ❓       | ❓       | ❓         | ❓             | ❌       | ❌       | ❓       |
+|Feature                 |Windows   |MacOS   |Linux x11|Linux Wayland|Android|iOS    |WASM      |
+|----------------------- | -----    | ----   | ------- | ----------- | ----- | ----- | -------- |
+|Mouse events            |✔️       |▢[#63]  |✔️       |✔️          |**N/A**|**N/A**|✔️        |
+|Mouse set location      |✔️       |✔️      |✔️       |❓           |**N/A**|**N/A**|**N/A**|
+|Cursor grab             |✔️       |▢[#165] |▢[#242]  |✔️         |**N/A**|**N/A**|❓        |
+|Cursor icon             |✔️       |✔️      |✔️       |✔️           |**N/A**|**N/A**|✔️        |
+|Touch events            |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |
+|Touch pressure          |✔️       |❌      |❌       |❌          |❌    |✔️     |❌        |
+|Multitouch              |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |
+|Keyboard events         |✔️       |✔️      |✔️       |✔️          |❓     |❌     |✔️        |
+|Drag & Drop             |▢[#720]  |▢[#720] |▢[#720]  |❌[#306]    |**N/A**|**N/A**|❓        |
+|Raw Device Events       |▢[#750]  |▢[#750] |▢[#750]  |❌          |❌    |❌     |❓        |
+|Gamepad/Joystick events |❌[#804] |❌      |❌       |❌          |❌    |❌     |❓        |
+|Device movement events  |❓        |❓       |❓       |❓           |❌    |❌     |❓        |
 
 ### Pending API Reworks
 Changes in the API that have been agreed upon but aren't implemented across all platforms.
 
-| Feature                           | Windows | MacOS | Linux x11 | Linux Wayland | Android | iOS | WASM |
-| --------------------------------- | ------- | ----- | --------- | ------------- | ------- | --- | ---- |
-| New API for HiDPI ([#315] [#319]) | ✔️       | ✔️     | ✔️         | ✔️             | ▢[#721] | ✔️   | ❓    |
-| Event Loop 2.0 ([#459])           | ✔️       | ✔️     | ❌         | ✔️             | ❌       | ✔️   | ❓    |
-| Keyboard Input ([#812])           | ❌       | ❌     | ❌         | ❌             | ❌       | ❌   | ❓    |
+|Feature                             |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |WASM      |
+|------------------------------      | ----- | ---- | ------- | ----------- | ----- | ----- | -------- |
+|New API for HiDPI ([#315] [#319])   |✔️    |✔️    |✔️       |✔️          |▢[#721]|✔️    |❓        |
+|Event Loop 2.0 ([#459])             |✔️    |✔️    |❌       |✔️          |❌     |✔️    |❓        |
+|Keyboard Input ([#812])             |❌    |❌    |❌       |❌          |❌     |❌    |❓        |
 
 ### Completed API Reworks
-| Feature | Windows | MacOS | Linux x11 | Linux Wayland | Android | iOS | WASM |
-| ------- | ------- | ----- | --------- | ------------- | ------- | --- | ---- |
+|Feature                             |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |WASM      |
+|------------------------------      | ----- | ---- | ------- | ----------- | ----- | ----- | -------- |
 
 [#165]: https://github.com/rust-windowing/winit/issues/165
 [#219]: https://github.com/rust-windowing/winit/issues/219

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -263,30 +263,31 @@ impl<T: 'static> EventLoop<T> {
                                                 }
                                             }
                                             MotionAction::Cancel => {
-                                                let location = PhysicalPosition {
-                                                    x: 0 as _,
-                                                    y: 0 as _,
-                                                };
+                                                for pointer in motion_event.pointers() {
+                                                    let location = PhysicalPosition {
+                                                        x: pointer.x() as _,
+                                                        y: pointer.y() as _,
+                                                    };
 
-                                                let event = event::Event::WindowEvent {
-                                                    window_id,
-                                                    event: event::WindowEvent::Touch(
-                                                        event::Touch {
-                                                            device_id,
-                                                            phase: event::TouchPhase::Cancelled,
-                                                            location,
-                                                            id: std::u64::MAX,
-                                                            force: None,
-                                                        },
-                                                    ),
-                                                };
-
-                                                call_event_handler!(
-                                                    event_handler,
-                                                    self.window_target(),
-                                                    control_flow,
-                                                    event
-                                                );
+                                                    let event = event::Event::WindowEvent {
+                                                        window_id,
+                                                        event: event::WindowEvent::Touch(
+                                                            event::Touch {
+                                                                device_id,
+                                                                phase: event::TouchPhase::Moved,
+                                                                location,
+                                                                id: pointer.pointer_id() as u64,
+                                                                force: None,
+                                                            },
+                                                        ),
+                                                    };
+                                                    call_event_handler!(
+                                                        event_handler,
+                                                        self.window_target(),
+                                                        control_flow,
+                                                        event
+                                                    );
+                                                }
                                             }
                                             _ => (), // TODO mouse events
                                         };


### PR DESCRIPTION
In the previous implementation of multi-touch there was a issue. When having two fingers on the screen and you would release one it would result in ended events being generated for all fingers even though not all fingers were lifted. This implementation will generate started and ended events for the right finger id's. Furthermore this implementation will generate a cancelled event with different defaults. These defaults should be according to spec since the user shouldn't preform any action it would normally perform: "_You will not receive any more points in it. You should treat this as an up event, but not perform any action that you normally would_" according to the [ndk documentation](https://developer.android.com/ndk/reference/group/input#anonymous-enum-32).


- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
