### PR TITLE
Retry XGrabPointer a couple of times (up to 500ms) if it failes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Breaking:** On Web, remove the `stdweb` backend.
 - Added `Window::focus_window`to bring the window to the front and set input focus.
 - On Wayland and X11, implement `is_maximized` method on `Window`.
+- On X11 retry cursor grab on failure (up to 10 times / 500ms)
 
 # 0.25.0 (2021-05-15)
 


### PR DESCRIPTION
If you try to grab the cursor right after you created the window you get the error:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os(OsError { line: 1266, file: "/home/visse/repos/winit/src/platform_impl/linux/x11/window.rs", error: XMisc("Cursor could not be grabbed: grab location not viewable") })', src/main.rs:11:34
```

Minimal repro:
```rust
use winit::{event_loop::EventLoop, window::WindowBuilder};

fn main() {
    let event_loop = EventLoop::new();

    let window = WindowBuilder::new()
        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
        .build(&event_loop)
        .unwrap();

    window.set_cursor_grab(true).unwrap();
}
```

Checking the sdl implementation, it looks like they are solving it by retrying it a couple of times:
https://github.com/libsdl-org/SDL/blob/e65a6583201ee1a9a3bc3064655b186fc16ef719/src/video/x11/SDL_x11window.c#L1611-L1619

This PR simply implements the same scheme and retries XGrabPointer up to 10 times with a slight delay between each, for a total delay up to 500ms.


- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
