### PR TITLE
Reduce duplication in `dpi` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+- Implement `PartialOrd` and `Ord` for position/size structs and enums where relevant.
 - **Breaking:** Rename the `Exit` variant of `ControlFlow` to `ExitWithCode`, which holds a value to control the exit code after running. Add an `Exit` constant which aliases to `ExitWithCode(0)` instead to avoid major breakage. This shouldn't affect most existing programs.
 
 # 0.26.1 (2022-01-05)

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -109,41 +109,24 @@ pub trait Pixel: Copy + Into<f64> {
     }
 }
 
-impl Pixel for u8 {
-    fn from_f64(f: f64) -> Self {
-        f.round() as u8
-    }
+macro_rules! pixel_int_impl {
+    ($($t:ty),*) => {$(
+        impl Pixel for $t {
+            fn from_f64(f: f64) -> Self {
+                f.round() as $t
+            }
+        }
+    )*}
 }
-impl Pixel for u16 {
-    fn from_f64(f: f64) -> Self {
-        f.round() as u16
-    }
-}
-impl Pixel for u32 {
-    fn from_f64(f: f64) -> Self {
-        f.round() as u32
-    }
-}
-impl Pixel for i8 {
-    fn from_f64(f: f64) -> Self {
-        f.round() as i8
-    }
-}
-impl Pixel for i16 {
-    fn from_f64(f: f64) -> Self {
-        f.round() as i16
-    }
-}
-impl Pixel for i32 {
-    fn from_f64(f: f64) -> Self {
-        f.round() as i32
-    }
-}
+
+pixel_int_impl!(u8, u16, u32, i8, i16, i32);
+
 impl Pixel for f32 {
     fn from_f64(f: f64) -> Self {
         f as f32
     }
 }
+
 impl Pixel for f64 {
     fn from_f64(f: f64) -> Self {
         f

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -165,7 +165,7 @@ pub fn validate_scale_factor(scale_factor: f64) -> bool {
 /// The position is stored as floats, so please be careful. Casting floats to integers truncates the
 /// fractional part, which can cause noticable issues. To help with that, an `Into<(i32, i32)>`
 /// implementation is provided which does the rounding for you.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LogicalPosition<P> {
     pub x: P,
@@ -244,7 +244,7 @@ impl<P: Pixel> From<LogicalPosition<P>> for mint::Point2<P> {
 }
 
 /// A position represented in physical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PhysicalPosition<P> {
     pub x: P,
@@ -323,7 +323,7 @@ impl<P: Pixel> From<PhysicalPosition<P>> for mint::Point2<P> {
 }
 
 /// A size represented in logical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LogicalSize<P> {
     pub width: P,
@@ -405,7 +405,7 @@ impl<P: Pixel> From<LogicalSize<P>> for mint::Vector2<P> {
 }
 
 /// A size represented in physical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PhysicalSize<P> {
     pub width: P,
@@ -484,7 +484,7 @@ impl<P: Pixel> From<PhysicalSize<P>> for mint::Vector2<P> {
 }
 
 /// A size that's either physical or logical.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Size {
     Physical(PhysicalSize<u32>),
@@ -526,7 +526,7 @@ impl<P: Pixel> From<LogicalSize<P>> for Size {
 }
 
 /// A position that's either physical or logical.
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Position {
     Physical(PhysicalPosition<i32>),

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -133,6 +133,48 @@ impl Pixel for f64 {
     }
 }
 
+macro_rules! vec2_from_impls {
+    ($t:ident, $a:ident, $b:ident, $mint_ty:ident) => {
+        impl<P: Pixel, X: Pixel> From<(X, X)> for $t<P> {
+            fn from(($a, $b): (X, X)) -> Self {
+                Self::new($a.cast(), $b.cast())
+            }
+        }
+
+        impl<P: Pixel, X: Pixel> From<$t<P>> for (X, X) {
+            fn from(p: $t<P>) -> Self {
+                (p.$a.cast(), p.$b.cast())
+            }
+        }
+
+        impl<P: Pixel, X: Pixel> From<[X; 2]> for $t<P> {
+            fn from([$a, $b]: [X; 2]) -> Self {
+                Self::new($a.cast(), $b.cast())
+            }
+        }
+
+        impl<P: Pixel, X: Pixel> From<$t<P>> for [X; 2] {
+            fn from(p: $t<P>) -> Self {
+                [p.$a.cast(), p.$b.cast()]
+            }
+        }
+
+        #[cfg(feature = "mint")]
+        impl<P: Pixel> From<mint::$mint_ty<P>> for $t<P> {
+            fn from(p: mint::$mint_ty<P>) -> Self {
+                Self::new(p.x, p.y)
+            }
+        }
+
+        #[cfg(feature = "mint")]
+        impl<P: Pixel> From<$t<P>> for mint::$mint_ty<P> {
+            fn from(p: $t<P>) -> Self {
+                Self { x: p.$a, y: p.$b }
+            }
+        }
+    };
+}
+
 /// Checks that the scale factor is a normal positive `f64`.
 ///
 /// All functions that take a scale factor assert that this will return `true`. If you're sourcing scale factors from
@@ -188,43 +230,7 @@ impl<P: Pixel> LogicalPosition<P> {
     }
 }
 
-impl<P: Pixel, X: Pixel> From<(X, X)> for LogicalPosition<P> {
-    fn from((x, y): (X, X)) -> LogicalPosition<P> {
-        LogicalPosition::new(x.cast(), y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<LogicalPosition<P>> for (X, X) {
-    fn from(p: LogicalPosition<P>) -> (X, X) {
-        (p.x.cast(), p.y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<[X; 2]> for LogicalPosition<P> {
-    fn from([x, y]: [X; 2]) -> LogicalPosition<P> {
-        LogicalPosition::new(x.cast(), y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<LogicalPosition<P>> for [X; 2] {
-    fn from(p: LogicalPosition<P>) -> [X; 2] {
-        [p.x.cast(), p.y.cast()]
-    }
-}
-
-#[cfg(feature = "mint")]
-impl<P: Pixel> From<mint::Point2<P>> for LogicalPosition<P> {
-    fn from(p: mint::Point2<P>) -> Self {
-        Self::new(p.x, p.y)
-    }
-}
-
-#[cfg(feature = "mint")]
-impl<P: Pixel> From<LogicalPosition<P>> for mint::Point2<P> {
-    fn from(p: LogicalPosition<P>) -> Self {
-        mint::Point2 { x: p.x, y: p.y }
-    }
-}
+vec2_from_impls!(LogicalPosition, x, y, Point2);
 
 /// A position represented in physical pixels.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
@@ -267,43 +273,7 @@ impl<P: Pixel> PhysicalPosition<P> {
     }
 }
 
-impl<P: Pixel, X: Pixel> From<(X, X)> for PhysicalPosition<P> {
-    fn from((x, y): (X, X)) -> PhysicalPosition<P> {
-        PhysicalPosition::new(x.cast(), y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<PhysicalPosition<P>> for (X, X) {
-    fn from(p: PhysicalPosition<P>) -> (X, X) {
-        (p.x.cast(), p.y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<[X; 2]> for PhysicalPosition<P> {
-    fn from([x, y]: [X; 2]) -> PhysicalPosition<P> {
-        PhysicalPosition::new(x.cast(), y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<PhysicalPosition<P>> for [X; 2] {
-    fn from(p: PhysicalPosition<P>) -> [X; 2] {
-        [p.x.cast(), p.y.cast()]
-    }
-}
-
-#[cfg(feature = "mint")]
-impl<P: Pixel> From<mint::Point2<P>> for PhysicalPosition<P> {
-    fn from(p: mint::Point2<P>) -> Self {
-        Self::new(p.x, p.y)
-    }
-}
-
-#[cfg(feature = "mint")]
-impl<P: Pixel> From<PhysicalPosition<P>> for mint::Point2<P> {
-    fn from(p: PhysicalPosition<P>) -> Self {
-        mint::Point2 { x: p.x, y: p.y }
-    }
-}
+vec2_from_impls!(PhysicalPosition, x, y, Point2);
 
 /// A size represented in logical pixels.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
@@ -346,46 +316,7 @@ impl<P: Pixel> LogicalSize<P> {
     }
 }
 
-impl<P: Pixel, X: Pixel> From<(X, X)> for LogicalSize<P> {
-    fn from((x, y): (X, X)) -> LogicalSize<P> {
-        LogicalSize::new(x.cast(), y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<LogicalSize<P>> for (X, X) {
-    fn from(s: LogicalSize<P>) -> (X, X) {
-        (s.width.cast(), s.height.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<[X; 2]> for LogicalSize<P> {
-    fn from([x, y]: [X; 2]) -> LogicalSize<P> {
-        LogicalSize::new(x.cast(), y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<LogicalSize<P>> for [X; 2] {
-    fn from(s: LogicalSize<P>) -> [X; 2] {
-        [s.width.cast(), s.height.cast()]
-    }
-}
-
-#[cfg(feature = "mint")]
-impl<P: Pixel> From<mint::Vector2<P>> for LogicalSize<P> {
-    fn from(v: mint::Vector2<P>) -> Self {
-        Self::new(v.x, v.y)
-    }
-}
-
-#[cfg(feature = "mint")]
-impl<P: Pixel> From<LogicalSize<P>> for mint::Vector2<P> {
-    fn from(s: LogicalSize<P>) -> Self {
-        mint::Vector2 {
-            x: s.width,
-            y: s.height,
-        }
-    }
-}
+vec2_from_impls!(LogicalSize, width, height, Vector2);
 
 /// A size represented in physical pixels.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
@@ -425,46 +356,7 @@ impl<P: Pixel> PhysicalSize<P> {
     }
 }
 
-impl<P: Pixel, X: Pixel> From<(X, X)> for PhysicalSize<P> {
-    fn from((x, y): (X, X)) -> PhysicalSize<P> {
-        PhysicalSize::new(x.cast(), y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<PhysicalSize<P>> for (X, X) {
-    fn from(s: PhysicalSize<P>) -> (X, X) {
-        (s.width.cast(), s.height.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<[X; 2]> for PhysicalSize<P> {
-    fn from([x, y]: [X; 2]) -> PhysicalSize<P> {
-        PhysicalSize::new(x.cast(), y.cast())
-    }
-}
-
-impl<P: Pixel, X: Pixel> From<PhysicalSize<P>> for [X; 2] {
-    fn from(s: PhysicalSize<P>) -> [X; 2] {
-        [s.width.cast(), s.height.cast()]
-    }
-}
-
-#[cfg(feature = "mint")]
-impl<P: Pixel> From<mint::Vector2<P>> for PhysicalSize<P> {
-    fn from(v: mint::Vector2<P>) -> Self {
-        Self::new(v.x, v.y)
-    }
-}
-
-#[cfg(feature = "mint")]
-impl<P: Pixel> From<PhysicalSize<P>> for mint::Vector2<P> {
-    fn from(s: PhysicalSize<P>) -> Self {
-        mint::Vector2 {
-            x: s.width,
-            y: s.height,
-        }
-    }
-}
+vec2_from_impls!(PhysicalSize, width, height, Vector2);
 
 /// A size that's either physical or logical.
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -185,259 +185,184 @@ pub fn validate_scale_factor(scale_factor: f64) -> bool {
     scale_factor.is_sign_positive() && scale_factor.is_normal()
 }
 
-/// A position represented in logical pixels.
-///
-/// The position is stored as floats, so please be careful. Casting floats to integers truncates the
-/// fractional part, which can cause noticable issues. To help with that, an `Into<(i32, i32)>`
-/// implementation is provided which does the rounding for you.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LogicalPosition<P> {
-    pub x: P,
-    pub y: P,
-}
+macro_rules! dpi_type {
+    (
+        let a = $a:ident;
+        let b = $b:ident;
+        let mint = $mint:ident;
 
-impl<P> LogicalPosition<P> {
-    #[inline]
-    pub const fn new(x: P, y: P) -> Self {
-        LogicalPosition { x, y }
-    }
-}
-
-impl<P: Pixel> LogicalPosition<P> {
-    #[inline]
-    pub fn from_physical<T: Into<PhysicalPosition<X>>, X: Pixel>(
-        physical: T,
-        scale_factor: f64,
-    ) -> Self {
-        physical.into().to_logical(scale_factor)
-    }
-
-    #[inline]
-    pub fn to_physical<X: Pixel>(&self, scale_factor: f64) -> PhysicalPosition<X> {
-        assert!(validate_scale_factor(scale_factor));
-        let x = self.x.into() * scale_factor;
-        let y = self.y.into() * scale_factor;
-        PhysicalPosition::new(x, y).cast()
-    }
-
-    #[inline]
-    pub fn cast<X: Pixel>(&self) -> LogicalPosition<X> {
-        LogicalPosition {
-            x: self.x.cast(),
-            y: self.y.cast(),
+        $(#[$logical_meta:meta])*
+        pub struct $LogicalType:ident;
+        $(#[$physical_meta:meta])*
+        pub struct $PhysicalType:ident;
+        $(#[$unified_meta:meta])*
+        pub enum $UnifiedType:ident {
+            Physical($unified_physical:ty),
+            Logical($unified_logical:ty),
         }
-    }
-}
-
-vec2_from_impls!(LogicalPosition, x, y, Point2);
-
-/// A position represented in physical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PhysicalPosition<P> {
-    pub x: P,
-    pub y: P,
-}
-
-impl<P> PhysicalPosition<P> {
-    #[inline]
-    pub const fn new(x: P, y: P) -> Self {
-        PhysicalPosition { x, y }
-    }
-}
-
-impl<P: Pixel> PhysicalPosition<P> {
-    #[inline]
-    pub fn from_logical<T: Into<LogicalPosition<X>>, X: Pixel>(
-        logical: T,
-        scale_factor: f64,
-    ) -> Self {
-        logical.into().to_physical(scale_factor)
-    }
-
-    #[inline]
-    pub fn to_logical<X: Pixel>(&self, scale_factor: f64) -> LogicalPosition<X> {
-        assert!(validate_scale_factor(scale_factor));
-        let x = self.x.into() / scale_factor;
-        let y = self.y.into() / scale_factor;
-        LogicalPosition::new(x, y).cast()
-    }
-
-    #[inline]
-    pub fn cast<X: Pixel>(&self) -> PhysicalPosition<X> {
-        PhysicalPosition {
-            x: self.x.cast(),
-            y: self.y.cast(),
+    ) => {
+        $(#[$logical_meta])*
+        #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        pub struct $LogicalType<P> {
+            pub $a: P,
+            pub $b: P,
         }
-    }
-}
 
-vec2_from_impls!(PhysicalPosition, x, y, Point2);
-
-/// A size represented in logical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct LogicalSize<P> {
-    pub width: P,
-    pub height: P,
-}
-
-impl<P> LogicalSize<P> {
-    #[inline]
-    pub const fn new(width: P, height: P) -> Self {
-        LogicalSize { width, height }
-    }
-}
-
-impl<P: Pixel> LogicalSize<P> {
-    #[inline]
-    pub fn from_physical<T: Into<PhysicalSize<X>>, X: Pixel>(
-        physical: T,
-        scale_factor: f64,
-    ) -> Self {
-        physical.into().to_logical(scale_factor)
-    }
-
-    #[inline]
-    pub fn to_physical<X: Pixel>(&self, scale_factor: f64) -> PhysicalSize<X> {
-        assert!(validate_scale_factor(scale_factor));
-        let width = self.width.into() * scale_factor;
-        let height = self.height.into() * scale_factor;
-        PhysicalSize::new(width, height).cast()
-    }
-
-    #[inline]
-    pub fn cast<X: Pixel>(&self) -> LogicalSize<X> {
-        LogicalSize {
-            width: self.width.cast(),
-            height: self.height.cast(),
+        impl<P> $LogicalType<P> {
+            #[inline]
+            pub const fn new($a: P, $b: P) -> Self {
+                $LogicalType { $a, $b }
+            }
         }
-    }
-}
 
-vec2_from_impls!(LogicalSize, width, height, Vector2);
+        impl<P: Pixel> $LogicalType<P> {
+            #[inline]
+            pub fn from_physical<T: Into<$PhysicalType<X>>, X: Pixel>(
+                physical: T,
+                scale_factor: f64,
+            ) -> Self {
+                physical.into().to_logical(scale_factor)
+            }
 
-/// A size represented in physical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct PhysicalSize<P> {
-    pub width: P,
-    pub height: P,
-}
+            #[inline]
+            pub fn to_physical<X: Pixel>(&self, scale_factor: f64) -> $PhysicalType<X> {
+                assert!(validate_scale_factor(scale_factor));
+                let $a = self.$a.into() * scale_factor;
+                let $b = self.$b.into() * scale_factor;
+                $PhysicalType::new($a, $b).cast()
+            }
 
-impl<P> PhysicalSize<P> {
-    #[inline]
-    pub const fn new(width: P, height: P) -> Self {
-        PhysicalSize { width, height }
-    }
-}
-
-impl<P: Pixel> PhysicalSize<P> {
-    #[inline]
-    pub fn from_logical<T: Into<LogicalSize<X>>, X: Pixel>(logical: T, scale_factor: f64) -> Self {
-        logical.into().to_physical(scale_factor)
-    }
-
-    #[inline]
-    pub fn to_logical<X: Pixel>(&self, scale_factor: f64) -> LogicalSize<X> {
-        assert!(validate_scale_factor(scale_factor));
-        let width = self.width.into() / scale_factor;
-        let height = self.height.into() / scale_factor;
-        LogicalSize::new(width, height).cast()
-    }
-
-    #[inline]
-    pub fn cast<X: Pixel>(&self) -> PhysicalSize<X> {
-        PhysicalSize {
-            width: self.width.cast(),
-            height: self.height.cast(),
+            #[inline]
+            pub fn cast<X: Pixel>(&self) -> $LogicalType<X> {
+                $LogicalType {
+                    $a: self.$a.cast(),
+                    $b: self.$b.cast(),
+                }
+            }
         }
-    }
-}
 
-vec2_from_impls!(PhysicalSize, width, height, Vector2);
+        vec2_from_impls!($LogicalType, $b, $a, $mint);
 
-/// A size that's either physical or logical.
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Size {
-    Physical(PhysicalSize<u32>),
-    Logical(LogicalSize<f64>),
-}
-
-impl Size {
-    pub fn new<S: Into<Size>>(size: S) -> Size {
-        size.into()
-    }
-
-    pub fn to_logical<P: Pixel>(&self, scale_factor: f64) -> LogicalSize<P> {
-        match *self {
-            Size::Physical(size) => size.to_logical(scale_factor),
-            Size::Logical(size) => size.cast(),
+        $(#[$physical_meta])*
+        #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash, PartialOrd, Ord)]
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        pub struct $PhysicalType<P> {
+            pub $a: P,
+            pub $b: P,
         }
-    }
 
-    pub fn to_physical<P: Pixel>(&self, scale_factor: f64) -> PhysicalSize<P> {
-        match *self {
-            Size::Physical(size) => size.cast(),
-            Size::Logical(size) => size.to_physical(scale_factor),
+        impl<P> $PhysicalType<P> {
+            #[inline]
+            pub const fn new($a: P, $b: P) -> Self {
+                $PhysicalType { $a, $b }
+            }
         }
-    }
-}
 
-impl<P: Pixel> From<PhysicalSize<P>> for Size {
-    #[inline]
-    fn from(size: PhysicalSize<P>) -> Size {
-        Size::Physical(size.cast())
-    }
-}
+        impl<P: Pixel> $PhysicalType<P> {
+            #[inline]
+            pub fn from_logical<T: Into<$LogicalType<X>>, X: Pixel>(
+                logical: T,
+                scale_factor: f64,
+            ) -> Self {
+                logical.into().to_physical(scale_factor)
+            }
 
-impl<P: Pixel> From<LogicalSize<P>> for Size {
-    #[inline]
-    fn from(size: LogicalSize<P>) -> Size {
-        Size::Logical(size.cast())
-    }
-}
+            #[inline]
+            pub fn to_logical<X: Pixel>(&self, scale_factor: f64) -> $LogicalType<X> {
+                assert!(validate_scale_factor(scale_factor));
+                let $a = self.$a.into() / scale_factor;
+                let $b = self.$b.into() / scale_factor;
+                $LogicalType::new($a, $b).cast()
+            }
 
-/// A position that's either physical or logical.
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum Position {
-    Physical(PhysicalPosition<i32>),
-    Logical(LogicalPosition<f64>),
-}
-
-impl Position {
-    pub fn new<S: Into<Position>>(position: S) -> Position {
-        position.into()
-    }
-
-    pub fn to_logical<P: Pixel>(&self, scale_factor: f64) -> LogicalPosition<P> {
-        match *self {
-            Position::Physical(position) => position.to_logical(scale_factor),
-            Position::Logical(position) => position.cast(),
+            #[inline]
+            pub fn cast<X: Pixel>(&self) -> $PhysicalType<X> {
+                $PhysicalType {
+                    $a: self.$a.cast(),
+                    $b: self.$b.cast(),
+                }
+            }
         }
-    }
 
-    pub fn to_physical<P: Pixel>(&self, scale_factor: f64) -> PhysicalPosition<P> {
-        match *self {
-            Position::Physical(position) => position.cast(),
-            Position::Logical(position) => position.to_physical(scale_factor),
+        vec2_from_impls!($PhysicalType, $b, $a, $mint);
+
+        $(#[$unified_meta])*
+        #[derive(Debug, Copy, Clone, PartialEq, PartialOrd)]
+        #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+        pub enum $UnifiedType {
+            Physical($unified_physical),
+            Logical($unified_logical),
         }
+
+        impl $UnifiedType {
+            pub fn new<S: Into<$UnifiedType>>(val: S) -> $UnifiedType {
+                val.into()
+            }
+
+            pub fn to_logical<P: Pixel>(&self, scale_factor: f64) -> $LogicalType<P> {
+                match *self {
+                    $UnifiedType::Physical(val) => val.to_logical(scale_factor),
+                    $UnifiedType::Logical(val) => val.cast(),
+                }
+            }
+
+            pub fn to_physical<P: Pixel>(&self, scale_factor: f64) -> $PhysicalType<P> {
+                match *self {
+                    $UnifiedType::Physical(val) => val.cast(),
+                    $UnifiedType::Logical(val) => val.to_physical(scale_factor),
+                }
+            }
+        }
+
+        impl<P: Pixel> From<$PhysicalType<P>> for $UnifiedType {
+            #[inline]
+            fn from(val: $PhysicalType<P>) -> $UnifiedType {
+                $UnifiedType::Physical(val.cast())
+            }
+        }
+
+        impl<P: Pixel> From<$LogicalType<P>> for $UnifiedType {
+            #[inline]
+            fn from(val: $LogicalType<P>) -> $UnifiedType {
+                $UnifiedType::Logical(val.cast())
+            }
+        }
+    };
+}
+
+dpi_type! {
+    let a = x;
+    let b = y;
+    let mint = Point2;
+
+    /// A position represented in logical pixels.
+    ///
+    /// The position is stored as floats, so please be careful. Casting floats to integers truncates the
+    /// fractional part, which can cause noticable issues. To help with that, an `Into<(i32, i32)>`
+    /// implementation is provided which does the rounding for you.
+    pub struct LogicalPosition;
+    /// A position represented in physical pixels.
+    pub struct PhysicalPosition;
+    /// A position that's either physical or logical.
+    pub enum Position {
+        Physical(PhysicalPosition<i32>),
+        Logical(LogicalPosition<f64>),
     }
 }
 
-impl<P: Pixel> From<PhysicalPosition<P>> for Position {
-    #[inline]
-    fn from(position: PhysicalPosition<P>) -> Position {
-        Position::Physical(position.cast())
-    }
-}
+dpi_type! {
+    let a = width;
+    let b = height;
+    let mint = Vector2;
 
-impl<P: Pixel> From<LogicalPosition<P>> for Position {
-    #[inline]
-    fn from(position: LogicalPosition<P>) -> Position {
-        Position::Logical(position.cast())
+    /// A size represented in logical pixels.
+    pub struct LogicalSize;
+    /// A size represented in physical pixels.
+    pub struct PhysicalSize;
+    /// A size that's either physical or logical.
+    pub enum Size {
+        Physical(PhysicalSize<u32>),
+        Logical(LogicalSize<f64>),
     }
 }


### PR DESCRIPTION
Grabbed from https://github.com/rust-windowing/winit/pull/1374. The motivation in here was to add a `Delta` variant of these (as part of a replacement of `MouseScrollDelta`).

The only API changes in this PR is the `PartialOrd`/`Ord` impls, as noted in the changelog, the rest is merely a code-reduction that I believe is valuable.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
