### PR TITLE
implement mint conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Implement `Default`, `Hash`, and `Eq` for `LogicalPosition`, `PhysicalPosition`, `LogicalSize`, and `PhysicalSize`.
 - On macOS, initialize the Menu Bar with minimal defaults. (Can be prevented using `enable_default_menu_creation`)
 - On macOS, change the default behavior for first click when the window was unfocused. Now the window becomes focused and then emits a `MouseInput` event on a "first mouse click".
+- Implement mint (math interoperability standard types) conversions (under feature flag `mint`).
 
 # 0.24.0 (2020-12-09)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ log = "0.4"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 raw-window-handle = "0.3"
 bitflags = "1"
+mint = { version = "0.5.6", optional = true }
 
 [dev-dependencies]
 image = "0.23.12"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 * `serde`: Enables serialization/deserialization of certain types with [Serde](https://crates.io/crates/serde).
 * `x11` (enabled by default): On Unix platform, compiles with the X11 backend
 * `wayland` (enabled by default): On Unix platform, compiles with the Wayland backend
+* `mint`: Enables mint (math interoperability standard types) conversions.
 
 ### Platform-specific usage
 

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -228,6 +228,23 @@ impl<P: Pixel, X: Pixel> Into<[X; 2]> for LogicalPosition<P> {
     }
 }
 
+#[cfg(feature = "mint")]
+impl<P: Pixel> From<mint::Point2<P>> for LogicalPosition<P> {
+    fn from(mint: mint::Point2<P>) -> Self {
+        Self::new(mint.x, mint.y)
+    }
+}
+
+#[cfg(feature = "mint")]
+impl<P: Pixel> From<LogicalPosition<P>> for mint::Point2<P> {
+    fn from(winit: LogicalPosition<P>) -> Self {
+        mint::Point2 {
+            x: winit.x,
+            y: winit.y,
+        }
+    }
+}
+
 /// A position represented in physical pixels.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -290,6 +307,23 @@ impl<P: Pixel, X: Pixel> From<[X; 2]> for PhysicalPosition<P> {
 impl<P: Pixel, X: Pixel> Into<[X; 2]> for PhysicalPosition<P> {
     fn into(self: Self) -> [X; 2] {
         [self.x.cast(), self.y.cast()]
+    }
+}
+
+#[cfg(feature = "mint")]
+impl<P: Pixel> From<mint::Point2<P>> for PhysicalPosition<P> {
+    fn from(mint: mint::Point2<P>) -> Self {
+        Self::new(mint.x, mint.y)
+    }
+}
+
+#[cfg(feature = "mint")]
+impl<P: Pixel> From<PhysicalPosition<P>> for mint::Point2<P> {
+    fn from(winit: PhysicalPosition<P>) -> Self {
+        mint::Point2 {
+            x: winit.x,
+            y: winit.y,
+        }
     }
 }
 
@@ -358,6 +392,23 @@ impl<P: Pixel, X: Pixel> Into<[X; 2]> for LogicalSize<P> {
     }
 }
 
+#[cfg(feature = "mint")]
+impl<P: Pixel> From<mint::Vector2<P>> for LogicalSize<P> {
+    fn from(mint: mint::Vector2<P>) -> Self {
+        Self::new(mint.x, mint.y)
+    }
+}
+
+#[cfg(feature = "mint")]
+impl<P: Pixel> From<LogicalSize<P>> for mint::Vector2<P> {
+    fn from(winit: LogicalSize<P>) -> Self {
+        mint::Vector2 {
+            x: winit.width,
+            y: winit.height,
+        }
+    }
+}
+
 /// A size represented in physical pixels.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -417,6 +468,23 @@ impl<P: Pixel, X: Pixel> From<[X; 2]> for PhysicalSize<P> {
 impl<P: Pixel, X: Pixel> Into<[X; 2]> for PhysicalSize<P> {
     fn into(self: Self) -> [X; 2] {
         [self.width.cast(), self.height.cast()]
+    }
+}
+
+#[cfg(feature = "mint")]
+impl<P: Pixel> From<mint::Vector2<P>> for PhysicalSize<P> {
+    fn from(mint: mint::Vector2<P>) -> Self {
+        Self::new(mint.x, mint.y)
+    }
+}
+
+#[cfg(feature = "mint")]
+impl<P: Pixel> From<PhysicalSize<P>> for mint::Vector2<P> {
+    fn from(winit: PhysicalSize<P>) -> Self {
+        mint::Vector2 {
+            x: winit.width,
+            y: winit.height,
+        }
     }
 }
 


### PR DESCRIPTION
Implement conversions for [mint](https://docs.rs/mint) (math interoperability standard types).

- `impl {From, Into}<mint::Point2> for {Physical, Logical}Position`
- `impl {From, Into}<mint::Vector2> for {Physical, Logical}Size`

Some crates that already support mint: cgmath, euclid, nalgebra, glam, kurbo, vek

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior (not needed?)
- [x] Created or updated an example program if it would help users understand this functionality (not needed)
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented (not needed)
