### PR TITLE
IOS ScreenEdge Corrected Default

### DIFF
--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -648,7 +648,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             valid_orientations: Default::default(),
             prefers_home_indicator_hidden: false,
             prefers_status_bar_hidden: false,
-            preferred_screen_edges_deferring_system_gestures: Default::default(),
+            preferred_screen_edges_deferring_system_gestures: ScreenEdge::ALL,
         }
     }
 }


### PR DESCRIPTION
With IOS' PlatformSpeccificWindowBuilderAttributes the
preferred_screen_edges_deferring_system_gestures value was previously
set to the default (u8 default). This was an invalid value and caused
different crashes under screen edge events. Changing this value to a
valid value from the ScreenEdge enum fixes these issues.

Fixes #1705 and fixes #1613

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
