### PR TITLE
Fix for exception thrown during shutdown on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On macOS, fix a bug that caused an exception getting thrown during exit.
 - **Breaking:** On macOS, replace `WindowBuilderExtMacOS::with_activation_policy` with `EventLoopExtMacOS::set_activation_policy`
 - On macOS, wait with activating the application until the application has initialized.
 - On macOS, fix creating new windows when the application has a main menu.

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -414,6 +414,8 @@ impl AppState {
                 }
                 pool.drain();
 
+                let windows: id = msg_send![app, windows];
+                let window_count: usize = msg_send![windows, count];
                 if window_count > 0 {
                     let window: id = msg_send![windows, objectAtIndex:0];
                     let window_has_focus = msg_send![window, isKeyWindow];


### PR DESCRIPTION
I think this fixes #1925 (although I can't reproduce it :D)

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
