### PR TITLE
Windows: replace struct interface with one from crate

### DIFF
--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -11,7 +11,7 @@ use winapi::{
         windef::HWND,
         winerror::S_OK,
     },
-    um::{libloaderapi, uxtheme, winuser},
+    um::{libloaderapi, uxtheme, winuser,HIGHCONTRASTA},
 };
 
 use crate::window::Theme;
@@ -184,13 +184,6 @@ fn should_apps_use_dark_mode() -> bool {
 // FIXME: This definition was missing from winapi. Can remove from
 // here and use winapi once the following PR is released:
 // https://github.com/retep998/winapi-rs/pull/815
-#[repr(C)]
-#[allow(non_snake_case)]
-struct HIGHCONTRASTA {
-    cbSize: UINT,
-    dwFlags: DWORD,
-    lpszDefaultScheme: LPSTR,
-}
 
 const HCF_HIGHCONTRASTON: DWORD = 1;
 

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -11,7 +11,7 @@ use winapi::{
         windef::HWND,
         winerror::S_OK,
     },
-    um::{libloaderapi, uxtheme, winuser,HIGHCONTRASTA},
+    um::{libloaderapi, uxtheme, winuser, HIGHCONTRASTA},
 };
 
 use crate::window::Theme;

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -181,10 +181,6 @@ fn should_apps_use_dark_mode() -> bool {
         .unwrap_or(false)
 }
 
-// FIXME: This definition was missing from winapi. Can remove from
-// here and use winapi once the following PR is released:
-// https://github.com/retep998/winapi-rs/pull/815
-
 const HCF_HIGHCONTRASTON: DWORD = 1;
 
 fn is_high_contrast() -> bool {


### PR DESCRIPTION
I replaced  the temporary struct with one from crate in windows/dark-mode.rs according to comment.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- []  Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
