### PR TITLE
Load "hand2" and "hand1" cursor icons for Wayland CursorIcon::Hand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `Window::focus_window`to bring the window to the front and set input focus.
 - On Wayland and X11, implement `is_maximized` method on `Window`.
 - On macOS, fix issue where `ReceivedCharacter` was not being emitted during some key repeat events.
+- On Wayland, load cursor icons `hand2` and `hand1` for `CursorIcon::Hand`.
 
 # 0.25.0 (2021-05-15)
 

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -70,7 +70,7 @@ impl WinitPointer {
             CursorIcon::Copy => &["copy"],
             CursorIcon::Crosshair => &["crosshair"],
             CursorIcon::Default => &["left_ptr"],
-            CursorIcon::Hand => &["hand"],
+            CursorIcon::Hand => &["hand2", "hand1"],
             CursorIcon::Help => &["question_arrow"],
             CursorIcon::Move => &["move"],
             CursorIcon::Grab => &["openhand", "grab"],


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

As per the X11 implementation https://github.com/rust-windowing/winit/blob/1c4d6e7613c3a3870cecb4cfa0eecc97409d45ff/src/platform_impl/linux/x11/util/cursor.rs#L84 the Wayland implementation should load cursors `hand2` and `hand1`, since some cursor themes such as Breeze do not ship an icon named `hand`. Without this change, Alacritty falls back to the default Adwaita hand icon when setting Breeze as the cursor theme, since Adwaita symlinks `hand` to `hand2`.