### PR TITLE
[Windows] Loop on WM_ENTERIDLE

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -893,6 +893,19 @@ unsafe fn public_window_callback_inner<T: 'static>(
             0
         }
 
+        winuser::WM_ENTERIDLE => {
+            let mut msg = mem::zeroed();
+            winuser::PeekMessageW(&mut msg, window, 0, 0, winuser::PM_NOREMOVE);
+            match msg.message {
+                winuser::WM_NULL | winuser::WM_PAINT => {
+                    userdata.send_event(Event::MainEventsCleared);
+                    winuser::PostMessageW(window, winuser::WM_ENTERIDLE, 0, 0);
+                }
+                _ => {}
+            }
+            0
+        }
+
         winuser::WM_NCLBUTTONDOWN => {
             if wparam == winuser::HTCAPTION as _ {
                 winuser::PostMessageW(window, winuser::WM_MOUSEMOVE, 0, lparam);


### PR DESCRIPTION
Relevant bug #1484 

When polling the event loop, if a user opens a context menu on the window decoration, we cease getting additional periodic events like WM_PAINT. The goal of this PR is to poll ourselves if we receive a [WM_ENTERIDLE](https://docs.microsoft.com/en-us/windows/win32/dlgbox/wm-enteridle). This doesn't respect `ControlFlow` in its current form. I'm looking for feedback since I'm not well read on winit. 

---

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented