### PR TITLE
On Wayland commit the window surface after setting the decoration mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.4.
 - On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
 - On macOS, fix native file dialogs hanging the event loop.
+- On Wayland, implement a workaround for wrong configure size when using `xdg_decoration` in `kwin_wayland`
 
 # 0.25.0 (2021-05-15)
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -139,6 +139,12 @@ impl Window {
         } else {
             window.set_decorate(Decorations::None);
         }
+        // Without this commit here at least on kwin 5.23.3 the initial configure
+        // will have a size (1,1), the second configure including the decoration
+        // mode will have the min_size as its size. With this commit the initial
+        // configure will have no size, the application will draw it's content
+        // with the initial size and everything works as expected afterwards.
+        window.surface().commit();
 
         // Min dimensions.
         let min_size = attributes


### PR DESCRIPTION
fixes #2064 

Looking at the `WAYLAND_DEBUG` output of `alacritty` shows that the initial `xdg_toplevel.configure` has a size of `1,1` set
on `kwin_wayland`. After setting the `decoration_mode` another `configure` is issued by the server and has the `min_size`
of the client set as the size, which is `2,1` in case of `alacritty`. The debug output of [toplevel_decoration.c](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/3a685b10b66b9da6e0baa3ad48409db14e76eced/examples/toplevel-decoration.c) and `kwrite` indicates that the size of the second `configure` has the size of the buffer that got attached/commited
after the first `configure`. Both clients commit the surface state after changing the decoration mode.

For reference see: [toplevel_decoration.c](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/3a685b10b66b9da6e0baa3ad48409db14e76eced/examples/toplevel-decoration.c#L236) in `wlroots/examples`

- [ ] Tested on all platforms changed
- [ ] Compilation warnings were addressed
- [ ] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
