### PR TITLE
Fix transparent window crash on Windows 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 - On X11, add mappings for numpad comma, numpad enter, numlock and pause.
+- On Windows, fix a crash with transparent windows on Windows 11.
 
 # 0.26.0 (2021-12-01)
 


### PR DESCRIPTION
Maybe the transparent setting in WM_NCCREATE on Windows 11 will cause a block when callling DwmEnableBlureBehindWindow and will crash. Puts them into WM_CREATE and it works. #2082 
I have not found any details about  the behavior change on Windows 11. Perhaps it's could be a Win11 bug.
I have no win8 or earlier enviroment so I can't test them on these platforms. 

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
