### PR TITLE
Show the menu bar in borderless fullscreen on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - On Wayland, add an enabled-by-default feature called `wayland-dlopen` so users can opt out of using `dlopen` to load system libraries.
 - **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.4.
 - On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
+- On macOS, fix an issue that prevented the menu bar from showing in borderless fullscreen mode.
 
 # 0.25.0 (2021-05-15)
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -909,6 +909,13 @@ impl UnownedWindow {
                 NSApp().setPresentationOptions_(presentation_options);
 
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
+
+                // Restore the normal window level following the Borderless fullscreen
+                // `CGShieldingWindowLevel() + 1` hack.
+                let () = msg_send![
+                    *self.ns_window,
+                    setLevel: ffi::NSWindowLevel::NSNormalWindowLevel
+                ];
             },
             _ => INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst),
         };

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -281,7 +281,10 @@ pub struct SharedState {
     is_simple_fullscreen: bool,
     pub saved_style: Option<NSWindowStyleMask>,
     /// Presentation options saved before entering `set_simple_fullscreen`, and
-    /// restored upon exiting it
+    /// restored upon exiting it. Also used when transitioning from Borderless to
+    /// Exclusive fullscreen in `set_fullscreen` because we need to disable the menu
+    /// bar in exclusive fullscreen but want to restore the original options when
+    /// transitioning back to borderless fullscreen.
     save_presentation_opts: Option<NSApplicationPresentationOptions>,
     pub saved_desktop_display_mode: Option<(CGDisplay, CGDisplayMode)>,
 }
@@ -783,6 +786,14 @@ impl UnownedWindow {
             let mut fade_token = ffi::kCGDisplayFadeReservationInvalidToken;
 
             unsafe {
+                let app = NSApp();
+                trace!("Locked shared state in `set_fullscreen`");
+
+                let mut shared_state_lock = self.shared_state.lock().unwrap();
+                shared_state_lock.save_presentation_opts = Some(app.presentationOptions_());
+            }
+
+            unsafe {
                 // Fade to black (and wait for the fade to complete) to hide the
                 // flicker from capturing the display and switching display mode
                 if ffi::CGAcquireDisplayFadeReservation(5.0, &mut fade_token)
@@ -832,7 +843,6 @@ impl UnownedWindow {
         trace!("Locked shared state in `set_fullscreen`");
         let mut shared_state_lock = self.shared_state.lock().unwrap();
         shared_state_lock.fullscreen = fullscreen.clone();
-        trace!("Unlocked shared state in `set_fullscreen`");
 
         INTERRUPT_EVENT_LOOP_EXIT.store(true, Ordering::SeqCst);
 
@@ -873,16 +883,33 @@ impl UnownedWindow {
                 // of the menu bar, and this looks broken, so we must make sure
                 // that the menu bar is disabled. This is done in the window
                 // delegate in `window:willUseFullScreenPresentationOptions:`.
+                let app = NSApp();
+                trace!("Locked shared state in `set_fullscreen`");
+                shared_state_lock.save_presentation_opts = Some(app.presentationOptions_());
+
+                let presentation_options =
+                    NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
+                        | NSApplicationPresentationOptions::NSApplicationPresentationHideDock
+                        | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar;
+                app.setPresentationOptions_(presentation_options);
+
                 let () = msg_send![*self.ns_window, setLevel: ffi::CGShieldingWindowLevel() + 1];
             },
             (
                 &Some(Fullscreen::Exclusive(RootVideoMode { ref video_mode })),
                 &Some(Fullscreen::Borderless(_)),
             ) => unsafe {
+                let presentation_options = shared_state_lock.save_presentation_opts;
+                if presentation_options.is_some() {
+                    let app = NSApp();
+                    app.setPresentationOptions_(presentation_options.unwrap());
+                }
+
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
             },
             _ => INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst),
-        }
+        };
+        trace!("Unlocked shared state in `set_fullscreen`");
     }
 
     #[inline]


### PR DESCRIPTION
Fixes #1195.

Following on from @cixel's work in #1326, this PR aims to fix the issue where the menu bar doesn't show up when using the borderless fullscreen mode on macOS.

#2046 was opened recently but following some discussion @francesca64 proposed reactivating this branch in a new PR.

There are a couple of edge cases that need to be manually tested, [e.g. this comment](https://github.com/rust-windowing/winit/pull/1326#issuecomment-761823885)
> Running `cargo run --example multithreaded`:
> 1. Press `esc` twice to close the first two windows
> 2. Press `alt`+`F`. The window goes into exclusive fullscreen
> 3. Press `F`. The window seems to change to borderless fullscreen which is indicated by the fact that I can use `cmd`+`tab` to switch between applications. But now the menu bar isn't shown.

Additionally, since I [first looked at this issue](https://github.com/rust-windowing/winit/pull/1326#issuecomment-933350528), I've added a fix for the following path:

Running `cargo run --example multithreaded`:
1. Press `F`. The window goes into borderless fullscreen.
2. Press `alt`+`F`. The window goes into exclusive fullscreen
3. Press `F`. The window returns to borderless fullscreen. At this point the menu bar should appear normal and the green 'resize' button should be active.

I assume that there are further edge cases to consider that I haven't found, the logic here is a bit thorny and it can be hard to keep track of all the options and modes, but for the main cases this seems to be working correctly, at least in my testing.

---

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
