### PR TITLE
Fix `CGDisplayCreateUUIDFromDisplayID` linking (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Fix linking to the `ColorSync` framework on macOS 10.7, and in newer Rust versions.
 - On Web, implement cursor grabbing through the pointer lock API.
 - On X11, add mappings for numpad comma, numpad enter, numlock and pause.
 - On macOS, fix Pinyin IME input by reverting a change that intended to improve IME.

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -163,9 +163,18 @@ pub const IO8BitOverlayPixels: &str = "O8";
 pub type CGWindowLevel = i32;
 pub type CGDisplayModeRef = *mut c_void;
 
+// `CGDisplayCreateUUIDFromDisplayID` comes from the `ColorSync` framework.
+// However, that framework was only introduced "publicly" in macOS 10.13.
+//
+// Since we want to support older versions, we can't link to `ColorSync`
+// directly. Fortunately, it has always been available as a subframework of
+// `ApplicationServices`, see:
+// https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html#//apple_ref/doc/uid/TP40001067-CH210-BBCFFIEG
+//
+// TODO: Remove the WINIT_LINK_COLORSYNC hack, it is probably not needed.
 #[cfg_attr(
     not(use_colorsync_cgdisplaycreateuuidfromdisplayid),
-    link(name = "CoreGraphics", kind = "framework")
+    link(name = "ApplicationServices", kind = "framework")
 )]
 #[cfg_attr(
     use_colorsync_cgdisplaycreateuuidfromdisplayid,


### PR DESCRIPTION
See previous issue: https://github.com/rust-windowing/winit/pull/1626.

The `cocoa` crate links to AppKit, which made the symbol `CGDisplayCreateUUIDFromDisplayID` from ApplicationServices/ColorSync (which AppKit uses internally) available to us (on macOS 10.8 to 10.13).

However, this does not work on macOS 10.7 (where AppKit does not link to ColorSync internally). Instead of relying on this, we should just link to ApplicationServices directly.

Also, lately something changed in rustc so that the linker's macOS version is 10.7, see https://github.com/rust-lang/rust/issues/91372, which is why the nightly builds were failing.

- [x] Tested on all platforms changed
  - [x] Tested on macOS Mojave 10.14.6, using `MACOSX_DEPLOYMENT_TARGET=X.Y cargo build --example window`.
  - [x] Tested on macOS 10.10
  - [x] And if @Imberflur could test this using their docker setup that would be nice as well!
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
