### PR TITLE
Fix some invalid `msg_send!` usage

### DIFF
--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -62,7 +62,8 @@
 // window size/position.
 macro_rules! assert_main_thread {
     ($($t:tt)*) => {
-        if !msg_send![class!(NSThread), isMainThread] {
+        let is_main_thread: ::objc::runtime::BOOL = msg_send!(class!(NSThread), isMainThread);
+        if is_main_thread == ::objc::runtime::NO {
             panic!($($t)*);
         }
     };

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -204,7 +204,8 @@ impl Inner {
             let uiscreen = match monitor {
                 Some(Fullscreen::Exclusive(video_mode)) => {
                     let uiscreen = video_mode.video_mode.monitor.ui_screen() as id;
-                    let () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode];
+                    let () =
+                        msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode.0];
                     uiscreen
                 }
                 Some(Fullscreen::Borderless(monitor)) => monitor

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -19,7 +19,7 @@ use cocoa::{
 };
 use objc::{
     rc::autoreleasepool,
-    runtime::{Object, YES},
+    runtime::{Object, BOOL, NO, YES},
 };
 
 use crate::{
@@ -356,14 +356,16 @@ impl AppState {
     }
 
     pub fn queue_event(wrapper: EventWrapper) {
-        if !unsafe { msg_send![class!(NSThread), isMainThread] } {
+        let is_main_thread: BOOL = unsafe { msg_send!(class!(NSThread), isMainThread) };
+        if is_main_thread == NO {
             panic!("Event queued from different thread: {:#?}", wrapper);
         }
         HANDLER.events().push_back(wrapper);
     }
 
     pub fn queue_events(mut wrappers: VecDeque<EventWrapper>) {
-        if !unsafe { msg_send![class!(NSThread), isMainThread] } {
+        let is_main_thread: BOOL = unsafe { msg_send!(class!(NSThread), isMainThread) };
+        if is_main_thread == NO {
             panic!("Events queued from different thread: {:#?}", wrappers);
         }
         HANDLER.events().append(&mut wrappers);
@@ -400,8 +402,9 @@ impl AppState {
 
                 let dialog_open = if window_count > 1 {
                     let dialog: id = msg_send![windows, lastObject];
-                    let is_main_window: bool = msg_send![dialog, isMainWindow];
-                    msg_send![dialog, isVisible] && !is_main_window
+                    let is_main_window: BOOL = msg_send![dialog, isMainWindow];
+                    let is_visible: BOOL = msg_send![dialog, isVisible];
+                    is_visible != NO && is_main_window == NO
                 } else {
                     false
                 };
@@ -419,9 +422,9 @@ impl AppState {
                 });
 
                 if window_count > 0 {
-                    let window: id = msg_send![windows, objectAtIndex:0];
-                    let window_has_focus = msg_send![window, isKeyWindow];
-                    if !dialog_open && window_has_focus && dialog_is_closing {
+                    let window: id = msg_send![windows, firstObject];
+                    let window_has_focus: BOOL = msg_send![window, isKeyWindow];
+                    if !dialog_open && window_has_focus != NO && dialog_is_closing {
                         HANDLER.dialog_is_closing.store(false, Ordering::SeqCst);
                     }
                     if dialog_open {

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -12,9 +12,9 @@ use std::{
 };
 
 use cocoa::{
-    appkit::{NSApp, NSEventType::NSApplicationDefined},
-    base::{id, nil, YES},
-    foundation::NSPoint,
+    appkit::{NSApp, NSEventModifierFlags, NSEventSubtype, NSEventType::NSApplicationDefined},
+    base::{id, nil, BOOL, NO, YES},
+    foundation::{NSInteger, NSPoint, NSTimeInterval},
 };
 use objc::rc::autoreleasepool;
 
@@ -117,7 +117,8 @@ pub struct EventLoop<T: 'static> {
 impl<T> EventLoop<T> {
     pub fn new() -> Self {
         let delegate = unsafe {
-            if !msg_send![class!(NSThread), isMainThread] {
+            let is_main_thread: BOOL = msg_send!(class!(NSThread), isMainThread);
+            if is_main_thread == NO {
                 panic!("On macOS, `EventLoop` must be created on the main thread!");
             }
 
@@ -208,13 +209,13 @@ pub unsafe fn post_dummy_event(target: id) {
         event_class,
         otherEventWithType: NSApplicationDefined
         location: NSPoint::new(0.0, 0.0)
-        modifierFlags: 0
-        timestamp: 0
-        windowNumber: 0
+        modifierFlags: NSEventModifierFlags::empty()
+        timestamp: 0 as NSTimeInterval
+        windowNumber: 0 as NSInteger
         context: nil
-        subtype: 0
-        data1: 0
-        data2: 0
+        subtype: NSEventSubtype::NSWindowExposedEventType
+        data1: 0 as NSInteger
+        data2: 0 as NSInteger
     ];
     let () = msg_send![target, postEvent: dummy_event atStart: YES];
 }

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -107,6 +107,7 @@ pub const kCGCursorWindowLevelKey: NSInteger = 19;
 pub const kCGNumberOfWindowLevelKeys: NSInteger = 20;
 
 #[derive(Debug, Clone, Copy)]
+#[repr(isize)]
 pub enum NSWindowLevel {
     NSNormalWindowLevel = kCGBaseWindowLevelKey as _,
     NSFloatingWindowLevel = kCGFloatingWindowLevelKey as _,

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -10,7 +10,7 @@ use cocoa::{
 };
 use dispatch::Queue;
 use objc::rc::autoreleasepool;
-use objc::runtime::NO;
+use objc::runtime::{BOOL, NO};
 
 use crate::{
     dpi::LogicalSize,
@@ -51,7 +51,8 @@ pub unsafe fn set_style_mask_async(ns_window: id, ns_view: id, mask: NSWindowSty
     });
 }
 pub unsafe fn set_style_mask_sync(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
-    if msg_send![class!(NSThread), isMainThread] {
+    let is_main_thread: BOOL = msg_send!(class!(NSThread), isMainThread);
+    if is_main_thread != NO {
         set_style_mask(ns_window, ns_view, mask);
     } else {
         let ns_window = MainThreadSafe(ns_window);

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -114,7 +114,8 @@ pub unsafe fn app_name() -> Option<id> {
 }
 
 pub unsafe fn superclass<'a>(this: &'a Object) -> &'a Class {
-    msg_send![this, superclass]
+    let superclass: *const Class = msg_send![this, superclass];
+    &*superclass
 }
 
 pub unsafe fn create_input_context(view: id) -> IdRef {

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -40,10 +40,9 @@ impl IdRef {
         IdRef(inner)
     }
 
-    #[allow(dead_code)]
     pub fn retain(inner: id) -> IdRef {
         if inner != nil {
-            let () = unsafe { msg_send![inner, retain] };
+            let _: id = unsafe { msg_send![inner, retain] };
         }
         IdRef(inner)
     }
@@ -76,10 +75,7 @@ impl Deref for IdRef {
 
 impl Clone for IdRef {
     fn clone(&self) -> IdRef {
-        if self.0 != nil {
-            let _: id = unsafe { msg_send![self.0, retain] };
-        }
-        IdRef(self.0)
+        IdRef::retain(self.0)
     }
 }
 
@@ -118,8 +114,7 @@ pub unsafe fn app_name() -> Option<id> {
 }
 
 pub unsafe fn superclass<'a>(this: &'a Object) -> &'a Class {
-    let superclass: id = msg_send![this, superclass];
-    &*(superclass as *const _)
+    msg_send![this, superclass]
 }
 
 pub unsafe fn create_input_context(view: id) -> IdRef {


### PR DESCRIPTION
Change a few types for more correct behaviour (e.g. using `bool` may be undefined behaviour, one should use `BOOL`).

The only critical thing here is the stuff in `unmark_text` (introduced in #2119), that part is certainly undefined behaviour, and will probably cause problems somewhere down the line.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented