### PR TITLE
Remove window subclassing

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -97,12 +97,12 @@ impl<T> WindowData<T> {
     }
 }
 
-struct ThreadMsgTargetCallbackData<T: 'static> {
+struct ThreadMsgTargetData<T: 'static> {
     event_loop_runner: EventLoopRunnerShared<T>,
     user_event_receiver: Receiver<T>,
 }
 
-impl<T> ThreadMsgTargetCallbackData<T> {
+impl<T> ThreadMsgTargetData<T> {
     unsafe fn send_event(&self, event: Event<'_, T>) {
         self.event_loop_runner.send_event(event);
     }
@@ -630,7 +630,7 @@ fn insert_event_target_window_data<T>(
 ) -> Sender<T> {
     let (tx, rx) = mpsc::channel();
 
-    let userdata = ThreadMsgTargetCallbackData {
+    let userdata = ThreadMsgTargetData {
         event_loop_runner,
         user_event_receiver: rx,
     };
@@ -1998,7 +1998,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     lparam: LPARAM,
 ) -> LRESULT {
     let userdata_ptr = winuser::GetWindowLongPtrW(window, winuser::GWL_USERDATA)
-        as *mut ThreadMsgTargetCallbackData<T>;
+        as *mut ThreadMsgTargetData<T>;
     if userdata_ptr.is_null() {
         // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE` and
         // `WM_CREATE`.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1996,7 +1996,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     if userdata_ptr.is_null() {
         // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE` and
         // `WM_CREATE`.
-        return 0;
+        return winuser::DefWindowProcW(window, msg, wparam, lparam);
     }
     let userdata = Box::from_raw(userdata_ptr);
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -791,6 +791,8 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
                 return -1;
             }
         }
+        // Getting here should quite frankly be impossible,
+        // but we'll make window creation fail here just in case.
         (0, winuser::WM_CREATE) => return -1,
         (0, _) => return winuser::DefWindowProcW(window, msg, wparam, lparam),
         _ => userdata as *mut WindowData<T>,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -155,8 +155,7 @@ impl<T: 'static> EventLoop<T> {
     pub fn new_dpi_unaware_any_thread() -> EventLoop<T> {
         let thread_id = unsafe { processthreadsapi::GetCurrentThreadId() };
 
-        register_window_class::<T>();
-        let thread_msg_target = create_event_target_window();
+        let thread_msg_target = create_event_target_window::<T>();
 
         let send_thread_msg_target = thread_msg_target as usize;
         thread::spawn(move || wait_thread(thread_id, send_thread_msg_target as HWND));
@@ -575,7 +574,7 @@ lazy_static! {
     };
 }
 
-fn register_window_class<T: 'static>() {
+fn create_event_target_window<T: 'static>() -> HWND {
     unsafe {
         let class = winuser::WNDCLASSEXW {
             cbSize: mem::size_of::<winuser::WNDCLASSEXW>() as UINT,
@@ -594,9 +593,7 @@ fn register_window_class<T: 'static>() {
 
         winuser::RegisterClassExW(&class);
     }
-}
 
-fn create_event_target_window() -> HWND {
     unsafe {
         let window = winuser::CreateWindowExW(
             winuser::WS_EX_NOACTIVATE | winuser::WS_EX_TRANSPARENT | winuser::WS_EX_LAYERED,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -16,7 +16,7 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
-use winapi::shared::basetsd::{DWORD_PTR, UINT_PTR};
+use winapi::shared::basetsd::LONG_PTR;
 
 use winapi::{
     shared::{
@@ -25,7 +25,7 @@ use winapi::{
         windowsx, winerror,
     },
     um::{
-        commctrl, libloaderapi, ole2, processthreadsapi, winbase,
+        libloaderapi, ole2, processthreadsapi, winbase,
         winnt::{HANDLE, LONG, LPCSTR, SHORT},
         winuser,
     },
@@ -82,27 +82,26 @@ lazy_static! {
     static ref GET_POINTER_PEN_INFO: Option<GetPointerPenInfo> =
         get_function!("user32.dll", GetPointerPenInfo);
 }
-
-pub(crate) struct SubclassInput<T: 'static> {
+pub(crate) struct WindowData<T: 'static> {
     pub window_state: Arc<Mutex<WindowState>>,
     pub event_loop_runner: EventLoopRunnerShared<T>,
     pub file_drop_handler: Option<FileDropHandler>,
-    pub subclass_removed: Cell<bool>,
+    pub userdata_removed: Cell<bool>,
     pub recurse_depth: Cell<u32>,
 }
 
-impl<T> SubclassInput<T> {
+impl<T> WindowData<T> {
     unsafe fn send_event(&self, event: Event<'_, T>) {
         self.event_loop_runner.send_event(event);
     }
 }
 
-struct ThreadMsgTargetSubclassInput<T: 'static> {
+struct ThreadMsgTargetCallbackData<T: 'static> {
     event_loop_runner: EventLoopRunnerShared<T>,
     user_event_receiver: Receiver<T>,
 }
 
-impl<T> ThreadMsgTargetSubclassInput<T> {
+impl<T> ThreadMsgTargetCallbackData<T> {
     unsafe fn send_event(&self, event: Event<'_, T>) {
         self.event_loop_runner.send_event(event);
     }
@@ -155,6 +154,7 @@ impl<T: 'static> EventLoop<T> {
     pub fn new_dpi_unaware_any_thread() -> EventLoop<T> {
         let thread_id = unsafe { processthreadsapi::GetCurrentThreadId() };
 
+        register_window_class::<T>();
         let thread_msg_target = create_event_target_window();
 
         let send_thread_msg_target = thread_msg_target as usize;
@@ -164,7 +164,7 @@ impl<T: 'static> EventLoop<T> {
         let runner_shared = Rc::new(EventLoopRunner::new(thread_msg_target, wait_thread_id));
 
         let thread_msg_sender =
-            subclass_event_target_window(thread_msg_target, runner_shared.clone());
+            insert_event_target_window_data::<T>(thread_msg_target, Rc::clone(&runner_shared));
         raw_input::register_all_mice_and_keyboards_for_raw_input(thread_msg_target);
 
         EventLoop {
@@ -563,19 +563,23 @@ lazy_static! {
     pub static ref SET_RETAIN_STATE_ON_SIZE_MSG_ID: u32 = unsafe {
         winuser::RegisterWindowMessageA("Winit::SetRetainMaximized\0".as_ptr() as LPCSTR)
     };
-    static ref THREAD_EVENT_TARGET_WINDOW_CLASS: Vec<u16> = unsafe {
+    static ref THREAD_EVENT_TARGET_WINDOW_CLASS: Vec<u16> =  {
         use std::ffi::OsStr;
         use std::os::windows::ffi::OsStrExt;
 
-        let class_name: Vec<_> = OsStr::new("Winit Thread Event Target")
+        OsStr::new("Winit Thread Event Target")
             .encode_wide()
             .chain(Some(0).into_iter())
-            .collect();
+            .collect()
+    };
+}
 
+fn register_window_class<T: 'static>() {
+    unsafe {
         let class = winuser::WNDCLASSEXW {
             cbSize: mem::size_of::<winuser::WNDCLASSEXW>() as UINT,
             style: 0,
-            lpfnWndProc: Some(winuser::DefWindowProcW),
+            lpfnWndProc: Some(thread_event_target_callback::<T>),
             cbClsExtra: 0,
             cbWndExtra: 0,
             hInstance: libloaderapi::GetModuleHandleW(ptr::null()),
@@ -583,14 +587,12 @@ lazy_static! {
             hCursor: ptr::null_mut(), // must be null in order for cursor state to work properly
             hbrBackground: ptr::null_mut(),
             lpszMenuName: ptr::null(),
-            lpszClassName: class_name.as_ptr(),
+            lpszClassName: THREAD_EVENT_TARGET_WINDOW_CLASS.as_ptr(),
             hIconSm: ptr::null_mut(),
         };
 
         winuser::RegisterClassExW(&class);
-
-        class_name
-    };
+    }
 }
 
 fn create_event_target_window() -> HWND {
@@ -621,39 +623,23 @@ fn create_event_target_window() -> HWND {
     }
 }
 
-fn subclass_event_target_window<T>(
-    window: HWND,
+fn insert_event_target_window_data<T>(
+    thread_msg_target: HWND,
     event_loop_runner: EventLoopRunnerShared<T>,
 ) -> Sender<T> {
-    unsafe {
-        let (tx, rx) = mpsc::channel();
+    let (tx, rx) = mpsc::channel();
 
-        let subclass_input = ThreadMsgTargetSubclassInput {
-            event_loop_runner,
-            user_event_receiver: rx,
-        };
-        let input_ptr = Box::into_raw(Box::new(subclass_input));
-        let subclass_result = commctrl::SetWindowSubclass(
-            window,
-            Some(thread_event_target_callback::<T>),
-            THREAD_EVENT_TARGET_SUBCLASS_ID,
-            input_ptr as DWORD_PTR,
-        );
-        assert_eq!(subclass_result, 1);
-
-        tx
-    }
-}
-
-fn remove_event_target_window_subclass<T: 'static>(window: HWND) {
-    let removal_result = unsafe {
-        commctrl::RemoveWindowSubclass(
-            window,
-            Some(thread_event_target_callback::<T>),
-            THREAD_EVENT_TARGET_SUBCLASS_ID,
-        )
+    let userdata = ThreadMsgTargetCallbackData {
+        event_loop_runner,
+        user_event_receiver: rx,
     };
-    assert_eq!(removal_result, 1);
+    let input_ptr = Box::into_raw(Box::new(userdata));
+
+    unsafe {
+        winuser::SetWindowLongPtrW(thread_msg_target, winuser::GWL_USERDATA, input_ptr as isize)
+    };
+
+    tx
 }
 
 /// Capture mouse input, allowing `window` to receive mouse events when the cursor is outside of
@@ -672,33 +658,6 @@ unsafe fn release_mouse(mut window_state: parking_lot::MutexGuard<'_, WindowStat
         drop(window_state);
         winuser::ReleaseCapture();
     }
-}
-
-const WINDOW_SUBCLASS_ID: UINT_PTR = 0;
-const THREAD_EVENT_TARGET_SUBCLASS_ID: UINT_PTR = 1;
-pub(crate) fn subclass_window<T>(window: HWND, subclass_input: SubclassInput<T>) {
-    subclass_input.event_loop_runner.register_window(window);
-    let input_ptr = Box::into_raw(Box::new(subclass_input));
-    let subclass_result = unsafe {
-        commctrl::SetWindowSubclass(
-            window,
-            Some(public_window_callback::<T>),
-            WINDOW_SUBCLASS_ID,
-            input_ptr as DWORD_PTR,
-        )
-    };
-    assert_eq!(subclass_result, 1);
-}
-
-fn remove_window_subclass<T: 'static>(window: HWND) {
-    let removal_result = unsafe {
-        commctrl::RemoveWindowSubclass(
-            window,
-            Some(public_window_callback::<T>),
-            WINDOW_SUBCLASS_ID,
-        )
-    };
-    assert_eq!(removal_result, 1);
 }
 
 fn normalize_pointer_pressure(pressure: u32) -> Option<Force> {
@@ -771,11 +730,11 @@ unsafe fn process_control_flow<T: 'static>(runner: &EventLoopRunner<T>) {
 }
 
 /// Emit a `ModifiersChanged` event whenever modifiers have changed.
-fn update_modifiers<T>(window: HWND, subclass_input: &SubclassInput<T>) {
+fn update_modifiers<T>(window: HWND, userdata: &WindowData<T>) {
     use crate::event::WindowEvent::ModifiersChanged;
 
     let modifiers = event::get_key_mods();
-    let mut window_state = subclass_input.window_state.lock();
+    let mut window_state = userdata.window_state.lock();
     if window_state.modifiers_state != modifiers {
         window_state.modifiers_state = modifiers;
 
@@ -783,7 +742,7 @@ fn update_modifiers<T>(window: HWND, subclass_input: &SubclassInput<T>) {
         drop(window_state);
 
         unsafe {
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: ModifiersChanged(modifiers),
             });
@@ -798,36 +757,58 @@ fn update_modifiers<T>(window: HWND, subclass_input: &SubclassInput<T>) {
 //
 // Returning 0 tells the Win32 API that the message has been processed.
 // FIXME: detect WM_DWMCOMPOSITIONCHANGED and call DwmEnableBlurBehindWindow if necessary
-unsafe extern "system" fn public_window_callback<T: 'static>(
+pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
     window: HWND,
     msg: UINT,
     wparam: WPARAM,
     lparam: LPARAM,
-    uidsubclass: UINT_PTR,
-    subclass_input_ptr: DWORD_PTR,
 ) -> LRESULT {
-    let subclass_input_ptr = subclass_input_ptr as *mut SubclassInput<T>;
-    let (result, subclass_removed, recurse_depth) = {
-        let subclass_input = &*subclass_input_ptr;
-        subclass_input
-            .recurse_depth
-            .set(subclass_input.recurse_depth.get() + 1);
+    let userdata = winuser::GetWindowLongPtrW(window, winuser::GWL_USERDATA);
+    // `userdata` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE`.
+    // Additionally, the data behind the pointer will be `None` until after `CreateWindowExW` has returned,
+    // i.e. after `WM_CREATE`.
+    let userdata = if msg == winuser::WM_NCCREATE && userdata == 0 {
+        let createstruct = &*(lparam as *const winuser::CREATESTRUCTW);
+        let userdata = createstruct.lpCreateParams as LONG_PTR;
+        assert_ne!(userdata, 0);
+        winuser::SetWindowLongPtrW(window, winuser::GWL_USERDATA, userdata);
+        userdata
+    } else {
+        if userdata == 0 {
+            return 0;
+        }
 
-        let result =
-            public_window_callback_inner(window, msg, wparam, lparam, uidsubclass, subclass_input);
-
-        let subclass_removed = subclass_input.subclass_removed.get();
-        let recurse_depth = subclass_input.recurse_depth.get() - 1;
-        subclass_input.recurse_depth.set(recurse_depth);
-
-        (result, subclass_removed, recurse_depth)
+        userdata
     };
 
-    if subclass_removed && recurse_depth == 0 {
-        Box::from_raw(subclass_input_ptr);
-    }
+    let userdata_ptr = userdata as *mut Option<WindowData<T>>;
+    if let Some(userdata) = &*userdata_ptr {
+        let (result, userdata_removed, recurse_depth) = {
+            userdata.recurse_depth.set(userdata.recurse_depth.get() + 1);
 
-    result
+            let result = public_window_callback_inner(window, msg, wparam, lparam, &userdata);
+
+            let userdata_removed = userdata.userdata_removed.get();
+            let recurse_depth = userdata.recurse_depth.get() - 1;
+            userdata.recurse_depth.set(recurse_depth);
+
+            (result, userdata_removed, recurse_depth)
+        };
+
+        if userdata_removed && recurse_depth == 0 {
+            Box::from_raw(userdata_ptr);
+        }
+
+        result
+    } else {
+        match msg {
+            winuser::WM_NCCREATE => {
+                enable_non_client_dpi_scaling(window);
+                winuser::DefWindowProcW(window, msg, wparam, lparam)
+            }
+            _ => winuser::DefWindowProcW(window, msg, wparam, lparam),
+        }
+    }
 }
 
 unsafe fn public_window_callback_inner<T: 'static>(
@@ -835,11 +816,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
     msg: UINT,
     wparam: WPARAM,
     lparam: LPARAM,
-    _: UINT_PTR,
-    subclass_input: &SubclassInput<T>,
+    userdata: &WindowData<T>,
 ) -> LRESULT {
     winuser::RedrawWindow(
-        subclass_input.event_loop_runner.thread_msg_target(),
+        userdata.event_loop_runner.thread_msg_target(),
         ptr::null(),
         ptr::null_mut(),
         winuser::RDW_INTERNALPAINT,
@@ -850,7 +830,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
     // the git blame and history would be preserved.
     let callback = || match msg {
         winuser::WM_ENTERSIZEMOVE => {
-            subclass_input
+            userdata
                 .window_state
                 .lock()
                 .set_window_flags_in_place(|f| f.insert(WindowFlags::MARKER_IN_SIZE_MOVE));
@@ -858,27 +838,23 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         winuser::WM_EXITSIZEMOVE => {
-            subclass_input
+            userdata
                 .window_state
                 .lock()
                 .set_window_flags_in_place(|f| f.remove(WindowFlags::MARKER_IN_SIZE_MOVE));
             0
         }
 
-        winuser::WM_NCCREATE => {
-            enable_non_client_dpi_scaling(window);
-            commctrl::DefSubclassProc(window, msg, wparam, lparam)
-        }
         winuser::WM_NCLBUTTONDOWN => {
             if wparam == winuser::HTCAPTION as _ {
                 winuser::PostMessageW(window, winuser::WM_MOUSEMOVE, 0, lparam);
             }
-            commctrl::DefSubclassProc(window, msg, wparam, lparam)
+            winuser::DefWindowProcW(window, msg, wparam, lparam)
         }
 
         winuser::WM_CLOSE => {
             use crate::event::WindowEvent::CloseRequested;
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: CloseRequested,
             });
@@ -888,22 +864,22 @@ unsafe fn public_window_callback_inner<T: 'static>(
         winuser::WM_DESTROY => {
             use crate::event::WindowEvent::Destroyed;
             ole2::RevokeDragDrop(window);
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: Destroyed,
             });
-            subclass_input.event_loop_runner.remove_window(window);
+            userdata.event_loop_runner.remove_window(window);
             0
         }
 
         winuser::WM_NCDESTROY => {
-            remove_window_subclass::<T>(window);
-            subclass_input.subclass_removed.set(true);
+            winuser::SetWindowLongPtrW(window, winuser::GWL_USERDATA, 0);
+            userdata.userdata_removed.set(true);
             0
         }
 
         winuser::WM_PAINT => {
-            if subclass_input.event_loop_runner.should_buffer() {
+            if userdata.event_loop_runner.should_buffer() {
                 // this branch can happen in response to `UpdateWindow`, if win32 decides to
                 // redraw the window outside the normal flow of the event loop.
                 winuser::RedrawWindow(
@@ -914,19 +890,19 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 );
             } else {
                 let managing_redraw =
-                    flush_paint_messages(Some(window), &subclass_input.event_loop_runner);
-                subclass_input.send_event(Event::RedrawRequested(RootWindowId(WindowId(window))));
+                    flush_paint_messages(Some(window), &userdata.event_loop_runner);
+                userdata.send_event(Event::RedrawRequested(RootWindowId(WindowId(window))));
                 if managing_redraw {
-                    subclass_input.event_loop_runner.redraw_events_cleared();
-                    process_control_flow(&subclass_input.event_loop_runner);
+                    userdata.event_loop_runner.redraw_events_cleared();
+                    process_control_flow(&userdata.event_loop_runner);
                 }
             }
 
-            commctrl::DefSubclassProc(window, msg, wparam, lparam)
+            winuser::DefWindowProcW(window, msg, wparam, lparam)
         }
 
         winuser::WM_WINDOWPOSCHANGING => {
-            let mut window_state = subclass_input.window_state.lock();
+            let mut window_state = userdata.window_state.lock();
             if let Some(ref mut fullscreen) = window_state.fullscreen {
                 let window_pos = &mut *(lparam as *mut winuser::WINDOWPOS);
                 let new_rect = RECT {
@@ -981,14 +957,14 @@ unsafe fn public_window_callback_inner<T: 'static>(
             if (*windowpos).flags & winuser::SWP_NOMOVE != winuser::SWP_NOMOVE {
                 let physical_position =
                     PhysicalPosition::new((*windowpos).x as i32, (*windowpos).y as i32);
-                subclass_input.send_event(Event::WindowEvent {
+                userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: Moved(physical_position),
                 });
             }
 
             // This is necessary for us to still get sent WM_SIZE.
-            commctrl::DefSubclassProc(window, msg, wparam, lparam)
+            winuser::DefWindowProcW(window, msg, wparam, lparam)
         }
 
         winuser::WM_SIZE => {
@@ -1003,7 +979,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
 
             {
-                let mut w = subclass_input.window_state.lock();
+                let mut w = userdata.window_state.lock();
                 // See WindowFlags::MARKER_RETAIN_STATE_ON_SIZE docs for info on why this `if` check exists.
                 if !w
                     .window_flags()
@@ -1014,7 +990,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 }
             }
 
-            subclass_input.send_event(event);
+            userdata.send_event(event);
             0
         }
 
@@ -1025,24 +1001,24 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let is_low_surrogate = 0xDC00 <= wparam && wparam <= 0xDFFF;
 
             if is_high_surrogate {
-                subclass_input.window_state.lock().high_surrogate = Some(wparam as u16);
+                userdata.window_state.lock().high_surrogate = Some(wparam as u16);
             } else if is_low_surrogate {
-                let high_surrogate = subclass_input.window_state.lock().high_surrogate.take();
+                let high_surrogate = userdata.window_state.lock().high_surrogate.take();
 
                 if let Some(high_surrogate) = high_surrogate {
                     let pair = [high_surrogate, wparam as u16];
                     if let Some(Ok(chr)) = char::decode_utf16(pair.iter().copied()).next() {
-                        subclass_input.send_event(Event::WindowEvent {
+                        userdata.send_event(Event::WindowEvent {
                             window_id: RootWindowId(WindowId(window)),
                             event: ReceivedCharacter(chr),
                         });
                     }
                 }
             } else {
-                subclass_input.window_state.lock().high_surrogate = None;
+                userdata.window_state.lock().high_surrogate = None;
 
                 if let Some(chr) = char::from_u32(wparam as u32) {
-                    subclass_input.send_event(Event::WindowEvent {
+                    userdata.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: ReceivedCharacter(chr),
                     });
@@ -1054,17 +1030,17 @@ unsafe fn public_window_callback_inner<T: 'static>(
         // this is necessary for us to maintain minimize/restore state
         winuser::WM_SYSCOMMAND => {
             if wparam == winuser::SC_RESTORE {
-                let mut w = subclass_input.window_state.lock();
+                let mut w = userdata.window_state.lock();
                 w.set_window_flags_in_place(|f| f.set(WindowFlags::MINIMIZED, false));
             }
             if wparam == winuser::SC_MINIMIZE {
-                let mut w = subclass_input.window_state.lock();
+                let mut w = userdata.window_state.lock();
                 w.set_window_flags_in_place(|f| f.set(WindowFlags::MINIMIZED, true));
             }
             // Send `WindowEvent::Minimized` here if we decide to implement one
 
             if wparam == winuser::SC_SCREENSAVE {
-                let window_state = subclass_input.window_state.lock();
+                let window_state = userdata.window_state.lock();
                 if window_state.fullscreen.is_some() {
                     return 0;
                 }
@@ -1076,7 +1052,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         winuser::WM_MOUSEMOVE => {
             use crate::event::WindowEvent::{CursorEntered, CursorMoved};
             let mouse_was_outside_window = {
-                let mut w = subclass_input.window_state.lock();
+                let mut w = userdata.window_state.lock();
 
                 let was_outside_window = !w.mouse.cursor_flags().contains(CursorFlags::IN_WINDOW);
                 w.mouse
@@ -1086,7 +1062,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
 
             if mouse_was_outside_window {
-                subclass_input.send_event(Event::WindowEvent {
+                userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: CursorEntered {
                         device_id: DEVICE_ID,
@@ -1110,14 +1086,14 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 // handle spurious WM_MOUSEMOVE messages
                 // see https://devblogs.microsoft.com/oldnewthing/20031001-00/?p=42343
                 // and http://debugandconquer.blogspot.com/2015/08/the-cause-of-spurious-mouse-move.html
-                let mut w = subclass_input.window_state.lock();
+                let mut w = userdata.window_state.lock();
                 cursor_moved = w.mouse.last_position != Some(position);
                 w.mouse.last_position = Some(position);
             }
             if cursor_moved {
-                update_modifiers(window, subclass_input);
+                update_modifiers(window, userdata);
 
-                subclass_input.send_event(Event::WindowEvent {
+                userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: CursorMoved {
                         device_id: DEVICE_ID,
@@ -1133,13 +1109,13 @@ unsafe fn public_window_callback_inner<T: 'static>(
         winuser::WM_MOUSELEAVE => {
             use crate::event::WindowEvent::CursorLeft;
             {
-                let mut w = subclass_input.window_state.lock();
+                let mut w = userdata.window_state.lock();
                 w.mouse
                     .set_cursor_flags(window, |f| f.set(CursorFlags::IN_WINDOW, false))
                     .ok();
             }
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: CursorLeft {
                     device_id: DEVICE_ID,
@@ -1156,9 +1132,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let value = value as i32;
             let value = value as f32 / winuser::WHEEL_DELTA as f32;
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: WindowEvent::MouseWheel {
                     device_id: DEVICE_ID,
@@ -1178,9 +1154,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let value = value as i32;
             let value = value as f32 / winuser::WHEEL_DELTA as f32;
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: WindowEvent::MouseWheel {
                     device_id: DEVICE_ID,
@@ -1196,13 +1172,13 @@ unsafe fn public_window_callback_inner<T: 'static>(
         winuser::WM_KEYDOWN | winuser::WM_SYSKEYDOWN => {
             use crate::event::{ElementState::Pressed, VirtualKeyCode};
             if msg == winuser::WM_SYSKEYDOWN && wparam as i32 == winuser::VK_F4 {
-                commctrl::DefSubclassProc(window, msg, wparam, lparam)
+                winuser::DefWindowProcW(window, msg, wparam, lparam)
             } else {
                 if let Some((scancode, vkey)) = process_key_params(wparam, lparam) {
-                    update_modifiers(window, subclass_input);
+                    update_modifiers(window, userdata);
 
                     #[allow(deprecated)]
-                    subclass_input.send_event(Event::WindowEvent {
+                    userdata.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: WindowEvent::KeyboardInput {
                             device_id: DEVICE_ID,
@@ -1218,7 +1194,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     // Windows doesn't emit a delete character by default, but in order to make it
                     // consistent with the other platforms we'll emit a delete character here.
                     if vkey == Some(VirtualKeyCode::Delete) {
-                        subclass_input.send_event(Event::WindowEvent {
+                        userdata.send_event(Event::WindowEvent {
                             window_id: RootWindowId(WindowId(window)),
                             event: WindowEvent::ReceivedCharacter('\u{7F}'),
                         });
@@ -1231,10 +1207,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
         winuser::WM_KEYUP | winuser::WM_SYSKEYUP => {
             use crate::event::ElementState::Released;
             if let Some((scancode, vkey)) = process_key_params(wparam, lparam) {
-                update_modifiers(window, subclass_input);
+                update_modifiers(window, userdata);
 
                 #[allow(deprecated)]
-                subclass_input.send_event(Event::WindowEvent {
+                userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
                         device_id: DEVICE_ID,
@@ -1254,11 +1230,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
         winuser::WM_LBUTTONDOWN => {
             use crate::event::{ElementState::Pressed, MouseButton::Left, WindowEvent::MouseInput};
 
-            capture_mouse(window, &mut *subclass_input.window_state.lock());
+            capture_mouse(window, &mut *userdata.window_state.lock());
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
@@ -1275,11 +1251,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Released, MouseButton::Left, WindowEvent::MouseInput,
             };
 
-            release_mouse(subclass_input.window_state.lock());
+            release_mouse(userdata.window_state.lock());
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
@@ -1296,11 +1272,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Pressed, MouseButton::Right, WindowEvent::MouseInput,
             };
 
-            capture_mouse(window, &mut *subclass_input.window_state.lock());
+            capture_mouse(window, &mut *userdata.window_state.lock());
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
@@ -1317,11 +1293,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Released, MouseButton::Right, WindowEvent::MouseInput,
             };
 
-            release_mouse(subclass_input.window_state.lock());
+            release_mouse(userdata.window_state.lock());
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
@@ -1338,11 +1314,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Pressed, MouseButton::Middle, WindowEvent::MouseInput,
             };
 
-            capture_mouse(window, &mut *subclass_input.window_state.lock());
+            capture_mouse(window, &mut *userdata.window_state.lock());
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
@@ -1359,11 +1335,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Released, MouseButton::Middle, WindowEvent::MouseInput,
             };
 
-            release_mouse(subclass_input.window_state.lock());
+            release_mouse(userdata.window_state.lock());
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
@@ -1381,11 +1357,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
             let xbutton = winuser::GET_XBUTTON_WPARAM(wparam);
 
-            capture_mouse(window, &mut *subclass_input.window_state.lock());
+            capture_mouse(window, &mut *userdata.window_state.lock());
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
@@ -1403,11 +1379,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
             let xbutton = winuser::GET_XBUTTON_WPARAM(wparam);
 
-            release_mouse(subclass_input.window_state.lock());
+            release_mouse(userdata.window_state.lock());
 
-            update_modifiers(window, subclass_input);
+            update_modifiers(window, userdata);
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
@@ -1425,7 +1401,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             // can happen if `SetCapture` is called on our window when it already has the mouse
             // capture.
             if lparam != window as isize {
-                subclass_input.window_state.lock().mouse.capture_count = 0;
+                userdata.window_state.lock().mouse.capture_count = 0;
             }
             0
         }
@@ -1455,7 +1431,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     let x = location.x as f64 + (input.x % 100) as f64 / 100f64;
                     let y = location.y as f64 + (input.y % 100) as f64 / 100f64;
                     let location = PhysicalPosition::new(x, y);
-                    subclass_input.send_event(Event::WindowEvent {
+                    userdata.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: WindowEvent::Touch(Touch {
                             phase: if input.dwFlags & winuser::TOUCHEVENTF_DOWN != 0 {
@@ -1593,7 +1569,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     let x = location.x as f64 + x.fract();
                     let y = location.y as f64 + y.fract();
                     let location = PhysicalPosition::new(x, y);
-                    subclass_input.send_event(Event::WindowEvent {
+                    userdata.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: WindowEvent::Touch(Touch {
                             phase: if pointer_info.pointerFlags & winuser::POINTER_FLAG_DOWN != 0 {
@@ -1626,10 +1602,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     winuser::MapVirtualKeyA(windows_keycode as _, winuser::MAPVK_VK_TO_VSC);
                 let virtual_keycode = event::vkey_to_winit_vkey(windows_keycode);
 
-                update_modifiers(window, subclass_input);
+                update_modifiers(window, userdata);
 
                 #[allow(deprecated)]
-                subclass_input.send_event(Event::WindowEvent {
+                userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
                         device_id: DEVICE_ID,
@@ -1644,7 +1620,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 })
             }
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: Focused(true),
             });
@@ -1664,7 +1640,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 let virtual_keycode = event::vkey_to_winit_vkey(windows_keycode);
 
                 #[allow(deprecated)]
-                subclass_input.send_event(Event::WindowEvent {
+                userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
                         device_id: DEVICE_ID,
@@ -1679,13 +1655,13 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 })
             }
 
-            subclass_input.window_state.lock().modifiers_state = ModifiersState::empty();
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.window_state.lock().modifiers_state = ModifiersState::empty();
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: ModifiersChanged(ModifiersState::empty()),
             });
 
-            subclass_input.send_event(Event::WindowEvent {
+            userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: Focused(false),
             });
@@ -1694,7 +1670,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
         winuser::WM_SETCURSOR => {
             let set_cursor_to = {
-                let window_state = subclass_input.window_state.lock();
+                let window_state = userdata.window_state.lock();
                 // The return value for the preceding `WM_NCHITTEST` message is conveniently
                 // provided through the low-order word of lParam. We use that here since
                 // `WM_MOUSEMOVE` seems to come after `WM_SETCURSOR` for a given cursor movement.
@@ -1724,7 +1700,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         winuser::WM_GETMINMAXINFO => {
             let mmi = lparam as *mut winuser::MINMAXINFO;
 
-            let window_state = subclass_input.window_state.lock();
+            let window_state = userdata.window_state.lock();
 
             if window_state.min_size.is_some() || window_state.max_size.is_some() {
                 if let Some(min_size) = window_state.min_size {
@@ -1762,7 +1738,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let old_scale_factor: f64;
 
             let allow_resize = {
-                let mut window_state = subclass_input.window_state.lock();
+                let mut window_state = userdata.window_state.lock();
                 old_scale_factor = window_state.scale_factor;
                 window_state.scale_factor = new_scale_factor;
 
@@ -1827,7 +1803,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 false => old_physical_inner_size,
             };
 
-            let _ = subclass_input.send_event(Event::WindowEvent {
+            let _ = userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: ScaleFactorChanged {
                     scale_factor: new_scale_factor,
@@ -1838,7 +1814,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let dragging_window: bool;
 
             {
-                let window_state = subclass_input.window_state.lock();
+                let window_state = userdata.window_state.lock();
                 dragging_window = window_state
                     .window_flags()
                     .contains(WindowFlags::MARKER_IN_SIZE_MOVE);
@@ -1968,23 +1944,23 @@ unsafe fn public_window_callback_inner<T: 'static>(
         winuser::WM_SETTINGCHANGE => {
             use crate::event::WindowEvent::ThemeChanged;
 
-            let preferred_theme = subclass_input.window_state.lock().preferred_theme;
+            let preferred_theme = userdata.window_state.lock().preferred_theme;
 
             if preferred_theme == None {
                 let new_theme = try_theme(window, preferred_theme);
-                let mut window_state = subclass_input.window_state.lock();
+                let mut window_state = userdata.window_state.lock();
 
                 if window_state.current_theme != new_theme {
                     window_state.current_theme = new_theme;
                     mem::drop(window_state);
-                    subclass_input.send_event(Event::WindowEvent {
+                    userdata.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: ThemeChanged(new_theme),
                     });
                 }
             }
 
-            commctrl::DefSubclassProc(window, msg, wparam, lparam)
+            winuser::DefWindowProcW(window, msg, wparam, lparam)
         }
 
         _ => {
@@ -1992,18 +1968,18 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 winuser::DestroyWindow(window);
                 0
             } else if msg == *SET_RETAIN_STATE_ON_SIZE_MSG_ID {
-                let mut window_state = subclass_input.window_state.lock();
+                let mut window_state = userdata.window_state.lock();
                 window_state.set_window_flags_in_place(|f| {
                     f.set(WindowFlags::MARKER_RETAIN_STATE_ON_SIZE, wparam != 0)
                 });
                 0
             } else {
-                commctrl::DefSubclassProc(window, msg, wparam, lparam)
+                winuser::DefWindowProcW(window, msg, wparam, lparam)
             }
         }
     };
 
-    subclass_input
+    userdata
         .event_loop_runner
         .catch_unwind(callback)
         .unwrap_or(-1)
@@ -2014,10 +1990,15 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     msg: UINT,
     wparam: WPARAM,
     lparam: LPARAM,
-    _: UINT_PTR,
-    subclass_input_ptr: DWORD_PTR,
 ) -> LRESULT {
-    let subclass_input = Box::from_raw(subclass_input_ptr as *mut ThreadMsgTargetSubclassInput<T>);
+    let userdata_ptr = winuser::GetWindowLongPtrW(window, winuser::GWL_USERDATA)
+        as *mut ThreadMsgTargetCallbackData<T>;
+    if userdata_ptr.is_null() {
+        // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE` and
+        // `WM_CREATE`.
+        return 0;
+    }
+    let userdata = Box::from_raw(userdata_ptr);
 
     if msg != winuser::WM_PAINT {
         winuser::RedrawWindow(
@@ -2028,15 +2009,15 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         );
     }
 
-    let mut subclass_removed = false;
+    let mut userdata_removed = false;
 
     // I decided to bind the closure to `callback` and pass it to catch_unwind rather than passing
     // the closure to catch_unwind directly so that the match body indendation wouldn't change and
     // the git blame and history would be preserved.
     let callback = || match msg {
         winuser::WM_NCDESTROY => {
-            remove_event_target_window_subclass::<T>(window);
-            subclass_removed = true;
+            winuser::SetWindowLongPtrW(window, winuser::GWL_USERDATA, 0);
+            userdata_removed = true;
             0
         }
         // Because WM_PAINT comes after all other messages, we use it during modal loops to detect
@@ -2046,8 +2027,8 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             // If the WM_PAINT handler in `public_window_callback` has already flushed the redraw
             // events, `handling_events` will return false and we won't emit a second
             // `RedrawEventsCleared` event.
-            if subclass_input.event_loop_runner.handling_events() {
-                if subclass_input.event_loop_runner.should_buffer() {
+            if userdata.event_loop_runner.handling_events() {
+                if userdata.event_loop_runner.should_buffer() {
                     // This branch can be triggered when a nested win32 event loop is triggered
                     // inside of the `event_handler` callback.
                     winuser::RedrawWindow(
@@ -2059,17 +2040,14 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                 } else {
                     // This WM_PAINT handler will never be re-entrant because `flush_paint_messages`
                     // doesn't call WM_PAINT for the thread event target (i.e. this window).
-                    assert!(flush_paint_messages(
-                        None,
-                        &subclass_input.event_loop_runner
-                    ));
-                    subclass_input.event_loop_runner.redraw_events_cleared();
-                    process_control_flow(&subclass_input.event_loop_runner);
+                    assert!(flush_paint_messages(None, &userdata.event_loop_runner));
+                    userdata.event_loop_runner.redraw_events_cleared();
+                    process_control_flow(&userdata.event_loop_runner);
                 }
             }
 
             // Default WM_PAINT behaviour. This makes sure modals and popups are shown immediatly when opening them.
-            commctrl::DefSubclassProc(window, msg, wparam, lparam)
+            winuser::DefWindowProcW(window, msg, wparam, lparam)
         }
 
         winuser::WM_INPUT_DEVICE_CHANGE => {
@@ -2079,7 +2057,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                 _ => unreachable!(),
             };
 
-            subclass_input.send_event(Event::DeviceEvent {
+            userdata.send_event(Event::DeviceEvent {
                 device_id: wrap_device_id(lparam as _),
                 event,
             });
@@ -2105,21 +2083,21 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                         let y = mouse.lLastY as f64;
 
                         if x != 0.0 {
-                            subclass_input.send_event(Event::DeviceEvent {
+                            userdata.send_event(Event::DeviceEvent {
                                 device_id,
                                 event: Motion { axis: 0, value: x },
                             });
                         }
 
                         if y != 0.0 {
-                            subclass_input.send_event(Event::DeviceEvent {
+                            userdata.send_event(Event::DeviceEvent {
                                 device_id,
                                 event: Motion { axis: 1, value: y },
                             });
                         }
 
                         if x != 0.0 || y != 0.0 {
-                            subclass_input.send_event(Event::DeviceEvent {
+                            userdata.send_event(Event::DeviceEvent {
                                 device_id,
                                 event: MouseMotion { delta: (x, y) },
                             });
@@ -2129,7 +2107,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                     if util::has_flag(mouse.usButtonFlags, winuser::RI_MOUSE_WHEEL) {
                         let delta =
                             mouse.usButtonData as SHORT as f32 / winuser::WHEEL_DELTA as f32;
-                        subclass_input.send_event(Event::DeviceEvent {
+                        userdata.send_event(Event::DeviceEvent {
                             device_id,
                             event: MouseWheel {
                                 delta: LineDelta(0.0, delta),
@@ -2145,7 +2123,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                             // seem to be anything else reasonable to do for a mouse
                             // button ID.
                             let button = (index + 1) as _;
-                            subclass_input.send_event(Event::DeviceEvent {
+                            userdata.send_event(Event::DeviceEvent {
                                 device_id,
                                 event: Button { button, state },
                             });
@@ -2172,7 +2150,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                             let virtual_keycode = vkey_to_winit_vkey(vkey);
 
                             #[allow(deprecated)]
-                            subclass_input.send_event(Event::DeviceEvent {
+                            userdata.send_event(Event::DeviceEvent {
                                 device_id,
                                 event: Key(KeyboardInput {
                                     scancode,
@@ -2186,12 +2164,12 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                 }
             }
 
-            commctrl::DefSubclassProc(window, msg, wparam, lparam)
+            winuser::DefWindowProcW(window, msg, wparam, lparam)
         }
 
         _ if msg == *USER_EVENT_MSG_ID => {
-            if let Ok(event) = subclass_input.user_event_receiver.recv() {
-                subclass_input.send_event(Event::UserEvent(event));
+            if let Ok(event) = userdata.user_event_receiver.recv() {
+                userdata.send_event(Event::UserEvent(event));
             }
             0
         }
@@ -2202,7 +2180,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         }
         _ if msg == *PROCESS_NEW_EVENTS_MSG_ID => {
             winuser::PostThreadMessageW(
-                subclass_input.event_loop_runner.wait_thread_id(),
+                userdata.event_loop_runner.wait_thread_id(),
                 *CANCEL_WAIT_UNTIL_MSG_ID,
                 0,
                 0,
@@ -2210,9 +2188,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
 
             // if the control_flow is WaitUntil, make sure the given moment has actually passed
             // before emitting NewEvents
-            if let ControlFlow::WaitUntil(wait_until) =
-                subclass_input.event_loop_runner.control_flow()
-            {
+            if let ControlFlow::WaitUntil(wait_until) = userdata.event_loop_runner.control_flow() {
                 let mut msg = mem::zeroed();
                 while Instant::now() < wait_until {
                     if 0 != winuser::PeekMessageW(&mut msg, ptr::null_mut(), 0, 0, 0) {
@@ -2238,20 +2214,20 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                     }
                 }
             }
-            subclass_input.event_loop_runner.poll();
+            userdata.event_loop_runner.poll();
             0
         }
-        _ => commctrl::DefSubclassProc(window, msg, wparam, lparam),
+        _ => winuser::DefWindowProcW(window, msg, wparam, lparam),
     };
 
-    let result = subclass_input
+    let result = userdata
         .event_loop_runner
         .catch_unwind(callback)
         .unwrap_or(-1);
-    if subclass_removed {
-        mem::drop(subclass_input);
+    if userdata_removed {
+        mem::drop(userdata);
     } else {
-        Box::into_raw(subclass_input);
+        Box::into_raw(userdata);
     }
     result
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -636,9 +636,7 @@ fn insert_event_target_window_data<T>(
     };
     let input_ptr = Box::into_raw(Box::new(userdata));
 
-    unsafe {
-        winuser::SetWindowLongPtrW(thread_msg_target, winuser::GWL_USERDATA, input_ptr as isize)
-    };
+    unsafe { winuser::SetWindowLongPtrW(thread_msg_target, winuser::GWL_USERDATA, input_ptr as _) };
 
     tx
 }
@@ -775,7 +773,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
             if let Some((win, userdata)) = runner.catch_unwind(|| (initdata.post_init)(window)) {
                 initdata.window = Some(win);
                 let userdata = Box::into_raw(Box::new(userdata));
-                winuser::SetWindowLongPtrW(window, winuser::GWL_USERDATA, userdata as LONG_PTR);
+                winuser::SetWindowLongPtrW(window, winuser::GWL_USERDATA, userdata as _);
                 userdata
             } else {
                 return -1;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -164,7 +164,7 @@ impl<T: 'static> EventLoop<T> {
         let runner_shared = Rc::new(EventLoopRunner::new(thread_msg_target, wait_thread_id));
 
         let thread_msg_sender =
-            insert_event_target_window_data::<T>(thread_msg_target, Rc::clone(&runner_shared));
+            insert_event_target_window_data::<T>(thread_msg_target, runner_shared.clone());
         raw_input::register_all_mice_and_keyboards_for_raw_input(thread_msg_target);
 
         EventLoop {

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -23,7 +23,7 @@ use crate::{
 pub(crate) type EventLoopRunnerShared<T> = Rc<EventLoopRunner<T>>;
 pub(crate) struct EventLoopRunner<T: 'static> {
     // The event loop's win32 handles
-    thread_msg_target: HWND,
+    pub(super) thread_msg_target: HWND,
     wait_thread_id: DWORD,
 
     control_flow: Cell<ControlFlow>,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -810,7 +810,7 @@ where
         &mut initdata as *mut _ as *mut _,
     );
 
-    // If any of the callbacks in `InitData` panicked, then should resume panicking here
+    // If the `post_init` callback in `InitData` panicked, then should resume panicking here
     if let Err(panic_error) = event_loop.runner_shared.take_panic_error() {
         panic::resume_unwind(panic_error)
     }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] ~~Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users~~
- [x] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [x] ~~Created or updated an example program if it would help users understand this functionality~~
- [x] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~

As discussed in #1891, using window subclasses exclusively to handle window messages has some unexpected edge cases, such as denying us the ability to react to `WM_NCCREATE` and `WM_CREATE`.

Moving away from subclasses may potentially fix alacritty/alacritty#4069. @desmap, if you could check if PR fixes your issue, then that would be awesome.

I'm not entirely happy with the way I solved this as the window creation code assumes that it's ok to create `WindowData` (`SubclassInput`) *after* the window has been created, which is awkward when we also need to pass a pointer to said structure to the window procedure through `CreateWindowExW`. I recall seeing that some of this logic was *inside* the window procedure on a previous trip through the repo's git history, so I'm going to dig through the repo's git history to see if it's ok to move the aforementioned code back where I believe it used to be.