### PR TITLE
Update doc comment to reflect that `is_maximized` is implemented on X11/Wayland

### DIFF
--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -87,7 +87,7 @@ impl Window {
 
         let window_id = super::make_wid(&surface);
         let maximized = Arc::new(AtomicBool::new(false));
-        let maximzied_clone = maximized.clone();
+        let maximized_clone = maximized.clone();
         let fullscreen = Arc::new(AtomicBool::new(false));
         let fullscreen_clone = fullscreen.clone();
 
@@ -115,7 +115,7 @@ impl Window {
                         }
                         Event::Configure { new_size, states } => {
                             let is_maximized = states.contains(&State::Maximized);
-                            maximzied_clone.store(is_maximized, Ordering::Relaxed);
+                            maximized_clone.store(is_maximized, Ordering::Relaxed);
                             let is_fullscreen = states.contains(&State::Fullscreen);
                             fullscreen_clone.store(is_fullscreen, Ordering::Relaxed);
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -718,7 +718,6 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **Wayland / X11:** Not implemented.
     /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn is_maximized(&self) -> bool {


### PR DESCRIPTION
This was fixed in #1848.

fix typo in wayland implementation
