### PR TITLE
Fix X11 memory leak and remove mio-misc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc", "i686-unknown-linux
 
 [features]
 default = ["x11", "wayland"]
-x11 = ["x11-dl", "mio", "mio-misc", "percent-encoding", "parking_lot"]
+x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
 wayland = ["wayland-client", "sctk"]
 
 [dependencies]
@@ -82,10 +82,9 @@ features = [
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-wayland-client = { version = "0.28", features = [ "dlopen"] , optional = true }
+wayland-client = { version = "0.28", features = [ "dlopen"], optional = true }
 sctk = { package = "smithay-client-toolkit", version = "0.12.3", optional = true }
 mio = { version = "0.7", features = ["os-ext"], optional = true }
-mio-misc = { version = "1.0", optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }
 parking_lot = { version = "0.11.0", optional = true }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -58,9 +58,9 @@ use crate::{
 const X_TOKEN: Token = Token(0);
 const USER_REDRAW_TOKEN: Token = Token(1);
 
-pub(self) struct WakeSender<T> {
-    pub sender: Sender<T>,
-    pub waker: Arc<Waker>,
+struct WakeSender<T> {
+    sender: Sender<T>,
+    waker: Arc<Waker>,
 }
 
 pub struct EventLoopWindowTarget<T> {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -32,7 +32,7 @@ use std::{
     ptr,
     rc::Rc,
     slice,
-    sync::mpsc::Receiver,
+    sync::mpsc::{Receiver, Sender},
     sync::{mpsc, Arc, Weak},
     time::{Duration, Instant},
 };
@@ -40,12 +40,6 @@ use std::{
 use libc::{self, setlocale, LC_CTYPE};
 
 use mio::{unix::SourceFd, Events, Interest, Poll, Token, Waker};
-
-use mio_misc::{
-    channel::{channel, SendError, Sender},
-    queue::NotificationQueue,
-    NotificationId,
-};
 
 use self::{
     dnd::{Dnd, DndState},
@@ -64,6 +58,11 @@ use crate::{
 const X_TOKEN: Token = Token(0);
 const USER_REDRAW_TOKEN: Token = Token(1);
 
+pub(self) struct WakeSender<T> {
+    pub sender: Sender<T>,
+    pub waker: Arc<Waker>,
+}
+
 pub struct EventLoopWindowTarget<T> {
     xconn: Arc<XConnection>,
     wm_delete_window: ffi::Atom,
@@ -72,27 +71,30 @@ pub struct EventLoopWindowTarget<T> {
     root: ffi::Window,
     ime: RefCell<Ime>,
     windows: RefCell<HashMap<WindowId, Weak<UnownedWindow>>>,
-    redraw_sender: Sender<WindowId>,
+    redraw_sender: WakeSender<WindowId>,
     _marker: ::std::marker::PhantomData<T>,
 }
 
 pub struct EventLoop<T: 'static> {
     poll: Poll,
+    waker: Arc<Waker>,
     event_processor: EventProcessor<T>,
     redraw_channel: Receiver<WindowId>,
-    user_channel: Receiver<T>,
+    user_channel: Receiver<T>, //waker.wake needs to be called whenever something gets sent
     user_sender: Sender<T>,
     target: Rc<RootELW<T>>,
 }
 
 pub struct EventLoopProxy<T: 'static> {
     user_sender: Sender<T>,
+    waker: Arc<Waker>,
 }
 
 impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
         EventLoopProxy {
             user_sender: self.user_sender.clone(),
+            waker: self.waker.clone(),
         }
     }
 }
@@ -185,15 +187,16 @@ impl<T: 'static> EventLoop<T> {
 
         let poll = Poll::new().unwrap();
         let waker = Arc::new(Waker::new(poll.registry(), USER_REDRAW_TOKEN).unwrap());
-        let queue = Arc::new(NotificationQueue::new(waker));
 
         poll.registry()
             .register(&mut SourceFd(&xconn.x11_fd), X_TOKEN, Interest::READABLE)
             .unwrap();
 
-        let (user_sender, user_channel) = channel(queue.clone(), NotificationId::gen_next());
+        //let (user_sender, user_channel) = channel(queue.clone(), NotificationId::gen_next());
+        let (user_sender, user_channel) = std::sync::mpsc::channel();
 
-        let (redraw_sender, redraw_channel) = channel(queue, NotificationId::gen_next());
+        //let (redraw_sender, redraw_channel) = channel(queue, NotificationId::gen_next());
+        let (redraw_sender, redraw_channel) = std::sync::mpsc::channel();
 
         let target = Rc::new(RootELW {
             p: super::EventLoopWindowTarget::X(EventLoopWindowTarget {
@@ -205,7 +208,10 @@ impl<T: 'static> EventLoop<T> {
                 xconn,
                 wm_delete_window,
                 net_wm_ping,
-                redraw_sender,
+                redraw_sender: WakeSender {
+                    sender: redraw_sender, // not used again so no clone
+                    waker: waker.clone(),
+                },
             }),
             _marker: ::std::marker::PhantomData,
         });
@@ -233,21 +239,21 @@ impl<T: 'static> EventLoop<T> {
 
         event_processor.init_device(ffi::XIAllDevices);
 
-        let result = EventLoop {
+        EventLoop {
             poll,
+            waker,
+            event_processor,
             redraw_channel,
             user_channel,
             user_sender,
-            event_processor,
             target,
-        };
-
-        result
+        }
     }
 
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         EventLoopProxy {
             user_sender: self.user_sender.clone(),
+            waker: self.waker.clone(),
         }
     }
 
@@ -392,7 +398,6 @@ impl<T: 'static> EventLoop<T> {
     {
         let target = &self.target;
         let mut xev = MaybeUninit::uninit();
-
         let wt = get_xtarget(&self.target);
 
         while unsafe { self.event_processor.poll_one_event(xev.as_mut_ptr()) } {
@@ -407,7 +412,8 @@ impl<T: 'static> EventLoop<T> {
                             super::WindowId::X(wid),
                         )) = event
                         {
-                            wt.redraw_sender.send(wid).unwrap();
+                            wt.redraw_sender.waker.wake().unwrap();
+                            wt.redraw_sender.sender.send(wid).unwrap();
                         } else {
                             callback(event, window_target, control_flow);
                         }
@@ -436,13 +442,12 @@ impl<T> EventLoopWindowTarget<T> {
 
 impl<T: 'static> EventLoopProxy<T> {
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
-        self.user_sender.send(event).map_err(|e| {
-            EventLoopClosed(if let SendError::Disconnected(x) = e {
-                x
-            } else {
-                unreachable!()
-            })
-        })
+        if self.waker.wake().is_err() {
+            return Err(EventLoopClosed(event));
+        }
+        self.user_sender
+            .send(event)
+            .map_err(|e| EventLoopClosed(e.0))
     }
 }
 
@@ -520,7 +525,7 @@ impl Window {
         attribs: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
-        let window = Arc::new(UnownedWindow::new(&event_loop, attribs, pl_attribs)?);
+        let window = Arc::new(UnownedWindow::new(event_loop, attribs, pl_attribs)?);
         event_loop
             .windows
             .borrow_mut()

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -10,7 +10,6 @@ use std::{
 };
 
 use libc;
-use mio_misc::channel::Sender;
 use parking_lot::Mutex;
 
 use crate::{
@@ -25,7 +24,9 @@ use crate::{
     window::{CursorIcon, Fullscreen, Icon, UserAttentionType, WindowAttributes},
 };
 
-use super::{ffi, util, EventLoopWindowTarget, ImeSender, WindowId, XConnection, XError};
+use super::{
+    ffi, util, EventLoopWindowTarget, ImeSender, WakeSender, WindowId, XConnection, XError,
+};
 
 #[derive(Debug)]
 pub struct SharedState {
@@ -103,7 +104,7 @@ pub struct UnownedWindow {
     cursor_visible: Mutex<bool>,
     ime_sender: Mutex<ImeSender>,
     pub shared_state: Mutex<SharedState>,
-    redraw_sender: Sender<WindowId>,
+    redraw_sender: WakeSender<WindowId>,
 }
 
 impl UnownedWindow {
@@ -252,7 +253,10 @@ impl UnownedWindow {
             cursor_visible: Mutex::new(true),
             ime_sender: Mutex::new(event_loop.ime_sender.clone()),
             shared_state: SharedState::new(guessed_monitor, window_attrs.visible),
-            redraw_sender: event_loop.redraw_sender.clone(),
+            redraw_sender: WakeSender {
+                waker: event_loop.redraw_sender.waker.clone(),
+                sender: event_loop.redraw_sender.sender.clone(),
+            },
         };
 
         // Title must be set before mapping. Some tiling window managers (i.e. i3) use the window
@@ -1080,7 +1084,7 @@ impl UnownedWindow {
 
     fn update_normal_hints<F>(&self, callback: F) -> Result<(), XError>
     where
-        F: FnOnce(&mut util::NormalHints<'_>) -> (),
+        F: FnOnce(&mut util::NormalHints<'_>),
     {
         let mut normal_hints = self.xconn.get_normal_hints(self.xwindow)?;
         callback(&mut normal_hints);
@@ -1161,7 +1165,7 @@ impl UnownedWindow {
             )
         } else {
             let window_size = Some(Size::from(self.inner_size()));
-            (window_size.clone(), window_size)
+            (window_size, window_size)
         };
 
         self.set_maximizable_inner(resizable).queue();
@@ -1423,7 +1427,11 @@ impl UnownedWindow {
 
     #[inline]
     pub fn request_redraw(&self) {
-        self.redraw_sender.send(WindowId(self.xwindow)).unwrap();
+        self.redraw_sender.waker.wake().unwrap();
+        self.redraw_sender
+            .sender
+            .send(WindowId(self.xwindow))
+            .unwrap();
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1427,11 +1427,11 @@ impl UnownedWindow {
 
     #[inline]
     pub fn request_redraw(&self) {
-        self.redraw_sender.waker.wake().unwrap();
         self.redraw_sender
             .sender
             .send(WindowId(self.xwindow))
             .unwrap();
+        self.redraw_sender.waker.wake().unwrap();
     }
 
     #[inline]


### PR DESCRIPTION
I also fixed a couple of clippy lints in the files relevant to the bug, but some of them I was afraid to touch. As far as I could tell, mio-misc was causing the bug, so I removed it. It was hardly used, and easily replaced. I tested it against the example in #1984 and the leak is gone.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
    I didn't see many bug fixes in the Changelog, so I didn't add it. No api changes were made.
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
    No user-facing changes.
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #1984