### PR TITLE
Quicker Mac builds by removing dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,9 +42,9 @@ ndk-glue = "0.6"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"
+libc = "0.2.64"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.24"
 core-foundation = "0.9"
 core-graphics = "0.22"
 dispatch = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,14 +45,7 @@ objc = "0.2.7"
 libc = "0.2.64"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-core-foundation = "0.9"
-core-graphics = "0.22"
 dispatch = "0.2.0"
-
-[target.'cfg(target_os = "macos")'.dependencies.core-video-sys]
-version = "0.1.4"
-default_features = false
-features = ["display_link"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 parking_lot = "0.12"

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,6 +1,6 @@
 use crate::{platform::macos::ActivationPolicy, platform_impl::platform::app_state::AppState};
 
-use cocoa::base::id;
+use super::thin_cocoa::id;
 use objc::{
     declare::ClassDecl,
     runtime::{Class, Object, Sel},

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -12,11 +12,7 @@ use std::{
     time::Instant,
 };
 
-use cocoa::{
-    appkit::{NSApp, NSApplication, NSWindow},
-    base::{id, nil},
-    foundation::NSSize,
-};
+use super::thin_cocoa::{id, nil, NSApp, NSApplication, NSSize, NSWindow};
 use objc::{
     rc::autoreleasepool,
     runtime::{Object, BOOL, NO, YES},
@@ -482,7 +478,7 @@ unsafe fn window_activation_hack(ns_app: id) {
 }
 fn apply_activation_policy(app_delegate: &Object) {
     unsafe {
-        use cocoa::appkit::NSApplicationActivationPolicy::*;
+        use super::thin_cocoa::NSApplicationActivationPolicy::*;
         let ns_app = NSApp();
         // We need to delay setting the activation policy and activating the app
         // until `applicationDidFinishLaunching` has been called. Otherwise the

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -1,9 +1,6 @@
 use std::os::raw::c_ushort;
 
-use cocoa::{
-    appkit::{NSEvent, NSEventModifierFlags},
-    base::id,
-};
+use super::thin_cocoa::{id, NSEvent, NSEventModifierFlags};
 
 use crate::{
     dpi::LogicalSize,
@@ -263,7 +260,7 @@ pub fn event_mods(event: id) -> ModifiersState {
     m
 }
 
-pub fn get_scancode(event: cocoa::base::id) -> c_ushort {
+pub fn get_scancode(event: super::thin_cocoa::id) -> c_ushort {
     // In AppKit, `keyCode` refers to the position (scancode) of a key rather than its character,
     // and there is no easy way to navtively retrieve the layout-dependent character.
     // In winit, we use keycode to refer to the key's character, and so this function aligns

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -11,10 +11,9 @@ use std::{
     sync::mpsc,
 };
 
-use cocoa::{
-    appkit::{NSApp, NSEventModifierFlags, NSEventSubtype, NSEventType::NSApplicationDefined},
-    base::{id, nil, BOOL, NO, YES},
-    foundation::{NSInteger, NSPoint, NSTimeInterval},
+use super::thin_cocoa::{
+    id, nil, NSApp, NSEventModifierFlags, NSEventSubtype, NSEventType::NSApplicationDefined,
+    NSInteger, NSPoint, NSTimeInterval, BOOL, NO, YES,
 };
 use objc::rc::autoreleasepool;
 
@@ -92,13 +91,13 @@ impl<T: 'static> EventLoopWindowTarget<T> {
 impl<T> EventLoopWindowTarget<T> {
     pub(crate) fn hide_application(&self) {
         let cls = objc::runtime::Class::get("NSApplication").unwrap();
-        let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
+        let app: super::thin_cocoa::id = unsafe { msg_send![cls, sharedApplication] };
         unsafe { msg_send![app, hide: 0] }
     }
 
     pub(crate) fn hide_other_applications(&self) {
         let cls = objc::runtime::Class::get("NSApplication").unwrap();
-        let app: cocoa::base::id = unsafe { msg_send![cls, sharedApplication] };
+        let app: super::thin_cocoa::id = unsafe { msg_send![cls, sharedApplication] };
         unsafe { msg_send![app, hideOtherApplications: 0] }
     }
 }

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -5,10 +5,10 @@
 use std::ffi::c_void;
 
 use super::thin_cocoa::{id, NSInteger, NSUInteger};
-use core_foundation::{
+use super::thin_core_foundation::{
     array::CFArrayRef, dictionary::CFDictionaryRef, string::CFStringRef, uuid::CFUUIDRef,
 };
-use core_graphics::{
+use super::thin_core_graphics::{
     base::CGError,
     display::{CGDirectDisplayID, CGDisplayConfigRef},
 };
@@ -216,5 +216,5 @@ extern "C" {
     pub fn CGDisplayModeGetRefreshRate(mode: CGDisplayModeRef) -> f64;
     pub fn CGDisplayModeCopyPixelEncoding(mode: CGDisplayModeRef) -> CFStringRef;
     pub fn CGDisplayModeRetain(mode: CGDisplayModeRef);
-    pub fn CGDisplayModeRelease(mode: CGDisplayModeRef);
+    // pub fn CGDisplayModeRelease(mode: CGDisplayModeRef);
 }

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -4,10 +4,7 @@
 
 use std::ffi::c_void;
 
-use cocoa::{
-    base::id,
-    foundation::{NSInteger, NSUInteger},
-};
+use super::thin_cocoa::{id, NSInteger, NSUInteger};
 use core_foundation::{
     array::CFArrayRef, dictionary::CFDictionaryRef, string::CFStringRef, uuid::CFUUIDRef,
 };

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -1,7 +1,7 @@
+use super::thin_cocoa::{nil, selector};
+use super::thin_cocoa::{NSApp, NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
+use super::thin_cocoa::{NSProcessInfo, NSString};
 use super::util::IdRef;
-use cocoa::appkit::{NSApp, NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
-use cocoa::base::{nil, selector};
-use cocoa::foundation::{NSProcessInfo, NSString};
 use objc::{
     rc::autoreleasepool,
     runtime::{Object, Sel},

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -4,6 +4,9 @@
 mod util;
 
 pub use util::thin_cocoa;
+pub use util::thin_core_foundation;
+pub use util::thin_core_graphics;
+pub use util::thin_core_video_sys;
 
 mod app;
 mod app_delegate;
@@ -56,7 +59,7 @@ pub struct Window {
 
 #[derive(Debug)]
 pub enum OsError {
-    CGError(core_graphics::base::CGError),
+    CGError(super::thin_core_graphics::base::CGError),
     CreationError(&'static str),
 }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -3,6 +3,8 @@
 #[macro_use]
 mod util;
 
+pub use util::thin_cocoa;
+
 mod app;
 mod app_delegate;
 mod app_state;

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -1,14 +1,10 @@
 use std::{collections::VecDeque, fmt};
 
+use super::thin_cocoa::{id, nil, NSScreen, NSUInteger};
 use super::{ffi, util};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
-};
-use cocoa::{
-    appkit::NSScreen,
-    base::{id, nil},
-    foundation::NSUInteger,
 };
 use core_foundation::{
     array::{CFArrayGetCount, CFArrayGetValueAtIndex},

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -1,20 +1,20 @@
 use std::{collections::VecDeque, fmt};
 
 use super::thin_cocoa::{id, nil, NSScreen, NSUInteger};
+use super::thin_core_foundation::{
+    array::{CFArrayGetCount, CFArrayGetValueAtIndex},
+    //string:CFString,
+    CFRelease,
+};
+use super::thin_core_graphics::display::{CGDirectDisplayID, CGDisplay, CGDisplayBounds};
+use super::thin_core_video_sys::{
+    kCVReturnSuccess, kCVTimeIsIndefinite, CVDisplayLinkCreateWithCGDisplay,
+    CVDisplayLinkGetNominalOutputVideoRefreshPeriod, CVDisplayLinkRelease,
+};
 use super::{ffi, util};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
-};
-use core_foundation::{
-    array::{CFArrayGetCount, CFArrayGetValueAtIndex},
-    base::{CFRelease, TCFType},
-    string::CFString,
-};
-use core_graphics::display::{CGDirectDisplayID, CGDisplay, CGDisplayBounds};
-use core_video_sys::{
-    kCVReturnSuccess, kCVTimeIsIndefinite, CVDisplayLinkCreateWithCGDisplay,
-    CVDisplayLinkGetNominalOutputVideoRefreshPeriod, CVDisplayLinkRelease,
 };
 
 #[derive(Clone)]
@@ -64,7 +64,7 @@ unsafe impl Send for NativeDisplayMode {}
 impl Drop for NativeDisplayMode {
     fn drop(&mut self) {
         unsafe {
-            ffi::CGDisplayModeRelease(self.0);
+            super::thin_core_graphics::display::CGDisplayModeRelease(self.0 as *mut _);
         }
     }
 }
@@ -265,6 +265,7 @@ impl MonitorHandle {
                     cv_refresh_rate
                 };
 
+                /*
                 let pixel_encoding =
                     CFString::wrap_under_create_rule(ffi::CGDisplayModeCopyPixelEncoding(mode))
                         .to_string();
@@ -277,6 +278,8 @@ impl MonitorHandle {
                 } else {
                     unimplemented!()
                 };
+                */
+                let bit_depth = 32;
 
                 let video_mode = VideoMode {
                     size: (

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -3,10 +3,8 @@ use std::{
     sync::{Mutex, Weak},
 };
 
-use cocoa::{
-    appkit::{CGFloat, NSScreen, NSWindow, NSWindowStyleMask},
-    base::{id, nil},
-    foundation::{NSPoint, NSSize, NSString},
+use super::thin_cocoa::{
+    id, nil, CGFloat, NSPoint, NSScreen, NSSize, NSString, NSWindow, NSWindowStyleMask,
 };
 use dispatch::Queue;
 use objc::rc::autoreleasepool;

--- a/src/platform_impl/macos/util/cursor.rs
+++ b/src/platform_impl/macos/util/cursor.rs
@@ -1,8 +1,4 @@
-use cocoa::{
-    appkit::NSImage,
-    base::{id, nil},
-    foundation::{NSDictionary, NSPoint, NSString},
-};
+use super::thin_cocoa::{id, nil, NSDictionary, NSImage, NSPoint, NSString};
 use objc::{runtime::Sel, runtime::NO};
 use std::cell::RefCell;
 

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -1,17 +1,14 @@
 mod r#async;
 mod cursor;
+pub mod thin_cocoa;
 
 pub use self::{cursor::*, r#async::*};
 
 use std::ops::{BitAnd, Deref};
 
-use cocoa::{
-    appkit::{NSApp, NSWindowStyleMask},
-    base::{id, nil},
-    foundation::{NSPoint, NSRect, NSString, NSUInteger},
-};
 use core_graphics::display::CGDisplay;
 use objc::runtime::{Class, Object};
+use thin_cocoa::{id, nil, NSApp, NSPoint, NSRect, NSString, NSUInteger, NSWindowStyleMask};
 
 use crate::dpi::LogicalPosition;
 use crate::platform_impl::platform::ffi;
@@ -159,7 +156,7 @@ pub unsafe fn open_emoji_picker() {
 }
 
 pub unsafe fn toggle_style_mask(window: id, view: id, mask: NSWindowStyleMask, on: bool) {
-    use cocoa::appkit::NSWindow;
+    use thin_cocoa::NSWindow;
 
     let current_style_mask = window.styleMask();
     if on {

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -1,14 +1,17 @@
 mod r#async;
 mod cursor;
 pub mod thin_cocoa;
+pub mod thin_core_foundation;
+pub mod thin_core_graphics;
+pub mod thin_core_video_sys;
 
 pub use self::{cursor::*, r#async::*};
 
 use std::ops::{BitAnd, Deref};
 
-use core_graphics::display::CGDisplay;
 use objc::runtime::{Class, Object};
 use thin_cocoa::{id, nil, NSApp, NSPoint, NSRect, NSString, NSUInteger, NSWindowStyleMask};
+use thin_core_graphics::display::CGDisplay;
 
 use crate::dpi::LogicalPosition;
 use crate::platform_impl::platform::ffi;

--- a/src/platform_impl/macos/util/thin_cocoa.rs
+++ b/src/platform_impl/macos/util/thin_cocoa.rs
@@ -1,0 +1,3449 @@
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+
+use core::ptr;
+
+use libc;
+pub use objc::{
+    runtime,
+    runtime::{BOOL, NO, YES},
+};
+
+#[allow(non_camel_case_types)]
+pub type id = *mut runtime::Object;
+
+pub unsafe fn NSApp() -> id {
+    msg_send![class!(NSApplication), sharedApplication]
+}
+
+#[cfg(target_pointer_width = "32")]
+pub type NSInteger = libc::c_int;
+#[cfg(target_pointer_width = "32")]
+pub type NSUInteger = libc::c_uint;
+
+#[cfg(target_pointer_width = "64")]
+pub type NSInteger = libc::c_long;
+#[cfg(target_pointer_width = "64")]
+pub type NSUInteger = libc::c_ulong;
+
+#[cfg(target_pointer_width = "64")]
+pub type CGFloat = libc::c_double;
+#[cfg(not(target_pointer_width = "64"))]
+pub type CGFloat = libc::c_float;
+
+// pub type Class = *mut runtime::Class;
+
+#[allow(non_upper_case_globals)]
+pub const nil: id = 0 as id;
+#[allow(non_upper_case_globals)]
+// pub const Nil: Class = 0 as Class;
+#[repr(i64)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum NSApplicationActivationPolicy {
+    NSApplicationActivationPolicyRegular = 0,
+    NSApplicationActivationPolicyAccessory = 1,
+    NSApplicationActivationPolicyProhibited = 2,
+    // NSApplicationActivationPolicyERROR = -1,
+}
+
+#[repr(u64)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum NSRequestUserAttentionType {
+    NSCriticalRequest = 0,
+    NSInformationalRequest = 10,
+}
+
+bitflags! {
+    pub struct NSWindowStyleMask: NSUInteger {
+        const NSBorderlessWindowMask      = 0;
+        const NSTitledWindowMask          = 1 << 0;
+        const NSClosableWindowMask        = 1 << 1;
+        const NSMiniaturizableWindowMask  = 1 << 2;
+        const NSResizableWindowMask       = 1 << 3;
+
+        const NSTexturedBackgroundWindowMask  = 1 << 8;
+
+        const NSUnifiedTitleAndToolbarWindowMask  = 1 << 12;
+
+        const NSFullScreenWindowMask      = 1 << 14;
+
+        const NSFullSizeContentViewWindowMask = 1 << 15;
+    }
+}
+
+bitflags! {
+    pub struct NSApplicationPresentationOptions : NSUInteger {
+        const NSApplicationPresentationDefault = 0;
+        const NSApplicationPresentationAutoHideDock = 1 << 0;
+        const NSApplicationPresentationHideDock = 1 << 1;
+        const NSApplicationPresentationAutoHideMenuBar = 1 << 2;
+        const NSApplicationPresentationHideMenuBar = 1 << 3;
+        const NSApplicationPresentationDisableAppleMenu = 1 << 4;
+        const NSApplicationPresentationDisableProcessSwitching = 1 << 5;
+        const NSApplicationPresentationDisableForceQuit = 1 << 6;
+        const NSApplicationPresentationDisableSessionTermination = 1 << 7;
+        const NSApplicationPresentationDisableHideApplication = 1 << 8;
+        const NSApplicationPresentationDisableMenuBarTransparency = 1 << 9;
+        const NSApplicationPresentationFullScreen = 1 << 10;
+        const NSApplicationPresentationAutoHideToolbar = 1 << 11;
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct NSPoint {
+    pub x: CGFloat,
+    pub y: CGFloat,
+}
+
+impl NSPoint {
+    #[inline]
+    pub fn new(x: CGFloat, y: CGFloat) -> NSPoint {
+        NSPoint { x, y }
+    }
+}
+
+unsafe impl objc::Encode for NSPoint {
+    fn encode() -> objc::Encoding {
+        let encoding = format!(
+            "{{CGPoint={}{}}}",
+            CGFloat::encode().as_str(),
+            CGFloat::encode().as_str()
+        );
+        unsafe { objc::Encoding::from_str(&encoding) }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct NSSize {
+    pub width: CGFloat,
+    pub height: CGFloat,
+}
+
+impl NSSize {
+    #[inline]
+    pub fn new(width: CGFloat, height: CGFloat) -> NSSize {
+        NSSize { width, height }
+    }
+}
+
+unsafe impl objc::Encode for NSSize {
+    fn encode() -> objc::Encoding {
+        let encoding = format!(
+            "{{CGSize={}{}}}",
+            CGFloat::encode().as_str(),
+            CGFloat::encode().as_str()
+        );
+        unsafe { objc::Encoding::from_str(&encoding) }
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct NSRect {
+    pub origin: NSPoint,
+    pub size: NSSize,
+}
+
+impl NSRect {
+    #[inline]
+    pub fn new(origin: NSPoint, size: NSSize) -> NSRect {
+        NSRect { origin, size }
+    }
+
+    /*
+    #[inline]
+    pub fn as_CGRect(&self) -> &CGRect {
+        unsafe { mem::transmute::<&NSRect, &CGRect>(self) }
+    }
+
+    #[inline]
+    pub fn inset(&self, x: CGFloat, y: CGFloat) -> NSRect {
+        unsafe { NSInsetRect(*self, x, y) }
+    }
+    */
+}
+
+unsafe impl objc::Encode for NSRect {
+    fn encode() -> objc::Encoding {
+        let encoding = format!(
+            "{{CGRect={}{}}}",
+            NSPoint::encode().as_str(),
+            NSSize::encode().as_str()
+        );
+        unsafe { objc::Encoding::from_str(&encoding) }
+    }
+}
+
+pub trait NSString: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSString), alloc]
+    }
+
+    unsafe fn stringByAppendingString_(self, other: id) -> id;
+    unsafe fn init_str(self, string: &str) -> Self;
+    unsafe fn UTF8String(self) -> *const libc::c_char;
+    unsafe fn len(self) -> usize;
+    unsafe fn isEqualToString(self, other: &str) -> bool;
+    unsafe fn substringWithRange(self, range: NSRange) -> id;
+}
+
+const UTF8_ENCODING: usize = 4;
+
+impl NSString for id {
+    unsafe fn isEqualToString(self, other: &str) -> bool {
+        let other = NSString::alloc(nil).init_str(other);
+        let rv: BOOL = msg_send![self, isEqualToString: other];
+        rv != NO
+    }
+
+    unsafe fn stringByAppendingString_(self, other: id) -> id {
+        msg_send![self, stringByAppendingString: other]
+    }
+
+    unsafe fn init_str(self, string: &str) -> id {
+        return msg_send![self,
+                         initWithBytes:string.as_ptr()
+                             length:string.len()
+                             encoding:UTF8_ENCODING as id];
+    }
+
+    unsafe fn len(self) -> usize {
+        msg_send![self, lengthOfBytesUsingEncoding: UTF8_ENCODING]
+    }
+
+    unsafe fn UTF8String(self) -> *const libc::c_char {
+        msg_send![self, UTF8String]
+    }
+
+    unsafe fn substringWithRange(self, range: NSRange) -> id {
+        msg_send![self, substringWithRange: range]
+    }
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct NSRange {
+    pub location: NSUInteger,
+    pub length: NSUInteger,
+}
+
+/*
+impl NSRange {
+    #[inline]
+    pub fn new(location: NSUInteger, length: NSUInteger) -> NSRange {
+        NSRange { location, length }
+    }
+}
+*/
+
+pub trait NSApplication: Sized {
+    unsafe fn sharedApplication(_: Self) -> id {
+        msg_send![class!(NSApplication), sharedApplication]
+    }
+
+    unsafe fn mainMenu(self) -> id;
+    unsafe fn setActivationPolicy_(self, policy: NSApplicationActivationPolicy) -> BOOL;
+    unsafe fn setPresentationOptions_(self, options: NSApplicationPresentationOptions) -> BOOL;
+    unsafe fn presentationOptions_(self) -> NSApplicationPresentationOptions;
+    unsafe fn setMainMenu_(self, menu: id);
+    unsafe fn setServicesMenu_(self, menu: id);
+    unsafe fn setWindowsMenu_(self, menu: id);
+    unsafe fn activateIgnoringOtherApps_(self, ignore: BOOL);
+    unsafe fn run(self);
+    unsafe fn finishLaunching(self);
+    unsafe fn nextEventMatchingMask_untilDate_inMode_dequeue_(
+        self,
+        mask: NSUInteger,
+        expiration: id,
+        in_mode: id,
+        dequeue: BOOL,
+    ) -> id;
+    unsafe fn sendEvent_(self, an_event: id);
+    unsafe fn postEvent_atStart_(self, anEvent: id, flag: BOOL);
+    unsafe fn stop_(self, sender: id);
+    unsafe fn setApplicationIconImage_(self, image: id);
+    unsafe fn requestUserAttention_(self, requestType: NSRequestUserAttentionType);
+}
+
+impl NSApplication for id {
+    unsafe fn mainMenu(self) -> id {
+        msg_send![self, mainMenu]
+    }
+
+    unsafe fn setActivationPolicy_(self, policy: NSApplicationActivationPolicy) -> BOOL {
+        msg_send![self, setActivationPolicy: policy as NSInteger]
+    }
+
+    unsafe fn setPresentationOptions_(self, options: NSApplicationPresentationOptions) -> BOOL {
+        msg_send![self, setPresentationOptions:options.bits]
+    }
+
+    unsafe fn presentationOptions_(self) -> NSApplicationPresentationOptions {
+        let options = msg_send![self, presentationOptions];
+        return NSApplicationPresentationOptions::from_bits(options).unwrap();
+    }
+
+    unsafe fn setMainMenu_(self, menu: id) {
+        msg_send![self, setMainMenu: menu]
+    }
+
+    unsafe fn setServicesMenu_(self, menu: id) {
+        msg_send![self, setServicesMenu: menu]
+    }
+
+    unsafe fn setWindowsMenu_(self, menu: id) {
+        msg_send![self, setWindowsMenu: menu]
+    }
+
+    unsafe fn activateIgnoringOtherApps_(self, ignore: BOOL) {
+        msg_send![self, activateIgnoringOtherApps: ignore]
+    }
+
+    unsafe fn run(self) {
+        msg_send![self, run]
+    }
+
+    unsafe fn finishLaunching(self) {
+        msg_send![self, finishLaunching]
+    }
+
+    unsafe fn nextEventMatchingMask_untilDate_inMode_dequeue_(
+        self,
+        mask: NSUInteger,
+        expiration: id,
+        in_mode: id,
+        dequeue: BOOL,
+    ) -> id {
+        msg_send![self, nextEventMatchingMask:mask
+                                    untilDate:expiration
+                                       inMode:in_mode
+                                      dequeue:dequeue]
+    }
+
+    unsafe fn sendEvent_(self, an_event: id) {
+        msg_send![self, sendEvent: an_event]
+    }
+
+    unsafe fn postEvent_atStart_(self, anEvent: id, flag: BOOL) {
+        msg_send![self, postEvent:anEvent atStart:flag]
+    }
+
+    unsafe fn stop_(self, sender: id) {
+        msg_send![self, stop: sender]
+    }
+
+    unsafe fn setApplicationIconImage_(self, icon: id) {
+        msg_send![self, setApplicationIconImage: icon]
+    }
+
+    unsafe fn requestUserAttention_(self, requestType: NSRequestUserAttentionType) {
+        msg_send![self, requestUserAttention: requestType]
+    }
+}
+
+pub trait NSEvent: Sized {
+    /*
+    // Creating Events
+    unsafe fn keyEventWithType_location_modifierFlags_timestamp_windowNumber_context_characters_charactersIgnoringModifiers_isARepeat_keyCode_(
+        _: Self,
+        eventType: NSEventType,
+        location: NSPoint,
+        modifierFlags: NSEventModifierFlags,
+        timestamp: NSTimeInterval,
+        windowNumber: NSInteger,
+        context: id /* (NSGraphicsContext *) */,
+        characters: id /* (NSString *) */,
+        unmodCharacters: id /* (NSString *) */,
+        repeatKey: BOOL,
+        code: libc::c_ushort) -> id /* (NSEvent *) */;
+    unsafe fn mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure_(
+        _: Self,
+        eventType: NSEventType,
+        location: NSPoint,
+        modifierFlags: NSEventModifierFlags,
+        timestamp: NSTimeInterval,
+        windowNumber: NSInteger,
+        context: id /* (NSGraphicsContext *) */,
+        eventNumber: NSInteger,
+        clickCount: NSInteger,
+        pressure: libc::c_float) -> id /* (NSEvent *) */;
+    unsafe fn enterExitEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_trackingNumber_userData_(
+        _: Self,
+        eventType: NSEventType,
+        location: NSPoint,
+        modifierFlags: NSEventModifierFlags,
+        timestamp: NSTimeInterval,
+        windowNumber: NSInteger,
+        context: id /* (NSGraphicsContext *) */,
+        eventNumber: NSInteger,
+        trackingNumber: NSInteger,
+        userData: *mut c_void) -> id /* (NSEvent *) */;
+    unsafe fn otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
+        _: Self,
+        eventType: NSEventType,
+        location: NSPoint,
+        modifierFlags: NSEventModifierFlags,
+        timestamp: NSTimeInterval,
+        windowNumber: NSInteger,
+        context: id /* (NSGraphicsContext *) */,
+        subtype: NSEventSubtype,
+        data1: NSInteger,
+        data2: NSInteger) -> id /* (NSEvent *) */;
+    unsafe fn eventWithEventRef_(_: Self, eventRef: *const c_void) -> id;
+    unsafe fn eventWithCGEvent_(_: Self, cgEvent: *mut c_void /* CGEventRef */) -> id;
+
+    // Getting General Event Information
+    unsafe fn context(self) -> id /* (NSGraphicsContext *) */;
+     */
+    unsafe fn locationInWindow(self) -> NSPoint;
+
+    unsafe fn modifierFlags(self) -> NSEventModifierFlags;
+    /*
+    unsafe fn timestamp(self) -> NSTimeInterval;
+    // NOTE: renamed from `- type` due to Rust keyword collision
+    */
+    unsafe fn eventType(self) -> NSEventType;
+    /*
+    unsafe fn window(self) -> id /* (NSWindow *) */;
+    unsafe fn windowNumber(self) -> NSInteger;
+    unsafe fn eventRef(self) -> *const c_void;
+    unsafe fn CGEvent(self) -> *mut c_void /* CGEventRef */;
+
+    // Getting Key Event Information
+    // NOTE: renamed from `+ modifierFlags` due to conflict with `- modifierFlags`
+    unsafe fn currentModifierFlags(_: Self) -> NSEventModifierFlags;
+    unsafe fn keyRepeatDelay(_: Self) -> NSTimeInterval;
+    unsafe fn keyRepeatInterval(_: Self) -> NSTimeInterval;
+    unsafe fn characters(self) -> id /* (NSString *) */;
+    unsafe fn charactersIgnoringModifiers(self) -> id /* (NSString *) */;
+    unsafe fn keyCode(self) -> libc::c_ushort;
+    unsafe fn isARepeat(self) -> BOOL;
+
+    // Getting Mouse Event Information
+    unsafe fn pressedMouseButtons(_: Self) -> NSUInteger;
+    unsafe fn doubleClickInterval(_: Self) -> NSTimeInterval;
+    unsafe fn mouseLocation(_: Self) -> NSPoint;
+
+    */
+    unsafe fn buttonNumber(self) -> NSInteger;
+
+    /*
+    unsafe fn clickCount(self) -> NSInteger;
+    */
+
+    unsafe fn pressure(self) -> libc::c_float;
+    unsafe fn stage(self) -> NSInteger;
+    /*
+    unsafe fn setMouseCoalescingEnabled_(_: Self, flag: BOOL);
+    unsafe fn isMouseCoalescingEnabled(_: Self) -> BOOL;
+
+    // Getting Mouse-Tracking Event Information
+    unsafe fn eventNumber(self) -> NSInteger;
+    unsafe fn trackingNumber(self) -> NSInteger;
+    unsafe fn trackingArea(self) -> id /* (NSTrackingArea *) */;
+    unsafe fn userData(self) -> *const c_void;
+
+    // Getting Custom Event Information
+    unsafe fn data1(self) -> NSInteger;
+    unsafe fn data2(self) -> NSInteger;
+    unsafe fn subtype(self) -> NSEventSubtype;
+
+    // Getting Scroll Wheel Event Information
+    */
+    unsafe fn deltaX(self) -> CGFloat;
+    unsafe fn deltaY(self) -> CGFloat;
+    unsafe fn deltaZ(self) -> CGFloat;
+
+    /*
+    // Getting Tablet Proximity Information
+    unsafe fn capabilityMask(self) -> NSUInteger;
+    unsafe fn deviceID(self) -> NSUInteger;
+    unsafe fn pointingDeviceID(self) -> NSUInteger;
+    unsafe fn pointingDeviceSerialNumber(self) -> NSUInteger;
+    unsafe fn pointingDeviceType(self) -> NSPointingDeviceType;
+    unsafe fn systemTabletID(self) -> NSUInteger;
+    unsafe fn tabletID(self) -> NSUInteger;
+    unsafe fn uniqueID(self) -> libc::c_ulonglong;
+    unsafe fn vendorID(self) -> NSUInteger;
+    unsafe fn vendorPointingDeviceType(self) -> NSUInteger;
+
+    // Getting Tablet Pointing Information
+    unsafe fn absoluteX(self) -> NSInteger;
+    unsafe fn absoluteY(self) -> NSInteger;
+    unsafe fn absoluteZ(self) -> NSInteger;
+    unsafe fn buttonMask(self) -> NSEventButtonMask;
+    unsafe fn rotation(self) -> libc::c_float;
+    unsafe fn tangentialPressure(self) -> libc::c_float;
+    unsafe fn tilt(self) -> NSPoint;
+    unsafe fn vendorDefined(self) -> id;
+
+    // Requesting and Stopping Periodic Events
+    unsafe fn startPeriodicEventsAfterDelay_withPeriod_(_: Self, delaySeconds: NSTimeInterval, periodSeconds: NSTimeInterval);
+    unsafe fn stopPeriodicEvents(_: Self);
+
+    // Getting Touch and Gesture Information
+    unsafe fn magnification(self) -> CGFloat;
+    unsafe fn touchesMatchingPhase_inView_(self, phase: NSTouchPhase, view: id /* (NSView *) */) -> id /* (NSSet *) */;
+    unsafe fn isSwipeTrackingFromScrollEventsEnabled(_: Self) -> BOOL;
+
+    // Monitoring Application Events
+    // TODO: addGlobalMonitorForEventsMatchingMask_handler_ (unsure how to bind to blocks)
+    // TODO: addLocalMonitorForEventsMatchingMask_handler_ (unsure how to bind to blocks)
+    unsafe fn removeMonitor_(_: Self, eventMonitor: id);
+    */
+    // Scroll Wheel and Flick Events
+    unsafe fn hasPreciseScrollingDeltas(self) -> BOOL;
+    unsafe fn scrollingDeltaX(self) -> CGFloat;
+    unsafe fn scrollingDeltaY(self) -> CGFloat;
+
+    /*
+    unsafe fn momentumPhase(self) -> NSEventPhase;
+     */
+    unsafe fn phase(self) -> NSEventPhase;
+    /*
+    // TODO: trackSwipeEventWithOptions_dampenAmountThresholdMin_max_usingHandler_ (unsure how to bind to blocks)
+
+    // Converting a Mouse Event’s Position into a Sprite Kit Node’s Coordinate Space
+    unsafe fn locationInNode_(self, node: id /* (SKNode *) */) -> CGPoint;
+    */
+}
+
+impl NSEvent for id {
+    /*
+    // Creating Events
+
+    unsafe fn keyEventWithType_location_modifierFlags_timestamp_windowNumber_context_characters_charactersIgnoringModifiers_isARepeat_keyCode_(
+        _: Self,
+        eventType: NSEventType,
+        location: NSPoint,
+        modifierFlags: NSEventModifierFlags,
+        timestamp: NSTimeInterval,
+        windowNumber: NSInteger,
+        context: id /* (NSGraphicsContext *) */,
+        characters: id /* (NSString *) */,
+        unmodCharacters: id /* (NSString *) */,
+        repeatKey: BOOL,
+        code: libc::c_ushort) -> id /* (NSEvent *) */
+    {
+        msg_send![class!(NSEvent), keyEventWithType:eventType
+                                            location:location
+                                       modifierFlags:modifierFlags
+                                           timestamp:timestamp
+                                        windowNumber:windowNumber
+                                             context:context
+                                          characters:characters
+                         charactersIgnoringModifiers:unmodCharacters
+                                           isARepeat:repeatKey
+                                             keyCode:code]
+    }
+
+    unsafe fn mouseEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_clickCount_pressure_(
+        _: Self,
+        eventType: NSEventType,
+        location: NSPoint,
+        modifierFlags: NSEventModifierFlags,
+        timestamp: NSTimeInterval,
+        windowNumber: NSInteger,
+        context: id /* (NSGraphicsContext *) */,
+        eventNumber: NSInteger,
+        clickCount: NSInteger,
+        pressure: libc::c_float) -> id /* (NSEvent *) */
+    {
+        msg_send![class!(NSEvent), mouseEventWithType:eventType
+                                              location:location
+                                         modifierFlags:modifierFlags
+                                             timestamp:timestamp
+                                          windowNumber:windowNumber
+                                               context:context
+                                           eventNumber:eventNumber
+                                            clickCount:clickCount
+                                              pressure:pressure]
+    }
+
+    unsafe fn enterExitEventWithType_location_modifierFlags_timestamp_windowNumber_context_eventNumber_trackingNumber_userData_(
+        _: Self,
+        eventType: NSEventType,
+        location: NSPoint,
+        modifierFlags: NSEventModifierFlags,
+        timestamp: NSTimeInterval,
+        windowNumber: NSInteger,
+        context: id /* (NSGraphicsContext *) */,
+        eventNumber: NSInteger,
+        trackingNumber: NSInteger,
+        userData: *mut c_void) -> id /* (NSEvent *) */
+    {
+        msg_send![class!(NSEvent), enterExitEventWithType:eventType
+                                                  location:location
+                                             modifierFlags:modifierFlags
+                                                 timestamp:timestamp
+                                              windowNumber:windowNumber
+                                                   context:context
+                                               eventNumber:eventNumber
+                                            trackingNumber:trackingNumber
+                                                  userData:userData]
+    }
+
+    unsafe fn otherEventWithType_location_modifierFlags_timestamp_windowNumber_context_subtype_data1_data2_(
+        _: Self,
+        eventType: NSEventType,
+        location: NSPoint,
+        modifierFlags: NSEventModifierFlags,
+        timestamp: NSTimeInterval,
+        windowNumber: NSInteger,
+        context: id /* (NSGraphicsContext *) */,
+        subtype: NSEventSubtype,
+        data1: NSInteger,
+        data2: NSInteger) -> id /* (NSEvent *) */
+    {
+        msg_send![class!(NSEvent), otherEventWithType:eventType
+                                              location:location
+                                         modifierFlags:modifierFlags
+                                             timestamp:timestamp
+                                          windowNumber:windowNumber
+                                               context:context
+                                               subtype:subtype
+                                                 data1:data1
+                                                 data2:data2]
+    }
+
+    unsafe fn eventWithEventRef_(_: Self, eventRef: *const c_void) -> id {
+        msg_send![class!(NSEvent), eventWithEventRef:eventRef]
+    }
+
+    unsafe fn eventWithCGEvent_(_: Self, cgEvent: *mut c_void /* CGEventRef */) -> id {
+        msg_send![class!(NSEvent), eventWithCGEvent:cgEvent]
+    }
+
+    // Getting General Event Information
+
+    unsafe fn context(self) -> id /* (NSGraphicsContext *) */ {
+        msg_send![self, context]
+    }
+    */
+    unsafe fn locationInWindow(self) -> NSPoint {
+        msg_send![self, locationInWindow]
+    }
+
+    unsafe fn modifierFlags(self) -> NSEventModifierFlags {
+        msg_send![self, modifierFlags]
+    }
+
+    /*
+    unsafe fn timestamp(self) -> NSTimeInterval {
+        msg_send![self, timestamp]
+    }
+    // NOTE: renamed from `- type` due to Rust keyword collision
+    */
+
+    unsafe fn eventType(self) -> NSEventType {
+        msg_send![self, type]
+    }
+
+    /*
+    unsafe fn window(self) -> id /* (NSWindow *) */ {
+        msg_send![self, window]
+    }
+
+    unsafe fn windowNumber(self) -> NSInteger {
+        msg_send![self, windowNumber]
+    }
+
+    unsafe fn eventRef(self) -> *const c_void {
+        msg_send![self, eventRef]
+    }
+
+    unsafe fn CGEvent(self) -> *mut c_void /* CGEventRef */ {
+        msg_send![self, CGEvent]
+    }
+
+    // Getting Key Event Information
+
+    // NOTE: renamed from `+ modifierFlags` due to conflict with `- modifierFlags`
+
+    unsafe fn currentModifierFlags(_: Self) -> NSEventModifierFlags {
+        msg_send![class!(NSEvent), currentModifierFlags]
+    }
+
+    unsafe fn keyRepeatDelay(_: Self) -> NSTimeInterval {
+        msg_send![class!(NSEvent), keyRepeatDelay]
+    }
+
+    unsafe fn keyRepeatInterval(_: Self) -> NSTimeInterval {
+        msg_send![class!(NSEvent), keyRepeatInterval]
+    }
+
+    unsafe fn characters(self) -> id /* (NSString *) */ {
+        msg_send![self, characters]
+    }
+
+    unsafe fn charactersIgnoringModifiers(self) -> id /* (NSString *) */ {
+        msg_send![self, charactersIgnoringModifiers]
+    }
+
+    unsafe fn keyCode(self) -> libc::c_ushort {
+        msg_send![self, keyCode]
+    }
+
+    unsafe fn isARepeat(self) -> BOOL {
+        msg_send![self, isARepeat]
+    }
+
+    // Getting Mouse Event Information
+
+    unsafe fn pressedMouseButtons(_: Self) -> NSUInteger {
+        msg_send![class!(NSEvent), pressedMouseButtons]
+    }
+
+    unsafe fn doubleClickInterval(_: Self) -> NSTimeInterval {
+        msg_send![class!(NSEvent), doubleClickInterval]
+    }
+
+    unsafe fn mouseLocation(_: Self) -> NSPoint {
+        msg_send![class!(NSEvent), mouseLocation]
+    }
+    */
+
+    unsafe fn buttonNumber(self) -> NSInteger {
+        msg_send![self, buttonNumber]
+    }
+
+    /*
+    unsafe fn clickCount(self) -> NSInteger {
+        msg_send![self, clickCount]
+    }
+    */
+    unsafe fn pressure(self) -> libc::c_float {
+        msg_send![self, pressure]
+    }
+
+    unsafe fn stage(self) -> NSInteger {
+        msg_send![self, stage]
+    }
+    /*
+    unsafe fn setMouseCoalescingEnabled_(_: Self, flag: BOOL) {
+        msg_send![class!(NSEvent), setMouseCoalescingEnabled:flag]
+    }
+
+    unsafe fn isMouseCoalescingEnabled(_: Self) -> BOOL {
+        msg_send![class!(NSEvent), isMouseCoalescingEnabled]
+    }
+
+    // Getting Mouse-Tracking Event Information
+
+    unsafe fn eventNumber(self) -> NSInteger {
+        msg_send![self, eventNumber]
+    }
+
+    unsafe fn trackingNumber(self) -> NSInteger {
+        msg_send![self, trackingNumber]
+    }
+
+    unsafe fn trackingArea(self) -> id /* (NSTrackingArea *) */ {
+        msg_send![self, trackingArea]
+    }
+
+    unsafe fn userData(self) -> *const c_void {
+        msg_send![self, userData]
+    }
+
+    // Getting Custom Event Information
+
+    unsafe fn data1(self) -> NSInteger {
+        msg_send![self, data1]
+    }
+
+    unsafe fn data2(self) -> NSInteger {
+        msg_send![self, data2]
+    }
+
+    unsafe fn subtype(self) -> NSEventSubtype {
+        msg_send![self, subtype]
+    }
+
+    // Getting Scroll Wheel Event Information
+    */
+
+    unsafe fn deltaX(self) -> CGFloat {
+        msg_send![self, deltaX]
+    }
+
+    unsafe fn deltaY(self) -> CGFloat {
+        msg_send![self, deltaY]
+    }
+
+    unsafe fn deltaZ(self) -> CGFloat {
+        msg_send![self, deltaZ]
+    }
+
+    /*
+
+    // Getting Tablet Proximity Information
+
+    unsafe fn capabilityMask(self) -> NSUInteger {
+        msg_send![self, capabilityMask]
+    }
+
+    unsafe fn deviceID(self) -> NSUInteger {
+        msg_send![self, deviceID]
+    }
+
+    unsafe fn pointingDeviceID(self) -> NSUInteger {
+        msg_send![self, pointingDeviceID]
+    }
+
+    unsafe fn pointingDeviceSerialNumber(self) -> NSUInteger {
+        msg_send![self, pointingDeviceSerialNumber]
+    }
+
+    unsafe fn pointingDeviceType(self) -> NSPointingDeviceType {
+        msg_send![self, pointingDeviceType]
+    }
+
+    unsafe fn systemTabletID(self) -> NSUInteger {
+        msg_send![self, systemTabletID]
+    }
+
+    unsafe fn tabletID(self) -> NSUInteger {
+        msg_send![self, tabletID]
+    }
+
+    unsafe fn uniqueID(self) -> libc::c_ulonglong {
+        msg_send![self, uniqueID]
+    }
+
+    unsafe fn vendorID(self) -> NSUInteger {
+        msg_send![self, vendorID]
+    }
+
+    unsafe fn vendorPointingDeviceType(self) -> NSUInteger {
+        msg_send![self, vendorPointingDeviceType]
+    }
+
+    // Getting Tablet Pointing Information
+
+    unsafe fn absoluteX(self) -> NSInteger {
+        msg_send![self, absoluteX]
+    }
+
+    unsafe fn absoluteY(self) -> NSInteger {
+        msg_send![self, absoluteY]
+    }
+
+    unsafe fn absoluteZ(self) -> NSInteger {
+        msg_send![self, absoluteZ]
+    }
+
+    unsafe fn buttonMask(self) -> NSEventButtonMask {
+        msg_send![self, buttonMask]
+    }
+
+    unsafe fn rotation(self) -> libc::c_float {
+        msg_send![self, rotation]
+    }
+
+    unsafe fn tangentialPressure(self) -> libc::c_float {
+        msg_send![self, tangentialPressure]
+    }
+
+    unsafe fn tilt(self) -> NSPoint {
+        msg_send![self, tilt]
+    }
+
+    unsafe fn vendorDefined(self) -> id {
+        msg_send![self, vendorDefined]
+    }
+
+    // Requesting and Stopping Periodic Events
+
+    unsafe fn startPeriodicEventsAfterDelay_withPeriod_(_: Self, delaySeconds: NSTimeInterval, periodSeconds: NSTimeInterval) {
+        msg_send![class!(NSEvent), startPeriodicEventsAfterDelay:delaySeconds withPeriod:periodSeconds]
+    }
+
+    unsafe fn stopPeriodicEvents(_: Self) {
+        msg_send![class!(NSEvent), stopPeriodicEvents]
+    }
+
+    // Getting Touch and Gesture Information
+
+    unsafe fn magnification(self) -> CGFloat {
+        msg_send![self, magnification]
+    }
+
+    unsafe fn touchesMatchingPhase_inView_(self, phase: NSTouchPhase, view: id /* (NSView *) */) -> id /* (NSSet *) */ {
+        msg_send![self, touchesMatchingPhase:phase inView:view]
+    }
+
+    unsafe fn isSwipeTrackingFromScrollEventsEnabled(_: Self) -> BOOL {
+        msg_send![class!(NSEvent), isSwipeTrackingFromScrollEventsEnabled]
+    }
+
+    // Monitoring Application Events
+
+    // TODO: addGlobalMonitorForEventsMatchingMask_handler_ (unsure how to bind to blocks)
+    // TODO: addLocalMonitorForEventsMatchingMask_handler_ (unsure how to bind to blocks)
+
+    unsafe fn removeMonitor_(_: Self, eventMonitor: id) {
+        msg_send![class!(NSEvent), removeMonitor:eventMonitor]
+    }
+
+    // Scroll Wheel and Flick Events
+    */
+
+    unsafe fn hasPreciseScrollingDeltas(self) -> BOOL {
+        msg_send![self, hasPreciseScrollingDeltas]
+    }
+    unsafe fn scrollingDeltaX(self) -> CGFloat {
+        msg_send![self, scrollingDeltaX]
+    }
+
+    unsafe fn scrollingDeltaY(self) -> CGFloat {
+        msg_send![self, scrollingDeltaY]
+    }
+
+    /*
+    unsafe fn momentumPhase(self) -> NSEventPhase {
+        msg_send![self, momentumPhase]
+    }
+    */
+    unsafe fn phase(self) -> NSEventPhase {
+        msg_send![self, phase]
+    }
+    /*
+    // TODO: trackSwipeEventWithOptions_dampenAmountThresholdMin_max_usingHandler_ (unsure how to bind to blocks)
+
+    // Converting a Mouse Event’s Position into a Sprite Kit Node’s Coordinate Space
+    unsafe fn locationInNode_(self, node: id /* (SKNode *) */) -> CGPoint {
+        msg_send![self, locationInNode:node]
+    }
+    */
+}
+
+bitflags! {
+    pub struct NSEventModifierFlags: NSUInteger {
+        const NSAlphaShiftKeyMask                     = 1 << 16;
+        const NSShiftKeyMask                          = 1 << 17;
+        const NSControlKeyMask                        = 1 << 18;
+        const NSAlternateKeyMask                      = 1 << 19;
+        const NSCommandKeyMask                        = 1 << 20;
+        const NSNumericPadKeyMask                     = 1 << 21;
+        const NSHelpKeyMask                           = 1 << 22;
+        const NSFunctionKeyMask                       = 1 << 23;
+        const NSDeviceIndependentModifierFlagsMask    = 0xffff0000;
+    }
+}
+
+#[repr(i16)]
+pub enum NSEventSubtype {
+    // TODO: Not sure what these values are
+    // NSMouseEventSubtype           = NX_SUBTYPE_DEFAULT,
+    // NSTabletPointEventSubtype     = NX_SUBTYPE_TABLET_POINT,
+    // NSTabletProximityEventSubtype = NX_SUBTYPE_TABLET_PROXIMITY
+    // NSTouchEventSubtype           = NX_SUBTYPE_MOUSE_TOUCH,
+    NSWindowExposedEventType = 0,
+    // NSApplicationActivatedEventType = 1,
+    // NSApplicationDeactivatedEventType = 2,
+    // NSWindowMovedEventType = 4,
+    // NSScreenChangedEventType = 8,
+    // NSAWTEventType = 16,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u64)] // NSUInteger
+#[allow(dead_code)]
+pub enum NSEventType {
+    NSLeftMouseDown = 1,
+    NSLeftMouseUp = 2,
+    NSRightMouseDown = 3,
+    NSRightMouseUp = 4,
+    NSMouseMoved = 5,
+    NSLeftMouseDragged = 6,
+    NSRightMouseDragged = 7,
+    NSMouseEntered = 8,
+    NSMouseExited = 9,
+    NSKeyDown = 10,
+    NSKeyUp = 11,
+    NSFlagsChanged = 12,
+    NSAppKitDefined = 13,
+    NSSystemDefined = 14,
+    NSApplicationDefined = 15,
+    NSPeriodic = 16,
+    NSCursorUpdate = 17,
+    NSScrollWheel = 22,
+    NSTabletPoint = 23,
+    NSTabletProximity = 24,
+    NSOtherMouseDown = 25,
+    NSOtherMouseUp = 26,
+    NSOtherMouseDragged = 27,
+    NSEventTypeGesture = 29,
+    NSEventTypeMagnify = 30,
+    NSEventTypeSwipe = 31,
+    NSEventTypeRotate = 18,
+    NSEventTypeBeginGesture = 19,
+    NSEventTypeEndGesture = 20,
+    NSEventTypePressure = 34,
+}
+
+pub type NSTimeInterval = libc::c_double;
+
+/// A convenience method to convert the name of a selector to the selector object.
+#[inline]
+pub fn selector(name: &str) -> SEL {
+    runtime::Sel::register(name)
+}
+pub type SEL = runtime::Sel;
+
+pub trait NSMenu: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSMenu), alloc]
+    }
+
+    unsafe fn new(_: Self) -> id {
+        msg_send![class!(NSMenu), new]
+    }
+
+    unsafe fn initWithTitle_(self, title: id /* NSString */) -> id;
+    unsafe fn setAutoenablesItems(self, state: BOOL);
+
+    unsafe fn addItem_(self, menu_item: id);
+    unsafe fn addItemWithTitle_action_keyEquivalent(self, title: id, action: SEL, key: id) -> id;
+    unsafe fn itemAtIndex_(self, index: NSInteger) -> id;
+}
+
+impl NSMenu for id {
+    unsafe fn initWithTitle_(self, title: id /* NSString */) -> id {
+        msg_send![self, initWithTitle: title]
+    }
+
+    unsafe fn setAutoenablesItems(self, state: BOOL) {
+        msg_send![self, setAutoenablesItems: state]
+    }
+
+    unsafe fn addItem_(self, menu_item: id) {
+        msg_send![self, addItem: menu_item]
+    }
+
+    unsafe fn addItemWithTitle_action_keyEquivalent(self, title: id, action: SEL, key: id) -> id {
+        msg_send![self, addItemWithTitle:title action:action keyEquivalent:key]
+    }
+
+    unsafe fn itemAtIndex_(self, index: NSInteger) -> id {
+        msg_send![self, itemAtIndex: index]
+    }
+}
+
+pub trait NSMenuItem: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSMenuItem), alloc]
+    }
+
+    unsafe fn new(_: Self) -> id {
+        msg_send![class!(NSMenuItem), new]
+    }
+
+    unsafe fn separatorItem(_: Self) -> id {
+        msg_send![class!(NSMenuItem), separatorItem]
+    }
+
+    unsafe fn initWithTitle_action_keyEquivalent_(self, title: id, action: SEL, key: id) -> id;
+    unsafe fn setKeyEquivalentModifierMask_(self, mask: NSEventModifierFlags);
+    unsafe fn setSubmenu_(self, submenu: id);
+    unsafe fn setTarget_(self, target: id);
+}
+
+impl NSMenuItem for id {
+    unsafe fn initWithTitle_action_keyEquivalent_(self, title: id, action: SEL, key: id) -> id {
+        msg_send![self, initWithTitle:title action:action keyEquivalent:key]
+    }
+
+    unsafe fn setKeyEquivalentModifierMask_(self, mask: NSEventModifierFlags) {
+        msg_send![self, setKeyEquivalentModifierMask: mask]
+    }
+
+    unsafe fn setSubmenu_(self, submenu: id) {
+        msg_send![self, setSubmenu: submenu]
+    }
+
+    unsafe fn setTarget_(self, target: id) {
+        msg_send![self, setTarget: target]
+    }
+}
+
+pub trait NSProcessInfo: Sized {
+    unsafe fn processInfo(_: Self) -> id {
+        msg_send![class!(NSProcessInfo), processInfo]
+    }
+
+    unsafe fn processName(self) -> id;
+    // unsafe fn operatingSystemVersion(self) -> NSOperatingSystemVersion;
+    // unsafe fn isOperatingSystemAtLeastVersion(self, version: NSOperatingSystemVersion) -> bool;
+}
+
+impl NSProcessInfo for id {
+    unsafe fn processName(self) -> id {
+        msg_send![self, processName]
+    }
+
+    // unsafe fn operatingSystemVersion(self) -> NSOperatingSystemVersion {
+    //     msg_send![self, operatingSystemVersion]
+    // }
+    //
+    // unsafe fn isOperatingSystemAtLeastVersion(self, version: NSOperatingSystemVersion) -> bool {
+    //     msg_send![self, isOperatingSystemAtLeastVersion: version]
+    // }
+}
+
+pub trait NSScreen: Sized {
+    // Getting NSScreen Objects
+    unsafe fn mainScreen(_: Self) -> id /* (NSScreen *) */;
+    //  unsafe fn deepestScreen(_: Self) -> id /* (NSScreen *) */;
+    unsafe fn screens(_: Self) -> id /* (NSArray *) */;
+    //
+    //  // Getting Screen Information
+    //  unsafe fn depth(self) -> NSWindowDepth;
+    unsafe fn frame(self) -> NSRect;
+    //  unsafe fn supportedWindowDepths(self) -> *const NSWindowDepth;
+    unsafe fn deviceDescription(self) -> id /* (NSDictionary *) */;
+    unsafe fn visibleFrame(self) -> NSRect;
+    //  unsafe fn colorSpace(self) -> id /* (NSColorSpace *) */;
+    //  unsafe fn screensHaveSeparateSpaces(_: Self) -> BOOL;
+    //
+    //  // Screen Backing Coordinate Conversion
+    //  unsafe fn backingAlignedRect_options_(
+    //      self,
+    //      aRect: NSRect,
+    //      options: NSAlignmentOptions,
+    //  ) -> NSRect;
+    unsafe fn backingScaleFactor(self) -> CGFloat;
+    //  unsafe fn convertRectFromBacking_(self, aRect: NSRect) -> NSRect;
+    //  unsafe fn convertRectToBacking_(self, aRect: NSRect) -> NSRect;
+}
+
+impl NSScreen for id {
+    // Getting NSScreen Objects
+
+    unsafe fn mainScreen(_: Self) -> id /* (NSScreen *) */ {
+        msg_send![class!(NSScreen), mainScreen]
+    }
+
+    /*
+            unsafe fn deepestScreen(_: Self) -> id /* (NSScreen *) */ {
+                msg_send![class!(NSScreen), deepestScreen]
+            }
+
+    */
+    unsafe fn screens(_: Self) -> id /* (NSArray *) */ {
+        msg_send![class!(NSScreen), screens]
+    }
+
+    /*
+              // Getting Screen Information
+
+              unsafe fn depth(self) -> NSWindowDepth {
+                  msg_send![self, depth]
+              }
+    */
+    unsafe fn frame(self) -> NSRect {
+        msg_send![self, frame]
+    }
+    /*
+          unsafe fn supportedWindowDepths(self) -> *const NSWindowDepth {
+              msg_send![self, supportedWindowDepths]
+          }
+    */
+    unsafe fn deviceDescription(self) -> id /* (NSDictionary *) */ {
+        msg_send![self, deviceDescription]
+    }
+
+    unsafe fn visibleFrame(self) -> NSRect {
+        msg_send![self, visibleFrame]
+    }
+
+    /*
+        unsafe fn colorSpace(self) -> id /* (NSColorSpace *) */ {
+            msg_send![self, colorSpace]
+        }
+
+        unsafe fn screensHaveSeparateSpaces(_: Self) -> BOOL {
+            msg_send![class!(NSScreen), screensHaveSeparateSpaces]
+        }
+
+        // Screen Backing Coordinate Conversion
+
+        unsafe fn backingAlignedRect_options_(
+            self,
+            aRect: NSRect,
+            options: NSAlignmentOptions,
+        ) -> NSRect {
+            msg_send![self, backingAlignedRect:aRect options:options]
+        }
+    */
+    unsafe fn backingScaleFactor(self) -> CGFloat {
+        msg_send![self, backingScaleFactor]
+    }
+
+    /*
+
+    unsafe fn convertRectFromBacking_(self, aRect: NSRect) -> NSRect {
+        msg_send![self, convertRectFromBacking: aRect]
+    }
+
+    unsafe fn convertRectToBacking_(self, aRect: NSRect) -> NSRect {
+        msg_send![self, convertRectToBacking: aRect]
+    }
+    */
+}
+
+pub trait NSView: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSView), alloc]
+    }
+
+    unsafe fn init(self) -> id;
+    unsafe fn initWithFrame_(self, frameRect: NSRect) -> id;
+    unsafe fn bounds(self) -> NSRect;
+    unsafe fn frame(self) -> NSRect;
+    unsafe fn setFrameSize(self, frameSize: NSSize);
+    unsafe fn setFrameOrigin(self, frameOrigin: NSPoint);
+    unsafe fn display_(self);
+    unsafe fn setWantsBestResolutionOpenGLSurface_(self, flag: BOOL);
+    unsafe fn convertPoint_fromView_(self, point: NSPoint, view: id) -> NSPoint;
+    unsafe fn addSubview_(self, view: id);
+    unsafe fn superview(self) -> id;
+    unsafe fn removeFromSuperview(self);
+    //  unsafe fn setAutoresizingMask_(self, autoresizingMask: NSAutoresizingMaskOptions);
+
+    unsafe fn wantsLayer(self) -> BOOL;
+    unsafe fn setWantsLayer(self, wantsLayer: BOOL);
+    unsafe fn layer(self) -> id;
+    unsafe fn setLayer(self, layer: id);
+
+    unsafe fn widthAnchor(self) -> id;
+    unsafe fn heightAnchor(self) -> id;
+    unsafe fn convertRectToBacking(self, rect: NSRect) -> NSRect;
+
+    // unsafe fn layerContentsPlacement(self) -> NSViewLayerContentsPlacement;
+    // unsafe fn setLayerContentsPlacement(self, placement: NSViewLayerContentsPlacement);
+}
+
+impl NSView for id {
+    unsafe fn init(self) -> id {
+        msg_send![self, init]
+    }
+
+    unsafe fn initWithFrame_(self, frameRect: NSRect) -> id {
+        msg_send![self, initWithFrame: frameRect]
+    }
+
+    unsafe fn bounds(self) -> NSRect {
+        msg_send![self, bounds]
+    }
+
+    unsafe fn frame(self) -> NSRect {
+        msg_send![self, frame]
+    }
+
+    unsafe fn setFrameSize(self, frameSize: NSSize) {
+        msg_send![self, setFrameSize: frameSize]
+    }
+
+    unsafe fn setFrameOrigin(self, frameOrigin: NSPoint) {
+        msg_send![self, setFrameOrigin: frameOrigin]
+    }
+
+    unsafe fn display_(self) {
+        msg_send![self, display]
+    }
+
+    unsafe fn setWantsBestResolutionOpenGLSurface_(self, flag: BOOL) {
+        msg_send![self, setWantsBestResolutionOpenGLSurface: flag]
+    }
+
+    unsafe fn convertPoint_fromView_(self, point: NSPoint, view: id) -> NSPoint {
+        msg_send![self, convertPoint:point fromView:view]
+    }
+
+    unsafe fn addSubview_(self, view: id) {
+        msg_send![self, addSubview: view]
+    }
+
+    unsafe fn superview(self) -> id {
+        msg_send![self, superview]
+    }
+
+    unsafe fn removeFromSuperview(self) {
+        msg_send![self, removeFromSuperview]
+    }
+
+    // unsafe fn setAutoresizingMask_(self, autoresizingMask: NSAutoresizingMaskOptions) {
+    //     msg_send![self, setAutoresizingMask: autoresizingMask]
+    // }
+
+    unsafe fn wantsLayer(self) -> BOOL {
+        msg_send![self, wantsLayer]
+    }
+
+    unsafe fn setWantsLayer(self, wantsLayer: BOOL) {
+        msg_send![self, setWantsLayer: wantsLayer]
+    }
+
+    unsafe fn layer(self) -> id {
+        msg_send![self, layer]
+    }
+
+    unsafe fn setLayer(self, layer: id) {
+        msg_send![self, setLayer: layer]
+    }
+
+    unsafe fn widthAnchor(self) -> id {
+        msg_send![self, widthAnchor]
+    }
+
+    unsafe fn heightAnchor(self) -> id {
+        msg_send![self, heightAnchor]
+    }
+
+    unsafe fn convertRectToBacking(self, rect: NSRect) -> NSRect {
+        msg_send![self, convertRectToBacking: rect]
+    }
+
+    // unsafe fn layerContentsPlacement(self) -> NSViewLayerContentsPlacement {
+    //     msg_send![self, layerContentsPlacement]
+    // }
+    //
+    // unsafe fn setLayerContentsPlacement(self, placement: NSViewLayerContentsPlacement) {
+    //     msg_send![self, setLayerContentsPlacement: placement]
+    // }
+}
+
+pub trait NSWindow: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSWindow), alloc]
+    }
+
+    // Creating Windows
+    unsafe fn initWithContentRect_styleMask_backing_defer_(
+        self,
+        rect: NSRect,
+        style: NSWindowStyleMask,
+        backing: NSBackingStoreType,
+        defer: BOOL,
+    ) -> id;
+    unsafe fn initWithContentRect_styleMask_backing_defer_screen_(
+        self,
+        rect: NSRect,
+        style: NSWindowStyleMask,
+        backing: NSBackingStoreType,
+        defer: BOOL,
+        screen: id,
+    ) -> id;
+
+    // Configuring Windows
+    unsafe fn styleMask(self) -> NSWindowStyleMask;
+    unsafe fn setStyleMask_(self, styleMask: NSWindowStyleMask);
+    unsafe fn toggleFullScreen_(self, sender: id);
+    unsafe fn worksWhenModal(self) -> BOOL;
+    unsafe fn alphaValue(self) -> CGFloat;
+    unsafe fn setAlphaValue_(self, windowAlpha: CGFloat);
+    unsafe fn backgroundColor(self) -> id;
+    unsafe fn setBackgroundColor_(self, color: id);
+    unsafe fn colorSpace(self) -> id;
+    unsafe fn setColorSpace_(self, colorSpace: id);
+    unsafe fn contentView(self) -> id;
+    unsafe fn setContentView_(self, view: id);
+    unsafe fn canHide(self) -> BOOL;
+    unsafe fn setCanHide_(self, canHide: BOOL);
+    unsafe fn hidesOnDeactivate(self) -> BOOL;
+    unsafe fn setHidesOnDeactivate_(self, hideOnDeactivate: BOOL);
+    // unsafe fn collectionBehavior(self) -> NSWindowCollectionBehavior;
+    // unsafe fn setCollectionBehavior_(self, collectionBehavior: NSWindowCollectionBehavior);
+    unsafe fn setOpaque_(self, opaque: BOOL);
+    unsafe fn hasShadow(self) -> BOOL;
+    unsafe fn setHasShadow_(self, hasShadow: BOOL);
+    unsafe fn invalidateShadow(self);
+    //  unsafe fn autorecalculatesContentBorderThicknessForEdge_(self, edge: NSRectEdge) -> BOOL;
+    //  unsafe fn setAutorecalculatesContentBorderThickness_forEdge_(
+    //      self,
+    //      autorecalculateContentBorderThickness: BOOL,
+    //      edge: NSRectEdge,
+    //  ) -> BOOL;
+    //  unsafe fn contentBorderThicknessForEdge_(self, edge: NSRectEdge) -> CGFloat;
+    // unsafe fn setContentBorderThickness_forEdge_(self, borderThickness: CGFloat, edge: NSRectEdge);
+    unsafe fn delegate(self) -> id;
+    unsafe fn setDelegate_(self, delegate: id);
+    unsafe fn preventsApplicationTerminationWhenModal(self) -> BOOL;
+    unsafe fn setPreventsApplicationTerminationWhenModal_(self, flag: BOOL);
+
+    // TODO: Accessing Window Information
+
+    // Getting Layout Information
+    unsafe fn contentRectForFrameRect_styleMask_(
+        self,
+        windowFrame: NSRect,
+        windowStyle: NSWindowStyleMask,
+    ) -> NSRect;
+    unsafe fn frameRectForContentRect_styleMask_(
+        self,
+        windowContentRect: NSRect,
+        windowStyle: NSWindowStyleMask,
+    ) -> NSRect;
+    unsafe fn minFrameWidthWithTitle_styleMask_(
+        self,
+        windowTitle: id,
+        windowStyle: NSWindowStyleMask,
+    ) -> CGFloat;
+    unsafe fn contentRectForFrameRect_(self, windowFrame: NSRect) -> NSRect;
+    unsafe fn frameRectForContentRect_(self, windowContent: NSRect) -> NSRect;
+
+    // Managing Windows
+    unsafe fn drawers(self) -> id;
+    unsafe fn windowController(self) -> id;
+    unsafe fn setWindowController_(self, windowController: id);
+
+    // TODO: Managing Sheets
+
+    // Sizing Windows
+    unsafe fn frame(self) -> NSRect;
+    unsafe fn setFrameOrigin_(self, point: NSPoint);
+    unsafe fn setFrameTopLeftPoint_(self, point: NSPoint);
+    unsafe fn constrainFrameRect_toScreen_(self, frameRect: NSRect, screen: id);
+    unsafe fn cascadeTopLeftFromPoint_(self, topLeft: NSPoint) -> NSPoint;
+    unsafe fn setFrame_display_(self, windowFrame: NSRect, display: BOOL);
+    unsafe fn setFrame_displayViews_(self, windowFrame: NSRect, display: BOOL);
+    unsafe fn aspectRatio(self) -> NSSize;
+    unsafe fn setAspectRatio_(self, aspectRatio: NSSize);
+    unsafe fn minSize(self) -> NSSize;
+    unsafe fn setMinSize_(self, minSize: NSSize);
+    unsafe fn maxSize(self) -> NSSize;
+    unsafe fn setMaxSize_(self, maxSize: NSSize);
+    unsafe fn performZoom_(self, sender: id);
+    unsafe fn zoom_(self, sender: id);
+    unsafe fn resizeFlags(self) -> NSInteger;
+    unsafe fn showsResizeIndicator(self) -> BOOL;
+    unsafe fn setShowsResizeIndicator_(self, showsResizeIndicator: BOOL);
+    unsafe fn resizeIncrements(self) -> NSSize;
+    unsafe fn setResizeIncrements_(self, resizeIncrements: NSSize);
+    unsafe fn preservesContentDuringLiveResize(self) -> BOOL;
+    unsafe fn setPreservesContentDuringLiveResize_(self, preservesContentDuringLiveResize: BOOL);
+    unsafe fn inLiveResize(self) -> BOOL;
+
+    // Sizing Content
+    unsafe fn contentAspectRatio(self) -> NSSize;
+    unsafe fn setContentAspectRatio_(self, contentAspectRatio: NSSize);
+    unsafe fn contentMinSize(self) -> NSSize;
+    unsafe fn setContentMinSize_(self, contentMinSize: NSSize);
+    unsafe fn contentSize(self) -> NSSize;
+    unsafe fn setContentSize_(self, contentSize: NSSize);
+    unsafe fn contentMaxSize(self) -> NSSize;
+    unsafe fn setContentMaxSize_(self, contentMaxSize: NSSize);
+    unsafe fn contentResizeIncrements(self) -> NSSize;
+    unsafe fn setContentResizeIncrements_(self, contentResizeIncrements: NSSize);
+
+    // Managing Window Visibility and Occlusion State
+    unsafe fn isVisible(self) -> BOOL; // NOTE: Deprecated in 10.9
+                                       // unsafe fn occlusionState(self) -> NSWindowOcclusionState;
+
+    // Managing Window Layers
+    unsafe fn orderOut_(self, sender: id);
+    unsafe fn orderBack_(self, sender: id);
+    unsafe fn orderFront_(self, sender: id);
+    unsafe fn orderFrontRegardless(self);
+    //  unsafe fn orderFrontWindow_relativeTo_(
+    //      self,
+    //      orderingMode: NSWindowOrderingMode,
+    //      otherWindowNumber: NSInteger,
+    //  );
+    unsafe fn level(self) -> NSInteger;
+    unsafe fn setLevel_(self, level: NSInteger);
+
+    // Managing Key Status
+    unsafe fn isKeyWindow(self) -> BOOL;
+    unsafe fn canBecomeKeyWindow(self) -> BOOL;
+    unsafe fn makeKeyWindow(self);
+    unsafe fn makeKeyAndOrderFront_(self, sender: id);
+    // skipped: becomeKeyWindow (should not be invoked directly, according to Apple's documentation)
+    // skipped: resignKeyWindow (should not be invoked directly, according to Apple's documentation)
+
+    // Managing Main Status
+    unsafe fn canBecomeMainWindow(self) -> BOOL;
+    unsafe fn makeMainWindow(self);
+    // skipped: becomeMainWindow (should not be invoked directly, according to Apple's documentation)
+    // skipped: resignMainWindow (should not be invoked directly, according to Apple's documentation)
+
+    // Managing Toolbars
+    unsafe fn toolbar(self) -> id /* NSToolbar */;
+    unsafe fn setToolbar_(self, toolbar: id /* NSToolbar */);
+    unsafe fn runToolbarCustomizationPalette(self, sender: id);
+
+    // TODO: Managing Attached Windows
+    // TODO: Managing Window Buffers
+    // TODO: Managing Default Buttons
+    // TODO: Managing Field Editors
+    // TODO: Managing the Window Menu
+    // TODO: Managing Cursor Rectangles
+
+    // Managing Title Bars
+    unsafe fn standardWindowButton_(self, windowButtonKind: NSWindowButton) -> id;
+
+    // Managing Window Tabs
+    unsafe fn allowsAutomaticWindowTabbing(_: Self) -> BOOL;
+    unsafe fn setAllowsAutomaticWindowTabbing_(_: Self, allowsAutomaticWindowTabbing: BOOL);
+    unsafe fn tabbingIdentifier(self) -> id;
+    // unsafe fn tabbingMode(self) -> NSWindowTabbingMode;
+    // unsafe fn setTabbingMode_(self, tabbingMode: NSWindowTabbingMode);
+    // unsafe fn addTabbedWindow_ordered_(self, window: id, ordering_mode: NSWindowOrderingMode);
+    unsafe fn toggleTabBar_(self, sender: id);
+
+    // TODO: Managing Tooltips
+    // TODO: Handling Events
+
+    // Managing Responders
+    unsafe fn initialFirstResponder(self) -> id;
+    unsafe fn firstResponder(self) -> id;
+    unsafe fn setInitialFirstResponder_(self, responder: id);
+    unsafe fn makeFirstResponder_(self, responder: id) -> BOOL;
+
+    // TODO: Managing the Key View Loop
+
+    // Handling Keyboard Events
+    unsafe fn keyDown_(self, event: id);
+
+    // Handling Mouse Events
+    unsafe fn acceptsMouseMovedEvents(self) -> BOOL;
+    unsafe fn ignoresMouseEvents(self) -> BOOL;
+    unsafe fn setIgnoresMouseEvents_(self, ignoreMouseEvents: BOOL);
+    unsafe fn mouseLocationOutsideOfEventStream(self) -> NSPoint;
+    unsafe fn setAcceptsMouseMovedEvents_(self, acceptMouseMovedEvents: BOOL);
+    unsafe fn windowNumberAtPoint_belowWindowWithWindowNumber_(
+        self,
+        point: NSPoint,
+        windowNumber: NSInteger,
+    ) -> NSInteger;
+
+    // TODO: Handling Window Restoration
+    // TODO: Bracketing Drawing Operations
+    // TODO: Drawing Windows
+    // TODO: Window Animation
+    // TODO: Updating Windows
+    // TODO: Dragging Items
+
+    // Converting Coordinates
+    unsafe fn backingScaleFactor(self) -> CGFloat;
+    //  unsafe fn backingAlignedRect_options_(
+    //      self,
+    //      rect: NSRect,
+    //      options: NSAlignmentOptions,
+    //  ) -> NSRect;
+    unsafe fn convertRectFromBacking_(self, rect: NSRect) -> NSRect;
+    unsafe fn convertRectToBacking_(self, rect: NSRect) -> NSRect;
+    unsafe fn convertRectToScreen_(self, rect: NSRect) -> NSRect;
+    unsafe fn convertRectFromScreen_(self, rect: NSRect) -> NSRect;
+
+    // Accessing Edited Status
+    unsafe fn setDocumentEdited_(self, documentEdited: BOOL);
+
+    // Managing Titles
+    unsafe fn title(self) -> id;
+    unsafe fn setTitle_(self, title: id);
+    unsafe fn setTitleWithRepresentedFilename_(self, filePath: id);
+    unsafe fn setTitleVisibility_(self, visibility: NSWindowTitleVisibility);
+    unsafe fn setTitlebarAppearsTransparent_(self, transparent: BOOL);
+    unsafe fn representedFilename(self) -> id;
+    unsafe fn setRepresentedFilename_(self, filePath: id);
+    unsafe fn representedURL(self) -> id;
+    unsafe fn setRepresentedURL_(self, representedURL: id);
+
+    // Accessing Screen Information
+    unsafe fn screen(self) -> id;
+    unsafe fn deepestScreen(self) -> id;
+    unsafe fn displaysWhenScreenProfileChanges(self) -> BOOL;
+    unsafe fn setDisplaysWhenScreenProfileChanges_(self, displaysWhenScreenProfileChanges: BOOL);
+
+    // Moving Windows
+    unsafe fn setMovableByWindowBackground_(self, movableByWindowBackground: BOOL);
+    unsafe fn setMovable_(self, movable: BOOL);
+    unsafe fn center(self);
+
+    // Closing Windows
+    unsafe fn performClose_(self, sender: id);
+    unsafe fn close(self);
+    unsafe fn setReleasedWhenClosed_(self, releasedWhenClosed: BOOL);
+
+    // Minimizing Windows
+    unsafe fn performMiniaturize_(self, sender: id);
+    unsafe fn miniaturize_(self, sender: id);
+    unsafe fn deminiaturize_(self, sender: id);
+    unsafe fn miniwindowImage(self) -> id;
+    unsafe fn setMiniwindowImage_(self, miniwindowImage: id);
+    unsafe fn miniwindowTitle(self) -> id;
+    unsafe fn setMiniwindowTitle_(self, miniwindowTitle: id);
+
+    // TODO: Getting the Dock Tile
+    // TODO: Printing Windows
+    // TODO: Providing Services
+    // TODO: Working with Carbon
+    // TODO: Triggering Constraint-Based Layout
+    // TODO: Debugging Constraint-Based Layout
+    // TODO: Constraint-Based Layouts
+}
+
+impl NSWindow for id {
+    // Creating Windows
+
+    unsafe fn initWithContentRect_styleMask_backing_defer_(
+        self,
+        rect: NSRect,
+        style: NSWindowStyleMask,
+        backing: NSBackingStoreType,
+        defer: BOOL,
+    ) -> id {
+        msg_send![self, initWithContentRect:rect
+                                  styleMask:style.bits
+                                    backing:backing as NSUInteger
+                                      defer:defer]
+    }
+
+    unsafe fn initWithContentRect_styleMask_backing_defer_screen_(
+        self,
+        rect: NSRect,
+        style: NSWindowStyleMask,
+        backing: NSBackingStoreType,
+        defer: BOOL,
+        screen: id,
+    ) -> id {
+        msg_send![self, initWithContentRect:rect
+                                  styleMask:style.bits
+                                    backing:backing as NSUInteger
+                                      defer:defer
+                                     screen:screen]
+    }
+
+    // Configuring Windows
+
+    unsafe fn styleMask(self) -> NSWindowStyleMask {
+        NSWindowStyleMask::from_bits_truncate(msg_send![self, styleMask])
+    }
+
+    unsafe fn setStyleMask_(self, styleMask: NSWindowStyleMask) {
+        msg_send![self, setStyleMask:styleMask.bits]
+    }
+
+    unsafe fn toggleFullScreen_(self, sender: id) {
+        msg_send![self, toggleFullScreen: sender]
+    }
+
+    unsafe fn worksWhenModal(self) -> BOOL {
+        msg_send![self, worksWhenModal]
+    }
+
+    unsafe fn alphaValue(self) -> CGFloat {
+        msg_send![self, alphaValue]
+    }
+
+    unsafe fn setAlphaValue_(self, windowAlpha: CGFloat) {
+        msg_send![self, setAlphaValue: windowAlpha]
+    }
+
+    unsafe fn backgroundColor(self) -> id {
+        msg_send![self, backgroundColor]
+    }
+
+    unsafe fn setBackgroundColor_(self, color: id) {
+        msg_send![self, setBackgroundColor: color]
+    }
+
+    unsafe fn colorSpace(self) -> id {
+        msg_send![self, colorSpace]
+    }
+
+    unsafe fn setColorSpace_(self, colorSpace: id) {
+        msg_send![self, setColorSpace: colorSpace]
+    }
+
+    unsafe fn contentView(self) -> id {
+        msg_send![self, contentView]
+    }
+
+    unsafe fn setContentView_(self, view: id) {
+        msg_send![self, setContentView: view]
+    }
+
+    unsafe fn canHide(self) -> BOOL {
+        msg_send![self, canHide]
+    }
+
+    unsafe fn setCanHide_(self, canHide: BOOL) {
+        msg_send![self, setCanHide: canHide]
+    }
+
+    unsafe fn hidesOnDeactivate(self) -> BOOL {
+        msg_send![self, hidesOnDeactivate]
+    }
+
+    unsafe fn setHidesOnDeactivate_(self, hideOnDeactivate: BOOL) {
+        msg_send![self, setHidesOnDeactivate: hideOnDeactivate]
+    }
+
+    // unsafe fn collectionBehavior(self) -> NSWindowCollectionBehavior {
+    //     msg_send![self, collectionBehavior]
+    // }
+    //
+    //     // unsafe fn setCollectionBehavior_(self, collectionBehavior: NSWindowCollectionBehavior) {
+    //     msg_send![self, setCollectionBehavior: collectionBehavior]
+    // }
+
+    unsafe fn setOpaque_(self, opaque: BOOL) {
+        msg_send![self, setOpaque: opaque]
+    }
+
+    unsafe fn hasShadow(self) -> BOOL {
+        msg_send![self, hasShadow]
+    }
+
+    unsafe fn setHasShadow_(self, hasShadow: BOOL) {
+        msg_send![self, setHasShadow: hasShadow]
+    }
+
+    unsafe fn invalidateShadow(self) {
+        msg_send![self, invalidateShadow]
+    }
+
+    //  unsafe fn autorecalculatesContentBorderThicknessForEdge_(self, edge: NSRectEdge) -> BOOL {
+    //      msg_send![self, autorecalculatesContentBorderThicknessForEdge: edge]
+    //  }
+    //
+    //  unsafe fn setAutorecalculatesContentBorderThickness_forEdge_(
+    //      self,
+    //      autorecalculateContentBorderThickness: BOOL,
+    //      edge: NSRectEdge,
+    //  ) -> BOOL {
+    //      msg_send![self, setAutorecalculatesContentBorderThickness:
+    //                      autorecalculateContentBorderThickness forEdge:edge]
+    //  }
+    //
+    //  unsafe fn contentBorderThicknessForEdge_(self, edge: NSRectEdge) -> CGFloat {
+    //      msg_send![self, contentBorderThicknessForEdge: edge]
+    //  }
+    //
+    //  unsafe fn setContentBorderThickness_forEdge_(self, borderThickness: CGFloat, edge: NSRectEdge) {
+    //      msg_send![self, setContentBorderThickness:borderThickness forEdge:edge]
+    //  }
+
+    unsafe fn delegate(self) -> id {
+        msg_send![self, delegate]
+    }
+
+    unsafe fn setDelegate_(self, delegate: id) {
+        msg_send![self, setDelegate: delegate]
+    }
+
+    unsafe fn preventsApplicationTerminationWhenModal(self) -> BOOL {
+        msg_send![self, preventsApplicationTerminationWhenModal]
+    }
+
+    unsafe fn setPreventsApplicationTerminationWhenModal_(self, flag: BOOL) {
+        msg_send![self, setPreventsApplicationTerminationWhenModal: flag]
+    }
+
+    // TODO: Accessing Window Information
+
+    // Getting Layout Information
+
+    unsafe fn contentRectForFrameRect_styleMask_(
+        self,
+        windowFrame: NSRect,
+        windowStyle: NSWindowStyleMask,
+    ) -> NSRect {
+        msg_send![self, contentRectForFrameRect:windowFrame styleMask:windowStyle.bits]
+    }
+
+    unsafe fn frameRectForContentRect_styleMask_(
+        self,
+        windowContentRect: NSRect,
+        windowStyle: NSWindowStyleMask,
+    ) -> NSRect {
+        msg_send![self, frameRectForContentRect:windowContentRect styleMask:windowStyle.bits]
+    }
+
+    unsafe fn minFrameWidthWithTitle_styleMask_(
+        self,
+        windowTitle: id,
+        windowStyle: NSWindowStyleMask,
+    ) -> CGFloat {
+        msg_send![self, minFrameWidthWithTitle:windowTitle styleMask:windowStyle.bits]
+    }
+
+    unsafe fn contentRectForFrameRect_(self, windowFrame: NSRect) -> NSRect {
+        msg_send![self, contentRectForFrameRect: windowFrame]
+    }
+
+    unsafe fn frameRectForContentRect_(self, windowContent: NSRect) -> NSRect {
+        msg_send![self, frameRectForContentRect: windowContent]
+    }
+
+    // Managing Windows
+
+    unsafe fn drawers(self) -> id {
+        msg_send![self, drawers]
+    }
+
+    unsafe fn windowController(self) -> id {
+        msg_send![self, windowController]
+    }
+
+    unsafe fn setWindowController_(self, windowController: id) {
+        msg_send![self, setWindowController: windowController]
+    }
+
+    // TODO: Managing Sheets
+
+    // Sizing Windows
+
+    unsafe fn frame(self) -> NSRect {
+        msg_send![self, frame]
+    }
+
+    unsafe fn setFrameOrigin_(self, point: NSPoint) {
+        msg_send![self, setFrameOrigin: point]
+    }
+
+    unsafe fn setFrameTopLeftPoint_(self, point: NSPoint) {
+        msg_send![self, setFrameTopLeftPoint: point]
+    }
+
+    unsafe fn constrainFrameRect_toScreen_(self, frameRect: NSRect, screen: id) {
+        msg_send![self, constrainFrameRect:frameRect toScreen:screen]
+    }
+
+    unsafe fn cascadeTopLeftFromPoint_(self, topLeft: NSPoint) -> NSPoint {
+        msg_send![self, cascadeTopLeftFromPoint: topLeft]
+    }
+
+    unsafe fn setFrame_display_(self, windowFrame: NSRect, display: BOOL) {
+        msg_send![self, setFrame:windowFrame display:display]
+    }
+
+    unsafe fn setFrame_displayViews_(self, windowFrame: NSRect, display: BOOL) {
+        msg_send![self, setFrame:windowFrame displayViews:display]
+    }
+
+    unsafe fn aspectRatio(self) -> NSSize {
+        msg_send![self, aspectRatio]
+    }
+
+    unsafe fn setAspectRatio_(self, aspectRatio: NSSize) {
+        msg_send![self, setAspectRatio: aspectRatio]
+    }
+
+    unsafe fn minSize(self) -> NSSize {
+        msg_send![self, minSize]
+    }
+
+    unsafe fn setMinSize_(self, minSize: NSSize) {
+        msg_send![self, setMinSize: minSize]
+    }
+
+    unsafe fn maxSize(self) -> NSSize {
+        msg_send![self, maxSize]
+    }
+
+    unsafe fn setMaxSize_(self, maxSize: NSSize) {
+        msg_send![self, setMaxSize: maxSize]
+    }
+
+    unsafe fn performZoom_(self, sender: id) {
+        msg_send![self, performZoom: sender]
+    }
+
+    unsafe fn zoom_(self, sender: id) {
+        msg_send![self, zoom: sender]
+    }
+
+    unsafe fn resizeFlags(self) -> NSInteger {
+        msg_send![self, resizeFlags]
+    }
+
+    unsafe fn showsResizeIndicator(self) -> BOOL {
+        msg_send![self, showsResizeIndicator]
+    }
+
+    unsafe fn setShowsResizeIndicator_(self, showsResizeIndicator: BOOL) {
+        msg_send![self, setShowsResizeIndicator: showsResizeIndicator]
+    }
+
+    unsafe fn resizeIncrements(self) -> NSSize {
+        msg_send![self, resizeIncrements]
+    }
+
+    unsafe fn setResizeIncrements_(self, resizeIncrements: NSSize) {
+        msg_send![self, setResizeIncrements: resizeIncrements]
+    }
+
+    unsafe fn preservesContentDuringLiveResize(self) -> BOOL {
+        msg_send![self, preservesContentDuringLiveResize]
+    }
+
+    unsafe fn setPreservesContentDuringLiveResize_(self, preservesContentDuringLiveResize: BOOL) {
+        msg_send![
+            self,
+            setPreservesContentDuringLiveResize: preservesContentDuringLiveResize
+        ]
+    }
+
+    unsafe fn inLiveResize(self) -> BOOL {
+        msg_send![self, inLiveResize]
+    }
+
+    // Sizing Content
+
+    unsafe fn contentAspectRatio(self) -> NSSize {
+        msg_send![self, contentAspectRatio]
+    }
+
+    unsafe fn setContentAspectRatio_(self, contentAspectRatio: NSSize) {
+        msg_send![self, setContentAspectRatio: contentAspectRatio]
+    }
+
+    unsafe fn contentMinSize(self) -> NSSize {
+        msg_send![self, contentMinSize]
+    }
+
+    unsafe fn setContentMinSize_(self, contentMinSize: NSSize) {
+        msg_send![self, setContentMinSize: contentMinSize]
+    }
+
+    unsafe fn contentSize(self) -> NSSize {
+        msg_send![self, contentSize]
+    }
+
+    unsafe fn setContentSize_(self, contentSize: NSSize) {
+        msg_send![self, setContentSize: contentSize]
+    }
+
+    unsafe fn contentMaxSize(self) -> NSSize {
+        msg_send![self, contentMaxSize]
+    }
+
+    unsafe fn setContentMaxSize_(self, contentMaxSize: NSSize) {
+        msg_send![self, setContentMaxSize: contentMaxSize]
+    }
+
+    unsafe fn contentResizeIncrements(self) -> NSSize {
+        msg_send![self, contentResizeIncrements]
+    }
+
+    unsafe fn setContentResizeIncrements_(self, contentResizeIncrements: NSSize) {
+        msg_send![self, setContentResizeIncrements: contentResizeIncrements]
+    }
+
+    // Managing Window Visibility and Occlusion State
+
+    unsafe fn isVisible(self) -> BOOL {
+        msg_send![self, isVisible]
+    }
+
+    // unsafe fn occlusionState(self) -> NSWindowOcclusionState {
+    //     msg_send![self, occlusionState]
+    // }
+
+    // Managing Window Layers
+
+    unsafe fn orderOut_(self, sender: id) {
+        msg_send![self, orderOut: sender]
+    }
+
+    unsafe fn orderBack_(self, sender: id) {
+        msg_send![self, orderBack: sender]
+    }
+
+    unsafe fn orderFront_(self, sender: id) {
+        msg_send![self, orderFront: sender]
+    }
+
+    unsafe fn orderFrontRegardless(self) {
+        msg_send![self, orderFrontRegardless]
+    }
+
+    // unsafe fn orderFrontWindow_relativeTo_(
+    //     self,
+    //     ordering_mode: NSWindowOrderingMode,
+    //     other_window_number: NSInteger,
+    // ) {
+    //     msg_send![self, orderWindow:ordering_mode relativeTo:other_window_number]
+    // }
+
+    unsafe fn level(self) -> NSInteger {
+        msg_send![self, level]
+    }
+
+    unsafe fn setLevel_(self, level: NSInteger) {
+        msg_send![self, setLevel: level]
+    }
+
+    // Managing Key Status
+
+    unsafe fn isKeyWindow(self) -> BOOL {
+        msg_send![self, isKeyWindow]
+    }
+
+    unsafe fn canBecomeKeyWindow(self) -> BOOL {
+        msg_send![self, canBecomeKeyWindow]
+    }
+
+    unsafe fn makeKeyWindow(self) {
+        msg_send![self, makeKeyWindow]
+    }
+
+    unsafe fn makeKeyAndOrderFront_(self, sender: id) {
+        msg_send![self, makeKeyAndOrderFront: sender]
+    }
+
+    // Managing Main Status
+
+    unsafe fn canBecomeMainWindow(self) -> BOOL {
+        msg_send![self, canBecomeMainWindow]
+    }
+
+    unsafe fn makeMainWindow(self) {
+        msg_send![self, makeMainWindow]
+    }
+
+    // Managing Toolbars
+
+    unsafe fn toolbar(self) -> id /* NSToolbar */ {
+        msg_send![self, toolbar]
+    }
+
+    unsafe fn setToolbar_(self, toolbar: id /* NSToolbar */) {
+        msg_send![self, setToolbar: toolbar]
+    }
+
+    unsafe fn runToolbarCustomizationPalette(self, sender: id) {
+        msg_send![self, runToolbarCustomizationPalette: sender]
+    }
+
+    // TODO: Managing Attached Windows
+    // TODO: Managing Window Buffers
+    // TODO: Managing Default Buttons
+    // TODO: Managing Field Editors
+    // TODO: Managing the Window Menu
+    // TODO: Managing Cursor Rectangles
+
+    // Managing Title Bars
+
+    unsafe fn standardWindowButton_(self, windowButtonKind: NSWindowButton) -> id {
+        msg_send![self, standardWindowButton: windowButtonKind]
+    }
+
+    // Managing Window Tabs
+    unsafe fn allowsAutomaticWindowTabbing(_: Self) -> BOOL {
+        msg_send![class!(NSWindow), allowsAutomaticWindowTabbing]
+    }
+
+    unsafe fn setAllowsAutomaticWindowTabbing_(_: Self, allowsAutomaticWindowTabbing: BOOL) {
+        msg_send![
+            class!(NSWindow),
+            setAllowsAutomaticWindowTabbing: allowsAutomaticWindowTabbing
+        ]
+    }
+
+    unsafe fn tabbingIdentifier(self) -> id {
+        msg_send![self, tabbingIdentifier]
+    }
+
+    //  unsafe fn tabbingMode(self) -> NSWindowTabbingMode {
+    //      msg_send!(self, tabbingMode)
+    //  }
+    //
+    //  unsafe fn setTabbingMode_(self, tabbingMode: NSWindowTabbingMode) {
+    //      msg_send![self, setTabbingMode: tabbingMode]
+    //  }
+    //
+    //  unsafe fn addTabbedWindow_ordered_(self, window: id, ordering_mode: NSWindowOrderingMode) {
+    //      msg_send![self, addTabbedWindow:window ordered: ordering_mode]
+    //  }
+
+    unsafe fn toggleTabBar_(self, sender: id) {
+        msg_send![self, toggleTabBar: sender]
+    }
+    // TODO: Managing Tooltips
+    // TODO: Handling Events
+
+    // Managing Responders
+
+    unsafe fn initialFirstResponder(self) -> id {
+        msg_send![self, initialFirstResponder]
+    }
+
+    unsafe fn firstResponder(self) -> id {
+        msg_send![self, firstResponder]
+    }
+
+    unsafe fn setInitialFirstResponder_(self, responder: id) {
+        msg_send![self, setInitialFirstResponder: responder]
+    }
+
+    unsafe fn makeFirstResponder_(self, responder: id) -> BOOL {
+        msg_send![self, makeFirstResponder: responder]
+    }
+
+    // TODO: Managing the Key View Loop
+
+    // Handling Keyboard Events
+
+    unsafe fn keyDown_(self, event: id) {
+        msg_send![self, keyDown: event]
+    }
+
+    // Handling Mouse Events
+
+    unsafe fn acceptsMouseMovedEvents(self) -> BOOL {
+        msg_send![self, acceptsMouseMovedEvents]
+    }
+
+    unsafe fn ignoresMouseEvents(self) -> BOOL {
+        msg_send![self, ignoresMouseEvents]
+    }
+
+    unsafe fn setIgnoresMouseEvents_(self, ignoreMouseEvents: BOOL) {
+        msg_send![self, setIgnoresMouseEvents: ignoreMouseEvents]
+    }
+
+    unsafe fn mouseLocationOutsideOfEventStream(self) -> NSPoint {
+        msg_send![self, mouseLocationOutsideOfEventStream]
+    }
+
+    unsafe fn setAcceptsMouseMovedEvents_(self, acceptMouseMovedEvents: BOOL) {
+        msg_send![self, setAcceptsMouseMovedEvents: acceptMouseMovedEvents]
+    }
+
+    unsafe fn windowNumberAtPoint_belowWindowWithWindowNumber_(
+        self,
+        point: NSPoint,
+        windowNumber: NSInteger,
+    ) -> NSInteger {
+        msg_send![self, windowNumberAtPoint:point belowWindowWithWindowNumber:windowNumber]
+    }
+
+    // Converting Coordinates
+
+    unsafe fn backingScaleFactor(self) -> CGFloat {
+        msg_send![self, backingScaleFactor]
+    }
+
+    //  unsafe fn backingAlignedRect_options_(
+    //      self,
+    //      rect: NSRect,
+    //      options: NSAlignmentOptions,
+    //  ) -> NSRect {
+    //      msg_send![self, backingAlignedRect:rect options:options]
+    //  }
+
+    unsafe fn convertRectFromBacking_(self, rect: NSRect) -> NSRect {
+        msg_send![self, convertRectFromBacking: rect]
+    }
+
+    unsafe fn convertRectToBacking_(self, rect: NSRect) -> NSRect {
+        msg_send![self, convertRectToBacking: rect]
+    }
+
+    unsafe fn convertRectToScreen_(self, rect: NSRect) -> NSRect {
+        msg_send![self, convertRectToScreen: rect]
+    }
+
+    unsafe fn convertRectFromScreen_(self, rect: NSRect) -> NSRect {
+        msg_send![self, convertRectFromScreen: rect]
+    }
+
+    // Accessing Edited Status
+
+    unsafe fn setDocumentEdited_(self, documentEdited: BOOL) {
+        msg_send![self, setDocumentEdited: documentEdited]
+    }
+
+    // Managing Titles
+
+    unsafe fn title(self) -> id {
+        msg_send![self, title]
+    }
+
+    unsafe fn setTitle_(self, title: id) {
+        msg_send![self, setTitle: title]
+    }
+
+    unsafe fn setTitleWithRepresentedFilename_(self, filePath: id) {
+        msg_send![self, setTitleWithRepresentedFilename: filePath]
+    }
+
+    unsafe fn setTitleVisibility_(self, visibility: NSWindowTitleVisibility) {
+        msg_send![self, setTitleVisibility: visibility]
+    }
+
+    unsafe fn setTitlebarAppearsTransparent_(self, transparent: BOOL) {
+        msg_send![self, setTitlebarAppearsTransparent: transparent]
+    }
+
+    unsafe fn representedFilename(self) -> id {
+        msg_send![self, representedFilename]
+    }
+
+    unsafe fn setRepresentedFilename_(self, filePath: id) {
+        msg_send![self, setRepresentedFilename: filePath]
+    }
+
+    unsafe fn representedURL(self) -> id {
+        msg_send![self, representedURL]
+    }
+
+    unsafe fn setRepresentedURL_(self, representedURL: id) {
+        msg_send![self, setRepresentedURL: representedURL]
+    }
+
+    // Accessing Screen Information
+
+    unsafe fn screen(self) -> id {
+        msg_send![self, screen]
+    }
+
+    unsafe fn deepestScreen(self) -> id {
+        msg_send![self, deepestScreen]
+    }
+
+    unsafe fn displaysWhenScreenProfileChanges(self) -> BOOL {
+        msg_send![self, displaysWhenScreenProfileChanges]
+    }
+
+    unsafe fn setDisplaysWhenScreenProfileChanges_(self, displaysWhenScreenProfileChanges: BOOL) {
+        msg_send![
+            self,
+            setDisplaysWhenScreenProfileChanges: displaysWhenScreenProfileChanges
+        ]
+    }
+
+    // Moving Windows
+
+    unsafe fn setMovableByWindowBackground_(self, movableByWindowBackground: BOOL) {
+        msg_send![
+            self,
+            setMovableByWindowBackground: movableByWindowBackground
+        ]
+    }
+
+    unsafe fn setMovable_(self, movable: BOOL) {
+        msg_send![self, setMovable: movable]
+    }
+
+    unsafe fn center(self) {
+        msg_send![self, center]
+    }
+
+    // Closing Windows
+
+    unsafe fn performClose_(self, sender: id) {
+        msg_send![self, performClose: sender]
+    }
+
+    unsafe fn close(self) {
+        msg_send![self, close]
+    }
+
+    unsafe fn setReleasedWhenClosed_(self, releasedWhenClosed: BOOL) {
+        msg_send![self, setReleasedWhenClosed: releasedWhenClosed]
+    }
+
+    // Minimizing Windows
+
+    unsafe fn performMiniaturize_(self, sender: id) {
+        msg_send![self, performMiniaturize: sender]
+    }
+
+    unsafe fn miniaturize_(self, sender: id) {
+        msg_send![self, miniaturize: sender]
+    }
+
+    unsafe fn deminiaturize_(self, sender: id) {
+        msg_send![self, deminiaturize: sender]
+    }
+
+    unsafe fn miniwindowImage(self) -> id {
+        msg_send![self, miniwindowImage]
+    }
+
+    unsafe fn setMiniwindowImage_(self, miniwindowImage: id) {
+        msg_send![self, setMiniwindowImage: miniwindowImage]
+    }
+
+    unsafe fn miniwindowTitle(self) -> id {
+        msg_send![self, miniwindowTitle]
+    }
+
+    unsafe fn setMiniwindowTitle_(self, miniwindowTitle: id) {
+        msg_send![self, setMiniwindowTitle: miniwindowTitle]
+    }
+
+    // TODO: Getting the Dock Tile
+    // TODO: Printing Windows
+    // TODO: Providing Services
+    // TODO: Working with Carbon
+    // TODO: Triggering Constraint-Based Layout
+    // TODO: Debugging Constraint-Based Layout
+    // TODO: Constraint-Based Layouts
+}
+
+#[repr(u64)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(dead_code)]
+
+pub enum NSBackingStoreType {
+    NSBackingStoreRetained = 0,
+    NSBackingStoreNonretained = 1,
+    NSBackingStoreBuffered = 2,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(dead_code)]
+
+pub enum NSWindowTitleVisibility {
+    NSWindowTitleVisible = 0,
+    NSWindowTitleHidden = 1,
+}
+
+pub trait NSPasteboard: Sized {
+    unsafe fn generalPasteboard(_: Self) -> id {
+        msg_send![class!(NSPasteboard), generalPasteboard]
+    }
+
+    unsafe fn pasteboardByFilteringData_ofType(_: Self, data: id, _type: id) -> id {
+        msg_send![class!(NSPasteboard), pasteboardByFilteringData:data ofType:_type]
+    }
+
+    unsafe fn pasteboardByFilteringFile(_: Self, file: id) -> id {
+        msg_send![class!(NSPasteboard), pasteboardByFilteringFile: file]
+    }
+
+    unsafe fn pasteboardByFilteringTypesInPasteboard(_: Self, pboard: id) -> id {
+        msg_send![
+            class!(NSPasteboard),
+            pasteboardByFilteringTypesInPasteboard: pboard
+        ]
+    }
+
+    unsafe fn pasteboardWithName(_: Self, name: id) -> id {
+        msg_send![class!(NSPasteboard), pasteboardWithName: name]
+    }
+
+    unsafe fn pasteboardWithUniqueName(_: Self) -> id {
+        msg_send![class!(NSPasteboard), pasteboardWithUniqueName]
+    }
+
+    unsafe fn releaseGlobally(self);
+
+    unsafe fn clearContents(self) -> NSInteger;
+    unsafe fn writeObjects(self, objects: id) -> BOOL;
+    unsafe fn setData_forType(self, data: id, dataType: id) -> BOOL;
+    unsafe fn setPropertyList_forType(self, plist: id, dataType: id) -> BOOL;
+    unsafe fn setString_forType(self, string: id, dataType: id) -> BOOL;
+
+    unsafe fn readObjectsForClasses_options(self, classArray: id, options: id) -> id;
+    unsafe fn pasteboardItems(self) -> id;
+    unsafe fn indexOfPasteboardItem(self, pasteboardItem: id) -> NSInteger;
+    unsafe fn dataForType(self, dataType: id) -> id;
+    unsafe fn propertyListForType(self, dataType: id) -> id;
+    unsafe fn stringForType(self, dataType: id) -> id;
+
+    unsafe fn availableTypeFromArray(self, types: id) -> id;
+    unsafe fn canReadItemWithDataConformingToTypes(self, types: id) -> BOOL;
+    unsafe fn canReadObjectForClasses_options(self, classArray: id, options: id) -> BOOL;
+    unsafe fn types(self) -> id;
+    unsafe fn typesFilterableTo(_: Self, _type: id) -> id {
+        msg_send![class!(NSPasteboard), typesFilterableTo: _type]
+    }
+
+    unsafe fn name(self) -> id;
+    unsafe fn changeCount(self) -> NSInteger;
+
+    unsafe fn declareTypes_owner(self, newTypes: id, newOwner: id) -> NSInteger;
+    unsafe fn addTypes_owner(self, newTypes: id, newOwner: id) -> NSInteger;
+    unsafe fn writeFileContents(self, filename: id) -> BOOL;
+    unsafe fn writeFileWrapper(self, wrapper: id) -> BOOL;
+
+    unsafe fn readFileContentsType_toFile(self, _type: id, filename: id) -> id;
+    unsafe fn readFileWrapper(self) -> id;
+}
+
+impl NSPasteboard for id {
+    unsafe fn releaseGlobally(self) {
+        msg_send![self, releaseGlobally]
+    }
+
+    unsafe fn clearContents(self) -> NSInteger {
+        msg_send![self, clearContents]
+    }
+
+    unsafe fn writeObjects(self, objects: id) -> BOOL {
+        msg_send![self, writeObjects: objects]
+    }
+
+    unsafe fn setData_forType(self, data: id, dataType: id) -> BOOL {
+        msg_send![self, setData:data forType:dataType]
+    }
+
+    unsafe fn setPropertyList_forType(self, plist: id, dataType: id) -> BOOL {
+        msg_send![self, setPropertyList:plist forType:dataType]
+    }
+
+    unsafe fn setString_forType(self, string: id, dataType: id) -> BOOL {
+        msg_send![self, setString:string forType:dataType]
+    }
+
+    unsafe fn readObjectsForClasses_options(self, classArray: id, options: id) -> id {
+        msg_send![self, readObjectsForClasses:classArray options:options]
+    }
+
+    unsafe fn pasteboardItems(self) -> id {
+        msg_send![self, pasteboardItems]
+    }
+
+    unsafe fn indexOfPasteboardItem(self, pasteboardItem: id) -> NSInteger {
+        msg_send![self, indexOfPasteboardItem: pasteboardItem]
+    }
+
+    unsafe fn dataForType(self, dataType: id) -> id {
+        msg_send![self, dataForType: dataType]
+    }
+
+    unsafe fn propertyListForType(self, dataType: id) -> id {
+        msg_send![self, propertyListForType: dataType]
+    }
+
+    unsafe fn stringForType(self, dataType: id) -> id {
+        msg_send![self, stringForType: dataType]
+    }
+
+    unsafe fn availableTypeFromArray(self, types: id) -> id {
+        msg_send![self, availableTypeFromArray: types]
+    }
+
+    unsafe fn canReadItemWithDataConformingToTypes(self, types: id) -> BOOL {
+        msg_send![self, canReadItemWithDataConformingToTypes: types]
+    }
+
+    unsafe fn canReadObjectForClasses_options(self, classArray: id, options: id) -> BOOL {
+        msg_send![self, canReadObjectForClasses:classArray options:options]
+    }
+
+    unsafe fn types(self) -> id {
+        msg_send![self, types]
+    }
+
+    unsafe fn name(self) -> id {
+        msg_send![self, name]
+    }
+
+    unsafe fn changeCount(self) -> NSInteger {
+        msg_send![self, changeCount]
+    }
+
+    unsafe fn declareTypes_owner(self, newTypes: id, newOwner: id) -> NSInteger {
+        msg_send![self, declareTypes:newTypes owner:newOwner]
+    }
+
+    unsafe fn addTypes_owner(self, newTypes: id, newOwner: id) -> NSInteger {
+        msg_send![self, addTypes:newTypes owner:newOwner]
+    }
+
+    unsafe fn writeFileContents(self, filename: id) -> BOOL {
+        msg_send![self, writeFileContents: filename]
+    }
+
+    unsafe fn writeFileWrapper(self, wrapper: id) -> BOOL {
+        msg_send![self, writeFileWrapper: wrapper]
+    }
+
+    unsafe fn readFileContentsType_toFile(self, _type: id, filename: id) -> id {
+        msg_send![self, readFileContentsType:_type toFile:filename]
+    }
+
+    unsafe fn readFileWrapper(self) -> id {
+        msg_send![self, readFileWrapper]
+    }
+}
+
+pub trait NSFastEnumeration: Sized {
+    unsafe fn iter(self) -> NSFastIterator;
+}
+
+impl NSFastEnumeration for id {
+    unsafe fn iter(self) -> NSFastIterator {
+        NSFastIterator {
+            state: NSFastEnumerationState {
+                state: 0,
+                items_ptr: ptr::null_mut(),
+                mutations_ptr: ptr::null_mut(),
+                extra: [0; 5],
+            },
+            buffer: [nil; NS_FAST_ENUM_BUF_SIZE],
+            mut_val: None,
+            len: 0,
+            idx: 0,
+            object: self,
+        }
+    }
+}
+
+const NS_FAST_ENUM_BUF_SIZE: usize = 16;
+
+#[repr(C)]
+struct NSFastEnumerationState {
+    pub state: libc::c_ulong,
+    pub items_ptr: *mut id,
+    pub mutations_ptr: *mut libc::c_ulong,
+    pub extra: [libc::c_ulong; 5],
+}
+
+pub struct NSFastIterator {
+    state: NSFastEnumerationState,
+    buffer: [id; NS_FAST_ENUM_BUF_SIZE],
+    mut_val: Option<libc::c_ulong>,
+    len: usize,
+    idx: usize,
+    object: id,
+}
+
+impl Iterator for NSFastIterator {
+    type Item = id;
+
+    fn next(&mut self) -> Option<id> {
+        if self.idx >= self.len {
+            self.len = unsafe {
+                msg_send![self.object, countByEnumeratingWithState:&mut self.state objects:self.buffer.as_mut_ptr() count:NS_FAST_ENUM_BUF_SIZE]
+            };
+            self.idx = 0;
+        }
+
+        let new_mut = unsafe { *self.state.mutations_ptr };
+
+        if let Some(old_mut) = self.mut_val {
+            assert!(
+                old_mut == new_mut,
+                "The collection was mutated while being enumerated"
+            );
+        }
+
+        if self.idx < self.len {
+            let object = unsafe { *self.state.items_ptr.offset(self.idx as isize) };
+            self.mut_val = Some(new_mut);
+            self.idx += 1;
+            Some(object)
+        } else {
+            None
+        }
+    }
+}
+
+pub trait NSColor: Sized {
+    unsafe fn clearColor(_: Self) -> id;
+    unsafe fn colorWithRed_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id;
+    unsafe fn colorWithSRGBRed_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id;
+    unsafe fn colorWithDeviceRed_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id;
+    unsafe fn colorWithDisplayP3Red_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id;
+    unsafe fn colorWithCalibratedRed_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id;
+
+    unsafe fn colorUsingColorSpace_(self, color_space: id) -> id;
+
+    unsafe fn alphaComponent(self) -> CGFloat;
+    unsafe fn whiteComponent(self) -> CGFloat;
+    unsafe fn redComponent(self) -> CGFloat;
+    unsafe fn greenComponent(self) -> CGFloat;
+    unsafe fn blueComponent(self) -> CGFloat;
+    unsafe fn cyanComponent(self) -> CGFloat;
+    unsafe fn magentaComponent(self) -> CGFloat;
+    unsafe fn yellowComponent(self) -> CGFloat;
+    unsafe fn blackComponent(self) -> CGFloat;
+    unsafe fn hueComponent(self) -> CGFloat;
+    unsafe fn saturationComponent(self) -> CGFloat;
+    unsafe fn brightnessComponent(self) -> CGFloat;
+}
+
+impl NSColor for id {
+    unsafe fn clearColor(_: Self) -> id {
+        msg_send![class!(NSColor), clearColor]
+    }
+    unsafe fn colorWithRed_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id {
+        msg_send![class!(NSColor), colorWithRed:r green:g blue:b alpha:a]
+    }
+    unsafe fn colorWithSRGBRed_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id {
+        msg_send![class!(NSColor), colorWithSRGBRed:r green:g blue:b alpha:a]
+    }
+    unsafe fn colorWithDeviceRed_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id {
+        msg_send![class!(NSColor), colorWithDeviceRed:r green:g blue:b alpha:a]
+    }
+    unsafe fn colorWithDisplayP3Red_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id {
+        msg_send![class!(NSColor), colorWithDisplayP3Red:r green:g blue:b alpha:a]
+    }
+    unsafe fn colorWithCalibratedRed_green_blue_alpha_(
+        _: Self,
+        r: CGFloat,
+        g: CGFloat,
+        b: CGFloat,
+        a: CGFloat,
+    ) -> id {
+        msg_send![class!(NSColor), colorWithCalibratedRed:r green:g blue:b alpha:a]
+    }
+
+    unsafe fn colorUsingColorSpace_(self, color_space: id) -> id {
+        msg_send![self, colorUsingColorSpace: color_space]
+    }
+
+    unsafe fn alphaComponent(self) -> CGFloat {
+        msg_send![self, alphaComponent]
+    }
+    unsafe fn whiteComponent(self) -> CGFloat {
+        msg_send![self, whiteComponent]
+    }
+    unsafe fn redComponent(self) -> CGFloat {
+        msg_send![self, redComponent]
+    }
+    unsafe fn greenComponent(self) -> CGFloat {
+        msg_send![self, greenComponent]
+    }
+    unsafe fn blueComponent(self) -> CGFloat {
+        msg_send![self, blueComponent]
+    }
+    unsafe fn cyanComponent(self) -> CGFloat {
+        msg_send![self, cyanComponent]
+    }
+    unsafe fn magentaComponent(self) -> CGFloat {
+        msg_send![self, magentaComponent]
+    }
+    unsafe fn yellowComponent(self) -> CGFloat {
+        msg_send![self, yellowComponent]
+    }
+    unsafe fn blackComponent(self) -> CGFloat {
+        msg_send![self, blackComponent]
+    }
+    unsafe fn hueComponent(self) -> CGFloat {
+        msg_send![self, hueComponent]
+    }
+    unsafe fn saturationComponent(self) -> CGFloat {
+        msg_send![self, saturationComponent]
+    }
+    unsafe fn brightnessComponent(self) -> CGFloat {
+        msg_send![self, brightnessComponent]
+    }
+}
+
+#[repr(u64)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(dead_code)]
+pub enum NSWindowButton {
+    NSWindowCloseButton = 0,
+    NSWindowMiniaturizeButton = 1,
+    NSWindowZoomButton = 2,
+    NSWindowToolbarButton = 3,
+    NSWindowDocumentIconButton = 4,
+    NSWindowDocumentVersionsButton = 6,
+    NSWindowFullScreenButton = 7,
+}
+
+pub trait NSArray: Sized {
+    unsafe fn array(_: Self) -> id {
+        msg_send![class!(NSArray), array]
+    }
+
+    unsafe fn arrayWithObjects(_: Self, objects: &[id]) -> id {
+        msg_send![class!(NSArray), arrayWithObjects:objects.as_ptr()
+                                    count:objects.len()]
+    }
+
+    unsafe fn arrayWithObject(_: Self, object: id) -> id {
+        msg_send![class!(NSArray), arrayWithObject: object]
+    }
+
+    unsafe fn init(self) -> id;
+
+    unsafe fn count(self) -> NSUInteger;
+
+    unsafe fn arrayByAddingObjectFromArray(self, object: id) -> id;
+    unsafe fn arrayByAddingObjectsFromArray(self, objects: id) -> id;
+    unsafe fn objectAtIndex(self, index: NSUInteger) -> id;
+}
+
+impl NSArray for id {
+    unsafe fn init(self) -> id {
+        msg_send![self, init]
+    }
+
+    unsafe fn count(self) -> NSUInteger {
+        msg_send![self, count]
+    }
+
+    unsafe fn arrayByAddingObjectFromArray(self, object: id) -> id {
+        msg_send![self, arrayByAddingObjectFromArray: object]
+    }
+
+    unsafe fn arrayByAddingObjectsFromArray(self, objects: id) -> id {
+        msg_send![self, arrayByAddingObjectsFromArray: objects]
+    }
+
+    unsafe fn objectAtIndex(self, index: NSUInteger) -> id {
+        msg_send![self, objectAtIndex: index]
+    }
+}
+
+pub trait NSImage: Sized {
+    unsafe fn alloc(_: Self) -> id {
+        msg_send![class!(NSImage), alloc]
+    }
+
+    unsafe fn initByReferencingFile_(self, file_name: id /* (NSString *) */) -> id;
+    /*
+    unsafe fn initWithContentsOfFile_(self, file_name: id /* (NSString *) */) -> id;
+    unsafe fn initWithData_(self, data: id /* (NSData *) */) -> id;
+    unsafe fn initWithDataIgnoringOrientation_(self, data: id /* (NSData *) */) -> id;
+    unsafe fn initWithPasteboard_(self, pasteboard: id /* (NSPasteboard *) */) -> id;
+    unsafe fn initWithSize_flipped_drawingHandler_(self, size: NSSize,
+                                                   drawingHandlerShouldBeCalledWithFlippedContext: BOOL,
+                                                   drawingHandler: *mut Block<(NSRect,), BOOL>);
+    unsafe fn initWithSize_(self, aSize: NSSize) -> id;
+
+    unsafe fn imageNamed_(_: Self, name: id /* (NSString *) */) -> id {
+        msg_send![class!(NSImage), imageNamed:name]
+    }
+
+    unsafe fn name(self) -> id /* (NSString *) */;
+    unsafe fn setName_(self, name: id /* (NSString *) */) -> BOOL;
+
+    unsafe fn size(self) -> NSSize;
+    unsafe fn template(self) -> BOOL;
+
+    unsafe fn canInitWithPasteboard_(self, pasteboard: id /* (NSPasteboard *) */) -> BOOL;
+    unsafe fn imageTypes(self) -> id /* (NSArray<NSString *> ) */;
+    unsafe fn imageUnfilteredTypes(self) -> id /* (NSArray<NSString *> ) */;
+
+    unsafe fn addRepresentation_(self, imageRep: id /* (NSImageRep *) */);
+    unsafe fn addRepresentations_(self, imageReps: id /* (NSArray<NSImageRep *> *) */);
+    unsafe fn representations(self) -> id /* (NSArray<NSImageRep *> *) */;
+    unsafe fn removeRepresentation_(self, imageRep: id /* (NSImageRep *) */);
+    unsafe fn bestRepresentationForRect_context_hints_(self, rect: NSRect,
+                                                       referenceContext: id /* (NSGraphicsContext *) */,
+                                                       hints: id /* (NSDictionary<NSString *, id> *) */)
+                                                       -> id /* (NSImageRep *) */;
+    unsafe fn prefersColorMatch(self) -> BOOL;
+    unsafe fn usesEPSOnResolutionMismatch(self) -> BOOL;
+    unsafe fn matchesOnMultipleResolution(self) -> BOOL;
+
+    unsafe fn drawInRect_(self, rect: NSRect);
+    unsafe fn drawAtPoint_fromRect_operation_fraction_(self, point: NSPoint, srcRect: NSRect,
+                                                       op: NSCompositingOperation, delta: CGFloat);
+    unsafe fn drawInRect_fromRect_operation_fraction_(self, dstRect: NSRect, srcRect: NSRect,
+                                                      op: NSCompositingOperation, delta: CGFloat);
+    unsafe fn drawInRect_fromRect_operation_fraction_respectFlipped_hints_(self, dstSpacePortionRect: NSRect,
+        srcSpacePortionRect: NSRect, op: NSCompositingOperation, delta: CGFloat, respectContextIsFlipped: BOOL,
+        hints: id /* (NSDictionary<NSString *, id> *) */);
+    unsafe fn drawRepresentation_inRect_(self, imageRep: id /* (NSImageRep *) */, dstRect: NSRect);
+
+    unsafe fn isValid(self) -> BOOL;
+    unsafe fn backgroundColor(self) -> id /* (NSColor *) */;
+
+    unsafe fn lockFocus(self);
+    unsafe fn lockFocusFlipped_(self, flipped: BOOL);
+    unsafe fn unlockFocus(self);
+
+    unsafe fn alignmentRect(self) -> NSRect;
+
+    unsafe fn cacheMode(self) -> NSImageCacheMode;
+    unsafe fn recache(self);
+
+    unsafe fn delegate(self) -> id /* (id<NSImageDelegate *> *) */;
+
+    unsafe fn TIFFRepresentation(self) -> id /* (NSData *) */;
+    unsafe fn TIFFRepresentationUsingCompression_factor_(self, comp: NSTIFFCompression, aFloat: f32)
+                                                         -> id /* (NSData *) */;
+
+    unsafe fn cancelIncrementalLoad(self);
+
+    unsafe fn hitTestRect_withImageDestinationRect_context_hints_flipped_(self, testRectDestSpace: NSRect,
+        imageRectDestSpace: NSRect, referenceContext: id /* (NSGraphicsContext *) */,
+        hints: id /* (NSDictionary<NSString *, id> *) */, flipped: BOOL) -> BOOL;
+
+    unsafe fn accessibilityDescription(self) -> id /* (NSString *) */;
+
+    unsafe fn layerContentsForContentsScale_(self, layerContentsScale: CGFloat) -> id /* (id) */;
+    unsafe fn recommendedLayerContentsScale_(self, preferredContentsScale: CGFloat) -> CGFloat;
+
+    unsafe fn matchesOnlyOnBestFittingAxis(self) -> BOOL;
+    */
+}
+
+impl NSImage for id {
+    unsafe fn initByReferencingFile_(self, file_name: id /* (NSString *) */) -> id {
+        msg_send![self, initByReferencingFile: file_name]
+    }
+
+    /*
+    unsafe fn initWithContentsOfFile_(self, file_name: id /* (NSString *) */) -> id {
+        msg_send![self, initWithContentsOfFile: file_name]
+    }
+
+    unsafe fn initWithData_(self, data: id /* (NSData *) */) -> id {
+        msg_send![self, initWithData: data]
+    }
+
+    unsafe fn initWithDataIgnoringOrientation_(self, data: id /* (NSData *) */) -> id {
+        msg_send![self, initWithDataIgnoringOrientation: data]
+    }
+
+    unsafe fn initWithPasteboard_(self, pasteboard: id /* (NSPasteboard *) */) -> id {
+        msg_send![self, initWithPasteboard: pasteboard]
+    }
+
+    unsafe fn initWithSize_flipped_drawingHandler_(
+        self,
+        size: NSSize,
+        drawingHandlerShouldBeCalledWithFlippedContext: BOOL,
+        drawingHandler: *mut Block<(NSRect,), BOOL>,
+    ) {
+        msg_send![self, initWithSize:size
+                             flipped:drawingHandlerShouldBeCalledWithFlippedContext
+                      drawingHandler:drawingHandler]
+    }
+
+    unsafe fn initWithSize_(self, aSize: NSSize) -> id {
+        msg_send![self, initWithSize: aSize]
+    }
+
+    unsafe fn name(self) -> id /* (NSString *) */ {
+        msg_send![self, name]
+    }
+
+    unsafe fn setName_(self, name: id /* (NSString *) */) -> BOOL {
+        msg_send![self, setName: name]
+    }
+
+    unsafe fn size(self) -> NSSize {
+        msg_send![self, size]
+    }
+
+    unsafe fn template(self) -> BOOL {
+        msg_send![self, template]
+    }
+
+    unsafe fn canInitWithPasteboard_(self, pasteboard: id /* (NSPasteboard *) */) -> BOOL {
+        msg_send![self, canInitWithPasteboard: pasteboard]
+    }
+
+    unsafe fn imageTypes(self) -> id /* (NSArray<NSString *> ) */ {
+        msg_send![self, imageTypes]
+    }
+
+    unsafe fn imageUnfilteredTypes(self) -> id /* (NSArray<NSString *> ) */ {
+        msg_send![self, imageUnfilteredTypes]
+    }
+
+    unsafe fn addRepresentation_(self, imageRep: id /* (NSImageRep *) */) {
+        msg_send![self, addRepresentation: imageRep]
+    }
+
+    unsafe fn addRepresentations_(self, imageReps: id /* (NSArray<NSImageRep *> *) */) {
+        msg_send![self, addRepresentations: imageReps]
+    }
+
+    unsafe fn representations(self) -> id /* (NSArray<NSImageRep *> *) */ {
+        msg_send![self, representations]
+    }
+
+    unsafe fn removeRepresentation_(self, imageRep: id /* (NSImageRep *) */) {
+        msg_send![self, removeRepresentation: imageRep]
+    }
+
+    unsafe fn bestRepresentationForRect_context_hints_(
+        self,
+        rect: NSRect,
+        referenceContext: id, /* (NSGraphicsContext *) */
+        hints: id,            /* (NSDictionary<NSString *, id> *) */
+    ) -> id /* (NSImageRep *) */ {
+        msg_send![self, bestRepresentationForRect:rect context:referenceContext hints:hints]
+    }
+
+    unsafe fn prefersColorMatch(self) -> BOOL {
+        msg_send![self, prefersColorMatch]
+    }
+
+    unsafe fn usesEPSOnResolutionMismatch(self) -> BOOL {
+        msg_send![self, usesEPSOnResolutionMismatch]
+    }
+
+    unsafe fn matchesOnMultipleResolution(self) -> BOOL {
+        msg_send![self, matchesOnMultipleResolution]
+    }
+
+    unsafe fn drawInRect_(self, rect: NSRect) {
+        msg_send![self, drawInRect: rect]
+    }
+
+    unsafe fn drawAtPoint_fromRect_operation_fraction_(
+        self,
+        point: NSPoint,
+        srcRect: NSRect,
+        op: NSCompositingOperation,
+        delta: CGFloat,
+    ) {
+        msg_send![self, drawAtPoint:point fromRect:srcRect operation:op fraction:delta]
+    }
+
+    unsafe fn drawInRect_fromRect_operation_fraction_(
+        self,
+        dstRect: NSRect,
+        srcRect: NSRect,
+        op: NSCompositingOperation,
+        delta: CGFloat,
+    ) {
+        msg_send![self, drawInRect:dstRect fromRect:srcRect operation:op fraction:delta]
+    }
+
+    unsafe fn drawInRect_fromRect_operation_fraction_respectFlipped_hints_(
+        self,
+        dstSpacePortionRect: NSRect,
+        srcSpacePortionRect: NSRect,
+        op: NSCompositingOperation,
+        delta: CGFloat,
+        respectContextIsFlipped: BOOL,
+        hints: id, /* (NSDictionary<NSString *, id> *) */
+    ) {
+        msg_send![self, drawInRect:dstSpacePortionRect
+                          fromRect:srcSpacePortionRect
+                         operation:op
+                          fraction:delta
+                    respectFlipped:respectContextIsFlipped
+                             hints:hints]
+    }
+
+    unsafe fn drawRepresentation_inRect_(
+        self,
+        imageRep: id, /* (NSImageRep *) */
+        dstRect: NSRect,
+    ) {
+        msg_send![self, drawRepresentation:imageRep inRect:dstRect]
+    }
+
+    unsafe fn isValid(self) -> BOOL {
+        msg_send![self, isValid]
+    }
+
+    unsafe fn backgroundColor(self) -> id /* (NSColor *) */ {
+        msg_send![self, backgroundColor]
+    }
+
+    unsafe fn lockFocus(self) {
+        msg_send![self, lockFocus]
+    }
+
+    unsafe fn lockFocusFlipped_(self, flipped: BOOL) {
+        msg_send![self, lockFocusFlipped: flipped]
+    }
+
+    unsafe fn unlockFocus(self) {
+        msg_send![self, unlockFocus]
+    }
+
+    unsafe fn alignmentRect(self) -> NSRect {
+        msg_send![self, alignmentRect]
+    }
+
+    unsafe fn cacheMode(self) -> NSImageCacheMode {
+        msg_send![self, cacheMode]
+    }
+
+    unsafe fn recache(self) {
+        msg_send![self, recache]
+    }
+
+    unsafe fn delegate(self) -> id /* (id<NSImageDelegate *> *) */ {
+        msg_send![self, delegate]
+    }
+
+    unsafe fn TIFFRepresentation(self) -> id /* (NSData *) */ {
+        msg_send![self, TIFFRepresentation]
+    }
+
+    unsafe fn TIFFRepresentationUsingCompression_factor_(
+        self,
+        comp: NSTIFFCompression,
+        aFloat: f32,
+    ) -> id /* (NSData *) */ {
+        msg_send![self, TIFFRepresentationUsingCompression:comp factor:aFloat]
+    }
+
+    unsafe fn cancelIncrementalLoad(self) {
+        msg_send![self, cancelIncrementalLoad]
+    }
+
+    unsafe fn hitTestRect_withImageDestinationRect_context_hints_flipped_(
+        self,
+        testRectDestSpace: NSRect,
+        imageRectDestSpace: NSRect,
+        referenceContext: id, /* (NSGraphicsContext *) */
+        hints: id,            /* (NSDictionary<NSString *, id> *) */
+        flipped: BOOL,
+    ) -> BOOL {
+        msg_send![self, hitTestRect:testRectDestSpace
+           withImageDestinationRect:imageRectDestSpace
+                            context:referenceContext
+                              hints:hints
+                            flipped:flipped]
+    }
+
+    unsafe fn accessibilityDescription(self) -> id /* (NSString *) */ {
+        msg_send![self, accessibilityDescription]
+    }
+
+    unsafe fn layerContentsForContentsScale_(self, layerContentsScale: CGFloat) -> id /* (id) */ {
+        msg_send![self, layerContentsForContentsScale: layerContentsScale]
+    }
+
+    unsafe fn recommendedLayerContentsScale_(self, preferredContentsScale: CGFloat) -> CGFloat {
+        msg_send![self, recommendedLayerContentsScale: preferredContentsScale]
+    }
+
+    unsafe fn matchesOnlyOnBestFittingAxis(self) -> BOOL {
+        msg_send![self, matchesOnlyOnBestFittingAxis]
+    }
+    */
+}
+
+pub trait NSDictionary: Sized {
+    // unsafe fn dictionary(_: Self) -> id {
+    //     msg_send![class!(NSDictionary), dictionary]
+    // }
+
+    unsafe fn dictionaryWithContentsOfFile_(_: Self, path: id) -> id {
+        msg_send![class!(NSDictionary), dictionaryWithContentsOfFile: path]
+    }
+
+    /*
+    unsafe fn dictionaryWithContentsOfURL_(_: Self, aURL: id) -> id {
+        msg_send![class!(NSDictionary), dictionaryWithContentsOfURL: aURL]
+    }
+
+    unsafe fn dictionaryWithDictionary_(_: Self, otherDictionary: id) -> id {
+        msg_send![
+            class!(NSDictionary),
+            dictionaryWithDictionary: otherDictionary
+        ]
+    }
+
+    unsafe fn dictionaryWithObject_forKey_(_: Self, anObject: id, aKey: id) -> id {
+        msg_send![class!(NSDictionary), dictionaryWithObject:anObject forKey:aKey]
+    }
+
+    unsafe fn dictionaryWithObjects_forKeys_(_: Self, objects: id, keys: id) -> id {
+        msg_send![class!(NSDictionary), dictionaryWithObjects:objects forKeys:keys]
+    }
+
+    unsafe fn dictionaryWithObjects_forKeys_count_(
+        _: Self,
+        objects: *const id,
+        keys: *const id,
+        count: NSUInteger,
+    ) -> id {
+        msg_send![class!(NSDictionary), dictionaryWithObjects:objects forKeys:keys count:count]
+    }
+
+    unsafe fn dictionaryWithObjectsAndKeys_(_: Self, firstObject: id) -> id {
+        msg_send![
+            class!(NSDictionary),
+            dictionaryWithObjectsAndKeys: firstObject
+        ]
+    }
+
+    unsafe fn init(self) -> id;
+    unsafe fn initWithContentsOfFile_(self, path: id) -> id;
+    unsafe fn initWithContentsOfURL_(self, aURL: id) -> id;
+    unsafe fn initWithDictionary_(self, otherDicitonary: id) -> id;
+    unsafe fn initWithDictionary_copyItems_(self, otherDicitonary: id, flag: BOOL) -> id;
+    unsafe fn initWithObjects_forKeys_(self, objects: id, keys: id) -> id;
+    unsafe fn initWithObjects_forKeys_count_(self, objects: id, keys: id, count: NSUInteger) -> id;
+    unsafe fn initWithObjectsAndKeys_(self, firstObject: id) -> id;
+
+    unsafe fn sharedKeySetForKeys_(_: Self, keys: id) -> id {
+        msg_send![class!(NSDictionary), sharedKeySetForKeys: keys]
+    }
+
+    unsafe fn count(self) -> NSUInteger;
+
+    unsafe fn isEqualToDictionary_(self, otherDictionary: id) -> BOOL;
+
+    unsafe fn allKeys(self) -> id;
+    unsafe fn allKeysForObject_(self, anObject: id) -> id;
+    unsafe fn allValues(self) -> id;
+    unsafe fn objectForKey_(self, aKey: id) -> id;
+    unsafe fn objectForKeyedSubscript_(self, key: id) -> id;
+    unsafe fn objectsForKeys_notFoundMarker_(self, keys: id, anObject: id) -> id;
+    */
+    unsafe fn valueForKey_(self, key: id) -> id;
+
+    /*
+        unsafe fn keyEnumerator(self) -> id;
+        unsafe fn objectEnumerator(self) -> id;
+        unsafe fn enumerateKeysAndObjectsUsingBlock_(self, block: *mut Block<(id, id, *mut BOOL), ()>);
+        unsafe fn enumerateKeysAndObjectsWithOptions_usingBlock_(
+            self,
+            opts: NSEnumerationOptions,
+            block: *mut Block<(id, id, *mut BOOL), ()>,
+        );
+
+        unsafe fn keysSortedByValueUsingSelector_(self, comparator: SEL) -> id;
+        unsafe fn keysSortedByValueUsingComparator_(self, cmptr: NSComparator) -> id;
+        unsafe fn keysSortedByValueWithOptions_usingComparator_(
+            self,
+            opts: NSEnumerationOptions,
+            cmptr: NSComparator,
+        ) -> id;
+
+        unsafe fn keysOfEntriesPassingTest_(
+            self,
+            predicate: *mut Block<(id, id, *mut BOOL), BOOL>,
+        ) -> id;
+        unsafe fn keysOfEntriesWithOptions_PassingTest_(
+            self,
+            opts: NSEnumerationOptions,
+            predicate: *mut Block<(id, id, *mut BOOL), BOOL>,
+        ) -> id;
+
+        unsafe fn writeToFile_atomically_(self, path: id, flag: BOOL) -> BOOL;
+        unsafe fn writeToURL_atomically_(self, aURL: id, flag: BOOL) -> BOOL;
+
+        unsafe fn fileCreationDate(self) -> id;
+        unsafe fn fileExtensionHidden(self) -> BOOL;
+        unsafe fn fileGroupOwnerAccountID(self) -> id;
+        unsafe fn fileGroupOwnerAccountName(self) -> id;
+        unsafe fn fileIsAppendOnly(self) -> BOOL;
+        unsafe fn fileIsImmutable(self) -> BOOL;
+        unsafe fn fileModificationDate(self) -> id;
+        unsafe fn fileOwnerAccountID(self) -> id;
+        unsafe fn fileOwnerAccountName(self) -> id;
+        unsafe fn filePosixPermissions(self) -> NSUInteger;
+        unsafe fn fileSize(self) -> libc::c_ulonglong;
+        unsafe fn fileSystemFileNumber(self) -> NSUInteger;
+        unsafe fn fileSystemNumber(self) -> NSInteger;
+        unsafe fn fileType(self) -> id;
+
+        unsafe fn description(self) -> id;
+        unsafe fn descriptionInStringsFileFormat(self) -> id;
+        unsafe fn descriptionWithLocale_(self, locale: id) -> id;
+        unsafe fn descriptionWithLocale_indent_(self, locale: id, indent: NSUInteger) -> id;
+    }
+    */
+}
+
+impl NSDictionary for id {
+    /*
+     unsafe fn init(self) -> id {
+         msg_send![self, init]
+     }
+
+    unsafe fn initWithContentsOfFile_(self, path: id) -> id {
+        msg_send![self, initWithContentsOfFile: path]
+    }
+
+
+    unsafe fn initWithContentsOfURL_(self, aURL: id) -> id {
+        msg_send![self, initWithContentsOfURL: aURL]
+    }
+
+    unsafe fn initWithDictionary_(self, otherDictionary: id) -> id {
+        msg_send![self, initWithDictionary: otherDictionary]
+    }
+
+    unsafe fn initWithDictionary_copyItems_(self, otherDictionary: id, flag: BOOL) -> id {
+        msg_send![self, initWithDictionary:otherDictionary copyItems:flag]
+    }
+
+    unsafe fn initWithObjects_forKeys_(self, objects: id, keys: id) -> id {
+        msg_send![self, initWithObjects:objects forKeys:keys]
+    }
+
+    unsafe fn initWithObjects_forKeys_count_(self, objects: id, keys: id, count: NSUInteger) -> id {
+        msg_send![self, initWithObjects:objects forKeys:keys count:count]
+    }
+
+    unsafe fn initWithObjectsAndKeys_(self, firstObject: id) -> id {
+        msg_send![self, initWithObjectsAndKeys: firstObject]
+    }
+
+    unsafe fn count(self) -> NSUInteger {
+        msg_send![self, count]
+    }
+
+    unsafe fn isEqualToDictionary_(self, otherDictionary: id) -> BOOL {
+        msg_send![self, isEqualToDictionary: otherDictionary]
+    }
+
+    unsafe fn allKeys(self) -> id {
+        msg_send![self, allKeys]
+    }
+
+    unsafe fn allKeysForObject_(self, anObject: id) -> id {
+        msg_send![self, allKeysForObject: anObject]
+    }
+
+    unsafe fn allValues(self) -> id {
+        msg_send![self, allValues]
+    }
+
+    unsafe fn objectForKey_(self, aKey: id) -> id {
+        msg_send![self, objectForKey: aKey]
+    }
+
+    unsafe fn objectForKeyedSubscript_(self, key: id) -> id {
+        msg_send![self, objectForKeyedSubscript: key]
+    }
+
+    unsafe fn objectsForKeys_notFoundMarker_(self, keys: id, anObject: id) -> id {
+        msg_send![self, objectsForKeys:keys notFoundMarker:anObject]
+    }
+    */
+
+    unsafe fn valueForKey_(self, key: id) -> id {
+        msg_send![self, valueForKey: key]
+    }
+
+    /*
+
+    unsafe fn keyEnumerator(self) -> id {
+        msg_send![self, keyEnumerator]
+    }
+
+    unsafe fn objectEnumerator(self) -> id {
+        msg_send![self, objectEnumerator]
+    }
+
+    unsafe fn enumerateKeysAndObjectsUsingBlock_(self, block: *mut Block<(id, id, *mut BOOL), ()>) {
+        msg_send![self, enumerateKeysAndObjectsUsingBlock: block]
+    }
+
+    unsafe fn enumerateKeysAndObjectsWithOptions_usingBlock_(
+        self,
+        opts: NSEnumerationOptions,
+        block: *mut Block<(id, id, *mut BOOL), ()>,
+    ) {
+        msg_send![self, enumerateKeysAndObjectsWithOptions:opts usingBlock:block]
+    }
+
+    unsafe fn keysSortedByValueUsingSelector_(self, comparator: SEL) -> id {
+        msg_send![self, keysSortedByValueUsingSelector: comparator]
+    }
+
+    unsafe fn keysSortedByValueUsingComparator_(self, cmptr: NSComparator) -> id {
+        msg_send![self, keysSortedByValueUsingComparator: cmptr]
+    }
+
+    unsafe fn keysSortedByValueWithOptions_usingComparator_(
+        self,
+        opts: NSEnumerationOptions,
+        cmptr: NSComparator,
+    ) -> id {
+        let rv: id = msg_send![self, keysSortedByValueWithOptions:opts usingComparator:cmptr];
+        rv
+    }
+
+    unsafe fn keysOfEntriesPassingTest_(
+        self,
+        predicate: *mut Block<(id, id, *mut BOOL), BOOL>,
+    ) -> id {
+        msg_send![self, keysOfEntriesPassingTest: predicate]
+    }
+
+    unsafe fn keysOfEntriesWithOptions_PassingTest_(
+        self,
+        opts: NSEnumerationOptions,
+        predicate: *mut Block<(id, id, *mut BOOL), BOOL>,
+    ) -> id {
+        msg_send![self, keysOfEntriesWithOptions:opts PassingTest:predicate]
+    }
+
+    unsafe fn writeToFile_atomically_(self, path: id, flag: BOOL) -> BOOL {
+        msg_send![self, writeToFile:path atomically:flag]
+    }
+
+    unsafe fn writeToURL_atomically_(self, aURL: id, flag: BOOL) -> BOOL {
+        msg_send![self, writeToURL:aURL atomically:flag]
+    }
+
+    unsafe fn fileCreationDate(self) -> id {
+        msg_send![self, fileCreationDate]
+    }
+
+    unsafe fn fileExtensionHidden(self) -> BOOL {
+        msg_send![self, fileExtensionHidden]
+    }
+
+    unsafe fn fileGroupOwnerAccountID(self) -> id {
+        msg_send![self, fileGroupOwnerAccountID]
+    }
+
+    unsafe fn fileGroupOwnerAccountName(self) -> id {
+        msg_send![self, fileGroupOwnerAccountName]
+    }
+
+    unsafe fn fileIsAppendOnly(self) -> BOOL {
+        msg_send![self, fileIsAppendOnly]
+    }
+
+    unsafe fn fileIsImmutable(self) -> BOOL {
+        msg_send![self, fileIsImmutable]
+    }
+
+    unsafe fn fileModificationDate(self) -> id {
+        msg_send![self, fileModificationDate]
+    }
+
+    unsafe fn fileOwnerAccountID(self) -> id {
+        msg_send![self, fileOwnerAccountID]
+    }
+
+    unsafe fn fileOwnerAccountName(self) -> id {
+        msg_send![self, fileOwnerAccountName]
+    }
+
+    unsafe fn filePosixPermissions(self) -> NSUInteger {
+        msg_send![self, filePosixPermissions]
+    }
+
+    unsafe fn fileSize(self) -> libc::c_ulonglong {
+        msg_send![self, fileSize]
+    }
+
+    unsafe fn fileSystemFileNumber(self) -> NSUInteger {
+        msg_send![self, fileSystemFileNumber]
+    }
+
+    unsafe fn fileSystemNumber(self) -> NSInteger {
+        msg_send![self, fileSystemNumber]
+    }
+
+    unsafe fn fileType(self) -> id {
+        msg_send![self, fileType]
+    }
+
+    unsafe fn description(self) -> id {
+        msg_send![self, description]
+    }
+
+    unsafe fn descriptionInStringsFileFormat(self) -> id {
+        msg_send![self, descriptionInStringsFileFormat]
+    }
+
+    unsafe fn descriptionWithLocale_(self, locale: id) -> id {
+        msg_send![self, descriptionWithLocale: locale]
+    }
+
+    unsafe fn descriptionWithLocale_indent_(self, locale: id, indent: NSUInteger) -> id {
+        msg_send![self, descriptionWithLocale:locale indent:indent]
+    }
+    */
+}
+
+bitflags! {
+    pub struct NSEnumerationOptions: libc::c_ulonglong {
+        const NSEnumerationConcurrent = 1 << 0;
+        const NSEnumerationReverse = 1 << 1;
+    }
+}
+
+bitflags! {
+    pub struct NSEventPhase: NSUInteger {
+       const NSEventPhaseNone        = 0;
+       const NSEventPhaseBegan       = 0x1 << 0;
+       const NSEventPhaseStationary  = 0x1 << 1;
+       const NSEventPhaseChanged     = 0x1 << 2;
+       const NSEventPhaseEnded       = 0x1 << 3;
+       const NSEventPhaseCancelled   = 0x1 << 4;
+       const NSEventPhaseMayBegin    = 0x1 << 5;
+    }
+}
+
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {
+    pub static NSFilenamesPboardType: id;
+
+    pub static NSAppKitVersionNumber: f64;
+}
+
+pub const NSAppKitVersionNumber10_12: f64 = 1504.0;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Default)]
+pub struct CGPoint {
+    pub x: CGFloat,
+    pub y: CGFloat,
+}
+
+impl CGPoint {
+    // #[inline]
+    // pub fn new(x: CGFloat, y: CGFloat) -> CGPoint {
+    //     CGPoint { x, y }
+    // }
+
+    // #[inline]
+    // pub fn apply_transform(&self, t: &CGAffineTransform) -> CGPoint {
+    //     unsafe { ffi::CGPointApplyAffineTransform(*self, *t) }
+    // }
+}

