### PR TITLE
Fix unsafe_op_in_unsafe_fn warning on nightly

### DIFF
--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -808,7 +808,7 @@ impl<'a, T: 'static> InitData<'a, T> {
     // The user data will be registered for the window and can be accessed within the window event callback.
     pub unsafe fn on_nccreate(&mut self, window: HWND) -> Option<WindowLongPtr> {
         let runner = self.event_loop.runner_shared.clone();
-        let result = runner.catch_unwind(|| unsafe {
+        let result = runner.catch_unwind(|| {
             let mut window = self.create_window(window);
             let window_data = self.create_window_data(&mut window);
             (window, window_data)


### PR DESCRIPTION
- ~~Tested on all platforms changed~~
- ~~Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users~~
- ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- ~~Created or updated an example program if it would help users understand this functionality~~
- ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~

The nightly builds on our CI started spitting out warnings for this today.
