### PR TITLE
Fix small typo in comments/docs

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -526,7 +526,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Andraid / Web:** Unsupported.
+    /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn set_max_inner_size<S: Into<Size>>(&self, max_size: Option<S>) {
         self.window.set_max_inner_size(max_size.map(|s| s.into()))


### PR DESCRIPTION
Fixes a typo where "Android" is misspelled as "Andraid".
- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented