### PR TITLE
Fix randr dpi with reported 1mm size displays

### DIFF
--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -18,8 +18,8 @@ pub fn calc_dpi_factor(
     (width_mm, height_mm): (u64, u64),
 ) -> f64 {
     // See http://xpra.org/trac/ticket/728 for more information.
-    if width_mm == 0 || height_mm == 0 {
-        warn!("XRandR reported that the display's 0mm in size, which is certifiably insane");
+    if (0..=1).contains(&width_mm) || (0..=1).contains(&height_mm) {
+        warn!("XRandR reported that the display's 0 or 1mm in size, which is certifiably insane");
         return 1.0;
     }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Some monitors have broken / wrong EDID like the Odyssey G9, which results in randr reporting them as size of 1mm x 1mm.
xrandr output: `DP-2 connected primary 5120x1440+0+1440 (normal left inverted right x axis y axis) 1mm x 1mm`

The current sanity check only looks for 0mm x 0mm, PR just extends the check to 0/1 instead of just 0. 
There theoretically could be displays with a size of 1x1, but I'm not aware of such displays existing (/ being useful). 
