### PR TITLE
On Wayland, log error for failure to set cursor

### DIFF
--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -112,7 +112,7 @@ impl WinitPointer {
                 return;
             }
         }
-        error!("Failed to set cursor");
+        warn!("Failed to set cursor");
     }
 
     /// Confine the pointer to a surface.

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -112,7 +112,7 @@ impl WinitPointer {
                 return;
             }
         }
-        warn!("Failed to set cursor");
+        warn!("Failed to set cursor to {:?}", cursor_icon);
     }
 
     /// Confine the pointer to a surface.

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -109,9 +109,10 @@ impl WinitPointer {
         let serial = Some(self.latest_serial.get());
         for cursor in cursors {
             if self.pointer.set_cursor(cursor, serial).is_ok() {
-                break;
+                return;
             }
         }
+        error!("Failed to set cursor");
     }
 
     /// Confine the pointer to a surface.


### PR DESCRIPTION
Fixes: #1988

The inability to set the cursor using any of the named cursor files
likely indicates an error in the system on which we are running.
WinitPointer::set_cursor also does not have any way of returning an
error so just log the error to assist users in diagnosing the problem.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
