### PR TITLE
Fix Window visibility regression

### DIFF
--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -882,6 +882,11 @@ unsafe fn post_init<T: 'static>(
         thread_executor: event_loop.create_thread_executor(),
     };
 
+    // Set visible before setting the size
+    // to ensure the the attribute is correctly
+    // applied.
+    win.set_visible(attributes.visible);
+
     let dimensions = attributes
         .inner_size
         .unwrap_or_else(|| PhysicalSize::new(800, 600).into());
@@ -891,7 +896,6 @@ unsafe fn post_init<T: 'static>(
         // `Window::set_inner_size` changes MAXIMIZED to false.
         win.set_maximized(true);
     }
-    win.set_visible(attributes.visible);
 
     if let Some(_) = attributes.fullscreen {
         win.set_fullscreen(attributes.fullscreen);

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -882,9 +882,8 @@ unsafe fn post_init<T: 'static>(
         thread_executor: event_loop.create_thread_executor(),
     };
 
-    // Set visible before setting the size
-    // to ensure the the attribute is correctly
-    // applied.
+    // Set visible before setting the size to ensure the
+    // attribute is correctly applied.
     win.set_visible(attributes.visible);
 
     let dimensions = attributes


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/1980

The `visible` attribute was not correctly applied in case the decorations were disabled. Reordering to ensure that a `WM_NCCALCSIZE` (I think that's the desired event) is triggered due to size update. 

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch

CHANGELOG entry omitted as the regression is not in any release.