### PR TITLE
Windows: Increase wait timer resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 - On Wayland, bump `smithay-client-toolkit` to 0.15.
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
-
 - On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
 
 # 0.25.0 (2021-05-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
 
+- On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
+
 # 0.25.0 (2021-05-15)
 
 - **Breaking:** On macOS, replace `WindowBuilderExtMacOS::with_activation_policy` with `EventLoopExtMacOS::set_activation_policy`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,8 @@ features = [
     "wingdi",
     "winnt",
     "winuser",
+    "mmsystem",
+    "timeapi"
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -383,7 +383,7 @@ fn wait_thread(parent_thread_id: DWORD, msg_window_id: HWND) {
                 let now = Instant::now();
                 if now < wait_until {
                     // Windows' scheduler has a default accuracy of several ms. This isn't good enough for
-                    // `WaitUntil`, so we request the Windows' scheduler to use a higher accuracy if possible.
+                    // `WaitUntil`, so we request the Windows scheduler to use a higher accuracy if possible.
                     // If we couldn't query the timer capabilities, then we use the default resolution.
                     if let Some(period) = *WAIT_PERIOD_MIN {
                         timeapi::timeBeginPeriod(period);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -25,7 +25,7 @@ use winapi::{
         windowsx, winerror,
     },
     um::{
-        libloaderapi, ole2, processthreadsapi, winbase,
+        libloaderapi, mmsystem, ole2, processthreadsapi, timeapi, winbase,
         winnt::{HANDLE, LONG, LPCSTR, SHORT},
         winuser,
     },
@@ -324,6 +324,22 @@ fn get_wait_thread_id() -> DWORD {
     }
 }
 
+lazy_static! {
+    static ref WAIT_PERIOD_MIN: Option<UINT> = unsafe {
+        let mut caps = mmsystem::TIMECAPS {
+            wPeriodMin: 0,
+            wPeriodMax: 0,
+        };
+        if timeapi::timeGetDevCaps(&mut caps, mem::size_of::<mmsystem::TIMECAPS>() as _)
+            == mmsystem::TIMERR_NOERROR
+        {
+            Some(caps.wPeriodMin)
+        } else {
+            None
+        }
+    };
+}
+
 fn wait_thread(parent_thread_id: DWORD, msg_window_id: HWND) {
     unsafe {
         let mut msg: winuser::MSG;
@@ -366,16 +382,26 @@ fn wait_thread(parent_thread_id: DWORD, msg_window_id: HWND) {
             if let Some(wait_until) = wait_until_opt {
                 let now = Instant::now();
                 if now < wait_until {
-                    // MsgWaitForMultipleObjects tends to overshoot just a little bit. We subtract
-                    // 1 millisecond from the requested time and spinlock for the remainder to
-                    // compensate for that.
+                    // Windows' scheduler has a default accuracy of several ms. This isn't good enough for
+                    // `WaitUntil`, so we request the Windows' scheduler to use a higher accuracy if possible.
+                    // If we couldn't query the timer capabilities, then we use the default resolution.
+                    if let Some(period) = *WAIT_PERIOD_MIN {
+                        timeapi::timeBeginPeriod(period);
+                    }
+                    // `MsgWaitForMultipleObjects` is bound by the granularity of the scheduler period.
+                    // Because of this, we try to reduce the requested time just enough to undershoot `wait_until`
+                    // by the smallest amount possible, and then we busy loop for the remaining time inside the
+                    // NewEvents message handler.
                     let resume_reason = winuser::MsgWaitForMultipleObjectsEx(
                         0,
                         ptr::null(),
-                        dur2timeout(wait_until - now).saturating_sub(1),
+                        dur2timeout(wait_until - now).saturating_sub(WAIT_PERIOD_MIN.unwrap_or(1)),
                         winuser::QS_ALLEVENTS,
                         winuser::MWMO_INPUTAVAILABLE,
                     );
+                    if let Some(period) = *WAIT_PERIOD_MIN {
+                        timeapi::timeEndPeriod(period);
+                    }
                     if resume_reason == winerror::WAIT_TIMEOUT {
                         winuser::PostMessageW(msg_window_id, *PROCESS_NEW_EVENTS_MSG_ID, 0, 0);
                         wait_until_opt = None;


### PR DESCRIPTION
Addresses #2005 

Temporarily increase the timer resolution for the wait operation. By default it's around 16ms which is too long for most realtime applications and leads to unpredictable results. A future enhancement in this direction could be allow the user to control it. Possible use case would be UI application with some animations running with minimal energy impact.

Reported by https://twitter.com/olson_dan/status/1428840173354160128?s=20
With the given change for the wgpu `water` example the framerate is much closer to the target of 16.6ms on my system.

Before
```
Avg frame time 28.707153ms
Avg frame time 28.356724ms
Avg frame time 28.303003ms
Avg frame time 28.835732ms
Avg frame time 29.122643ms
Avg frame time 27.729534ms
```

After
```
Avg frame time 16.845396ms
Avg frame time 16.859407ms
Avg frame time 16.840519ms
Avg frame time 16.862593ms
Avg frame time 16.856462ms
Avg frame time 16.870092ms
Avg frame time 16.868887ms
```

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
