### PR TITLE
Bump versions of ndk to 0.6, ndk-sys to 0.3, ndk-glue to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Remove no longer needed `WINIT_LINK_COLORSYNC` environment variable.
 - **Breaking:** Rename the `Exit` variant of `ControlFlow` to `ExitWithCode`, which holds a value to control the exit code after running. Add an `Exit` constant which aliases to `ExitWithCode(0)` instead to avoid major breakage. This shouldn't affect most existing programs.
+- Bump `ndk` version to 0.6, ndk-sys to `v0.3`, `ndk-glue` to `0.6`.
 
 # 0.26.1 (2022-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** Bump `ndk` version to 0.6, ndk-sys to `v0.3`, `ndk-glue` to `0.6`.
 - Remove no longer needed `WINIT_LINK_COLORSYNC` environment variable.
 - **Breaking:** Rename the `Exit` variant of `ControlFlow` to `ExitWithCode`, which holds a value to control the exit code after running. Add an `Exit` constant which aliases to `ExitWithCode(0)` instead to avoid major breakage. This shouldn't affect most existing programs.
-- Bump `ndk` version to 0.6, ndk-sys to `v0.3`, `ndk-glue` to `0.6`.
 
 # 0.26.1 (2022-01-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,9 @@ image = "0.23.12"
 simple_logger = "1.9"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = "0.5"
-ndk-sys = "0.2.0"
-ndk-glue = "0.5"
+ndk = "0.6"
+ndk-sys = "0.3"
+ndk-glue = "0.6"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The `ndk_glue` version needs to match the version used by `winit`. Otherwise, th
 | :---: | :------------------: |
 | 0.24  | `ndk_glue = "0.2.0"` |
 | 0.25  | `ndk_glue = "0.3.0"` |
-| 0.26  | `ndk_glue = "0.5.0"` |
+| 0.26  | `ndk_glue = "0.6.0"` |
 
 Running on an Android device needs a dynamic system library, add this to Cargo.toml:
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ The `ndk_glue` version needs to match the version used by `winit`. Otherwise, th
 | :---: | :------------------: |
 | 0.24  | `ndk_glue = "0.2.0"` |
 | 0.25  | `ndk_glue = "0.3.0"` |
-| 0.26  | `ndk_glue = "0.6.0"` |
+| 0.26  | `ndk_glue = "0.5.0"` |
+| 0.27  | `ndk_glue = "0.6.0"` |
 
 Running on an Android device needs a dynamic system library, add this to Cargo.toml:
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
