### PR TITLE
feat: add set_ignore_cursor_events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - On macOS, initialize the Menu Bar with minimal defaults. (Can be prevented using `enable_default_menu_creation`)
 - On macOS, change the default behavior for first click when the window was unfocused. Now the window becomes focused and then emits a `MouseInput` event on a "first mouse click".
 - Implement mint (math interoperability standard types) conversions (under feature flag `mint`).
+- On macOS and Windows, added `set_ignore_mouse_events` to let the window ignore mouse events.
 
 # 0.24.0 (2020-12-09)
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -563,6 +563,12 @@ impl Window {
         ))
     }
 
+    pub fn set_ignore_mouse_events(&self, _ignore: bool) -> Result<(), error::ExternalError> {
+        Err(error::ExternalError::NotSupported(
+            error::NotSupportedError::new(),
+        ))
+    }
+
     pub fn raw_window_handle(&self) -> raw_window_handle::RawWindowHandle {
         let a_native_window = if let Some(native_window) = ndk_glue::native_window().as_ref() {
             unsafe { native_window.ptr().as_mut() as *mut _ as *mut _ }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -186,6 +186,10 @@ impl Inner {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
+    pub fn set_ignore_mouse_events(&self, _ignore: bool) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
     pub fn set_minimized(&self, _minimized: bool) {
         warn!("`Window::set_minimized` is ignored on iOS")
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -364,6 +364,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_ignore_mouse_events(&self, _ignore: bool) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
+    #[inline]
     pub fn scale_factor(&self) -> f64 {
         x11_or_wayland!(match self; Window(w) => w.scale_factor() as f64)
     }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -599,6 +599,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_ignore_mouse_events(&self, ignore: bool) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
+    #[inline]
     pub fn set_ime_position(&self, position: Position) {
         let scale_factor = self.scale_factor() as f64;
         let position = position.to_logical(scale_factor);

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -10,7 +10,7 @@ use cocoa::{
 };
 use dispatch::Queue;
 use objc::rc::autoreleasepool;
-use objc::runtime::NO;
+use objc::runtime::{NO, YES};
 
 use crate::{
     dpi::LogicalSize,
@@ -85,6 +85,14 @@ pub unsafe fn set_level_async(ns_window: id, level: ffi::NSWindowLevel) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
         ns_window.setLevel_(level as _);
+    });
+}
+
+// `setIgnoresMouseEvents_:` isn't thread-safe, and fails silently.
+pub unsafe fn set_ignore_mouse_events(ns_window: id, ignore: bool) {
+    let ns_window = MainThreadSafe(ns_window);
+    Queue::main().exec_async(move || {
+        ns_window.setIgnoresMouseEvents_(if ignore { YES } else { NO });
     });
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -622,6 +622,15 @@ impl UnownedWindow {
         Ok(())
     }
 
+    #[inline]
+    pub fn set_ignore_mouse_events(&self, ignore: bool) -> Result<(), ExternalError> {
+        unsafe {
+            util::set_ignore_mouse_events(*self.ns_window, ignore);
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn is_zoomed(&self) -> bool {
         // because `isZoomed` doesn't work if the window's borderless,
         // we make it resizable temporalily.

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -228,6 +228,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_ignore_mouse_events(&self, _ignore: bool) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
+    #[inline]
     pub fn set_minimized(&self, _minimized: bool) {
         // Intentionally a no-op, as canvases cannot be 'minimized'
     }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -382,6 +382,19 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_ignore_mouse_events(&self, ignore: bool) -> Result<(), ExternalError> {
+        let window = self.window.clone();
+        let window_state = Arc::clone(&self.window_state);
+        self.thread_executor.execute_in_thread(move || {
+            WindowState::set_window_flags(window_state.lock(), window.0, |f| {
+                f.set(WindowFlags::IGNORE_CURSOR_EVENT, ignore)
+            });
+        });
+
+        Ok(())
+    }
+
+    #[inline]
     pub fn id(&self) -> WindowId {
         WindowId(self.window.0)
     }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -86,6 +86,8 @@ bitflags! {
 
         const MINIMIZED = 1 << 12;
 
+        const IGNORE_CURSOR_EVENT = 1 << 14;
+
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits;
         const NO_DECORATIONS_AND_MASK = !WindowFlags::RESIZABLE.bits;
         const INVISIBLE_AND_MASK = !WindowFlags::MAXIMIZED.bits;
@@ -222,6 +224,9 @@ impl WindowFlags {
         }
         if self.contains(WindowFlags::MAXIMIZED) {
             style |= WS_MAXIMIZE;
+        }
+        if self.contains(WindowFlags::IGNORE_CURSOR_EVENT) {
+            style_ex |= WS_EX_TRANSPARENT | WS_EX_LAYERED;
         }
 
         style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;

--- a/src/window.rs
+++ b/src/window.rs
@@ -817,6 +817,20 @@ impl Window {
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         self.window.drag_window()
     }
+
+    /// Modifies whether the window catches cursor events.
+    ///
+    /// Mouse events pass through the window such that any other window behind it receives them.
+    ///
+    /// If `false`, this will catch the cursor events. If `true`, this will ignore the cursor.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / X11 / Wayland:** Unsupported.
+    #[inline]
+    pub fn set_ignore_mouse_events(&self, ignore: bool) -> Result<(), ExternalError> {
+        self.window.set_ignore_mouse_events(ignore)
+    }
 }
 
 /// Monitor info functions.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

On macOS and Windows, added `set_ignore_cursor_events` to make window catch or ignore mouse events.
