### PR TITLE
Fix potential bug

### DIFF
--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -213,7 +213,7 @@ impl UnownedWindow {
                     let visual = vi.visual;
                     (xconn.xlib.XCreateColormap)(xconn.display, root, visual, ffi::AllocNone)
                 }
-            } else if window_attrs.transparent {
+            } else if visual as c_int != ffi::CopyFromParent {
                 unsafe { (xconn.xlib.XCreateColormap)(xconn.display, root, visual, ffi::AllocNone) }
             } else {
                 0

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -181,8 +181,8 @@ impl UnownedWindow {
         };
 
         // creating
-        let (visual, depth) = match pl_attribs.visual_infos {
-            Some(vi) => (vi.visual, vi.depth),
+        let (visual, depth, require_colormap) = match pl_attribs.visual_infos {
+            Some(vi) => (vi.visual, vi.depth, false),
             None if window_attrs.transparent == true => {
                 // Find a suitable visual
                 let mut vinfo = MaybeUninit::uninit();
@@ -197,13 +197,21 @@ impl UnownedWindow {
                 };
                 if vinfo_initialized {
                     let vinfo = unsafe { vinfo.assume_init() };
-                    (vinfo.visual, vinfo.depth)
+                    (vinfo.visual, vinfo.depth, true)
                 } else {
                     debug!("Could not set transparency, because XMatchVisualInfo returned zero for the required parameters");
-                    (ffi::CopyFromParent as *mut ffi::Visual, ffi::CopyFromParent)
+                    (
+                        ffi::CopyFromParent as *mut ffi::Visual,
+                        ffi::CopyFromParent,
+                        false,
+                    )
                 }
             }
-            _ => (ffi::CopyFromParent as *mut ffi::Visual, ffi::CopyFromParent),
+            _ => (
+                ffi::CopyFromParent as *mut ffi::Visual,
+                ffi::CopyFromParent,
+                false,
+            ),
         };
 
         let mut set_win_attr = {
@@ -213,7 +221,7 @@ impl UnownedWindow {
                     let visual = vi.visual;
                     (xconn.xlib.XCreateColormap)(xconn.display, root, visual, ffi::AllocNone)
                 }
-            } else if visual as c_int != ffi::CopyFromParent {
+            } else if require_colormap {
                 unsafe { (xconn.xlib.XCreateColormap)(xconn.display, root, visual, ffi::AllocNone) }
             } else {
                 0


### PR DESCRIPTION
So, after my last PR I realized of at small bug that can happen if we cannot find a visual for transparency. If that is the case the code anyway will attempt to create a `ColorMap` with `ffi::CopyFromParent` which even if I'm not sure what the result would be is not the intended behavior and I think that can possible cause problems.

- [X] Tested on all platforms changed
- [X] Compilation warnings were addressed
- [X] `cargo fmt` has been run on this branch
- [X] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
