### PR TITLE
Drop the event callback before exiting on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On macOS, drop the event callback before exiting.
 - **Breaking:** On Web, remove the `stdweb` backend.
 - Added `Window::focus_window`to bring the window to the front and set input focus.
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -141,7 +141,6 @@ impl<T> EventLoop<T> {
         F: 'static + FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         self.run_return(callback);
-        drop(self._callback.take());
         process::exit(0);
     }
 
@@ -175,10 +174,12 @@ impl<T> EventLoop<T> {
             let () = msg_send![app, run];
 
             if let Some(panic) = self.panic_info.take() {
+                drop(self._callback.take());
                 resume_unwind(panic);
             }
             AppState::exit();
         });
+        drop(self._callback.take());
     }
 
     pub fn create_proxy(&self) -> Proxy<T> {

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -141,6 +141,8 @@ impl<T> EventLoop<T> {
         F: 'static + FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         self.run_return(callback);
+        // Drop the callback before exiting
+        self._callback = None;
         process::exit(0);
     }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -141,8 +141,7 @@ impl<T> EventLoop<T> {
         F: 'static + FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         self.run_return(callback);
-        // Drop the callback before exiting
-        self._callback = None;
+        drop(self._callback.take());
         process::exit(0);
     }
 


### PR DESCRIPTION
Closes #1948 

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
