### PR TITLE
Emit ScaleFactorChanged event on monitor reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - **Breaking:** On Wayland, Theme trait and its support types are dropped.
 - On Wayland, bump `smithay-client-toolkit` to 0.15.
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
-
+- On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
 
 # 0.25.0 (2021-05-15)
 


### PR DESCRIPTION
Fixes #1962 
When disconnect the only monitor, scale factor is reset to 1.0. We need
to set it back when the monitor is reconnected.

We previously assume current window must be on an existing monitor, but
that's not true in case of reconnecting the only one monitor.

- [x] Tested on all platforms changed
  - Tested on X11, KDE, via alacritty. (Fixes https://github.com/alacritty/alacritty/issues/5213)
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
