### PR TITLE
Prevent SEGFAULT on X11 composition event handling

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -270,6 +270,9 @@ pub enum WindowEvent<'a> {
     ///   issue, and it should get fixed - but it's the current state of the API.
     ModifiersChanged(ModifiersState),
 
+    /// An event from IME
+    Composition(CompositionEvent),
+
     /// The cursor has moved on the window.
     CursorMoved {
         device_id: DeviceId,
@@ -376,7 +379,7 @@ impl Clone for WindowEvent<'static> {
                 input: *input,
                 is_synthetic: *is_synthetic,
             },
-
+            Composition(composition) => Composition(composition.clone()),
             ModifiersChanged(modifiers) => ModifiersChanged(modifiers.clone()),
             #[allow(deprecated)]
             CursorMoved {
@@ -468,6 +471,7 @@ impl<'a> WindowEvent<'a> {
                 is_synthetic,
             }),
             ModifiersChanged(modifiers) => Some(ModifiersChanged(modifiers)),
+            Composition(event) => Some(Composition(event)),
             #[allow(deprecated)]
             CursorMoved {
                 device_id,
@@ -621,6 +625,14 @@ pub struct KeyboardInput {
     /// this device are not being delivered to the application, e.g. due to keyboard focus being elsewhere.
     #[deprecated = "Deprecated in favor of WindowEvent::ModifiersChanged"]
     pub modifiers: ModifiersState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum CompositionEvent {
+    CompositionStart(String),
+    CompositionUpdate(String, usize),
+    CompositionEnd(String),
 }
 
 /// Describes touch-screen input state.

--- a/src/event.rs
+++ b/src/event.rs
@@ -271,7 +271,7 @@ pub enum WindowEvent<'a> {
     ModifiersChanged(ModifiersState),
 
     /// An event from IME
-    Composition(CompositionEvent),
+    IME(IME),
 
     /// The cursor has moved on the window.
     CursorMoved {
@@ -379,7 +379,7 @@ impl Clone for WindowEvent<'static> {
                 input: *input,
                 is_synthetic: *is_synthetic,
             },
-            Composition(composition) => Composition(composition.clone()),
+            IME(preedit_state) => IME(preedit_state.clone()),
             ModifiersChanged(modifiers) => ModifiersChanged(modifiers.clone()),
             #[allow(deprecated)]
             CursorMoved {
@@ -471,7 +471,7 @@ impl<'a> WindowEvent<'a> {
                 is_synthetic,
             }),
             ModifiersChanged(modifiers) => Some(ModifiersChanged(modifiers)),
-            Composition(event) => Some(Composition(event)),
+            IME(event) => Some(IME(event)),
             #[allow(deprecated)]
             CursorMoved {
                 device_id,
@@ -627,12 +627,26 @@ pub struct KeyboardInput {
     pub modifiers: ModifiersState,
 }
 
+/// Describes an event from input method.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum CompositionEvent {
-    CompositionStart(String),
-    CompositionUpdate(String, usize),
-    CompositionEnd(String),
+pub enum IME {
+    /// Notifies when the IME was enabled.
+    Enabled,
+
+    /// Notifies when a new composing text should be set at the cursor position.
+    ///
+    /// The value represents a pair of the preedit string and the cursor begin position and end
+    /// position. When both indices are `None`, the cursor should be hidden.
+    ///
+    /// The cursor position is byte-wise indexed.
+    Preedit(String, Option<usize>, Option<usize>),
+
+    /// Notifies when text should be inserted into the editor widget.
+    Commit(String),
+
+    /// Notifies when the IME was disabled.
+    Disabled,
 }
 
 /// Describes touch-screen input state.

--- a/src/platform_impl/linux/x11/ime/callbacks.rs
+++ b/src/platform_impl/linux/x11/ime/callbacks.rs
@@ -108,7 +108,13 @@ unsafe fn replace_im(inner: *mut ImeInner) -> Result<(), ReplaceImError> {
     for (window, old_context) in (*inner).contexts.iter() {
         let spot = old_context.as_ref().map(|old_context| old_context.ic_spot);
         let new_context = {
-            let result = ImeContext::new(xconn, new_im.im, *window, spot);
+            let result = ImeContext::new(
+                xconn,
+                new_im.im,
+                *window,
+                spot,
+                (*inner).event_sender.clone(),
+            );
             if result.is_err() {
                 let _ = close_im(xconn, new_im.im);
             }

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -1,20 +1,153 @@
 use std::{
+    mem::transmute,
     os::raw::{c_short, c_void},
     ptr,
     sync::Arc,
 };
 
 use super::{ffi, util, XConnection, XError};
+use crate::platform_impl::platform::x11::ime::{ImeEvent, ImeEventSender};
+use std::ffi::CStr;
+use x11_dl::xlib::{XIMCallback, XIMPreeditCaretCallbackStruct, XIMPreeditDrawCallbackStruct};
 
 #[derive(Debug)]
 pub enum ImeContextCreationError {
     XError(XError),
     Null,
 }
+type XIMProcNonnull = unsafe extern "C" fn(ffi::XIM, ffi::XPointer, ffi::XPointer);
+extern "C" fn preedit_start_callback(
+    _xim: ffi::XIM,
+    client_data: ffi::XPointer,
+    _call_data: ffi::XPointer,
+) -> i32 {
+    let client_data = unsafe { &mut *(client_data as *mut ImeContextClientData) };
+
+    client_data.text.clear();
+    client_data.cursor_pos = 0;
+    client_data
+        .event_sender
+        .send((client_data.window, ImeEvent::Start))
+        .expect("failed to send composition start event");
+    -1
+}
+
+extern "C" fn preedit_done_callback(
+    _xim: ffi::XIM,
+    client_data: ffi::XPointer,
+    _call_data: ffi::XPointer,
+) {
+    let client_data = unsafe { &mut *(client_data as *mut ImeContextClientData) };
+
+    client_data
+        .event_sender
+        .send((client_data.window, ImeEvent::End))
+        .expect("failed to send composition end event");
+}
+
+fn calc_byte_position(text: &Vec<char>, pos: usize) -> usize {
+    let mut byte_pos = 0;
+    for i in 0..pos {
+        byte_pos += text[i].len_utf8();
+    }
+    byte_pos
+}
+
+extern "C" fn preedit_draw_callback(
+    _xim: ffi::XIM,
+    client_data: ffi::XPointer,
+    call_data: ffi::XPointer,
+) {
+    let client_data = unsafe { &mut *(client_data as *mut ImeContextClientData) };
+    let call_data = unsafe { &mut *(call_data as *mut XIMPreeditDrawCallbackStruct) };
+    client_data.cursor_pos = call_data.caret as usize;
+
+    let chg_range =
+        call_data.chg_first as usize..(call_data.chg_first + call_data.chg_length) as usize;
+    if chg_range.start > client_data.text.len() || chg_range.end > client_data.text.len() {
+        warn!(
+            "invalid chg range: buffer length={}, but chg_first={} chg_lengthg={}",
+            client_data.text.len(),
+            call_data.chg_first,
+            call_data.chg_length
+        );
+        return;
+    }
+
+    // NULL indicate text deletion
+    let mut new_chars = if call_data.text.is_null() {
+        Vec::new()
+    } else {
+        let xim_text = unsafe { &mut *(call_data.text) };
+        if xim_text.encoding_is_wchar > 0 {
+            return;
+        }
+        let new_text = unsafe { CStr::from_ptr(xim_text.string.multi_byte) };
+
+        String::from(new_text.to_str().expect("Invalid UTF-8 String from IME"))
+            .chars()
+            .collect()
+    };
+    let mut old_text_tail = client_data.text.split_off(chg_range.end);
+    client_data.text.split_off(chg_range.start);
+    client_data.text.append(&mut new_chars);
+    client_data.text.append(&mut old_text_tail);
+    let cursor_byte_pos = calc_byte_position(&client_data.text, client_data.cursor_pos);
+
+    client_data
+        .event_sender
+        .send((
+            client_data.window,
+            ImeEvent::Update(client_data.text.iter().collect(), cursor_byte_pos),
+        ))
+        .expect("failed to send composition update event");
+}
+
+extern "C" fn preedit_caret_callback(
+    _xim: ffi::XIM,
+    client_data: ffi::XPointer,
+    call_data: ffi::XPointer,
+) {
+    let client_data = unsafe { &mut *(client_data as *mut ImeContextClientData) };
+    let call_data = unsafe { &mut *(call_data as *mut XIMPreeditCaretCallbackStruct) };
+    client_data.cursor_pos = call_data.position as usize;
+    let cursor_byte_pos = calc_byte_position(&client_data.text, client_data.cursor_pos);
+
+    client_data
+        .event_sender
+        .send((
+            client_data.window,
+            ImeEvent::Update(client_data.text.iter().collect(), cursor_byte_pos),
+        ))
+        .expect("failed to send composition update event");
+}
 
 unsafe fn create_pre_edit_attr<'a>(
     xconn: &'a Arc<XConnection>,
+    preedit_callbacks: &'a PreeditCallbacks,
+) -> util::XSmartPointer<'a, c_void> {
+    util::XSmartPointer::new(
+        xconn,
+        (xconn.xlib.XVaCreateNestedList)(
+            0,
+            ffi::XNPreeditStartCallback_0.as_ptr() as *const _,
+            &(preedit_callbacks.start_callback) as *const _,
+            ffi::XNPreeditDoneCallback_0.as_ptr() as *const _,
+            &(preedit_callbacks.done_callback) as *const _,
+            ffi::XNPreeditCaretCallback_0.as_ptr() as *const _,
+            &(preedit_callbacks.caret_callback) as *const _,
+            ffi::XNPreeditDrawCallback_0.as_ptr() as *const _,
+            &(preedit_callbacks.draw_callback) as *const _,
+            ptr::null_mut::<()>(),
+        ),
+    )
+    .expect("XVaCreateNestedList returned NULL")
+}
+
+unsafe fn create_pre_edit_attr_with_spot<'a>(
+    xconn: &'a Arc<XConnection>,
     ic_spot: &'a ffi::XPoint,
+    preedit_callbacks: &'a PreeditCallbacks,
 ) -> util::XSmartPointer<'a, c_void> {
     util::XSmartPointer::new(
         xconn,
@@ -22,20 +155,68 @@ unsafe fn create_pre_edit_attr<'a>(
             0,
             ffi::XNSpotLocation_0.as_ptr() as *const _,
             ic_spot,
+            ffi::XNPreeditStartCallback_0.as_ptr() as *const _,
+            &preedit_callbacks.start_callback as *const _,
+            ffi::XNPreeditDoneCallback_0.as_ptr() as *const _,
+            &preedit_callbacks.done_callback as *const _,
+            ffi::XNPreeditCaretCallback_0.as_ptr() as *const _,
+            &preedit_callbacks.caret_callback as *const _,
+            ffi::XNPreeditDrawCallback_0.as_ptr() as *const _,
+            &preedit_callbacks.draw_callback as *const _,
             ptr::null_mut::<()>(),
         ),
     )
     .expect("XVaCreateNestedList returned NULL")
 }
 
+fn create_xim_callback(client_data: ffi::XPointer, callback: XIMProcNonnull) -> ffi::XIMCallback {
+    XIMCallback {
+        client_data,
+        callback: Some(callback),
+    }
+}
+
+pub struct PreeditCallbacks {
+    pub start_callback: ffi::XIMCallback,
+    pub done_callback: ffi::XIMCallback,
+    pub draw_callback: ffi::XIMCallback,
+    pub caret_callback: ffi::XIMCallback,
+}
+
+impl PreeditCallbacks {
+    pub fn new(client_data: ffi::XPointer) -> PreeditCallbacks {
+        let start_callback = create_xim_callback(client_data, unsafe {
+            transmute(preedit_start_callback as usize)
+        });
+        let done_callback = create_xim_callback(client_data, preedit_done_callback);
+        let caret_callback = create_xim_callback(client_data, preedit_caret_callback);
+        let draw_callback = create_xim_callback(client_data, preedit_draw_callback);
+
+        PreeditCallbacks {
+            start_callback,
+            done_callback,
+            caret_callback,
+            draw_callback,
+        }
+    }
+}
+
+pub struct ImeContextClientData {
+    pub window: ffi::Window,
+    pub event_sender: ImeEventSender,
+    pub text: Vec<char>,
+    pub cursor_pos: usize,
+}
+
 // WARNING: this struct doesn't destroy its XIC resource when dropped.
 // This is intentional, as it doesn't have enough information to know whether or not the context
 // still exists on the server. Since `ImeInner` has that awareness, destruction must be handled
 // through `ImeInner`.
-#[derive(Debug)]
 pub struct ImeContext {
     pub ic: ffi::XIC,
     pub ic_spot: ffi::XPoint,
+    pub preedit_callbacks: PreeditCallbacks,
+    pub client_data: Box<ImeContextClientData>,
 }
 
 impl ImeContext {
@@ -44,11 +225,20 @@ impl ImeContext {
         im: ffi::XIM,
         window: ffi::Window,
         ic_spot: Option<ffi::XPoint>,
+        event_sender: ImeEventSender,
     ) -> Result<Self, ImeContextCreationError> {
+        let client_data = Box::new(ImeContextClientData {
+            window,
+            event_sender,
+            text: Vec::new(),
+            cursor_pos: 0,
+        });
+        let client_data_ptr = Box::into_raw(client_data);
+        let preedit_callbacks = PreeditCallbacks::new(client_data_ptr as ffi::XPointer);
         let ic = if let Some(ic_spot) = ic_spot {
-            ImeContext::create_ic_with_spot(xconn, im, window, ic_spot)
+            ImeContext::create_ic_with_spot(xconn, im, window, ic_spot, &preedit_callbacks)
         } else {
-            ImeContext::create_ic(xconn, im, window)
+            ImeContext::create_ic(xconn, im, window, &preedit_callbacks)
         };
 
         let ic = ic.ok_or(ImeContextCreationError::Null)?;
@@ -59,6 +249,8 @@ impl ImeContext {
         Ok(ImeContext {
             ic,
             ic_spot: ic_spot.unwrap_or_else(|| ffi::XPoint { x: 0, y: 0 }),
+            preedit_callbacks,
+            client_data: Box::from_raw(client_data_ptr),
         })
     }
 
@@ -66,13 +258,17 @@ impl ImeContext {
         xconn: &Arc<XConnection>,
         im: ffi::XIM,
         window: ffi::Window,
+        preedit_callbacks: &PreeditCallbacks,
     ) -> Option<ffi::XIC> {
+        let pre_edit_attr = create_pre_edit_attr(xconn, preedit_callbacks);
         let ic = (xconn.xlib.XCreateIC)(
             im,
             ffi::XNInputStyle_0.as_ptr() as *const _,
-            ffi::XIMPreeditNothing | ffi::XIMStatusNothing,
+            ffi::XIMPreeditCallbacks | ffi::XIMStatusNothing,
             ffi::XNClientWindow_0.as_ptr() as *const _,
             window,
+            ffi::XNPreeditAttributes_0.as_ptr(),
+            pre_edit_attr.ptr,
             ptr::null_mut::<()>(),
         );
         if ic.is_null() {
@@ -87,12 +283,13 @@ impl ImeContext {
         im: ffi::XIM,
         window: ffi::Window,
         ic_spot: ffi::XPoint,
+        preedit_callbacks: &PreeditCallbacks,
     ) -> Option<ffi::XIC> {
-        let pre_edit_attr = create_pre_edit_attr(xconn, &ic_spot);
+        let pre_edit_attr = create_pre_edit_attr_with_spot(xconn, &ic_spot, preedit_callbacks);
         let ic = (xconn.xlib.XCreateIC)(
             im,
             ffi::XNInputStyle_0.as_ptr() as *const _,
-            ffi::XIMPreeditNothing | ffi::XIMStatusNothing,
+            ffi::XIMPreeditCallbacks | ffi::XIMStatusNothing,
             ffi::XNClientWindow_0.as_ptr() as *const _,
             window,
             ffi::XNPreeditAttributes_0.as_ptr() as *const _,
@@ -127,7 +324,8 @@ impl ImeContext {
         self.ic_spot = ffi::XPoint { x, y };
 
         unsafe {
-            let pre_edit_attr = create_pre_edit_attr(xconn, &self.ic_spot);
+            let pre_edit_attr =
+                create_pre_edit_attr_with_spot(xconn, &self.ic_spot, &self.preedit_callbacks);
             (xconn.xlib.XSetICValues)(
                 self.ic,
                 ffi::XNPreeditAttributes_0.as_ptr() as *const _,

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -82,7 +82,14 @@ extern "C" fn preedit_draw_callback(
         if xim_text.encoding_is_wchar > 0 {
             return;
         }
-        let new_text = unsafe { CStr::from_ptr(xim_text.string.multi_byte) };
+
+        let new_text = unsafe { xim_text.string.multi_byte };
+
+        if new_text.is_null() {
+            return;
+        }
+
+        let new_text = unsafe { CStr::from_ptr(new_text) };
 
         String::from(new_text.to_str().expect("Invalid UTF-8 String from IME"))
             .chars()

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -28,7 +28,7 @@ extern "C" fn preedit_start_callback(
     client_data
         .event_sender
         .send((client_data.window, ImeEvent::Start))
-        .expect("failed to send composition start event");
+        .expect("failed to send preedit start event");
     -1
 }
 
@@ -42,7 +42,7 @@ extern "C" fn preedit_done_callback(
     client_data
         .event_sender
         .send((client_data.window, ImeEvent::End))
-        .expect("failed to send composition end event");
+        .expect("failed to send preedit end event");
 }
 
 fn calc_byte_position(text: &Vec<char>, pos: usize) -> usize {
@@ -89,7 +89,7 @@ extern "C" fn preedit_draw_callback(
             .collect()
     };
     let mut old_text_tail = client_data.text.split_off(chg_range.end);
-    client_data.text.split_off(chg_range.start);
+    let _ = client_data.text.split_off(chg_range.start);
     client_data.text.append(&mut new_chars);
     client_data.text.append(&mut old_text_tail);
     let cursor_byte_pos = calc_byte_position(&client_data.text, client_data.cursor_pos);
@@ -100,7 +100,7 @@ extern "C" fn preedit_draw_callback(
             client_data.window,
             ImeEvent::Update(client_data.text.iter().collect(), cursor_byte_pos),
         ))
-        .expect("failed to send composition update event");
+        .expect("failed to send preedit update event");
 }
 
 extern "C" fn preedit_caret_callback(
@@ -119,7 +119,7 @@ extern "C" fn preedit_caret_callback(
             client_data.window,
             ImeEvent::Update(client_data.text.iter().collect(), cursor_byte_pos),
         ))
-        .expect("failed to send composition update event");
+        .expect("failed to send preedit update event");
 }
 
 unsafe fn create_pre_edit_attr<'a>(

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -19,9 +19,18 @@ use self::{
     inner::{close_im, ImeInner},
     input_method::PotentialInputMethods,
 };
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum ImeEvent {
+    Start,
+    Update(String, usize),
+    End,
+}
 
 pub type ImeReceiver = Receiver<(ffi::Window, i16, i16)>;
 pub type ImeSender = Sender<(ffi::Window, i16, i16)>;
+pub type ImeEventReceiver = Receiver<(ffi::Window, ImeEvent)>;
+pub type ImeEventSender = Sender<(ffi::Window, ImeEvent)>;
 
 #[derive(Debug)]
 pub enum ImeCreationError {
@@ -37,11 +46,14 @@ pub struct Ime {
 }
 
 impl Ime {
-    pub fn new(xconn: Arc<XConnection>) -> Result<Self, ImeCreationError> {
+    pub fn new(
+        xconn: Arc<XConnection>,
+        event_sender: ImeEventSender,
+    ) -> Result<Self, ImeCreationError> {
         let potential_input_methods = PotentialInputMethods::new(&xconn);
 
         let (mut inner, client_data) = {
-            let mut inner = Box::new(ImeInner::new(xconn, potential_input_methods));
+            let mut inner = Box::new(ImeInner::new(xconn, potential_input_methods, event_sender));
             let inner_ptr = Box::into_raw(inner);
             let client_data = inner_ptr as _;
             let destroy_callback = ffi::XIMCallback {
@@ -93,7 +105,15 @@ impl Ime {
             // Create empty entry in map, so that when IME is rebuilt, this window has a context.
             None
         } else {
-            Some(unsafe { ImeContext::new(&self.inner.xconn, self.inner.im, window, None) }?)
+            Some(unsafe {
+                ImeContext::new(
+                    &self.inner.xconn,
+                    self.inner.im,
+                    window,
+                    None,
+                    self.inner.event_sender.clone(),
+                )
+            }?)
         };
         self.inner.contexts.insert(window, context);
         Ok(!self.is_destroyed())

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -22,6 +22,7 @@ use self::{
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ImeEvent {
+    Enabled,
     Start,
     Update(String, usize),
     End,
@@ -105,6 +106,10 @@ impl Ime {
             // Create empty entry in map, so that when IME is rebuilt, this window has a context.
             None
         } else {
+            self.inner
+                .event_sender
+                .send((window, ImeEvent::Enabled))
+                .expect("Failed to send enabled event");
             Some(unsafe {
                 ImeContext::new(
                     &self.inner.xconn,

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -103,6 +103,7 @@ impl<T: 'static> EventLoop<T> {
             .expect("Failed to call XInternAtoms when initializing drag and drop");
 
         let (ime_sender, ime_receiver) = mpsc::channel();
+        let (ime_event_sender, ime_event_receiver) = mpsc::channel();
         // Input methods will open successfully without setting the locale, but it won't be
         // possible to actually commit pre-edit sequences.
         unsafe {
@@ -127,7 +128,7 @@ impl<T: 'static> EventLoop<T> {
             }
         }
         let ime = RefCell::new({
-            let result = Ime::new(Arc::clone(&xconn));
+            let result = Ime::new(Arc::clone(&xconn), ime_event_sender);
             if let Err(ImeCreationError::OpenFailure(ref state)) = result {
                 panic!(format!("Failed to open input method: {:#?}", state));
             }
@@ -220,12 +221,15 @@ impl<T: 'static> EventLoop<T> {
             devices: Default::default(),
             randr_event_offset,
             ime_receiver,
+            ime_event_receiver,
             xi2ext,
             mod_keymap,
             device_mod_state: Default::default(),
             num_touch: 0,
             first_touch: None,
             active_window: None,
+            is_composing: false,
+            composed_text: None,
         };
 
         // Register for device hotplug events

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -83,8 +83,8 @@ impl Window {
                     } else if ole_init_result == RPC_E_CHANGED_MODE {
                         panic!(
                             "OleInitialize failed! Result was: `RPC_E_CHANGED_MODE`. \
-                            Make sure other crates are not using multithreaded COM library \
-                            on the same thread or disable drag and drop support."
+                             Make sure other crates are not using multithreaded COM library \
+                             on the same thread or disable drag and drop support."
                         );
                     }
 


### PR DESCRIPTION
note: I'm opening PR to `composition-event` branch, not master.

I found that `preedit_draw_callback` function dereferences a null pointer when system locale is not properly set. This PR adds null-check so that prevent segfault.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
