### PR TITLE
Android: Bump ndk/ndk-glue to 0.3 and use constants for event ident

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - On Windows, fix bug causing mouse capture to not be released.
 - On Windows, fix fullscreen not preserving minimized/maximized state.
 - On Android, unimplemented events are marked as unhandled on the native event loop.
+- On Android, bump `ndk` and `ndk-glue` to 0.3: use predefined constants for event `ident`.
 
 # 0.24.0 (2020-12-09)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ image = "0.23.12"
 simple_logger = "1.9"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = "0.2.0"
+ndk = "0.3"
 ndk-sys = "0.2.0"
-ndk-glue = "0.2.0"
+ndk-glue = "0.3"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -31,8 +31,8 @@ enum EventSource {
 fn poll(poll: Poll) -> Option<EventSource> {
     match poll {
         Poll::Event { ident, .. } => match ident {
-            0 => Some(EventSource::Callback),
-            1 => Some(EventSource::InputQueue),
+            ndk_glue::NDK_GLUE_LOOPER_EVENT_PIPE_IDENT => Some(EventSource::Callback),
+            ndk_glue::NDK_GLUE_LOOPER_INPUT_QUEUE_IDENT => Some(EventSource::InputQueue),
             _ => unreachable!(),
         },
         Poll::Timeout => None,


### PR DESCRIPTION
Following the changes in [1] this bumps ndk and ndk-glue to 0.3 and uses the new constants. The minor version has been bumped to prevent applications from running an older winit (without #1826) with a newer ndk/ndk-glue that does not pass this `ident` through the `data` pointer anymore.

[1]: https://github.com/rust-windowing/android-ndk-rs/pull/112

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
