### PR TITLE
rename PlatformSpecificBuilderAttributes -> PlatformSpecificWindowBuilderAttributes

### DIFF
--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -33,10 +33,7 @@ pub(crate) use self::event_loop::{
     WindowTarget as EventLoopWindowTarget,
 };
 pub use self::monitor::{Handle as MonitorHandle, Mode as VideoMode};
-pub use self::window::{
-    Id as WindowId, PlatformSpecificBuilderAttributes as PlatformSpecificWindowBuilderAttributes,
-    Window,
-};
+pub use self::window::{Id as WindowId, PlatformSpecificWindowBuilderAttributes, Window};
 
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -29,7 +29,7 @@ impl Window {
     pub fn new<T>(
         target: &EventLoopWindowTarget<T>,
         attr: WindowAttributes,
-        platform_attr: PlatformSpecificBuilderAttributes,
+        platform_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOE> {
         let runner = target.runner.clone();
 
@@ -363,6 +363,6 @@ impl Id {
 }
 
 #[derive(Default, Clone)]
-pub struct PlatformSpecificBuilderAttributes {
+pub struct PlatformSpecificWindowBuilderAttributes {
     pub(crate) canvas: Option<backend::RawCanvasType>,
 }


### PR DESCRIPTION

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I mean sure technically its a canvas not a window in the context of web, but keeping the type name consistent with the other PlatformSpecificWindowBuilderAttributes types removes a lot of confusion.