### PR TITLE
On Wayland commit after setting all startup props

### DIFF
--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -145,12 +145,6 @@ impl Window {
         } else {
             window.set_decorate(Decorations::None);
         }
-        // Without this commit here at least on kwin 5.23.3 the initial configure
-        // will have a size (1,1), the second configure including the decoration
-        // mode will have the min_size as its size. With this commit the initial
-        // configure will have no size, the application will draw it's content
-        // with the initial size and everything works as expected afterwards.
-        window.surface().commit();
 
         // Min dimensions.
         let min_size = attributes
@@ -197,6 +191,16 @@ impl Window {
                 }
             }
         }
+
+        // Without this commit here at least on kwin 5.23.3 the initial configure
+        // will have a size (1,1), the second configure including the decoration
+        // mode will have the min_size as its size. With this commit the initial
+        // configure will have no size, the application will draw it's content
+        // with the initial size and everything works as expected afterwards.
+        //
+        // The window commit must be after setting on top level properties, but right before any
+        // buffer attachments commits.
+        window.surface().commit();
 
         let size = Arc::new(Mutex::new(LogicalSize::new(width, height)));
 


### PR DESCRIPTION
The commit without buffer attached should be done after setting all
top level size/application related properties. While c4df7ad7a added
commit after setting decorations, it accounted just for decorations,
however we should account for the min/max size and other attributes.