### PR TITLE
Fix X11 KeyboardInput events sending with ibus input method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
-- On X11, fix for repeated event loop iteration when `ControlFlow` was `Wait`
+- On X11, fix for repeated event loop iteration when `ControlFlow` was `Wait`.
+- On X11, fix KeyboardInput events sending with ibus input method.
 - On Wayland, report unaccelerated mouse deltas in `DeviceEvent::MouseMotion`.
 - **Breaking:** Bump `ndk` version to 0.6, ndk-sys to `v0.3`, `ndk-glue` to `0.6`.
 - Remove no longer needed `WINIT_LINK_COLORSYNC` environment variable.

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -258,6 +258,7 @@ impl<T: 'static> EventLoop<T> {
             num_touch: 0,
             first_touch: None,
             active_window: None,
+            key_event_times: [0; 256],
         };
 
         // Register for device hotplug events


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Previously, KeyboardInput events were sent when they weren't filtered by
the IM. In cases where the IM first filtered an event and later replayed
it, the replayed event was the one to be sent. This caused issues under
the ibus input method and repeated keys. Ibus replays the repeated key
events one by one, which depending on frame rate, can be long after the
key was released.
The solution is to keep track of the time of arrival of the last event
of each keycode. An event is a repeat if its time is not later than the
previous event for the same keycode.
This solution is in use in glfw as well: https://github.com/glfw/glfw/commit/9a3664b
