### PR TITLE
Require setting the activation policy on the event loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ rls/
 *.ts
 *.js
 #*#
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- **Breaking:** On macOS, replace `WindowBuilderExtMacOS::with_activation_policy` with `EventLoopExtMacOS::set_activation_policy`
 - On macOS, wait with activating the application until the application has initialized.
 - On macOS, fix creating new windows when the application has a main menu.
 - On Windows, fix fractional deltas for mouse wheel device events.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -180,8 +180,11 @@ impl WindowBuilderExtMacOS for WindowBuilder {
 }
 
 pub trait EventLoopExtMacOS {
-    /// Sets the activation policy for the application.
-    /// It is set to `NSApplicationActivationPolicyRegular` by default.
+    /// Sets the activation policy for the application. It is set to
+    /// `NSApplicationActivationPolicyRegular` by default.
+    ///
+    /// This function only takes effect if it's called before calling [`run`](crate::event_loop::EventLoop::run) or
+    /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
     fn set_activation_policy(&mut self, activation_policy: ActivationPolicy);
 }
 impl<T> EventLoopExtMacOS for EventLoop<T> {

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -13,9 +13,9 @@ use std::{
 static AUX_DELEGATE_STATE_NAME: &str = "auxState";
 
 pub struct AuxDelegateState {
-    /// We store this value in order to be able defer setting the activation policy until
+    /// We store this value in order to be able to defer setting the activation policy until
     /// after the app has finished launching. If the activation policy is set earlier, the
-    /// menubar is unresponsive for example.
+    /// menubar is initially unresponsive on macOS 10.15 for example.
     pub activation_policy: ActivationPolicy,
 }
 

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,9 +1,26 @@
-use super::app_state::AppState;
+use crate::{
+    platform::macos::ActivationPolicy,
+    platform_impl::platform::{app_state::AppState},
+};
+
 use cocoa::base::id;
 use objc::{
     declare::ClassDecl,
     runtime::{Class, Object, Sel},
 };
+use std::{
+    cell::{RefCell, RefMut},
+    os::raw::c_void,
+};
+
+static AUX_DELEGATE_STATE_NAME: &str = "auxState";
+
+pub struct AuxDelegateState {
+    /// We store this value in order to be able defer setting the activation policy until
+    /// after the app has finished launching. If the activation policy is set earlier, the
+    /// menubar is unresponsive for example.
+    pub activation_policy: ActivationPolicy,
+}
 
 pub struct AppDelegateClass(pub *const Class);
 unsafe impl Send for AppDelegateClass {}
@@ -14,17 +31,51 @@ lazy_static! {
         let superclass = class!(NSResponder);
         let mut decl = ClassDecl::new("WinitAppDelegate", superclass).unwrap();
 
+        decl.add_class_method(sel!(new), new as extern "C" fn(&Class, Sel) -> id);
+        decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
+        
         decl.add_method(
             sel!(applicationDidFinishLaunching:),
             did_finish_launching as extern "C" fn(&Object, Sel, id),
         );
+        decl.add_ivar::<*mut c_void>(AUX_DELEGATE_STATE_NAME);
 
         AppDelegateClass(decl.register())
     };
 }
 
-extern "C" fn did_finish_launching(_: &Object, _: Sel, _: id) {
+/// Safety: Assumes that Object is an instance of APP_DELEGATE_CLASS
+pub unsafe fn get_aux_state_mut(this: &Object) -> RefMut<'_, AuxDelegateState> {
+    let ptr: *mut c_void = *this.get_ivar(AUX_DELEGATE_STATE_NAME);
+    // Watch out that this needs to be the correct type
+    (*(ptr as *mut RefCell<AuxDelegateState>)).borrow_mut()
+}
+
+extern "C" fn new(class: &Class, _: Sel) -> id {
+    unsafe {
+        let this: id = msg_send![class, alloc];
+        let this: id = msg_send![this, init];
+        (*this).set_ivar(
+            AUX_DELEGATE_STATE_NAME,
+            Box::into_raw(Box::new(RefCell::new(AuxDelegateState {
+                activation_policy: ActivationPolicy::Regular,
+            }))) as *mut c_void,
+        );
+        this
+    }
+}
+
+extern "C" fn dealloc(this: &Object, _: Sel) {
+    unsafe {
+        let state_ptr: *mut c_void = *(this.get_ivar(AUX_DELEGATE_STATE_NAME));
+        // As soon as the box is constructed it is immediately dropped, releasing the underlying
+        // memory
+        Box::from_raw(state_ptr as *mut RefCell<AuxDelegateState>);
+    }
+}
+
+extern "C" fn did_finish_launching(this: &Object, _: Sel, _: id) {
     trace!("Triggered `applicationDidFinishLaunching`");
-    AppState::launched();
+    AppState::launched(this);
     trace!("Completed `applicationDidFinishLaunching`");
 }

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,7 +1,4 @@
-use crate::{
-    platform::macos::ActivationPolicy,
-    platform_impl::platform::{app_state::AppState},
-};
+use crate::{platform::macos::ActivationPolicy, platform_impl::platform::app_state::AppState};
 
 use cocoa::base::id;
 use objc::{
@@ -33,7 +30,7 @@ lazy_static! {
 
         decl.add_class_method(sel!(new), new as extern "C" fn(&Class, Sel) -> id);
         decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
-        
+
         decl.add_method(
             sel!(applicationDidFinishLaunching:),
             did_finish_launching as extern "C" fn(&Object, Sel, id),

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -476,6 +476,5 @@ fn apply_activation_policy(app_delegate: &Object) {
             ActivationPolicy::Accessory => NSApplicationActivationPolicyAccessory,
             ActivationPolicy::Prohibited => NSApplicationActivationPolicyProhibited,
         });
-        let () = msg_send![ns_app, activateIgnoringOtherApps: YES];
     }
 }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -19,17 +19,23 @@ use cocoa::{
 };
 use objc::runtime::YES;
 
+use objc::runtime::Object;
+
 use crate::{
     dpi::LogicalSize,
     event::{Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoopWindowTarget as RootWindowTarget},
-    platform_impl::platform::{
-        event::{EventProxy, EventWrapper},
-        event_loop::{post_dummy_event, PanicInfo},
-        menu,
-        observer::{CFRunLoopGetMain, CFRunLoopWakeUp, EventLoopWaker},
-        util::{IdRef, Never},
-        window::get_window_id,
+    platform::macos::ActivationPolicy,
+    platform_impl::{
+        get_aux_state_mut,
+        platform::{
+            event::{EventProxy, EventWrapper},
+            event_loop::{post_dummy_event, PanicInfo},
+            menu,
+            observer::{CFRunLoopGetMain, CFRunLoopWakeUp, EventLoopWaker},
+            util::{IdRef, Never},
+            window::get_window_id,
+        },
     },
     window::WindowId,
 };
@@ -273,7 +279,8 @@ impl AppState {
         HANDLER.callback.lock().unwrap().take();
     }
 
-    pub fn launched() {
+    pub fn launched(app_delegate: &Object) {
+        apply_activation_policy(app_delegate);
         unsafe {
             let ns_app = NSApp();
             window_activation_hack(ns_app);
@@ -455,5 +462,20 @@ unsafe fn window_activation_hack(ns_app: id) {
         } else {
             trace!("Skipping activating invisible window");
         }
+    }
+}
+fn apply_activation_policy(app_delegate: &Object) {
+    unsafe {
+        use cocoa::appkit::{NSApplicationActivationPolicy::*};
+        let ns_app = NSApp();
+        // We need to delay setting the activation policy and activating the app
+        // until we have the main menu all set up. Otherwise the menu won't be interactable.
+        let act_pol = get_aux_state_mut(app_delegate).activation_policy;
+        ns_app.setActivationPolicy_(match act_pol {
+            ActivationPolicy::Regular => NSApplicationActivationPolicyRegular,
+            ActivationPolicy::Accessory => NSApplicationActivationPolicyAccessory,
+            ActivationPolicy::Prohibited => NSApplicationActivationPolicyProhibited,
+        });
+        let () = msg_send![ns_app, activateIgnoringOtherApps: YES];
     }
 }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -469,7 +469,8 @@ fn apply_activation_policy(app_delegate: &Object) {
         use cocoa::appkit::NSApplicationActivationPolicy::*;
         let ns_app = NSApp();
         // We need to delay setting the activation policy and activating the app
-        // until we have the main menu all set up. Otherwise the menu won't be interactable.
+        // until `applicationDidFinishLaunching` has been called. Otherwise the
+        // menu bar won't be interactable.
         let act_pol = get_aux_state_mut(app_delegate).activation_policy;
         ns_app.setActivationPolicy_(match act_pol {
             ActivationPolicy::Regular => NSApplicationActivationPolicyRegular,

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -466,7 +466,7 @@ unsafe fn window_activation_hack(ns_app: id) {
 }
 fn apply_activation_policy(app_delegate: &Object) {
     unsafe {
-        use cocoa::appkit::{NSApplicationActivationPolicy::*};
+        use cocoa::appkit::NSApplicationActivationPolicy::*;
         let ns_app = NSApp();
         // We need to delay setting the activation policy and activating the app
         // until we have the main menu all set up. Otherwise the menu won't be interactable.

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -87,6 +87,8 @@ impl<T: 'static> EventLoopWindowTarget<T> {
 }
 
 pub struct EventLoop<T: 'static> {
+    pub(crate) delegate: IdRef,
+
     window_target: Rc<RootWindowTarget<T>>,
     panic_info: Rc<PanicInfo>,
 
@@ -97,7 +99,6 @@ pub struct EventLoop<T: 'static> {
     /// into a strong reference in order to call the callback but then the
     /// strong reference should be dropped as soon as possible.
     _callback: Option<Rc<RefCell<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>>,
-    _delegate: IdRef,
 }
 
 impl<T> EventLoop<T> {
@@ -122,13 +123,13 @@ impl<T> EventLoop<T> {
         let panic_info: Rc<PanicInfo> = Default::default();
         setup_control_flow_observers(Rc::downgrade(&panic_info));
         EventLoop {
+            delegate,
             window_target: Rc::new(RootWindowTarget {
                 p: Default::default(),
                 _marker: PhantomData,
             }),
             panic_info,
             _callback: None,
-            _delegate: delegate,
         }
     }
 

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -1,7 +1,4 @@
-use cocoa::appkit::{
-    NSApp, NSApplication, NSApplicationActivationPolicyRegular, NSEventModifierFlags, NSMenu,
-    NSMenuItem,
-};
+use cocoa::appkit::{NSApp, NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
 use cocoa::base::{nil, selector};
 use cocoa::foundation::{NSAutoreleasePool, NSProcessInfo, NSString};
 use objc::{

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -17,6 +17,7 @@ mod window_delegate;
 use std::{fmt, ops::Deref, sync::Arc};
 
 pub use self::{
+    app_delegate::{get_aux_state_mut, AuxDelegateState},
     event_loop::{EventLoop, EventLoopWindowTarget, Proxy as EventLoopProxy},
     monitor::{MonitorHandle, VideoMode},
     window::{Id as WindowId, PlatformSpecificWindowBuilderAttributes, UnownedWindow},

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -337,12 +337,6 @@ impl UnownedWindow {
         trace!("Creating new window");
 
         let pool = unsafe { NSAutoreleasePool::new(nil) };
-
-        let ns_app = unsafe { NSApp() };
-        if ns_app == nil {
-            unsafe { pool.drain() };
-            return Err(os_error!(OsError::CreationError("`NSApp()` returned nil")));
-        }
         let ns_window = create_window(&win_attribs, &pl_attribs).ok_or_else(|| {
             unsafe { pool.drain() };
             os_error!(OsError::CreationError("Couldn't create `NSWindow`"))


### PR DESCRIPTION
The activation policy could previously be specified through the window builder. This was incorrect because the activation policy is an application-wide property, not window-specific.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
