### PR TITLE
Update `raw-window-handle` to `0.4.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Update `raw-window-handle` to `v0.4`. This is _not_ a breaking change, we still implement `HasRawWindowHandle` from `v0.3`, see [rust-windowing/raw-window-handle#74](https://github.com/rust-windowing/raw-window-handle/pull/74).
 - On X11, bump `mio` to 0.8.
 - On Android, fixed `WindowExtAndroid::config` initially returning an empty `Configuration`.
 - On Android, fixed `Window::scale_factor` and `MonitorHandle::scale_factor` initially always returning 1.0.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 lazy_static = "1"
 log = "0.4"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
-raw-window-handle = "0.3"
+raw-window-handle = "0.4.2"
 bitflags = "1"
 mint = { version = "0.5.6", optional = true }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -595,9 +595,9 @@ impl Window {
         } else {
             panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
         };
-        let mut handle = raw_window_handle::android::AndroidHandle::empty();
+        let mut handle = raw_window_handle::AndroidNdkHandle::empty();
         handle.a_native_window = a_native_window;
-        raw_window_handle::RawWindowHandle::Android(handle)
+        raw_window_handle::RawWindowHandle::AndroidNdk(handle)
     }
 
     pub fn config(&self) -> Configuration {

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -12,6 +12,7 @@ use ndk::{
     looper::{ForeignLooper, Poll, ThreadLooper},
 };
 use ndk_glue::{Event, Rect};
+use raw_window_handle::{AndroidNdkHandle, RawWindowHandle};
 use std::{
     collections::VecDeque,
     sync::{Arc, Mutex, RwLock},
@@ -589,15 +590,14 @@ impl Window {
         ))
     }
 
-    pub fn raw_window_handle(&self) -> raw_window_handle::RawWindowHandle {
-        let a_native_window = if let Some(native_window) = ndk_glue::native_window().as_ref() {
-            unsafe { native_window.ptr().as_mut() as *mut _ as *mut _ }
+    pub fn raw_window_handle(&self) -> RawWindowHandle {
+        let mut handle = AndroidNdkHandle::empty();
+        if let Some(native_window) = ndk_glue::native_window().as_ref() {
+            handle.a_native_window = unsafe { native_window.ptr().as_mut() as *mut _ as *mut _ }
         } else {
             panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
         };
-        let mut handle = raw_window_handle::AndroidNdkHandle::empty();
-        handle.a_native_window = a_native_window;
-        raw_window_handle::RawWindowHandle::AndroidNdk(handle)
+        RawWindowHandle::AndroidNdk(handle)
     }
 
     pub fn config(&self) -> Configuration {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -1,4 +1,4 @@
-use raw_window_handle::{ios::IOSHandle, RawWindowHandle};
+use raw_window_handle::{UiKitHandle, RawWindowHandle};
 use std::{
     collections::VecDeque,
     ops::{Deref, DerefMut},
@@ -307,13 +307,13 @@ impl Inner {
     }
 
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let handle = IOSHandle {
+        let handle = UiKitHandle {
             ui_window: self.window as _,
             ui_view: self.view as _,
             ui_view_controller: self.view_controller as _,
-            ..IOSHandle::empty()
+            ..UiKitHandle::empty()
         };
-        RawWindowHandle::IOS(handle)
+        RawWindowHandle::UiKit(handle)
     }
 }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -1,4 +1,4 @@
-use raw_window_handle::{UiKitHandle, RawWindowHandle};
+use raw_window_handle::{RawWindowHandle, UiKitHandle};
 use std::{
     collections::VecDeque,
     ops::{Deref, DerefMut},
@@ -307,12 +307,10 @@ impl Inner {
     }
 
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let handle = UiKitHandle {
-            ui_window: self.window as _,
-            ui_view: self.view as _,
-            ui_view_controller: self.view_controller as _,
-            ..UiKitHandle::empty()
-        };
+        let mut handle = UiKitHandle::empty();
+        handle.ui_window = self.window as _;
+        handle.ui_view = self.view as _;
+        handle.ui_view_controller = self.view_controller as _;
         RawWindowHandle::UiKit(handle)
     }
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -7,7 +7,7 @@ use sctk::reexports::client::Display;
 
 use sctk::reexports::calloop;
 
-use raw_window_handle::unix::WaylandHandle;
+use raw_window_handle::WaylandHandle;
 use sctk::window::{Decorations, FallbackFrame};
 
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -488,14 +488,10 @@ impl Window {
 
     #[inline]
     pub fn raw_window_handle(&self) -> WaylandHandle {
-        let display = self.display.get_display_ptr() as *mut _;
-        let surface = self.surface.as_ref().c_ptr() as *mut _;
-
-        WaylandHandle {
-            display,
-            surface,
-            ..WaylandHandle::empty()
-        }
+        let mut handle = WaylandHandle::empty();
+        handle.display = self.display.get_display_ptr() as *mut _;
+        handle.surface = self.surface.as_ref().c_ptr() as *mut _;
+        handle
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1,4 +1,4 @@
-use raw_window_handle::unix::XlibHandle;
+use raw_window_handle::XlibHandle;
 use std::{
     cmp, env,
     ffi::CString,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1458,10 +1458,9 @@ impl UnownedWindow {
 
     #[inline]
     pub fn raw_window_handle(&self) -> XlibHandle {
-        XlibHandle {
-            window: self.xwindow,
-            display: self.xconn.display as _,
-            ..XlibHandle::empty()
-        }
+        let mut handle = XlibHandle::empty();
+        handle.window = self.xlib_window();
+        handle.display = self.xlib_display();
+        handle
     }
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1059,11 +1059,9 @@ impl UnownedWindow {
 
     #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let handle = AppKitHandle {
-            ns_window: *self.ns_window as *mut _,
-            ns_view: *self.ns_view as *mut _,
-            ..AppKitHandle::empty()
-        };
+        let mut handle = AppKitHandle::empty();
+        handle.ns_window = *self.ns_window as *mut _;
+        handle.ns_view = *self.ns_view as *mut _;
         RawWindowHandle::AppKit(handle)
     }
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1,4 +1,4 @@
-use raw_window_handle::{macos::MacOSHandle, RawWindowHandle};
+use raw_window_handle::{AppKitHandle, RawWindowHandle};
 use std::{
     collections::VecDeque,
     f64,
@@ -1059,12 +1059,12 @@ impl UnownedWindow {
 
     #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let handle = MacOSHandle {
+        let handle = AppKitHandle {
             ns_window: *self.ns_window as *mut _,
             ns_view: *self.ns_view as *mut _,
-            ..MacOSHandle::empty()
+            ..AppKitHandle::empty()
         };
-        RawWindowHandle::MacOS(handle)
+        RawWindowHandle::AppKit(handle)
     }
 }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -7,7 +7,7 @@ use crate::window::{
     CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWI,
 };
 
-use raw_window_handle::web::WebHandle;
+use raw_window_handle::WebHandle;
 
 use super::{backend, monitor, EventLoopWindowTarget};
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -7,7 +7,7 @@ use crate::window::{
     CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWI,
 };
 
-use raw_window_handle::WebHandle;
+use raw_window_handle::{RawWindowHandle, WebHandle};
 
 use super::{backend, monitor, EventLoopWindowTarget};
 
@@ -322,13 +322,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> raw_window_handle::RawWindowHandle {
-        let handle = WebHandle {
-            id: self.id.0,
-            ..WebHandle::empty()
-        };
-
-        raw_window_handle::RawWindowHandle::Web(handle)
+    pub fn raw_window_handle(&self) -> RawWindowHandle {
+        let mut handle = WebHandle::empty();
+        handle.id = self.id.0;
+        RawWindowHandle::Web(handle)
     }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "windows")]
 
 use parking_lot::Mutex;
-use raw_window_handle::{windows::WindowsHandle, RawWindowHandle};
+use raw_window_handle::{Win32Handle, RawWindowHandle};
 use std::{
     cell::Cell,
     ffi::OsStr,
@@ -233,12 +233,12 @@ impl Window {
 
     #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let handle = WindowsHandle {
+        let handle = Win32Handle {
             hwnd: self.window.0 as *mut _,
             hinstance: self.hinstance() as *mut _,
-            ..WindowsHandle::empty()
+            ..Win32Handle::empty()
         };
-        RawWindowHandle::Windows(handle)
+        RawWindowHandle::Win32(handle)
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1,7 +1,7 @@
 #![cfg(target_os = "windows")]
 
 use parking_lot::Mutex;
-use raw_window_handle::{Win32Handle, RawWindowHandle};
+use raw_window_handle::{RawWindowHandle, Win32Handle};
 use std::{
     cell::Cell,
     ffi::OsStr,
@@ -233,11 +233,9 @@ impl Window {
 
     #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let handle = Win32Handle {
-            hwnd: self.window.0 as *mut _,
-            hinstance: self.hinstance() as *mut _,
-            ..Win32Handle::empty()
-        };
+        let mut handle = Win32Handle::empty();
+        handle.hwnd = self.window.0 as *mut _;
+        handle.hinstance = self.hinstance() as *mut _;
         RawWindowHandle::Win32(handle)
     }
 


### PR DESCRIPTION
Ready for when https://github.com/rust-windowing/raw-window-handle/pull/70 gets merged, and a stable version published.

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
