### PR TITLE
Add cargo audit CI + audit and deps.rs badges

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,28 @@
+name: Audit
+
+# This is a separate file so it can have a separate badge in readme
+# and therefore spread awareness of cargo audit a tiny bit.
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    # Runs at 15:00 UTC on Fri
+    - cron: "0 15 * * 5"
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/install@v0.1
+        with:
+          crate: cargo-audit
+          version: latest
+      - run: cargo audit --version
+      - run: cargo audit --deny warnings

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Crates.io](https://img.shields.io/crates/v/winit.svg)](https://crates.io/crates/winit)
 [![Docs.rs](https://docs.rs/winit/badge.svg)](https://docs.rs/winit)
 [![CI Status](https://github.com/rust-windowing/winit/workflows/CI/badge.svg)](https://github.com/rust-windowing/winit/actions)
+[![Cargo Audit](https://github.com/rust-windowing/winit/workflows/Audit/badge.svg)](https://github.com/rust-windowing/winit/actions)
+[![Dependency Status](https://deps.rs/repo/github/rust-windowing/winit/status.svg)](https://deps.rs/repo/github/rust-windowing/winit)
 
 ```toml
 [dependencies]


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This will allow to automatically detect potential vulnerabilities as part of CI. It also runs periodically once a week because new ones can be discovered as time passes without any changes to winit.

I also added 2 badges to readme
- For cargo audit - I think a separate badge is better because it helps spread awareness of cargo audit and as more crates throughout the ecosystem begin using it, issues will be fixed faster.
- For deps.rs - It helps people notice outdated dependencies faster and often can be used to quickly determine the health / maintenance status of a project.

Currently winit transitively depends on time and chrono which have advisories released for them (but chrono [doesn't yet have a fix](https://github.com/chronotope/chrono/issues/602)), this means CI will fail and that's expected. You might want to merge this PR only after those have been fixed to avoid a constantly failing CI. It's also possible to avoid them by using simple_logger without default features (but then logs in examples will lack timestamps AFAICT).