### PR TITLE
feat: add interface for changing window's z-level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - On macOS, initialize the Menu Bar with minimal defaults. (Can be prevented using `enable_default_menu_creation`)
 - On macOS, change the default behavior for first click when the window was unfocused. Now the window becomes focused and then emits a `MouseInput` event on a "first mouse click".
 - Implement mint (math interoperability standard types) conversions (under feature flag `mint`).
+- On macOS, added `set_level` and `get_level` to set and get window's z-level.
 
 # 0.24.0 (2020-12-09)
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -6,7 +6,7 @@ use crate::{
     dpi::LogicalSize,
     event_loop::{EventLoop, EventLoopWindowTarget},
     monitor::MonitorHandle,
-    platform_impl::get_aux_state_mut,
+    platform_impl::{get_aux_state_mut, util},
     window::{Window, WindowBuilder},
 };
 
@@ -39,6 +39,12 @@ pub trait WindowExtMacOS {
 
     /// Sets whether or not the window has shadow.
     fn set_has_shadow(&self, has_shadow: bool);
+
+    /// Get window z-level
+    fn get_level(&self) -> isize;
+
+    /// Set window z-level
+    fn set_level(&self, level: isize);
 }
 
 impl WindowExtMacOS for Window {
@@ -70,6 +76,16 @@ impl WindowExtMacOS for Window {
     #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
         self.window.set_has_shadow(has_shadow)
+    }
+
+    #[inline]
+    fn get_level(&self) -> isize {
+        unsafe { util::get_level_async(*self.ns_window()) }
+    }
+
+    #[inline]
+    fn set_level(&self, level: isize) {
+        unsafe { util::set_level_async(*self.ns_window(), level) };
     }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1137,6 +1137,16 @@ impl WindowExtMacOS for UnownedWindow {
                 .setHasShadow_(if has_shadow { YES } else { NO })
         }
     }
+
+    #[inline]
+    fn get_level(&self) -> isize {
+        unsafe { self.ns_window.level() }
+    }
+
+    #[inline]
+    fn set_level(&self, level: isize) {
+        unsafe { self.ns_window.setLevel_(level) }
+    }
 }
 
 impl Drop for UnownedWindow {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

On macOS, added `set_window_level` and `get_window_level` to set and get window's z-level.