### PR TITLE
Modified repaint system on Mac OS to use the OS-mediated system instead of doing it entirely in winit to better support non-GPU-accelerated rendering

### DIFF
--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -33,7 +33,7 @@ use crate::{
             event::{EventProxy, EventWrapper},
             event_loop::{post_dummy_event, PanicInfo},
             menu,
-            observer::EventLoopWaker,
+            observer::{CFRunLoopGetMain, CFRunLoopWakeUp, EventLoopWaker},
             util::{IdRef, Never},
             window::get_window_id,
         },
@@ -133,6 +133,7 @@ struct Handler {
     start_time: Mutex<Option<Instant>>,
     callback: Mutex<Option<Box<dyn EventHandler>>>,
     pending_events: Mutex<VecDeque<EventWrapper>>,
+    pending_redraw: Mutex<Vec<WindowId>>,
     waker: Mutex<EventLoopWaker>,
 }
 
@@ -142,6 +143,10 @@ unsafe impl Sync for Handler {}
 impl Handler {
     fn events(&self) -> MutexGuard<'_, VecDeque<EventWrapper>> {
         self.pending_events.lock().unwrap()
+    }
+
+    fn redraw(&self) -> MutexGuard<'_, Vec<WindowId>> {
+        self.pending_redraw.lock().unwrap()
     }
 
     fn waker(&self) -> MutexGuard<'_, EventLoopWaker> {
@@ -185,6 +190,10 @@ impl Handler {
 
     fn take_events(&self) -> VecDeque<EventWrapper> {
         mem::take(&mut *self.events())
+    }
+
+    fn should_redraw(&self) -> Vec<WindowId> {
+        mem::take(&mut *self.redraw())
     }
 
     fn get_in_callback(&self) -> bool {
@@ -336,6 +345,18 @@ impl AppState {
         HANDLER.set_in_callback(false);
     }
 
+    // This is called from multiple threads at present
+    pub fn queue_redraw(window_id: WindowId) {
+        let mut pending_redraw = HANDLER.redraw();
+        if !pending_redraw.contains(&window_id) {
+            pending_redraw.push(window_id);
+        }
+        unsafe {
+            let rl = CFRunLoopGetMain();
+            CFRunLoopWakeUp(rl);
+        }
+    }
+
     pub fn handle_redraw(window_id: WindowId) {
         HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawRequested(window_id)));
     }
@@ -372,6 +393,10 @@ impl AppState {
             HANDLER.handle_nonuser_event(event);
         }
         HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::MainEventsCleared));
+        for window_id in HANDLER.should_redraw() {
+            HANDLER
+                .handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawRequested(window_id)));
+        }
         HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawEventsCleared));
         HANDLER.set_in_callback(false);
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -503,7 +503,12 @@ impl UnownedWindow {
     }
 
     pub fn request_redraw(&self) {
-        AppState::queue_redraw(RootWindowId(self.id()));
+        use objc::{msg_send, runtime::{Object, YES}};
+        println!("Modified redraw request");
+        let view = *self.ns_view as *mut _;
+        unsafe{
+            let _: () = objc::msg_send![view, setNeedsDisplay:YES];
+        }
     }
 
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -19,6 +19,7 @@ use crate::{
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform::macos::WindowExtMacOS,
     platform_impl::platform::{
+        app_state::AppState,
         app_state::INTERRUPT_EVENT_LOOP_EXIT,
         ffi,
         monitor::{self, MonitorHandle, VideoMode},
@@ -28,7 +29,9 @@ use crate::{
         window_delegate::new_delegate,
         OsError,
     },
-    window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
+    window::{
+        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
+    },
 };
 use cocoa::{
     appkit::{
@@ -41,7 +44,6 @@ use cocoa::{
 use core_graphics::display::{CGDisplay, CGDisplayMode};
 use objc::{
     declare::ClassDecl,
-    msg_send,
     rc::autoreleasepool,
     runtime::{Class, Object, Sel, BOOL, NO, YES},
 };
@@ -505,6 +507,7 @@ impl UnownedWindow {
         unsafe {
             let _: () = objc::msg_send![view, setNeedsDisplay: YES];
         }
+        AppState::queue_redraw(RootWindowId(self.id()));
     }
 
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -19,7 +19,6 @@ use crate::{
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform::macos::WindowExtMacOS,
     platform_impl::platform::{
-        app_state::AppState,
         app_state::INTERRUPT_EVENT_LOOP_EXIT,
         ffi,
         monitor::{self, MonitorHandle, VideoMode},
@@ -29,9 +28,7 @@ use crate::{
         window_delegate::new_delegate,
         OsError,
     },
-    window::{
-        CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
-    },
+    window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
 };
 use cocoa::{
     appkit::{
@@ -44,6 +41,7 @@ use cocoa::{
 use core_graphics::display::{CGDisplay, CGDisplayMode};
 use objc::{
     declare::ClassDecl,
+    msg_send,
     rc::autoreleasepool,
     runtime::{Class, Object, Sel, BOOL, NO, YES},
 };
@@ -503,11 +501,9 @@ impl UnownedWindow {
     }
 
     pub fn request_redraw(&self) {
-        use objc::{msg_send, runtime::{Object, YES}};
-        println!("Modified redraw request");
         let view = *self.ns_view as *mut _;
-        unsafe{
-            let _: () = objc::msg_send![view, setNeedsDisplay:YES];
+        unsafe {
+            let _: () = objc::msg_send![view, setNeedsDisplay: YES];
         }
     }
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [ ] ~~Created or updated an example program if it would help users understand this functionality~~
- [ ] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~

There has been prior discussion of this issue and how I found out that this is the needed fix:
 - https://github.com/servo/core-foundation-rs/issues/497
 - https://github.com/john01dav/softbuffer/pull/1
 - https://github.com/rust-windowing/winit/issues/1605

The short version of the context for this change is that in working on [softbuffer](https://crates.io/crates/softbuffer), my new crate to allow GPU-less 2D display to a raw window handle window I encountered a bug where once something was shown to a Mac OS window (during a resize) then nothing more could be shown until the window resized. After much digging, it turned out that the cause for this is that winit is not properly notifying Mac OS of the repaints in order to cause it to allow it to push these repaints to the screen. This is because on Mac OS winit handles repaints entirely within itself and does not notify the OS or allow it to mediate them. This pull request changes that by making request_repaint() notify the OS instead of simply tracking it internally. It also removes the internal tracking system as it is no longer used.

My biggest concern with this pull request is that it might break GPU-accelerated rendering. I can't test this myself as the only Mac computer that I have access to is too old to support Metal and this Wgpu. I tried to find some opengl crates with usable examples for testing, but what I found didn't work properly before the change so the results from after the change are not meaningful. **As such, before this is merged it is *vital* that someone who has access to a more modern Mac computer test this with wgpu and other GPU-accelerated rendering systems to ensure that they are not broken**.