### PR TITLE
Fix Windows' try_theme returning Theme::Dark when new theme is light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - On Android, unimplemented events are marked as unhandled on the native event loop.
 - On Windows, added `WindowBuilderExtWindows::with_menu` to set a custom menu at window creation time.
 - On Android, bump `ndk` and `ndk-glue` to 0.3: use predefined constants for event `ident`.
+- On Windows, fixed `WindowEvent::ThemeChanged` not properly firing and fixed `Window::theme` returning the wrong theme.
 
 # 0.24.0 (2020-12-09)
 

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -81,16 +81,20 @@ pub fn try_theme(hwnd: HWND, preferred_theme: Option<Theme>) -> Theme {
             None => should_use_dark_mode(),
         };
 
-        let theme_name = if is_dark_mode {
-            DARK_THEME_NAME.as_ptr()
+        let theme = if is_dark_mode {
+            Theme::Dark
         } else {
-            LIGHT_THEME_NAME.as_ptr()
+            Theme::Light
+        };
+        let theme_name = match theme {
+            Theme::Dark => DARK_THEME_NAME.as_ptr(),
+            Theme::Light => LIGHT_THEME_NAME.as_ptr(),
         };
 
         let status = unsafe { uxtheme::SetWindowTheme(hwnd, theme_name as _, std::ptr::null()) };
 
         if status == S_OK && set_dark_mode_for_window(hwnd, is_dark_mode) {
-            return Theme::Dark;
+            return theme;
         }
     }
 


### PR DESCRIPTION
This PR fixes the return value of `dark_mode::try_theme` when dark mode is supported.

Currently, `try_theme` returns `Theme::Dark` whether if the new theme is light or dark, resulting in `WindowEvent::ThemeChanged` and `window::theme` not working properly:
![winit-theme](https://user-images.githubusercontent.com/24357633/108102943-88a0c480-7089-11eb-8f13-5d9bcc24376b.gif)

When returning the correct `Theme` value, everything works perfectly:
![winit-theme-fixed](https://user-images.githubusercontent.com/24357633/108103026-a0784880-7089-11eb-8e7c-a88a3c57aad7.gif)

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented