### PR TITLE
On Wayland, fix resize not propagating properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Replaced `EventLoopExtMacOS` with `EventLoopBuilderExtMacOS` (which also has renamed methods).
 - **Breaking:** Replaced `EventLoopExtWindows` with `EventLoopBuilderExtWindows` (which also has renamed methods).
 - **Breaking:** Replaced `EventLoopExtUnix` with `EventLoopBuilderExtUnix` (which also has renamed methods).
+- On Wayland, fix resize and scale factor changes not being propagated properly.
 
 # 0.26.1 (2022-01-05)
 


### PR DESCRIPTION
On Wayland window size and scaling are double buffered, so winit should
send redraw requested for a client on the next frame as well.