### PR TITLE
macOS: Wake up run loop immediately when request redraw is received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `is_maximized` method to `Window`.
 - On Windows, fix bug where clicking the decoration bar would make the cursor blink.
 - On Windows, fix bug causing newly created windows to erroneously display the "wait" (spinning) cursor.
+- On macOS, wake up the event loop immediately when a redraw is requested.
 - On Windows, change the default window size (1024x768) to match the default on other desktop platforms (800x600).
 - On Windows, fix bug causing mouse capture to not be released.
 - On Windows, fix fullscreen not preserving minimized/maximized state.

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -25,7 +25,7 @@ use crate::{
     platform_impl::platform::{
         event::{EventProxy, EventWrapper},
         event_loop::{post_dummy_event, PanicInfo},
-        observer::EventLoopWaker,
+        observer::{CFRunLoopGetMain, CFRunLoopWakeUp, EventLoopWaker},
         util::{IdRef, Never},
         window::get_window_id,
     },
@@ -320,6 +320,10 @@ impl AppState {
         let mut pending_redraw = HANDLER.redraw();
         if !pending_redraw.contains(&window_id) {
             pending_redraw.push(window_id);
+        }
+        unsafe {
+            let rl = CFRunLoopGetMain();
+            CFRunLoopWakeUp(rl);
         }
     }
 


### PR DESCRIPTION
We allow to have RunLoop running only on the main thread. Which means if
we call Window::request_redraw() from other the thread then we have to
wait until some other event arrives on the main thread. That situation
is even worse when we have ControlFlow set to the `Wait` mode then user
will not ever render anything.

The goal of this PR is a try to fix macOS-related part of the issue #1763 I was not sure if it is a good idea to wake up RunLoop directly from the AppState, so please correct me with the right place to add this logic if needed.

- [x] Tested on all platforms changed (only macOS is affected)
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
