### PR TITLE
MacOS: Fix tracking of phase changes for mousewheel (scroll) on trackpad

### DIFF
--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -1016,8 +1016,12 @@ extern "C" fn scroll_wheel(this: &Object, _sel: Sel, event: id) {
             NSEventPhase::NSEventPhaseMayBegin | NSEventPhase::NSEventPhaseBegan => {
                 TouchPhase::Started
             }
-            NSEventPhase::NSEventPhaseEnded => TouchPhase::Ended,
-            _ => TouchPhase::Moved,
+            NSEventPhase::NSEventPhaseEnded | NSEventPhase::NSEventPhaseCancelled => {
+                TouchPhase::Ended
+            }
+            _ => {
+                TouchPhase::Moved
+            }
         };
 
         let device_event = Event::DeviceEvent {


### PR DESCRIPTION
I noticed that TouchPhase::Ended events were occasionally not reported when scrolling with two fingers with a trackpad. Logging the events generated by view.rs/scroll_wheel confirmed that, in certain cases such as touching and then letting go quickly after a Start event had been posted, no corresponding Ended event would be posted.

The problem was that only a NSEventPhase::NSEventPhaseEnded generated a corresponding winit event, but MacOS posts NSEventPhase::NSEventPhaseCancelled as well to signal that the tracking has finished.

Adding NSEventPhase::NSEventPhaseCancelled fixes the problem, now all Started events receive a corresponding Ended event, regardless of how the user taps the trackpad.