### PR TITLE
Always set timer when polling to avoid slow waking

### DIFF
--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -410,9 +410,6 @@ impl AppState {
 
         let new = self.control_flow;
         match (old, new) {
-            (ControlFlow::Poll, ControlFlow::Poll) => self.set_state(AppStateImpl::PollFinished {
-                waiting_event_handler,
-            }),
             (ControlFlow::Wait, ControlFlow::Wait) => {
                 let start = Instant::now();
                 self.set_state(AppStateImpl::Waiting {


### PR DESCRIPTION
This fixes #2167. I suspect that the timer needs to be reset after suspending, but I can't find anything on it yet.

Note that removing this case causes the match to drop down to the other polling case that does the same thing, and calls `self.waker.start()`. So effectively, this change calls `self.waker.start()` (setting the next firing time to `std::f64::MIN`) every time through the loop, not just when the polling mode changes.

I'm submitting this PR because it works, and was a very frustrating bug for me, so it should help others encountering the same thing. I'd be grateful for an explanation of *why* it works, though.

- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
