### PR TITLE
[Windows] Reverse horizonal scroll direction in `WindowEvent::MouseWheel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On X11, add mappings for numpad comma, numpad enter, numlock and pause.
+- On Windows, reversed horizontal scrolling in `WindowEvent::MouseWheel` to match the direction of vertical scrolling.
 
 # 0.26.0 (2021-12-01)
 

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -1,6 +1,6 @@
 use simple_logger::SimpleLogger;
 use winit::{
-    event::{DeviceEvent, Event, WindowEvent},
+    event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     window::WindowBuilder,
 };
@@ -20,23 +20,20 @@ fn main() {
         match event {
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
-                _ => (),
-            },
-            Event::DeviceEvent { event, .. } => match event {
-                DeviceEvent::MouseWheel { delta } => match delta {
+                WindowEvent::MouseWheel { delta, .. } => match delta {
                     winit::event::MouseScrollDelta::LineDelta(x, y) => {
                         println!("mouse wheel Line Delta: ({},{})", x, y);
                         let pixels_per_line = 120.0;
                         let mut pos = window.outer_position().unwrap();
-                        pos.x -= (x * pixels_per_line) as i32;
-                        pos.y -= (y * pixels_per_line) as i32;
+                        pos.x += (x * pixels_per_line) as i32;
+                        pos.y += (y * pixels_per_line) as i32;
                         window.set_outer_position(pos)
                     }
                     winit::event::MouseScrollDelta::PixelDelta(p) => {
                         println!("mouse wheel Pixel Delta: ({},{})", p.x, p.y);
                         let mut pos = window.outer_position().unwrap();
-                        pos.x -= p.x as i32;
-                        pos.y -= p.y as i32;
+                        pos.x += p.x as i32;
+                        pos.y += p.y as i32;
                         window.set_outer_position(pos)
                     }
                 },

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1200,7 +1200,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
             let value = (wparam >> 16) as i16;
             let value = value as i32;
-            let value = value as f32 / winuser::WHEEL_DELTA as f32;
+            let value = -value as f32 / winuser::WHEEL_DELTA as f32;
 
             update_modifiers(window, userdata);
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #2099
Addresses part of downstream issue https://github.com/emilk/egui/issues/356

On windows, the horizonal and vertical scrolling directions do not match when running the MRE in #2099. Considering vertical scroll is used in many places already, it seems sensible to swap horizontal scroll deltas on windows, like #1695.

This PR also changes the `mouse_wheel` example to demonstrate scroll behavior. In its current state, it only reports mouse device events, which don't seem to report horizontal scrolling on windows. I've changed this to ` WindowEvent::MouseWheel`, which allows you to test x and y scrolling - which seems to be the intent of the example considering it already allows repositioning the window in x and y. I've also flipped the delta applied to the window, so it moves in the direction the page you are scrolling would move. This makes it easier to verify "natural" scrolling is working as expected.