### PR TITLE
macOS: Emit resize on frame_did_change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Added new `WindowEvent::Ime` supported on desktop platforms.
 - Added `Window::set_ime_allowed` supported on desktop platforms.
 - **Breaking:** IME input on desktop platforms won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::Ime` events are handled.
+- On macOS, `WindowEvent::Resized` is now emitted in `frameDidChange` instead of `windowDidResize`.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -20,7 +20,7 @@ use objc::{
 };
 
 use crate::{
-    dpi::LogicalPosition,
+    dpi::{LogicalPosition, LogicalSize},
     event::{
         DeviceEvent, ElementState, Event, Ime, KeyboardInput, ModifiersState, MouseButton,
         MouseScrollDelta, TouchPhase, VirtualKeyCode, WindowEvent,
@@ -400,8 +400,17 @@ extern "C" fn frame_did_change(this: &Object, _sel: Sel, _event: id) {
             userData:ptr::null_mut::<c_void>()
             assumeInside:NO
         ];
-
         state.tracking_rect = Some(tracking_rect);
+
+        // Emit resize event here rather than from windowDidResize because:
+        // 1. When a new window is created as a tab, the frame size may change without a window resize occurring.
+        // 2. Even when a window resize does occur on a new tabbed window, it contains the wrong size (includes tab height).
+        let logical_size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
+        let size = logical_size.to_physical::<u32>(state.get_scale_factor());
+        AppState::queue_event(EventWrapper::StaticEvent(Event::WindowEvent {
+            window_id: WindowId(get_window_id(state.ns_window)),
+            event: WindowEvent::Resized(size),
+        }));
     }
 }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -98,14 +98,6 @@ impl WindowDelegateState {
         AppState::queue_event(wrapper);
     }
 
-    pub fn emit_resize_event(&mut self) {
-        let rect = unsafe { NSView::frame(*self.ns_view) };
-        let scale_factor = self.get_scale_factor();
-        let logical_size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
-        let size = logical_size.to_physical(scale_factor);
-        self.emit_event(WindowEvent::Resized(size));
-    }
-
     fn emit_move_event(&mut self) {
         let rect = unsafe { NSWindow::frame(*self.ns_window) };
         let x = rect.origin.x as f64;
@@ -286,7 +278,7 @@ extern "C" fn window_will_close(this: &Object, _: Sel, _: id) {
 extern "C" fn window_did_resize(this: &Object, _: Sel, _: id) {
     trace_scope!("windowDidResize:");
     with_state(this, |state| {
-        state.emit_resize_event();
+        // NOTE: WindowEvent::Resized is reported in frameDidChange.
         state.emit_move_event();
     });
 }


### PR DESCRIPTION
* Fixes https://github.com/rust-windowing/winit/issues/2191
* Fixes downstream https://github.com/alacritty/alacritty/issues/5876

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- (n/a) Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- (n/a) Created or updated an example program if it would help users understand this functionality
- (n/a) Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

For testing:
* First make sure "Prefer tabs" is set to "always" in macOS system preferences
    * (so new windows will get grouped as tabs).
* Add a debug statements such as `println!("emitting resize event with size = {:?}", size);`
    * Add to `emit_resize_event` method in src/platform_impl/macos/window_delegate.rs.
    * Add to `frame_did_change` method in src/platform_impl/macos/view.rs. (next to new code)
* Run the `multiwindow` example program.
    * Each time you hit a key to create a new window, note that the last resize event emitted has the correct size.