### PR TITLE
Implement `Window::request_redraw` on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - **Breaking:** On Web, remove the `stdweb` backend.
 - Added `Window::focus_window`to bring the window to the front and set input focus.
+- Implement `Window::request_redraw` on Android
 
 # 0.25.0 (2021-05-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
 
+- On Android, implement `Window::request_redraw`
 - **Breaking:** On Web, remove the `stdweb` backend.
 - Added `Window::focus_window`to bring the window to the front and set input focus.
-- Implement `Window::request_redraw` on Android
 
 # 0.25.0 (2021-05-15)
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -438,7 +438,7 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS:** Can only be called on the main thread.
-    /// - **Android:** Unsupported.
+    /// - **Android:** Subsequent calls after `MainEventsCleared` are not handled.
     #[inline]
     pub fn request_redraw(&self) {
         self.window.request_redraw()


### PR DESCRIPTION
This implements `Window::request_redraw` on Android based on the feedback given here: https://github.com/rust-windowing/winit/pull/1822#issuecomment-760769960

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #1723