### PR TITLE
Fix transparency on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On X11, select an appropriate visual for transparency if is requested
 - On Wayland and X11, fix diagonal window resize cursor orientation.
 - On macOS, drop the event callback before exiting.
 - On Android, implement `Window::request_redraw`

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -239,11 +239,6 @@ impl UnownedWindow {
             window_attributes |= ffi::CWOverrideRedirect;
         }
 
-        xconn
-            .sync_with_server()
-            .map_err(|x_err| os_error!(OsError::XError(x_err)))
-            .unwrap();
-
         // finally creating the window
         let xwindow = unsafe {
             (xconn.xlib.XCreateWindow)(
@@ -261,11 +256,6 @@ impl UnownedWindow {
                 &mut set_win_attr,
             )
         };
-
-        xconn
-            .sync_with_server()
-            .map_err(|x_err| os_error!(OsError::XError(x_err)))
-            .unwrap();
 
         let mut window = UnownedWindow {
             xconn: Arc::clone(xconn),


### PR DESCRIPTION
This PR fixes the broke transparency feature on X11.

Note that for this [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md) said that this already worked, but it was code as TODO and only would work if someone provide a custom visual, which is not documented. This PR fixes that, allowing winit to find an appropriate visual for transparency.

This also fix [this issue](https://github.com/gfx-rs/wgpu/issues/687) in wgpu for X11 allowing to create transparent background(I just tried that, I didn't do extensive testing).

- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
