### PR TITLE
On Windows, fix left mouse button release event not being sent on drag finish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Added `Window::is_decorated`.
 - On X11, fix for repeated event loop iteration when `ControlFlow` was `Wait`
 - On Wayland, report unaccelerated mouse deltas in `DeviceEvent::MouseMotion`.
+- On Windows, fix left mouse button release event not being sent on drag finish
 - **Breaking:** Bump `ndk` version to 0.6, ndk-sys to `v0.3`, `ndk-glue` to `0.6`.
 - Remove no longer needed `WINIT_LINK_COLORSYNC` environment variable.
 - **Breaking:** Rename the `Exit` variant of `ControlFlow` to `ExitWithCode`, which holds a value to control the exit code after running. Add an `Exit` constant which aliases to `ExitWithCode(0)` instead to avoid major breakage. This shouldn't affect most existing programs.

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -26,6 +26,8 @@ pub struct WindowState {
     pub window_icon: Option<Icon>,
     pub taskbar_icon: Option<Icon>,
 
+    pub dragging: bool,
+
     pub saved_window: Option<SavedWindow>,
     pub scale_factor: f64,
 
@@ -113,6 +115,8 @@ impl WindowState {
 
             window_icon: attributes.window_icon.clone(),
             taskbar_icon,
+
+            dragging: false,
 
             saved_window: None,
             scale_factor,


### PR DESCRIPTION
After tricking windows into thinking we are pressing on `HTCAPTION`, we would not get `WM_NCLBUTTONUP`, thus creating unexpected behavior in `winit` dependent projects (https://github.com/emilk/egui/issues/1245#issue-1134534176)
Some debugging after it appears that `wine` have different logic that `winapi` (for context see [this](https://matrix.to/#/!DGpLzJTRzBDTwZiogk:matrix.org/$8hlJG0C6Eiorsj0suXpUr5IOXx0if1nhIfPRHoMwZI8?via=matrix.org&via=libera.chat))

With event tracing we can see that the most suitable event triggered on every drag is `WM_EXITSIZEMOVE`([docs](https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-exitsizemove)):
![image](https://user-images.githubusercontent.com/47575622/154812898-9f1b1b3b-ef6c-4e59-bdca-f2579e43a4fb.png)

- Fixes: https://github.com/rust-windowing/winit/issues/2192