### PR TITLE
Windows: Preserve minimized/maximized state in fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- On Windows, fix fullscreen doesn't preserve minimized/maximized state.
+- On Windows, fix fullscreen not preserving minimized/maximized state.
 
 # 0.24.0 (2020-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+# Unreleased
+
+- On Windows, fix fullscreen doesn't preserve minimized/maximized state.
+
 # 0.24.0 (2020-12-09)
 
 - On Windows, fix applications not exiting gracefully due to thread_event_target_callback accessing corrupted memory.
 - On Windows, implement `Window::set_ime_position`.
 - **Breaking:** On Windows, Renamed `WindowBuilderExtWindows`'s `is_dark_mode` to `theme`.
-- On Windows, fix fullscreen doesn't preserve minimized/maximized state.
 - **Breaking:** On Windows, renamed `WindowBuilderExtWindows::is_dark_mode` to `theme`.
 - On Windows, add `WindowBuilderExtWindows::with_theme` to set a preferred theme.
 - On Windows, fix bug causing message boxes to appear delayed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,23 +3,25 @@
 - On Windows, fix applications not exiting gracefully due to thread_event_target_callback accessing corrupted memory.
 - On Windows, implement `Window::set_ime_position`.
 - **Breaking:** On Windows, Renamed `WindowBuilderExtWindows`'s `is_dark_mode` to `theme`.
+- On Windows, fix fullscreen doesn't preserve minimized/maximized state.
+- **Breaking:** On Windows, renamed `WindowBuilderExtWindows::is_dark_mode` to `theme`.
 - On Windows, add `WindowBuilderExtWindows::with_theme` to set a preferred theme.
 - On Windows, fix bug causing message boxes to appear delayed.
-- On Android, calling `WindowEvent::Focused` now works properly instead of always returning false. 
-- On Windows, fix alt-tab behaviour by removing borderless fullscreen "always on top" flag.
+- On Android, calling `WindowEvent::Focused` now works properly instead of always returning false.
+- On Windows, fix Alt-Tab behaviour by removing borderless fullscreen "always on top" flag.
 - On Windows, fix bug preventing windows with transparency enabled from having fully-opaque regions.
 - **Breaking:** On Windows, include prefix byte in scancodes.
-- On Wayland, fix window not being resizeable when using `with_min_inner_size` in `WindowBuilder`.
+- On Wayland, fix window not being resizeable when using `WindowBuilder::with_min_inner_size`.
 - On Unix, fix cross-compiling to wasm32 without enabling X11 or Wayland.
-- On Windows, fix use after free crash during window destruction.
+- On Windows, fix use-after-free crash during window destruction.
 - On Web, fix `WindowEvent::ReceivedCharacter` never being sent on key input.
-- On macOS, fix compilation when targeting aarch64
+- On macOS, fix compilation when targeting aarch64.
 - On X11, fix `Window::request_redraw` not waking the event loop.
 - On Wayland, the keypad arrow keys are now recognized.
 - **Breaking** Rename `desktop::EventLoopExtDesktop` to `run_return::EventLoopExtRunReturn`.
 - Added `request_user_attention` method to `Window`.
-- **Breaking:** On macOS, removed `WindowExt::request_user_attention`, use `Window::request_user_attention`.  
-- **Breaking:** On X11, removed `WindowExt::set_urgent`, use `Window::request_user_attention`. 
+- **Breaking:** On macOS, removed `WindowExt::request_user_attention`, use `Window::request_user_attention`.
+- **Breaking:** On X11, removed `WindowExt::set_urgent`, use `Window::request_user_attention`.
 - On Wayland, default font size in CSD increased from 11 to 17.
 - On Windows, fix bug causing message boxes to appear delayed.
 - On Android, support multi-touch.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -518,7 +518,7 @@ impl Window {
                             position.1,
                             size.0 as i32,
                             size.1 as i32,
-                            winuser::SWP_NOOWNERZORDER | winuser::SWP_FRAMECHANGED,
+                            winuser::SWP_ASYNCWINDOWPOS | winuser::SWP_NOZORDER,
                         );
                         winuser::InvalidateRgn(window.0, ptr::null_mut(), 0);
                     }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -12,7 +12,7 @@ use winapi::{
         minwindef::DWORD,
         windef::{HWND, RECT},
     },
-    um::{winnt::LONG, winuser},
+    um::winuser,
 };
 
 /// Contains information about states and the window that the callback is going to use.
@@ -39,9 +39,7 @@ pub struct WindowState {
 
 #[derive(Clone)]
 pub struct SavedWindow {
-    pub style: LONG,
-    pub ex_style: LONG,
-    pub window_rect: RECT,
+    pub placement: winuser::WINDOWPLACEMENT,
 }
 
 #[derive(Clone)]

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -12,7 +12,7 @@ use winapi::{
         minwindef::DWORD,
         windef::{HWND, RECT},
     },
-    um::winuser,
+    um::{winnt::LONG, winuser},
 };
 
 /// Contains information about states and the window that the callback is going to use.
@@ -39,8 +39,9 @@ pub struct WindowState {
 
 #[derive(Clone)]
 pub struct SavedWindow {
-    pub client_rect: RECT,
-    pub scale_factor: f64,
+    pub style: LONG,
+    pub ex_style: LONG,
+    pub window_rect: RECT,
 }
 
 #[derive(Clone)]

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -85,11 +85,6 @@ bitflags! {
 
         const MINIMIZED = 1 << 12;
 
-        const FULLSCREEN_AND_MASK = !(
-            WindowFlags::DECORATIONS.bits |
-            WindowFlags::RESIZABLE.bits |
-            WindowFlags::MAXIMIZED.bits
-        );
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits;
         const NO_DECORATIONS_AND_MASK = !WindowFlags::RESIZABLE.bits;
         const INVISIBLE_AND_MASK = !WindowFlags::MAXIMIZED.bits;
@@ -180,10 +175,7 @@ impl MouseProperties {
 impl WindowFlags {
     fn mask(mut self) -> WindowFlags {
         if self.contains(WindowFlags::MARKER_EXCLUSIVE_FULLSCREEN) {
-            self &= WindowFlags::FULLSCREEN_AND_MASK;
             self |= WindowFlags::EXCLUSIVE_FULLSCREEN_OR_MASK;
-        } else if self.contains(WindowFlags::MARKER_BORDERLESS_FULLSCREEN) {
-            self &= WindowFlags::FULLSCREEN_AND_MASK;
         }
         if !self.contains(WindowFlags::VISIBLE) {
             self &= WindowFlags::INVISIBLE_AND_MASK;
@@ -233,6 +225,12 @@ impl WindowFlags {
 
         style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
         style_ex |= WS_EX_ACCEPTFILES;
+
+        if self.intersects(
+            WindowFlags::MARKER_EXCLUSIVE_FULLSCREEN | WindowFlags::MARKER_BORDERLESS_FULLSCREEN,
+        ) {
+            style &= !WS_OVERLAPPEDWINDOW;
+        }
 
         (style, style_ex)
     }


### PR DESCRIPTION
By lining up `Window::set_fullscreen` with Chromium's [`FullscreenHandler::SetFullscreenImpl`](https://chromium.googlesource.com/chromium/src/+/40351207e40888d64d3e02711287144ede7b4454/ui/views/win/fullscreen_handler.cc#55).

**EDIT**: `Window::set_fullscreen` is now based on https://devblogs.microsoft.com/oldnewthing/20100412-00/?p=14353, as it seems to be much more clean and simple compared to the Chromium way. I would also like to receive some feedback regarding the chosen method.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #1765.