### PR TITLE
Make winit focus take activity into account on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Added `MonitorHandle::refresh_rate_millihertz` to get monitor's refresh rate.
 - **Breaking**, Replaced `VideoMode::refresh_rate` with `VideoMode::refresh_rate_millihertz` providing better precision.
 - On Web, add `with_prevent_default` and `with_focusable` to `WindowBuilderExtWebSys` to control whether events should be propagated.
+- On Windows, fix focus events being sent to inactive windows.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -45,6 +45,10 @@ pub struct WindowState {
 
     pub ime_state: ImeState,
     pub ime_allowed: bool,
+
+    // Used by WM_NCACTIVATE, WM_SETFOCUS and WM_KILLFOCUS
+    pub is_active: bool,
+    pub is_focused: bool,
 }
 
 #[derive(Clone)]
@@ -145,6 +149,9 @@ impl WindowState {
 
             ime_state: ImeState::Disabled,
             ime_allowed: false,
+
+            is_active: false,
+            is_focused: false,
         }
     }
 
@@ -169,6 +176,24 @@ impl WindowState {
         F: FnOnce(&mut WindowFlags),
     {
         f(&mut self.window_flags);
+    }
+
+    pub fn has_active_focus(&self) -> bool {
+        self.is_active && self.is_focused
+    }
+
+    // Updates is_active and returns whether active-focus state has changed
+    pub fn set_active(&mut self, is_active: bool) -> bool {
+        let old = self.has_active_focus();
+        self.is_active = is_active;
+        old != self.has_active_focus()
+    }
+
+    // Updates is_focused and returns whether active-focus state has changed
+    pub fn set_focused(&mut self, is_focused: bool) -> bool {
+        let old = self.has_active_focus();
+        self.is_focused = is_focused;
+        old != self.has_active_focus()
     }
 }
 


### PR DESCRIPTION
Fix for issue #2102

`winit`'s notion of "focus" is very simple; you're either focused or not.
However, Windows has both notions of focused window and active window
and paying attention only to `WM_SETFOCUS`/`WM_KILLFOCUS` can cause a window
to believe the user is interacting with it when they're not. (this
manifests when a user switches to another application between when a
`winit` application starts and it creates its first window)
