### PR TITLE
Add composition event on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ cocoa = "0.24"
 core-foundation = "0.9"
 core-graphics = "0.22"
 dispatch = "0.2.0"
+block = "0.1"
 
 [target.'cfg(target_os = "macos")'.dependencies.core-video-sys]
 version = "0.1.4"

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -118,6 +118,8 @@ pub enum NSWindowLevel {
     NSScreenSaverWindowLevel = kCGScreenSaverWindowLevelKey as _,
 }
 
+pub const NSStringEnumerationByComposedCharacterSequences: NSUInteger = 2;
+
 pub type CGDisplayFadeInterval = f32;
 pub type CGDisplayReservationInterval = f32;
 pub type CGDisplayBlendFraction = f32;

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -3,8 +3,13 @@ mod cursor;
 
 pub use self::{cursor::*, r#async::*};
 
-use std::ops::{BitAnd, Deref};
+use std::{
+    cell::Cell,
+    ops::{BitAnd, Deref},
+    rc::Rc,
+};
 
+use block::ConcreteBlock;
 use cocoa::{
     appkit::{NSApp, NSWindowStyleMask},
     base::{id, nil},
@@ -13,8 +18,12 @@ use cocoa::{
 use core_graphics::display::CGDisplay;
 use objc::runtime::{Class, Object, Sel, BOOL, YES};
 
-use crate::dpi::LogicalPosition;
-use crate::platform_impl::platform::ffi;
+use crate::{
+    dpi::LogicalPosition,
+    platform_impl::platform::ffi::{
+        self, NSRange, NSStringEnumerationByComposedCharacterSequences,
+    },
+};
 
 // Replace with `!` once stable
 #[derive(Debug)]
@@ -102,6 +111,31 @@ pub fn window_position(position: LogicalPosition<f64>) -> NSPoint {
 
 pub unsafe fn ns_string_id_ref(s: &str) -> IdRef {
     IdRef::new(NSString::alloc(nil).init_str(s))
+}
+
+/// Returns the number of characters in a string.
+/// (A single character may consist of multiple UTF-32 code units.
+/// This is possible when long sequences of composing characters are present)
+///
+/// Unsafe because assumes that the `string` is an `NSString` object
+pub unsafe fn ns_string_char_count(string: id) -> usize {
+    let length: NSUInteger = msg_send![string, length];
+    let range = NSRange {
+        location: 0,
+        length,
+    };
+    let char_count = Rc::new(Cell::new(0));
+    let block = {
+        let char_count = char_count.clone();
+        ConcreteBlock::new(move || char_count.set(char_count.get() + 1)).copy()
+    };
+    let block = &*block;
+    let () = msg_send![string,
+        enumerateSubstringsInRange:range
+        options:NSStringEnumerationByComposedCharacterSequences
+        usingBlock:block
+    ];
+    char_count.get()
 }
 
 #[allow(dead_code)] // In case we want to use this function in the future

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -436,7 +436,6 @@ extern "C" fn set_marked_text(
 ) {
     trace!("Triggered `setMarkedText`");
     unsafe {
-        println!("marked_range : {:?}", marked_range(this, _sel).length);
         this.set_ivar("isIMEActivated", true);
         let marked_text_ref: &mut id = this.get_mut_ivar("markedText");
 
@@ -466,9 +465,6 @@ extern "C" fn set_marked_text(
         // Delete previous marked text, so that we don't see duplicated texts.
         let previous_cursor_position = *this.get_ivar::<i32>("previousCursorPosition");
         delete_marked_text(state, previous_cursor_position);
-
-        println!("Current: {:?}  {:?}", composed_string, cursor_position);
-        println!("Previous: {:?}", previous_cursor_position);
 
         for character in composed_string.chars() {
             AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -58,7 +58,6 @@ pub(super) struct ViewState {
     pub(super) modifiers: ModifiersState,
     tracking_rect: Option<NSInteger>,
     is_ime_activated: bool,
-    is_preediting: bool,
     marked_text: id,
 }
 
@@ -81,7 +80,6 @@ pub fn new_view(ns_window: id) -> (IdRef, Weak<Mutex<CursorState>>) {
         modifiers: Default::default(),
         tracking_rect: None,
         is_ime_activated: false,
-        is_preediting: false,
         marked_text,
     };
     unsafe {
@@ -546,7 +544,6 @@ extern "C" fn insert_text(this: &mut Object, _sel: Sel, string: id, _replacement
         if is_ime_activated {
             clear_marked_text(this);
             state.is_ime_activated = false;
-            state.is_preediting = false;
             return;
         }
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -153,7 +153,10 @@ lazy_static! {
             sel!(setMarkedText:selectedRange:replacementRange:),
             set_marked_text as extern "C" fn(&mut Object, Sel, id, NSRange, NSRange),
         );
-        decl.add_method(sel!(unmarkText), unmark_text as extern "C" fn(&mut Object, Sel));
+        decl.add_method(
+            sel!(unmarkText),
+            unmark_text as extern "C" fn(&mut Object, Sel),
+        );
         decl.add_method(
             sel!(validAttributesForMarkedText),
             valid_attributes_for_marked_text as extern "C" fn(&Object, Sel) -> id,

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -183,10 +183,7 @@ lazy_static! {
             sel!(doCommandBySelector:),
             do_command_by_selector as extern "C" fn(&Object, Sel, Sel),
         );
-        decl.add_method(
-            sel!(keyDown:),
-            key_down as extern "C" fn(&Object, Sel, id),
-        );
+        decl.add_method(sel!(keyDown:), key_down as extern "C" fn(&Object, Sel, id));
         decl.add_method(sel!(keyUp:), key_up as extern "C" fn(&Object, Sel, id));
         decl.add_method(
             sel!(flagsChanged:),

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -263,7 +263,6 @@ lazy_static! {
         );
         decl.add_ivar::<*mut c_void>("winitState");
         decl.add_ivar::<id>("markedText");
-        decl.add_ivar::<id>("previousMarkedText");
         decl.add_ivar::<bool>("isIMEActivated");
         decl.add_ivar::<i32>("currentCursorPosition");
         decl.add_ivar::<i32>("previousCursorPosition");
@@ -277,9 +276,7 @@ extern "C" fn dealloc(this: &Object, _sel: Sel) {
     unsafe {
         let state: *mut c_void = *this.get_ivar("winitState");
         let marked_text: id = *this.get_ivar("markedText");
-        let previous_marked_text: id = *this.get_ivar("previousMarkedText");
         let _: () = msg_send![marked_text, release];
-        let _: () = msg_send![previous_marked_text, release];
         Box::from_raw(state as *mut ViewState);
     }
 }
@@ -292,7 +289,6 @@ extern "C" fn init_with_winit(this: &Object, _sel: Sel, state: *mut c_void) -> i
             let marked_text =
                 <id as NSMutableAttributedString>::init(NSMutableAttributedString::alloc(nil));
             (*this).set_ivar("markedText", marked_text);
-            (*this).set_ivar("previousMarkedText", marked_text);
             (*this).set_ivar("isIMEActivated", false);
             (*this).set_ivar("currentCursorPosition", 0);
             (*this).set_ivar("previousCursorPosition", 0);

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -174,7 +174,10 @@ lazy_static! {
             sel!(doCommandBySelector:),
             do_command_by_selector as extern "C" fn(&Object, Sel, Sel),
         );
-        decl.add_method(sel!(keyDown:), key_down as extern "C" fn(&mut Object, Sel, id));
+        decl.add_method(
+            sel!(keyDown:),
+            key_down as extern "C" fn(&mut Object, Sel, id),
+        );
         decl.add_method(sel!(keyUp:), key_up as extern "C" fn(&Object, Sel, id));
         decl.add_method(
             sel!(flagsChanged:),
@@ -629,7 +632,7 @@ fn delete_marked_text(state: &mut ViewState, count: i32) {
     for _ in 0..count {
         AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
             window_id: WindowId(get_window_id(state.ns_window)),
-            event: WindowEvent::ReceivedCharacter('\u{7f}')  // fire DELETE
+            event: WindowEvent::ReceivedCharacter('\u{7f}'), // fire DELETE
         }));
     }
 }

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -185,7 +185,7 @@ lazy_static! {
         );
         decl.add_method(
             sel!(keyDown:),
-            key_down as extern "C" fn(&mut Object, Sel, id),
+            key_down as extern "C" fn(&Object, Sel, id),
         );
         decl.add_method(sel!(keyUp:), key_up as extern "C" fn(&Object, Sel, id));
         decl.add_method(
@@ -699,7 +699,7 @@ fn update_potentially_stale_modifiers(state: &mut ViewState, event: id) {
     }
 }
 
-extern "C" fn key_down(this: &mut Object, _sel: Sel, event: id) {
+extern "C" fn key_down(this: &Object, _sel: Sel, event: id) {
     trace!("Triggered `keyDown`");
     unsafe {
         let state_ptr: *mut c_void = *this.get_ivar("winitState");

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -659,17 +659,6 @@ fn is_corporate_character(c: char) -> bool {
     }
 }
 
-fn is_arrow_or_space_key(virtual_keycode: VirtualKeyCode) -> bool {
-    match virtual_keycode {
-        VirtualKeyCode::Up
-        | VirtualKeyCode::Right
-        | VirtualKeyCode::Down
-        | VirtualKeyCode::Left
-        | VirtualKeyCode::Space => true,
-        _ => false,
-    }
-}
-
 // Retrieves a layout-independent keycode given an event.
 fn retrieve_keycode(event: id) -> Option<VirtualKeyCode> {
     #[inline]


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This change is to enable to use IME.

Before:

https://user-images.githubusercontent.com/27967726/127104794-4469f128-565b-4b56-a5a5-5a327f89a5da.mov

After:

https://user-images.githubusercontent.com/27967726/127105174-c3b703be-68f8-4354-830c-05f8e178ce27.mov