### PR TITLE
On Wayland, fix consecutive run_return not polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** The platform specific extensions for Windows `winit::platform::windows` have changed. All `HANDLE`-like types e.g. `HWND` and `HMENU` were converted from winapi types or `*mut c_void` to `isize`. This was done to be consistent with the type definitions in windows-sys and to not expose internal dependencies.
 - The internal bindings to the [Windows API](https://docs.microsoft.com/en-us/windows/) were changed from the unofficial [winapi](https://github.com/retep998/winapi-rs) bindings to the official Microsoft [windows-sys](https://github.com/microsoft/windows-rs) bindings.
 - On Wayland, fix resize and scale factor changes not being propagated properly.
+- On Wayland, fix polling during consecutive `EventLoop::run_return` invocations.
 
 # 0.26.1 (2022-01-05)
 


### PR DESCRIPTION
If you try to use `EventLoop::run_return` API in a way that you do on
demand polling of events it won't actually poll, since in such strategy
the `ControlFlow::Exit` is sent right before Wayland backend starts to
poll.

This was observed with smithay compositor Anvil which was doing this
particular thing leading to GNOME thinking that app isn't responding.
