### PR TITLE
Prevent ghost window from showing up on taskbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Breaking:** On Web, remove the `stdweb` backend.
 - Added `Window::focus_window`to bring the window to the front and set input focus.
 - On Wayland and X11, implement `is_maximized` method on `Window`.
+- On Windows, prevent ghost window from showing up in taskbar after several hours of use.
 
 # 0.25.0 (2021-05-15)
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -599,6 +599,15 @@ fn create_event_target_window() -> HWND {
             winuser::WS_EX_NOACTIVATE
                 | winuser::WS_EX_TRANSPARENT
                 | winuser::WS_EX_LAYERED
+                // WS_EX_TOOLWINDOW prevents this window from ever showing up in the taskbar, which
+                // we want to avoid. If you remove this style, this window won't show up in the
+                // taskbar *initially*, but will eventually magically appear in the taskbar.
+                //
+                // Now, I wasn't able to figure out what *causes* the window to eventually show up
+                // in the taskbar, since it does so without warning, after several hours, with no
+                // obvious code-visible state changes to this window. I'd guess that some win32
+                // state change gets triggered at some point, but I'd need to be able to debug the
+                // windows shell directly to figure that out and I can't do that.
                 | winuser::WS_EX_TOOLWINDOW,
             THREAD_EVENT_TARGET_WINDOW_CLASS.as_ptr(),
             ptr::null_mut(),

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -596,7 +596,10 @@ lazy_static! {
 fn create_event_target_window() -> HWND {
     unsafe {
         let window = winuser::CreateWindowExW(
-            winuser::WS_EX_NOACTIVATE | winuser::WS_EX_TRANSPARENT | winuser::WS_EX_LAYERED | winuser::WS_EX_TOOLWINDOW,
+            winuser::WS_EX_NOACTIVATE
+                | winuser::WS_EX_TRANSPARENT
+                | winuser::WS_EX_LAYERED
+                | winuser::WS_EX_TOOLWINDOW,
             THREAD_EVENT_TARGET_WINDOW_CLASS.as_ptr(),
             ptr::null_mut(),
             0,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -596,7 +596,7 @@ lazy_static! {
 fn create_event_target_window() -> HWND {
     unsafe {
         let window = winuser::CreateWindowExW(
-            winuser::WS_EX_NOACTIVATE | winuser::WS_EX_TRANSPARENT | winuser::WS_EX_LAYERED,
+            winuser::WS_EX_NOACTIVATE | winuser::WS_EX_TRANSPARENT | winuser::WS_EX_LAYERED | winuser::WS_EX_TOOLWINDOW,
             THREAD_EVENT_TARGET_WINDOW_CLASS.as_ptr(),
             ptr::null_mut(),
             0,


### PR DESCRIPTION
Closes #1265. The only way to reproduce this I've found is to wait around for several hours, and after I added this code I haven't seen the issue crop up at all, so I'm fairly sure the underlying bug is fixed. 

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [x] ~~Created or updated an example program if it would help users understand this functionality~~
- [x] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~
