### PR TITLE
Doc tweak: Discourage use of WaitUntil to implement VSync

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -140,6 +140,10 @@ pub enum ControlFlow {
     Wait,
     /// When the current loop iteration finishes, suspend the thread until either another event
     /// arrives or the given time is reached.
+    ///
+    /// Useful for implementing efficient timers. Applications which want to render at the display's
+    /// native refresh rate should instead use `Poll` and the VSync functionality of a graphics API
+    /// to reduce odds of missed frames.
     WaitUntil(Instant),
     /// Send a `LoopDestroyed` event and stop the event loop. This variant is *sticky* - once set,
     /// `control_flow` cannot be changed from `ExitWithCode`, and any future attempts to do so will


### PR DESCRIPTION
I occasionally observe user confusion regarding the best way to render at the display refresh rate rather than a wasteful unlimited FPS. `WaitUntil` is a poor choice because a loop based on it is unlikely to be in-phase with the refresh interval, putting applications at high risk of erratic frame drops, and may not be sufficiently precise. This added text should help guide people towards the more robust solution.