### PR TITLE
Map NumpadEnter on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - On Windows, fix bug causing mouse capture to not be released.
 - On Windows, fix fullscreen not preserving minimized/maximized state.
 - On Android, unimplemented events are marked as unhandled on the native event loop.
+- On X11, the numpad's enter key is now mapped to `NumpadEnter`.
 
 # 0.24.0 (2020-12-09)
 

--- a/src/platform_impl/linux/x11/events.rs
+++ b/src/platform_impl/linux/x11/events.rs
@@ -62,7 +62,7 @@ pub fn keysym_to_element(keysym: libc::c_uint) -> Option<VirtualKeyCode> {
         //ffi::XK_Num_Lock => VirtualKeyCode::Num_lock,
         //ffi::XK_KP_Space => VirtualKeyCode::Kp_space,
         //ffi::XK_KP_Tab => VirtualKeyCode::Kp_tab,
-        //ffi::XK_KP_Enter => VirtualKeyCode::Kp_enter,
+        ffi::XK_KP_Enter => VirtualKeyCode::NumpadEnter,
         //ffi::XK_KP_F1 => VirtualKeyCode::Kp_f1,
         //ffi::XK_KP_F2 => VirtualKeyCode::Kp_f2,
         //ffi::XK_KP_F3 => VirtualKeyCode::Kp_f3,


### PR DESCRIPTION
I'll be honest, I have no idea why this wasn't initially mapped, and the commit log doesn't provide a hint. I noticed it was unmapped and simple have uncommented the relevant mapping in X11.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
