### PR TITLE
Mac: Redraw immediately to prevent shaking on window resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Added `WindowBuilder::with_position` to allow setting the position of a `Window` on creation. Supported on Windows, macOS and X11.
 - Added `Window::drag_window`. Implemented on Windows, macOS, X11 and Wayland.
 - On X11, bump `mio` to 0.7.
-- On macOS, emit `RedrawRequested` events while the window is being resized.
+- On macOS, emit `RedrawRequested` events immediately while the window is being resized.
 
 # 0.24.0 (2020-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Added `WindowBuilder::with_position` to allow setting the position of a `Window` on creation. Supported on Windows, macOS and X11.
 - Added `Window::drag_window`. Implemented on Windows, macOS, X11 and Wayland.
 - On X11, bump `mio` to 0.7.
+- On macOS, emit `RedrawRequested` events while the window is being resized.
 
 # 0.24.0 (2020-12-09)
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -323,6 +323,10 @@ impl AppState {
         }
     }
 
+    pub fn handle_redraw(window_id: WindowId) {
+        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawRequested(window_id)));
+    }
+
     pub fn queue_event(wrapper: EventWrapper) {
         if !unsafe { msg_send![class!(NSThread), isMainThread] } {
             panic!("Event queued from different thread: {:#?}", wrapper);

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -346,7 +346,7 @@ extern "C" fn draw_rect(this: &Object, _sel: Sel, rect: NSRect) {
         let state_ptr: *mut c_void = *this.get_ivar("winitState");
         let state = &mut *(state_ptr as *mut ViewState);
 
-        AppState::queue_redraw(WindowId(get_window_id(state.ns_window)));
+        AppState::handle_redraw(WindowId(get_window_id(state.ns_window)));
 
         let superclass = util::superclass(this);
         let () = msg_send![super(this, superclass), drawRect: rect];


### PR DESCRIPTION
Fixes #1837, gfx-rs/wgpu-rs#536, rust-windowing/glutin#1340, servo/webrender#1640
