### PR TITLE
Release 0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.26.1 (2022-01-05)
 
 - Fix linking to the `ColorSync` framework on macOS 10.7, and in newer Rust versions.
 - On Web, implement cursor grabbing through the pointer lock API.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.26.0"
+version = "0.26.1"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-winit = "0.26.0"
+winit = "0.26.1"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
v0.26.0 had a regression that made the Pinyin IME input unusable on macOS. See #2097

#2119 fixed that regression, and I think it's a good idea to publish a new release with the fix quickly.

Blocked on:

- [x] #2078
- [x] #2025 
- [x] #2121


###### Sorry for the noise, I realized that I shouldn't have created the issue.