### PR TITLE
Fix wasm CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,6 @@ jobs:
     - name: Install cargo-apk
       if: contains(matrix.platform.target, 'android')
       run: cargo install cargo-apk
-    - name: Install cargo-web
-      continue-on-error: true
-      if: contains(matrix.platform.target, 'wasm32')
-      run: cargo install cargo-web
 
     - name: Check documentation
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - { target: aarch64-apple-ios,        os: macos-latest,    }
           # We're using Windows rather than Ubuntu to run the wasm tests because caching cargo-web
           # doesn't currently work on Linux.
-          - { target: wasm32-unknown-unknown,   os: windows-latest, cmd: web }
+          - { target: wasm32-unknown-unknown,   os: windows-latest,  }
 
     env:
       RUST_BACKTRACE: 1

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -99,7 +99,7 @@ fn main() {
                         if wait_cancelled {
                             *control_flow
                         } else {
-                            ControlFlow::WaitUntil(time::Instant::now() + WAIT_TIME)
+                            ControlFlow::WaitUntil(instant::Instant::now() + WAIT_TIME)
                         }
                     }
                     Mode::Poll => {

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -7,6 +7,7 @@ use winit::{
     window::WindowBuilder,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
@@ -37,4 +38,9 @@ fn main() {
             _ => (),
         }
     });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {
+    unimplemented!() // `Window` can't be sent between threads
 }


### PR DESCRIPTION
This removes the `cargo-web` CI dependency as development has stalled and apparently didn't check our examples correctly.
Patched the issues which appeared when running with `cargo test` for the wasm32-unknown-unknown target,

While the underlying issue with `--profile` regression might be fixed in the upcoming cargo release in 5-6 weeks I think it makes sense to remove the extra dependency on our side.

Results from my fork: https://github.com/msiglreith/winit/runs/3601802273

- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented