### PR TITLE
Update smithay-client-toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - On macOS, fix issue where `ReceivedCharacter` was not being emitted during some key repeat events.
 - On Wayland, load cursor icons `hand2` and `hand1` for `CursorIcon::Hand`.
 - **Breaking:** On Wayland, Theme trait and its support types are dropped.
-- On Wayland, bump `smithay-client-toolkit` to 0.15.
+- On Wayland, bump `smithay-client-toolkit` to 0.15.1.
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ features = [
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 wayland-client = { version = "0.29", features = [ "dlopen"], optional = true }
 wayland-protocols = { version = "0.29", features = [ "staging_protocols"], optional = true }
-sctk = { package = "smithay-client-toolkit", version = "0.15.0", optional = true }
+sctk = { package = "smithay-client-toolkit", version = "0.15.1", optional = true }
 mio = { version = "0.7", features = ["os-ext"], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }


### PR DESCRIPTION
to fix libxcbcommon linking on OpenBSD by using pkg-config when
building without dlopen feature.
For details see [`Smithay/client-toolkit#198`](https://github.com/Smithay/client-toolkit/pull/198).
This will address [`alacritty/alacritty#5422`](https://github.com/alacritty/alacritty/issues/5422) and [`alacritty/alacritty#5497`](https://github.com/alacritty/alacritty/issues/5497)

---

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Updated entry in `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
