### PR TITLE
Add `is_resizable` and `is_decorated` on Wayland

### DIFF
--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -58,6 +58,12 @@ pub struct Window {
 
     /// Requests that SCTK window should perform.
     window_requests: Arc<Mutex<Vec<WindowRequest>>>,
+
+    /// Whether the window is resizeable.
+    resizeable: AtomicBool,
+
+    /// Whether the window is decorated.
+    decorated: AtomicBool,
 }
 
 impl Window {
@@ -248,6 +254,8 @@ impl Window {
             fullscreen,
             maximized,
             windowing_features,
+            resizeable: AtomicBool::new(attributes.resizable),
+            decorated: AtomicBool::new(attributes.decorations),
         };
 
         Ok(window)
@@ -338,12 +346,13 @@ impl Window {
 
     #[inline]
     pub fn set_resizable(&self, resizable: bool) {
+        self.resizeable.store(resizable, Ordering::Relaxed);
         self.send_request(WindowRequest::Resizeable(resizable));
     }
 
     #[inline]
     pub fn is_resizable(&self) -> bool {
-        true
+        self.resizeable.load(Ordering::Relaxed)
     }
 
     #[inline]
@@ -355,12 +364,13 @@ impl Window {
 
     #[inline]
     pub fn set_decorations(&self, decorate: bool) {
+        self.decorated.store(decorate, Ordering::Relaxed);
         self.send_request(WindowRequest::Decorate(decorate));
     }
 
     #[inline]
     pub fn is_decorated(&self) -> bool {
-        true
+        self.decorated.load(Ordering::Relaxed)
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -686,7 +686,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **Wayland / X11:** Not implemented.
+    /// - **X11:** Not implemented.
     /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn is_resizable(&self) -> bool {
@@ -777,7 +777,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **Wayland / X11:** Not implemented.
+    /// - **X11:** Not implemented.
     /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn is_decorated(&self) -> bool {


### PR DESCRIPTION
This commit brings `is_resizable` and `is_decorated`. Since the client
is responsible for both of them, they could be tracked without deep
syncing with server.
