### PR TITLE
Pen tablet support on X11

### DIFF
--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -748,18 +748,20 @@ impl<T: 'static> EventProcessor<T> {
                                 };
 
                                 let pressure = get_value(stylus.pressure) / stylus.pressure.max;
-                                let tilt_x = if let Some(vi) = stylus.tilt_x { get_value(vi) } else { 0. };
-                                let tilt_y = if let Some(vi) = stylus.tilt_y { get_value(vi) } else { 0. };
+                                //let tilt_x = if let Some(vi) = stylus.tilt_x { get_value(vi) } else { 0. };
+                                //let tilt_y = if let Some(vi) = stylus.tilt_y { get_value(vi) } else { 0. };
+
+                                let touch = Touch {
+                                    device_id,
+                                    phase: TouchPhase::Moved,
+                                    location: position,
+                                    force: Some(crate::event::Force::Normalized(pressure)),
+                                    id: xev.sourceid as u64
+                                };
 
                                 callback(Event::WindowEvent {
                                     window_id,
-                                    event: StylusMoved {
-                                        device_id,
-                                        position,
-                                        pressure,
-                                        tilt_x,
-                                        tilt_y
-                                    }
+                                    event: crate::event::WindowEvent::Touch(touch),
                                 });
                             } else {
                                 callback(Event::WindowEvent {

--- a/src/window.rs
+++ b/src/window.rs
@@ -526,7 +526,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Andraid / Web:** Unsupported.
+    /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn set_max_inner_size<S: Into<Size>>(&self, max_size: Option<S>) {
         self.window.set_max_inner_size(max_size.map(|s| s.into()))


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This is based on @DorianRudolph's work for adding pen tablet support on Linux on X11. The only thing I changed was to have it send `Touch` events in a similar manner to how pen tablet input is handled on Windows. There are quite a few things to address before accepting this PR, but I'd like to get feedback on whether such a change would be accepted before cleaning it up.