### PR TITLE
Add ability to assign a menu when creating a window on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - On Windows, fix bug causing mouse capture to not be released.
 - On Windows, fix fullscreen not preserving minimized/maximized state.
 - On Android, unimplemented events are marked as unhandled on the native event loop.
+- On Windows, added `WindowBuilderExtWindows::with_menu` to set a custom menu at window creation time.
 
 # 0.24.0 (2020-12-09)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -116,6 +116,7 @@ If your PR makes notable changes to Winit's features, please update this section
 ### Windows
 * Setting the taskbar icon
 * Setting the parent window
+* Setting a menu bar
 * `WS_EX_NOREDIRECTIONBITMAP` support
 * Theme the title bar according to Windows 10 Dark Mode setting or set a preferred theme
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 
 use libc;
 use winapi::shared::minwindef::WORD;
-use winapi::shared::windef::HWND;
+use winapi::shared::windef::{HMENU, HWND};
 
 use crate::{
     dpi::PhysicalSize,
@@ -112,6 +112,14 @@ pub trait WindowBuilderExtWindows {
     /// Sets a parent to the window to be created.
     fn with_parent_window(self, parent: HWND) -> WindowBuilder;
 
+    /// Sets a menu on the window to be created.
+    ///
+    /// The menu must have been manually created beforehand with [`winapi::um::winuser::CreateMenu`] or similar.
+    ///
+    /// Note: Dark mode cannot be supported for win32 menus, it's simply not possible to change how the menus look.
+    /// If you use this, it is recommended that you combine it with `with_theme(Some(Theme::Light))` to avoid a jarring effect.
+    fn with_menu(self, menu: HMENU) -> WindowBuilder;
+
     /// This sets `ICON_BIG`. A good ceiling here is 256x256.
     fn with_taskbar_icon(self, taskbar_icon: Option<Icon>) -> WindowBuilder;
 
@@ -134,6 +142,12 @@ impl WindowBuilderExtWindows for WindowBuilder {
     #[inline]
     fn with_parent_window(mut self, parent: HWND) -> WindowBuilder {
         self.platform_specific.parent = Some(parent);
+        self
+    }
+
+    #[inline]
+    fn with_menu(mut self, menu: HMENU) -> WindowBuilder {
+        self.platform_specific.menu = Some(menu);
         self
     }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -114,6 +114,8 @@ pub trait WindowBuilderExtWindows {
 
     /// Sets a menu on the window to be created.
     ///
+    /// Parent and menu are mutually exclusive; a child window cannot have a menu!
+    ///
     /// The menu must have been manually created beforehand with [`winapi::um::winuser::CreateMenu`] or similar.
     ///
     /// Note: Dark mode cannot be supported for win32 menus, it's simply not possible to change how the menus look.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -17,7 +17,6 @@ use crate::window::Theme;
 
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
-    // TODO: parent and menu are mutually exclusive; a child window cannot have a menu!
     pub parent: Option<HWND>,
     pub menu: Option<HMENU>,
     pub taskbar_icon: Option<Icon>,

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1,6 +1,6 @@
 #![cfg(target_os = "windows")]
 
-use winapi::{self, shared::windef::HWND};
+use winapi::{self, shared::windef::HMENU, shared::windef::HWND};
 
 pub use self::{
     event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget},
@@ -17,7 +17,9 @@ use crate::window::Theme;
 
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
+    // TODO: parent and menu are mutually exclusive; a child window cannot have a menu!
     pub parent: Option<HWND>,
+    pub menu: Option<HMENU>,
     pub taskbar_icon: Option<Icon>,
     pub no_redirection_bitmap: bool,
     pub drag_and_drop: bool,
@@ -28,6 +30,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
     fn default() -> Self {
         Self {
             parent: None,
+            menu: None,
             taskbar_icon: None,
             no_redirection_bitmap: false,
             drag_and_drop: true,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -705,6 +705,10 @@ unsafe fn init<T: 'static>(
     window_flags.set(WindowFlags::CHILD, pl_attribs.parent.is_some());
     window_flags.set(WindowFlags::ON_TASKBAR, true);
 
+    if pl_attribs.parent.is_some() && pl_attribs.menu.is_some() {
+        warn!("Setting a menu on windows that have a parent is unsupported");
+    }
+
     // creating the real window this time, by using the functions in `extra_functions`
     let real_window = {
         let (style, ex_style) = window_flags.to_window_styles();

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -718,7 +718,7 @@ unsafe fn init<T: 'static>(
             winuser::CW_USEDEFAULT,
             winuser::CW_USEDEFAULT,
             pl_attribs.parent.unwrap_or(ptr::null_mut()),
-            ptr::null_mut(),
+            pl_attribs.menu.unwrap_or(ptr::null_mut()),
             libloaderapi::GetModuleHandleW(ptr::null()),
             ptr::null_mut(),
         );


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Added `WindowBuilderExtWindows::with_menu`.

The primary reason for doing it here instead of just assigning a menu later on with `winapi::um::winuser::SetMenu` is to avoid that `with_inner_size` breaks, since the menu takes up some space that is not taken into account, which means the user would have to use `set_inner_size` again after adding the menu.
This, I'm guessing, could cause a jarring effect for the user (that the window resizes when starting).

Unresolved:
- [x] ~Child windows cannot have a menu, so perhaps this should be represented typewise?~