### PR TITLE
Add Window::is_maximized method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- Added `maximized` method to `Window`.
+- Added `is_maximized` method to `Window`.
 - On Windows, change the default window size (1024x768) to match the default on other desktop platforms (800x600).
 - On Windows, fix bug causing mouse capture to not be released.
 - On Windows, fix fullscreen not preserving minimized/maximized state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Added `maximized` method to `Window`.
 - On Windows, fix bug causing mouse capture to not be released.
 - On Windows, fix fullscreen not preserving minimized/maximized state.
 

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -58,7 +58,7 @@ fn main() {
                         println!("window.fullscreen {:?}", window.fullscreen());
                     }
                     (VirtualKeyCode::M, ElementState::Pressed) => {
-                        let is_maximized = window.maximized();
+                        let is_maximized = window.is_maximized();
                         window.set_maximized(!is_maximized);
                     }
                     (VirtualKeyCode::D, ElementState::Pressed) => {

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -23,7 +23,6 @@ fn main() {
         _ => panic!("Please enter a valid number"),
     });
 
-    let mut is_maximized = false;
     let mut decorations = true;
 
     let window = WindowBuilder::new()
@@ -59,8 +58,8 @@ fn main() {
                         println!("window.fullscreen {:?}", window.fullscreen());
                     }
                     (VirtualKeyCode::M, ElementState::Pressed) => {
-                        is_maximized = !is_maximized;
-                        window.set_maximized(is_maximized);
+                        let is_maximized = window.maximized();
+                        window.set_maximized(!is_maximized);
                     }
                     (VirtualKeyCode::D, ElementState::Pressed) => {
                         decorations = !decorations;

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -108,7 +108,7 @@ fn main() {
                         window.set_visible(visible);
                     }
                     VirtualKeyCode::X => {
-                        let is_maximized = window.maximized();
+                        let is_maximized = window.is_maximized();
                         window.set_maximized(!is_maximized);
                     }
                     _ => (),

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -28,7 +28,6 @@ fn main() {
     eprintln!("  (X) Toggle maximized");
 
     let mut minimized = false;
-    let mut maximized = false;
     let mut visible = true;
 
     event_loop.run(move |event, _, control_flow| {
@@ -109,8 +108,8 @@ fn main() {
                         window.set_visible(visible);
                     }
                     VirtualKeyCode::X => {
-                        maximized = !maximized;
-                        window.set_maximized(maximized);
+                        let is_maximized = window.maximized();
+                        window.set_maximized(!is_maximized);
                     }
                     _ => (),
                 },

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -489,7 +489,9 @@ impl Window {
 
     pub fn set_maximized(&self, _maximized: bool) {}
 
-    pub fn maximized(&self) -> bool { false }
+    pub fn maximized(&self) -> bool {
+        false
+    }
 
     pub fn set_fullscreen(&self, _monitor: Option<window::Fullscreen>) {
         warn!("Cannot set fullscreen on Android");

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -489,7 +489,7 @@ impl Window {
 
     pub fn set_maximized(&self, _maximized: bool) {}
 
-    pub fn maximized(&self) -> bool {
+    pub fn is_maximized(&self) -> bool {
         false
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -489,6 +489,8 @@ impl Window {
 
     pub fn set_maximized(&self, _maximized: bool) {}
 
+    pub fn maximized(&self) -> bool { false }
+
     pub fn set_fullscreen(&self, _monitor: Option<window::Fullscreen>) {
         warn!("Cannot set fullscreen on Android");
     }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -190,8 +190,8 @@ impl Inner {
         warn!("`Window::set_maximized` is ignored on iOS")
     }
 
-    pub fn maximized(&self) -> bool {
-        warn!("`Window::maximized` is ignored on iOS");
+    pub fn is_maximized(&self) -> bool {
+        warn!("`Window::is_maximized` is ignored on iOS");
         false
     }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -190,6 +190,11 @@ impl Inner {
         warn!("`Window::set_maximized` is ignored on iOS")
     }
 
+    pub fn maximized(&self) -> bool {
+        warn!("`Window::maximized` is ignored on iOS");
+        false
+    }
+
     pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
         unsafe {
             let uiscreen = match monitor {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -374,7 +374,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn maximized(&self) -> bool {
+    pub fn is_maximized(&self) -> bool {
         // TODO: Not implemented
         false
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -374,6 +374,12 @@ impl Window {
     }
 
     #[inline]
+    pub fn maximized(&self) -> bool {
+        // TODO: Not implemented
+        false
+    }
+
+    #[inline]
     pub fn set_minimized(&self, minimized: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_minimized(minimized))
     }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -732,8 +732,7 @@ impl UnownedWindow {
 
     #[inline]
     pub fn maximized(&self) -> bool {
-        let shared_state_lock = self.shared_state.lock().unwrap();
-        shared_state_lock.maximized
+        self.is_zoomed()
     }
 
     #[inline]

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -731,7 +731,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn maximized(&self) -> bool {
+    pub fn is_maximized(&self) -> bool {
         self.is_zoomed()
     }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -731,6 +731,12 @@ impl UnownedWindow {
     }
 
     #[inline]
+    pub fn maximized(&self) -> bool {
+        let shared_state_lock = self.shared_state.lock().unwrap();
+        shared_state_lock.maximized
+    }
+
+    #[inline]
     pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         trace!("Locked shared state in `set_fullscreen`");
         let mut shared_state_lock = self.shared_state.lock().unwrap();

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -233,6 +233,12 @@ impl Window {
     }
 
     #[inline]
+    pub fn maximized(&self) -> bool {
+        // Canvas cannot be 'maximized'
+        false
+    }
+
+    #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.borrow().is_fullscreen() {
             Some(Fullscreen::Borderless(Some(self.current_monitor_inner())))

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -233,7 +233,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn maximized(&self) -> bool {
+    pub fn is_maximized(&self) -> bool {
         // Canvas cannot be 'maximized'
         false
     }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -384,6 +384,12 @@ impl Window {
     }
 
     #[inline]
+    pub fn maximized(&self) -> bool {
+        let window_state = self.window_state.lock();
+        window_state.window_flags.contains(WindowFlags::MAXIMIZED)
+    }
+
+    #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         let window_state = self.window_state.lock();
         window_state.fullscreen.clone()

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -386,7 +386,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn maximized(&self) -> bool {
+    pub fn is_maximized(&self) -> bool {
         let window_state = self.window_state.lock();
         window_state.window_flags.contains(WindowFlags::MAXIMIZED)
     }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -34,7 +34,7 @@ pub struct WindowState {
     pub current_theme: Theme,
     pub preferred_theme: Option<Theme>,
     pub high_surrogate: Option<u16>,
-    window_flags: WindowFlags,
+    pub window_flags: WindowFlags,
 }
 
 #[derive(Clone)]

--- a/src/window.rs
+++ b/src/window.rs
@@ -604,8 +604,8 @@ impl Window {
     /// - **Wayland / X11:** Not implemented.
     /// - **iOS / Android / Web:** Unsupported.
     #[inline]
-    pub fn maximized(&self) -> bool {
-        self.window.maximized()
+    pub fn is_maximized(&self) -> bool {
+        self.window.is_maximized()
     }
 
     /// Sets the window to fullscreen or back.

--- a/src/window.rs
+++ b/src/window.rs
@@ -601,6 +601,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
+    /// - **Wayland / X11:** Not implemented.
     /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn maximized(&self) -> bool {

--- a/src/window.rs
+++ b/src/window.rs
@@ -597,6 +597,16 @@ impl Window {
         self.window.set_maximized(maximized)
     }
 
+    /// Gets the window's current maximized state.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web:** Unsupported.
+    #[inline]
+    pub fn maximized(&self) -> bool {
+        self.window.maximized()
+    }
+
     /// Sets the window to fullscreen or back.
     ///
     /// ## Platform-specific


### PR DESCRIPTION
Related issues: #208 #1578

Currently, if you want to save window state to a persistent config (position, size, fullscreen/maximized flags etc) and then restore when user is relaunching your application - this is not possible for maximized window state at all. We have `Window::set_maximized` and `WindowBuilder::with_maximized` - but no way to query current state. Current maximized state can be changed outside of API (e.g. users clicking on maximize button in window frame).

Tested on Windows and macOS. This should probably be supported for Wayland/X11 - but I am not too familiar with the API and could not figure out how to implement it. Marked linux API as not implemented and set it to always return `false` for now. Maybe some linux platform maintainers could help get this functionality covered under this platform as well?

- [x] Tested on all platforms changed
(only Windows and macOS)
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
