### PR TITLE
MacOS: Use `initialFirstResponder` instead of `makeFirstResponder`

### DIFF
--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -131,8 +131,6 @@ unsafe fn create_view(
             ns_view.setWantsLayer(YES);
         }
 
-        ns_window.setContentView_(*ns_view);
-        ns_window.makeFirstResponder_(*ns_view);
         (ns_view, cursor_state)
     })
 }
@@ -376,6 +374,12 @@ impl UnownedWindow {
                 unsafe { pool.drain() };
                 os_error!(OsError::CreationError("Couldn't create `NSView`"))
             })?;
+
+        // Configure the new view as the "key view" for the window
+        unsafe {
+            ns_window.setContentView_(*ns_view);
+            ns_window.setInitialFirstResponder_(*ns_view);
+        }
 
         let input_context = unsafe { util::create_input_context(*ns_view) };
 


### PR DESCRIPTION
Minor nit, as recommended by [the documentation](https://developer.apple.com/documentation/appkit/nswindow/1419366-makefirstresponder?language=objc).

This changes the point at which `becomeFirstResponder` (a notification we don't use) is emitted to later on when `makeKeyAndOrderFront`/`makeKeyWindow` is called, which I think is more correct behaviour.

- [x] Tested on all platforms changed
    - MacOS 10.14.6 Mojave
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
