### PR TITLE
Windows: implement Window.set_ime_position() with IMM API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Windows, implement `Window::set_ime_position`.
 - **Breaking:** On Windows, Renamed `WindowBuilderExtWindows`'s `is_dark_mode` to `theme`.
 - On Windows, add `WindowBuilderExtWindows::with_theme` to set a preferred theme.
 - On Windows, fix bug causing message boxes to appear delayed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ features = [
     "commctrl",
     "dwmapi",
     "errhandlingapi",
+    "imm",
     "hidusage",
     "libloaderapi",
     "objbase",

--- a/examples/set_ime_position.rs
+++ b/examples/set_ime_position.rs
@@ -1,0 +1,58 @@
+use simple_logger::SimpleLogger;
+use winit::{
+    dpi::{LogicalPosition, Position},
+    event::{ElementState, Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+};
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    window.set_title("A fantastic window!");
+
+    println!("Ime position will system default");
+    let mut ime_follow_cursor = false;
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent {
+                event:
+                    WindowEvent::MouseInput {
+                        state: ElementState::Released,
+                        ..
+                    },
+                ..
+            } => {
+                ime_follow_cursor = !ime_follow_cursor;
+                if !ime_follow_cursor {
+                    println!("Setting ime position to 10.0, 10.0");
+                    window.set_ime_position(Position::Logical(LogicalPosition::new(10.0, 10.0)));
+                } else {
+                    println!("Ime will follow your mouse cursor");
+                }
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CursorMoved { position, .. },
+                ..
+            } => {
+                if ime_follow_cursor {
+                    println!("Setting ime position to {}, {}", position.x, position.y);
+                    window.set_ime_position(position);
+                }
+            }
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                *control_flow = ControlFlow::Exit;
+                return;
+            }
+            _ => (),
+        }
+    });
+}

--- a/examples/set_ime_position.rs
+++ b/examples/set_ime_position.rs
@@ -1,6 +1,6 @@
 use simple_logger::SimpleLogger;
 use winit::{
-    dpi::{LogicalPosition, Position},
+    dpi::PhysicalPosition,
     event::{ElementState, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     window::WindowBuilder,
@@ -14,12 +14,19 @@ fn main() {
     window.set_title("A fantastic window!");
 
     println!("Ime position will system default");
-    let mut ime_follow_cursor = false;
+    println!("Click to set ime position to cursor's");
 
+    let mut cursor_position = PhysicalPosition::new(0.0, 0.0);
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
         match event {
+            Event::WindowEvent {
+                event: WindowEvent::CursorMoved { position, .. },
+                ..
+            } => {
+                cursor_position = position;
+            }
             Event::WindowEvent {
                 event:
                     WindowEvent::MouseInput {
@@ -28,22 +35,11 @@ fn main() {
                     },
                 ..
             } => {
-                ime_follow_cursor = !ime_follow_cursor;
-                if !ime_follow_cursor {
-                    println!("Setting ime position to 10.0, 10.0");
-                    window.set_ime_position(Position::Logical(LogicalPosition::new(10.0, 10.0)));
-                } else {
-                    println!("Ime will follow your mouse cursor");
-                }
-            }
-            Event::WindowEvent {
-                event: WindowEvent::CursorMoved { position, .. },
-                ..
-            } => {
-                if ime_follow_cursor {
-                    println!("Setting ime position to {}, {}", position.x, position.y);
-                    window.set_ime_position(position);
-                }
+                println!(
+                    "Setting ime position to {}, {}",
+                    cursor_position.x, cursor_position.y
+                );
+                window.set_ime_position(cursor_position);
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -619,7 +619,7 @@ impl Window {
     }
 
     pub(crate) fn set_ime_position_physical(&self, x: i32, y: i32) {
-        if unsafe { winuser::GetSystemMetrics(winuser::SM_DBCSENABLED) } != 0 {
+        if unsafe { winuser::GetSystemMetrics(winuser::SM_IMMENABLED) } != 0 {
             let mut composition_form = COMPOSITIONFORM {
                 dwStyle: CFS_POINT,
                 ptCurrentPos: POINT { x, y },

--- a/src/window.rs
+++ b/src/window.rs
@@ -677,7 +677,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Windows:** Unsupported.
+    /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn set_ime_position<P: Into<Position>>(&self, position: P) {
         self.window.set_ime_position(position.into())


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I tested in Windows 10 18363.1198 with Microsoft Japanese IME. I am not tested without IME. I followed IMM documentation and implementation will not call IMM API if Windows has no IME.

IMM docs: https://docs.microsoft.com/ja-jp/windows/win32/intl/about-input-method-manager
ImmSetCompositionWindow docs: https://docs.microsoft.com/en-us/windows/win32/api/imm/nf-imm-immsetcompositionwindow
COMPOSITIONFORM docs: https://docs.microsoft.com/en-us/windows/win32/api/imm/ns-imm-compositionform
GetSystemMetrics and SM_IMMENABLED docs: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetrics