### PR TITLE
Fix scale factor calculation when the only monitor is reconnected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Added `Window::is_resizable`.
 - Added `Window::is_decorated`.
 - On X11, fix for repeated event loop iteration when `ControlFlow` was `Wait`
+- On X11, fix scale factor calculation when the only monitor is reconnected
 - On Wayland, report unaccelerated mouse deltas in `DeviceEvent::MouseMotion`.
 - **Breaking:** Bump `ndk` version to 0.6, ndk-sys to `v0.3`, `ndk-glue` to `0.6`.
 - Remove no longer needed `WINIT_LINK_COLORSYNC` environment variable.

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1179,9 +1179,12 @@ impl<T: 'static> EventProcessor<T> {
                                         if monitor.name == new_monitor.name {
                                             let (width, height) = window.inner_size_physical();
                                             let (new_width, new_height) = window.adjust_for_dpi(
-                                                // If there all monitors are closed before, scale
-                                                // factor would be already changed to 1.0.
-                                                maybe_prev_scale_factor.unwrap_or(1.0),
+                                                // If we couldn't determine the previous scale
+                                                // factor (e.g., because all monitors were closed
+                                                // before), just pick whatever the current monitor
+                                                // has set as a baseline.
+                                                maybe_prev_scale_factor
+                                                    .unwrap_or(monitor.scale_factor),
                                                 new_monitor.scale_factor,
                                                 width,
                                                 height,


### PR DESCRIPTION
The scale factor being sent when the only monitor is disconnected and
reconnected is hard coded to 1.0. That may work by chance, if that's the
scale factor in use currently, but it does not work in the general case.
As a result, clients may end up with wrongly scaled or laid out window
contents after reconnect, as was reported over in
https://github.com/alacritty/alacritty/issues/5703, for example.

The problem was introduced by change 125ee0b, which caused an additional
ScaleFactorChanged event to be sent on monitor reconnect, but got the
scale factor wrong when the only monitor is disconnected and
reconnected.
This change fixes the problem by using the current monitor's scale
factor in this case. The event is still being sent as intended by
125ee0b.

Closes: #2123

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
