### PR TITLE
Add web_aspect_ratio example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,6 @@ mint = { version = "0.5.6", optional = true }
 [dev-dependencies]
 image = { version = "0.24.0", default-features = false, features = ["png"] }
 simple_logger = { version = "2.1.0", default_features = false }
-web-sys = { version = "0.3.4", features = ['CanvasRenderingContext2d'] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995
@@ -143,6 +142,7 @@ version = "0.2.45"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_log = "0.2"
+web-sys = { version = "0.3.22", features = ['CanvasRenderingContext2d'] }
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ mint = { version = "0.5.6", optional = true }
 [dev-dependencies]
 image = { version = "0.24.0", default-features = false, features = ["png"] }
 simple_logger = { version = "2.1.0", default_features = false }
+web-sys = { version = "0.3.4", features = ['CanvasRenderingContext2d'] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -15,7 +15,7 @@ pub fn main() {
         .unwrap();
 
     #[cfg(target_arch = "wasm32")]
-    let log_list = wasm::create_log_list(&window);
+    let log_list = wasm::insert_canvas_and_create_log_list(&window);
 
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();
@@ -49,7 +49,7 @@ mod wasm {
         super::main();
     }
 
-    pub fn create_log_list(window: &Window) -> web_sys::Element {
+    pub fn insert_canvas_and_create_log_list(window: &Window) -> web_sys::Element {
         use winit::platform::web::WindowExtWebSys;
 
         let canvas = window.canvas();
@@ -58,7 +58,7 @@ mod wasm {
         let document = window.document().unwrap();
         let body = document.body().unwrap();
 
-        // Set a background color for the canvas to make it easier to tell the where the canvas is for debugging purposes.
+        // Set a background color for the canvas to make it easier to tell where the canvas is for debugging purposes.
         canvas.style().set_css_text("background-color: crimson;");
         body.append_child(&canvas).unwrap();
 

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -1,0 +1,107 @@
+pub fn main() {
+    println!("This example must be run with cargo run-wasm --example web_aspect_ratio")
+}
+
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+    use wasm_bindgen::JsCast;
+    use web_sys::{HtmlCanvasElement, HtmlElement};
+    use winit::{
+        dpi::PhysicalSize,
+        event::{Event, WindowEvent},
+        event_loop::{ControlFlow, EventLoop},
+        window::{Window, WindowBuilder},
+    };
+
+    const EXPLANATION: &str = "
+This example draws a circle in the middle of a 4/1 aspect ratio canvas which acts as a useful demonstration of winit's resize handling on web.
+Even when the browser window is resized or aspect-ratio of the div changed the circle should always:
+* Fill the entire width or height of the canvas (whichever is smaller) without exceeding it.
+* Be perfectly round
+* Not be blurry or pixelated (there is no antialiasing so you may still see jagged edges depending on the DPI of your monitor)
+";
+
+    #[wasm_bindgen(start)]
+    pub fn run() {
+        console_log::init_with_level(log::Level::Debug).expect("error initializing logger");
+        let event_loop = EventLoop::new();
+
+        let window = WindowBuilder::new()
+            .with_title("A fantastic window!")
+            // A small default size is used to better demonstrate issues that come from failing to update the size
+            .with_inner_size(PhysicalSize::new(100, 100))
+            .build(&event_loop)
+            .unwrap();
+
+        let canvas = create_canvas(&window);
+
+        // Render once with the size info we currently have
+        render_circle(&canvas, window.inner_size());
+
+        event_loop.run(move |event, _, control_flow| {
+            *control_flow = ControlFlow::Wait;
+
+            match event {
+                Event::WindowEvent {
+                    event: WindowEvent::Resized(resize),
+                    window_id,
+                } if window_id == window.id() => {
+                    render_circle(&canvas, resize);
+                }
+                _ => (),
+            }
+        });
+    }
+
+    pub fn create_canvas(window: &Window) -> HtmlCanvasElement {
+        use winit::platform::web::WindowExtWebSys;
+
+        let web_window = web_sys::window().unwrap();
+        let document = web_window.document().unwrap();
+        let body = document.body().unwrap();
+
+        let parent_div = document.create_element("div").unwrap();
+        parent_div
+            .dyn_ref::<HtmlElement>()
+            .unwrap()
+            .style()
+            .set_css_text("margin: auto; width: 50%; aspect-ratio: 4 / 1;");
+        body.append_child(&parent_div).unwrap();
+
+        // Set a background color for the canvas to make it easier to tell the where the canvas is for debugging purposes.
+        let canvas = window.canvas();
+        canvas
+            .style()
+            .set_css_text("display: block; width: 100%; height: 100%; background-color: crimson;");
+        parent_div.append_child(&canvas).unwrap();
+
+        let explanation = document.create_element("pre").unwrap();
+        explanation.set_text_content(Some(EXPLANATION));
+        body.append_child(&explanation).unwrap();
+
+        canvas
+    }
+
+    pub fn render_circle(canvas: &HtmlCanvasElement, size: PhysicalSize<u32>) {
+        log::info!("rendering circle with canvas size: {:?}", size);
+        let context = canvas
+            .get_context("2d")
+            .unwrap()
+            .unwrap()
+            .dyn_into::<web_sys::CanvasRenderingContext2d>()
+            .unwrap();
+
+        context.begin_path();
+        context
+            .arc(
+                size.width as f64 / 2.0,
+                size.height as f64 / 2.0,
+                size.width.min(size.height) as f64 / 2.0,
+                0.0,
+                std::f64::consts::PI * 2.0,
+            )
+            .unwrap();
+        context.fill();
+    }
+}


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Adds a new example that creates a web canvas that fills an aspect-ratio'd div
The main point of this example is to demonstrate the functionality provided by https://github.com/rust-windowing/winit/pull/2074
The example can land before or after, but landing it before will make it easier to test #2074

Another benefit of this example is demonstrating how to create a web canvas that fills up the available space while maintaining the same aspect ratio.
Although this is slightly out of scope of winit I believe it would be extremely useful to provide as figuring out what combination of html elements and css configuration I needed to get this to work was surprisingly difficult for me even though I've been dabbling with web technologies for ages.

Pinging @liamolucko for feedback as this relates to your PR.

Currently running `cargo run-wasm --example web_aspect_ratio` will give:
![image](https://user-images.githubusercontent.com/5120858/188248497-b858e1e0-e8e6-4248-8522-ed5c15e9c4bd.png)
With #2074 and running `RUSTFLAGS="--cfg=web_sys_unstable_apis" cargo run-wasm --example web_aspect_ratio --features css-size` will give:
![image](https://user-images.githubusercontent.com/5120858/188248925-78c45ddc-202c-4ca8-b724-0335e10a44f4.png)

