### PR TITLE
Unify behavior of `resizable` across platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   sent a cancel or frame event.
 - On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
 - **Breaking:** Replaced `Window::with_app_id` and `Window::with_class` with `Window::with_name` on `WindowBuilderExtUnix`.
+- On Wayland and X11, fix window not resizing with `Window::set_inner_size` after calling `Window:set_resizable(false)`.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -220,6 +220,9 @@ impl Window {
             window_requests.clone(),
         );
 
+        // Set resizable state, so we can determine how to handle `Window::set_inner_size`.
+        window_handle.is_resizable.set(attributes.resizable);
+
         let mut winit_state = event_loop_window_target.state.borrow_mut();
 
         winit_state.window_map.insert(window_id, window_handle);

--- a/src/window.rs
+++ b/src/window.rs
@@ -665,8 +665,9 @@ impl Window {
 
     /// Sets whether the window is resizable or not.
     ///
-    /// Note that making the window unresizable doesn't exempt you from handling `Resized`, as that event can still be
-    /// triggered by DPI scaling, entering fullscreen mode, etc.
+    /// Note that making the window unresizable doesn't exempt you from handling `Resized`, as that
+    /// event can still be triggered by DPI scaling, entering fullscreen mode, etc. Also, the
+    /// window could still be resized by calling `[Window::set_inner_size]`.
     ///
     /// ## Platform-specific
     ///


### PR DESCRIPTION
This makes X11 and Wayland follow Windows and macOS, so the size of the
window could be set even though it has resizable attribute set to false.

Fixes #2242.
