### PR TITLE
Windows: Add composition event support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,6 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Added new `WindowEvent::IME` supported on desktop platforms.
 - Added `Window::set_ime_allowed` supported on desktop platforms.
 - **Breaking:** IME input on desktop platforms won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::IME` events are handled.
-- **Breaking:** On Windows, IME-drawn composing text won't be rendered and the behavior is the same with the other platforms.
 
 # 0.26.1 (2022-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix polling during consecutive `EventLoop::run_return` invocations.
 - On Windows, fix race issue creating fullscreen windows with `WindowBuilder::with_fullscreen`
 - On Android, `virtual_keycode` for `KeyboardInput` events is now filled in where a suitable match is found.
-- **Breaking:** Added new `WindowEvent::IME` supported on macOS, X11, and Wayland.
-- Added `Window::set_ime_allowed` supported on macOS, X11, and Wayland.
-- **Breaking:** IME input on macOS, X11, and Wayland won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::IME` events are handled.
+- **Breaking:** Added new `WindowEvent::IME` supported on macOS, Windows, X11, and Wayland.
+- Added `Window::set_ime_allowed` supported on macOS, Windows, X11, and Wayland.
+- **Breaking:** IME input on macOS, Windows, X11, and Wayland won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::IME` events are handled.
 
 # 0.26.1 (2022-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Added new `WindowEvent::IME` supported on macOS, Windows, X11, and Wayland.
 - Added `Window::set_ime_allowed` supported on macOS, Windows, X11, and Wayland.
 - **Breaking:** IME input on macOS, Windows, X11, and Wayland won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::IME` events are handled.
+- **Breaking:** On Windows, IME-drawn composing text won't be rendered and the behavior is the same with the other platforms.
 
 # 0.26.1 (2022-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,9 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix polling during consecutive `EventLoop::run_return` invocations.
 - On Windows, fix race issue creating fullscreen windows with `WindowBuilder::with_fullscreen`
 - On Android, `virtual_keycode` for `KeyboardInput` events is now filled in where a suitable match is found.
