### PR TITLE
Fix inner_size and inner_position of minimized window

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1084,9 +1084,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
             if wparam == winuser::SC_RESTORE {
                 let mut w = userdata.window_state.lock();
                 w.set_window_flags_in_place(|f| f.set(WindowFlags::MINIMIZED, false));
+                w.saved_inner_rect = None;
             }
             if wparam == winuser::SC_MINIMIZE {
                 let mut w = userdata.window_state.lock();
+                w.saved_inner_rect = Some(util::get_client_rect(&mut *window).unwrap());
                 w.set_window_flags_in_place(|f| f.set(WindowFlags::MINIMIZED, true));
             }
             // Send `WindowEvent::Minimized` here if we decide to implement one

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -27,6 +27,7 @@ pub struct WindowState {
     pub taskbar_icon: Option<Icon>,
 
     pub saved_window: Option<SavedWindow>,
+    pub saved_inner_rect: Option<RECT>,
     pub scale_factor: f64,
 
     pub modifiers_state: ModifiersState,
@@ -115,6 +116,7 @@ impl WindowState {
             taskbar_icon,
 
             saved_window: None,
+            saved_inner_rect: None,
             scale_factor,
 
             modifiers_state: ModifiersState::default(),


### PR DESCRIPTION
This PR fixes #2015.
I found that `minimized_window.inner_position()` also returns invalid value which is `Ok(PhysicalPosition { x: -32000, y: -32000 })`, so I fixed it too.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

