### PR TITLE
Add X11 opt-in function for device events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Added `Window::set_ime_allowed` supported on desktop platforms.
 - **Breaking:** IME input on desktop platforms won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::Ime` events are handled.
 - On macOS, `WindowEvent::Resized` is now emitted in `frameDidChange` instead of `windowDidResize`.
+- **Breaking:** On X11, device events are now ignored for unfocused windows by default, use `EventLoopWindowTarget::set_device_event_filter` to set the filter level.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -30,7 +30,9 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
     event::Event,
-    event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
+    event_loop::{
+        ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
+    },
     icon::Icon,
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
@@ -732,7 +734,7 @@ impl<T: 'static> EventLoop<T> {
     }
 
     pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget<T> {
-        x11_or_wayland!(match self; EventLoop(evl) => evl.window_target())
+        x11_or_wayland!(match self; EventLoop(evlp) => evlp.window_target())
     }
 }
 
@@ -791,6 +793,16 @@ impl<T> EventLoopWindowTarget<T> {
                     inner: primary_monitor,
                 })
             }
+        }
+    }
+
+    #[inline]
+    pub fn set_device_event_filter(&mut self, _filter: DeviceEventFilter) {
+        match *self {
+            #[cfg(feature = "wayland")]
+            EventLoopWindowTarget::Wayland(_) => (),
+            #[cfg(feature = "x11")]
+            EventLoopWindowTarget::X(ref mut evlp) => evlp.set_device_event_filter(_filter),
         }
     }
 }

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -49,7 +49,7 @@ impl<T: 'static> EventProcessor<T> {
         let mut devices = self.devices.borrow_mut();
         if let Some(info) = DeviceInfo::get(&wt.xconn, device) {
             for info in info.iter() {
-                devices.insert(DeviceId(info.deviceid), Device::new(self, info));
+                devices.insert(DeviceId(info.deviceid), Device::new(info));
             }
         }
     }
@@ -907,6 +907,8 @@ impl<T: 'static> EventProcessor<T> {
                         if self.active_window != Some(xev.event) {
                             self.active_window = Some(xev.event);
 
+                            wt.update_device_event_filter(true);
+
                             let window_id = mkwid(xev.event);
                             let position = PhysicalPosition::new(xev.event_x, xev.event_y);
 
@@ -956,6 +958,7 @@ impl<T: 'static> EventProcessor<T> {
                         if !self.window_exists(xev.event) {
                             return;
                         }
+
                         wt.ime
                             .borrow_mut()
                             .unfocus(xev.event)
@@ -963,6 +966,8 @@ impl<T: 'static> EventProcessor<T> {
 
                         if self.active_window.take() == Some(xev.event) {
                             let window_id = mkwid(xev.event);
+
+                            wt.update_device_event_filter(false);
 
                             // Issue key release events for all pressed keys
                             Self::handle_pressed_keys(


### PR DESCRIPTION
Previously on X11, by default all global events were broadcasted to
every Winit application. This unnecessarily drains battery due to
excessive CPU usage when moving the mouse.

To resolve this, device events are now ignored by default and users must
manually opt into it using `EventLoop::set_filter_device_events`.

Fixes (#1634) on Linux.