--- a/src/platform_impl/macos/util/thin_core_foundation.rs
+++ b/src/platform_impl/macos/util/thin_core_foundation.rs
@@ -1,0 +1,1012 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(unused)]
+
+use std::os::raw::{c_int, c_uint, c_void};
+
+#[repr(C)]
+pub struct __CFString(c_void);
+
+pub type CFStringRef = *const __CFString;
+
+pub type Boolean = u8;
+pub type mach_port_t = c_uint;
+pub type CFAllocatorRef = *const c_void;
+pub type CFNullRef = *const c_void;
+pub type CFTypeRef = *const c_void;
+pub type OSStatus = i32;
+pub type SInt32 = c_int;
+pub type CFTypeID = usize;
+pub type CFOptionFlags = usize;
+pub type CFHashCode = usize;
+pub type CFIndex = isize;
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CFRange {
+    pub location: CFIndex,
+    pub length: CFIndex,
+}
+
+// for back-compat
+impl CFRange {
+    pub fn init(location: CFIndex, length: CFIndex) -> CFRange {
+        CFRange { location, length }
+    }
+}
+
+extern "C" {
+    /*
+     * CFBase.h
+     */
+
+    /* CFAllocator Reference */
+
+    pub static kCFAllocatorDefault: CFAllocatorRef;
+    pub static kCFAllocatorSystemDefault: CFAllocatorRef;
+    pub static kCFAllocatorMalloc: CFAllocatorRef;
+    pub static kCFAllocatorMallocZone: CFAllocatorRef;
+    pub static kCFAllocatorNull: CFAllocatorRef;
+    pub static kCFAllocatorUseContext: CFAllocatorRef;
+
+    pub fn CFAllocatorCreate(
+        allocator: CFAllocatorRef,
+        context: *mut CFAllocatorContext,
+    ) -> CFAllocatorRef;
+    pub fn CFAllocatorAllocate(
+        allocator: CFAllocatorRef,
+        size: CFIndex,
+        hint: CFOptionFlags,
+    ) -> *mut c_void;
+    pub fn CFAllocatorDeallocate(allocator: CFAllocatorRef, ptr: *mut c_void);
+    pub fn CFAllocatorGetPreferredSizeForSize(
+        allocator: CFAllocatorRef,
+        size: CFIndex,
+        hint: CFOptionFlags,
+    ) -> CFIndex;
+    pub fn CFAllocatorReallocate(
+        allocator: CFAllocatorRef,
+        ptr: *mut c_void,
+        newsize: CFIndex,
+        hint: CFOptionFlags,
+    ) -> *mut c_void;
+    pub fn CFAllocatorGetDefault() -> CFAllocatorRef;
+    pub fn CFAllocatorSetDefault(allocator: CFAllocatorRef);
+    pub fn CFAllocatorGetContext(allocator: CFAllocatorRef, context: *mut CFAllocatorContext);
+    pub fn CFAllocatorGetTypeID() -> CFTypeID;
+
+    /* CFNull Reference */
+
+    pub static kCFNull: CFNullRef;
+
+    /* CFType Reference */
+
+    //fn CFCopyTypeIDDescription
+    //fn CFGetAllocator
+    pub fn CFCopyDescription(cf: CFTypeRef) -> CFStringRef;
+    pub fn CFEqual(cf1: CFTypeRef, cf2: CFTypeRef) -> Boolean;
+    pub fn CFGetRetainCount(cf: CFTypeRef) -> CFIndex;
+    pub fn CFGetTypeID(cf: CFTypeRef) -> CFTypeID;
+    pub fn CFHash(cf: CFTypeRef) -> CFHashCode;
+    //fn CFMakeCollectable
+    pub fn CFRelease(cf: CFTypeRef);
+    pub fn CFRetain(cf: CFTypeRef) -> CFTypeRef;
+    pub fn CFShow(obj: CFTypeRef);
+
+    /* Base Utilities Reference */
+    // N.B. Some things missing here.
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CFAllocatorContext {
+    pub version: CFIndex,
+    pub info: *mut c_void,
+    pub retain: Option<CFAllocatorRetainCallBack>,
+    pub release: Option<CFAllocatorReleaseCallBack>,
+    pub copyDescription: Option<CFAllocatorCopyDescriptionCallBack>,
+    pub allocate: Option<CFAllocatorAllocateCallBack>,
+    pub reallocate: Option<CFAllocatorReallocateCallBack>,
+    pub deallocate: Option<CFAllocatorDeallocateCallBack>,
+    pub preferredSize: Option<CFAllocatorPreferredSizeCallBack>,
+}
+
+pub type CFAllocatorRetainCallBack = extern "C" fn(info: *mut c_void) -> *mut c_void;
+pub type CFAllocatorReleaseCallBack = extern "C" fn(info: *mut c_void);
+pub type CFAllocatorCopyDescriptionCallBack = extern "C" fn(info: *mut c_void) -> CFStringRef;
+pub type CFAllocatorAllocateCallBack =
+    extern "C" fn(allocSize: CFIndex, hint: CFOptionFlags, info: *mut c_void) -> *mut c_void;
+pub type CFAllocatorReallocateCallBack = extern "C" fn(
+    ptr: *mut c_void,
+    newsize: CFIndex,
+    hint: CFOptionFlags,
+    info: *mut c_void,
+) -> *mut c_void;
+pub type CFAllocatorDeallocateCallBack = extern "C" fn(ptr: *mut c_void, info: *mut c_void);
+pub type CFAllocatorPreferredSizeCallBack =
+    extern "C" fn(size: CFIndex, hint: CFOptionFlags, info: *mut c_void) -> CFIndex;
+
+pub mod array {
+    // Copyright 2013-2015 The Servo Project Developers. See the COPYRIGHT
+    // file at the top-level directory of this distribution.
+    //
+    // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+    // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+    // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+    // option. This file may not be copied, modified, or distributed
+    // except according to those terms.
+
+    use std::os::raw::c_void;
+
+    use super::CFStringRef;
+    use super::{Boolean, CFAllocatorRef, CFIndex, CFRange, CFTypeID};
+
+    pub type CFArrayRetainCallBack =
+        extern "C" fn(allocator: CFAllocatorRef, value: *const c_void) -> *const c_void;
+    pub type CFArrayReleaseCallBack =
+        extern "C" fn(allocator: CFAllocatorRef, value: *const c_void);
+    pub type CFArrayCopyDescriptionCallBack = extern "C" fn(value: *const c_void) -> CFStringRef;
+    pub type CFArrayEqualCallBack =
+        extern "C" fn(value1: *const c_void, value2: *const c_void) -> Boolean;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct CFArrayCallBacks {
+        pub version: CFIndex,
+        pub retain: CFArrayRetainCallBack,
+        pub release: CFArrayReleaseCallBack,
+        pub copyDescription: CFArrayCopyDescriptionCallBack,
+        pub equal: CFArrayEqualCallBack,
+    }
+
+    #[repr(C)]
+    pub struct __CFArray(c_void);
+
+    pub type CFArrayRef = *const __CFArray;
+
+    extern "C" {
+        /*
+         * CFArray.h
+         */
+        pub static kCFTypeArrayCallBacks: CFArrayCallBacks;
+
+        pub fn CFArrayCreate(
+            allocator: CFAllocatorRef,
+            values: *const *const c_void,
+            numValues: CFIndex,
+            callBacks: *const CFArrayCallBacks,
+        ) -> CFArrayRef;
+        pub fn CFArrayCreateCopy(allocator: CFAllocatorRef, theArray: CFArrayRef) -> CFArrayRef;
+
+        // CFArrayBSearchValues
+        // CFArrayContainsValue
+        pub fn CFArrayGetCount(theArray: CFArrayRef) -> CFIndex;
+        // CFArrayGetCountOfValue
+        // CFArrayGetFirstIndexOfValue
+        // CFArrayGetLastIndexOfValue
+        pub fn CFArrayGetValues(theArray: CFArrayRef, range: CFRange, values: *mut *const c_void);
+        pub fn CFArrayGetValueAtIndex(theArray: CFArrayRef, idx: CFIndex) -> *const c_void;
+        // CFArrayApplyFunction
+        pub fn CFArrayGetTypeID() -> CFTypeID;
+    }
+}
+
+pub mod dictionary {
+    // Copyright 2013-2015 The Servo Project Developers. See the COPYRIGHT
+    // file at the top-level directory of this distribution.
+    //
+    // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+    // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+    // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+    // option. This file may not be copied, modified, or distributed
+    // except according to those terms.
+
+    use std::os::raw::c_void;
+
+    use super::CFStringRef;
+    use super::{Boolean, CFAllocatorRef, CFHashCode, CFIndex, CFTypeID};
+
+    pub type CFDictionaryApplierFunction =
+        extern "C" fn(key: *const c_void, value: *const c_void, context: *mut c_void);
+
+    pub type CFDictionaryRetainCallBack =
+        extern "C" fn(allocator: CFAllocatorRef, value: *const c_void) -> *const c_void;
+    pub type CFDictionaryReleaseCallBack =
+        extern "C" fn(allocator: CFAllocatorRef, value: *const c_void);
+    pub type CFDictionaryCopyDescriptionCallBack =
+        extern "C" fn(value: *const c_void) -> CFStringRef;
+    pub type CFDictionaryEqualCallBack =
+        extern "C" fn(value1: *const c_void, value2: *const c_void) -> Boolean;
+    pub type CFDictionaryHashCallBack = extern "C" fn(value: *const c_void) -> CFHashCode;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct CFDictionaryKeyCallBacks {
+        pub version: CFIndex,
+        pub retain: CFDictionaryRetainCallBack,
+        pub release: CFDictionaryReleaseCallBack,
+        pub copyDescription: CFDictionaryCopyDescriptionCallBack,
+        pub equal: CFDictionaryEqualCallBack,
+        pub hash: CFDictionaryHashCallBack,
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    pub struct CFDictionaryValueCallBacks {
+        pub version: CFIndex,
+        pub retain: CFDictionaryRetainCallBack,
+        pub release: CFDictionaryReleaseCallBack,
+        pub copyDescription: CFDictionaryCopyDescriptionCallBack,
+        pub equal: CFDictionaryEqualCallBack,
+    }
+
+    #[repr(C)]
+    pub struct __CFDictionary(c_void);
+
+    pub type CFDictionaryRef = *const __CFDictionary;
+    pub type CFMutableDictionaryRef = *mut __CFDictionary;
+
+    extern "C" {
+        /*
+         * CFDictionary.h
+         */
+
+        pub static kCFTypeDictionaryKeyCallBacks: CFDictionaryKeyCallBacks;
+        pub static kCFTypeDictionaryValueCallBacks: CFDictionaryValueCallBacks;
+
+        pub fn CFDictionaryContainsKey(theDict: CFDictionaryRef, key: *const c_void) -> Boolean;
+        pub fn CFDictionaryCreate(
+            allocator: CFAllocatorRef,
+            keys: *const *const c_void,
+            values: *const *const c_void,
+            numValues: CFIndex,
+            keyCallBacks: *const CFDictionaryKeyCallBacks,
+            valueCallBacks: *const CFDictionaryValueCallBacks,
+        ) -> CFDictionaryRef;
+        pub fn CFDictionaryGetCount(theDict: CFDictionaryRef) -> CFIndex;
+        pub fn CFDictionaryGetTypeID() -> CFTypeID;
+        pub fn CFDictionaryGetValueIfPresent(
+            theDict: CFDictionaryRef,
+            key: *const c_void,
+            value: *mut *const c_void,
+        ) -> Boolean;
+        pub fn CFDictionaryApplyFunction(
+            theDict: CFDictionaryRef,
+            applier: CFDictionaryApplierFunction,
+            context: *mut c_void,
+        );
+        pub fn CFDictionaryGetKeysAndValues(
+            theDict: CFDictionaryRef,
+            keys: *mut *const c_void,
+            values: *mut *const c_void,
+        );
+
+        pub fn CFDictionaryCreateMutable(
+            allocator: CFAllocatorRef,
+            capacity: CFIndex,
+            keyCallbacks: *const CFDictionaryKeyCallBacks,
+            valueCallbacks: *const CFDictionaryValueCallBacks,
+        ) -> CFMutableDictionaryRef;
+        pub fn CFDictionaryCreateMutableCopy(
+            allocator: CFAllocatorRef,
+            capacity: CFIndex,
+            theDict: CFDictionaryRef,
+        ) -> CFMutableDictionaryRef;
+        pub fn CFDictionaryAddValue(
+            theDict: CFMutableDictionaryRef,
+            key: *const c_void,
+            value: *const c_void,
+        );
+        pub fn CFDictionarySetValue(
+            theDict: CFMutableDictionaryRef,
+            key: *const c_void,
+            value: *const c_void,
+        );
+        pub fn CFDictionaryReplaceValue(
+            theDict: CFMutableDictionaryRef,
+            key: *const c_void,
+            value: *const c_void,
+        );
+        pub fn CFDictionaryRemoveValue(theDict: CFMutableDictionaryRef, key: *const c_void);
+        pub fn CFDictionaryRemoveAllValues(theDict: CFMutableDictionaryRef);
+    }
+}
+
+pub mod string {
+    // Copyright 2013-2015 The Servo Project Developers. See the COPYRIGHT
+    // file at the top-level directory of this distribution.
+    //
+    // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+    // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+    // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+    // option. This file may not be copied, modified, or distributed
+    // except according to those terms.
+
+    use std::os::raw::{c_char, c_ushort, c_void};
+
+    use super::{Boolean, CFAllocatorRef, CFIndex, CFOptionFlags, CFRange, CFTypeID};
+
+    pub type UniChar = c_ushort;
+
+    // CFString.h
+
+    pub type CFStringCompareFlags = CFOptionFlags;
+    //static kCFCompareCaseInsensitive: CFStringCompareFlags = 1;
+    //static kCFCompareBackwards: CFStringCompareFlags = 4;
+    //static kCFCompareAnchored: CFStringCompareFlags = 8;
+    //static kCFCompareNonliteral: CFStringCompareFlags = 16;
+    //static kCFCompareLocalized: CFStringCompareFlags = 32;
+    //static kCFCompareNumerically: CFStringCompareFlags = 64;
+    //static kCFCompareDiacriticInsensitive: CFStringCompareFlags = 128;
+    //static kCFCompareWidthInsensitive: CFStringCompareFlags = 256;
+    //static kCFCompareForcedOrdering: CFStringCompareFlags = 512;
+
+    pub type CFStringEncoding = u32;
+
+    // macOS built-in encodings.
+
+    //static kCFStringEncodingMacRoman: CFStringEncoding = 0;
+    //static kCFStringEncodingWindowsLatin1: CFStringEncoding = 0x0500;
+    //static kCFStringEncodingISOLatin1: CFStringEncoding = 0x0201;
+    //static kCFStringEncodingNextStepLatin: CFStringEncoding = 0x0B01;
+    //static kCFStringEncodingASCII: CFStringEncoding = 0x0600;
+    //static kCFStringEncodingUnicode: CFStringEncoding = 0x0100;
+    pub static kCFStringEncodingUTF8: CFStringEncoding = 0x08000100;
+    //static kCFStringEncodingNonLossyASCII: CFStringEncoding = 0x0BFF;
+
+    //static kCFStringEncodingUTF16: CFStringEncoding = 0x0100;
+    //static kCFStringEncodingUTF16BE: CFStringEncoding = 0x10000100;
+    //static kCFStringEncodingUTF16LE: CFStringEncoding = 0x14000100;
+    //static kCFStringEncodingUTF32: CFStringEncoding = 0x0c000100;
+    //static kCFStringEncodingUTF32BE: CFStringEncoding = 0x18000100;
+    //static kCFStringEncodingUTF32LE: CFStringEncoding = 0x1c000100;
+
+    // CFStringEncodingExt.h
+
+    pub type CFStringEncodings = CFIndex;
+
+    // External encodings, except those defined above.
+    // Defined above: kCFStringEncodingMacRoman = 0
+    //static kCFStringEncodingMacJapanese: CFStringEncoding = 1;
+    //static kCFStringEncodingMacChineseTrad: CFStringEncoding = 2;
+    //static kCFStringEncodingMacKorean: CFStringEncoding = 3;
+    //static kCFStringEncodingMacArabic: CFStringEncoding = 4;
+    //static kCFStringEncodingMacHebrew: CFStringEncoding = 5;
+    //static kCFStringEncodingMacGreek: CFStringEncoding = 6;
+    //static kCFStringEncodingMacCyrillic: CFStringEncoding = 7;
+    //static kCFStringEncodingMacDevanagari: CFStringEncoding = 9;
+    //static kCFStringEncodingMacGurmukhi: CFStringEncoding = 10;
+    //static kCFStringEncodingMacGujarati: CFStringEncoding = 11;
+    //static kCFStringEncodingMacOriya: CFStringEncoding = 12;
+    //static kCFStringEncodingMacBengali: CFStringEncoding = 13;
+    //static kCFStringEncodingMacTamil: CFStringEncoding = 14;
+    //static kCFStringEncodingMacTelugu: CFStringEncoding = 15;
+    //static kCFStringEncodingMacKannada: CFStringEncoding = 16;
+    //static kCFStringEncodingMacMalayalam: CFStringEncoding = 17;
+    //static kCFStringEncodingMacSinhalese: CFStringEncoding = 18;
+    //static kCFStringEncodingMacBurmese: CFStringEncoding = 19;
+    //static kCFStringEncodingMacKhmer: CFStringEncoding = 20;
+    //static kCFStringEncodingMacThai: CFStringEncoding = 21;
+    //static kCFStringEncodingMacLaotian: CFStringEncoding = 22;
+    //static kCFStringEncodingMacGeorgian: CFStringEncoding = 23;
+    //static kCFStringEncodingMacArmenian: CFStringEncoding = 24;
+    //static kCFStringEncodingMacChineseSimp: CFStringEncoding = 25;
+    //static kCFStringEncodingMacTibetan: CFStringEncoding = 26;
+    //static kCFStringEncodingMacMongolian: CFStringEncoding = 27;
+    //static kCFStringEncodingMacEthiopic: CFStringEncoding = 28;
+    //static kCFStringEncodingMacCentralEurRoman: CFStringEncoding = 29;
+    //static kCFStringEncodingMacVietnamese: CFStringEncoding = 30;
+    //static kCFStringEncodingMacExtArabic: CFStringEncoding = 31;
+    //static kCFStringEncodingMacSymbol: CFStringEncoding = 33;
+    //static kCFStringEncodingMacDingbats: CFStringEncoding = 34;
+    //static kCFStringEncodingMacTurkish: CFStringEncoding = 35;
+    //static kCFStringEncodingMacCroatian: CFStringEncoding = 36;
+    //static kCFStringEncodingMacIcelandic: CFStringEncoding = 37;
+    //static kCFStringEncodingMacRomanian: CFStringEncoding = 38;
+    //static kCFStringEncodingMacCeltic: CFStringEncoding = 39;
+    //static kCFStringEncodingMacGaelic: CFStringEncoding = 40;
+    //static kCFStringEncodingMacFarsi: CFStringEncoding = 0x8C;
+    //static kCFStringEncodingMacUkrainian: CFStringEncoding = 0x98;
+    //static kCFStringEncodingMacInuit: CFStringEncoding = 0xEC;
+    //static kCFStringEncodingMacVT100: CFStringEncoding = 0xFC;
+    //static kCFStringEncodingMacHFS: CFStringEncoding = 0xFF;
+    // Defined above: kCFStringEncodingISOLatin1 = 0x0201
+    //static kCFStringEncodingISOLatin2: CFStringEncoding = 0x0202;
+    //static kCFStringEncodingISOLatin3: CFStringEncoding = 0x0203;
+    //static kCFStringEncodingISOLatin4: CFStringEncoding = 0x0204;
+    //static kCFStringEncodingISOLatinCyrillic: CFStringEncoding = 0x0205;
+    //static kCFStringEncodingISOLatinArabic: CFStringEncoding = 0x0206;
+    //static kCFStringEncodingISOLatinGreek: CFStringEncoding = 0x0207;
+    //static kCFStringEncodingISOLatinHebrew: CFStringEncoding = 0x0208;
+    //static kCFStringEncodingISOLatin5: CFStringEncoding = 0x0209;
+    //static kCFStringEncodingISOLatin6: CFStringEncoding = 0x020A;
+    //static kCFStringEncodingISOLatinThai: CFStringEncoding = 0x020B;
+    //static kCFStringEncodingISOLatin7: CFStringEncoding = 0x020D;
+    //static kCFStringEncodingISOLatin8: CFStringEncoding = 0x020E;
+    //static kCFStringEncodingISOLatin9: CFStringEncoding = 0x020F;
+    //static kCFStringEncodingISOLatin10: CFStringEncoding = 0x0210;
+    //static kCFStringEncodingDOSLatinUS: CFStringEncoding = 0x0400;
+    //static kCFStringEncodingDOSGreek: CFStringEncoding = 0x0405;
+    //static kCFStringEncodingDOSBalticRim: CFStringEncoding = 0x0406;
+    //static kCFStringEncodingDOSLatin1: CFStringEncoding = 0x0410;
+    //static kCFStringEncodingDOSGreek1: CFStringEncoding = 0x0411;
+    //static kCFStringEncodingDOSLatin2: CFStringEncoding = 0x0412;
+    //static kCFStringEncodingDOSCyrillic: CFStringEncoding = 0x0413;
+    //static kCFStringEncodingDOSTurkish: CFStringEncoding = 0x0414;
+    //static kCFStringEncodingDOSPortuguese: CFStringEncoding = 0x0415;
+    //static kCFStringEncodingDOSIcelandic: CFStringEncoding = 0x0416;
+    //static kCFStringEncodingDOSHebrew: CFStringEncoding = 0x0417;
+    //static kCFStringEncodingDOSCanadianFrench: CFStringEncoding = 0x0418;
+    //static kCFStringEncodingDOSArabic: CFStringEncoding = 0x0419;
+    //static kCFStringEncodingDOSNordic: CFStringEncoding = 0x041A;
+    //static kCFStringEncodingDOSRussian: CFStringEncoding = 0x041B;
+    //static kCFStringEncodingDOSGreek2: CFStringEncoding = 0x041C;
+    //static kCFStringEncodingDOSThai: CFStringEncoding = 0x041D;
+    //static kCFStringEncodingDOSJapanese: CFStringEncoding = 0x0420;
+    //static kCFStringEncodingDOSChineseSimplif: CFStringEncoding = 0x0421;
+    //static kCFStringEncodingDOSKorean: CFStringEncoding = 0x0422;
+    //static kCFStringEncodingDOSChineseTrad: CFStringEncoding = 0x0423;
+    // Defined above: kCFStringEncodingWindowsLatin1 = 0x0500
+    //static kCFStringEncodingWindowsLatin2: CFStringEncoding = 0x0501;
+    //static kCFStringEncodingWindowsCyrillic: CFStringEncoding = 0x0502;
+    //static kCFStringEncodingWindowsGreek: CFStringEncoding = 0x0503;
+    //static kCFStringEncodingWindowsLatin5: CFStringEncoding = 0x0504;
+    //static kCFStringEncodingWindowsHebrew: CFStringEncoding = 0x0505;
+    //static kCFStringEncodingWindowsArabic: CFStringEncoding = 0x0506;
+    //static kCFStringEncodingWindowsBalticRim: CFStringEncoding = 0x0507;
+    //static kCFStringEncodingWindowsVietnamese: CFStringEncoding = 0x0508;
+    //static kCFStringEncodingWindowsKoreanJohab: CFStringEncoding = 0x0510;
+    // Defined above: kCFStringEncodingASCII = 0x0600
+    //static kCFStringEncodingANSEL: CFStringEncoding = 0x0601;
+    //static kCFStringEncodingJIS_X0201_76: CFStringEncoding = 0x0620;
+    //static kCFStringEncodingJIS_X0208_83: CFStringEncoding = 0x0621;
+    //static kCFStringEncodingJIS_X0208_90: CFStringEncoding = 0x0622;
+    //static kCFStringEncodingJIS_X0212_90: CFStringEncoding = 0x0623;
+    //static kCFStringEncodingJIS_C6226_78: CFStringEncoding = 0x0624;
+    //static kCFStringEncodingShiftJIS_X0213: CFStringEncoding = 0x0628;
+    //static kCFStringEncodingShiftJIS_X0213_MenKuTen: CFStringEncoding = 0x0629;
+    //static kCFStringEncodingGB_2312_80: CFStringEncoding = 0x0630;
+    //static kCFStringEncodingGBK_95: CFStringEncoding = 0x0631;
+    //static kCFStringEncodingGB_18030_2000: CFStringEncoding = 0x0632;
+    //static kCFStringEncodingKSC_5601_87: CFStringEncoding = 0x0640;
+    //static kCFStringEncodingKSC_5601_92_Johab: CFStringEncoding = 0x0641;
+    //static kCFStringEncodingCNS_11643_92_P1: CFStringEncoding = 0x0651;
+    //static kCFStringEncodingCNS_11643_92_P2: CFStringEncoding = 0x0652;
+    //static kCFStringEncodingCNS_11643_92_P3: CFStringEncoding = 0x0653;
+    //static kCFStringEncodingISO_2022_JP: CFStringEncoding = 0x0820;
+    //static kCFStringEncodingISO_2022_JP_2: CFStringEncoding = 0x0821;
+    //static kCFStringEncodingISO_2022_JP_1: CFStringEncoding = 0x0822;
+    //static kCFStringEncodingISO_2022_JP_3: CFStringEncoding = 0x0823;
+    //static kCFStringEncodingISO_2022_CN: CFStringEncoding = 0x0830;
+    //static kCFStringEncodingISO_2022_CN_EXT: CFStringEncoding = 0x0831;
+    //static kCFStringEncodingISO_2022_KR: CFStringEncoding = 0x0840;
+    //static kCFStringEncodingEUC_JP: CFStringEncoding = 0x0920;
+    //static kCFStringEncodingEUC_CN: CFStringEncoding = 0x0930;
+    //static kCFStringEncodingEUC_TW: CFStringEncoding = 0x0931;
+    //static kCFStringEncodingEUC_KR: CFStringEncoding = 0x0940;
+    //static kCFStringEncodingShiftJIS: CFStringEncoding = 0x0A01;
+    //static kCFStringEncodingKOI8_R: CFStringEncoding = 0x0A02;
+    //static kCFStringEncodingBig5: CFStringEncoding = 0x0A03;
+    //static kCFStringEncodingMacRomanLatin1: CFStringEncoding = 0x0A04;
+    //static kCFStringEncodingHZ_GB_2312: CFStringEncoding = 0x0A05;
+    //static kCFStringEncodingBig5_HKSCS_1999: CFStringEncoding = 0x0A06;
+    //static kCFStringEncodingVISCII: CFStringEncoding = 0x0A07;
+    //static kCFStringEncodingKOI8_U: CFStringEncoding = 0x0A08;
+    //static kCFStringEncodingBig5_E: CFStringEncoding = 0x0A09;
+    // Defined above: kCFStringEncodingNextStepLatin = 0x0B01
+    //static kCFStringEncodingNextStepJapanese: CFStringEncoding = 0x0B02;
+    //static kCFStringEncodingEBCDIC_US: CFStringEncoding = 0x0C01;
+    //static kCFStringEncodingEBCDIC_CP037: CFStringEncoding = 0x0C02;
+    //static kCFStringEncodingUTF7: CFStringEncoding = 0x04000100;
+    //static kCFStringEncodingUTF7_IMAP: CFStringEncoding = 0x0A10;
+    //static kCFStringEncodingShiftJIS_X0213_00: CFStringEncoding = 0x0628; /* Deprecated */
+    #[repr(C)]
+    pub struct __CFString(c_void);
+
+    pub type CFStringRef = *const __CFString;
+
+    extern "C" {
+        /*
+         * CFString.h
+         */
+
+        // N.B. organized according to "Functions by task" in docs
+
+        /* Creating a CFString */
+        //fn CFSTR
+        //fn CFStringCreateArrayBySeparatingStrings
+        //fn CFStringCreateByCombiningStrings
+        //fn CFStringCreateCopy
+        //fn CFStringCreateFromExternalRepresentation
+        pub fn CFStringCreateWithBytes(
+            alloc: CFAllocatorRef,
+            bytes: *const u8,
+            numBytes: CFIndex,
+            encoding: CFStringEncoding,
+            isExternalRepresentation: Boolean,
+        ) -> CFStringRef;
+        pub fn CFStringCreateWithBytesNoCopy(
+            alloc: CFAllocatorRef,
+            bytes: *const u8,
+            numBytes: CFIndex,
+            encoding: CFStringEncoding,
+            isExternalRepresentation: Boolean,
+            contentsDeallocator: CFAllocatorRef,
+        ) -> CFStringRef;
+        //fn CFStringCreateWithCharacters
+        pub fn CFStringCreateWithCharactersNoCopy(
+            alloc: CFAllocatorRef,
+            chars: *const UniChar,
+            numChars: CFIndex,
+            contentsDeallocator: CFAllocatorRef,
+        ) -> CFStringRef;
+        pub fn CFStringCreateWithCString(
+            alloc: CFAllocatorRef,
+            cStr: *const c_char,
+            encoding: CFStringEncoding,
+        ) -> CFStringRef;
+        //fn CFStringCreateWithCStringNoCopy
+        //fn CFStringCreateWithFormat
+        //fn CFStringCreateWithFormatAndArguments
+        //fn CFStringCreateWithPascalString
+        //fn CFStringCreateWithPascalStringNoCopy
+        //fn CFStringCreateWithSubstring
+
+        /* Searching Strings */
+        //fn CFStringCreateArrayWithFindResults
+        //fn CFStringFind
+        //fn CFStringFindCharacterFromSet
+        //fn CFStringFindWithOptions
+        //fn CFStringFindWithOptionsAndLocale
+        //fn CFStringGetLineBounds
+
+        /* Comparing Strings */
+        //fn CFStringCompare
+        //fn CFStringCompareWithOptions
+        //fn CFStringCompareWithOptionsAndLocale
+        //fn CFStringHasPrefix
+        //fn CFStringHasSuffix
+
+        /* Accessing Characters */
+        //fn CFStringCreateExternalRepresentation
+        pub fn CFStringGetBytes(
+            theString: CFStringRef,
+            range: CFRange,
+            encoding: CFStringEncoding,
+            lossByte: u8,
+            isExternalRepresentation: Boolean,
+            buffer: *mut u8,
+            maxBufLen: CFIndex,
+            usedBufLen: *mut CFIndex,
+        ) -> CFIndex;
+        //fn CFStringGetCharacterAtIndex
+        //fn CFStringGetCharacters
+        //fn CFStringGetCharactersPtr
+        //fn CFStringGetCharacterFromInlineBuffer
+        pub fn CFStringGetCString(
+            theString: CFStringRef,
+            buffer: *mut c_char,
+            bufferSize: CFIndex,
+            encoding: CFStringEncoding,
+        ) -> Boolean;
+        pub fn CFStringGetCStringPtr(
+            theString: CFStringRef,
+            encoding: CFStringEncoding,
+        ) -> *const c_char;
+        pub fn CFStringGetLength(theString: CFStringRef) -> CFIndex;
+        //fn CFStringGetPascalString
+        //fn CFStringGetPascalStringPtr
+        //fn CFStringGetRangeOfComposedCharactersAtIndex
+        //fn CFStringInitInlineBuffer
+
+        /* Working With Hyphenation */
+        //fn CFStringGetHyphenationLocationBeforeIndex
+        //fn CFStringIsHyphenationAvailableForLocale
+
+        /* Working With Encodings */
+        //fn CFStringConvertEncodingToIANACharSetName
+        //fn CFStringConvertEncodingToNSStringEncoding
+        //fn CFStringConvertEncodingToWindowsCodepage
+        //fn CFStringConvertIANACharSetNameToEncoding
+        //fn CFStringConvertNSStringEncodingToEncoding
+        //fn CFStringConvertWindowsCodepageToEncoding
+        //fn CFStringGetFastestEncoding
+        //fn CFStringGetListOfAvailableEncodings
+        //fn CFStringGetMaximumSizeForEncoding
+        //fn CFStringGetMostCompatibleMacStringEncoding
+        //fn CFStringGetNameOfEncoding
+        //fn CFStringGetSmallestEncoding
+        //fn CFStringGetSystemEncoding
+        //fn CFStringIsEncodingAvailable
+
+        /* Getting Numeric Values */
+        //fn CFStringGetDoubleValue
+        //fn CFStringGetIntValue
+
+        /* Getting String Properties */
+        //fn CFShowStr
+        pub fn CFStringGetTypeID() -> CFTypeID;
+
+        /* String File System Representations */
+        //fn CFStringCreateWithFileSystemRepresentation
+        //fn CFStringGetFileSystemRepresentation
+        //fn CFStringGetMaximumSizeOfFileSystemRepresentation
+
+        /* Getting Paragraph Bounds */
+        //fn CFStringGetParagraphBounds
+
+        /* Managing Surrogates */
+        //fn CFStringGetLongCharacterForSurrogatePair
+        //fn CFStringGetSurrogatePairForLongCharacter
+        //fn CFStringIsSurrogateHighCharacter
+        //fn CFStringIsSurrogateLowCharacter
+    }
+}
+
+pub mod uuid {
+    // Copyright 2013-2015 The Servo Project Developers. See the COPYRIGHT
+    // file at the top-level directory of this distribution.
+    //
+    // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+    // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+    // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+    // option. This file may not be copied, modified, or distributed
+    // except according to those terms.
+
+    use std::os::raw::c_void;
+
+    use super::{CFAllocatorRef, CFTypeID};
+
+    #[repr(C)]
+    pub struct __CFUUID(c_void);
+
+    pub type CFUUIDRef = *const __CFUUID;
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Default)]
+    pub struct CFUUIDBytes {
+        pub byte0: u8,
+        pub byte1: u8,
+        pub byte2: u8,
+        pub byte3: u8,
+        pub byte4: u8,
+        pub byte5: u8,
+        pub byte6: u8,
+        pub byte7: u8,
+        pub byte8: u8,
+        pub byte9: u8,
+        pub byte10: u8,
+        pub byte11: u8,
+        pub byte12: u8,
+        pub byte13: u8,
+        pub byte14: u8,
+        pub byte15: u8,
+    }
+
+    extern "C" {
+        /*
+         * CFUUID.h
+         */
+        pub fn CFUUIDCreate(allocator: CFAllocatorRef) -> CFUUIDRef;
+        pub fn CFUUIDCreateFromUUIDBytes(
+            allocator: CFAllocatorRef,
+            bytes: CFUUIDBytes,
+        ) -> CFUUIDRef;
+        pub fn CFUUIDGetUUIDBytes(uuid: CFUUIDRef) -> CFUUIDBytes;
+
+        pub fn CFUUIDGetTypeID() -> CFTypeID;
+    }
+}
+
+/*
+extern crate libc;
+
+#[cfg(feature = "with-chrono")]
+extern crate chrono;
+
+pub unsafe trait ConcreteCFType: TCFType {}
+
+/// Declare a Rust type that wraps an underlying CoreFoundation type.
+///
+/// This will provide an implementation of `Drop` using [`CFRelease`].
+/// The type must have an implementation of the [`TCFType`] trait, usually
+/// provided using the [`impl_TCFType`] macro.
+///
+/// ```
+/// #[macro_use] extern crate core_foundation;
+/// // Make sure that the `TCFType` trait is in scope.
+/// use core_foundation::base::{CFTypeID, TCFType};
+///
+/// extern "C" {
+///     // We need a function that returns the `CFTypeID`.
+///     pub fn ShrubberyGetTypeID() -> CFTypeID;
+/// }
+///
+/// pub struct __Shrubbery {}
+/// // The ref type must be a pointer to the underlying struct.
+/// pub type ShrubberyRef = *const __Shrubbery;
+///
+/// declare_TCFType!(Shrubbery, ShrubberyRef);
+/// impl_TCFType!(Shrubbery, ShrubberyRef, ShrubberyGetTypeID);
+/// # fn main() {}
+/// ```
+///
+/// [`CFRelease`]: https://developer.apple.com/documentation/corefoundation/1521153-cfrelease
+/// [`TCFType`]: base/trait.TCFType.html
+/// [`impl_TCFType`]: macro.impl_TCFType.html
+#[macro_export]
+macro_rules! declare_TCFType {
+    (
+        $(#[$doc:meta])*
+        $ty:ident, $raw:ident
+    ) => {
+        $(#[$doc])*
+        pub struct $ty($raw);
+
+        impl Drop for $ty {
+            fn drop(&mut self) {
+                unsafe { $crate::base::CFRelease(self.as_CFTypeRef()) }
+            }
+        }
+    }
+}
+
+/// Provide an implementation of the [`TCFType`] trait for the Rust
+/// wrapper type around an underlying CoreFoundation type.
+///
+/// See [`declare_TCFType`] for details.
+///
+/// [`declare_TCFType`]: macro.declare_TCFType.html
+/// [`TCFType`]: base/trait.TCFType.html
+#[macro_export]
+macro_rules! impl_TCFType {
+    ($ty:ident, $ty_ref:ident, $ty_id:ident) => {
+        impl_TCFType!($ty<>, $ty_ref, $ty_id);
+        unsafe impl $crate::ConcreteCFType for $ty { }
+    };
+
+    ($ty:ident<$($p:ident $(: $bound:path)*),*>, $ty_ref:ident, $ty_id:ident) => {
+        impl<$($p $(: $bound)*),*> $crate::base::TCFType for $ty<$($p),*> {
+            type Ref = $ty_ref;
+
+            #[inline]
+            fn as_concrete_TypeRef(&self) -> $ty_ref {
+                self.0
+            }
+
+            #[inline]
+            unsafe fn wrap_under_get_rule(reference: $ty_ref) -> Self {
+                assert!(!reference.is_null(), "Attempted to create a NULL object.");
+                let reference = $crate::base::CFRetain(reference as *const ::std::os::raw::c_void) as $ty_ref;
+                $crate::base::TCFType::wrap_under_create_rule(reference)
+            }
+
+            #[inline]
+            fn as_CFTypeRef(&self) -> $crate::base::CFTypeRef {
+                self.as_concrete_TypeRef() as $crate::base::CFTypeRef
+            }
+
+            #[inline]
+            unsafe fn wrap_under_create_rule(reference: $ty_ref) -> Self {
+                assert!(!reference.is_null(), "Attempted to create a NULL object.");
+                // we need one PhantomData for each type parameter so call ourselves
+                // again with @Phantom $p to produce that
+                $ty(reference $(, impl_TCFType!(@Phantom $p))*)
+            }
+
+            #[inline]
+            fn type_id() -> $crate::base::CFTypeID {
+                unsafe {
+                    $ty_id()
+                }
+            }
+        }
+
+        impl Clone for $ty {
+            #[inline]
+            fn clone(&self) -> $ty {
+                unsafe {
+                    $ty::wrap_under_get_rule(self.0)
+                }
+            }
+        }
+
+        impl PartialEq for $ty {
+            #[inline]
+            fn eq(&self, other: &$ty) -> bool {
+                self.as_CFType().eq(&other.as_CFType())
+            }
+        }
+
+        impl Eq for $ty { }
+
+        unsafe impl<'a> $crate::base::ToVoid<$ty> for &'a $ty {
+            fn to_void(&self) -> *const ::std::os::raw::c_void {
+                use $crate::base::TCFTypeRef;
+                self.as_concrete_TypeRef().as_void_ptr()
+            }
+        }
+
+        unsafe impl $crate::base::ToVoid<$ty> for $ty {
+            fn to_void(&self) -> *const ::std::os::raw::c_void {
+                use $crate::base::TCFTypeRef;
+                self.as_concrete_TypeRef().as_void_ptr()
+            }
+        }
+
+        unsafe impl $crate::base::ToVoid<$ty> for $ty_ref {
+            fn to_void(&self) -> *const ::std::os::raw::c_void {
+                use $crate::base::TCFTypeRef;
+                self.as_void_ptr()
+            }
+        }
+
+    };
+
+    (@Phantom $x:ident) => { ::std::marker::PhantomData };
+}
+
+/// Implement `std::fmt::Debug` for the given type.
+///
+/// This will invoke the implementation of `Debug` for [`CFType`]
+/// which invokes [`CFCopyDescription`].
+///
+/// The type must have an implementation of the [`TCFType`] trait, usually
+/// provided using the [`impl_TCFType`] macro.
+///
+/// [`CFType`]: base/struct.CFType.html#impl-Debug
+/// [`CFCopyDescription`]: https://developer.apple.com/documentation/corefoundation/1521252-cfcopydescription?language=objc
+/// [`TCFType`]: base/trait.TCFType.html
+/// [`impl_TCFType`]: macro.impl_TCFType.html
+#[macro_export]
+macro_rules! impl_CFTypeDescription {
+    ($ty:ident) => {
+        // it's fine to use an empty <> list
+        impl_CFTypeDescription!($ty<>);
+    };
+    ($ty:ident<$($p:ident $(: $bound:path)*),*>) => {
+        impl<$($p $(: $bound)*),*> ::std::fmt::Debug for $ty<$($p),*> {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                self.as_CFType().fmt(f)
+            }
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! impl_CFComparison {
+    ($ty:ident, $compare:ident) => {
+        impl PartialOrd for $ty {
+            #[inline]
+            fn partial_cmp(&self, other: &$ty) -> Option<::std::cmp::Ordering> {
+                unsafe {
+                    Some(
+                        $compare(
+                            self.as_concrete_TypeRef(),
+                            other.as_concrete_TypeRef(),
+                            ::std::ptr::null_mut(),
+                        )
+                        .into(),
+                    )
+                }
+            }
+        }
+
+        impl Ord for $ty {
+            #[inline]
+            fn cmp(&self, other: &$ty) -> ::std::cmp::Ordering {
+                self.partial_cmp(other).unwrap()
+            }
+        }
+    };
+}
+
+/// All Core Foundation types implement this trait. The associated type `Ref` specifies the
+/// associated Core Foundation type: e.g. for `CFType` this is `CFTypeRef`; for `CFArray` this is
+/// `CFArrayRef`.
+///
+/// Most structs that implement this trait will do so via the [`impl_TCFType`] macro.
+///
+/// [`impl_TCFType`]: ../macro.impl_TCFType.html
+pub trait TCFType {
+    /// The reference type wrapped inside this type.
+    type Ref: TCFTypeRef;
+
+    /// Returns the object as its concrete TypeRef.
+    fn as_concrete_TypeRef(&self) -> Self::Ref;
+
+    /// Returns an instance of the object, wrapping the underlying `CFTypeRef` subclass. Use this
+    /// when following Core Foundation's "Create Rule". The reference count is *not* bumped.
+    unsafe fn wrap_under_create_rule(obj: Self::Ref) -> Self;
+
+    /// Returns the type ID for this class.
+    fn type_id() -> CFTypeID;
+
+    /// Returns the object as a wrapped `CFType`. The reference count is incremented by one.
+    #[inline]
+    fn as_CFType(&self) -> CFType {
+        unsafe { TCFType::wrap_under_get_rule(self.as_CFTypeRef()) }
+    }
+
+    /// Returns the object as a wrapped `CFType`. Consumes self and avoids changing the reference
+    /// count.
+    #[inline]
+    fn into_CFType(self) -> CFType
+    where
+        Self: Sized,
+    {
+        let reference = self.as_CFTypeRef();
+        mem::forget(self);
+        unsafe { TCFType::wrap_under_create_rule(reference) }
+    }
+
+    /// Returns the object as a raw `CFTypeRef`. The reference count is not adjusted.
+    fn as_CFTypeRef(&self) -> CFTypeRef;
+
+    /// Returns an instance of the object, wrapping the underlying `CFTypeRef` subclass. Use this
+    /// when following Core Foundation's "Get Rule". The reference count *is* bumped.
+    unsafe fn wrap_under_get_rule(reference: Self::Ref) -> Self;
+
+    /// Returns the reference count of the object. It is unwise to do anything other than test
+    /// whether the return value of this method is greater than zero.
+    #[inline]
+    fn retain_count(&self) -> CFIndex {
+        unsafe { CFGetRetainCount(self.as_CFTypeRef()) }
+    }
+
+    /// Returns the type ID of this object.
+    #[inline]
+    fn type_of(&self) -> CFTypeID {
+        unsafe { CFGetTypeID(self.as_CFTypeRef()) }
+    }
+
+    /// Writes a debugging version of this object on standard error.
+    fn show(&self) {
+        unsafe { CFShow(self.as_CFTypeRef()) }
+    }
+
+    /// Returns true if this value is an instance of another type.
+    #[inline]
+    fn instance_of<OtherCFType: TCFType>(&self) -> bool {
+        self.type_of() == OtherCFType::type_id()
+    }
+}
+
+impl TCFType for CFType {
+    type Ref = CFTypeRef;
+
+    #[inline]
+    fn as_concrete_TypeRef(&self) -> CFTypeRef {
+        self.0
+    }
+
+    #[inline]
+    unsafe fn wrap_under_get_rule(reference: CFTypeRef) -> CFType {
+        assert!(!reference.is_null(), "Attempted to create a NULL object.");
+        let reference: CFTypeRef = CFRetain(reference);
+        TCFType::wrap_under_create_rule(reference)
+    }
+
+    #[inline]
+    fn as_CFTypeRef(&self) -> CFTypeRef {
+        self.as_concrete_TypeRef()
+    }
+
+    #[inline]
+    unsafe fn wrap_under_create_rule(obj: CFTypeRef) -> CFType {
+        assert!(!obj.is_null(), "Attempted to create a NULL object.");
+        CFType(obj)
+    }
+
+    #[inline]
+    fn type_id() -> CFTypeID {
+        // FIXME(pcwalton): Is this right?
+        0
+    }
+}
+*/
+
+#[repr(C)]
+pub struct __CFMachPort(c_void);
+pub type CFMachPortRef = *const __CFMachPort;

