### PR TITLE
MacOS: Use objc's autoreleasepool instead of manually with NSAutoreleasePool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ cocoa = "0.24"
 core-foundation = "0.9"
 core-graphics = "0.22"
 dispatch = "0.2.0"
-scopeguard = "1.1"
 
 [target.'cfg(target_os = "macos")'.dependencies.core-video-sys]
 version = "0.1.4"

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -1,6 +1,7 @@
+use super::util::IdRef;
 use cocoa::appkit::{NSApp, NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
 use cocoa::base::{nil, selector};
-use cocoa::foundation::{NSAutoreleasePool, NSProcessInfo, NSString};
+use cocoa::foundation::{NSProcessInfo, NSString};
 use objc::{
     rc::autoreleasepool,
     runtime::{Object, Sel},
@@ -13,11 +14,11 @@ struct KeyEquivalent<'a> {
 
 pub fn initialize() {
     autoreleasepool(|| unsafe {
-        let menubar = NSMenu::new(nil).autorelease();
-        let app_menu_item = NSMenuItem::new(nil).autorelease();
-        menubar.addItem_(app_menu_item);
+        let menubar = IdRef::new(NSMenu::new(nil));
+        let app_menu_item = IdRef::new(NSMenuItem::new(nil));
+        menubar.addItem_(*app_menu_item);
         let app = NSApp();
-        app.setMainMenu_(menubar);
+        app.setMainMenu_(*menubar);
 
         let app_menu = NSMenu::new(nil);
         let process_name = NSProcessInfo::processInfo(nil).processName();

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -25,6 +25,7 @@ pub use self::{
 use crate::{
     error::OsError as RootOsError, event::DeviceId as RootDeviceId, window::WindowAttributes,
 };
+use objc::rc::autoreleasepool;
 
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
@@ -69,7 +70,7 @@ impl Window {
         attributes: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
-        let (window, _delegate) = UnownedWindow::new(attributes, pl_attribs)?;
+        let (window, _delegate) = autoreleasepool(|| UnownedWindow::new(attributes, pl_attribs))?;
         Ok(Window { window, _delegate })
     }
 }

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -8,7 +8,7 @@ use std::ops::{BitAnd, Deref};
 use cocoa::{
     appkit::{NSApp, NSWindowStyleMask},
     base::{id, nil},
-    foundation::{NSAutoreleasePool, NSPoint, NSRect, NSString, NSUInteger},
+    foundation::{NSPoint, NSRect, NSString, NSUInteger},
 };
 use core_graphics::display::CGDisplay;
 use objc::runtime::{Class, Object, Sel, BOOL, YES};
@@ -61,9 +61,7 @@ impl Drop for IdRef {
     fn drop(&mut self) {
         if self.0 != nil {
             unsafe {
-                let pool = NSAutoreleasePool::new(nil);
                 let () = msg_send![self.0, release];
-                pool.drain();
             };
         }
     }

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -289,7 +289,7 @@ extern "C" fn init_with_winit(this: &Object, _sel: Sel, state: *mut c_void) -> i
             let notification_center: &Object =
                 msg_send![class!(NSNotificationCenter), defaultCenter];
             let notification_name =
-                NSString::alloc(nil).init_str("NSViewFrameDidChangeNotification");
+                IdRef::new(NSString::alloc(nil).init_str("NSViewFrameDidChangeNotification"));
             let _: () = msg_send![
                 notification_center,
                 addObserver: this


### PR DESCRIPTION
Ensures the pools are released even if we panic.

Also, we no longer directly depend on `scopeguard`, so that's nice.

- [x] Tested on all platforms changed
  - MacOS 10.14.6 Mojave
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented