### PR TITLE
Android: Do not mark unhandled events as handled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - On Windows, change the default window size (1024x768) to match the default on other desktop platforms (800x600).
 - On Windows, fix bug causing mouse capture to not be released.
 - On Windows, fix fullscreen not preserving minimized/maximized state.
+- On Android, unimplemented events are marked as unhandled on the native event loop.
 
 # 0.24.0 (2020-12-09)
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -176,6 +176,7 @@ impl<T: 'static> EventLoop<T> {
                     if let Some(input_queue) = ndk_glue::input_queue().as_ref() {
                         while let Some(event) = input_queue.get_event() {
                             if let Some(event) = input_queue.pre_dispatch(event) {
+                                let mut handled = true;
                                 let window_id = window::WindowId(WindowId);
                                 let device_id = event::DeviceId(DeviceId);
                                 match &event {
@@ -191,7 +192,10 @@ impl<T: 'static> EventLoop<T> {
                                             MotionAction::Cancel => {
                                                 Some(event::TouchPhase::Cancelled)
                                             }
-                                            _ => None, // TODO mouse events
+                                            _ => {
+                                                handled = false;
+                                                None // TODO mouse events
+                                            }
                                         };
                                         if let Some(phase) = phase {
                                             let pointers: Box<
@@ -235,9 +239,12 @@ impl<T: 'static> EventLoop<T> {
                                             }
                                         }
                                     }
-                                    InputEvent::KeyEvent(_) => {} // TODO
+                                    InputEvent::KeyEvent(_) => {
+                                        // TODO
+                                        handled = false;
+                                    }
                                 };
-                                input_queue.finish_event(event, true);
+                                input_queue.finish_event(event, handled);
                             }
                         }
                     }


### PR DESCRIPTION
Android backend doesn't handle support certain input events, but still marks them as handled, which stops eg. volume buttons from working.

- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
