### PR TITLE
macOS: Fix native file dialogs freezing the event loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.4.
 - On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
 - On macOS, fix native file dialogs hanging the even loop.
+- On macOS, fix native file dialogs hanging the event loop.
 
 # 0.25.0 (2021-05-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@
 - On Wayland, add an enabled-by-default feature called `wayland-dlopen` so users can opt out of using `dlopen` to load system libraries.
 - **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.4.
 - On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
-- On macOS, fix native file dialogs hanging the even loop.
 - On macOS, fix native file dialogs hanging the event loop.
 
 # 0.25.0 (2021-05-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - On Wayland, add an enabled-by-default feature called `wayland-dlopen` so users can opt out of using `dlopen` to load system libraries.
 - **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.4.
 - On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
+- On macOS, fix native file dialogs hanging the even loop.
 
 # 0.25.0 (2021-05-15)
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -307,6 +307,8 @@ impl AppState {
         let panic_info = panic_info
             .upgrade()
             .expect("The panic info must exist here. This failure indicates a developer error.");
+
+        // Return when in callback due to https://github.com/rust-windowing/winit/issues/1779
         if panic_info.is_panicking() || !HANDLER.is_ready() || HANDLER.get_in_callback() {
             return;
         }
@@ -371,6 +373,8 @@ impl AppState {
         let panic_info = panic_info
             .upgrade()
             .expect("The panic info must exist here. This failure indicates a developer error.");
+
+        // Return when in callback due to https://github.com/rust-windowing/winit/issues/1779
         if panic_info.is_panicking() || !HANDLER.is_ready() || HANDLER.get_in_callback() {
             return;
         }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -307,7 +307,7 @@ impl AppState {
         let panic_info = panic_info
             .upgrade()
             .expect("The panic info must exist here. This failure indicates a developer error.");
-        if panic_info.is_panicking() || !HANDLER.is_ready() {
+        if panic_info.is_panicking() || !HANDLER.is_ready() || HANDLER.get_in_callback() {
             return;
         }
         let start = HANDLER.get_start_time().unwrap();
@@ -371,24 +371,23 @@ impl AppState {
         let panic_info = panic_info
             .upgrade()
             .expect("The panic info must exist here. This failure indicates a developer error.");
-        if panic_info.is_panicking() || !HANDLER.is_ready() {
+        if panic_info.is_panicking() || !HANDLER.is_ready() || HANDLER.get_in_callback() {
             return;
         }
-        if !HANDLER.get_in_callback() {
-            HANDLER.set_in_callback(true);
-            HANDLER.handle_user_events();
-            for event in HANDLER.take_events() {
-                HANDLER.handle_nonuser_event(event);
-            }
-            HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::MainEventsCleared));
-            for window_id in HANDLER.should_redraw() {
-                HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawRequested(
-                    window_id,
-                )));
-            }
-            HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawEventsCleared));
-            HANDLER.set_in_callback(false);
+
+        HANDLER.set_in_callback(true);
+        HANDLER.handle_user_events();
+        for event in HANDLER.take_events() {
+            HANDLER.handle_nonuser_event(event);
         }
+        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::MainEventsCleared));
+        for window_id in HANDLER.should_redraw() {
+            HANDLER
+                .handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawRequested(window_id)));
+        }
+        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawEventsCleared));
+        HANDLER.set_in_callback(false);
+
         if HANDLER.should_exit() {
             unsafe {
                 let app: id = NSApp();


### PR DESCRIPTION
Closes https://github.com/rust-windowing/winit/issues/1779

Previously all native dialogs, such as [rfd](https://github.com/PolyMeilex/rfd), would cause the event loop (event_loop.run) to freeze.

All code by @PolyMeilex (at https://github.com/PolyMeilex/winit/commit/e4a0a15fc42496a03b76a633ea9d123209751f39)

I just opened the PR as @PolyMeilex says he doesn't have the time for it right now.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] ~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- [ ] ~Created or updated an example program if it would help users understand this functionality~
- [ ] ~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~
