### PR TITLE
Clippy fixes for windows platform

### DIFF
--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -21,6 +21,9 @@ use crate::{
 };
 
 pub(crate) type EventLoopRunnerShared<T> = Rc<EventLoopRunner<T>>;
+
+type EventHandler<T> = Cell<Option<Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>>>;
+
 pub(crate) struct EventLoopRunner<T: 'static> {
     // The event loop's win32 handles
     pub(super) thread_msg_target: HWND,
@@ -29,8 +32,7 @@ pub(crate) struct EventLoopRunner<T: 'static> {
     control_flow: Cell<ControlFlow>,
     runner_state: Cell<RunnerState>,
     last_events_cleared: Cell<Instant>,
-
-    event_handler: Cell<Option<Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>>>,
+    event_handler: EventHandler<T>,
     event_buffer: RefCell<VecDeque<BufferedEvent<T>>>,
 
     owned_windows: Cell<HashSet<HWND>>,

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -18,7 +18,7 @@ use crate::icon::*;
 use super::util;
 
 impl Pixel {
-    fn to_bgra(&mut self) {
+    fn convert_to_bgra(&mut self) {
         mem::swap(&mut self.r, &mut self.b);
     }
 }
@@ -32,7 +32,7 @@ impl RgbaIcon {
             unsafe { std::slice::from_raw_parts_mut(rgba.as_ptr() as *mut Pixel, pixel_count) };
         for pixel in pixels {
             and_mask.push(pixel.a.wrapping_sub(std::u8::MAX)); // invert alpha channel
-            pixel.to_bgra();
+            pixel.convert_to_bgra();
         }
         assert_eq!(and_mask.len(), pixel_count);
         let handle = unsafe {

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -33,7 +33,8 @@ pub struct VideoMode {
     pub(crate) bit_depth: u16,
     pub(crate) refresh_rate: u16,
     pub(crate) monitor: MonitorHandle,
-    pub(crate) native_video_mode: DEVMODEW,
+    // DEVMODEW is huge so we box it to avoid blowing up the size of winit::window::Fullscreen
+    pub(crate) native_video_mode: Box<DEVMODEW>,
 }
 
 impl PartialEq for VideoMode {
@@ -236,7 +237,7 @@ impl MonitorHandle {
                         bit_depth: mode.dmBitsPerPel as u16,
                         refresh_rate: mode.dmDisplayFrequency as u16,
                         monitor: self.clone(),
-                        native_video_mode: mode,
+                        native_video_mode: Box::new(mode),
                     },
                 });
             }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Resolves all windows specific warnings/errors given by `cargo +nightly clippy --target=x86_64-pc-windows-msvc`

~~The `0 as UINT` -> `0_u32` changes are the only possibly concerning change, but I think the change makes sense as its better to directly use a literal than to have to convert the type.
Rust will perform proper type checking when calling functions that take UINT so we would still catch type issues at compile time.~~