### PR TITLE
Update smithay-client-toolkit to 'v0.15.0'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - On Wayland and X11, implement `is_maximized` method on `Window`.
 - On macOS, fix issue where `ReceivedCharacter` was not being emitted during some key repeat events.
 - On Wayland, load cursor icons `hand2` and `hand1` for `CursorIcon::Hand`.
+- **Breaking:** On Wayland, Theme trait and its support types are dropped.
+- On Wayland, bump `smithay-client-toolkit` to 0.15.
+
 
 # 0.25.0 (2021-05-15)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ features = [
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 wayland-client = { version = "0.28", features = [ "dlopen"] , optional = true }
-sctk = { package = "smithay-client-toolkit", version = "0.12.3", optional = true }
+sctk = { package = "smithay-client-toolkit", version = "0.15.0", optional = true }
 mio = { version = "0.7", features = ["os-ext"], optional = true }
 mio-misc = { version = "1.0", optional = true }
 x11-dl = { version = "2.18.5", optional = true }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -237,10 +237,6 @@ pub trait WindowExtUnix {
     #[cfg(feature = "wayland")]
     fn wayland_display(&self) -> Option<*mut raw::c_void>;
 
-    /// Sets the color theme of the client side window decorations on wayland
-    #[cfg(feature = "wayland")]
-    fn set_wayland_theme<T: Theme>(&self, theme: T);
-
     /// Check if the window is ready for drawing
     ///
     /// It is a remnant of a previous implementation detail for the
@@ -320,16 +316,6 @@ impl WindowExtUnix for Window {
             LinuxWindow::Wayland(ref w) => Some(w.display().get_display_ptr() as *mut _),
             #[cfg(feature = "x11")]
             _ => None,
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn set_wayland_theme<T: Theme>(&self, theme: T) {
-        match self.window {
-            LinuxWindow::Wayland(ref w) => w.set_theme(theme),
-            #[cfg(feature = "x11")]
-            _ => {}
         }
     }
 
@@ -453,79 +439,4 @@ impl MonitorHandleExtUnix for MonitorHandle {
     fn native_id(&self) -> u32 {
         self.inner.native_identifier()
     }
-}
-
-/// A theme for a Wayland's client side decorations.
-#[cfg(feature = "wayland")]
-pub trait Theme: Send + 'static {
-    /// Title bar color.
-    fn element_color(&self, element: Element, window_active: bool) -> ARGBColor;
-
-    /// Color for a given button part.
-    fn button_color(
-        &self,
-        button: Button,
-        state: ButtonState,
-        foreground: bool,
-        window_active: bool,
-    ) -> ARGBColor;
-
-    /// Font name and the size for the title bar.
-    ///
-    /// By default the font is `sans-serif` at the size of 17.
-    ///
-    /// Returning `None` means that title won't be drawn.
-    fn font(&self) -> Option<(String, f32)> {
-        // Not having any title isn't something desirable for the users, so setting it to
-        // something generic.
-        Some((String::from("sans-serif"), 17.))
-    }
-}
-
-/// A button on Wayland's client side decorations.
-#[cfg(feature = "wayland")]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Button {
-    /// Button that maximizes the window.
-    Maximize,
-
-    /// Button that minimizes the window.
-    Minimize,
-
-    /// Button that closes the window.
-    Close,
-}
-
-/// A button state of the button on Wayland's client side decorations.
-#[cfg(feature = "wayland")]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ButtonState {
-    /// Button is being hovered over by pointer.
-    Hovered,
-    /// Button is not being hovered over by pointer.
-    Idle,
-    /// Button is disabled.
-    Disabled,
-}
-
-#[cfg(feature = "wayland")]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Element {
-    /// Bar itself.
-    Bar,
-
-    /// Separator between window and title bar.
-    Separator,
-
-    /// Title bar text.
-    Text,
-}
-
-#[cfg(feature = "wayland")]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct ARGBColor {
-    pub a: u8,
-    pub r: u8,
-    pub g: u8,
-    pub b: u8,
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -407,7 +407,7 @@ impl Window {
     pub fn set_always_on_top(&self, _always_on_top: bool) {
         match self {
             #[cfg(feature = "x11")]
-            &Window::X(ref w) => w.set_always_on_top(_always_on_top),
+            Window::X(ref w) => w.set_always_on_top(_always_on_top),
             #[cfg(feature = "wayland")]
             _ => (),
         }
@@ -417,7 +417,7 @@ impl Window {
     pub fn set_window_icon(&self, _window_icon: Option<Icon>) {
         match self {
             #[cfg(feature = "x11")]
-            &Window::X(ref w) => w.set_window_icon(_window_icon),
+            Window::X(ref w) => w.set_window_icon(_window_icon),
             #[cfg(feature = "wayland")]
             _ => (),
         }
@@ -432,7 +432,7 @@ impl Window {
     pub fn focus_window(&self) {
         match self {
             #[cfg(feature = "x11")]
-            &Window::X(ref w) => w.focus_window(),
+            Window::X(ref w) => w.focus_window(),
             #[cfg(feature = "wayland")]
             _ => (),
         }
@@ -440,7 +440,7 @@ impl Window {
     pub fn request_user_attention(&self, _request_type: Option<UserAttentionType>) {
         match self {
             #[cfg(feature = "x11")]
-            &Window::X(ref w) => w.request_user_attention(_request_type),
+            Window::X(ref w) => w.request_user_attention(_request_type),
             #[cfg(feature = "wayland")]
             _ => (),
         }
@@ -455,14 +455,14 @@ impl Window {
     pub fn current_monitor(&self) -> Option<RootMonitorHandle> {
         match self {
             #[cfg(feature = "x11")]
-            &Window::X(ref window) => {
+            Window::X(ref window) => {
                 let current_monitor = MonitorHandle::X(window.current_monitor());
                 Some(RootMonitorHandle {
                     inner: current_monitor,
                 })
             }
             #[cfg(feature = "wayland")]
-            &Window::Wayland(ref window) => {
+            Window::Wayland(ref window) => {
                 let current_monitor = MonitorHandle::Wayland(window.current_monitor()?);
                 Some(RootMonitorHandle {
                     inner: current_monitor,
@@ -475,13 +475,13 @@ impl Window {
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         match self {
             #[cfg(feature = "x11")]
-            &Window::X(ref window) => window
+            Window::X(ref window) => window
                 .available_monitors()
                 .into_iter()
                 .map(MonitorHandle::X)
                 .collect(),
             #[cfg(feature = "wayland")]
-            &Window::Wayland(ref window) => window
+            Window::Wayland(ref window) => window
                 .available_monitors()
                 .into_iter()
                 .map(MonitorHandle::Wayland)
@@ -493,23 +493,23 @@ impl Window {
     pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
         match self {
             #[cfg(feature = "x11")]
-            &Window::X(ref window) => {
+            Window::X(ref window) => {
                 let primary_monitor = MonitorHandle::X(window.primary_monitor());
                 Some(RootMonitorHandle {
                     inner: primary_monitor,
                 })
             }
             #[cfg(feature = "wayland")]
-            &Window::Wayland(ref window) => window.primary_monitor(),
+            Window::Wayland(ref window) => window.primary_monitor(),
         }
     }
 
     pub fn raw_window_handle(&self) -> RawWindowHandle {
         match self {
             #[cfg(feature = "x11")]
-            &Window::X(ref window) => RawWindowHandle::Xlib(window.raw_window_handle()),
+            Window::X(ref window) => RawWindowHandle::Xlib(window.raw_window_handle()),
             #[cfg(feature = "wayland")]
-            &Window::Wayland(ref window) => RawWindowHandle::Wayland(window.raw_window_handle()),
+            Window::Wayland(ref window) => RawWindowHandle::Wayland(window.raw_window_handle()),
         }
     }
 }

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -112,7 +112,7 @@ impl Eq for MonitorHandle {}
 
 impl PartialOrd for MonitorHandle {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
@@ -129,7 +129,7 @@ pub(super) fn handle_pointer(
 
             let window_id = wayland::make_wid(surface);
 
-            let scale_factor = sctk::get_surface_scale_factor(&surface) as f64;
+            let scale_factor = sctk::get_surface_scale_factor(surface) as f64;
             let position = LogicalPosition::new(surface_x, surface_y).to_physical(scale_factor);
 
             event_sink.push_window_event(
@@ -186,7 +186,7 @@ pub(super) fn handle_pointer(
                 None => return,
             };
 
-            let window_id = wayland::make_wid(&surface);
+            let window_id = wayland::make_wid(surface);
 
             if pointer.as_ref().version() < 5 {
                 let (mut x, mut y) = (0.0, 0.0);
@@ -199,7 +199,7 @@ pub(super) fn handle_pointer(
                     _ => unreachable!(),
                 }
 
-                let scale_factor = sctk::get_surface_scale_factor(&surface) as f64;
+                let scale_factor = sctk::get_surface_scale_factor(surface) as f64;
                 let delta = LogicalPosition::new(x as f64, y as f64).to_physical(scale_factor);
 
                 event_sink.push_window_event(
@@ -262,7 +262,7 @@ pub(super) fn handle_pointer(
                 Some(surface) => surface,
                 None => return,
             };
-            let window_id = wayland::make_wid(&surface);
+            let window_id = wayland::make_wid(surface);
 
             let window_event = if let Some((x, y)) = axis_discrete_buffer {
                 WindowEvent::MouseWheel {
@@ -274,7 +274,7 @@ pub(super) fn handle_pointer(
                     modifiers: *pointer_data.modifiers_state.borrow(),
                 }
             } else if let Some((x, y)) = axis_buffer {
-                let scale_factor = sctk::get_surface_scale_factor(&surface) as f64;
+                let scale_factor = sctk::get_surface_scale_factor(surface) as f64;
                 let delta = LogicalPosition::new(x, y).to_physical(scale_factor);
 
                 WindowEvent::MouseWheel {

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -13,7 +13,7 @@ use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_p
 use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_confined_pointer_v1::ZwpConfinedPointerV1;
 
 use sctk::seat::pointer::{ThemeManager, ThemedPointer};
-use sctk::window::{ConceptFrame, Window};
+use sctk::window::{FallbackFrame, Window};
 
 use crate::event::ModifiersState;
 use crate::platform_impl::wayland::event_loop::WinitState;
@@ -128,8 +128,8 @@ impl WinitPointer {
         };
 
         *confined_pointer.borrow_mut() = Some(init_confined_pointer(
-            &pointer_constraints,
-            &surface,
+            pointer_constraints,
+            surface,
             &*self.pointer,
         ));
     }
@@ -149,7 +149,7 @@ impl WinitPointer {
         }
     }
 
-    pub fn drag_window(&self, window: &Window<ConceptFrame>) {
+    pub fn drag_window(&self, window: &Window<FallbackFrame>) {
         window.start_interactive_move(&self.seat, self.latest_serial.get());
     }
 }
@@ -196,12 +196,11 @@ impl Pointers {
         );
 
         // Setup relative_pointer if it's available.
-        let relative_pointer = match relative_pointer_manager.as_ref() {
-            Some(relative_pointer_manager) => {
-                Some(init_relative_pointer(&relative_pointer_manager, &*pointer))
-            }
-            None => None,
-        };
+        let relative_pointer = relative_pointer_manager
+            .as_ref()
+            .map(|relative_pointer_manager| {
+                init_relative_pointer(relative_pointer_manager, &*pointer)
+            });
 
         Self {
             pointer,
@@ -249,7 +248,7 @@ pub(super) fn init_confined_pointer(
     pointer: &WlPointer,
 ) -> ZwpConfinedPointerV1 {
     let confined_pointer =
-        pointer_constraints.confine_pointer(surface, pointer, None, Lifetime::Persistent.to_raw());
+        pointer_constraints.confine_pointer(surface, pointer, None, Lifetime::Persistent);
 
     confined_pointer.quick_assign(move |_, _, _| {});
 


### PR DESCRIPTION
This commit also drops 'Theme' trait with its support types
in favor of 'FallbackFrame' meaning that winit will use some
predefined frame for the time being, since porting 'ConceptFrame'
will require adding font rendering librarires right into winit,
which is not desired.