--- a/src/platform_impl/macos/util/thin_core_graphics.rs
+++ b/src/platform_impl/macos/util/thin_core_graphics.rs
@@ -1,0 +1,358 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(unused)]
+
+use super::thin_core_foundation::*;
+use libc;
+
+pub mod base {
+    #[cfg(any(target_arch = "x86", target_arch = "arm", target_arch = "aarch64"))]
+    pub type boolean_t = libc::c_int;
+    #[cfg(target_arch = "x86_64")]
+    pub type boolean_t = libc::c_uint;
+
+    #[cfg(target_pointer_width = "64")]
+    pub type CGFloat = libc::c_double;
+    #[cfg(not(target_pointer_width = "64"))]
+    pub type CGFloat = libc::c_float;
+
+    pub type CGError = i32;
+
+    pub type CGGlyph = libc::c_ushort;
+}
+
+pub mod display {
+    use super::{base::*, *};
+    use std::ptr;
+
+    #[derive(Copy, Clone, Debug)]
+    pub struct CGDisplay {
+        pub id: CGDirectDisplayID,
+    }
+
+    impl CGDisplay {
+        #[inline]
+        pub fn new(id: CGDirectDisplayID) -> CGDisplay {
+            CGDisplay { id }
+        }
+
+        /// Returns the the main display.
+        #[inline]
+        pub fn main() -> CGDisplay {
+            CGDisplay::new(unsafe { CGMainDisplayID() })
+        }
+
+        /// Returns the display height in pixel units.
+        #[inline]
+        pub fn pixels_high(&self) -> u64 {
+            unsafe { CGDisplayPixelsHigh(self.id) as u64 }
+        }
+
+        /// Returns the display width in pixel units.
+        #[inline]
+        pub fn pixels_wide(&self) -> u64 {
+            unsafe { CGDisplayPixelsWide(self.id) as u64 }
+        }
+
+        /// Returns the model number of a display monitor.
+        #[inline]
+        pub fn model_number(&self) -> u32 {
+            unsafe { CGDisplayModelNumber(self.id) }
+        }
+
+        /// Provides a list of displays that are active (or drawable).
+        #[inline]
+        pub fn active_displays() -> Result<Vec<CGDirectDisplayID>, CGError> {
+            let count = CGDisplay::active_display_count()?;
+            let mut buf: Vec<CGDirectDisplayID> = vec![0; count as usize];
+            let result =
+                unsafe { CGGetActiveDisplayList(count as u32, buf.as_mut_ptr(), ptr::null_mut()) };
+            if result == 0 {
+                Ok(buf)
+            } else {
+                Err(result)
+            }
+        }
+
+        /// Provides count of displays that are active (or drawable).
+        #[inline]
+        pub fn active_display_count() -> Result<u32, CGError> {
+            let mut count: u32 = 0;
+            let result = unsafe { CGGetActiveDisplayList(0, ptr::null_mut(), &mut count) };
+            if result == 0 {
+                Ok(count as u32)
+            } else {
+                Err(result)
+            }
+        }
+
+        /// Moves the mouse cursor without generating events.
+        #[inline]
+        pub fn warp_mouse_cursor_position(point: CGPoint) -> Result<(), CGError> {
+            let result = unsafe { CGWarpMouseCursorPosition(point) };
+            if result == 0 {
+                Ok(())
+            } else {
+                Err(result)
+            }
+        }
+
+        /// Connects or disconnects the mouse and cursor while an application is
+        /// in the foreground.
+        #[inline]
+        pub fn associate_mouse_and_mouse_cursor_position(connected: bool) -> Result<(), CGError> {
+            let result = unsafe { CGAssociateMouseAndMouseCursorPosition(connected as boolean_t) };
+            if result == 0 {
+                Ok(())
+            } else {
+                Err(result)
+            }
+        }
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct CGRect {
+        pub origin: CGPoint,
+        pub size: CGSize,
+    }
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct CGSize {
+        pub width: CGFloat,
+        pub height: CGFloat,
+    }
+
+    impl CGSize {
+        #[inline]
+        pub fn new(width: CGFloat, height: CGFloat) -> CGSize {
+            CGSize { width, height }
+        }
+
+        // #[inline]
+        // pub fn apply_transform(&self, t: &CGAffineTransform) -> CGSize {
+        //     unsafe { ffi::CGSizeApplyAffineTransform(*self, *t) }
+        // }
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct CGPoint {
+        pub x: CGFloat,
+        pub y: CGFloat,
+    }
+
+    impl CGPoint {
+        #[inline]
+        pub fn new(x: CGFloat, y: CGFloat) -> CGPoint {
+            CGPoint { x, y }
+        }
+
+        // #[inline]
+        // pub fn apply_transform(&self, t: &CGAffineTransform) -> CGPoint {
+        //     unsafe { ffi::CGPointApplyAffineTransform(*self, *t) }
+        // }
+    }
+
+    pub type CGDirectDisplayID = u32;
+    pub type CGWindowID = u32;
+    pub type CGDisplayConfigRef = *mut libc::c_void;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        pub fn CGMainDisplayID() -> CGDirectDisplayID;
+
+        pub fn CGDisplayPixelsHigh(display: CGDirectDisplayID) -> libc::size_t;
+        pub fn CGDisplayPixelsWide(display: CGDirectDisplayID) -> libc::size_t;
+        pub fn CGDisplayModelNumber(display: CGDirectDisplayID) -> u32;
+        pub fn CGDisplayBounds(display: CGDirectDisplayID) -> CGRect;
+        pub fn CGDisplayModeRelease(mode: sys::CGDisplayModeRef);
+        pub fn CGGetActiveDisplayList(
+            max_displays: u32,
+            active_displays: *mut CGDirectDisplayID,
+            display_count: *mut u32,
+        ) -> CGError;
+        pub fn CGWarpMouseCursorPosition(point: CGPoint) -> CGError;
+        pub fn CGAssociateMouseAndMouseCursorPosition(connected: boolean_t) -> CGError;
+    }
+
+    mod sys {
+        #[cfg(target_os = "macos")]
+        mod macos {
+            pub enum CGEventTap {}
+            pub type CGEventTapRef = crate::platform_impl::thin_core_foundation::CFMachPortRef;
+            pub enum CGEvent {}
+            pub type CGEventRef = *mut CGEvent;
+
+            pub enum CGEventSource {}
+            pub type CGEventSourceRef = *mut CGEventSource;
+
+            pub enum CGDisplayMode {}
+            pub type CGDisplayModeRef = *mut CGDisplayMode;
+        }
+
+        #[cfg(target_os = "macos")]
+        pub use self::macos::*;
+    }
+
+    use super::foreign_types::*;
+
+    crate::foreign_type! {
+        #[doc(hidden)]
+        type CType = sys::CGDisplayMode;
+        fn drop = CGDisplayModeRelease;
+        fn clone = |p| CFRetain(p as *const _) as *mut _;
+        pub struct CGDisplayMode;
+        pub struct CGDisplayModeRef;
+    }
+
+    #[macro_export]
+    macro_rules! foreign_type {
+    (
+        $(#[$impl_attr:meta])*
+        type CType = $ctype:ty;
+        fn drop = $drop:expr;
+        $(fn clone = $clone:expr;)*
+        $(#[$owned_attr:meta])*
+        pub struct $owned:ident;
+        $(#[$borrowed_attr:meta])*
+        pub struct $borrowed:ident;
+    ) => {
+        $(#[$owned_attr])*
+        pub struct $owned(*mut $ctype);
+
+        $(#[$impl_attr])*
+        impl ForeignType for $owned {
+            type CType = $ctype;
+            type Ref = $borrowed;
+
+            #[inline]
+            unsafe fn from_ptr(ptr: *mut $ctype) -> $owned {
+                $owned(ptr)
+            }
+
+            #[inline]
+            fn as_ptr(&self) -> *mut $ctype {
+                self.0
+            }
+        }
+
+        impl Drop for $owned {
+            #[inline]
+            fn drop(&mut self) {
+                unsafe { $drop(self.0) }
+            }
+        }
+
+        $(
+            impl Clone for $owned {
+                #[inline]
+                fn clone(&self) -> $owned {
+                    unsafe {
+                        let handle: *mut $ctype = $clone(self.0);
+                        ForeignType::from_ptr(handle)
+                    }
+                }
+            }
+
+            impl ::std::borrow::ToOwned for $borrowed {
+                type Owned = $owned;
+                #[inline]
+                fn to_owned(&self) -> $owned {
+                    unsafe {
+                        let handle: *mut $ctype = $clone(ForeignTypeRef::as_ptr(self));
+                        ForeignType::from_ptr(handle)
+                    }
+                }
+            }
+        )*
+
+        impl ::std::ops::Deref for $owned {
+            type Target = $borrowed;
+
+            #[inline]
+            fn deref(&self) -> &$borrowed {
+                unsafe { ForeignTypeRef::from_ptr(self.0) }
+            }
+        }
+
+        impl ::std::ops::DerefMut for $owned {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut $borrowed {
+                unsafe { ForeignTypeRef::from_ptr_mut(self.0) }
+            }
+        }
+
+        impl ::std::borrow::Borrow<$borrowed> for $owned {
+            #[inline]
+            fn borrow(&self) -> &$borrowed {
+                &**self
+            }
+        }
+
+        impl ::std::convert::AsRef<$borrowed> for $owned {
+            #[inline]
+            fn as_ref(&self) -> &$borrowed {
+                &**self
+            }
+        }
+
+        $(#[$borrowed_attr])*
+        pub struct $borrowed(Opaque);
+
+        $(#[$impl_attr])*
+        impl ForeignTypeRef for $borrowed {
+            type CType = $ctype;
+        }
+    }
+}
+}
+
+mod foreign_types {
+    use core::cell::UnsafeCell;
+
+    /// An opaque type used to define `ForeignTypeRef` types.
+    ///
+    /// A type implementing `ForeignTypeRef` should simply be a newtype wrapper around this type.
+    pub struct Opaque(UnsafeCell<()>);
+
+    /// A type implemented by wrappers over foreign types.
+    pub trait ForeignType: Sized {
+        /// The raw C type.
+        type CType;
+
+        /// The type representing a reference to this type.
+        type Ref: ForeignTypeRef<CType = Self::CType>;
+
+        /// Constructs an instance of this type from its raw type.
+        unsafe fn from_ptr(ptr: *mut Self::CType) -> Self;
+
+        /// Returns a raw pointer to the wrapped value.
+        fn as_ptr(&self) -> *mut Self::CType;
+    }
+
+    /// A trait implemented by types which reference borrowed foreign types.
+    pub trait ForeignTypeRef: Sized {
+        /// The raw C type.
+        type CType;
+
+        /// Constructs a shared instance of this type from its raw type.
+        #[inline]
+        unsafe fn from_ptr<'a>(ptr: *mut Self::CType) -> &'a Self {
+            &*(ptr as *mut _)
+        }
+
+        /// Constructs a mutable reference of this type from its raw type.
+        #[inline]
+        unsafe fn from_ptr_mut<'a>(ptr: *mut Self::CType) -> &'a mut Self {
+            &mut *(ptr as *mut _)
+        }
+
+        /// Returns a raw pointer to the wrapped value.
+        #[inline]
+        fn as_ptr(&self) -> *mut Self::CType {
+            self as *const _ as *mut _
+        }
+    }
+}

--- a/src/platform_impl/macos/util/thin_core_video_sys.rs
+++ b/src/platform_impl/macos/util/thin_core_video_sys.rs
@@ -1,0 +1,38 @@
+#![allow(non_camel_case_types)]
+#![allow(non_upper_case_globals)]
+#![allow(non_snake_case)]
+#![allow(unused)]
+
+pub type CVReturn = i32;
+
+pub const kCVReturnSuccess: CVReturn = 0;
+
+pub const kCVTimeIsIndefinite: CVTimeFlags = 1 << 0;
+
+pub type CFTypeID = usize;
+
+#[derive(Debug, Copy, Clone)]
+pub enum __CVDisplayLink {}
+pub type CVDisplayLinkRef = *mut __CVDisplayLink;
+
+extern "C" {
+    pub fn CVDisplayLinkGetTypeID() -> CFTypeID;
+    pub fn CVDisplayLinkCreateWithCGDisplay(
+        displayID: CGDirectDisplayID,
+        displayLinkOut: *mut CVDisplayLinkRef,
+    ) -> CVReturn;
+    pub fn CVDisplayLinkGetNominalOutputVideoRefreshPeriod(displayLink: CVDisplayLinkRef)
+        -> CVTime;
+    pub fn CVDisplayLinkRelease(displayLink: CVDisplayLinkRef);
+}
+
+pub type CGDirectDisplayID = u32;
+
+#[repr(C)]
+#[derive(Debug, Clone)]
+pub struct CVTime {
+    pub timeValue: i64,
+    pub timeScale: i32,
+    pub flags: i32,
+}
+pub type CVTimeFlags = i32;

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -6,10 +6,9 @@ use std::{
     sync::{Arc, Mutex, Weak},
 };
 
-use cocoa::{
-    appkit::{NSApp, NSEvent, NSEventModifierFlags, NSEventPhase, NSView, NSWindow},
-    base::{id, nil},
-    foundation::{NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger},
+use super::thin_cocoa::{
+    id, nil, NSApp, NSEvent, NSEventModifierFlags, NSEventPhase, NSInteger, NSPoint, NSRect,
+    NSSize, NSString, NSUInteger, NSView, NSWindow,
 };
 use objc::{
     declare::ClassDecl,

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -17,6 +17,7 @@ use super::thin_cocoa::{
     },
     {id, nil}, {NSDictionary, NSPoint, NSRect, NSSize, NSUInteger},
 };
+use super::thin_core_graphics::display::{CGDisplay, CGDisplayMode};
 use crate::{
     dpi::{
         LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size, Size::Logical,
@@ -40,7 +41,6 @@ use crate::{
         CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
     },
 };
-use core_graphics::display::{CGDisplay, CGDisplayMode};
 use objc::{
     declare::ClassDecl,
     rc::autoreleasepool,

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -4,10 +4,8 @@ use std::{
     sync::{atomic::Ordering, Arc, Weak},
 };
 
-use cocoa::{
-    appkit::{self, NSApplicationPresentationOptions, NSView, NSWindow},
-    base::{id, nil},
-    foundation::NSUInteger,
+use super::thin_cocoa::{
+    self, id, nil, NSApplicationPresentationOptions, NSUInteger, NSView, NSWindow,
 };
 use objc::{
     declare::ClassDecl,
@@ -349,14 +347,15 @@ extern "C" fn window_did_resign_key(this: &Object, _: Sel, _: id) {
 extern "C" fn dragging_entered(this: &Object, _: Sel, sender: id) -> BOOL {
     trace_scope!("draggingEntered:");
 
-    use cocoa::{appkit::NSPasteboard, foundation::NSFastEnumeration};
+    use super::thin_cocoa::{NSFastEnumeration, NSPasteboard};
     use std::path::PathBuf;
 
     let pb: id = unsafe { msg_send![sender, draggingPasteboard] };
-    let filenames = unsafe { NSPasteboard::propertyListForType(pb, appkit::NSFilenamesPboardType) };
+    let filenames =
+        unsafe { NSPasteboard::propertyListForType(pb, super::thin_cocoa::NSFilenamesPboardType) };
 
     for file in unsafe { filenames.iter() } {
-        use cocoa::foundation::NSString;
+        use super::thin_cocoa::NSString;
         use std::ffi::CStr;
 
         unsafe {
@@ -382,15 +381,16 @@ extern "C" fn prepare_for_drag_operation(_: &Object, _: Sel, _: id) -> BOOL {
 extern "C" fn perform_drag_operation(this: &Object, _: Sel, sender: id) -> BOOL {
     trace_scope!("performDragOperation:");
 
-    use cocoa::{appkit::NSPasteboard, foundation::NSFastEnumeration};
     use std::path::PathBuf;
+    use thin_cocoa::{NSFastEnumeration, NSPasteboard};
 
     let pb: id = unsafe { msg_send![sender, draggingPasteboard] };
-    let filenames = unsafe { NSPasteboard::propertyListForType(pb, appkit::NSFilenamesPboardType) };
+    let filenames =
+        unsafe { NSPasteboard::propertyListForType(pb, thin_cocoa::NSFilenamesPboardType) };
 
     for file in unsafe { filenames.iter() } {
-        use cocoa::foundation::NSString;
         use std::ffi::CStr;
+        use thin_cocoa::NSString;
 
         unsafe {
             let f = NSString::UTF8String(file);


### PR DESCRIPTION
This PR is not ready to go, but I wanted to create a pull request to have a record of the concept.  It might be useful as a point of reference even if not directly used.

This change removes direct dependencies on the `cocoa`, `core-foundation`, and `core-graphics` crates by copy-pasting the used parts from those libraries directly into `winit`.

On my M1 Mac Air this dropped release build times from ~3.95 seconds to ~2.7 seconds.

No functionality was changed other than one tiny segment of code that I was too lazy to figure out how to port over.

For this to become a real PR it would need a few things:

* More organized copy-pasted code. I didn't have a formed strategy when I started out so the structure is all over the place.
* An evaluation and plan of the ongoing maintenance burden added by this approach.
* A fix for that one spot I was too lazy to port correctly.
* Consideration of how to properly attribute the libraries copied from.