### PR TITLE
Remove libc dependency on non-linux platforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ wayland = ["wayland-client", "sctk"]
 [dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 lazy_static = "1"
-libc = "0.2.64"
 log = "0.4"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 raw-window-handle = "0.3"
@@ -90,6 +89,7 @@ mio-misc = { version = "1.0", optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }
 parking_lot = { version = "0.11.0", optional = true }
+libc = "0.2.64"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web_sys]
 package = "web-sys"

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -3,7 +3,6 @@
 use std::os::raw::c_void;
 use std::path::Path;
 
-use libc;
 use winapi::shared::minwindef::WORD;
 use winapi::shared::windef::{HMENU, HWND};
 
@@ -72,11 +71,11 @@ impl<T> EventLoopExtWindows for EventLoop<T> {
 /// Additional methods on `Window` that are specific to Windows.
 pub trait WindowExtWindows {
     /// Returns the HINSTANCE of the window
-    fn hinstance(&self) -> *mut libc::c_void;
+    fn hinstance(&self) -> *mut c_void;
     /// Returns the native handle that is used by this window.
     ///
     /// The pointer will become invalid when the native window was destroyed.
-    fn hwnd(&self) -> *mut libc::c_void;
+    fn hwnd(&self) -> *mut c_void;
 
     /// Enables or disables mouse and keyboard input to the specified window.
     ///
@@ -102,12 +101,12 @@ pub trait WindowExtWindows {
 
 impl WindowExtWindows for Window {
     #[inline]
-    fn hinstance(&self) -> *mut libc::c_void {
+    fn hinstance(&self) -> *mut c_void {
         self.window.hinstance() as *mut _
     }
 
     #[inline]
-    fn hwnd(&self) -> *mut libc::c_void {
+    fn hwnd(&self) -> *mut c_void {
         self.window.hwnd() as *mut _
     }
 

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -2,6 +2,8 @@
 
 #![allow(dead_code, non_snake_case, non_upper_case_globals)]
 
+use std::ffi::c_void;
+
 use cocoa::{
     base::id,
     foundation::{NSInteger, NSUInteger},
@@ -159,7 +161,7 @@ pub const IOYUV422Pixels: &str = "Y4U2V2";
 pub const IO8BitOverlayPixels: &str = "O8";
 
 pub type CGWindowLevel = i32;
-pub type CGDisplayModeRef = *mut libc::c_void;
+pub type CGDisplayModeRef = *mut c_void;
 
 #[cfg_attr(
     not(use_colorsync_cgdisplaycreateuuidfromdisplayid),


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- ~~Created or updated an example program if it would help users understand this functionality~~
- ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~

---

We don't really need to bring in all of `libc` when all we're using is `libc::c_void`, which is just an alias for `core::ffi::c_void` after `libc = "0.2.0"` anyway.
