### PR TITLE
Only try publishing when a version tag is pushed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@ name: Publish
 
 on:
   push:
-    branches: [master]
-    paths: "Cargo.toml"
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   Publish:


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Currently the publish workflow attempts to publish every time a change in the `Cargo.toml` is pushed to the `master`. The publish fails if the version already exists but the failure happens only after compiling winit, wasting compute time and sending a false "publish failed" notification to the maintainer who made the merge. I understand that it's not a "serious" problem but the fix is very simple, so I think it's worth applying.

Just tagging a few maintainers for a review:  @msiglreith, @vberger, @murarth 
