### PR TITLE
Provide system clipboard handling API on `Window`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - On X11, add mappings for numpad comma, numpad enter, numlock and pause.
 - On macOS, fix Pinyin IME input by reverting a change that intended to improve IME.
 - On Windows, fix a crash with transparent windows on Windows 11.
+- Add `set_clipboard_content` and `request_clipboard_content` API on `Window`
+- Add `set_primary_clipboard_content` and `request_primary_clipboard_content` API on `WindowExtUnix`
 
 # 0.26.0 (2021-12-01)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -217,6 +217,7 @@ Changes in the API that have been agreed upon but aren't implemented across all 
 |New API for HiDPI ([#315] [#319])   |✔️    |✔️    |✔️       |✔️          |▢[#721]|✔️    |❓        |
 |Event Loop 2.0 ([#459])             |✔️    |✔️    |❌       |✔️          |❌     |✔️    |❓        |
 |Keyboard Input ([#812])             |❌    |❌    |❌       |❌          |❌     |❌    |❓        |
+|Clipboard handling                  |❌    |❌    |❌       |✔️          |❌     |❌    |❓        |
 
 ### Completed API Reworks
 |Feature                             |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS    |WASM      |

--- a/src/event.rs
+++ b/src/event.rs
@@ -270,6 +270,9 @@ pub enum WindowEvent<'a> {
     ///   issue, and it should get fixed - but it's the current state of the API.
     ModifiersChanged(ModifiersState),
 
+    /// Loaded clipboard content.
+    ClipboardContent(ClipboardContent),
+
     /// The cursor has moved on the window.
     CursorMoved {
         device_id: DeviceId,
@@ -354,6 +357,27 @@ pub enum WindowEvent<'a> {
     ThemeChanged(Theme),
 }
 
+/// Metadata which is passed along request to load clipboard.
+pub type ClipboardMetadata = dyn std::any::Any + Send + Sync + 'static;
+
+#[derive(Debug, Clone)]
+pub struct ClipboardContent {
+    /// Clipboard data.
+    pub data: Vec<u8>,
+
+    /// Mime type which was picked to be loaded.
+    pub mime: String,
+
+    /// Metadata passed to `request_clipboard_content`.
+    pub metadata: Option<std::sync::Arc<ClipboardMetadata>>,
+}
+
+impl PartialEq for ClipboardContent {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data
+    }
+}
+
 impl Clone for WindowEvent<'static> {
     fn clone(&self) -> Self {
         use self::WindowEvent::*;
@@ -366,6 +390,7 @@ impl Clone for WindowEvent<'static> {
             HoveredFile(file) => HoveredFile(file.clone()),
             HoveredFileCancelled => HoveredFileCancelled,
             ReceivedCharacter(c) => ReceivedCharacter(*c),
+            ClipboardContent(content) => ClipboardContent(content.clone()),
             Focused(f) => Focused(*f),
             KeyboardInput {
                 device_id,
@@ -456,6 +481,7 @@ impl<'a> WindowEvent<'a> {
             DroppedFile(file) => Some(DroppedFile(file)),
             HoveredFile(file) => Some(HoveredFile(file)),
             HoveredFileCancelled => Some(HoveredFileCancelled),
+            ClipboardContent(content) => Some(ClipboardContent(content)),
             ReceivedCharacter(c) => Some(ReceivedCharacter(c)),
             Focused(focused) => Some(Focused(focused)),
             KeyboardInput {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -9,9 +9,10 @@
 #[cfg(all(not(feature = "x11"), not(feature = "wayland")))]
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
+use std::collections::{HashSet, VecDeque};
 #[cfg(feature = "wayland")]
 use std::error::Error;
-use std::{collections::VecDeque, env, fmt};
+use std::{env, fmt};
 #[cfg(feature = "x11")]
 use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Arc};
 
@@ -26,7 +27,7 @@ use self::x11::{ffi::XVisualInfo, util::WindowType as XWindowType, XConnection, 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
-    event::Event,
+    event::{ClipboardMetadata, Event},
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
     icon::Icon,
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
@@ -449,6 +450,42 @@ impl Window {
     #[inline]
     pub fn request_redraw(&self) {
         x11_or_wayland!(match self; Window(w) => w.request_redraw())
+    }
+
+    #[inline]
+    pub fn request_clipboard_content(
+        &self,
+        mime: HashSet<String>,
+        metadata: Option<std::sync::Arc<ClipboardMetadata>>,
+    ) {
+        x11_or_wayland!(match self; Window(w) => w.request_clipboard_content(mime, metadata))
+    }
+
+    #[inline]
+    pub fn set_clipboard_content<C: AsRef<[u8]> + 'static>(
+        &self,
+        content: C,
+        mimes: HashSet<String>,
+    ) {
+        x11_or_wayland!(match self; Window(w) => w.set_clipboard_content(content, mimes))
+    }
+
+    #[inline]
+    pub fn request_primary_clipboard_content(
+        &self,
+        mimes: HashSet<String>,
+        metadata: Option<std::sync::Arc<ClipboardMetadata>>,
+    ) {
+        x11_or_wayland!(match self; Window(w) => w.request_primary_clipboard_content(mimes, metadata))
+    }
+
+    #[inline]
+    pub fn set_primary_clipboard_content<C: AsRef<[u8]> + 'static>(
+        &self,
+        content: C,
+        mimes: HashSet<String>,
+    ) {
+        x11_or_wayland!(match self; Window(w) => w.set_primary_clipboard_content(content, mimes))
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/clipboard.rs
+++ b/src/platform_impl/linux/wayland/clipboard.rs
@@ -1,0 +1,308 @@
+//! Wayland clipboard handling.
+
+use std::collections::HashSet;
+use std::fs::File;
+use std::io::{Error, ErrorKind, Read, Result, Write};
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use sctk::reexports::calloop::generic::Generic;
+use sctk::reexports::calloop::{Interest, LoopHandle, Mode, PostAction};
+
+use sctk::data_device::{DataSourceEvent, ReadPipe, WritePipe};
+use sctk::environment::Environment;
+use sctk::primary_selection::PrimarySelectionSourceEvent;
+
+use crate::event::{ClipboardContent, ClipboardMetadata, WindowEvent};
+use crate::platform_impl::wayland::env::WinitEnv;
+use crate::platform_impl::wayland::event_loop::WinitState;
+use crate::platform_impl::wayland::window::shim::LatestSeat;
+
+use super::WindowId;
+
+#[derive(Clone, Copy)]
+pub enum ClipboardType {
+    /// Primary clipboard which is provided by `gtk_primary_selection_device_manager` or
+    /// `zwp_primary_selection_device_manager` protocols.
+    Primary,
+
+    /// Clipboard which is provided by `wl_data_device_manager`.
+    Clipboard,
+}
+
+pub struct ClipboardManager {
+    /// Environment to access clipboard related globals.
+    env: Environment<WinitEnv>,
+
+    /// Loop handle which is used to register pipes in main event loop.
+    loop_handle: LoopHandle<'static, WinitState>,
+
+    /// Latest seat information.
+    seat: Option<LatestSeat>,
+}
+
+impl ClipboardManager {
+    pub fn new(env: Environment<WinitEnv>, loop_handle: LoopHandle<'static, WinitState>) -> Self {
+        Self {
+            env,
+            loop_handle,
+            seat: None,
+        }
+    }
+
+    /// Update information about the latest observed seat and its serial.
+    pub fn update_seat_info(&mut self, seat: Option<LatestSeat>) {
+        self.seat = seat;
+    }
+
+    /// Set `ty` clipboard content to `content` and offering it with `mimes` mime types.
+    pub fn set_content(
+        &self,
+        ty: ClipboardType,
+        content: Rc<dyn AsRef<[u8]>>,
+        mimes: HashSet<String>,
+    ) {
+        let seat = match self.seat.as_ref() {
+            Some(seat) => seat,
+            None => return,
+        };
+
+        let mimes = mimes.into_iter().collect();
+        match ty {
+            ClipboardType::Clipboard => self.set_clipboard_content(seat, content, mimes),
+            ClipboardType::Primary => self.set_primary_content(seat, content, mimes),
+        }
+    }
+
+    fn set_clipboard_content(
+        &self,
+        seat: &LatestSeat,
+        content: Rc<dyn AsRef<[u8]>>,
+        mimes: Vec<String>,
+    ) {
+        let loop_handle = self.loop_handle.clone();
+        let data_source = self.env.new_data_source(mimes, move |event, _| {
+            let pipe = match event {
+                DataSourceEvent::Send { pipe, .. } => pipe,
+                _ => return,
+            };
+
+            write_clipboard(pipe, content.clone(), &loop_handle);
+        });
+
+        let _ = self.env.with_data_device(&seat.seat, |device| {
+            device.set_selection(&Some(data_source), seat.serial);
+        });
+    }
+
+    fn set_primary_content(
+        &self,
+        seat: &LatestSeat,
+        content: Rc<dyn AsRef<[u8]>>,
+        mimes: Vec<String>,
+    ) {
+        let loop_handle = self.loop_handle.clone();
+        let primary_source = self
+            .env
+            .new_primary_selection_source(mimes, move |event, _| {
+                let pipe = match event {
+                    PrimarySelectionSourceEvent::Send { pipe, .. } => pipe,
+                    _ => return,
+                };
+
+                write_clipboard(pipe, content.clone(), &loop_handle);
+            });
+
+        let _ = self.env.with_primary_selection(&seat.seat, |device| {
+            device.set_selection(&Some(primary_source), seat.serial);
+        });
+    }
+
+    /// Request `ty` clipboard content picking from `mimes` forwarding it to `window_id` passing
+    /// `metadata`.
+    pub fn request_content(
+        &self,
+        window_id: WindowId,
+        ty: ClipboardType,
+        mimes: HashSet<String>,
+        metadata: Option<Arc<ClipboardMetadata>>,
+    ) {
+        let seat = match self.seat.as_ref() {
+            Some(seat) => seat,
+            None => return,
+        };
+
+        match ty {
+            ClipboardType::Primary => {
+                self.request_primary_content(seat, window_id, mimes, metadata)
+            }
+            ClipboardType::Clipboard => {
+                self.request_clipboard_content(seat, window_id, mimes, metadata)
+            }
+        }
+    }
+
+    fn request_clipboard_content(
+        &self,
+        seat: &LatestSeat,
+        window_id: WindowId,
+        mimes: HashSet<String>,
+        metadata: Option<Arc<ClipboardMetadata>>,
+    ) {
+        let loop_handle = self.loop_handle.clone();
+        let _ = self.env.with_data_device(&seat.seat, move |device| {
+            device.with_selection(move |offer| {
+                let offer = match offer {
+                    Some(offer) => offer,
+                    None => return,
+                };
+
+                let mut mime = String::new();
+                offer.with_mime_types(|types| {
+                    for ty in types {
+                        if mimes.contains(ty) {
+                            mime = ty.to_string();
+                        }
+                    }
+                });
+
+                let reader = match offer.receive(mime.clone()) {
+                    Ok(reader) => reader,
+                    Err(_) => return,
+                };
+
+                read_clipboard(reader, mime, metadata, window_id, &loop_handle);
+            })
+        });
+    }
+
+    fn request_primary_content(
+        &self,
+        seat: &LatestSeat,
+        window_id: WindowId,
+        mimes: HashSet<String>,
+        metadata: Option<Arc<ClipboardMetadata>>,
+    ) {
+        let loop_handle = self.loop_handle.clone();
+        let _ = self.env.with_primary_selection(&seat.seat, move |device| {
+            device.with_selection(move |offer| {
+                let offer = match offer {
+                    Some(offer) => offer,
+                    None => return,
+                };
+
+                let mut mime = String::new();
+                offer.with_mime_types(|types| {
+                    for ty in types {
+                        if mimes.contains(ty) {
+                            mime = ty.to_string();
+                        }
+                    }
+                });
+
+                let reader = match offer.receive(mime.clone()) {
+                    Ok(reader) => reader,
+                    Err(_) => return,
+                };
+
+                read_clipboard(reader, mime, metadata, window_id, &loop_handle);
+            })
+        });
+    }
+}
+
+/// Handle writing to clipboard's pipe write end.
+fn write_clipboard(
+    writer: WritePipe,
+    content: Rc<dyn AsRef<[u8]> + 'static>,
+    loop_handle: &LoopHandle<'static, WinitState>,
+) {
+    let mut writer = unsafe {
+        match raw_fd_into_non_blocking_file(writer.into_raw_fd()) {
+            Ok(writer) => writer,
+            Err(_) => return,
+        }
+    };
+
+    let written = match writer.write((&*content).as_ref()) {
+        Ok(n) if n == (&*content).as_ref().len() => return,
+        Ok(n) => n,
+        Err(err) if err.kind() == ErrorKind::WouldBlock => 0,
+        Err(_) => return,
+    };
+
+    // We weren't able to write all content at once, so add pipe as a `calloop`'s event source
+    // and continue writing when current content will be read.
+    let mut written = Rc::new(written);
+    let left_to_write = content.clone();
+    let writer = Generic::new(writer, Interest::WRITE, Mode::Level);
+    let _ = loop_handle.insert_source(writer, move |_, file, _| {
+        let left_to_write = (&*left_to_write).as_ref();
+        let (n, action) = match file.write(&left_to_write[*written..]) {
+            Ok(n) if *written + n == left_to_write.len() => (n, PostAction::Remove),
+            Ok(n) => (n, PostAction::Continue),
+            Err(err) if err.kind() == ErrorKind::WouldBlock => (0, PostAction::Continue),
+            Err(_) => (0, PostAction::Remove),
+        };
+
+        *Rc::get_mut(&mut written).unwrap() += n;
+        Ok(action)
+    });
+}
+
+/// Handle writing to clipboard's pipes read end.
+fn read_clipboard(
+    reader: ReadPipe,
+    mime: String,
+    metadata: Option<Arc<ClipboardMetadata>>,
+    window_id: WindowId,
+    loop_handle: &LoopHandle<'static, WinitState>,
+) {
+    let reader = unsafe {
+        match raw_fd_into_non_blocking_file(reader.into_raw_fd()) {
+            Ok(reader) => reader,
+            Err(_) => return,
+        }
+    };
+    let mut content = Vec::<u8>::with_capacity(u16::MAX as usize);
+    let mut reader_buffer = [0; u16::MAX as usize];
+    let reader = Generic::new(reader, Interest::READ, Mode::Level);
+    let _ = loop_handle.insert_source(reader, move |_, file, winit_state| {
+        let action = loop {
+            match file.read(&mut reader_buffer) {
+                Ok(0) => {
+                    let event_sink = &mut winit_state.event_sink;
+                    let data = std::mem::take(&mut content);
+                    let content = ClipboardContent {
+                        data,
+                        mime: mime.clone(),
+                        metadata: metadata.clone(),
+                    };
+                    let window_event = WindowEvent::ClipboardContent(content);
+                    event_sink.push_window_event(window_event, window_id);
+                    break PostAction::Remove;
+                }
+                Ok(n) => content.extend_from_slice(&reader_buffer[..n]),
+                Err(err) if err.kind() == ErrorKind::WouldBlock => break PostAction::Continue,
+                Err(_) => break PostAction::Remove,
+            }
+        };
+
+        Ok(action)
+    });
+}
+
+/// Create a `File` from `RawFd` marking it with `O_NONBLOCK`.
+unsafe fn raw_fd_into_non_blocking_file(raw_fd: RawFd) -> Result<File> {
+    let flags = libc::fcntl(raw_fd, libc::F_GETFD);
+    if flags < 0 {
+        return Err(Error::from_raw_os_error(flags));
+    }
+    let result = libc::fcntl(raw_fd, libc::F_SETFL, flags | libc::O_NONBLOCK);
+    if result < 0 {
+        return Err(Error::from_raw_os_error(result));
+    }
+
+    Ok(File::from_raw_fd(raw_fd))
+}

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -8,10 +8,12 @@
 
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
 
+pub use clipboard::{ClipboardManager, ClipboardType};
 pub use event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
 pub use output::{MonitorHandle, VideoMode};
 pub use window::Window;
 
+mod clipboard;
 mod env;
 mod event_loop;
 mod output;

--- a/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
@@ -34,7 +34,7 @@ impl Keyboard {
         loop_handle: LoopHandle<'static, WinitState>,
         modifiers_state: Rc<RefCell<ModifiersState>>,
     ) -> Option<Self> {
-        let mut inner = KeyboardInner::new(modifiers_state);
+        let mut inner = KeyboardInner::new(seat.detach(), modifiers_state);
         let keyboard_data = keyboard::map_keyboard_repeat(
             loop_handle.clone(),
             seat,
@@ -72,6 +72,9 @@ struct KeyboardInner {
     /// Currently focused surface.
     target_window_id: Option<WindowId>,
 
+    /// Seat assocciated with this keyboard.
+    seat: WlSeat,
+
     /// A pending state of modifiers.
     ///
     /// This state is getting set if we've got a modifiers update
@@ -84,11 +87,12 @@ struct KeyboardInner {
 }
 
 impl KeyboardInner {
-    fn new(modifiers_state: Rc<RefCell<ModifiersState>>) -> Self {
+    fn new(seat: WlSeat, modifiers_state: Rc<RefCell<ModifiersState>>) -> Self {
         Self {
             target_window_id: None,
             pending_modifers_state: None,
             modifiers_state,
+            seat,
         }
     }
 }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1,6 +1,9 @@
 use raw_window_handle::XlibHandle;
+
 use std::{
-    cmp, env,
+    cmp,
+    collections::HashSet,
+    env,
     ffi::CString,
     mem::{self, replace, MaybeUninit},
     os::raw::*,
@@ -8,6 +11,7 @@ use std::{
     ptr, slice,
     sync::Arc,
 };
+
 use x11_dl::xlib::TrueColor;
 
 use libc;
@@ -16,6 +20,7 @@ use parking_lot::Mutex;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
+    event::ClipboardMetadata,
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform_impl::{
         x11::{ime::ImeContextCreationError, MonitorHandle as X11MonitorHandle},
@@ -1445,6 +1450,38 @@ impl UnownedWindow {
     #[inline]
     pub fn id(&self) -> WindowId {
         WindowId(self.xwindow)
+    }
+
+    #[inline]
+    pub fn request_clipboard_content(
+        &self,
+        _mimes: HashSet<String>,
+        _metadata: Option<std::sync::Arc<ClipboardMetadata>>,
+    ) {
+        unimplemented!();
+    }
+
+    #[inline]
+    pub fn set_clipboard_content<C: AsRef<[u8]>>(&self, _content: C, _mimes: HashSet<String>) {
+        unimplemented!();
+    }
+
+    #[inline]
+    pub fn request_primary_clipboard_content(
+        &self,
+        _mimes: HashSet<String>,
+        _metadata: Option<std::sync::Arc<ClipboardMetadata>>,
+    ) {
+        unimplemented!();
+    }
+
+    #[inline]
+    pub fn set_primary_clipboard_content<C: AsRef<[u8]>>(
+        &self,
+        _content: C,
+        _mimes: HashSet<String>,
+    ) {
+        unimplemented!();
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,9 +1,11 @@
 //! The `Window` struct and associated types.
+use std::collections::HashSet;
 use std::fmt;
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError},
+    event::ClipboardMetadata,
     event_loop::EventLoopWindowTarget,
     monitor::{MonitorHandle, VideoMode},
     platform_impl,
@@ -959,6 +961,33 @@ impl Window {
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         self.window.primary_monitor()
+    }
+}
+
+/// Clipboard functions.
+impl Window {
+    /// Request system clipboard content.
+    ///
+    /// The result of loading content with provided `mimes` mime types is delivered via
+    /// [`crate::event::WindowEvent::ClipboardContent`] with the given `metadata`.
+    #[inline]
+    pub fn request_clipboard_content(
+        &self,
+        mimes: HashSet<String>,
+        metadata: Option<std::sync::Arc<ClipboardMetadata>>,
+    ) {
+        self.window.request_clipboard_content(mimes, metadata);
+    }
+
+    /// Set system clipboard content to provided `content` and advertising it with given `mimes`
+    /// mime types.
+    #[inline]
+    pub fn set_clipboard_content<C: AsRef<[u8]> + 'static>(
+        &self,
+        content: C,
+        mimes: HashSet<String>,
+    ) {
+        self.window.set_clipboard_content(content, mimes);
     }
 }
 


### PR DESCRIPTION
Clipboard handling is essential for system window handling and also is a
complicated task to be implemented and handled properly. So abstracting
this code into a windowing library like `winit` is the most sensible
thing to do.

While it could be offloaded to crates like copypasta[1] the result is
always not good enough[2][3] and it also results in
overengineering[4] (look at its codebase size and compare to what we've
got in winit for Wayland and how much better the handling is done in
winit).

The new API is on the `Window` and is the following:

```rust
pub fn set_clipboard_content<C: AsRef<[u8]> + 'static>(
    &self,
    content:
    C, mimes: HashSet<String>);

pub fn request_clipboard_content(
    &self,
    mimes: HashSet<String>,
    metadata: Option<std::sync::Arc<ClipboardMetadata>>);
```

And also on `WindowExtUnix` where added similar methods to get primary
selection content (The one on middle mouse button).

Working with clipboard is async and loading it is in resulted window
event in `event::WindowEvent::ClipboardContent`.

The use of metadata is due to provide ability to identify requested
load from system's clipboard.

[1] - https://github.com/alacritty/copypasta.
[2] - https://github.com/alacritty/alacritty/issues/3108
[3] - https://github.com/alacritty/alacritty/issues/3601
[4] - https://github.com/Smithay/smithay-clipboard
