### PR TITLE
android: Use event identifier instead of userdata pointer

### DIFF
--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -30,7 +30,7 @@ enum EventSource {
 
 fn poll(poll: Poll) -> Option<EventSource> {
     match poll {
-        Poll::Event { data, .. } => match data as usize {
+        Poll::Event { ident, .. } => match ident {
             0 => Some(EventSource::Callback),
             1 => Some(EventSource::InputQueue),
             _ => unreachable!(),


### PR DESCRIPTION
ndk-glue currently sets both the `ident` field and user-data pointer to `0` or `1` for the event pipe and input queue respectively, to tell these sources apart. While it works to reinterpret this `data` pointer as integer identifier it shouldn't be abused for that, in particular when one may wish to provide extra information with an event in the future; then the `data` field is used as pointer (or abused as abstract value) for that.

---

These constants (`0` and `1`) are internal to `ndk-glue` and not publicly documented anywhere (afaik). I believe they should at least be exposed as constants, or perhaps abstracted behind a `poll` function internal to `ndk-glue`. Consequently we might want to warn API users when they try use one of these "reserved `ident`s" (but only on the thread looper set up by `ndk-glue`s `init()` function)?

CC @dvc94ch @msiglreith 

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

