### PR TITLE
Always send RedrawEventsCleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix polling during consecutive `EventLoop::run_return` invocations.
 - On Windows, fix race issue creating fullscreen windows with `WindowBuilder::with_fullscreen`
 - On Android, `virtual_keycode` for `KeyboardInput` events is now filled in where a suitable match is found.
+- On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -811,9 +811,7 @@ pub unsafe fn handle_main_events_cleared() {
         })
         .collect();
 
-    if !redraw_events.is_empty() {
-        redraw_events.push(EventWrapper::StaticEvent(Event::RedrawEventsCleared));
-    }
+    redraw_events.push(EventWrapper::StaticEvent(Event::RedrawEventsCleared));
     drop(this);
 
     handle_nonuser_events(redraw_events);


### PR DESCRIPTION
For all platforms other than iOS, `RedrawEventsCleared` is sent even if there are no redraw events. This change makes iOS consistent with the other platforms.

This solves a bug on iOS where Bevy relies on this event in https://github.com/bevyengine/bevy/pull/3974

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