-- **Breaking:** Added new `WindowEvent::IME` supported on macOS, Windows, X11, and Wayland.
-- Added `Window::set_ime_allowed` supported on macOS, Windows, X11, and Wayland.
-- **Breaking:** IME input on macOS, Windows, X11, and Wayland won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::IME` events are handled.
+- **Breaking:** Added new `WindowEvent::IME` supported on desktop platforms.
+- Added `Window::set_ime_allowed` supported on desktop platforms.
+- **Breaking:** IME input on desktop platforms won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::IME` events are handled.
 - **Breaking:** On Windows, IME-drawn composing text won't be rendered and the behavior is the same with the other platforms.
 
 # 0.26.1 (2022-01-05)

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -34,7 +34,7 @@ use windows_sys::Win32::{
     UI::{
         Controls::{HOVER_DEFAULT, WM_MOUSELEAVE},
         Input::{
-            Ime::{GCS_COMPSTR, GCS_RESULTSTR},
+            Ime::{GCS_COMPSTR, GCS_RESULTSTR, ISC_SHOWUICOMPOSITIONWINDOW},
             KeyboardAndMouse::{
                 MapVirtualKeyA, ReleaseCapture, SetCapture, TrackMouseEvent, TME_LEAVE,
                 TRACKMOUSEEVENT, VK_F4,
@@ -1134,7 +1134,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 event: WindowEvent::IME(event),
             });
 
-            DefWindowProcW(window, msg, wparam, lparam)
+            // Hide composing text drwan by IME.
+            0
         }
 
         WM_IME_ENDCOMPOSITION => {
@@ -1147,8 +1148,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         WM_IME_SETCONTEXT => {
-            // hide composing text drwan by IME.
-            0
+            // Hide composing text drwan by IME.
+            let wparam = wparam & (!ISC_SHOWUICOMPOSITIONWINDOW as usize);
+
+            DefWindowProcW(window, msg, wparam, lparam)
         }
 
         // this is necessary for us to maintain minimize/restore state

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1115,7 +1115,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     GCS_COMPSTR
                 };
 
-                let comp_str = unsafe { ImeContext::new(window).get_composition_string(gcs_mode) };
+                let comp_str =
+                    unsafe { ImeContext::current(window).get_composition_string(gcs_mode) };
                 if let Some(comp_str) = comp_str {
                     if gcs_mode == GCS_RESULTSTR {
                         IME::Commit(comp_str)

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1118,10 +1118,13 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 w.ime_allowed && w.ime_state != ImeState::Disabled
             };
             if ime_allowed_and_composing {
+                // Windows Hangul IME sends WM_IME_COMPOSITION after WM_IME_ENDCOMPOSITION, so
+                // check whether composing.
+
                 if lparam as u32 & (GCS_COMPSTR | GCS_RESULTSTR) != 0 {
                     let ime_context = ImeContext::current(window);
 
-                    // Google Japanese IME and ATOK have both flags, so
+                    // Google Japanese Input and ATOK have both flags, so
                     // first, receive composing result if exist.
                     if (lparam as u32 & GCS_RESULTSTR) != 0 {
                         if let Some(text) = ime_context.get_composed_text() {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1190,7 +1190,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         WM_IME_SETCONTEXT => {
-            // Hide composing text drwan by IME.
+            // Hide composing text drawn by IME.
             let wparam = wparam & (!ISC_SHOWUICOMPOSITIONWINDOW as usize);
 
             DefWindowProcW(window, msg, wparam, lparam)

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1121,34 +1121,37 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 // Windows Hangul IME sends WM_IME_COMPOSITION after WM_IME_ENDCOMPOSITION, so
                 // check whether composing.
 
-                if lparam as u32 & (GCS_COMPSTR | GCS_RESULTSTR) != 0 {
-                    let ime_context = ImeContext::current(window);
+                let ime_context = ImeContext::current(window);
 
-                    // Google Japanese Input and ATOK have both flags, so
-                    // first, receive composing result if exist.
-                    if (lparam as u32 & GCS_RESULTSTR) != 0 {
-                        if let Some(text) = ime_context.get_composed_text() {
-                            userdata.window_state.lock().ime_state = ImeState::Enabled;
+                if lparam == 0 {
+                    userdata.send_event(Event::WindowEvent {
+                        window_id: RootWindowId(WindowId(window)),
+                        event: WindowEvent::IME(IME::Preedit(String::new(), None, None)),
+                    });
+                }
 
-                            userdata.send_event(Event::WindowEvent {
-                                window_id: RootWindowId(WindowId(window)),
-                                event: WindowEvent::IME(IME::Commit(text)),
-                            });
-                        }
+                // Google Japanese Input and ATOK have both flags, so
+                // first, receive composing result if exist.
+                if (lparam as u32 & GCS_RESULTSTR) != 0 {
+                    if let Some(text) = ime_context.get_composed_text() {
+                        userdata.window_state.lock().ime_state = ImeState::Enabled;
+
+                        userdata.send_event(Event::WindowEvent {
+                            window_id: RootWindowId(WindowId(window)),
+                            event: WindowEvent::IME(IME::Commit(text)),
+                        });
                     }
+                }
 
-                    // Next, receive preedit range for next composing if exist.
-                    if (lparam as u32 & GCS_COMPSTR) != 0 {
-                        if let Some((text, first, last)) =
-                            ime_context.get_composing_text_and_cursor()
-                        {
-                            userdata.window_state.lock().ime_state = ImeState::Preedit;
+                // Next, receive preedit range for next composing if exist.
+                if (lparam as u32 & GCS_COMPSTR) != 0 {
+                    if let Some((text, first, last)) = ime_context.get_composing_text_and_cursor() {
+                        userdata.window_state.lock().ime_state = ImeState::Preedit;
 
-                            userdata.send_event(Event::WindowEvent {
-                                window_id: RootWindowId(WindowId(window)),
-                                event: WindowEvent::IME(IME::Preedit(text, first, last)),
-                            });
-                        }
+                        userdata.send_event(Event::WindowEvent {
+                            window_id: RootWindowId(WindowId(window)),
+                            event: WindowEvent::IME(IME::Preedit(text, first, last)),
+                        });
                     }
                 }
             }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1115,8 +1115,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     GCS_COMPSTR
                 };
 
-                let comp_str =
-                    unsafe { ImeContext::current(window).get_composition_string(gcs_mode) };
+                let comp_str = ImeContext::current(window).get_composition_string(gcs_mode);
                 if let Some(comp_str) = comp_str {
                     if gcs_mode == GCS_RESULTSTR {
                         IME::Commit(comp_str)

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1099,7 +1099,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         WM_IME_STARTCOMPOSITION => {
-            let ime_allowed = { userdata.window_state.lock().ime_allowed };
+            let ime_allowed = userdata.window_state.lock().ime_allowed;
             if ime_allowed {
                 userdata.window_state.lock().ime_state = ImeState::Enabled;
 
@@ -1117,10 +1117,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 let w = userdata.window_state.lock();
                 w.ime_allowed && w.ime_state != ImeState::Disabled
             };
+            // Windows Hangul IME sends WM_IME_COMPOSITION after WM_IME_ENDCOMPOSITION, so
+            // check whether composing.
             if ime_allowed_and_composing {
-                // Windows Hangul IME sends WM_IME_COMPOSITION after WM_IME_ENDCOMPOSITION, so
-                // check whether composing.
-
                 let ime_context = ImeContext::current(window);
 
                 if lparam == 0 {

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -9,8 +9,8 @@ use windows_sys::Win32::{
     Foundation::POINT,
     Globalization::HIMC,
     UI::Input::Ime::{
-        ImmGetCompositionStringW, ImmGetContext, ImmReleaseContext, ImmSetCompositionWindow,
-        CFS_POINT, COMPOSITIONFORM,
+        ImmGetCompositionStringW, ImmGetContext, ImmReleaseContext, ImmSetCandidateWindow,
+        CANDIDATEFORM, CFS_CANDIDATEPOS,
     },
 };
 
@@ -55,13 +55,14 @@ impl ImeContext {
     pub unsafe fn set_ime_position(self, spot: Position, scale_factor: f64) {
         let (x, y) = spot.to_physical::<i32>(scale_factor).into();
 
-        let composition_form = COMPOSITIONFORM {
-            dwStyle: CFS_POINT,
+        let candidate_form = CANDIDATEFORM {
+            dwIndex: 0,
+            dwStyle: CFS_CANDIDATEPOS,
             ptCurrentPos: POINT { x, y },
             rcArea: zeroed(),
         };
 
-        ImmSetCompositionWindow(self.himc, &composition_form);
+        ImmSetCandidateWindow(self.himc, &candidate_form);
     }
 }
 

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -109,11 +109,13 @@ impl ImeContext {
             buf.as_mut_ptr() as *mut c_void,
             size as _,
         );
+        
         if size < 0 {
-            return None;
+            None
+        } else {
+            buf.set_len(size as _);
+            Some(buf)
         }
-        buf.set_len(size as _);
-        return Some(buf);
     }
 
     pub unsafe fn set_ime_position(&self, spot: Position, scale_factor: f64) {

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -10,9 +10,10 @@ use windows_sys::Win32::{
     Globalization::HIMC,
     UI::{
         Input::Ime::{
-            ImmAssociateContext, ImmGetCompositionStringW, ImmGetContext, ImmReleaseContext,
+            ImmAssociateContextEx, ImmGetCompositionStringW, ImmGetContext, ImmReleaseContext,
             ImmSetCandidateWindow, ATTR_TARGET_CONVERTED, ATTR_TARGET_NOTCONVERTED, CANDIDATEFORM,
-            CFS_CANDIDATEPOS, GCS_COMPATTR, GCS_COMPSTR, GCS_RESULTSTR,
+            CFS_CANDIDATEPOS, GCS_COMPATTR, GCS_COMPSTR, GCS_RESULTSTR, IACE_CHILDREN,
+            IACE_DEFAULT,
         },
         WindowsAndMessaging::{GetSystemMetrics, SM_IMMENABLED},
     },
@@ -123,12 +124,12 @@ impl ImeContext {
         }
     }
 
-    pub unsafe fn set_ime_allowed(&self, allowed: bool) {
+    pub unsafe fn set_ime_allowed(hwnd: HWND, allowed: bool) {
         if ImeContext::system_has_ime() {
             if allowed {
-                ImmAssociateContext(self.hwnd, self.himc);
+                ImmAssociateContextEx(hwnd, 0, IACE_DEFAULT);
             } else {
-                ImmAssociateContext(self.hwnd, 0);
+                ImmAssociateContextEx(hwnd, 0, IACE_CHILDREN);
             }
         }
     }

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -1,0 +1,72 @@
+use std::{
+    ffi::{c_void, OsString},
+    mem::zeroed,
+    os::windows::prelude::OsStringExt,
+    ptr::null_mut,
+};
+
+use windows_sys::Win32::{
+    Foundation::POINT,
+    Globalization::HIMC,
+    UI::Input::Ime::{
+        ImmGetCompositionStringW, ImmGetContext, ImmReleaseContext, ImmSetCompositionWindow,
+        CFS_POINT, COMPOSITIONFORM,
+    },
+};
+
+use crate::{dpi::Position, platform::windows::HWND};
+
+pub struct ImeContext {
+    hwnd: HWND,
+    himc: HIMC,
+}
+
+impl ImeContext {
+    pub unsafe fn new(hwnd: HWND) -> Self {
+        let himc = ImmGetContext(hwnd);
+        ImeContext { hwnd, himc }
+    }
+
+    pub unsafe fn get_composition_string(self, gcs_mode: u32) -> Option<String> {
+        let size = ImmGetCompositionStringW(self.himc, gcs_mode, null_mut(), 0);
+        if size <= 0 {
+            return None;
+        }
+        let mut buf = Vec::<u8>::with_capacity(size as _);
+        let size = ImmGetCompositionStringW(
+            self.himc,
+            gcs_mode,
+            buf.as_mut_ptr() as *mut c_void,
+            size as _,
+        );
+        if size <= 0 {
+            return None;
+        }
+        buf.set_len(size as _);
+        let (prefix, shorts, suffix) = buf.align_to::<u16>();
+
+        if prefix.is_empty() && suffix.is_empty() {
+            OsString::from_wide(&shorts).into_string().ok()
+        } else {
+            None
+        }
+    }
+
+    pub unsafe fn set_ime_position(self, spot: Position, scale_factor: f64) {
+        let (x, y) = spot.to_physical::<i32>(scale_factor).into();
+
+        let composition_form = COMPOSITIONFORM {
+            dwStyle: CFS_POINT,
+            ptCurrentPos: POINT { x, y },
+            rcArea: zeroed(),
+        };
+
+        ImmSetCompositionWindow(self.himc, &composition_form);
+    }
+}
+
+impl Drop for ImeContext {
+    fn drop(&mut self) {
+        unsafe { ImmReleaseContext(self.hwnd, self.himc) };
+    }
+}

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -134,6 +134,7 @@ impl ImeContext {
         if !ImeContext::system_has_ime() {
             return;
         }
+        
         if allowed {
             ImmAssociateContextEx(hwnd, 0, IACE_DEFAULT);
         } else {

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -100,6 +100,7 @@ impl ImeContext {
         if size == 0 {
             return Some(Vec::new());
         }
+        
         let mut buf = Vec::<u8>::with_capacity(size as _);
         let size = ImmGetCompositionStringW(
             self.himc,

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -54,7 +54,7 @@ impl ImeContext {
 
             boundary_before_char += chr.len_utf8();
         }
-        
+
         if first.is_some() && last.is_none() {
             last = Some(text.len());
         } else if first.is_none() {
@@ -93,7 +93,7 @@ impl ImeContext {
         } else if size == 0 {
             return Some(Vec::new());
         }
-        
+
         let mut buf = Vec::<u8>::with_capacity(size as _);
         let size = ImmGetCompositionStringW(
             self.himc,
@@ -101,7 +101,7 @@ impl ImeContext {
             buf.as_mut_ptr() as *mut c_void,
             size as _,
         );
-        
+
         if size < 0 {
             None
         } else {
@@ -114,7 +114,7 @@ impl ImeContext {
         if !ImeContext::system_has_ime() {
             return;
         }
-        
+
         let (x, y) = spot.to_physical::<i32>(scale_factor).into();
         let candidate_form = CANDIDATEFORM {
             dwIndex: 0,
@@ -130,7 +130,7 @@ impl ImeContext {
         if !ImeContext::system_has_ime() {
             return;
         }
-        
+
         if allowed {
             ImmAssociateContextEx(hwnd, 0, IACE_DEFAULT);
         } else {

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -49,17 +49,17 @@ impl ImeContext {
             let char_is_targetted =
                 attr as u32 == ATTR_TARGET_CONVERTED || attr as u32 == ATTR_TARGET_NOTCONVERTED;
 
-            if first == None && char_is_targetted {
+            if first.is_none() && char_is_targetted {
                 first = Some(boundary_before_char);
-            } else if first != None && last == None && !char_is_targetted {
+            } else if first.is_some() && last.is_none() && !char_is_targetted {
                 last = Some(boundary_before_char);
             }
 
             boundary_before_char += chr.len_utf8();
         }
-        if first != None && last == None {
+        if first.is_some() && last.is_none() {
             last = Some(text.len());
-        } else if first == None {
+        } else if first.is_none() {
             // IME haven't split words and select any clause yet, so trying to retrieve normal cursor.
             let cursor = self.get_composition_cursor(&text);
             first = cursor;

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -120,8 +120,8 @@ impl ImeContext {
         if !ImeContext::system_has_ime() {
             return;
         }
+        
         let (x, y) = spot.to_physical::<i32>(scale_factor).into();
-
         let candidate_form = CANDIDATEFORM {
             dwIndex: 0,
             dwStyle: CFS_EXCLUDE,

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -12,8 +12,7 @@ use windows_sys::Win32::{
         Input::Ime::{
             ImmAssociateContextEx, ImmGetCompositionStringW, ImmGetContext, ImmReleaseContext,
             ImmSetCandidateWindow, ATTR_TARGET_CONVERTED, ATTR_TARGET_NOTCONVERTED, CANDIDATEFORM,
-            CFS_CANDIDATEPOS, GCS_COMPATTR, GCS_COMPSTR, GCS_RESULTSTR, IACE_CHILDREN,
-            IACE_DEFAULT,
+            CFS_EXCLUDE, GCS_COMPATTR, GCS_COMPSTR, GCS_RESULTSTR, IACE_CHILDREN, IACE_DEFAULT,
         },
         WindowsAndMessaging::{GetSystemMetrics, SM_IMMENABLED},
     },
@@ -115,7 +114,7 @@ impl ImeContext {
 
             let candidate_form = CANDIDATEFORM {
                 dwIndex: 0,
-                dwStyle: CFS_CANDIDATEPOS,
+                dwStyle: CFS_EXCLUDE,
                 ptCurrentPos: POINT { x, y },
                 rcArea: zeroed(),
             };

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -22,7 +22,7 @@ pub struct ImeContext {
 }
 
 impl ImeContext {
-    pub unsafe fn new(hwnd: HWND) -> Self {
+    pub unsafe fn current(hwnd: HWND) -> Self {
         let himc = ImmGetContext(hwnd);
         ImeContext { hwnd, himc }
     }

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -12,7 +12,8 @@ use windows_sys::Win32::{
         Input::Ime::{
             ImmAssociateContextEx, ImmGetCompositionStringW, ImmGetContext, ImmReleaseContext,
             ImmSetCandidateWindow, ATTR_TARGET_CONVERTED, ATTR_TARGET_NOTCONVERTED, CANDIDATEFORM,
-            CFS_EXCLUDE, GCS_COMPATTR, GCS_COMPSTR, GCS_RESULTSTR, IACE_CHILDREN, IACE_DEFAULT,
+            CFS_EXCLUDE, GCS_COMPATTR, GCS_COMPSTR, GCS_CURSORPOS, GCS_RESULTSTR, IACE_CHILDREN,
+            IACE_DEFAULT,
         },
         WindowsAndMessaging::{GetSystemMetrics, SM_IMMENABLED},
     },
@@ -55,14 +56,16 @@ impl ImeContext {
                 if first != None && last == None {
                     last = Some(text.len());
                 } else if first == None {
-                    // IME haven't split words and select any clause yet.
-                    first = None;
-                    last = None;
+                    // IME haven't split words and select any clause yet, so trying to retrieve normal cursor.
+                    let cursor = self.get_composition_cursor(&text);
+                    first = cursor;
+                    last = cursor;
                 }
 
                 Some((text, first, last))
             } else {
-                Some((text, None, None))
+                let cursor = self.get_composition_cursor(&text);
+                Some((text, cursor, cursor))
             }
         } else {
             None
@@ -71,6 +74,15 @@ impl ImeContext {
 
     pub unsafe fn get_composed_text(&self) -> Option<String> {
         self.get_composition_string(GCS_RESULTSTR)
+    }
+
+    unsafe fn get_composition_cursor(&self, text: &str) -> Option<usize> {
+        let cursor = ImmGetCompositionStringW(self.himc, GCS_CURSORPOS, null_mut(), 0);
+        if cursor >= 0 {
+            Some(text.chars().take(cursor as _).map(|c| c.len_utf8()).sum())
+        } else {
+            None
+        }
     }
 
     unsafe fn get_composition_string(&self, gcs_mode: u32) -> Option<String> {

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -57,6 +57,7 @@ impl ImeContext {
 
             boundary_before_char += chr.len_utf8();
         }
+        
         if first.is_some() && last.is_none() {
             last = Some(text.len());
         } else if first.is_none() {

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -97,8 +97,7 @@ impl ImeContext {
         let size = ImmGetCompositionStringW(self.himc, gcs_mode, null_mut(), 0);
         if size < 0 {
             return None;
-        }
-        if size == 0 {
+        } else if size == 0 {
             return Some(Vec::new());
         }
         

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -36,10 +36,7 @@ impl ImeContext {
         &self,
     ) -> Option<(String, Option<usize>, Option<usize>)> {
         let text = self.get_composition_string(GCS_COMPSTR)?;
-        let attrs = match self.get_composition_data(GCS_COMPATTR) {
-            Some(attrs) => attrs,
-            None => Vec::new(),
-        };
+        let attrs = self.get_composition_data(GCS_COMPATTR).unwrap_or_default();
 
         let mut first = None;
         let mut last = None;
@@ -76,11 +73,7 @@ impl ImeContext {
 
     unsafe fn get_composition_cursor(&self, text: &str) -> Option<usize> {
         let cursor = ImmGetCompositionStringW(self.himc, GCS_CURSORPOS, null_mut(), 0);
-        if cursor >= 0 {
-            Some(text.chars().take(cursor as _).map(|c| c.len_utf8()).sum())
-        } else {
-            None
-        }
+        (cursor >= 0).then(|| text.chars().take(cursor as _).map(|c| c.len_utf8()).sum())
     }
 
     unsafe fn get_composition_string(&self, gcs_mode: u32) -> Option<String> {

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -11,7 +11,8 @@ use windows_sys::Win32::{
     UI::{
         Input::Ime::{
             ImmAssociateContext, ImmGetCompositionStringW, ImmGetContext, ImmReleaseContext,
-            ImmSetCandidateWindow, CANDIDATEFORM, CFS_CANDIDATEPOS,
+            ImmSetCandidateWindow, ATTR_TARGET_CONVERTED, ATTR_TARGET_NOTCONVERTED, CANDIDATEFORM,
+            CFS_CANDIDATEPOS, GCS_COMPATTR, GCS_COMPSTR, GCS_RESULTSTR,
         },
         WindowsAndMessaging::{GetSystemMetrics, SM_IMMENABLED},
     },
@@ -30,13 +31,68 @@ impl ImeContext {
         ImeContext { hwnd, himc }
     }
 
-    pub unsafe fn get_composition_string(&self, gcs_mode: u32) -> Option<String> {
-        if !ImeContext::system_has_ime() {
+    pub unsafe fn get_composing_text_and_cursor(
+        &self,
+    ) -> Option<(String, Option<usize>, Option<usize>)> {
+        if let Some(text) = self.get_composition_string(GCS_COMPSTR) {
+            if let Some(attrs) = self.get_composition_data(GCS_COMPATTR) {
+                let mut first: Option<usize> = None;
+                let mut last: Option<usize> = None;
+                let mut boundary_before_char = 0;
+
+                for (attr, chr) in attrs.into_iter().zip(text.chars()) {
+                    let char_is_targetted = attr as u32 == ATTR_TARGET_CONVERTED
+                        || attr as u32 == ATTR_TARGET_NOTCONVERTED;
+
+                    if first == None && char_is_targetted {
+                        first = Some(boundary_before_char);
+                    } else if first != None && last == None && !char_is_targetted {
+                        last = Some(boundary_before_char);
+                    }
+
+                    boundary_before_char += chr.len_utf8();
+                }
+                if first != None && last == None {
+                    last = Some(text.len());
+                } else if first == None {
+                    // IME haven't split words and select any clause yet.
+                    first = None;
+                    last = None;
+                }
+
+                Some((text, first, last))
+            } else {
+                Some((text, None, None))
+            }
+        } else {
+            None
+        }
+    }
+
+    pub unsafe fn get_composed_text(&self) -> Option<String> {
+        self.get_composition_string(GCS_RESULTSTR)
+    }
+
+    unsafe fn get_composition_string(&self, gcs_mode: u32) -> Option<String> {
+        if let Some(data) = self.get_composition_data(gcs_mode) {
+            let (prefix, shorts, suffix) = data.align_to::<u16>();
+            if prefix.is_empty() && suffix.is_empty() {
+                OsString::from_wide(&shorts).into_string().ok()
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    unsafe fn get_composition_data(&self, gcs_mode: u32) -> Option<Vec<u8>> {
+        let size = ImmGetCompositionStringW(self.himc, gcs_mode, null_mut(), 0);
+        if size < 0 {
             return None;
         }
-        let size = ImmGetCompositionStringW(self.himc, gcs_mode, null_mut(), 0);
-        if size <= 0 {
-            return None;
+        if size == 0 {
+            return Some(Vec::new());
         }
         let mut buf = Vec::<u8>::with_capacity(size as _);
         let size = ImmGetCompositionStringW(
@@ -45,17 +101,11 @@ impl ImeContext {
             buf.as_mut_ptr() as *mut c_void,
             size as _,
         );
-        if size <= 0 {
+        if size < 0 {
             return None;
         }
         buf.set_len(size as _);
-        let (prefix, shorts, suffix) = buf.align_to::<u16>();
-
-        if prefix.is_empty() && suffix.is_empty() {
-            OsString::from_wide(&shorts).into_string().ok()
-        } else {
-            None
-        }
+        return Some(buf);
     }
 
     pub unsafe fn set_ime_position(&self, spot: Position, scale_factor: f64) {

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -154,6 +154,7 @@ mod drop_handler;
 mod event;
 mod event_loop;
 mod icon;
+mod ime;
 mod monitor;
 mod raw_input;
 mod window;

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -31,10 +31,6 @@ use windows_sys::Win32::{
     },
     UI::{
         Input::{
-            Ime::{
-                ImmGetContext, ImmReleaseContext, ImmSetCompositionWindow, CFS_POINT,
-                COMPOSITIONFORM,
-            },
             KeyboardAndMouse::{
                 EnableWindow, GetActiveWindow, MapVirtualKeyW, ReleaseCapture, SendInput, INPUT,
                 INPUT_0, INPUT_KEYBOARD, KEYBDINPUT, KEYEVENTF_EXTENDEDKEY, KEYEVENTF_KEYUP,
@@ -49,8 +45,8 @@ use windows_sys::Win32::{
             SetWindowPlacement, SetWindowPos, SetWindowTextW, CS_HREDRAW, CS_VREDRAW,
             CW_USEDEFAULT, FLASHWINFO, FLASHW_ALL, FLASHW_STOP, FLASHW_TIMERNOFG, FLASHW_TRAY,
             GWLP_HINSTANCE, HTCAPTION, MAPVK_VK_TO_VSC, NID_READY, PM_NOREMOVE, SM_DIGITIZER,
-            SM_IMMENABLED, SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER,
-            WM_NCLBUTTONDOWN, WNDCLASSEXW,
+            SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, WM_NCLBUTTONDOWN,
+            WNDCLASSEXW,
         },
     },
 };
@@ -69,6 +65,7 @@ use crate::{
         drop_handler::FileDropHandler,
         event_loop::{self, EventLoopWindowTarget, DESTROY_MSG_ID},
         icon::{self, IconType},
+        ime::ImeContext,
         monitor, util,
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
         Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
@@ -613,25 +610,11 @@ impl Window {
         self.window_state.lock().taskbar_icon = taskbar_icon;
     }
 
-    pub(crate) fn set_ime_position_physical(&self, x: i32, y: i32) {
-        if unsafe { GetSystemMetrics(SM_IMMENABLED) } != 0 {
-            let composition_form = COMPOSITIONFORM {
-                dwStyle: CFS_POINT,
-                ptCurrentPos: POINT { x, y },
-                rcArea: unsafe { mem::zeroed() },
-            };
-            unsafe {
-                let himc = ImmGetContext(self.hwnd());
-                ImmSetCompositionWindow(himc, &composition_form);
-                ImmReleaseContext(self.hwnd(), himc);
-            }
-        }
-    }
-
     #[inline]
     pub fn set_ime_position(&self, spot: Position) {
-        let (x, y) = spot.to_physical::<i32>(self.scale_factor()).into();
-        self.set_ime_position_physical(x, y);
+        unsafe {
+            ImeContext::new(self.hwnd()).set_ime_position(spot, self.scale_factor());
+        }
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -625,7 +625,6 @@ impl Window {
         unsafe {
             self.ime_context.set_ime_allowed(allowed);
         }
-        self.window_state.lock().ime_allowed = allowed;
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -83,9 +83,6 @@ pub struct Window {
 
     // The events loop proxy.
     thread_executor: event_loop::EventLoopThreadExecutor,
-
-    // The IME context.
-    ime_context: ImeContext,
 }
 
 impl Window {
@@ -616,14 +613,14 @@ impl Window {
     #[inline]
     pub fn set_ime_position(&self, spot: Position) {
         unsafe {
-            self.ime_context.set_ime_position(spot, self.scale_factor());
+            ImeContext::current(self.hwnd()).set_ime_position(spot, self.scale_factor());
         }
     }
 
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         unsafe {
-            self.ime_context.set_ime_allowed(allowed);
+            ImeContext::set_ime_allowed(self.hwnd(), allowed);
         }
     }
 
@@ -778,11 +775,12 @@ impl<'a, T: 'static> InitData<'a, T> {
 
         enable_non_client_dpi_scaling(window);
 
+        ImeContext::set_ime_allowed(window, false);
+
         Window {
             window: WindowWrapper(window),
             window_state,
             thread_executor: self.event_loop.create_thread_executor(),
-            ime_context: ImeContext::current(window),
         }
     }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -619,6 +619,7 @@ impl Window {
 
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
+        self.window_state.lock().ime_allowed = allowed;
         unsafe {
             ImeContext::set_ime_allowed(self.hwnd(), allowed);
         }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -635,8 +635,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_ime_allowed(&self, _allowed: bool) {
-        error!("`Window::set_ime_allowed` is not yet implemented");
+    pub fn set_ime_allowed(&self, allowed: bool) {
+        self.window_state.lock().ime_allowed = allowed;
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -83,6 +83,9 @@ pub struct Window {
 
     // The events loop proxy.
     thread_executor: event_loop::EventLoopThreadExecutor,
+
+    // The IME context.
+    ime_context: ImeContext,
 }
 
 impl Window {
@@ -613,12 +616,15 @@ impl Window {
     #[inline]
     pub fn set_ime_position(&self, spot: Position) {
         unsafe {
-            ImeContext::new(self.hwnd()).set_ime_position(spot, self.scale_factor());
+            self.ime_context.set_ime_position(spot, self.scale_factor());
         }
     }
 
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
+        unsafe {
+            self.ime_context.set_ime_allowed(allowed);
+        }
         self.window_state.lock().ime_allowed = allowed;
     }
 
@@ -777,6 +783,7 @@ impl<'a, T: 'static> InitData<'a, T> {
             window: WindowWrapper(window),
             window_state,
             thread_executor: self.event_loop.create_thread_executor(),
+            ime_context: ImeContext::new(window),
         }
     }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -783,7 +783,7 @@ impl<'a, T: 'static> InitData<'a, T> {
             window: WindowWrapper(window),
             window_state,
             thread_executor: self.event_loop.create_thread_executor(),
-            ime_context: ImeContext::new(window),
+            ime_context: ImeContext::current(window),
         }
     }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -42,6 +42,8 @@ pub struct WindowState {
     pub preferred_theme: Option<Theme>,
     pub high_surrogate: Option<u16>,
     pub window_flags: WindowFlags,
+
+    pub ime_allowed: bool,
 }
 
 #[derive(Clone)]
@@ -130,6 +132,8 @@ impl WindowState {
             preferred_theme,
             high_surrogate: None,
             window_flags: WindowFlags::empty(),
+
+            ime_allowed: false,
         }
     }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -42,8 +42,6 @@ pub struct WindowState {
     pub preferred_theme: Option<Theme>,
     pub high_surrogate: Option<u16>,
     pub window_flags: WindowFlags,
-
-    pub ime_allowed: bool,
 }
 
 #[derive(Clone)]
@@ -132,8 +130,6 @@ impl WindowState {
             preferred_theme,
             high_surrogate: None,
             window_flags: WindowFlags::empty(),
-
-            ime_allowed: false,
         }
     }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -42,6 +42,9 @@ pub struct WindowState {
     pub preferred_theme: Option<Theme>,
     pub high_surrogate: Option<u16>,
     pub window_flags: WindowFlags,
+
+    pub ime_state: ImeState,
+    pub ime_allowed: bool,
 }
 
 #[derive(Clone)]
@@ -99,6 +102,13 @@ bitflags! {
     }
 }
 
+#[derive(Eq, PartialEq)]
+pub enum ImeState {
+    Disabled,
+    Enabled,
+    Preedit,
+}
+
 impl WindowState {
     pub fn new(
         attributes: &WindowAttributes,
@@ -130,6 +140,9 @@ impl WindowState {
             preferred_theme,
             high_surrogate: None,
             window_flags: WindowFlags::empty(),
+
+            ime_state: ImeState::Disabled,
+            ime_allowed: false,
         }
     }
 


### PR DESCRIPTION
This PR will add composition event support.
Related: #1497

- IME events for Windows
- Window::set_ime_allowed() for Windows
- **Breaking:** Hide OS-drawn composing text for Windows (same as the other platforms)

Tested on `ime` example (feel free to comment if you try this PR):
- Microsoft IME - Japanese (on Windows 10 19044.1620)
- Google Japanese Input - Japanese (on Windows 10 19044.1620)
- ATOK - Japanese (on Windows 10 19044.1620)

Tested on `ime` example but I am not native
- Microsoft IME - Korean (on Windows 10 19044.1620)
- Microsoft IME Pinyin - Chinese (Simplified, China) (on Windows 10 19044.1620)
- (Microsoft) Vietnamse Telex - Vietnamse (on Windows 10 19044.1620)

----

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented