### PR TITLE
macOS: Adapt new KeyboardEvent on IME event interface

### DIFF
--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -719,7 +719,7 @@ extern "C" fn key_down(this: &Object, _sel: Sel, event: id) {
                     virtual_keycode,
                     modifiers: event_mods(event),
                 },
-                is_synthetic: false,
+                is_synthetic: state.is_ime_activated,
             },
         };
 
@@ -772,7 +772,7 @@ extern "C" fn key_up(this: &Object, _sel: Sel, event: id) {
                     virtual_keycode,
                     modifiers: event_mods(event),
                 },
-                is_synthetic: false,
+                is_synthetic: state.is_ime_activated,
             },
         };
 
@@ -891,7 +891,7 @@ extern "C" fn cancel_operation(this: &Object, _sel: Sel, _sender: id) {
                     virtual_keycode,
                     modifiers: event_mods(event),
                 },
-                is_synthetic: false,
+                is_synthetic: state.is_ime_activated,
             },
         };
 


### PR DESCRIPTION
This is related to #1497 and #1979.
I made `is_synthetic` field in KeyboardEvent filled with OS's IME status.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
