### PR TITLE
[X11] Create windows with a parent window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Bump `ndk` version to 0.6, ndk-sys to `v0.3`, `ndk-glue` to `0.6`.
 - Remove no longer needed `WINIT_LINK_COLORSYNC` environment variable.
 - **Breaking:** Rename the `Exit` variant of `ControlFlow` to `ExitWithCode`, which holds a value to control the exit code after running. Add an `Exit` constant which aliases to `ExitWithCode(0)` instead to avoid major breakage. This shouldn't affect most existing programs.
+- On X11, create windows with a parent window via `WindowBuilder::with_x11_parent()`.
 
 # 0.26.1 (2022-01-05)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -130,6 +130,7 @@ If your PR makes notable changes to Winit's features, please update this section
 
 ### Unix
 * Window urgency
+* Setting the X11 parent window
 * X11 Window Class
 * X11 Override Redirect Flag
 * GTK Theme Variant

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -1,0 +1,71 @@
+use std::collections::HashMap;
+
+use simple_logger::SimpleLogger;
+use winit::{
+    dpi::{LogicalPosition, LogicalSize, Position},
+    event::{ElementState, Event, KeyboardInput, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::WindowBuilder,
+};
+
+#[cfg(feature = "x11")]
+use winit::platform::unix::{WindowBuilderExtUnix, WindowExtUnix};
+
+#[cfg(feature = "x11")]
+fn main() {
+    SimpleLogger::new().init().unwrap();
+    let mut windows = HashMap::new();
+
+    let event_loop: EventLoop<()> = EventLoop::new();
+    let parent_window = WindowBuilder::new()
+        .with_title("parent window")
+        .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+        .with_inner_size(LogicalSize::new(640.0, 480.0))
+        .build(&event_loop)
+        .unwrap();
+    let root = parent_window.xlib_window().unwrap();
+    println!("parent window id: {})", root);
+
+    event_loop.run(move |event: Event<'_, ()>, event_loop, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent { event, window_id } => match event {
+                WindowEvent::CloseRequested => {
+                    windows.clear();
+                    *control_flow = ControlFlow::Exit;
+                }
+                WindowEvent::CursorEntered { device_id: _ } => {
+                    println!("cursor entered in the window {:?}", window_id);
+                }
+                WindowEvent::KeyboardInput {
+                    input:
+                        KeyboardInput {
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                } => {
+                    let child_window = WindowBuilder::new()
+                        .with_x11_parent(root)
+                        .with_title("child window")
+                        .with_inner_size(LogicalSize::new(100.0, 100.0))
+                        .build(&event_loop)
+                        .unwrap();
+                    println!(
+                        "child window created with id: {}",
+                        child_window.xlib_window().unwrap()
+                    );
+                    windows.insert(child_window.id(), child_window);
+                }
+                _ => (),
+            },
+            _ => (),
+        }
+    })
+}
+
+#[cfg(not(feature = "x11"))]
+fn main() {
+    panic!("This example is supported only on x11.");
+}

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -331,6 +331,8 @@ pub trait WindowBuilderExtUnix {
     fn with_x11_visual<T>(self, visual_infos: *const T) -> Self;
     #[cfg(feature = "x11")]
     fn with_x11_screen(self, screen_id: i32) -> Self;
+    #[cfg(feature = "x11")]
+    fn with_x11_parent(self, parent_id: u64) -> Self;
 
     /// Build window with `WM_CLASS` hint; defaults to the name of the binary. Only relevant on X11.
     #[cfg(feature = "x11")]
@@ -397,6 +399,13 @@ impl WindowBuilderExtUnix for WindowBuilder {
     #[cfg(feature = "x11")]
     fn with_x11_screen(mut self, screen_id: i32) -> Self {
         self.platform_specific.screen_id = Some(screen_id);
+        self
+    }
+
+    #[inline]
+    #[cfg(feature = "x11")]
+    fn with_x11_parent(mut self, parent_id: u64) -> Self {
+        self.platform_specific.parent_id = Some(parent_id);
         self
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -56,6 +56,8 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     #[cfg(feature = "x11")]
     pub screen_id: Option<i32>,
     #[cfg(feature = "x11")]
+    pub parent_id: Option<u64>,
+    #[cfg(feature = "x11")]
     pub resize_increments: Option<Size>,
     #[cfg(feature = "x11")]
     pub base_size: Option<Size>,
@@ -78,6 +80,8 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             visual_infos: None,
             #[cfg(feature = "x11")]
             screen_id: None,
+            #[cfg(feature = "x11")]
+            parent_id: None,
             #[cfg(feature = "x11")]
             resize_increments: None,
             #[cfg(feature = "x11")]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -115,7 +115,11 @@ impl UnownedWindow {
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<UnownedWindow, RootOsError> {
         let xconn = &event_loop.xconn;
-        let root = event_loop.root;
+        let root = if let Some(id) = pl_attribs.parent_id {
+            id
+        } else {
+            event_loop.root
+        };
 
         let mut monitors = xconn.available_monitors();
         let guessed_monitor = if monitors.is_empty() {


### PR DESCRIPTION
This PR can create windows with a user-specified parent window. It's intended to realize what discussed in issue #159 for X11.

EDITED: ~~For compatibility, this introduces a new method `new_x11_any_thread_with_root()` to create such windows. I considered to change the signature of `new_x11_any_thread()`, it takes a parent window ID, but I cannot decide that so simply create a new method. I want to discuss about this point.~~

The way above was an wrong way. For now this PR adds `with_x11_parent()` method to `WindowBuilder` by importing `winit::platform::unix::WindowBuilderExtUnix`, we can set X11 window ID as a parent with it. It seems good because it's similar way in supporting child window in Windows (#96).

~~By the way this PR is for my VST3 plugin using [vst3-sys](https://github.com/RustAudio/vst3-sys) so I don't have any ideas to test this PR without VST3 codes. I want some advice about testing.~~ This PR adds example code and it works.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
