### PR TITLE
Document how `main_thread_id` for Windows works

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -267,17 +267,19 @@ impl<T> EventLoopWindowTarget<T> {
 
 /// Returns the id of the main thread.
 ///
-/// Windows has no real API to check if the current executing thread is the "main thread", unlike macOS.
+/// Windows has no real API to check if the current executing thread is the "main thread", unlike
+/// macOS.
 ///
-/// Windows will let us look up the current thread's id, but there's no API that lets us check what the
-/// id of the main thread is. We would somehow need to get the main thread's id before a developer
-/// could spin off any other threads inside of the main entrypoint in order to emulate the capabilities
-/// of other platforms.
+/// Windows will let us look up the current thread's id, but there's no API that lets us check what
+/// the id of the main thread is. We would somehow need to get the main thread's id before a
+/// developer could spin off any other threads inside of the main entrypoint in order to emulate the
+/// capabilities of other platforms.
 ///
 /// We can get the id of the main thread by using CRT initialization. CRT initialization can be used
-/// to setup global state within a program. The OS will call a list of function pointers which assign
-/// values to a static variable. To have get a hold of the main thread id, we need to place our
-/// function pointer inside of the `.CRT$XCU` section so it is called before the main entrypoint.
+/// to setup global state within a program. The OS will call a list of function pointers which
+/// assign values to a static variable. To have get a hold of the main thread id, we need to place
+/// our function pointer inside of the `.CRT$XCU` section so it is called before the main
+/// entrypoint.
 ///
 /// Full details of CRT initialization can be found here:
 /// https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-160

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -270,15 +270,14 @@ impl<T> EventLoopWindowTarget<T> {
 /// Windows has no real API to check if the current executing thread is the "main thread", unlike macOS.
 ///
 /// Windows will let us look up the current thread's id, but there's no API that lets us check what the
-/// id of the main thread is.
-/// We would somehow need to get the main thread's id before a developer could spin off any other
-/// threads inside of the main entrypoint in order to emulate the capabilities of other platforms.
+/// id of the main thread is. We would somehow need to get the main thread's id before a developer
+/// could spin off any other threads inside of the main entrypoint in order to emulate the capabilities
+/// of other platforms.
 ///
-/// We can get the id of the main thread by using CRT initialization.
-/// CRT initialization can be used to setup global state within a program.
-/// The OS will call a list of function pointers which assign a values to a static fields.
-/// To have get a hold of the main thread id, we need to place our function pointer inside
-/// of the `.CRT$XCU` section so it is called before the main entrypoint.
+/// We can get the id of the main thread by using CRT initialization. CRT initialization can be used
+/// to setup global state within a program. The OS will call a list of function pointers which assign
+/// values to a static fields. To have get a hold of the main thread id, we need to place our
+/// function pointer inside of the `.CRT$XCU` section so it is called before the main entrypoint.
 ///
 /// Full details of CRT initialization can be found here:
 /// https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-160

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -276,7 +276,7 @@ impl<T> EventLoopWindowTarget<T> {
 ///
 /// We can get the id of the main thread by using CRT initialization. CRT initialization can be used
 /// to setup global state within a program. The OS will call a list of function pointers which assign
-/// values to a static fields. To have get a hold of the main thread id, we need to place our
+/// values to a static variable. To have get a hold of the main thread id, we need to place our
 /// function pointer inside of the `.CRT$XCU` section so it is called before the main entrypoint.
 ///
 /// Full details of CRT initialization can be found here:

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -268,8 +268,6 @@ impl<T> EventLoopWindowTarget<T> {
 /// Returns the id of the main thread.
 ///
 /// Windows has no real API to check if the current executing thread is the "main thread", unlike macOS.
-/// Unix-like OSes have some APIs or semantics that exist regarding whether the main thread is in use or
-/// if the main thread id equals the pid like on Linux.
 ///
 /// Windows will let us look up the current thread's id, but there's no API that lets us check what the
 /// id of the main thread is.
@@ -277,8 +275,8 @@ impl<T> EventLoopWindowTarget<T> {
 /// threads inside of the main entrypoint in order to emulate the capabilities of other platforms.
 ///
 /// We can get the id of the main thread by using CRT initialization.
-/// CRT initialization can be used to setup global state within a program by calling a list of
-/// function pointers which should assign a value to a static field.
+/// CRT initialization can be used to setup global state within a program.
+/// The OS will call a list of function pointers which assign a values to a static fields.
 /// To have get a hold of the main thread id, we need to place our function pointer inside
 /// of the `.CRT$XCU` section so it is called before the main entrypoint.
 ///

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -267,20 +267,20 @@ impl<T> EventLoopWindowTarget<T> {
 
 /// Returns the id of the main thread.
 ///
-/// Windows has no real API to check if the current executing thread is the "main thread" unlike macOS.
+/// Windows has no real API to check if the current executing thread is the "main thread", unlike macOS.
 /// Unix-like OSes have some APIs or semantics that exist regarding whether the main thread is in use or
 /// if the main thread id equals the pid like on Linux.
 ///
-/// Windows will let us look up the current thread's id but this leaves us with the question of what
-/// is the main thread's id?
+/// Windows will let us look up the current thread's id, but there's no API that lets us check what the
+/// id of the main thread is.
 /// We would somehow need to get the main thread's id before a developer could spin off any other
 /// threads inside of the main entrypoint in order to emulate the capabilities of other platforms.
 ///
 /// We can get the id of the main thread by using CRT initialization.
 /// CRT initialization can be used to setup global state within a program by calling a list of
 /// function pointers which should assign a value to a static field.
-/// To have the field's value set to the main thread id, we need to place our function pointer inside
-/// of the section `.CRT$XCU` so it is called before the main entrypoint.
+/// To have get a hold of the main thread id, we need to place our function pointer inside
+/// of the `.CRT$XCU` section so it is called before the main entrypoint.
 ///
 /// Full details of CRT initialization can be found here:
 /// https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-160

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -265,10 +265,37 @@ impl<T> EventLoopWindowTarget<T> {
     }
 }
 
+/// Returns the id of the main thread.
+///
+/// Windows has no real API to check if the current executing thread is the "main thread" unlike macOS.
+/// Unix-like OSes have some APIs or semantics that exist regarding whether the main thread is in use or
+/// if the main thread id equals the pid like on Linux.
+///
+/// Windows will let us look up the current thread's id but this leaves us with the question of what
+/// is the main thread's id?
+/// We would somehow need to get the main thread's id before a developer could spin off any other
+/// threads inside of the main entrypoint in order to emulate the capabilities of other platforms.
+///
+/// We can get the id of the main thread by using CRT initialization.
+/// CRT initialization can be used to setup global state within a program by calling a list of
+/// function pointers which should assign a value to a static field.
+/// To have the field's value set to the main thread id, we need to place our function pointer inside
+/// of the section `.CRT$XCU` so it is called before the main entrypoint.
+///
+/// Full details of CRT initialization can be found here:
+/// https://docs.microsoft.com/en-us/cpp/c-runtime-library/crt-initialization?view=msvc-160
 fn main_thread_id() -> DWORD {
     static mut MAIN_THREAD_ID: DWORD = 0;
+
+    /// Function pointer used in CRT initialization section to set the above static field's value.
+
+    // Mark as used so this is not removable.
     #[used]
     #[allow(non_upper_case_globals)]
+    // Place the function pointer inside of CRT initialization section so it is loaded before
+    // main entrypoint.
+    //
+    // See: https://doc.rust-lang.org/stable/reference/abi.html#the-link_section-attribute
     #[link_section = ".CRT$XCU"]
     static INIT_MAIN_THREAD_ID: unsafe fn() = {
         unsafe fn initer() {


### PR DESCRIPTION
- [ ] Tested on all platforms changed (N/A, no source level changes)
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I was looking around winit one day and I found this method with no documentation. Upon looking further into the topic of getting the main thread id on Windows, it is more complex than the few LOC with no documentation.
Therefore I decided to add the documentation so a random onlooker is not confused when they see this method in the future.

I think I got the general idea documented, ironing out grammar can be done before merging :)

I think this one is addressed to you @msiglreith since you are listed as the maintainer.