### PR TITLE
Fix HINSTANCE returned by raw_window_handle on 64 bit Windows

### DIFF
--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -278,7 +278,7 @@ impl Window {
 
     #[inline]
     pub fn hinstance(&self) -> HINSTANCE {
-        unsafe { winuser::GetWindowLongW(self.hwnd(), winuser::GWL_HINSTANCE) as *mut _ }
+        unsafe { winuser::GetWindowLongPtrW(self.hwnd(), winuser::GWLP_HINSTANCE) as *mut _ }
     }
 
     #[inline]


### PR DESCRIPTION
- [ ] Tested on all platforms changed
  - Tested with `x86_64-pc-windows-gnu`, but can't get my build system to produce a 32bit version, so can't test that :/
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
  - I didn't add it to the changelog since this is a very small fix.
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

We previously retrieved the value using `GetWindowLongW`, but [the documentation](https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getwindowlongw) explicity says that `GetWindowLongPtrW` should be used for pointers and handles (which is what we're fetching).