### PR TITLE
Set WindowBuilder to must_use

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -85,6 +85,7 @@ impl WindowId {
 
 /// Object that allows you to build windows.
 #[derive(Clone, Default)]
+#[must_use]
 pub struct WindowBuilder {
     /// The attributes to use to create the window.
     pub window: WindowAttributes,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Makes sense to be must_use as failing to call finish() would almost certainly indicate a bug.
