### PR TITLE
X11: Retry Interrupted event polls once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - On macOS, drop the event callback before exiting.
 - On Android, implement `Window::request_redraw`
+- On X11, prevent a panic on interrupted system calls.
 - **Breaking:** On Web, remove the `stdweb` backend.
 - Added `Window::focus_window`to bring the window to the front and set input focus.
 - On Wayland and X11, implement `is_maximized` method on `Window`.


### PR DESCRIPTION
As the description of `std::io::ErrorKind::Interrupted` states:
> Interrupted operations can typically be retried.

If there is a poll, which fails for being interrupted, it may succeed on a retry. Therefore this commit retries such an interrupted operation once. The background is, that entering sleep mode will cause interrupted events, which leads to panics on wake-up. This commit handles that case gracefully.

Fixes #1947.

- [x] Tested on all platforms changed (only X11 backend affected)
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality (not relevant for this bug-fix)
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented (none)
