### PR TITLE
Rename internal structs for consistency

### DIFF
--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -226,8 +226,8 @@ impl<T> EventLoop<T> {
         exit_code
     }
 
-    pub fn create_proxy(&self) -> Proxy<T> {
-        Proxy::new(self.window_target.p.sender.clone())
+    pub fn create_proxy(&self) -> EventLoopProxy<T> {
+        EventLoopProxy::new(self.window_target.p.sender.clone())
     }
 }
 
@@ -281,14 +281,14 @@ pub fn stop_app_on_panic<F: FnOnce() -> R + UnwindSafe, R>(
     }
 }
 
-pub struct Proxy<T> {
+pub struct EventLoopProxy<T> {
     sender: mpsc::Sender<T>,
     source: CFRunLoopSourceRef,
 }
 
-unsafe impl<T: Send> Send for Proxy<T> {}
+unsafe impl<T: Send> Send for EventLoopProxy<T> {}
 
-impl<T> Drop for Proxy<T> {
+impl<T> Drop for EventLoopProxy<T> {
     fn drop(&mut self) {
         unsafe {
             CFRelease(self.source as _);
@@ -296,13 +296,13 @@ impl<T> Drop for Proxy<T> {
     }
 }
 
-impl<T> Clone for Proxy<T> {
+impl<T> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
-        Proxy::new(self.sender.clone())
+        EventLoopProxy::new(self.sender.clone())
     }
 }
 
-impl<T> Proxy<T> {
+impl<T> EventLoopProxy<T> {
     fn new(sender: mpsc::Sender<T>) -> Self {
         unsafe {
             // just wake up the eventloop
@@ -318,7 +318,7 @@ impl<T> Proxy<T> {
             CFRunLoopAddSource(rl, source, kCFRunLoopCommonModes);
             CFRunLoopWakeUp(rl);
 
-            Proxy { sender, source }
+            EventLoopProxy { sender, source }
         }
     }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -21,11 +21,10 @@ use std::{fmt, ops::Deref, sync::Arc};
 pub(crate) use self::{
     app_delegate::get_aux_state_mut,
     event_loop::{
-        EventLoop, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
-        Proxy as EventLoopProxy,
+        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
     },
     monitor::{MonitorHandle, VideoMode},
-    window::{Id as WindowId, PlatformSpecificWindowBuilderAttributes, UnownedWindow},
+    window::{PlatformSpecificWindowBuilderAttributes, UnownedWindow, WindowId},
 };
 use crate::{
     error::OsError as RootOsError, event::DeviceId as RootDeviceId, window::WindowAttributes,

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -49,18 +49,18 @@ use objc::{
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Id(pub usize);
+pub struct WindowId(pub usize);
 
-impl Id {
+impl WindowId {
     pub const unsafe fn dummy() -> Self {
-        Id(0)
+        Self(0)
     }
 }
 
 // Convert the `cocoa::base::id` associated with a window to a usize to use as a unique identifier
 // for the window.
-pub fn get_window_id(window_cocoa_id: id) -> Id {
-    Id(window_cocoa_id as *const Object as _)
+pub fn get_window_id(window_cocoa_id: id) -> WindowId {
+    WindowId(window_cocoa_id as *const Object as _)
 }
 
 #[derive(Clone)]
@@ -485,7 +485,7 @@ impl UnownedWindow {
         unsafe { util::set_style_mask_sync(*self.ns_window, *self.ns_view, mask) };
     }
 
-    pub fn id(&self) -> Id {
+    pub fn id(&self) -> WindowId {
         get_window_id(*self.ns_window)
     }
 

--- a/src/platform_impl/web/device.rs
+++ b/src/platform_impl/web/device.rs
@@ -1,8 +1,8 @@
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Id(pub i32);
+pub struct DeviceId(pub i32);
 
-impl Id {
+impl DeviceId {
     pub const unsafe fn dummy() -> Self {
-        Id(0)
+        Self(0)
     }
 }

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -3,17 +3,17 @@ mod runner;
 mod state;
 mod window_target;
 
-pub use self::proxy::Proxy;
-pub use self::window_target::WindowTarget;
+pub use self::proxy::EventLoopProxy;
+pub use self::window_target::EventLoopWindowTarget;
 
 use super::{backend, device, window};
 use crate::event::Event;
-use crate::event_loop as root;
+use crate::event_loop::{ControlFlow, EventLoopWindowTarget as RootEventLoopWindowTarget};
 
 use std::marker::PhantomData;
 
 pub struct EventLoop<T: 'static> {
-    elw: root::EventLoopWindowTarget<T>,
+    elw: RootEventLoopWindowTarget<T>,
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Hash)]
@@ -22,8 +22,8 @@ pub(crate) struct PlatformSpecificEventLoopAttributes {}
 impl<T> EventLoop<T> {
     pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> Self {
         EventLoop {
-            elw: root::EventLoopWindowTarget {
-                p: WindowTarget::new(),
+            elw: RootEventLoopWindowTarget {
+                p: EventLoopWindowTarget::new(),
                 _marker: PhantomData,
             },
         }
@@ -31,9 +31,9 @@ impl<T> EventLoop<T> {
 
     pub fn run<F>(self, mut event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<'_, T>, &root::EventLoopWindowTarget<T>, &mut root::ControlFlow),
+        F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
-        let target = root::EventLoopWindowTarget {
+        let target = RootEventLoopWindowTarget {
             p: self.elw.p.clone(),
             _marker: PhantomData,
         };
@@ -51,11 +51,11 @@ impl<T> EventLoop<T> {
         unreachable!();
     }
 
-    pub fn create_proxy(&self) -> Proxy<T> {
+    pub fn create_proxy(&self) -> EventLoopProxy<T> {
         self.elw.p.proxy()
     }
 
-    pub fn window_target(&self) -> &root::EventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &RootEventLoopWindowTarget<T> {
         &self.elw
     }
 }

--- a/src/platform_impl/web/event_loop/proxy.rs
+++ b/src/platform_impl/web/event_loop/proxy.rs
@@ -2,13 +2,13 @@ use super::runner;
 use crate::event::Event;
 use crate::event_loop::EventLoopClosed;
 
-pub struct Proxy<T: 'static> {
+pub struct EventLoopProxy<T: 'static> {
     runner: runner::Shared<T>,
 }
 
-impl<T: 'static> Proxy<T> {
+impl<T: 'static> EventLoopProxy<T> {
     pub fn new(runner: runner::Shared<T>) -> Self {
-        Proxy { runner }
+        Self { runner }
     }
 
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
@@ -17,9 +17,9 @@ impl<T: 'static> Proxy<T> {
     }
 }
 
-impl<T: 'static> Clone for Proxy<T> {
+impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
-        Proxy {
+        Self {
             runner: self.runner.clone(),
         }
     }

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -1,6 +1,6 @@
 use super::{super::ScaleChangeArgs, backend, state::State};
 use crate::event::{Event, StartCause};
-use crate::event_loop as root;
+use crate::event_loop::ControlFlow;
 use crate::window::WindowId;
 
 use instant::{Duration, Instant};
@@ -54,11 +54,11 @@ impl<T: 'static> RunnerEnum<T> {
 
 struct Runner<T: 'static> {
     state: State,
-    event_handler: Box<dyn FnMut(Event<'_, T>, &mut root::ControlFlow)>,
+    event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
 }
 
 impl<T: 'static> Runner<T> {
-    pub fn new(event_handler: Box<dyn FnMut(Event<'_, T>, &mut root::ControlFlow)>) -> Self {
+    pub fn new(event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>) -> Self {
         Runner {
             state: State::Init,
             event_handler,
@@ -83,14 +83,14 @@ impl<T: 'static> Runner<T> {
         })
     }
 
-    fn handle_single_event(&mut self, event: Event<'_, T>, control: &mut root::ControlFlow) {
-        let is_closed = matches!(*control, root::ControlFlow::ExitWithCode(_));
+    fn handle_single_event(&mut self, event: Event<'_, T>, control: &mut ControlFlow) {
+        let is_closed = matches!(*control, ControlFlow::ExitWithCode(_));
 
         (self.event_handler)(event, control);
 
         // Maintain closed state, even if the callback changes it
         if is_closed {
-            *control = root::ControlFlow::Exit;
+            *control = ControlFlow::Exit;
         }
     }
 }
@@ -123,10 +123,7 @@ impl<T: 'static> Shared<T> {
     // Set the event callback to use for the event loop runner
     // This the event callback is a fairly thin layer over the user-provided callback that closes
     // over a RootEventLoopWindowTarget reference
-    pub fn set_listener(
-        &self,
-        event_handler: Box<dyn FnMut(Event<'_, T>, &mut root::ControlFlow)>,
-    ) {
+    pub fn set_listener(&self, event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>) {
         {
             let mut runner = self.0.runner.borrow_mut();
             assert!(matches!(*runner, RunnerEnum::Pending));
@@ -245,7 +242,7 @@ impl<T: 'static> Shared<T> {
     // Process the destroy-pending windows. This should only be called from
     // `run_until_cleared` and `handle_scale_changed`, somewhere between emitting
     // `NewEvents` and `MainEventsCleared`.
-    fn process_destroy_pending_windows(&self, control: &mut root::ControlFlow) {
+    fn process_destroy_pending_windows(&self, control: &mut ControlFlow) {
         while let Some(id) = self.0.destroy_pending.borrow_mut().pop_front() {
             self.0
                 .all_canvases
@@ -369,7 +366,7 @@ impl<T: 'static> Shared<T> {
     }
 
     fn handle_unload(&self) {
-        self.apply_control_flow(root::ControlFlow::Exit);
+        self.apply_control_flow(ControlFlow::Exit);
         let mut control = self.current_control_flow();
         // We don't call `handle_loop_destroyed` here because we don't need to
         // perform cleanup when the web browser is going to destroy the page.
@@ -379,9 +376,9 @@ impl<T: 'static> Shared<T> {
     // handle_single_event_sync takes in an event and handles it synchronously.
     //
     // It should only ever be called from `scale_changed`.
-    fn handle_single_event_sync(&self, event: Event<'_, T>, control: &mut root::ControlFlow) {
+    fn handle_single_event_sync(&self, event: Event<'_, T>, control: &mut ControlFlow) {
         if self.is_closed() {
-            *control = root::ControlFlow::Exit;
+            *control = ControlFlow::Exit;
         }
         match *self.0.runner.borrow_mut() {
             RunnerEnum::Running(ref mut runner) => {
@@ -394,9 +391,9 @@ impl<T: 'static> Shared<T> {
     // handle_event takes in events and either queues them or applies a callback
     //
     // It should only ever be called from `run_until_cleared` and `scale_changed`.
-    fn handle_event(&self, event: Event<'static, T>, control: &mut root::ControlFlow) {
+    fn handle_event(&self, event: Event<'static, T>, control: &mut ControlFlow) {
         if self.is_closed() {
-            *control = root::ControlFlow::Exit;
+            *control = ControlFlow::Exit;
         }
         match *self.0.runner.borrow_mut() {
             RunnerEnum::Running(ref mut runner) => {
@@ -409,7 +406,7 @@ impl<T: 'static> Shared<T> {
             RunnerEnum::Destroyed => return,
         }
 
-        let is_closed = matches!(*control, root::ControlFlow::ExitWithCode(_));
+        let is_closed = matches!(*control, ControlFlow::ExitWithCode(_));
 
         // Don't take events out of the queue if the loop is closed or the runner doesn't exist
         // If the runner doesn't exist and this method recurses, it will recurse infinitely
@@ -425,18 +422,18 @@ impl<T: 'static> Shared<T> {
 
     // Apply the new ControlFlow that has been selected by the user
     // Start any necessary timeouts etc
-    fn apply_control_flow(&self, control_flow: root::ControlFlow) {
+    fn apply_control_flow(&self, control_flow: ControlFlow) {
         let new_state = match control_flow {
-            root::ControlFlow::Poll => {
+            ControlFlow::Poll => {
                 let cloned = self.clone();
                 State::Poll {
                     request: backend::AnimationFrameRequest::new(move || cloned.poll()),
                 }
             }
-            root::ControlFlow::Wait => State::Wait {
+            ControlFlow::Wait => State::Wait {
                 start: Instant::now(),
             },
-            root::ControlFlow::WaitUntil(end) => {
+            ControlFlow::WaitUntil(end) => {
                 let start = Instant::now();
 
                 let delay = if end <= start {
@@ -456,7 +453,7 @@ impl<T: 'static> Shared<T> {
                     ),
                 }
             }
-            root::ControlFlow::ExitWithCode(_) => State::Exit,
+            ControlFlow::ExitWithCode(_) => State::Exit,
         };
 
         match *self.0.runner.borrow_mut() {
@@ -467,7 +464,7 @@ impl<T: 'static> Shared<T> {
         }
     }
 
-    fn handle_loop_destroyed(&self, control: &mut root::ControlFlow) {
+    fn handle_loop_destroyed(&self, control: &mut ControlFlow) {
         self.handle_event(Event::LoopDestroyed, control);
         let all_canvases = std::mem::take(&mut *self.0.all_canvases.borrow_mut());
         *self.0.scale_change_detector.borrow_mut() = None;
@@ -510,11 +507,11 @@ impl<T: 'static> Shared<T> {
     }
 
     // Get the current control flow state
-    fn current_control_flow(&self) -> root::ControlFlow {
+    fn current_control_flow(&self) -> ControlFlow {
         match *self.0.runner.borrow() {
             RunnerEnum::Running(ref runner) => runner.state.control_flow(),
-            RunnerEnum::Pending => root::ControlFlow::Poll,
-            RunnerEnum::Destroyed => root::ControlFlow::Exit,
+            RunnerEnum::Pending => ControlFlow::Poll,
+            RunnerEnum::Destroyed => ControlFlow::Exit,
         }
     }
 }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -1,37 +1,41 @@
-use super::{super::monitor, backend, device, proxy::Proxy, runner, window};
+use super::{
+    super::monitor::MonitorHandle, backend, device::DeviceId, proxy::EventLoopProxy, runner,
+    window::WindowId,
+};
 use crate::dpi::{PhysicalSize, Size};
 use crate::event::{
-    DeviceEvent, DeviceId, ElementState, Event, KeyboardInput, TouchPhase, WindowEvent,
+    DeviceEvent, DeviceId as RootDeviceId, ElementState, Event, KeyboardInput, TouchPhase,
+    WindowEvent,
 };
 use crate::event_loop::ControlFlow;
 use crate::monitor::MonitorHandle as RootMH;
-use crate::window::{Theme, WindowId};
+use crate::window::{Theme, WindowId as RootWindowId};
 use std::cell::RefCell;
 use std::clone::Clone;
 use std::collections::{vec_deque::IntoIter as VecDequeIter, VecDeque};
 use std::rc::Rc;
 
-pub struct WindowTarget<T: 'static> {
+pub struct EventLoopWindowTarget<T: 'static> {
     pub(crate) runner: runner::Shared<T>,
 }
 
-impl<T> Clone for WindowTarget<T> {
+impl<T> Clone for EventLoopWindowTarget<T> {
     fn clone(&self) -> Self {
-        WindowTarget {
+        Self {
             runner: self.runner.clone(),
         }
     }
 }
 
-impl<T> WindowTarget<T> {
+impl<T> EventLoopWindowTarget<T> {
     pub fn new() -> Self {
-        WindowTarget {
+        Self {
             runner: runner::Shared::new(),
         }
     }
 
-    pub fn proxy(&self) -> Proxy<T> {
-        Proxy::new(self.runner.clone())
+    pub fn proxy(&self) -> EventLoopProxy<T> {
+        EventLoopProxy::new(self.runner.clone())
     }
 
     pub fn run(&self, event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>) {
@@ -42,19 +46,19 @@ impl<T> WindowTarget<T> {
         });
     }
 
-    pub fn generate_id(&self) -> window::Id {
-        window::Id(self.runner.generate_id())
+    pub fn generate_id(&self) -> WindowId {
+        WindowId(self.runner.generate_id())
     }
 
-    pub fn register(&self, canvas: &Rc<RefCell<backend::Canvas>>, id: window::Id) {
-        self.runner.add_canvas(WindowId(id), canvas);
+    pub fn register(&self, canvas: &Rc<RefCell<backend::Canvas>>, id: WindowId) {
+        self.runner.add_canvas(RootWindowId(id), canvas);
         let mut canvas = canvas.borrow_mut();
         canvas.set_attribute("data-raw-handle", &id.0.to_string());
 
         let runner = self.runner.clone();
         canvas.on_blur(move || {
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::Focused(false),
             });
         });
@@ -62,7 +66,7 @@ impl<T> WindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_focus(move || {
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::Focused(true),
             });
         });
@@ -71,9 +75,9 @@ impl<T> WindowTarget<T> {
         canvas.on_keyboard_press(move |scancode, virtual_keycode, modifiers| {
             #[allow(deprecated)]
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::KeyboardInput {
-                    device_id: DeviceId(unsafe { device::Id::dummy() }),
+                    device_id: RootDeviceId(unsafe { DeviceId::dummy() }),
                     input: KeyboardInput {
                         scancode,
                         state: ElementState::Pressed,
@@ -89,9 +93,9 @@ impl<T> WindowTarget<T> {
         canvas.on_keyboard_release(move |scancode, virtual_keycode, modifiers| {
             #[allow(deprecated)]
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::KeyboardInput {
-                    device_id: DeviceId(unsafe { device::Id::dummy() }),
+                    device_id: RootDeviceId(unsafe { DeviceId::dummy() }),
                     input: KeyboardInput {
                         scancode,
                         state: ElementState::Released,
@@ -106,7 +110,7 @@ impl<T> WindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_received_character(move |char_code| {
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::ReceivedCharacter(char_code),
             });
         });
@@ -114,9 +118,9 @@ impl<T> WindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_cursor_leave(move |pointer_id| {
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::CursorLeft {
-                    device_id: DeviceId(device::Id(pointer_id)),
+                    device_id: RootDeviceId(DeviceId(pointer_id)),
                 },
             });
         });
@@ -124,9 +128,9 @@ impl<T> WindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_cursor_enter(move |pointer_id| {
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::CursorEntered {
-                    device_id: DeviceId(device::Id(pointer_id)),
+                    device_id: RootDeviceId(DeviceId(pointer_id)),
                 },
             });
         });
@@ -134,15 +138,15 @@ impl<T> WindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_cursor_move(move |pointer_id, position, delta, modifiers| {
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::CursorMoved {
-                    device_id: DeviceId(device::Id(pointer_id)),
+                    device_id: RootDeviceId(DeviceId(pointer_id)),
                     position,
                     modifiers,
                 },
             });
             runner.send_event(Event::DeviceEvent {
-                device_id: DeviceId(device::Id(pointer_id)),
+                device_id: RootDeviceId(DeviceId(pointer_id)),
                 event: DeviceEvent::MouseMotion {
                     delta: (delta.x, delta.y),
                 },
@@ -156,17 +160,17 @@ impl<T> WindowTarget<T> {
             // user code has the correct cursor position.
             runner.send_events(
                 std::iter::once(Event::WindowEvent {
-                    window_id: WindowId(id),
+                    window_id: RootWindowId(id),
                     event: WindowEvent::CursorMoved {
-                        device_id: DeviceId(device::Id(pointer_id)),
+                        device_id: RootDeviceId(DeviceId(pointer_id)),
                         position,
                         modifiers,
                     },
                 })
                 .chain(std::iter::once(Event::WindowEvent {
-                    window_id: WindowId(id),
+                    window_id: RootWindowId(id),
                     event: WindowEvent::MouseInput {
-                        device_id: DeviceId(device::Id(pointer_id)),
+                        device_id: RootDeviceId(DeviceId(pointer_id)),
                         state: ElementState::Pressed,
                         button,
                         modifiers,
@@ -178,9 +182,9 @@ impl<T> WindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_mouse_release(move |pointer_id, button, modifiers| {
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::MouseInput {
-                    device_id: DeviceId(device::Id(pointer_id)),
+                    device_id: RootDeviceId(DeviceId(pointer_id)),
                     state: ElementState::Released,
                     button,
                     modifiers,
@@ -191,9 +195,9 @@ impl<T> WindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_mouse_wheel(move |pointer_id, delta, modifiers| {
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::MouseWheel {
-                    device_id: DeviceId(device::Id(pointer_id)),
+                    device_id: RootDeviceId(DeviceId(pointer_id)),
                     delta,
                     phase: TouchPhase::Moved,
                     modifiers,
@@ -225,10 +229,10 @@ impl<T> WindowTarget<T> {
 
             backend::set_canvas_size(&raw, Size::Physical(new_size));
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::Resized(new_size),
             });
-            runner.request_redraw(WindowId(id));
+            runner.request_redraw(RootWindowId(id));
         });
 
         let runner = self.runner.clone();
@@ -239,19 +243,19 @@ impl<T> WindowTarget<T> {
                 Theme::Light
             };
             runner.send_event(Event::WindowEvent {
-                window_id: WindowId(id),
+                window_id: RootWindowId(id),
                 event: WindowEvent::ThemeChanged(theme),
             });
         });
     }
 
-    pub fn available_monitors(&self) -> VecDequeIter<monitor::Handle> {
+    pub fn available_monitors(&self) -> VecDequeIter<MonitorHandle> {
         VecDeque::new().into_iter()
     }
 
     pub fn primary_monitor(&self) -> Option<RootMH> {
         Some(RootMH {
-            inner: monitor::Handle,
+            inner: MonitorHandle,
         })
     }
 }

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -26,17 +26,13 @@ mod window;
 #[path = "web_sys/mod.rs"]
 mod backend;
 
-pub use self::device::Id as DeviceId;
+pub use self::device::DeviceId;
 pub use self::error::OsError;
 pub(crate) use self::event_loop::{
-    EventLoop, PlatformSpecificEventLoopAttributes, Proxy as EventLoopProxy,
-    WindowTarget as EventLoopWindowTarget,
+    EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
 };
-pub use self::monitor::{Handle as MonitorHandle, Mode as VideoMode};
-pub use self::window::{
-    Id as WindowId, PlatformSpecificBuilderAttributes as PlatformSpecificWindowBuilderAttributes,
-    Window,
-};
+pub use self::monitor::{MonitorHandle, VideoMode};
+pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId};
 
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -1,10 +1,10 @@
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::{MonitorHandle, VideoMode};
+use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Handle;
+pub struct MonitorHandle;
 
-impl Handle {
+impl MonitorHandle {
     pub fn scale_factor(&self) -> f64 {
         1.0
     }
@@ -24,15 +24,15 @@ impl Handle {
         }
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
         std::iter::empty()
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct Mode;
+pub struct VideoMode;
 
-impl Mode {
+impl VideoMode {
     pub fn size(&self) -> PhysicalSize<u32> {
         unimplemented!();
     }
@@ -45,7 +45,9 @@ impl Mode {
         32
     }
 
-    pub fn monitor(&self) -> MonitorHandle {
-        MonitorHandle { inner: Handle }
+    pub fn monitor(&self) -> RootMonitorHandle {
+        RootMonitorHandle {
+            inner: MonitorHandle,
+        }
     }
 }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -9,7 +9,7 @@ use crate::window::{
 
 use raw_window_handle::{RawWindowHandle, WebHandle};
 
-use super::{backend, monitor, EventLoopWindowTarget};
+use super::{backend, monitor::MonitorHandle, EventLoopWindowTarget};
 
 use std::cell::{Ref, RefCell};
 use std::collections::vec_deque::IntoIter as VecDequeIter;
@@ -19,7 +19,7 @@ use std::rc::Rc;
 pub struct Window {
     canvas: Rc<RefCell<backend::Canvas>>,
     previous_pointer: RefCell<&'static str>,
-    id: Id,
+    id: WindowId,
     register_redraw_request: Box<dyn Fn()>,
     resize_notify_fn: Box<dyn Fn(PhysicalSize<u32>)>,
     destroy_fn: Option<Box<dyn FnOnce()>>,
@@ -29,7 +29,7 @@ impl Window {
     pub fn new<T>(
         target: &EventLoopWindowTarget<T>,
         attr: WindowAttributes,
-        platform_attr: PlatformSpecificBuilderAttributes,
+        platform_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOE> {
         let runner = target.runner.clone();
 
@@ -311,7 +311,7 @@ impl Window {
     // Allow directly accessing the current monitor internally without unwrapping.
     fn current_monitor_inner(&self) -> RootMH {
         RootMH {
-            inner: monitor::Handle,
+            inner: MonitorHandle,
         }
     }
 
@@ -321,19 +321,19 @@ impl Window {
     }
 
     #[inline]
-    pub fn available_monitors(&self) -> VecDequeIter<monitor::Handle> {
+    pub fn available_monitors(&self) -> VecDequeIter<MonitorHandle> {
         VecDeque::new().into_iter()
     }
 
     #[inline]
     pub fn primary_monitor(&self) -> Option<RootMH> {
         Some(RootMH {
-            inner: monitor::Handle,
+            inner: MonitorHandle,
         })
     }
 
     #[inline]
-    pub fn id(&self) -> Id {
+    pub fn id(&self) -> WindowId {
         return self.id;
     }
 
@@ -354,15 +354,15 @@ impl Drop for Window {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Id(pub(crate) u32);
+pub struct WindowId(pub(crate) u32);
 
-impl Id {
-    pub const unsafe fn dummy() -> Id {
-        Id(0)
+impl WindowId {
+    pub const unsafe fn dummy() -> Self {
+        Self(0)
     }
 }
 
 #[derive(Default, Clone)]
-pub struct PlatformSpecificBuilderAttributes {
+pub struct PlatformSpecificWindowBuilderAttributes {
     pub(crate) canvas: Option<backend::RawCanvasType>,
 }

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -23,7 +23,8 @@ use crate::platform_impl::platform::{
     definitions::{IDataObjectVtbl, IDropTarget, IDropTargetVtbl, IUnknownVtbl},
     WindowId,
 };
-use crate::{event::Event, window::WindowId as SuperWindowId};
+
+use crate::{event::Event, window::WindowId as RootWindowId};
 
 #[repr(C)]
 pub struct FileDropHandlerData {
@@ -95,7 +96,7 @@ impl FileDropHandler {
         let drop_handler = Self::from_interface(this);
         let hdrop = Self::iterate_filenames(pDataObj, |filename| {
             drop_handler.send_event(Event::WindowEvent {
-                window_id: SuperWindowId(WindowId(drop_handler.window)),
+                window_id: RootWindowId(WindowId(drop_handler.window)),
                 event: HoveredFile(filename),
             });
         });
@@ -127,7 +128,7 @@ impl FileDropHandler {
         let drop_handler = Self::from_interface(this);
         if drop_handler.hovered_is_valid {
             drop_handler.send_event(Event::WindowEvent {
-                window_id: SuperWindowId(WindowId(drop_handler.window)),
+                window_id: RootWindowId(WindowId(drop_handler.window)),
                 event: HoveredFileCancelled,
             });
         }
@@ -146,7 +147,7 @@ impl FileDropHandler {
         let drop_handler = Self::from_interface(this);
         let hdrop = Self::iterate_filenames(pDataObj, |filename| {
             drop_handler.send_event(Event::WindowEvent {
-                window_id: SuperWindowId(WindowId(drop_handler.window)),
+                window_id: RootWindowId(WindowId(drop_handler.window)),
                 event: DroppedFile(filename),
             });
         });


### PR DESCRIPTION
Seeing `Id` in the macOS backend has confused me _many_ times (especially because `Id` has another meaning in Objective-C), this PR is just a generalization of that problem (of structs not being named what they're exported as).

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
