### PR TITLE
Clippy fixes macos platform

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -162,7 +162,7 @@ impl WindowBuilderExtMacOS for WindowBuilder {
 
     #[inline]
     fn with_resize_increments(mut self, increments: LogicalSize<f64>) -> WindowBuilder {
-        self.platform_specific.resize_increments = Some(increments.into());
+        self.platform_specific.resize_increments = Some(increments);
         self
     }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -25,7 +25,7 @@ use crate::{
     platform_impl::platform::{
         app::APP_CLASS,
         app_delegate::APP_DELEGATE_CLASS,
-        app_state::AppState,
+        app_state::{AppState, Callback},
         monitor::{self, MonitorHandle},
         observer::*,
         util::IdRef,
@@ -111,7 +111,7 @@ pub struct EventLoop<T: 'static> {
     /// Every other reference should be a Weak reference which is only upgraded
     /// into a strong reference in order to call the callback but then the
     /// strong reference should be dropped as soon as possible.
-    _callback: Option<Rc<RefCell<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>>,
+    _callback: Option<Rc<Callback<T>>>,
 }
 
 impl<T> EventLoop<T> {

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -15,7 +15,6 @@ use core_graphics::{
     base::CGError,
     display::{CGDirectDisplayID, CGDisplayConfigRef},
 };
-use objc;
 
 pub const NSNotFound: NSInteger = NSInteger::max_value();
 
@@ -108,6 +107,7 @@ pub const kCGNumberOfWindowLevelKeys: NSInteger = 20;
 
 #[derive(Debug, Clone, Copy)]
 #[repr(isize)]
+#[allow(clippy::enum_variant_names)]
 pub enum NSWindowLevel {
     NSNormalWindowLevel = kCGBaseWindowLevelKey as _,
     NSFloatingWindowLevel = kCGFloatingWindowLevelKey as _,

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -121,7 +121,7 @@ impl Eq for MonitorHandle {}
 
 impl PartialOrd for MonitorHandle {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/platform_impl/macos/util/cursor.rs
+++ b/src/platform_impl/macos/util/cursor.rs
@@ -104,7 +104,7 @@ impl Cursor {
 // Note that loading `busybutclickable` with this code won't animate the frames;
 // instead you'll just get them all in a column.
 pub unsafe fn load_webkit_cursor(cursor_name: &str) -> id {
-    static CURSOR_ROOT: &'static str = "/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/Resources/cursors";
+    static CURSOR_ROOT: &str = "/System/Library/Frameworks/ApplicationServices.framework/Versions/A/Frameworks/HIServices.framework/Versions/A/Resources/cursors";
     let cursor_root = NSString::alloc(nil).init_str(CURSOR_ROOT);
     let cursor_name = NSString::alloc(nil).init_str(cursor_name);
     let cursor_pdf = NSString::alloc(nil).init_str("cursor.pdf");

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -68,7 +68,7 @@ impl Drop for IdRef {
 
 impl Deref for IdRef {
     type Target = id;
-    fn deref<'a>(&'a self) -> &'a id {
+    fn deref(&self) -> &id {
         &self.0
     }
 }
@@ -113,7 +113,7 @@ pub unsafe fn app_name() -> Option<id> {
     }
 }
 
-pub unsafe fn superclass<'a>(this: &'a Object) -> &'a Class {
+pub unsafe fn superclass(this: &Object) -> &Class {
     let superclass: *const Class = msg_send![this, superclass];
     &*superclass
 }

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -260,7 +260,7 @@ lazy_static! {
         decl.add_ivar::<*mut c_void>("winitState");
         decl.add_ivar::<id>("markedText");
         let protocol = Protocol::get("NSTextInputClient").unwrap();
-        decl.add_protocol(&protocol);
+        decl.add_protocol(protocol);
         ViewClass(decl.register())
     };
 }
@@ -589,7 +589,7 @@ fn get_characters(event: id, ignore_modifiers: bool) -> String {
 
 // As defined in: https://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/CORPCHAR.TXT
 fn is_corporate_character(c: char) -> bool {
-    match c {
+    matches!(c,
         '\u{F700}'..='\u{F747}'
         | '\u{F802}'..='\u{F84F}'
         | '\u{F850}'
@@ -597,9 +597,8 @@ fn is_corporate_character(c: char) -> bool {
         | '\u{F85D}'
         | '\u{F85F}'
         | '\u{F860}'..='\u{F86B}'
-        | '\u{F870}'..='\u{F8FF}' => true,
-        _ => false,
-    }
+        | '\u{F870}'..='\u{F8FF}'
+    )
 }
 
 // Retrieves a layout-independent keycode given an event.
@@ -607,7 +606,7 @@ fn retrieve_keycode(event: id) -> Option<VirtualKeyCode> {
     #[inline]
     fn get_code(ev: id, raw: bool) -> Option<VirtualKeyCode> {
         let characters = get_characters(ev, raw);
-        characters.chars().next().and_then(|c| char_to_keycode(c))
+        characters.chars().next().and_then(char_to_keycode)
     }
 
     // Cmd switches Roman letters for Dvorak-QWERTY layout, so we try modified characters first.

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -55,7 +55,7 @@ impl WindowDelegateState {
         let mut delegate_state = WindowDelegateState {
             ns_window: window.ns_window.clone(),
             ns_view: window.ns_view.clone(),
-            window: Arc::downgrade(&window),
+            window: Arc::downgrade(window),
             initial_fullscreen,
             previous_position: None,
             previous_scale_factor: scale_factor,
@@ -86,7 +86,7 @@ impl WindowDelegateState {
     pub fn emit_static_scale_factor_changed_event(&mut self) {
         let scale_factor = self.get_scale_factor();
         if scale_factor == self.previous_scale_factor {
-            return ();
+            return;
         };
 
         self.previous_scale_factor = scale_factor;


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Resolves all mac os specific warnings/errors given by `cargo +nightly clippy --target=x86_64-apple-darwin`