### PR TITLE
Fix for closure-captured values not being dropped on panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - On Android, unimplemented events are marked as unhandled on the native event loop.
 - On Windows, added `WindowBuilderExtWindows::with_menu` to set a custom menu at window creation time.
 - On Android, bump `ndk` and `ndk-glue` to 0.3: use predefined constants for event `ident`.
+- On macOS, fix event-closure-captured objects not being dropped on panic.
 
 # 0.24.0 (2020-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - On Android, unimplemented events are marked as unhandled on the native event loop.
 - On Windows, added `WindowBuilderExtWindows::with_menu` to set a custom menu at window creation time.
 - On Android, bump `ndk` and `ndk-glue` to 0.3: use predefined constants for event `ident`.
-- On macOS, fix event-closure-captured objects not being dropped on panic.
+- On macOS, fix objects captured by the event loop closure not being dropped on panic.
 
 # 0.24.0 (2020-12-09)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ cocoa = "0.24"
 core-foundation = "0.9"
 core-graphics = "0.22"
 dispatch = "0.2.0"
+scopeguard = "1.1"
 
 [target.'cfg(target_os = "macos")'.dependencies.core-video-sys]
 version = "0.1.4"

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -249,7 +249,6 @@ pub static INTERRUPT_EVENT_LOOP_EXIT: AtomicBool = AtomicBool::new(false);
 pub enum AppState {}
 
 impl AppState {
-    // This function extends lifetime of `callback` to 'static as its side effect
     pub fn set_callback<T>(
         callback: Weak<Mutex<Box<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>>,
         window_target: Rc<RootWindowTarget<T>>,

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -26,6 +26,7 @@ use crate::{
     event_loop::{ControlFlow, EventLoopWindowTarget as RootWindowTarget},
     platform_impl::platform::{
         event::{EventProxy, EventWrapper},
+        event_loop::CURRENT_PANIC,
         observer::EventLoopWaker,
         util::{IdRef, Never},
         window::get_window_id,
@@ -285,6 +286,9 @@ impl AppState {
     }
 
     pub fn wakeup() {
+        if CURRENT_PANIC.lock().unwrap().is_some() {
+            return;
+        }
         if !HANDLER.is_ready() {
             return;
         }
@@ -338,6 +342,9 @@ impl AppState {
     }
 
     pub fn cleared() {
+        if CURRENT_PANIC.lock().unwrap().is_some() {
+            return;
+        }
         if !HANDLER.is_ready() {
             return;
         }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -250,7 +250,7 @@ impl Handler {
 
 pub static INTERRUPT_EVENT_LOOP_EXIT: AtomicBool = AtomicBool::new(false);
 
-pub(crate) enum AppState {}
+pub enum AppState {}
 
 impl AppState {
     pub fn set_callback<T>(
@@ -282,7 +282,9 @@ impl AppState {
     }
 
     pub fn wakeup(panic_info: Weak<PanicInfo>) {
-        let panic_info = panic_info.upgrade().unwrap();
+        let panic_info = panic_info
+            .upgrade()
+            .expect("The panic info must exist here. This failure indicates a developer error.");
         if panic_info.is_panicking() || !HANDLER.is_ready() {
             return;
         }
@@ -336,7 +338,9 @@ impl AppState {
     }
 
     pub fn cleared(panic_info: Weak<PanicInfo>) {
-        let panic_info = panic_info.upgrade().unwrap();
+        let panic_info = panic_info
+            .upgrade()
+            .expect("The panic info must exist here. This failure indicates a developer error.");
         if panic_info.is_panicking() || !HANDLER.is_ready() {
             return;
         }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -76,10 +76,10 @@ impl<T> EventHandler for EventLoopHandler<T> {
                 *control_flow = ControlFlow::Exit;
             }
         } else {
-            // Logging an error instead of panicing because might happen while the
-            // application is already panicing.
+            // Logging an error instead of panicking because this might happen while the
+            // application is already panicking.
             error!(
-                "Tried to dispatch an event but the event loop that \
+                "Tried to dispatch an event, but the event loop that \
                 owned the event handler callback seems to be destroyed"
             );
         }
@@ -98,10 +98,10 @@ impl<T> EventHandler for EventLoopHandler<T> {
             }
             self.will_exit = will_exit;
         } else {
-            // Logging an error instead of panicing because might happen while the
-            // application is already panicing.
+            // Logging an error instead of panicking because this might happen while the
+            // application is already panicking.
             error!(
-                "Tried to dispatch an event but the event loop that \
+                "Tried to dispatch an event, but the event loop that \
                 owned the event handler callback seems to be destroyed"
             );
         }

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -62,7 +62,7 @@ pub struct EventLoop<T: 'static> {
     /// Every other reference should be a Weak reference which is only upgraded
     /// into a strong reference in order to call the callback but then the
     /// strong reference should be dropped as soon as possible.
-    callback:
+    _callback:
         Option<Arc<Mutex<Box<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>>>,
 
     _delegate: IdRef,
@@ -93,7 +93,7 @@ impl<T> EventLoop<T> {
                 p: Default::default(),
                 _marker: PhantomData,
             }),
-            callback: None,
+            _callback: None,
             _delegate: delegate,
         }
     }
@@ -125,7 +125,7 @@ impl<T> EventLoop<T> {
             >(Box::new(callback))
         }));
 
-        self.callback = Some(callback.clone());
+        self._callback = Some(callback.clone());
 
         unsafe {
             let pool = NSAutoreleasePool::new(nil);

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -71,7 +71,7 @@ pub struct EventLoop<T: 'static> {
     /// Every other reference should be a Weak reference which is only upgraded
     /// into a strong reference in order to call the callback but then the
     /// strong reference should be dropped as soon as possible.
-    callback: Option<Rc<RefCell<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>>,
+    _callback: Option<Rc<RefCell<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>>,
 
     _delegate: IdRef,
 }
@@ -101,7 +101,7 @@ impl<T> EventLoop<T> {
                 p: Default::default(),
                 _marker: PhantomData,
             }),
-            callback: None,
+            _callback: None,
             _delegate: delegate,
         }
     }
@@ -133,7 +133,7 @@ impl<T> EventLoop<T> {
             >(Rc::new(RefCell::new(callback)))
         };
 
-        self.callback = Some(callback.clone());
+        self._callback = Some(callback.clone());
 
         unsafe {
             let pool = NSAutoreleasePool::new(nil);

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -33,18 +33,14 @@ use crate::{
     },
 };
 
-//pub type PanicData = Option<Box<dyn Any + Send + 'static>>;
-
 #[derive(Default)]
-pub(crate) struct PanicInfo {
+pub struct PanicInfo {
     inner: Cell<Option<Box<dyn Any + Send + 'static>>>,
 }
-// ------------------------------------
+
 // WARNING:
-// This struct is UnwindSafe if `get_mut` is never called on the inner data.
-// (`get_mut` can be used in ways such that it is unwind safe but it can also be used
-// in ways that breaks unwind safety)
-// ------------------------------------
+// As long as this struct is used through its `impl`, it is UnwindSafe.
+// (If `get_mut` is called on `inner`, unwind safety may get broken.)
 impl UnwindSafe for PanicInfo {}
 impl RefUnwindSafe for PanicInfo {}
 impl PanicInfo {
@@ -191,7 +187,8 @@ impl<T> EventLoop<T> {
     }
 }
 
-pub(crate) unsafe fn post_dummy_event(target: id) {
+#[inline]
+pub unsafe fn post_dummy_event(target: id) {
     let event_class = class!(NSEvent);
     let dummy_event: id = msg_send![
         event_class,
@@ -210,7 +207,8 @@ pub(crate) unsafe fn post_dummy_event(target: id) {
 
 /// Catches panics that happen inside `f` and when a panic
 /// happens, stops the `sharedApplication`
-pub(crate) fn stop_app_on_panic<F: FnOnce() -> R + UnwindSafe, R>(
+#[inline]
+pub fn stop_app_on_panic<F: FnOnce() -> R + UnwindSafe, R>(
     panic_info: Weak<PanicInfo>,
     f: F,
 ) -> Option<R> {

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -163,7 +163,7 @@ impl<T> EventLoop<T> {
             >(Rc::new(RefCell::new(callback)))
         };
 
-        self._callback = Some(callback.clone());
+        self._callback = Some(Rc::clone(&callback));
 
         unsafe {
             let pool = NSAutoreleasePool::new(nil);
@@ -230,7 +230,7 @@ pub(crate) fn stop_app_on_panic<F: FnOnce() -> R + UnwindSafe, R>(
                 let app: id = msg_send![app_class, sharedApplication];
                 let () = msg_send![app, stop: nil];
 
-                // Posting an dummy event to get stop to take effect immediately.
+                // Posting a dummy event to get `stop` to take effect immediately.
                 // See: https://stackoverflow.com/questions/48041279/stopping-the-nsapplication-main-event-loop/48064752#48064752
                 post_dummy_event(app);
             }

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -135,7 +135,7 @@ impl<T> EventLoop<T> {
             // A bit of juggling with the callback references to make sure
             // that `self.callback` is the only owner of the callback.
             let weak_cb: Weak<_> = Arc::downgrade(&callback);
-            std::mem::drop(callback);
+            mem::drop(callback);
 
             AppState::set_callback(weak_cb, Rc::clone(&self.window_target));
             let _: () = msg_send![app, run];

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -124,7 +124,7 @@ pub struct CFRunLoopSourceContext {
     pub perform: Option<extern "C" fn(*mut c_void)>,
 }
 
-fn control_flow_handler<F>(panic_info: *mut c_void, f: F)
+unsafe fn control_flow_handler<F>(panic_info: *mut c_void, f: F)
 where
     F: FnOnce(Weak<PanicInfo>) + UnwindSafe,
 {
@@ -136,7 +136,7 @@ where
     let forgotten = panic_info.clone();
     std::mem::forget(forgotten);
 
-    stop_app_on_panic(panic_info.clone(), move || f(panic_info.0));
+    stop_app_on_panic(Weak::clone(&panic_info), move || f(panic_info.0));
 }
 
 // begin is queued with the highest priority to ensure it is processed before other observers


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #1850

This moves the ownership of the callback-closure to the `EventLoop`. The colusre is now contained within an `Rc` and the global handler only has a `Weak` reference to it, in order to ensure that the closure gets dropped with the `EventLoop`. Furthermore this catches panic unwinding, coming from the user callback to prevent it from unwinding into foreign code. The application is then requested to stop and the caught unwinding is resumed at a point where the callstack doesn't contain foreign code.