### PR TITLE
Provide examples for all window position/size setters

### DIFF
--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -345,9 +345,31 @@ pub trait WindowBuilderExtUnix {
     #[cfg(feature = "x11")]
     fn with_gtk_theme_variant(self, variant: String) -> Self;
     /// Build window with resize increment hint. Only implemented on X11.
+    ///
+    /// ```
+    /// # use winit::dpi::{LogicalSize, PhysicalSize};
+    /// # use winit::window::WindowBuilder;
+    /// # use winit::platform::unix::WindowBuilderExtUnix;
+    /// // Specify the size in logical dimensions like this:
+    /// WindowBuilder::new().with_resize_increments(LogicalSize::new(400.0, 200.0));
+    ///
+    /// // Or specify the size in physical dimensions like this:
+    /// WindowBuilder::new().with_resize_increments(PhysicalSize::new(400, 200));
+    /// ```
     #[cfg(feature = "x11")]
     fn with_resize_increments<S: Into<Size>>(self, increments: S) -> Self;
     /// Build window with base size hint. Only implemented on X11.
+    ///
+    /// ```
+    /// # use winit::dpi::{LogicalSize, PhysicalSize};
+    /// # use winit::window::WindowBuilder;
+    /// # use winit::platform::unix::WindowBuilderExtUnix;
+    /// // Specify the size in logical dimensions like this:
+    /// WindowBuilder::new().with_base_size(LogicalSize::new(400.0, 200.0));
+    ///
+    /// // Or specify the size in physical dimensions like this:
+    /// WindowBuilder::new().with_base_size(PhysicalSize::new(400, 200));
+    /// ```
     #[cfg(feature = "x11")]
     fn with_base_size<S: Into<Size>>(self, base_size: S) -> Self;
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -496,6 +496,19 @@ impl Window {
     /// See `outer_position` for more information about the coordinates. This automatically un-maximizes the
     /// window if it's maximized.
     ///
+    /// ```no_run
+    /// # use winit::dpi::{LogicalPosition, PhysicalPosition};
+    /// # use winit::event_loop::EventLoop;
+    /// # use winit::window::Window;
+    /// # let mut event_loop = EventLoop::new();
+    /// # let window = Window::new(&event_loop).unwrap();
+    /// // Specify the position in logical dimensions like this:
+    /// window.set_outer_position(LogicalPosition::new(400.0, 200.0));
+    ///
+    /// // Or specify the position in physical dimensions like this:
+    /// window.set_outer_position(PhysicalPosition::new(400, 200));
+    /// ```
+    ///
     /// ## Platform-specific
     ///
     /// - **iOS:** Can only be called on the main thread. Sets the top left coordinates of the
@@ -528,6 +541,19 @@ impl Window {
     /// See `inner_size` for more information about the values. This automatically un-maximizes the
     /// window if it's maximized.
     ///
+    /// ```no_run
+    /// # use winit::dpi::{LogicalSize, PhysicalSize};
+    /// # use winit::event_loop::EventLoop;
+    /// # use winit::window::Window;
+    /// # let mut event_loop = EventLoop::new();
+    /// # let window = Window::new(&event_loop).unwrap();
+    /// // Specify the size in logical dimensions like this:
+    /// window.set_inner_size(LogicalSize::new(400.0, 200.0));
+    ///
+    /// // Or specify the size in physical dimensions like this:
+    /// window.set_inner_size(PhysicalSize::new(400, 200));
+    /// ```
+    ///
     /// ## Platform-specific
     ///
     /// - **iOS / Android:** Unsupported.
@@ -555,6 +581,19 @@ impl Window {
 
     /// Sets a minimum dimension size for the window.
     ///
+    /// ```no_run
+    /// # use winit::dpi::{LogicalSize, PhysicalSize};
+    /// # use winit::event_loop::EventLoop;
+    /// # use winit::window::Window;
+    /// # let mut event_loop = EventLoop::new();
+    /// # let window = Window::new(&event_loop).unwrap();
+    /// // Specify the size in logical dimensions like this:
+    /// window.set_min_inner_size(Some(LogicalSize::new(400.0, 200.0)));
+    ///
+    /// // Or specify the size in physical dimensions like this:
+    /// window.set_min_inner_size(Some(PhysicalSize::new(400, 200)));
+    /// ```
+    ///
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web:** Unsupported.
@@ -564,6 +603,19 @@ impl Window {
     }
 
     /// Sets a maximum dimension size for the window.
+    ///
+    /// ```no_run
+    /// # use winit::dpi::{LogicalSize, PhysicalSize};
+    /// # use winit::event_loop::EventLoop;
+    /// # use winit::window::Window;
+    /// # let mut event_loop = EventLoop::new();
+    /// # let window = Window::new(&event_loop).unwrap();
+    /// // Specify the size in logical dimensions like this:
+    /// window.set_max_inner_size(Some(LogicalSize::new(400.0, 200.0)));
+    ///
+    /// // Or specify the size in physical dimensions like this:
+    /// window.set_max_inner_size(Some(PhysicalSize::new(400, 200)));
+    /// ```
     ///
     /// ## Platform-specific
     ///
@@ -727,6 +779,19 @@ impl Window {
 
     /// Sets location of IME candidate box in client area coordinates relative to the top left.
     ///
+    /// ```no_run
+    /// # use winit::dpi::{LogicalPosition, PhysicalPosition};
+    /// # use winit::event_loop::EventLoop;
+    /// # use winit::window::Window;
+    /// # let mut event_loop = EventLoop::new();
+    /// # let window = Window::new(&event_loop).unwrap();
+    /// // Specify the position in logical dimensions like this:
+    /// window.set_ime_position(LogicalPosition::new(400.0, 200.0));
+    ///
+    /// // Or specify the position in physical dimensions like this:
+    /// window.set_ime_position(PhysicalPosition::new(400, 200));
+    /// ```
+    ///
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web:** Unsupported.
@@ -782,6 +847,19 @@ impl Window {
     }
 
     /// Changes the position of the cursor in window coordinates.
+    ///
+    /// ```no_run
+    /// # use winit::dpi::{LogicalPosition, PhysicalPosition};
+    /// # use winit::event_loop::EventLoop;
+    /// # use winit::window::Window;
+    /// # let mut event_loop = EventLoop::new();
+    /// # let window = Window::new(&event_loop).unwrap();
+    /// // Specify the position in logical dimensions like this:
+    /// window.set_cursor_position(LogicalPosition::new(400.0, 200.0));
+    ///
+    /// // Or specify the position in physical dimensions like this:
+    /// window.set_cursor_position(PhysicalPosition::new(400, 200));
+    /// ```
     ///
     /// ## Platform-specific
     ///


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


This API is easy to understand once you've seen an example, but figuring it out from just the type signature is really difficult.
So every method with args of `<S: Into<Size>>` or `<P: Into<Position>>` should have an example demonstrating how to use it.

I considered putting this documentation just once in `Size` or `Position`.
But that would have been strange as we would be documenting how to instantiate a different type on a types documentation page.
And it would be harder to find for the user.