### PR TITLE
detect left and right option keys as modifiers on macos implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix `TouchPhase::Ended` always reporting the location of the first touch down, unless the compositor
   sent a cancel or frame event.
 - On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
+- On MacOS implementation left and right option keys are detected as `LAlt` and `RAlt` modifiers.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1018,10 +1018,10 @@ bitflags! {
         /// The "alt" key.
         const ALT = 0b100 << 6;
         /// the left "alt" key.
-        #[cfg(target_os = "macos")]
+        /// IMPORTANT: This flag will only be set on macos
         const LALT = 0b010 << 6;
         /// the right "alt" key.
-        #[cfg(target_os = "macos")]
+        /// IMPORTANT: This flag will only be set on macos
         const RALT = 0b001 << 6;
         /// This is the "windows" key on PC and "command" key on Mac.
         const LOGO = 0b100 << 9;

--- a/src/event.rs
+++ b/src/event.rs
@@ -1007,8 +1007,6 @@ bitflags! {
     /// Each flag represents a modifier and is set if this modifier is active.
     #[derive(Default)]
     pub struct ModifiersState: u32 {
-        // left and right modifiers are currently commented out, but we should be able to support
-        // them in a future release
         /// The "shift" key.
         const SHIFT = 0b100;
         // const LSHIFT = 0b010;
@@ -1019,8 +1017,12 @@ bitflags! {
         // const RCTRL = 0b001 << 3;
         /// The "alt" key.
         const ALT = 0b100 << 6;
-        // const LALT = 0b010 << 6;
-        // const RALT = 0b001 << 6;
+        /// the left "alt" key.
+        #[cfg(target_os = "macos")]
+        const LALT = 0b010 << 6;
+        /// the right "alt" key.
+        #[cfg(target_os = "macos")]
+        const RALT = 0b001 << 6;
         /// This is the "windows" key on PC and "command" key on Mac.
         const LOGO = 0b100 << 9;
         // const LLOGO = 0b010 << 9;

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -241,8 +241,16 @@ pub fn check_function_keys(string: &str) -> Option<VirtualKeyCode> {
     None
 }
 
+const NS_LEFT_ALTERNATE_KEY_MASK: u64 = 0x000020 | NSEventModifierFlags::NSAlternateKeyMask.bits();
+const NS_RIGHT_ALTERNATE_KEY_MASK: u64 = 0x000040 | NSEventModifierFlags::NSAlternateKeyMask.bits();
+
+fn contains_left_or_right(flags: NSEventModifierFlags, mask: u64) -> bool {
+    (mask & flags.bits()) == mask
+}
+
 pub fn event_mods(event: id) -> ModifiersState {
     let flags = unsafe { NSEvent::modifierFlags(event) };
+
     let mut m = ModifiersState::empty();
     m.set(
         ModifiersState::SHIFT,
@@ -253,13 +261,23 @@ pub fn event_mods(event: id) -> ModifiersState {
         flags.contains(NSEventModifierFlags::NSControlKeyMask),
     );
     m.set(
+        ModifiersState::LOGO,
+        flags.contains(NSEventModifierFlags::NSCommandKeyMask),
+    );
+
+    m.set(
         ModifiersState::ALT,
         flags.contains(NSEventModifierFlags::NSAlternateKeyMask),
     );
     m.set(
-        ModifiersState::LOGO,
-        flags.contains(NSEventModifierFlags::NSCommandKeyMask),
+        ModifiersState::LALT,
+        contains_left_or_right(flags, NS_LEFT_ALTERNATE_KEY_MASK),
     );
+    m.set(
+        ModifiersState::RALT,
+        contains_left_or_right(flags, NS_RIGHT_ALTERNATE_KEY_MASK),
+    );
+
     m
 }
 


### PR DESCRIPTION
The left and right alt keys modifiers were previously detected as the same modifier. It created some problems on macos mainly on terminal emulators like alacritty. https://github.com/alacritty/alacritty/issues/62 would be possible to fix with this PR.

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
