### PR TITLE
On Wayland, don't drop extra mouse buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - On Wayland, default font size in CSD increased from 11 to 17.
 - On Windows, fix bug causing message boxes to appear delayed.
 - On Android, support multi-touch.
+- On Wayland, extra mouse buttons are not dropped anymore.
+- **Breaking**: `MouseButton::Other` now uses `u16`.
 
 # 0.23.0 (2020-10-02)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ raw-window-handle = "0.3"
 bitflags = "1"
 
 [dev-dependencies]
-image = "0.23"
+image = "0.23.12"
 simple_logger = "1.9"
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/src/event.rs
+++ b/src/event.rs
@@ -745,7 +745,7 @@ pub enum MouseButton {
     Left,
     Right,
     Middle,
-    Other(u8),
+    Other(u16),
 }
 
 /// Describes a difference in the mouse scroll wheel state.

--- a/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
@@ -17,6 +17,11 @@ use crate::platform_impl::wayland::{self, DeviceId};
 
 use super::{PointerData, WinitPointer};
 
+// These values are comming from <linux/input-event-codes.h>.
+const BTN_LEFT: u32 = 0x110;
+const BTN_RIGHT: u32 = 0x111;
+const BTN_MIDDLE: u32 = 0x112;
+
 #[inline]
 pub(super) fn handle_pointer(
     pointer: ThemedPointer,
@@ -153,11 +158,10 @@ pub(super) fn handle_pointer(
             };
 
             let button = match button {
-                0x110 => MouseButton::Left,
-                0x111 => MouseButton::Right,
-                0x112 => MouseButton::Middle,
-                // TODO - figure out the translation.
-                _ => return,
+                BTN_LEFT => MouseButton::Left,
+                BTN_RIGHT => MouseButton::Right,
+                BTN_MIDDLE => MouseButton::Middle,
+                button => MouseButton::Other(button as u16),
             };
 
             event_sink.push_window_event(

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -709,7 +709,7 @@ impl<T: 'static> EventProcessor<T> {
                                 event: MouseInput {
                                     device_id,
                                     state,
-                                    button: Other(x as u8),
+                                    button: Other(x as u16),
                                     modifiers,
                                 },
                             }),

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1307,7 +1307,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 event: MouseInput {
                     device_id: DEVICE_ID,
                     state: Pressed,
-                    button: Other(xbutton as u8),
+                    button: Other(xbutton),
                     modifiers: event::get_key_mods(),
                 },
             });
@@ -1329,7 +1329,7 @@ unsafe extern "system" fn public_window_callback<T: 'static>(
                 event: MouseInput {
                     device_id: DEVICE_ID,
                     state: Released,
-                    button: Other(xbutton as u8),
+                    button: Other(xbutton),
                     modifiers: event::get_key_mods(),
                 },
             });


### PR DESCRIPTION
Since Wayland mouse buttons are generally u16, we can only somehow
translate them into u8 used by winit. Also, they're coming from
linux/input-event-codes.h directly, thus translating them into
something cross-platform is cumbersome, thus just passing them
downstream as 'button - BTN_LEFT' for now.