### PR TITLE
On Wayland, add wayland-dlopen feature to use dlopen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           - { target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
           - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: x11 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: wayland }
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "wayland,wayland-dlopen" }
           - { target: aarch64-linux-android,    os: ubuntu-latest,  cmd: 'apk --' }
           - { target: x86_64-apple-darwin,      os: macos-latest,    }
           - { target: x86_64-apple-ios,         os: macos-latest,    }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
 - On X11, if RANDR based scale factor is higher than 20 reset it to 1
-- On Wayland, feature `wayland-dlopen` to use `dlopen` for opening system libraries enabled by default.
+- On Wayland, add an enabled-by-default feature called `wayland-dlopen` so users can opt out of using `dlopen` to load system libraries.
 
 # 0.25.0 (2021-05-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
 - On X11, if RANDR based scale factor is higher than 20 reset it to 1
+- On Wayland, feature `wayland-dlopen` to use `dlopen` for opening system libraries enabled by default.
 
 # 0.25.0 (2021-05-15)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc", "i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-unknown-unknown"]
 
 [features]
-default = ["x11", "wayland"]
+default = ["x11", "wayland", "wayland-dlopen"]
 x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
 wayland = ["wayland-client", "wayland-protocols", "sctk"]
+wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
 
 [dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }
@@ -83,9 +84,9 @@ features = [
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
-wayland-client = { version = "0.29", features = [ "dlopen"], optional = true }
+wayland-client = { version = "0.29", default_features = false,  features = ["use_system_lib"], optional = true }
 wayland-protocols = { version = "0.29", features = [ "staging_protocols"], optional = true }
-sctk = { package = "smithay-client-toolkit", version = "0.15.1", optional = true }
+sctk = { package = "smithay-client-toolkit", version = "0.15.1", default_features = false, features = ["calloop"],  optional = true }
 mio = { version = "0.7", features = ["os-ext"], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }


### PR DESCRIPTION
While winit was always using dlopen for opening system libs, it
provides a way now to disable dlopen feature helping with linking
on some targets.

Fixes #2037.