### PR TITLE
Allow preventing the creation of the default menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - On Windows, added `WindowExtWindows::set_enable` to allow creating modal popup windows.
 - On macOS, emit `RedrawRequested` events immediately while the window is being resized.
 - Implement `Default`, `Hash`, and `Eq` for `LogicalPosition`, `PhysicalPosition`, `LogicalSize`, and `PhysicalSize`.
-- On macOS, initialize the Menu Bar with minimal defaults.
+- On macOS, initialize the Menu Bar with minimal defaults. (Can be prevented using `enable_default_menu_creation`)
 - On macOS, change the default behavior for first click when the window was unfocused. Now the window becomes focused and then emits a `MouseInput` event on a "first mouse click".
 
 # 0.24.0 (2020-12-09)

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -186,12 +186,28 @@ pub trait EventLoopExtMacOS {
     /// This function only takes effect if it's called before calling [`run`](crate::event_loop::EventLoop::run) or
     /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
     fn set_activation_policy(&mut self, activation_policy: ActivationPolicy);
+
+    /// Can be used to prevent a default menubar menu from getting created
+    ///
+    /// The default menu creation is enabled by default.
+    ///
+    /// This function only takes effect if it's called before calling
+    /// [`run`](crate::event_loop::EventLoop::run) or
+    /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
+    fn enable_creating_default_menu(&mut self, enable: bool);
 }
 impl<T> EventLoopExtMacOS for EventLoop<T> {
     #[inline]
     fn set_activation_policy(&mut self, activation_policy: ActivationPolicy) {
         unsafe {
             get_aux_state_mut(&**self.event_loop.delegate).activation_policy = activation_policy;
+        }
+    }
+
+    #[inline]
+    fn enable_creating_default_menu(&mut self, enable: bool) {
+        unsafe {
+            get_aux_state_mut(&**self.event_loop.delegate).create_default_menu = enable;
         }
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -187,14 +187,14 @@ pub trait EventLoopExtMacOS {
     /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
     fn set_activation_policy(&mut self, activation_policy: ActivationPolicy);
 
-    /// Can be used to prevent a default menubar menu from getting created
+    /// Used to prevent a default menubar menu from getting created
     ///
     /// The default menu creation is enabled by default.
     ///
     /// This function only takes effect if it's called before calling
     /// [`run`](crate::event_loop::EventLoop::run) or
     /// [`run_return`](crate::platform::run_return::EventLoopExtRunReturn::run_return)
-    fn enable_creating_default_menu(&mut self, enable: bool);
+    fn enable_default_menu_creation(&mut self, enable: bool);
 }
 impl<T> EventLoopExtMacOS for EventLoop<T> {
     #[inline]
@@ -205,7 +205,7 @@ impl<T> EventLoopExtMacOS for EventLoop<T> {
     }
 
     #[inline]
-    fn enable_creating_default_menu(&mut self, enable: bool) {
+    fn enable_default_menu_creation(&mut self, enable: bool) {
         unsafe {
             get_aux_state_mut(&**self.event_loop.delegate).create_default_menu = enable;
         }

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -17,6 +17,8 @@ pub struct AuxDelegateState {
     /// after the app has finished launching. If the activation policy is set earlier, the
     /// menubar is initially unresponsive on macOS 10.15 for example.
     pub activation_policy: ActivationPolicy,
+
+    pub create_default_menu: bool,
 }
 
 pub struct AppDelegateClass(pub *const Class);
@@ -56,6 +58,7 @@ extern "C" fn new(class: &Class, _: Sel) -> id {
             AUX_DELEGATE_STATE_NAME,
             Box::into_raw(Box::new(RefCell::new(AuxDelegateState {
                 activation_policy: ActivationPolicy::Regular,
+                create_default_menu: true,
             }))) as *mut c_void,
         );
         this

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -289,9 +289,12 @@ impl AppState {
         };
         HANDLER.set_ready();
         HANDLER.waker().start();
-        // The menubar initialization should be before the `NewEvents` event, to allow overriding
-        // of the default menu in the event
-        menu::initialize();
+        let create_default_menu = unsafe { get_aux_state_mut(app_delegate).create_default_menu };
+        if create_default_menu {
+            // The menubar initialization should be before the `NewEvents` event, to allow
+            // overriding of the default menu even if it's created
+            menu::initialize();
+        }
         HANDLER.set_in_callback(true);
         HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::NewEvents(
             StartCause::Init,


### PR DESCRIPTION
The changelog is not modified, because the default menu wasn't created in the previous release.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
