### PR TITLE
Hold on to Android NativeWindow lock to prevent races

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ image = "0.23.12"
 simple_logger = "1.9"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = "0.3"
-ndk-sys = "0.2.0"
-ndk-glue = "0.3"
+ndk = { path = "../android-ndk-rs/ndk" }
+ndk-sys = { path = "../android-ndk-rs/ndk-sys" }
+ndk-glue = { path = "../android-ndk-rs/ndk-glue" }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -44,9 +44,11 @@ fn poll(poll: Poll) -> Option<EventSource> {
 
 pub struct EventLoop<T: 'static> {
     window_target: event_loop::EventLoopWindowTarget<T>,
-    // This read guard will be held between each pair of `Resumed` and `Suspended`
-    // events to ensure that `ndk_glue` does not release the `NativeWindow` prematurely,
-    // invalidating raw handles obtained by the user through `Window::raw_window_handle()`
+    /// This read guard will be held between each pair of
+    /// [`event::Event::Resumed`] and [`event::Event::Suspended`] events to
+    /// ensure that [`ndk_glue`] does not release the [`NativeWindow`]
+    /// prematurely, invalidating raw handles obtained by the user through
+    /// [`Window::raw_window_handle()`].
     native_window_lock: Option<RwLockReadGuard<'static, Option<NativeWindow>>>,
     user_queue: Arc<Mutex<VecDeque<T>>>,
     first_event: Option<EventSource>,


### PR DESCRIPTION
The current Android implementation of winit aims to guarantee the validity of pointers handed out by `Window::raw_window_handle()` between a `Resumed` event and a matching `Suspended` event. I don't think this guarantee is actually upheld.

The design of the `ndk_glue` crate requires that users hold on to a read lock on the `NativeWindow` handle received from `ndk_glue::native_window()` while they intend to use it, including through implicitly dependent objects such as `RawWindowHandle` (or `EGLSurface`, and so on). Otherwise, Android may destroy the underlying resource before dependent resources are cleaned up, leading to a race condition and UB.

Unfortunately, due to a subtle bug, such user behavior would cause a deadlock in the current version of `ndk_glue`. This should no longer be the case once rust-windowing/android-ndk-rs#117 is resolved.

From that point on, in order to ensure validity of the raw pointers to Android's `ANativeWindow` handed out by `Window::raw_window_handle()`, winit's Android `EventLoop` should hold on to a read lock on the `NativeWindow` returned by `ndk_glue::native_window()` between receiving the `WindowCreated` event and the matching `WindowDestroyed` event from `ndk_glue`'s event pipe.

Other designs are possible, of course, but as long as raw pointers are being handed out, some similar protection will be necessary.

﻿Depends on: https://github.com/rust-windowing/android-ndk-rs/pull/134

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
