### PR TITLE
Bump `dev-dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ bitflags = "1"
 mint = { version = "0.5.6", optional = true }
 
 [dev-dependencies]
-image = "0.23.12"
-simple_logger = "1.9"
+image = "0.24.0"
+simple_logger = "2.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 ndk = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ bitflags = "1"
 mint = { version = "0.5.6", optional = true }
 
 [dev-dependencies]
-image = "0.24.0"
+image = { version = "0.24.0", default-features = false, features = ["png"] }
 simple_logger = "2.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
Update:
- `image` from 0.23 to 0.24
- `simple_logger` from 1.9 to 2.1

Fixes an annoying issue on macOS where `simple_logger` sometimes fails to initialize, see https://github.com/borntyping/rust-simple_logger/issues/52.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
