### PR TITLE
Remove entries from PULL_REQUEST_TEMPLATE.md that are now covered by CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,4 @@
 - [ ] Tested on all platforms changed
-- [ ] Compilation warnings were addressed
-- [ ] `cargo fmt` has been run on this branch
-- [ ] `cargo doc` builds successfully
 - [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
 - [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
 - [ ] Created or updated an example program if it would help users understand this functionality


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

The more entries there are, the more likely people are to start just ignoring them all.
By removing the ones already covered by CI then the remaining entries are more likely to be followed.