### PR TITLE
macOS: titlebar in borderless fullscreen fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- On macOS, fixed being unable to reveal the titlebar in borderless fullscreen mode.
 - On Android, fixed `WindowExtAndroid::config` initially returning an empty `Configuration`.
 - On Android, fixed `Window::scale_factor` and `MonitorHandle::scale_factor` initially always returning 1.0.
 - On X11, select an appropriate visual for transparency if is requested


### PR DESCRIPTION
Fixes #1195, but does not implement the user-facing changes talked about in that issue (should we create a new issue for that feature?)


- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
