### PR TITLE
[X11] Create windows with a parent window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, `wayland-csd-adwaita` now uses `ab_glyph` instead of `crossfont` to render the title for decorations.
 - On Wayland, a new `wayland-csd-adwaita-crossfont` feature was added to use `crossfont` instead of `ab_glyph` for decorations.
 - On Wayland, if not otherwise specified use upstream automatic CSD theme selection.
+- On X11, added `WindowExtX11::with_parent` to create child windows.
 
 # 0.27.3
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -137,6 +137,7 @@ If your PR makes notable changes to Winit's features, please update this section
 * X11 Override Redirect Flag
 * GTK Theme Variant
 * Base window size
+* Setting the X11 parent window
 
 ### iOS
 * `winit` has a minimum OS requirement of iOS 8

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -1,0 +1,83 @@
+#[cfg(all(target_os = "linux", feature = "x11"))]
+use std::collections::HashMap;
+
+#[cfg(all(target_os = "linux", feature = "x11"))]
+use winit::{
+    dpi::{LogicalPosition, LogicalSize, Position},
+    event::{ElementState, Event, KeyboardInput, WindowEvent},
+    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+    platform::unix::{WindowBuilderExtUnix, WindowExtUnix},
+    window::{Window, WindowBuilder},
+};
+
+#[cfg(all(target_os = "linux", feature = "x11"))]
+fn spawn_child_window(
+    parent: usize,
+    event_loop: &EventLoopWindowTarget<()>,
+    windows: &mut HashMap<usize, Window>,
+) {
+    let child_window = WindowBuilder::new()
+        .with_x11_parent(parent)
+        .with_title("child window")
+        .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
+        .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+        .with_visible(true)
+        .build(&event_loop)
+        .unwrap();
+
+    let id: usize = child_window.xlib_window().unwrap().try_into().unwrap();
+    windows.insert(id, child_window);
+    println!("child window created with id: {}", id);
+}
+
+#[cfg(all(target_os = "linux", feature = "x11"))]
+fn main() {
+    let mut windows = HashMap::new();
+
+    let event_loop: EventLoop<()> = EventLoop::new();
+    let parent_window = WindowBuilder::new()
+        .with_title("parent window")
+        .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+        .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))
+        .build(&event_loop)
+        .unwrap();
+    let root: usize = parent_window.xlib_window().unwrap().try_into().unwrap();
+    println!("parent window id: {})", root);
+
+    event_loop.run(move |event: Event<'_, ()>, event_loop, control_flow| {
+        *control_flow = ControlFlow::Wait;
+
+        match event {
+            Event::WindowEvent { event, window_id } => match event {
+                WindowEvent::CloseRequested => {
+                    windows.clear();
+                    *control_flow = ControlFlow::Exit;
+                }
+                WindowEvent::CursorEntered { device_id: _ } => {
+                    // println when the cursor entered in a window even if the child window is created
+                    // by some key inputs.
+                    // the child windows are always placed at (0, 0) with size (200, 200) in the parent window,
+                    // so we also can see this log when we move the cursor arround (200, 200) in parent window.
+                    println!("cursor entered in the window {:?}", window_id);
+                }
+                WindowEvent::KeyboardInput {
+                    input:
+                        KeyboardInput {
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                } => {
+                    spawn_child_window(root, event_loop, &mut windows);
+                }
+                _ => (),
+            },
+            _ => (),
+        }
+    })
+}
+
+#[cfg(not(all(target_os = "linux", feature = "x11")))]
+fn main() {
+    panic!("This example is supported only on x11.");
+}

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -12,12 +12,12 @@ use winit::{
 
 #[cfg(all(target_os = "linux", feature = "x11"))]
 fn spawn_child_window(
-    parent: usize,
+    parent: u64,
     event_loop: &EventLoopWindowTarget<()>,
     windows: &mut HashMap<usize, Window>,
 ) {
     let child_window = WindowBuilder::new()
-        .with_x11_parent(parent)
+        .with_x11_parent(parent.try_into().unwrap())
         .with_title("child window")
         .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
         .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
@@ -41,7 +41,7 @@ fn main() {
         .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))
         .build(&event_loop)
         .unwrap();
-    let root: usize = parent_window.xlib_window().unwrap().try_into().unwrap();
+    let root: u64 = parent_window.xlib_window().unwrap().try_into().unwrap();
     println!("parent window id: {})", root);
 
     event_loop.run(move |event: Event<'_, ()>, event_loop, control_flow| {

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -14,7 +14,7 @@ use winit::{
 fn spawn_child_window(
     parent: u64,
     event_loop: &EventLoopWindowTarget<()>,
-    windows: &mut HashMap<usize, Window>,
+    windows: &mut HashMap<u64, Window>,
 ) {
     let child_window = WindowBuilder::new()
         .with_x11_parent(parent.try_into().unwrap())
@@ -25,7 +25,10 @@ fn spawn_child_window(
         .build(&event_loop)
         .unwrap();
 
-    let id: usize = child_window.xlib_window().unwrap().try_into().unwrap();
+    #[cfg(target_pointer_width = "64")]
+    let id = child_window.xlib_window().unwrap();
+    #[cfg(not(target_pointer_width = "64"))]
+    let id = child_window.xlib_window().unwrap().try_into().unwrap();
     windows.insert(id, child_window);
     println!("child window created with id: {}", id);
 }
@@ -41,7 +44,11 @@ fn main() {
         .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))
         .build(&event_loop)
         .unwrap();
-    let root: u64 = parent_window.xlib_window().unwrap().try_into().unwrap();
+
+    #[cfg(target_pointer_width = "64")]
+    let root = parent_window.xlib_window().unwrap();
+    #[cfg(not(target_pointer_width = "64"))]
+    let root = parent_window.xlib_window().unwrap().try_into().unwrap();
     println!("parent window id: {})", root);
 
     event_loop.run(move |event: Event<'_, ()>, event_loop, control_flow| {

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -22,7 +22,7 @@ fn spawn_child_window(
         .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
         .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
         .with_visible(true)
-        .build(&event_loop)
+        .build(event_loop)
         .unwrap();
 
     #[cfg(target_pointer_width = "64")]
@@ -54,8 +54,8 @@ fn main() {
     event_loop.run(move |event: Event<'_, ()>, event_loop, control_flow| {
         *control_flow = ControlFlow::Wait;
 
-        match event {
-            Event::WindowEvent { event, window_id } => match event {
+        if let Event::WindowEvent { event, window_id } = event {
+            match event {
                 WindowEvent::CloseRequested => {
                     windows.clear();
                     *control_flow = ControlFlow::Exit;
@@ -78,8 +78,7 @@ fn main() {
                     spawn_child_window(root, event_loop, &mut windows);
                 }
                 _ => (),
-            },
-            _ => (),
+            }
         }
     })
 }

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -6,7 +6,7 @@ use winit::{
     dpi::{LogicalPosition, LogicalSize, Position},
     event::{ElementState, Event, KeyboardInput, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
-    platform::unix::{WindowBuilderExtUnix, WindowExtUnix},
+    platform::x11::{WindowBuilderExtX11, WindowExtX11},
     window::{Window, WindowBuilder, WindowId},
 };
 
@@ -17,7 +17,7 @@ fn spawn_child_window(
     windows: &mut HashMap<u32, Window>,
 ) {
     let child_window = WindowBuilder::new()
-        .with_x11_parent(WindowId::from(parent as u64))
+        .with_parent(WindowId::from(parent as u64))
         .with_title("child window")
         .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
         .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -7,17 +7,17 @@ use winit::{
     event::{ElementState, Event, KeyboardInput, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
     platform::unix::{WindowBuilderExtUnix, WindowExtUnix},
-    window::{Window, WindowBuilder},
+    window::{Window, WindowBuilder, WindowId},
 };
 
 #[cfg(all(target_os = "linux", feature = "x11"))]
 fn spawn_child_window(
-    parent: u64,
+    parent: u32,
     event_loop: &EventLoopWindowTarget<()>,
-    windows: &mut HashMap<u64, Window>,
+    windows: &mut HashMap<u32, Window>,
 ) {
     let child_window = WindowBuilder::new()
-        .with_x11_parent(parent.try_into().unwrap())
+        .with_x11_parent(WindowId::from(parent as u64))
         .with_title("child window")
         .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
         .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
@@ -25,10 +25,7 @@ fn spawn_child_window(
         .build(event_loop)
         .unwrap();
 
-    #[cfg(target_pointer_width = "64")]
-    let id = child_window.xlib_window().unwrap();
-    #[cfg(not(target_pointer_width = "64"))]
-    let id = child_window.xlib_window().unwrap().try_into().unwrap();
+    let id = child_window.xlib_window().unwrap() as u32;
     windows.insert(id, child_window);
     println!("child window created with id: {}", id);
 }
@@ -45,10 +42,7 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    #[cfg(target_pointer_width = "64")]
-    let root = parent_window.xlib_window().unwrap();
-    #[cfg(not(target_pointer_width = "64"))]
-    let root = parent_window.xlib_window().unwrap().try_into().unwrap();
+    let root = parent_window.xlib_window().unwrap() as u32;
     println!("parent window id: {})", root);
 
     event_loop.run(move |event: Event<'_, ()>, event_loop, control_flow| {

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -172,8 +172,7 @@ pub trait WindowBuilderExtX11 {
     fn with_x11_visual<T>(self, visual_infos: *const T) -> Self;
 
     fn with_x11_screen(self, screen_id: i32) -> Self;
-    #[cfg(feature = "x11")]
-    /// Build window with X11's parent window. Only relevant on X11.
+    /// Build window with parent window.
     fn with_parent(self, parent_id: WindowId) -> Self;
 
     /// Build window with the given `general` and `instance` names.

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -171,6 +171,9 @@ pub trait WindowBuilderExtX11 {
     fn with_x11_visual<T>(self, visual_infos: *const T) -> Self;
 
     fn with_x11_screen(self, screen_id: i32) -> Self;
+    #[cfg(feature = "x11")]
+    /// Build window with X11's parent window. Only relevant on X11.
+    fn with_x11_parent(self, parent_id: usize) -> Self;
 
     /// Build window with the given `general` and `instance` names.
     ///
@@ -224,6 +227,13 @@ impl WindowBuilderExtX11 for WindowBuilder {
     #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
         self.platform_specific.name = Some(ApplicationName::new(general.into(), instance.into()));
+        self
+    }
+
+    #[inline]
+    #[cfg(feature = "x11")]
+    fn with_x11_parent(mut self, parent_id: usize) -> Self {
+        self.platform_specific.parent_id = Some(parent_id);
         self
     }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -1,10 +1,12 @@
 use std::os::raw;
 use std::{ptr, sync::Arc};
 
+#[cfg(feature = "x11")]
+use crate::window::WindowId;
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
     monitor::MonitorHandle,
-    window::{Window, WindowBuilder, WindowId},
+    window::{Window, WindowBuilder},
 };
 
 use crate::dpi::Size;

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -1,7 +1,6 @@
 use std::os::raw;
 use std::{ptr, sync::Arc};
 
-#[cfg(feature = "x11")]
 use crate::window::WindowId;
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
@@ -175,7 +174,7 @@ pub trait WindowBuilderExtX11 {
     fn with_x11_screen(self, screen_id: i32) -> Self;
     #[cfg(feature = "x11")]
     /// Build window with X11's parent window. Only relevant on X11.
-    fn with_x11_parent(self, parent_id: WindowId) -> Self;
+    fn with_parent(self, parent_id: WindowId) -> Self;
 
     /// Build window with the given `general` and `instance` names.
     ///
@@ -233,8 +232,7 @@ impl WindowBuilderExtX11 for WindowBuilder {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
-    fn with_x11_parent(mut self, parent_id: WindowId) -> Self {
+    fn with_parent(mut self, parent_id: WindowId) -> Self {
         self.platform_specific.parent_id = Some(parent_id.0);
         self
     }

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -4,7 +4,7 @@ use std::{ptr, sync::Arc};
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
     monitor::MonitorHandle,
-    window::{Window, WindowBuilder},
+    window::{Window, WindowBuilder, WindowId},
 };
 
 use crate::dpi::Size;
@@ -173,7 +173,7 @@ pub trait WindowBuilderExtX11 {
     fn with_x11_screen(self, screen_id: i32) -> Self;
     #[cfg(feature = "x11")]
     /// Build window with X11's parent window. Only relevant on X11.
-    fn with_x11_parent(self, parent_id: usize) -> Self;
+    fn with_x11_parent(self, parent_id: WindowId) -> Self;
 
     /// Build window with the given `general` and `instance` names.
     ///
@@ -232,8 +232,8 @@ impl WindowBuilderExtX11 for WindowBuilder {
 
     #[inline]
     #[cfg(feature = "x11")]
-    fn with_x11_parent(mut self, parent_id: usize) -> Self {
-        self.platform_specific.parent_id = Some(parent_id);
+    fn with_x11_parent(mut self, parent_id: WindowId) -> Self {
+        self.platform_specific.parent_id = Some(parent_id.0);
         self
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -95,7 +95,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     #[cfg(feature = "x11")]
     pub screen_id: Option<i32>,
     #[cfg(feature = "x11")]
-    pub parent_id: Option<usize>,
+    pub parent_id: Option<WindowId>,
     #[cfg(feature = "x11")]
     pub base_size: Option<Size>,
     #[cfg(feature = "x11")]

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -95,6 +95,8 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     #[cfg(feature = "x11")]
     pub screen_id: Option<i32>,
     #[cfg(feature = "x11")]
+    pub parent_id: Option<usize>,
+    #[cfg(feature = "x11")]
     pub base_size: Option<Size>,
     #[cfg(feature = "x11")]
     pub override_redirect: bool,
@@ -114,6 +116,8 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             visual_infos: None,
             #[cfg(feature = "x11")]
             screen_id: None,
+            #[cfg(feature = "x11")]
+            parent_id: None,
             #[cfg(feature = "x11")]
             base_size: None,
             #[cfg(feature = "x11")]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -123,7 +123,12 @@ impl UnownedWindow {
         // root should be a type ffi::Window and it is finally c_ulong.
         // cf. https://docs.rs/x11-dl/2.19.1/x11_dl/xlib/type.Window.html
         let root = if let Some(id) = pl_attribs.parent_id {
-            u64::from(id).try_into().unwrap()
+            #[cfg(target_pointer_width = "64")]
+            let root = u64::from(id);
+            #[cfg(not(target_pointer_width = "64"))]
+            let root = u64::from(id).try_into().unwrap();
+
+            root
         } else {
             event_loop.root
         };

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -120,12 +120,8 @@ impl UnownedWindow {
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<UnownedWindow, RootOsError> {
         let xconn = &event_loop.xconn;
-        // root should be a type ffi::Window and it is finally c_ulong.
-        // cf. https://docs.rs/x11-dl/2.19.1/x11_dl/xlib/type.Window.html
         let root = if let Some(id) = pl_attribs.parent_id {
-            // XID is defined as 32-bit value in the X11 protocol so
-            // there's no problem about higher bits truncation.
-            // cf. https://www.x.org/docs/XProtocol/proto.pdf
+            // WindowId is XID under the hood which doesn't exceed u32, so this conversion is lossless
             u64::from(id) as _
         } else {
             event_loop.root

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -123,7 +123,7 @@ impl UnownedWindow {
         // root should be a type ffi::Window and it is finally c_ulong.
         // cf. https://docs.rs/x11-dl/2.19.1/x11_dl/xlib/type.Window.html
         let root = if let Some(id) = pl_attribs.parent_id {
-            id as ffi::Window
+            id.into()
         } else {
             event_loop.root
         };

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -120,7 +120,13 @@ impl UnownedWindow {
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<UnownedWindow, RootOsError> {
         let xconn = &event_loop.xconn;
-        let root = event_loop.root;
+        // root should be a type ffi::Window and it is finally c_ulong.
+        // cf. https://docs.rs/x11-dl/2.19.1/x11_dl/xlib/type.Window.html
+        let root = if let Some(id) = pl_attribs.parent_id {
+            id as ffi::Window
+        } else {
+            event_loop.root
+        };
 
         let mut monitors = xconn.available_monitors();
         let guessed_monitor = if monitors.is_empty() {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -123,7 +123,7 @@ impl UnownedWindow {
         // root should be a type ffi::Window and it is finally c_ulong.
         // cf. https://docs.rs/x11-dl/2.19.1/x11_dl/xlib/type.Window.html
         let root = if let Some(id) = pl_attribs.parent_id {
-            id.into()
+            u64::from(id).try_into().unwrap()
         } else {
             event_loop.root
         };

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -125,8 +125,12 @@ impl UnownedWindow {
         let root = if let Some(id) = pl_attribs.parent_id {
             #[cfg(target_pointer_width = "64")]
             let root = u64::from(id);
+
             #[cfg(not(target_pointer_width = "64"))]
-            let root = u64::from(id).try_into().unwrap();
+            // XID is defined as 32-bit value in the X11 protocol so
+            // there's no problem about higher bits truncation.
+            // cf. https://www.x.org/docs/XProtocol/proto.pdf
+            let root = u64::from(id) as u32;
 
             root
         } else {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -123,16 +123,10 @@ impl UnownedWindow {
         // root should be a type ffi::Window and it is finally c_ulong.
         // cf. https://docs.rs/x11-dl/2.19.1/x11_dl/xlib/type.Window.html
         let root = if let Some(id) = pl_attribs.parent_id {
-            #[cfg(target_pointer_width = "64")]
-            let root = u64::from(id);
-
-            #[cfg(not(target_pointer_width = "64"))]
             // XID is defined as 32-bit value in the X11 protocol so
             // there's no problem about higher bits truncation.
             // cf. https://www.x.org/docs/XProtocol/proto.pdf
-            let root = u64::from(id) as u32;
-
-            root
+            u64::from(id) as _
         } else {
             event_loop.root
         };


### PR DESCRIPTION
This PR can create windows with a user-specified parent window. It's intended to realize what discussed in issue https://github.com/rust-windowing/winit/issues/159 for X11.

This is a retry https://github.com/rust-windowing/winit/pull/2096. In that time I was not aware CI fails so passed long time, the master branch proceeds so much from that PR so I cannot follow changes.

## TODO

- [x] Tested on all platforms changed
    - [x] X11
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
