### PR TITLE
Add methods to set ControlFlow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix polling during consecutive `EventLoop::run_return` invocations.
 - On Windows, fix race issue creating fullscreen windows with `WindowBuilder::with_fullscreen`
 - On Android, `virtual_keycode` for `KeyboardInput` events is now filled in where a suitable match is found.
+- Added helper methods on `ControlFlow` to set its value.
 
 # 0.26.1 (2022-01-05)
 

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -3,7 +3,7 @@ use std::{thread, time};
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, KeyboardInput, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -88,23 +88,21 @@ fn main() {
                     window.request_redraw();
                 }
                 if close_requested {
-                    *control_flow = ControlFlow::Exit;
+                    control_flow.set_exit();
                 }
             }
             Event::RedrawRequested(_window_id) => {}
             Event::RedrawEventsCleared => {
-                *control_flow = match mode {
-                    Mode::Wait => ControlFlow::Wait,
+                match mode {
+                    Mode::Wait => control_flow.set_wait(),
                     Mode::WaitUntil => {
-                        if wait_cancelled {
-                            *control_flow
-                        } else {
-                            ControlFlow::WaitUntil(instant::Instant::now() + WAIT_TIME)
+                        if !wait_cancelled {
+                            control_flow.set_wait_until(instant::Instant::now() + WAIT_TIME);
                         }
                     }
                     Mode::Poll => {
                         thread::sleep(POLL_SLEEP_TIME);
-                        ControlFlow::Poll
+                        control_flow.set_poll();
                     }
                 };
             }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyboardInput, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::{CursorIcon, WindowBuilder},
 };
 
@@ -15,7 +15,7 @@ fn main() {
     let mut cursor_idx = 0;
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent {
@@ -42,7 +42,7 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
-                *control_flow = ControlFlow::Exit;
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{DeviceEvent, ElementState, Event, KeyboardInput, ModifiersState, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -17,11 +17,11 @@ fn main() {
     let mut modifiers = ModifiersState::default();
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::KeyboardInput {
                     input:
                         KeyboardInput {
@@ -33,7 +33,7 @@ fn main() {
                 } => {
                     use winit::event::VirtualKeyCode::*;
                     match key {
-                        Escape => *control_flow = ControlFlow::Exit,
+                        Escape => control_flow.set_exit(),
                         G => window.set_cursor_grab(!modifiers.shift()).unwrap(),
                         H => window.set_cursor_visible(modifiers.shift()),
                         _ => (),

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -3,7 +3,7 @@ fn main() {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoopBuilder},
+        event_loop::EventLoopBuilder,
         window::WindowBuilder,
     };
 
@@ -34,14 +34,14 @@ fn main() {
     });
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::UserEvent(event) => println!("user event: {:?}", event),
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = ControlFlow::Exit,
+            } => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -3,7 +3,7 @@ use winit::{
     event::{
         ElementState, Event, KeyboardInput, MouseButton, StartCause, VirtualKeyCode, WindowEvent,
     },
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::{Window, WindowBuilder, WindowId},
 };
 
@@ -22,7 +22,7 @@ fn main() {
             eprintln!("Switch which window is to be dragged by pressing \"x\".")
         }
         Event::WindowEvent { event, window_id } => match event {
-            WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+            WindowEvent::CloseRequested => control_flow.set_exit(),
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Left,

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -2,7 +2,7 @@ use std::io::{stdin, stdout, Write};
 
 use simple_logger::SimpleLogger;
 use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoop};
+use winit::event_loop::EventLoop;
 use winit::monitor::{MonitorHandle, VideoMode};
 use winit::window::{Fullscreen, WindowBuilder};
 
@@ -32,11 +32,11 @@ fn main() {
         .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::KeyboardInput {
                     input:
                         KeyboardInput {
@@ -46,7 +46,7 @@ fn main() {
                         },
                     ..
                 } => match (virtual_code, state) {
-                    (VirtualKeyCode::Escape, _) => *control_flow = ControlFlow::Exit,
+                    (VirtualKeyCode::Escape, _) => control_flow.set_exit(),
                     (VirtualKeyCode::F, ElementState::Pressed) => {
                         if window.fullscreen().is_some() {
                             window.set_fullscreen(None);

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, KeyboardInput, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -21,7 +21,7 @@ fn main() {
             ElementState::Released,
             VirtualKeyCode::{N, Y},
         };
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent { event, .. } => {
@@ -63,7 +63,7 @@ fn main() {
                                     // event loop (i.e. if it's a multi-window application), you need to
                                     // drop the window. That closes it, and results in `Destroyed` being
                                     // sent.
-                                    *control_flow = ControlFlow::Exit;
+                                    control_flow.set_exit();
                                 }
                             }
                             N => {

--- a/examples/min_max_size.rs
+++ b/examples/min_max_size.rs
@@ -2,7 +2,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -16,14 +16,14 @@ fn main() {
     window.set_max_inner_size(Some(LogicalSize::new(800.0, 400.0)));
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
         println!("{:?}", event);
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = ControlFlow::Exit,
+            } => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/minimize.rs
+++ b/examples/minimize.rs
@@ -2,7 +2,7 @@ extern crate winit;
 
 use simple_logger::SimpleLogger;
 use winit::event::{Event, VirtualKeyCode, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoop};
+use winit::event_loop::EventLoop;
 use winit::window::WindowBuilder;
 
 fn main() {
@@ -15,13 +15,13 @@ fn main() {
         .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = ControlFlow::Exit,
+            } => control_flow.set_exit(),
 
             // Keyboard input event to handle minimize via a hotkey
             Event::WindowEvent {

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -30,11 +30,11 @@ In other words, the deltas indicate the direction in which to move the content (
     );
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::MouseWheel { delta, .. } => match delta {
                     winit::event::MouseScrollDelta::LineDelta(x, y) => {
                         println!("mouse wheel Line Delta: ({},{})", x, y);

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -6,7 +6,7 @@ fn main() {
     use winit::{
         dpi::{PhysicalPosition, PhysicalSize, Position, Size},
         event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         window::{CursorIcon, Fullscreen, WindowBuilder},
     };
 
@@ -143,9 +143,9 @@ fn main() {
         });
     }
     event_loop.run(move |event, _event_loop, control_flow| {
-        *control_flow = match !window_senders.is_empty() {
-            true => ControlFlow::Wait,
-            false => ControlFlow::Exit,
+        match !window_senders.is_empty() {
+            true => control_flow.set_wait(),
+            false => control_flow.set_exit(),
         };
         match event {
             Event::WindowEvent { event, window_id } => match event {

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyboardInput, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::Window,
 };
 
@@ -18,7 +18,7 @@ fn main() {
     }
 
     event_loop.run(move |event, event_loop, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent { event, window_id } => {
@@ -30,7 +30,7 @@ fn main() {
                         windows.remove(&window_id);
 
                         if windows.is_empty() {
-                            *control_flow = ControlFlow::Exit;
+                            control_flow.set_exit();
                         }
                     }
                     WindowEvent::KeyboardInput {

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -17,11 +17,11 @@ fn main() {
     event_loop.run(move |event, _, control_flow| {
         println!("{:?}", event);
 
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::MouseInput {
                     state: ElementState::Released,
                     ..

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -5,7 +5,7 @@ fn main() {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         window::WindowBuilder,
     };
 
@@ -25,11 +25,11 @@ fn main() {
     event_loop.run(move |event, _, control_flow| {
         println!("{:?}", event);
 
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => control_flow.set_exit(),
                 _ => (),
             },
             Event::RedrawRequested(_) => {

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -2,7 +2,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -20,11 +20,11 @@ fn main() {
         .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::KeyboardInput {
                     input:
                         KeyboardInput {

--- a/examples/set_ime_position.rs
+++ b/examples/set_ime_position.rs
@@ -2,7 +2,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::PhysicalPosition,
     event::{ElementState, Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -18,7 +18,7 @@ fn main() {
 
     let mut cursor_position = PhysicalPosition::new(0.0, 0.0);
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::WindowEvent {
@@ -45,7 +45,7 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
-                *control_flow = ControlFlow::Exit;
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, StartCause, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -24,16 +24,16 @@ fn main() {
 
         match event {
             Event::NewEvents(StartCause::Init) => {
-                *control_flow = ControlFlow::WaitUntil(Instant::now() + timer_length)
+                control_flow.set_wait_until(Instant::now() + timer_length);
             }
             Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
-                *control_flow = ControlFlow::WaitUntil(Instant::now() + timer_length);
+                control_flow.set_wait_until(Instant::now() + timer_length);
                 println!("\nTimer\n");
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = ControlFlow::Exit,
+            } => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -18,14 +18,14 @@ fn main() {
     window.set_title("A fantastic window!");
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
         println!("{:?}", event);
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => *control_flow = ControlFlow::Exit,
+            } => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -1,6 +1,6 @@
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -16,7 +16,7 @@ pub fn main() {
     let log_list = wasm::create_log_list(&window);
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         #[cfg(target_arch = "wasm32")]
         wasm::log_event(&log_list, &event);
@@ -25,7 +25,7 @@ pub fn main() {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            } if window_id == window.id() => control_flow.set_exit(),
             Event::MainEventsCleared => {
                 window.request_redraw();
             }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -16,14 +16,14 @@ fn main() {
         .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
         println!("{:?}", event);
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            } if window_id == window.id() => control_flow.set_exit(),
             Event::MainEventsCleared => {
                 window.request_redraw();
             }

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::{LogicalSize, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::{Fullscreen, WindowBuilder},
 };
 
@@ -31,7 +31,7 @@ fn main() {
     let mut visible = true;
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         match event {
             Event::DeviceEvent {
@@ -101,7 +101,7 @@ fn main() {
                         window.set_minimized(minimized);
                     }
                     VirtualKeyCode::Q => {
-                        *control_flow = ControlFlow::Exit;
+                        control_flow.set_exit();
                     }
                     VirtualKeyCode::V => {
                         visible = !visible;
@@ -118,7 +118,7 @@ fn main() {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            } if window_id == window.id() => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use simple_logger::SimpleLogger;
 use winit::{
     event::Event,
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::{Icon, WindowBuilder},
 };
 
@@ -30,12 +30,12 @@ fn main() {
         .unwrap();
 
     event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+        control_flow.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             use winit::event::WindowEvent::*;
             match event {
-                CloseRequested => *control_flow = ControlFlow::Exit,
+                CloseRequested => control_flow.set_exit(),
                 DroppedFile(path) => {
                     window.set_window_icon(Some(load_icon(&path)));
                 }

--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -14,7 +14,7 @@ fn main() {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         platform::run_return::EventLoopExtRunReturn,
         window::WindowBuilder,
     };
@@ -30,7 +30,7 @@ fn main() {
 
     while !quit {
         event_loop.run_return(|event, _, control_flow| {
-            *control_flow = ControlFlow::Wait;
+            control_flow.set_wait();
 
             if let Event::WindowEvent { event, .. } = &event {
                 // Print only Window events to reduce noise
@@ -45,7 +45,7 @@ fn main() {
                     quit = true;
                 }
                 Event::MainEventsCleared => {
-                    *control_flow = ControlFlow::Exit;
+                    control_flow.set_exit();
                 }
                 _ => (),
             }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -169,6 +169,41 @@ impl ControlFlow {
     /// [`ExitWithCode`]: ControlFlow::ExitWithCode
     #[allow(non_upper_case_globals)]
     pub const Exit: Self = Self::ExitWithCode(0);
+
+    /// Sets this to [`Poll`].
+    ///
+    /// [`Poll`]: ControlFlow::Poll
+    pub fn set_poll(&mut self) {
+        *self = Self::Poll;
+    }
+
+    /// Sets this to [`Wait`].
+    ///
+    /// [`Wait`]: ControlFlow::Wait
+    pub fn set_wait(&mut self) {
+        *self = Self::Wait;
+    }
+
+    /// Sets this to [`WaitUntil`]`(instant)`.
+    ///
+    /// [`WaitUntil`]: ControlFlow::WaitUntil
+    pub fn set_wait_until(&mut self, instant: Instant) {
+        *self = Self::WaitUntil(instant);
+    }
+
+    /// Sets this to [`ExitWithCode`]`(code)`.
+    ///
+    /// [`ExitWithCode`]: ControlFlow::ExitWithCode
+    pub fn set_exit_with_code(&mut self, code: i32) {
+        *self = Self::ExitWithCode(code);
+    }
+
+    /// Sets this to [`Exit`].
+    ///
+    /// [`Exit`]: ControlFlow::Exit
+    pub fn set_exit(&mut self) {
+        *self = Self::Exit;
+    }
 }
 
 impl Default for ControlFlow {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! ```no_run
 //! use winit::{
 //!     event::{Event, WindowEvent},
-//!     event_loop::{ControlFlow, EventLoop},
+//!     event_loop::EventLoop,
 //!     window::WindowBuilder,
 //! };
 //!
@@ -54,12 +54,12 @@
 //! event_loop.run(move |event, _, control_flow| {
 //!     // ControlFlow::Poll continuously runs the event loop, even if the OS hasn't
 //!     // dispatched any events. This is ideal for games and similar applications.
-//!     *control_flow = ControlFlow::Poll;
+//!     control_flow.set_poll();
 //!
 //!     // ControlFlow::Wait pauses the event loop if no events are available to process.
 //!     // This is ideal for non-game applications that only update in response to user
 //!     // input, and uses significantly less power/CPU time than ControlFlow::Poll.
-//!     *control_flow = ControlFlow::Wait;
+//!     control_flow.set_wait();
 //!
 //!     match event {
 //!         Event::WindowEvent {
@@ -67,7 +67,7 @@
 //!             ..
 //!         } => {
 //!             println!("The close button was pressed; stopping");
-//!             *control_flow = ControlFlow::Exit
+//!             control_flow.set_exit();
 //!         },
 //!         Event::MainEventsCleared => {
 //!             // Application update code.

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,7 +18,7 @@ pub use crate::icon::{BadIcon, Icon};
 /// ```no_run
 /// use winit::{
 ///     event::{Event, WindowEvent},
-///     event_loop::{ControlFlow, EventLoop},
+///     event_loop::EventLoop,
 ///     window::Window,
 /// };
 ///
@@ -26,13 +26,13 @@ pub use crate::icon::{BadIcon, Icon};
 /// let window = Window::new(&event_loop).unwrap();
 ///
 /// event_loop.run(move |event, _, control_flow| {
-///     *control_flow = ControlFlow::Wait;
+///     control_flow.set_wait();
 ///
 ///     match event {
 ///         Event::WindowEvent {
 ///             event: WindowEvent::CloseRequested,
 ///             ..
-///         } => *control_flow = ControlFlow::Exit,
+///         } => control_flow.set_exit(),
 ///         _ => (),
 ///     }
 /// });


### PR DESCRIPTION
Bare-bones `winit` applications must import many different types from `winit`... this PR reduces that by adding methods so `ControlFlow` can be updated without naming its type, hopefully resulting in minor simplifications to the examples.

- [ ] Tested on all platforms changed
 **(I've only tested on Windows, but I've run all examples)**
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
 **(not applicable)**
