### PR TITLE
Android: add request_redraw based on ndk_glue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-
+- On Android, implemented `request_redraw`, fixing issue where iced would not render properly
 - On Windows, fix bug causing newly created windows to erroneously display the "wait" (spinning) cursor.
 - On Windows, change the default window size (1024x768) to match the default on other desktop platforms (800x600).
 - On Windows, fix bug causing mouse capture to not be released.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -448,7 +448,20 @@ impl Window {
     }
 
     pub fn request_redraw(&self) {
-        // TODO
+        match ndk_glue::native_window().as_ref() {
+            Some(native_window) => {
+                let a_native_window: *mut ndk_sys::ANativeWindow = native_window.ptr().as_ptr();
+                let a_native_activity: *mut ndk_sys::ANativeActivity =
+                    ndk_glue::native_activity().ptr().as_ptr();
+                unsafe {
+                    match (*(*a_native_activity).callbacks).onNativeWindowRedrawNeeded {
+                        Some(callback) => callback(a_native_activity, a_native_window),
+                        None => (),
+                    };
+                };
+            }
+            None => (),
+        }
     }
 
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


Fixes https://github.com/rust-windowing/winit/issues/1723, just picked up the code from there, seems to work fine