### PR TITLE
Fix communication of fractional RI_MOUSE_WHEEL events (Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- On Windows, fix communication of fractional RI_MOUSE_WHEEL events
+- On Windows, fix fractional deltas for mouse wheel device events.
 - On macOS, fix segmentation fault after dropping the main window.
 - On Android, `InputEvent::KeyEvent` is partially implemented providing the key scancode.
 - Added `is_maximized` method to `Window`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On Windows, fix communication of fractional RI_MOUSE_WHEEL events
 - On macOS, fix segmentation fault after dropping the main window.
 - On Android, `InputEvent::KeyEvent` is partially implemented providing the key scancode.
 - Added `is_maximized` method to `Window`.

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -1,0 +1,32 @@
+use simple_logger::SimpleLogger;
+use winit::{
+    event::{DeviceEvent, Event, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+};
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title("Mouse Wheel events")
+        .build(&event_loop)
+        .unwrap();
+
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                _ => (),
+            },
+            Event::DeviceEvent { event, .. } => match event {
+                DeviceEvent::MouseWheel { delta } => println!("mouse wheel: {:?}", delta),
+                _ => (),
+            },
+            _ => (),
+        }
+    });
+}

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -23,7 +23,26 @@ fn main() {
                 _ => (),
             },
             Event::DeviceEvent { event, .. } => match event {
-                DeviceEvent::MouseWheel { delta } => println!("mouse wheel: {:?}", delta),
+                DeviceEvent::MouseWheel { delta } => {
+                    match delta {
+                        winit::event::MouseScrollDelta::LineDelta(x,y) => {
+                            println!("mouse wheel Line Delta: ({},{})", x, y);
+                            let pixels_per_line = 120.0;
+                            let mut pos = window.outer_position().unwrap();
+                            pos.x -= (x * pixels_per_line) as i32;
+                            pos.y -= (y * pixels_per_line) as i32;
+                            window.set_outer_position(pos)
+                        }
+                        winit::event::MouseScrollDelta::PixelDelta(p) =>
+                        {
+                            println!("mouse wheel Pixel Delta: ({},{})", p.x, p.y);
+                            let mut pos = window.outer_position().unwrap();
+                            pos.x -= p.x as i32;
+                            pos.y -= p.y as i32;
+                            window.set_outer_position(pos)
+                        }
+                    }
+                }
                 _ => (),
             },
             _ => (),

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -23,26 +23,23 @@ fn main() {
                 _ => (),
             },
             Event::DeviceEvent { event, .. } => match event {
-                DeviceEvent::MouseWheel { delta } => {
-                    match delta {
-                        winit::event::MouseScrollDelta::LineDelta(x,y) => {
-                            println!("mouse wheel Line Delta: ({},{})", x, y);
-                            let pixels_per_line = 120.0;
-                            let mut pos = window.outer_position().unwrap();
-                            pos.x -= (x * pixels_per_line) as i32;
-                            pos.y -= (y * pixels_per_line) as i32;
-                            window.set_outer_position(pos)
-                        }
-                        winit::event::MouseScrollDelta::PixelDelta(p) =>
-                        {
-                            println!("mouse wheel Pixel Delta: ({},{})", p.x, p.y);
-                            let mut pos = window.outer_position().unwrap();
-                            pos.x -= p.x as i32;
-                            pos.y -= p.y as i32;
-                            window.set_outer_position(pos)
-                        }
+                DeviceEvent::MouseWheel { delta } => match delta {
+                    winit::event::MouseScrollDelta::LineDelta(x, y) => {
+                        println!("mouse wheel Line Delta: ({},{})", x, y);
+                        let pixels_per_line = 120.0;
+                        let mut pos = window.outer_position().unwrap();
+                        pos.x -= (x * pixels_per_line) as i32;
+                        pos.y -= (y * pixels_per_line) as i32;
+                        window.set_outer_position(pos)
                     }
-                }
+                    winit::event::MouseScrollDelta::PixelDelta(p) => {
+                        println!("mouse wheel Pixel Delta: ({},{})", p.x, p.y);
+                        let mut pos = window.outer_position().unwrap();
+                        pos.x -= p.x as i32;
+                        pos.y -= p.y as i32;
+                        window.set_outer_position(pos)
+                    }
+                },
                 _ => (),
             },
             _ => (),

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2101,7 +2101,8 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                     }
 
                     if util::has_flag(mouse.usButtonFlags, winuser::RI_MOUSE_WHEEL) {
-                        let delta = mouse.usButtonData as SHORT as f32 / winuser::WHEEL_DELTA as f32;
+                        let delta =
+                            mouse.usButtonData as SHORT as f32 / winuser::WHEEL_DELTA as f32;
                         subclass_input.send_event(Event::DeviceEvent {
                             device_id,
                             event: MouseWheel {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2106,7 +2106,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                         subclass_input.send_event(Event::DeviceEvent {
                             device_id,
                             event: MouseWheel {
-                                delta: LineDelta(0.0, delta as f32),
+                                delta: LineDelta(0.0, delta),
                             },
                         });
                     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2101,7 +2101,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                     }
 
                     if util::has_flag(mouse.usButtonFlags, winuser::RI_MOUSE_WHEEL) {
-                        let delta = mouse.usButtonData as SHORT / winuser::WHEEL_DELTA;
+                        let delta = mouse.usButtonData as SHORT as f32 / winuser::WHEEL_DELTA as f32;
                         subclass_input.send_event(Event::DeviceEvent {
                             device_id,
                             event: MouseWheel {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
