### PR TITLE
Add drag-resizing with cursor feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Breaking:** On Wayland, Theme trait and its support types are dropped.
 - On Wayland, bump `smithay-client-toolkit` to 0.15.
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
+- On Windows, added `drag_resize_window` method
 
 
 # 0.25.0 (2021-05-15)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -193,21 +193,22 @@ Legend:
 |Video mode query |✔️    |✔️    |✔️       |✔️          |❌     |✔️      |**N/A**|
 
 ### Input handling
-|Feature                 |Windows   |MacOS   |Linux x11|Linux Wayland|Android|iOS    |WASM      |
-|----------------------- | -----    | ----   | ------- | ----------- | ----- | ----- | -------- |
-|Mouse events            |✔️       |▢[#63]  |✔️       |✔️          |**N/A**|**N/A**|✔️        |
-|Mouse set location      |✔️       |✔️      |✔️       |❓           |**N/A**|**N/A**|**N/A**|
-|Cursor grab             |✔️       |▢[#165] |▢[#242]  |✔️         |**N/A**|**N/A**|❓        |
-|Cursor icon             |✔️       |✔️      |✔️       |✔️           |**N/A**|**N/A**|✔️        |
-|Touch events            |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |
-|Touch pressure          |✔️       |❌      |❌       |❌          |❌    |✔️     |❌        |
-|Multitouch              |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |
-|Keyboard events         |✔️       |✔️      |✔️       |✔️          |❓     |❌     |✔️        |
-|Drag & Drop             |▢[#720]  |▢[#720] |▢[#720]  |❌[#306]    |**N/A**|**N/A**|❓        |
-|Raw Device Events       |▢[#750]  |▢[#750] |▢[#750]  |❌          |❌    |❌     |❓        |
-|Gamepad/Joystick events |❌[#804] |❌      |❌       |❌          |❌    |❌     |❓        |
-|Device movement events  |❓        |❓       |❓       |❓           |❌    |❌     |❓        |
-|Drag window with cursor |✔️         |✔️       |✔️        |✔️            |**N/A**|**N/A**|**N/A**   |
+|Feature                   |Windows   |MacOS    |Linux x11|Linux Wayland|Android |iOS     |WASM     |
+|-----------------------   | -----    | ----    | -------  | ---------- |-----   |-----   | ------- |
+|Mouse events              |✔️        |▢[#63]  |✔️       |✔️          |**N/A** |**N/A** |✔️      |
+|Mouse set location        |✔️        |✔️      |✔️       |❓           |**N/A** |**N/A** |**N/A** |
+|Cursor grab               |✔️        |▢[#165] |▢[#242]  |✔️          |**N/A** |**N/A** |❓       |
+|Cursor icon               |✔️        |✔️      |✔️       |✔️          |**N/A** |**N/A** |✔️      |
+|Touch events              |✔️        |❌      |✔️       |✔️          |✔️      |✔️     |❌      |
+|Touch pressure            |✔️        |❌      |❌       |❌          |❌      |✔️     |❌      |
+|Multitouch                |✔️        |❌      |✔️       |✔️          |✔️      |✔️     |❌      |
+|Keyboard events           |✔️        |✔️      |✔️       |✔️          |❓       |❌     |✔️      |
+|Drag & Drop               |▢[#720]   |▢[#720] |▢[#720]  |❌[#306]    |**N/A** |**N/A** |❓       |
+|Raw Device Events         |▢[#750]   |▢[#750] |▢[#750]  |❌          |❌      |❌     |❓       |
+|Gamepad/Joystick events   |❌[#804]  |❌      |❌       |❌          |❌      |❌     |❓       |
+|Device movement events    |❓         |❓      |❓        |❓           |❌      |❌     |❓       |
+|Drag window with cursor   |✔️        |✔️      |✔️       |✔️          |**N/A** |**N/A** |**N/A**  |
+|Resize window with cursor |✔️        |❌      |❌       |❌          |**N/A** |**N/A** |**N/A**  |
 
 ### Pending API Reworks
 Changes in the API that have been agreed upon but aren't implemented across all platforms.

--- a/examples/borderless.rs
+++ b/examples/borderless.rs
@@ -1,0 +1,156 @@
+use simple_logger::SimpleLogger;
+use winit::{
+    dpi::LogicalSize,
+    event::{
+        ElementState, Event, KeyboardInput, MouseButton, StartCause, VirtualKeyCode, WindowEvent,
+    },
+    event_loop::{ControlFlow, EventLoop},
+    window::{WindowBuilder, ResizeDirection, CursorIcon},
+};
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum CursorLocation{
+    Caption,
+    Top,
+    Bottom,
+    Right,
+    Left,
+    TopRight,
+    TopLeft,
+    BottomRight,
+    BottomLeft,
+    Default
+}
+
+impl CursorLocation{
+    // Conversion to appropriate cursor Icon
+    fn get_cursor_icon(&self) -> CursorIcon {
+        match self {
+            CursorLocation::Top | CursorLocation::Bottom=> CursorIcon::NsResize,
+            CursorLocation::Right | CursorLocation::Left => CursorIcon::EwResize,
+            CursorLocation::TopRight | CursorLocation::BottomLeft => CursorIcon::NeswResize,
+            CursorLocation::TopLeft | CursorLocation::BottomRight => CursorIcon::NwseResize,
+            _ => CursorIcon::Arrow,
+        }
+    }
+
+    // Conversion to a resize direction
+    fn to_resize_direction(&self) -> Option<ResizeDirection> {
+        match self {
+            CursorLocation::Top => Some(ResizeDirection::Top),
+            CursorLocation::Bottom => Some(ResizeDirection::Bottom),
+            CursorLocation::Right => Some(ResizeDirection::Right),
+            CursorLocation::Left => Some(ResizeDirection::Left),
+            CursorLocation::TopRight => Some(ResizeDirection::TopRight),
+            CursorLocation::TopLeft => Some(ResizeDirection::TopLeft),
+            CursorLocation::BottomRight => Some(ResizeDirection::BottomRight),
+            CursorLocation::BottomLeft => Some(ResizeDirection::BottomLeft),
+            _ => None,
+        }
+    }
+
+    // Intersects X locations and Y locations
+    // Assumes that the x_location will only be Left, Right or Default
+    // Assumes that the y_location will only be Top, Caption, Bottom or Default
+    fn intersect(x_location: Self, y_location: Self) -> Self {
+        match (x_location, y_location) {
+            (CursorLocation::Default, _) => y_location,
+            (_, CursorLocation::Default) => x_location,
+            (CursorLocation::Left, CursorLocation::Top) => CursorLocation::TopLeft,
+            (CursorLocation::Left, CursorLocation::Bottom) => CursorLocation::BottomLeft,
+            (CursorLocation::Right, CursorLocation::Top) => CursorLocation::TopRight,
+            (CursorLocation::Right, CursorLocation::Bottom) => CursorLocation::BottomRight,
+            _ => CursorLocation::Default
+        }
+    }
+}
+
+const BORDER: f64 = 5.;
+const CAPTIONHEIGHT: f64 = 20.; // Titlebar
+const INIT_WIDTH: f64 = 400.;
+const INIT_HEIGHT: f64 = 200.;
+
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    window.set_min_inner_size(Some(LogicalSize::new(INIT_WIDTH, INIT_HEIGHT)));
+
+    let mut border = false;
+    window.set_decorations(border);
+
+    let mut cursor_location = CursorLocation::Caption;
+    let mut x_border = INIT_WIDTH - BORDER;
+    let mut y_border = INIT_HEIGHT - BORDER;
+
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::NewEvents(StartCause::Init) => {
+            eprintln!("Press 'B' to toggle borderless \nThe top of the screen functions as a titlebar")
+        }
+        Event::WindowEvent { event, .. } => match event {
+            WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+            WindowEvent::CursorMoved { position, ..} => {
+
+                // Test for X
+                let x_location = if position.x < BORDER {
+                    CursorLocation::Left
+                } else if position.x > x_border {
+                    CursorLocation::Right
+                } else {
+                    CursorLocation::Default
+                };
+
+                // Test for Y 
+                let y_location = if position.y < BORDER {
+                    CursorLocation::Top
+                } else if position.y < CAPTIONHEIGHT {
+                    CursorLocation::Caption
+                } else if position.y > y_border {
+                    CursorLocation::Bottom
+                } else {
+                    CursorLocation::Default
+                };
+
+                let new_location = CursorLocation::intersect(x_location, y_location);
+
+                if new_location != cursor_location {
+                    cursor_location = new_location;
+                    window.set_cursor_icon(cursor_location.get_cursor_icon())
+                }
+            },
+
+            WindowEvent::Resized(new_size) => {
+                x_border = new_size.width as f64 - BORDER;
+                y_border = new_size.height as f64 - BORDER;
+            }
+
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Left,
+                ..
+            } => {
+                if let Some(dir) = cursor_location.to_resize_direction() {
+                    window.drag_resize_window(dir).unwrap()
+                } else if cursor_location == CursorLocation::Caption {
+                    window.drag_window().unwrap()
+                }
+            }
+            WindowEvent::KeyboardInput {
+                input:
+                    KeyboardInput {
+                        state: ElementState::Released,
+                        virtual_keycode: Some(VirtualKeyCode::B),
+                        ..
+                    },
+                ..
+            } => {
+                border = !border;
+                window.set_decorations(border);
+            }
+            _ => (),
+        },
+        _ => (),
+    });
+}

--- a/examples/borderless.rs
+++ b/examples/borderless.rs
@@ -5,11 +5,11 @@ use winit::{
         ElementState, Event, KeyboardInput, MouseButton, StartCause, VirtualKeyCode, WindowEvent,
     },
     event_loop::{ControlFlow, EventLoop},
-    window::{WindowBuilder, ResizeDirection, CursorIcon},
+    window::{CursorIcon, ResizeDirection, WindowBuilder},
 };
 
 #[derive(PartialEq, Eq, Clone, Copy)]
-enum CursorLocation{
+enum CursorLocation {
     Caption,
     Top,
     Bottom,
@@ -19,14 +19,14 @@ enum CursorLocation{
     TopLeft,
     BottomRight,
     BottomLeft,
-    Default
+    Default,
 }
 
-impl CursorLocation{
+impl CursorLocation {
     // Conversion to appropriate cursor Icon
     fn get_cursor_icon(&self) -> CursorIcon {
         match self {
-            CursorLocation::Top | CursorLocation::Bottom=> CursorIcon::NsResize,
+            CursorLocation::Top | CursorLocation::Bottom => CursorIcon::NsResize,
             CursorLocation::Right | CursorLocation::Left => CursorIcon::EwResize,
             CursorLocation::TopRight | CursorLocation::BottomLeft => CursorIcon::NeswResize,
             CursorLocation::TopLeft | CursorLocation::BottomRight => CursorIcon::NwseResize,
@@ -60,7 +60,7 @@ impl CursorLocation{
             (CursorLocation::Left, CursorLocation::Bottom) => CursorLocation::BottomLeft,
             (CursorLocation::Right, CursorLocation::Top) => CursorLocation::TopRight,
             (CursorLocation::Right, CursorLocation::Bottom) => CursorLocation::BottomRight,
-            _ => CursorLocation::Default
+            _ => CursorLocation::Default,
         }
     }
 }
@@ -69,7 +69,6 @@ const BORDER: f64 = 5.;
 const CAPTIONHEIGHT: f64 = 20.; // Titlebar
 const INIT_WIDTH: f64 = 400.;
 const INIT_HEIGHT: f64 = 200.;
-
 
 fn main() {
     SimpleLogger::new().init().unwrap();
@@ -87,12 +86,13 @@ fn main() {
 
     event_loop.run(move |event, _, control_flow| match event {
         Event::NewEvents(StartCause::Init) => {
-            eprintln!("Press 'B' to toggle borderless \nThe top of the screen functions as a titlebar")
+            eprintln!(
+                "Press 'B' to toggle borderless \nThe top of the screen functions as a titlebar"
+            )
         }
         Event::WindowEvent { event, .. } => match event {
             WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
-            WindowEvent::CursorMoved { position, ..} => {
-
+            WindowEvent::CursorMoved { position, .. } => {
                 // Test for X
                 let x_location = if position.x < BORDER {
                     CursorLocation::Left
@@ -102,7 +102,7 @@ fn main() {
                     CursorLocation::Default
                 };
 
-                // Test for Y 
+                // Test for Y
                 let y_location = if position.y < BORDER {
                     CursorLocation::Top
                 } else if position.y < CAPTIONHEIGHT {
@@ -119,7 +119,7 @@ fn main() {
                     cursor_location = new_location;
                     window.set_cursor_icon(cursor_location.get_cursor_icon())
                 }
-            },
+            }
 
             WindowEvent::Resized(new_size) => {
                 x_border = new_size.width as f64 - BORDER;

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -587,7 +587,7 @@ impl Window {
         ))
     }
 
-    pub fn drag_resize_window(&self) -> Result<(), error::ExternalError> {
+    pub fn drag_resize_window(&self, _direction: Window::ResizeDirection) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(
             error::NotSupportedError::new(),
         ))

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -589,7 +589,7 @@ impl Window {
 
     pub fn drag_resize_window(
         &self,
-        _direction: Window::ResizeDirection,
+        _direction: window::ResizeDirection,
     ) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(
             error::NotSupportedError::new(),

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -587,6 +587,12 @@ impl Window {
         ))
     }
 
+    pub fn drag_resize_window(&self) -> Result<(), error::ExternalError> {
+        Err(error::ExternalError::NotSupported(
+            error::NotSupportedError::new(),
+        ))
+    }
+
     pub fn raw_window_handle(&self) -> raw_window_handle::RawWindowHandle {
         let a_native_window = if let Some(native_window) = ndk_glue::native_window().as_ref() {
             unsafe { native_window.ptr().as_mut() as *mut _ as *mut _ }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -587,7 +587,10 @@ impl Window {
         ))
     }
 
-    pub fn drag_resize_window(&self, _direction: Window::ResizeDirection) -> Result<(), error::ExternalError> {
+    pub fn drag_resize_window(
+        &self,
+        _direction: Window::ResizeDirection,
+    ) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(
             error::NotSupportedError::new(),
         ))

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -23,7 +23,8 @@ use crate::{
         monitor, view, EventLoopWindowTarget, MonitorHandle,
     },
     window::{
-        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
+        CursorIcon, Fullscreen, ResizeDirection, UserAttentionType, WindowAttributes,
+        WindowId as RootWindowId,
     },
 };
 
@@ -186,10 +187,7 @@ impl Inner {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn drag_resize_window(
-        &self,
-        _direction: Window::ResizeDirection,
-    ) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -186,7 +186,7 @@ impl Inner {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(&self, _direction: Window::ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -186,7 +186,10 @@ impl Inner {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn drag_resize_window(&self, _direction: Window::ResizeDirection) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(
+        &self,
+        _direction: Window::ResizeDirection,
+    ) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -186,6 +186,10 @@ impl Inner {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
+    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
     pub fn set_minimized(&self, _minimized: bool) {
         warn!("`Window::set_minimized` is ignored on iOS")
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
     icon::Icon,
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
-    window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
+    window::{CursorIcon, Fullscreen, ResizeDirection, UserAttentionType, WindowAttributes},
 };
 
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
@@ -361,6 +361,11 @@ impl Window {
     #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         x11_or_wayland!(match self; Window(window) => window.drag_window())
+    }
+
+    #[inline]
+    pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+        x11_or_wayland!(match self; Window(window) => window.drag_resize_window(direction))
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -448,6 +448,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
+    #[inline]
     pub fn set_ime_position(&self, position: Position) {
         let scale_factor = self.scale_factor() as f64;
         let position = position.to_logical(scale_factor);

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -17,7 +17,7 @@ use crate::platform_impl::{
     MonitorHandle as PlatformMonitorHandle, OsError,
     PlatformSpecificWindowBuilderAttributes as PlatformAttributes,
 };
-use crate::window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes};
+use crate::window::{CursorIcon, Fullscreen, ResizeDirection, UserAttentionType, WindowAttributes};
 
 use super::env::WindowingFeatures;
 use super::event_loop::WinitState;
@@ -448,7 +448,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1351,6 +1351,11 @@ impl UnownedWindow {
             .map_err(|err| ExternalError::Os(os_error!(OsError::XError(err))))
     }
 
+    #[inline]
+    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
     pub(crate) fn set_ime_position_physical(&self, x: i32, y: i32) {
         let _ = self
             .ime_sender

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -22,7 +22,7 @@ use crate::{
         MonitorHandle as PlatformMonitorHandle, OsError, PlatformSpecificWindowBuilderAttributes,
         VideoMode as PlatformVideoMode,
     },
-    window::{CursorIcon, Fullscreen, Icon, UserAttentionType, WindowAttributes},
+    window::{CursorIcon, Fullscreen, Icon, ResizeDirection, UserAttentionType, WindowAttributes},
 };
 
 use super::{ffi, util, EventLoopWindowTarget, ImeSender, WindowId, XConnection, XError};
@@ -1352,7 +1352,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -29,7 +29,7 @@ use crate::{
         OsError,
     },
     window::{
-        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
+        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId, ResizeDirection,
     },
 };
 use cocoa::{
@@ -614,7 +614,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -29,7 +29,8 @@ use crate::{
         OsError,
     },
     window::{
-        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId, ResizeDirection,
+        CursorIcon, Fullscreen, ResizeDirection, UserAttentionType, WindowAttributes,
+        WindowId as RootWindowId,
     },
 };
 use cocoa::{

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -613,6 +613,11 @@ impl UnownedWindow {
         Ok(())
     }
 
+    #[inline]
+    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
     pub(crate) fn is_zoomed(&self) -> bool {
         // because `isZoomed` doesn't work if the window's borderless,
         // we make it resizable temporalily.

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -4,7 +4,8 @@ use crate::event;
 use crate::icon::Icon;
 use crate::monitor::MonitorHandle as RootMH;
 use crate::window::{
-    CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWI,
+    CursorIcon, Fullscreen, ResizeDirection, UserAttentionType, WindowAttributes,
+    WindowId as RootWI,
 };
 
 use raw_window_handle::web::WebHandle;
@@ -228,10 +229,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn drag_resize_window(
-        &self,
-        _direction: Window::ResizeDirection,
-    ) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -228,7 +228,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn drag_resize_window(&self, _direction: Window::ResizeDirection) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(
+        &self,
+        _direction: Window::ResizeDirection,
+    ) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -228,7 +228,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(&self, _direction: Window::ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -228,6 +228,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn drag_resize_window(&self) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
+    #[inline]
     pub fn set_minimized(&self, _minimized: bool) {
         // Intentionally a no-op, as canvases cannot be 'minimized'
     }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -46,7 +46,7 @@ use crate::{
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
         Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
-    window::{CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes, ResizeDirection},
+    window::{CursorIcon, Fullscreen, ResizeDirection, Theme, UserAttentionType, WindowAttributes},
 };
 
 /// The Win32 implementation of the main `Window` object.
@@ -390,7 +390,7 @@ impl Window {
             ResizeDirection::TopLeft => winuser::HTTOPLEFT,
             ResizeDirection::TopRight => winuser::HTTOPRIGHT,
             ResizeDirection::BottomLeft => winuser::HTBOTTOMLEFT,
-            ResizeDirection::BottomRight => winuser::HTBOTTOMRIGHT
+            ResizeDirection::BottomRight => winuser::HTBOTTOMRIGHT,
         };
 
         unsafe {
@@ -405,10 +405,10 @@ impl Window {
             };
             winuser::ReleaseCapture();
             winuser::PostMessageW(
-                self.window.0, 
+                self.window.0,
                 winuser::WM_NCLBUTTONDOWN, // Non-Client Left Button Down
                 ht_dir as WPARAM,
-                &points as *const _ as LPARAM
+                &points as *const _ as LPARAM,
             );
         }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -188,16 +188,22 @@ impl WindowFlags {
     }
 
     pub fn to_window_styles(self) -> (DWORD, DWORD) {
+        // WS_CAPTION: The Titlebar
+        // WS_SYSMENU | WS_MAXIMIZEBOX | WS_MINIMIZEBOX; These add the titlebar buttons close /min /max etc
+        // WS_SIZEBOX: The window has a sizing border. Same as the WS_THICKFRAME style
+
         use winapi::um::winuser::*;
 
         let (mut style, mut style_ex) = (0, 0);
 
-        if self.contains(WindowFlags::RESIZABLE) {
-            style |= WS_SIZEBOX | WS_MAXIMIZEBOX;
-        }
         if self.contains(WindowFlags::DECORATIONS) {
-            style |= WS_CAPTION | WS_MINIMIZEBOX | WS_BORDER;
-            style_ex = WS_EX_WINDOWEDGE;
+            style |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX; // Note WS_BORDER IS INCLUDED IN WS_CAPTION
+            style_ex |= WS_EX_WINDOWEDGE;
+
+            // Nest inside Decorations to preserve borderless windows
+            if self.contains(WindowFlags::RESIZABLE) {
+                style |= WS_SIZEBOX | WS_MAXIMIZEBOX;
+            }
         }
         if self.contains(WindowFlags::VISIBLE) {
             style |= WS_VISIBLE;
@@ -224,7 +230,7 @@ impl WindowFlags {
             style |= WS_MAXIMIZE;
         }
 
-        style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
+        style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN;
         style_ex |= WS_EX_ACCEPTFILES;
 
         if self.intersects(

--- a/src/window.rs
+++ b/src/window.rs
@@ -755,9 +755,10 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Wayland:** Unsupported.
+    /// - **iOS / Android / Web :** Unsupported.
     /// - **macOS:** `None` has no effect.
     /// - **X11:** Requests for user attention must be manually cleared.
+    /// - **Wayland:** Requires `xdg_activation_v1` protocol, `None` has no effect.
     #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
         self.window.request_user_attention(request_type)

--- a/src/window.rs
+++ b/src/window.rs
@@ -755,10 +755,9 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web :** Unsupported.
+    /// - **iOS / Android / Web / Wayland:** Unsupported.
     /// - **macOS:** `None` has no effect.
     /// - **X11:** Requests for user attention must be manually cleared.
-    /// - **Wayland:** Requires `xdg_activation_v1` protocol, `None` has no effect.
     #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
         self.window.request_user_attention(request_type)
@@ -832,6 +831,16 @@ impl Window {
     #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         self.window.drag_window()
+    }
+
+    /// Resizes the window with the left mouse button until the button is relased
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / Wayland / X11:** Always returns an [`ExternalError::NotSupported`].
+    #[inline]
+    pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+        self.window.drag_resize_window(direction)
     }
 }
 
@@ -955,6 +964,20 @@ impl Default for CursorIcon {
     fn default() -> Self {
         CursorIcon::Default
     }
+}
+
+/// Directional enumeration representing a location on the border of a window
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ResizeDirection {
+    Top,
+    Bottom,
+    Left,
+    Right,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight
 }
 
 /// Fullscreen modes.

--- a/src/window.rs
+++ b/src/window.rs
@@ -836,6 +836,9 @@ impl Window {
 
     /// Resizes the window with the left mouse button until the button is relased
     ///
+    /// There's no guarantee that this will work unless the left mouse button was pressed
+    /// immediately before this function is called.
+    ///
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web / Wayland / X11:** Always returns an [`ExternalError::NotSupported`].

--- a/src/window.rs
+++ b/src/window.rs
@@ -977,7 +977,7 @@ pub enum ResizeDirection {
     TopLeft,
     TopRight,
     BottomLeft,
-    BottomRight
+    BottomRight,
 }
 
 /// Fullscreen modes.


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fix for https://github.com/rust-windowing/winit/issues/725 on windows
Similar in scope to https://github.com/rust-windowing/winit/pull/1840

This has only been implemented for windows:  
This [comment](https://github.com/rust-windowing/winit/issues/725#issuecomment-873463281) offer insight as to how this would translate to Linux platforms.

As far as using this to make a borderless window in similar fashion to electron, the approach has several drawbacks:
- No window resizing from win-hotkeys
- No shadows on the borders

To solve those issues [this SO Question](https://stackoverflow.com/questions/39731497/create-window-without-titlebar-with-resizable-border-and-without-bogus-6px-whit) and [this windows dev tutorial](https://docs.microsoft.com/en-us/windows/win32/dwm/customframe?redirectedfrom=MSDN) seem to be the standard. I don't understand how this would fit into winit at this time however.

I briefly experimented with removing the title bar and not the border through winapi, which also seems to mostly solve the issues above and this may be preferable to hiding *all* decorations and implementing standard window functionality manually.