### PR TITLE
Add ability to hook/wrap an EventLoop.

### DIFF
--- a/examples/hook.rs
+++ b/examples/hook.rs
@@ -1,12 +1,21 @@
 use simple_logger::SimpleLogger;
-use winit::{event::{ElementState, Event, WindowEvent}, event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget, Hook}, window::WindowBuilder};
+use winit::{
+    event::{ElementState, Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget, Hook},
+    window::WindowBuilder,
+};
 
 struct ExampleHook;
 
 impl<T: std::fmt::Debug> Hook<T> for ExampleHook {
-    fn run<F>(&mut self, handler: F, event: Event<'_, T>, target: &EventLoopWindowTarget<T>, control_flow: &mut ControlFlow)
-    where
-        F: FnOnce(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow)
+    fn run<F>(
+        &mut self,
+        handler: F,
+        event: Event<'_, T>,
+        target: &EventLoopWindowTarget<T>,
+        control_flow: &mut ControlFlow,
+    ) where
+        F: FnOnce(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         println!("before event handler: {:?}", event);
         handler(event, target, control_flow);
@@ -17,10 +26,7 @@ impl<T: std::fmt::Debug> Hook<T> for ExampleHook {
 fn main() {
     SimpleLogger::new().init().unwrap();
 
-    let hook = ExampleHook;
-
-    let event_loop = EventLoop::new()
-        .set_hook(ExampleHook);
+    let event_loop = EventLoop::new().set_hook(ExampleHook);
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/hook.rs
+++ b/examples/hook.rs
@@ -1,0 +1,52 @@
+use simple_logger::SimpleLogger;
+use winit::{event::{ElementState, Event, WindowEvent}, event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget, Hook}, window::WindowBuilder};
+
+struct ExampleHook;
+
+impl<T: std::fmt::Debug> Hook<T> for ExampleHook {
+    fn run<F>(&mut self, handler: F, event: Event<'_, T>, target: &EventLoopWindowTarget<T>, control_flow: &mut ControlFlow)
+    where
+        F: FnOnce(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow)
+    {
+        println!("before event handler: {:?}", event);
+        handler(event, target, control_flow);
+        println!("after event handler: {:?}", control_flow);
+    }
+}
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+
+    let hook = ExampleHook;
+
+    let event_loop = EventLoop::new()
+        .set_hook(ExampleHook);
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .build(&event_loop)
+        .unwrap();
+
+    event_loop.run(move |event, _, control_flow| {
+        println!("in handler: {:?}", event);
+
+        *control_flow = ControlFlow::Poll;
+
+        match event {
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::MouseInput {
+                    state: ElementState::Released,
+                    ..
+                } => {
+                    window.request_redraw();
+                }
+                _ => (),
+            },
+            Event::RedrawRequested(_) => {
+                println!("\nredrawing!\n");
+            }
+            _ => (),
+        }
+    });
+}

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -10,23 +10,33 @@
 //! [event_loop_proxy]: crate::event_loop::EventLoopProxy
 //! [send_event]: crate::event_loop::EventLoopProxy::send_event
 use instant::Instant;
-use std::{marker::PhantomData, ops::Deref};
 use std::{error, fmt};
+use std::{marker::PhantomData, ops::Deref};
 
 use crate::{event::Event, monitor::MonitorHandle, platform_impl};
 
 /// Hook an event loop to wrap the user-specified event handler.
 /// See [`EventLoop::set_hook`].
 pub trait Hook<T> {
-    fn run<F>(&mut self, handler: F, event: Event<'_, T>, target: &EventLoopWindowTarget<T>, control_flow: &mut ControlFlow)
-    where
+    fn run<F>(
+        &mut self,
+        handler: F,
+        event: Event<'_, T>,
+        target: &EventLoopWindowTarget<T>,
+        control_flow: &mut ControlFlow,
+    ) where
         F: FnOnce(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow);
 }
 
 impl<T> Hook<T> for () {
-    fn run<F>(&mut self, handler: F, event: Event<'_, T>, target: &EventLoopWindowTarget<T>, control_flow: &mut ControlFlow)
-    where
-        F: FnOnce(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow)
+    fn run<F>(
+        &mut self,
+        handler: F,
+        event: Event<'_, T>,
+        target: &EventLoopWindowTarget<T>,
+        control_flow: &mut ControlFlow,
+    ) where
+        F: FnOnce(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         handler(event, target, control_flow);
     }
@@ -189,7 +199,7 @@ impl<T, H> EventLoop<T, H> {
     /// Add a hook to this event loop that will wrap the user-specified event handler
     /// provided to [`EventLoop::run`].
     ///
-    /// ```rust
+    /// ```rust,ignore
     /// # use winit::event_loop::{EventLoop, EventLoopWindowTarget, ControlFlow};
     /// # use winit::event::Event;
     /// use winit::event_loop::Hook;

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -14,7 +14,7 @@ pub trait EventLoopExtIOS {
     fn idiom(&self) -> Idiom;
 }
 
-impl<T: 'static> EventLoopExtIOS for EventLoop<T> {
+impl<T: 'static, H> EventLoopExtIOS for EventLoop<T, H> {
     fn idiom(&self) -> Idiom {
         self.event_loop.idiom()
     }

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -9,7 +9,10 @@
     target_os = "openbsd"
 ))]
 
-use crate::{event::Event, event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget, Hook}};
+use crate::{
+    event::Event,
+    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget, Hook},
+};
 
 /// Additional methods on `EventLoop` to return control flow to the caller.
 pub trait EventLoopExtRunReturn {
@@ -54,8 +57,9 @@ where
         ),
     {
         let hook = &mut self.hook;
-        self.event_loop.run_return(move |event, target, control_flow| {
-            hook.run(&mut event_handler, event, target, control_flow);
-        })
+        self.event_loop
+            .run_return(move |event, target, control_flow| {
+                hook.run(&mut event_handler, event, target, control_flow);
+            })
     }
 }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -147,6 +147,7 @@ pub trait EventLoopExtUnix {
 fn wrap_ev<T>(event_loop: LinuxEventLoop<T>) -> EventLoop<T> {
     EventLoop {
         event_loop,
+        hook: (),
         _marker: std::marker::PhantomData,
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -48,6 +48,7 @@ impl<T> EventLoopExtWindows for EventLoop<T> {
     fn new_any_thread() -> Self {
         EventLoop {
             event_loop: WindowsEventLoop::new_any_thread(),
+            hook: (),
             _marker: ::std::marker::PhantomData,
         }
     }
@@ -56,6 +57,7 @@ impl<T> EventLoopExtWindows for EventLoop<T> {
     fn new_dpi_unaware() -> Self {
         EventLoop {
             event_loop: WindowsEventLoop::new_dpi_unaware(),
+            hook: (),
             _marker: ::std::marker::PhantomData,
         }
     }
@@ -64,6 +66,7 @@ impl<T> EventLoopExtWindows for EventLoop<T> {
     fn new_dpi_unaware_any_thread() -> Self {
         EventLoop {
             event_loop: WindowsEventLoop::new_dpi_unaware_any_thread(),
+            hook: (),
             _marker: ::std::marker::PhantomData,
         }
     }


### PR DESCRIPTION
I've been thinking about how to get wgpu to integrate into the winit event loop (specifically to avoid needing users to continually call `device.poll` in order for gpu buffers to actually get mapped).

Anyhow, there were two ways of doing this:

1. Add some special casing to winit for wgpu that will call `device.poll` once per frame.
2. Add generalized hooking ability to winit.

The second option seemed preferable to me. Another issue is that, if `control_flow` is set to `Wait`, the event handler will only be called if the user interacts. That's not good enough in this case, so the hook wraps the user-specified event handler so it can detect if the handler set the control flow to `Wait` and change it to `WaitUntil` or similar instead.

The main things added are the `Hook` trait and `EventLoop::set_hook`.

`EventLoop::set_hook` actually consumes the `EventLoop` and returns a new type of `EventLoop<T, H>`, where `H: Hook<T>`.
