### PR TITLE
Unify `with_app_id` and `with_class` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix `TouchPhase::Ended` always reporting the location of the first touch down, unless the compositor
   sent a cancel or frame event.
 - On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
+- **Breaking:** Replaced `Window::with_app_id` and `Window::with_class` with `Window::with_name` on `WindowBuilderExtUnix`.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -72,8 +72,21 @@ impl Default for PlatformSpecificEventLoopAttributes {
     }
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub struct ApplicationName {
+    pub general: String,
+    pub instance: String,
+}
+
+impl ApplicationName {
+    pub fn new(general: String, instance: String) -> Self {
+        Self { general, instance }
+    }
+}
+
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
+    pub name: Option<ApplicationName>,
     #[cfg(feature = "x11")]
     pub visual_infos: Option<XVisualInfo>,
     #[cfg(feature = "x11")]
@@ -83,20 +96,17 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     #[cfg(feature = "x11")]
     pub base_size: Option<Size>,
     #[cfg(feature = "x11")]
-    pub class: Option<(String, String)>,
-    #[cfg(feature = "x11")]
     pub override_redirect: bool,
     #[cfg(feature = "x11")]
     pub x11_window_types: Vec<XWindowType>,
     #[cfg(feature = "x11")]
     pub gtk_theme_variant: Option<String>,
-    #[cfg(feature = "wayland")]
-    pub app_id: Option<String>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
     fn default() -> Self {
         Self {
+            name: None,
             #[cfg(feature = "x11")]
             visual_infos: None,
             #[cfg(feature = "x11")]
@@ -106,15 +116,11 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             #[cfg(feature = "x11")]
             base_size: None,
             #[cfg(feature = "x11")]
-            class: None,
-            #[cfg(feature = "x11")]
             override_redirect: false,
             #[cfg(feature = "x11")]
             x11_window_types: vec![XWindowType::Normal],
             #[cfg(feature = "x11")]
             gtk_theme_variant: None,
-            #[cfg(feature = "wayland")]
-            app_id: None,
         }
     }
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -159,8 +159,8 @@ impl Window {
         window.set_max_size(max_size);
 
         // Set Wayland specific window attributes.
-        if let Some(app_id) = platform_attributes.app_id {
-            window.set_app_id(app_id);
+        if let Some(name) = platform_attributes.name {
+            window.set_app_id(name.general);
         }
 
         // Set common window attributes.

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -310,11 +310,11 @@ impl UnownedWindow {
 
             // WM_CLASS must be set *before* mapping the window, as per ICCCM!
             {
-                let (class, instance) = if let Some((instance, class)) = pl_attribs.class {
-                    let instance = CString::new(instance.as_str())
+                let (class, instance) = if let Some(name) = pl_attribs.name {
+                    let instance = CString::new(name.instance.as_str())
                         .expect("`WM_CLASS` instance contained null byte");
-                    let class =
-                        CString::new(class.as_str()).expect("`WM_CLASS` class contained null byte");
+                    let class = CString::new(name.general.as_str())
+                        .expect("`WM_CLASS` class contained null byte");
                     (instance, class)
                 } else {
                     let class = env::args()


### PR DESCRIPTION
Both APIs are used to set application name. This commit unifies the API
between Wayland and X11, so downstream applications can remove platform
specific code here.

Fixes #1739.

cc @chrisduerr 