### PR TITLE
bump ndk dependencies to 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - On X11, emit missing `WindowEvent::ScaleFactorChanged` when the only monitor gets reconnected.
 - On X11, if RANDR based scale factor is higher than 20 reset it to 1
 - On Wayland, add an enabled-by-default feature called `wayland-dlopen` so users can opt out of using `dlopen` to load system libraries.
-- **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.4.
+- **Breaking:** On Android, bump `ndk` and `ndk-glue` to 0.5.
 - On Windows, increase wait timer resolution for more accurate timing when using `WaitUntil`.
 - On macOS, fix native file dialogs hanging the event loop.
 - On Wayland, implement a workaround for wrong configure size when using `xdg_decoration` in `kwin_wayland`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ image = "0.23.12"
 simple_logger = "1.9"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = "0.4"
+ndk = "0.5"
 ndk-sys = "0.2.0"
-ndk-glue = "0.4"
+ndk-glue = "0.5"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The `ndk_glue` version needs to match the version used by `winit`. Otherwise, th
 | :---: | :------------------: |
 | 0.24  | `ndk_glue = "0.2.0"` |
 | 0.25  | `ndk_glue = "0.3.0"` |
-| 0.26  | `ndk_glue = "0.4.0"` |
+| 0.26  | `ndk_glue = "0.5.0"` |
 
 Running on an Android device needs a dynamic system library, add this to Cargo.toml:
 


### PR DESCRIPTION
It's been tested on an android 12 device. The test application is [here](https://github.com/adrien-ben/vulkan-triangle-rs/tree/android)

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
