### PR TITLE
Fix windows deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - On macOS, initialize the Menu Bar with minimal defaults. (Can be prevented using `enable_default_menu_creation`)
 - On macOS, change the default behavior for first click when the window was unfocused. Now the window becomes focused and then emits a `MouseInput` event on a "first mouse click".
 - Implement mint (math interoperability standard types) conversions (under feature flag `mint`).
+- On Windows, fix bug causing deadlocks when resizing or moving windows
 
 # 0.24.0 (2020-12-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@
 - On macOS, initialize the Menu Bar with minimal defaults. (Can be prevented using `enable_default_menu_creation`)
 - On macOS, change the default behavior for first click when the window was unfocused. Now the window becomes focused and then emits a `MouseInput` event on a "first mouse click".
 - Implement mint (math interoperability standard types) conversions (under feature flag `mint`).
-- On Windows, fix bug causing deadlocks when resizing or moving windows
 
 # 0.24.0 (2020-12-09)
 

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -76,6 +76,7 @@ impl KeyEventBuilder {
         msg_kind: u32,
         wparam: WPARAM,
         lparam: LPARAM,
+        next_msg: &Option<winuser::MSG>,
         result: &mut ProcResult,
     ) -> Vec<MessageAsKeyEvent> {
         match msg_kind {
@@ -111,21 +112,9 @@ impl KeyEventBuilder {
                     &mut layouts,
                 );
 
-                let mut next_msg = MaybeUninit::uninit();
-                let peek_retval = unsafe {
-                    winuser::PeekMessageW(
-                        next_msg.as_mut_ptr(),
-                        hwnd,
-                        winuser::WM_KEYFIRST,
-                        winuser::WM_KEYLAST,
-                        winuser::PM_NOREMOVE,
-                    )
-                };
-                let has_next_key_message = peek_retval != 0;
                 self.event_info = None;
                 let mut finished_event_info = Some(event_info);
-                if has_next_key_message {
-                    let next_msg = unsafe { next_msg.assume_init() };
+                if let Some(next_msg) = next_msg {
                     let next_msg_kind = next_msg.message;
                     let next_belongs_to_this = !matches!(
                         next_msg_kind,
@@ -178,28 +167,11 @@ impl KeyEventBuilder {
 
                 let is_utf16 = is_high_surrogate || is_low_surrogate;
 
-                let more_char_coming;
-                unsafe {
-                    let mut next_msg = MaybeUninit::uninit();
-                    let has_message = winuser::PeekMessageW(
-                        next_msg.as_mut_ptr(),
-                        hwnd,
-                        winuser::WM_KEYFIRST,
-                        winuser::WM_KEYLAST,
-                        winuser::PM_NOREMOVE,
-                    );
-                    let has_message = has_message != 0;
-                    if !has_message {
-                        more_char_coming = false;
-                    } else {
-                        let next_msg = next_msg.assume_init().message;
-                        if next_msg == winuser::WM_CHAR || next_msg == winuser::WM_SYSCHAR {
-                            more_char_coming = true;
-                        } else {
-                            more_char_coming = false;
-                        }
-                    }
-                }
+                let more_char_coming = next_msg.map(|next_msg| {
+                    matches!(
+                        next_msg.message,
+                        winuser::WM_CHAR | winuser::WM_SYSCHAR)
+                }).unwrap_or(false);
 
                 if is_utf16 {
                     if let Some(ev_info) = self.event_info.as_mut() {
@@ -278,20 +250,8 @@ impl KeyEventBuilder {
                     ElementState::Released,
                     &mut layouts,
                 );
-                let mut next_msg = MaybeUninit::uninit();
-                let peek_retval = unsafe {
-                    winuser::PeekMessageW(
-                        next_msg.as_mut_ptr(),
-                        hwnd,
-                        winuser::WM_KEYFIRST,
-                        winuser::WM_KEYLAST,
-                        winuser::PM_NOREMOVE,
-                    )
-                };
-                let has_next_key_message = peek_retval != 0;
                 let mut valid_event_info = Some(event_info);
-                if has_next_key_message {
-                    let next_msg = unsafe { next_msg.assume_init() };
+                if let Some(next_msg) = next_msg {
                     let (_, layout) = layouts.get_current_layout();
                     let is_fake = {
                         let event_info = valid_event_info.as_ref().unwrap();
@@ -755,7 +715,7 @@ fn get_async_kbd_state() -> [u8; 256] {
 /// fake Ctrl event.
 fn is_current_fake(
     curr_info: &PartialKeyEventInfo,
-    next_msg: winuser::MSG,
+    next_msg: &winuser::MSG,
     layout: &Layout,
 ) -> bool {
     let curr_is_ctrl = matches!(curr_info.logical_key, PartialLogicalKey::This(Key::Control));


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Details about this change found here: https://github.com/rust-windowing/winit/pull/2143#issuecomment-1009408778

TLDR: We have been encountering a deadlock on windows when using a fork of the new keyboard changes in neovide. This change fixes that deadlock