### PR TITLE
Android: Bump ndk/ndk-glue version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - On Wayland, implement `request_user_attention` with `xdg_activation_v1`.
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
 - On X11, if RANDR based scale factor is higher than 20 reset it to 1
+- **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.4.
 
 # 0.25.0 (2021-05-15)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,9 @@ image = "0.23.12"
 simple_logger = "1.9"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = "0.3"
+ndk = "0.4"
 ndk-sys = "0.2.0"
-ndk-glue = "0.3"
+ndk-glue = "0.4"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The `ndk_glue` version needs to match the version used by `winit`. Otherwise, th
 | :---: | :------------------: |
 | 0.24  | `ndk_glue = "0.2.0"` |
 | 0.25  | `ndk_glue = "0.3.0"` |
+| 0.26  | `ndk_glue = "0.4.0"` |
 
 Running on an Android device needs a dynamic system library, add this to Cargo.toml:
 
@@ -125,6 +126,6 @@ To ensure compatibility with older MacOS systems, winit links to
 CGDisplayCreateUUIDFromDisplayID through the CoreGraphics framework.
 However, under certain setups this function is only available to be linked
 through the newer ColorSync framework. So, winit provides the
-`WINIT_LINK_COLORSYNC` environment variable which can be set to `1` or `true` 
+`WINIT_LINK_COLORSYNC` environment variable which can be set to `1` or `true`
 while compiling to enable linking via ColorSync.
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Tested with a small sample application that it still runs with the updated ndk version.
This is breaking as users need to update their version of `ndk-glue` as well as it internally has a static global variable which should be unique across crates!

https://github.com/rust-windowing/winit/issues/1995