### PR TITLE
wayland: Replace fallback CSD with proper one

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,9 @@ jobs:
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
       run: sudo apt-get update && sudo apt-get install gcc-multilib
+    - name: Install Freetype & FontConfig
+      if: matrix.platform.os == 'ubuntu-latest'
+      run: sudo apt-get update && sudo apt-get install pkg-config libfreetype6-dev libfontconfig1-dev cmake
     - name: Install cargo-apk
       if: contains(matrix.platform.target, 'android')
       run: cargo install cargo-apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       CARGO_INCREMENTAL: 0
+      PKG_CONFIG_ALLOW_CROSS: 1
       RUSTFLAGS: "-C debuginfo=0 --deny warnings"
       OPTIONS: ${{ matrix.platform.options }}
       FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
@@ -62,12 +63,12 @@ jobs:
         rust-version: ${{ matrix.rust_version }}${{ matrix.platform.host }}
         targets: ${{ matrix.platform.target }}
 
+    - name: Install Linux dependencies
+      if: (matrix.platform.os == 'ubuntu-latest')
+      run: sudo apt-get update && sudo apt-get install pkg-config cmake libfreetype6-dev libfontconfig1-dev
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
-      run: sudo apt-get update && sudo apt-get install gcc-multilib
-    - name: Install Freetype & FontConfig
-      if: matrix.platform.os == 'ubuntu-latest'
-      run: sudo apt-get update && sudo apt-get install pkg-config libfreetype6-dev libfontconfig1-dev cmake
+      run: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install g++-multilib gcc-multilib libfreetype6-dev:i386 libfontconfig1-dev:i386
     - name: Install cargo-apk
       if: contains(matrix.platform.target, 'android')
       run: cargo install cargo-apk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   sent a cancel or frame event.
 - On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
 - **Breaking:** Replaced `Window::with_app_id` and `Window::with_class` with `Window::with_name` on `WindowBuilderExtUnix`.
-- On Wayland, fallback CSD was replaced with proper one;
+- On Wayland, fallback CSD was replaced with proper one:
   - `WindowBuilderExtUnix::with_wayland_csd_theme` to set color theme in builder.
   - `WindowExtUnix::wayland_set_csd_theme` to set color theme when creating a window.
   - `WINIT_WAYLAND_CSD_THEME` env variable was added, it can be used to set "dark"/"light" theme in apps that don't expose theme setting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   sent a cancel or frame event.
 - On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
 - **Breaking:** Replaced `Window::with_app_id` and `Window::with_class` with `Window::with_name` on `WindowBuilderExtUnix`.
+- On Wayland, fallback CSD was replaced with proper one.
 - On Wayland and X11, fix window not resizing with `Window::set_inner_size` after calling `Window:set_resizable(false)`.
 - On Windows, fix wrong fullscreen monitors being recognized when handling WM_WINDOWPOSCHANGING messages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,12 +39,12 @@ And please only add new entries to the top of this list, right below the `# Unre
   sent a cancel or frame event.
 - On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
 - **Breaking:** Replaced `Window::with_app_id` and `Window::with_class` with `Window::with_name` on `WindowBuilderExtUnix`.
-- On Wayland, fallback CSD was replaced with proper one.
-  - `WindowBuilderExtUnix::with_wayland_csd_theme` used to set color theme in builder.
-  - `WindowExtUnix::wayland_set_csd_theme` used to change color theme on the fly.
+- On Wayland, fallback CSD was replaced with proper one;
+  - `WindowBuilderExtUnix::with_wayland_csd_theme` to set color theme in builder.
+  - `WindowExtUnix::wayland_set_csd_theme` to set color theme when creating a window.
   - `WINIT_WAYLAND_CSD_THEME` env variable was added, it can be used to set "dark"/"light" theme in apps that don't expose theme setting.
-  - `wayland-csd-adwaita` feature that enables proper CSD.
-  - `wayland-csd-title` feature that enables title rendering, uses FreeType system library.
+  - `wayland-csd-adwaita` feature that enables proper CSD with title rendering using FreeType system library.
+  - `wayland-csd-adwaita-notitle` feature that enables CSD but without title rendering.
 - On Wayland and X11, fix window not resizing with `Window::set_inner_size` after calling `Window:set_resizable(false)`.
 - On Windows, fix wrong fullscreen monitors being recognized when handling WM_WINDOWPOSCHANGING messages
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fallback CSD was replaced with proper one.
   - `WindowBuilderExtUnix::with_wayland_csd_theme` used to set color theme in builder.
   - `WindowExtUnix::wayland_set_csd_theme` used to change color theme on the fly.
+  - `WINIT_WAYLAND_CSD_THEME` env variable was added, it can be used to set "dark"/"light" theme in apps that don't expose theme setting.
   - `wayland-csd-adwaita` feature that enables proper CSD.
   - `wayland-csd-title` feature that enables title rendering, uses FreeType system library.
 - On Wayland and X11, fix window not resizing with `Window::set_inner_size` after calling `Window:set_resizable(false)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
 - **Breaking:** Replaced `Window::with_app_id` and `Window::with_class` with `Window::with_name` on `WindowBuilderExtUnix`.
 - On Wayland, fallback CSD was replaced with proper one.
+  - `WindowBuilderExtUnix::with_wayland_csd_theme` used to set color theme in builder.
+  - `WindowExtUnix::wayland_set_csd_theme` used to change color theme on the fly.
+  - `wayland-csd-adwaita` feature that enables proper CSD.
+  - `wayland-csd-title` feature that enables title rendering, uses FreeType system library.
 - On Wayland and X11, fix window not resizing with `Window::set_inner_size` after calling `Window:set_resizable(false)`.
 - On Windows, fix wrong fullscreen monitors being recognized when handling WM_WINDOWPOSCHANGING messages
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc", "i686-unknown-linux
 [features]
 default = ["x11", "wayland", "wayland-dlopen"]
 x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
-wayland = ["wayland-client", "wayland-protocols", "sctk"]
+wayland = ["wayland-client", "wayland-protocols", "sctk", "sctk-adwaita"]
 wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
 
 [dependencies]
@@ -90,6 +90,7 @@ features = [
 wayland-client = { version = "0.29", default_features = false,  features = ["use_system_lib"], optional = true }
 wayland-protocols = { version = "0.29", features = [ "staging_protocols"], optional = true }
 sctk = { package = "smithay-client-toolkit", version = "0.15.4", default_features = false, features = ["calloop"],  optional = true }
+sctk-adwaita = { version = "0.3", optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
 wayland = ["wayland-client", "wayland-protocols", "sctk"]
 wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
 wayland-csd-adwaita = ["sctk-adwaita"]
+wayland-csd-title = ["sctk-adwaita/title"]
 
 [dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = ["i686-pc-windows-msvc", "x86_64-pc-windows-msvc", "i686-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-apple-darwin", "wasm32-unknown-unknown"]
 
 [features]
-default = ["x11", "wayland", "wayland-dlopen"]
+default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
-wayland = ["wayland-client", "wayland-protocols", "sctk", "sctk-adwaita"]
+wayland = ["wayland-client", "wayland-protocols", "sctk"]
 wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
+wayland-csd-adwaita = ["sctk-adwaita"]
 
 [dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
 wayland = ["wayland-client", "wayland-protocols", "sctk"]
 wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
-wayland-csd-adwaita = ["sctk-adwaita"]
-wayland-csd-title = ["sctk-adwaita/title"]
+wayland-csd-adwaita = ["sctk-adwaita", "sctk-adwaita/title"]
+wayland-csd-adwaita-notitle = ["sctk-adwaita"]
 
 [dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ features = [
 wayland-client = { version = "0.29", default_features = false,  features = ["use_system_lib"], optional = true }
 wayland-protocols = { version = "0.29", features = [ "staging_protocols"], optional = true }
 sctk = { package = "smithay-client-toolkit", version = "0.15.4", default_features = false, features = ["calloop"],  optional = true }
-sctk-adwaita = { version = "0.3", optional = true }
+sctk-adwaita = { version = "0.3.5", optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -173,7 +173,7 @@ Legend:
 |Window initialization            |✔️     |✔️     |▢[#5]      |✔️             |▢[#33]|▢[#33] |✔️        |
 |Providing pointer to init OpenGL |✔️     |✔️     |✔️         |✔️             |✔️     |✔️    |**N/A**|
 |Providing pointer to init Vulkan |✔️     |✔️     |✔️         |✔️             |✔️     |❓     |**N/A**|
-|Window decorations               |✔️     |✔️     |✔️         |▢[#306]        |**N/A**|**N/A**|**N/A**|
+|Window decorations               |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
 |Window decorations toggle        |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
 |Window resizing                  |✔️     |▢[#219]|✔️         |▢[#306]        |**N/A**|**N/A**|✔️        |
 |Window resize increments         |❌     |❌     |❌         |❌             |❌    |❌     |**N/A**|

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -182,6 +182,9 @@ pub trait WindowExtUnix {
     fn wayland_display(&self) -> Option<*mut raw::c_void>;
 
     /// Updates [`Theme`] of window decorations.
+    ///
+    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+    /// Possible values for env variable are: "dark" and light"
     #[cfg(feature = "wayland")]
     fn wayland_set_csd_theme(&self, config: Theme);
 
@@ -315,6 +318,9 @@ pub trait WindowBuilderExtUnix {
     fn with_gtk_theme_variant(self, variant: String) -> Self;
 
     /// Build window with certain decoration [`Theme`]
+    ///
+    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+    /// Possible values for env variable are: "dark" and light"
     #[cfg(feature = "wayland")]
     fn with_wayland_csd_theme(self, theme: Theme) -> Self;
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -73,7 +73,6 @@ impl<T> EventLoopWindowTargetExtUnix for EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    #[doc(hidden)]
     #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.p {
@@ -228,7 +227,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[doc(hidden)]
     #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.window {

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -33,7 +33,7 @@ pub use crate::platform_impl::x11;
 pub use crate::platform_impl::{x11::util::WindowType as XWindowType, XNotSupported};
 
 #[cfg(feature = "wayland")]
-pub use sctk_adwaita::FrameConfig;
+pub use crate::window::Theme;
 
 /// Additional methods on `EventLoopWindowTarget` that are specific to Unix.
 pub trait EventLoopWindowTargetExtUnix {
@@ -182,11 +182,9 @@ pub trait WindowExtUnix {
     #[cfg(feature = "wayland")]
     fn wayland_display(&self) -> Option<*mut raw::c_void>;
 
-    /// Updates FrameConfig of a window.
-    ///
-    /// Usually used to switch a theme.
+    /// Updates [`Theme`] of window decorations.
     #[cfg(feature = "wayland")]
-    fn wayland_set_csd_config(&self, config: FrameConfig);
+    fn wayland_set_csd_theme(&self, config: Theme);
 
     /// Check if the window is ready for drawing
     ///
@@ -272,9 +270,9 @@ impl WindowExtUnix for Window {
 
     #[inline]
     #[cfg(feature = "wayland")]
-    fn wayland_set_csd_config(&self, config: FrameConfig) {
+    fn wayland_set_csd_theme(&self, theme: Theme) {
         match self.window {
-            LinuxWindow::Wayland(ref w) => w.set_csd_config(config),
+            LinuxWindow::Wayland(ref w) => w.set_csd_theme(theme),
             #[cfg(feature = "x11")]
             _ => {}
         }
@@ -318,9 +316,9 @@ pub trait WindowBuilderExtUnix {
     #[cfg(feature = "x11")]
     fn with_gtk_theme_variant(self, variant: String) -> Self;
 
-    /// Build window with certain FrameConfig (aka Theme)
+    /// Build window with certain decoration [`Theme`]
     #[cfg(feature = "wayland")]
-    fn with_wayland_csd_config(self, config: FrameConfig) -> Self;
+    fn with_wayland_csd_theme(self, theme: Theme) -> Self;
 
     /// Build window with resize increment hint. Only implemented on X11.
     ///
@@ -400,8 +398,8 @@ impl WindowBuilderExtUnix for WindowBuilder {
 
     #[inline]
     #[cfg(feature = "wayland")]
-    fn with_wayland_csd_config(mut self, config: FrameConfig) -> Self {
-        self.platform_specific.csd_config = Some(config);
+    fn with_wayland_csd_theme(mut self, theme: Theme) -> Self {
+        self.platform_specific.csd_theme = Some(theme);
         self
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -10,7 +10,7 @@
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
 #[cfg(feature = "wayland")]
-use sctk_adwaita::FrameConfig;
+use crate::window::Theme;
 #[cfg(feature = "wayland")]
 use std::error::Error;
 
@@ -105,7 +105,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     #[cfg(feature = "x11")]
     pub gtk_theme_variant: Option<String>,
     #[cfg(feature = "wayland")]
-    pub csd_config: Option<FrameConfig>,
+    pub csd_theme: Option<Theme>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -127,7 +127,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             #[cfg(feature = "x11")]
             gtk_theme_variant: None,
             #[cfg(feature = "wayland")]
-            csd_config: None,
+            csd_theme: None,
         }
     }
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -10,7 +10,10 @@
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
 #[cfg(feature = "wayland")]
+use sctk_adwaita::FrameConfig;
+#[cfg(feature = "wayland")]
 use std::error::Error;
+
 use std::{collections::VecDeque, env, fmt};
 #[cfg(feature = "x11")]
 use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Arc};
@@ -101,6 +104,8 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub x11_window_types: Vec<XWindowType>,
     #[cfg(feature = "x11")]
     pub gtk_theme_variant: Option<String>,
+    #[cfg(feature = "wayland")]
+    pub csd_config: Option<FrameConfig>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -121,6 +126,8 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             x11_window_types: vec![XWindowType::Normal],
             #[cfg(feature = "x11")]
             gtk_theme_variant: None,
+            #[cfg(feature = "wayland")]
+            csd_config: None,
         }
     }
 }

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -13,7 +13,8 @@ use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_p
 use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_confined_pointer_v1::ZwpConfinedPointerV1;
 
 use sctk::seat::pointer::{ThemeManager, ThemedPointer};
-use sctk::window::{FallbackFrame, Window};
+use sctk::window::Window;
+use sctk_adwaita::AdwaitaFrame;
 
 use crate::event::ModifiersState;
 use crate::platform_impl::wayland::event_loop::WinitState;

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -14,10 +14,10 @@ use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_c
 
 use sctk::seat::pointer::{ThemeManager, ThemedPointer};
 use sctk::window::Window;
-use sctk_adwaita::AdwaitaFrame;
 
 use crate::event::ModifiersState;
 use crate::platform_impl::wayland::event_loop::WinitState;
+use crate::platform_impl::wayland::window::WinitFrame;
 use crate::window::CursorIcon;
 
 mod data;
@@ -157,7 +157,7 @@ impl WinitPointer {
         }
     }
 
-    pub fn drag_window(&self, window: &Window<FallbackFrame>) {
+    pub fn drag_window(&self, window: &Window<WinitFrame>) {
         // WlPointer::setart_interactive_move() expects the last serial of *any*
         // pointer event (compare to set_cursor()).
         window.start_interactive_move(&self.seat, self.latest_serial.get());

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -33,6 +33,8 @@ pub type WinitFrame = sctk_adwaita::AdwaitaFrame;
 #[cfg(not(feature = "sctk-adwaita"))]
 pub type WinitFrame = sctk::window::FallbackFrame;
 
+const WAYLAND_CSD_THEME_ENV_VAR: &str = "WINIT_WAYLAND_CSD_THEME";
+
 pub struct Window {
     /// Window id.
     window_id: WindowId,
@@ -152,6 +154,18 @@ impl Window {
                 Theme::Dark => sctk_adwaita::FrameConfig::dark(),
             };
             window.set_frame_config(config);
+        } else {
+            if let Ok(env) = std::env::var(WAYLAND_CSD_THEME_ENV_VAR) {
+                match env.to_lowercase().as_str() {
+                    "dark" => {
+                        window.set_frame_config(sctk_adwaita::FrameConfig::dark());
+                    }
+                    "light" => {
+                        window.set_frame_config(sctk_adwaita::FrameConfig::light());
+                    }
+                    _ => {}
+                }
+            }
         }
 
         // Set decorations.

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -8,7 +8,8 @@ use sctk::reexports::client::Display;
 use sctk::reexports::calloop;
 
 use raw_window_handle::WaylandHandle;
-use sctk::window::{Decorations, FallbackFrame};
+use sctk::window::Decorations;
+use sctk_adwaita::AdwaitaFrame;
 
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
@@ -105,7 +106,7 @@ impl Window {
         let theme_manager = event_loop_window_target.theme_manager.clone();
         let mut window = event_loop_window_target
             .env
-            .create_window::<FallbackFrame, _>(
+            .create_window::<AdwaitaFrame, _>(
                 surface.clone(),
                 Some(theme_manager),
                 (width, height),

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -147,11 +147,9 @@ impl Window {
         // Set CSD frame config
         #[cfg(feature = "sctk-adwaita")]
         if let Some(theme) = platform_attributes.csd_theme {
-            use sctk_adwaita::FrameConfig;
-
             let config = match theme {
-                Theme::Light => FrameConfig::light(),
-                Theme::Dark => FrameConfig::dark(),
+                Theme::Light => sctk_adwaita::FrameConfig::light(),
+                Theme::Dark => sctk_adwaita::FrameConfig::dark(),
             };
             window.set_frame_config(config);
         }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -18,7 +18,7 @@ use crate::platform_impl::{
     MonitorHandle as PlatformMonitorHandle, OsError,
     PlatformSpecificWindowBuilderAttributes as PlatformAttributes,
 };
-use crate::window::{CursorIcon, Fullscreen, UserAttentionType, WindowAttributes};
+use crate::window::{CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes};
 
 use super::env::WindowingFeatures;
 use super::event_loop::WinitState;
@@ -141,7 +141,11 @@ impl Window {
             .map_err(|_| os_error!(OsError::WaylandMisc("failed to create window.")))?;
 
         // Set CSD frame config
-        if let Some(config) = platform_attributes.csd_config {
+        if let Some(theme) = platform_attributes.csd_theme {
+            let config = match theme {
+                Theme::Light => FrameConfig::light(),
+                Theme::Dark => FrameConfig::dark(),
+            };
             window.set_frame_config(config);
         }
 
@@ -387,8 +391,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_csd_config(&self, config: FrameConfig) {
-        self.send_request(WindowRequest::CsdConfig(config));
+    pub fn set_csd_theme(&self, theme: Theme) {
+        self.send_request(WindowRequest::CsdThemeVariant(theme));
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -158,12 +158,7 @@ impl Window {
                 }
             });
 
-            let config = match theme {
-                Theme::Light => sctk_adwaita::FrameConfig::light(),
-                Theme::Dark => sctk_adwaita::FrameConfig::dark(),
-            };
-
-            window.set_frame_config(config);
+            window.set_frame_config(theme.into());
         }
 
         // Set decorations.
@@ -575,5 +570,15 @@ impl Window {
 impl Drop for Window {
     fn drop(&mut self) {
         self.send_request(WindowRequest::Close);
+    }
+}
+
+#[cfg(feature = "sctk-adwaita")]
+impl From<Theme> for sctk_adwaita::FrameConfig {
+    fn from(theme: Theme) -> Self {
+        match theme {
+            Theme::Light => sctk_adwaita::FrameConfig::light(),
+            Theme::Dark => sctk_adwaita::FrameConfig::dark(),
+        }
     }
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -9,7 +9,7 @@ use sctk::reexports::calloop;
 
 use raw_window_handle::WaylandHandle;
 use sctk::window::Decorations;
-use sctk_adwaita::AdwaitaFrame;
+use sctk_adwaita::{AdwaitaFrame, FrameConfig};
 
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
@@ -139,6 +139,11 @@ impl Window {
                 },
             )
             .map_err(|_| os_error!(OsError::WaylandMisc("failed to create window.")))?;
+
+        // Set CSD frame config
+        if let Some(config) = platform_attributes.csd_config {
+            window.set_frame_config(config);
+        }
 
         // Set decorations.
         if attributes.decorations {
@@ -379,6 +384,11 @@ impl Window {
     #[inline]
     pub fn is_decorated(&self) -> bool {
         self.decorated.load(Ordering::Relaxed)
+    }
+
+    #[inline]
+    pub fn set_csd_config(&self, config: FrameConfig) {
+        self.send_request(WindowRequest::CsdConfig(config));
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/shim.rs
+++ b/src/platform_impl/linux/wayland/window/shim.rs
@@ -425,11 +425,7 @@ pub fn handle_window_requests(winit_state: &mut WinitState) {
                 }
                 #[cfg(feature = "sctk-adwaita")]
                 WindowRequest::CsdThemeVariant(theme) => {
-                    let config = match theme {
-                        Theme::Light => sctk_adwaita::FrameConfig::light(),
-                        Theme::Dark => sctk_adwaita::FrameConfig::dark(),
-                    };
-                    window_handle.window.set_frame_config(config);
+                    window_handle.window.set_frame_config(theme.into());
 
                     let window_update = window_updates.get_mut(window_id).unwrap();
                     window_update.refresh_frame = true;

--- a/src/platform_impl/linux/wayland/window/shim.rs
+++ b/src/platform_impl/linux/wayland/window/shim.rs
@@ -8,7 +8,8 @@ use sctk::reexports::protocols::staging::xdg_activation::v1::client::xdg_activat
 use sctk::reexports::protocols::staging::xdg_activation::v1::client::xdg_activation_v1::XdgActivationV1;
 
 use sctk::environment::Environment;
-use sctk::window::{Decorations, FallbackFrame, Window};
+use sctk::window::{Decorations, Window};
+use sctk_adwaita::AdwaitaFrame;
 
 use crate::dpi::{LogicalPosition, LogicalSize};
 
@@ -143,7 +144,7 @@ impl WindowUpdate {
 /// and react to events.
 pub struct WindowHandle {
     /// An actual window.
-    pub window: Window<FallbackFrame>,
+    pub window: Window<AdwaitaFrame>,
 
     /// The current size of the window.
     pub size: Arc<Mutex<LogicalSize<u32>>>,
@@ -182,7 +183,7 @@ pub struct WindowHandle {
 impl WindowHandle {
     pub fn new(
         env: &Environment<WinitEnv>,
-        window: Window<FallbackFrame>,
+        window: Window<AdwaitaFrame>,
         size: Arc<Mutex<LogicalSize<u32>>>,
         pending_window_requests: Arc<Mutex<Vec<WindowRequest>>>,
     ) -> Self {

--- a/src/platform_impl/linux/wayland/window/shim.rs
+++ b/src/platform_impl/linux/wayland/window/shim.rs
@@ -9,7 +9,7 @@ use sctk::reexports::protocols::staging::xdg_activation::v1::client::xdg_activat
 
 use sctk::environment::Environment;
 use sctk::window::{Decorations, Window};
-use sctk_adwaita::AdwaitaFrame;
+use sctk_adwaita::{AdwaitaFrame, FrameConfig};
 
 use crate::dpi::{LogicalPosition, LogicalSize};
 
@@ -53,6 +53,9 @@ pub enum WindowRequest {
 
     /// Request decorations change.
     Decorate(bool),
+
+    /// Request decorations change.
+    CsdConfig(FrameConfig),
 
     /// Make the window resizeable.
     Resizeable(bool),
@@ -416,6 +419,12 @@ pub fn handle_window_requests(winit_state: &mut WinitState) {
                     window_handle.window.set_decorate(decorations);
 
                     // We should refresh the frame to apply decorations change.
+                    let window_update = window_updates.get_mut(window_id).unwrap();
+                    window_update.refresh_frame = true;
+                }
+                WindowRequest::CsdConfig(config) => {
+                    window_handle.window.set_frame_config(config);
+
                     let window_update = window_updates.get_mut(window_id).unwrap();
                     window_update.refresh_frame = true;
                 }

--- a/src/platform_impl/linux/wayland/window/shim.rs
+++ b/src/platform_impl/linux/wayland/window/shim.rs
@@ -423,23 +423,19 @@ pub fn handle_window_requests(winit_state: &mut WinitState) {
                     let window_update = window_updates.get_mut(window_id).unwrap();
                     window_update.refresh_frame = true;
                 }
+                #[cfg(feature = "sctk-adwaita")]
                 WindowRequest::CsdThemeVariant(theme) => {
-                    #[cfg(feature = "sctk-adwaita")]
-                    {
-                        use sctk_adwaita::FrameConfig;
+                    let config = match theme {
+                        Theme::Light => sctk_adwaita::FrameConfig::light(),
+                        Theme::Dark => sctk_adwaita::FrameConfig::dark(),
+                    };
+                    window_handle.window.set_frame_config(config);
 
-                        let config = match theme {
-                            Theme::Light => FrameConfig::light(),
-                            Theme::Dark => FrameConfig::dark(),
-                        };
-                        window_handle.window.set_frame_config(config);
-
-                        let window_update = window_updates.get_mut(window_id).unwrap();
-                        window_update.refresh_frame = true;
-                    }
-                    #[cfg(not(feature = "sctk-adwaita"))]
-                    let _ = theme;
+                    let window_update = window_updates.get_mut(window_id).unwrap();
+                    window_update.refresh_frame = true;
                 }
+                #[cfg(not(feature = "sctk-adwaita"))]
+                WindowRequest::CsdThemeVariant(_) => {}
                 WindowRequest::Resizeable(resizeable) => {
                     window_handle.window.set_resizable(resizeable);
 

--- a/src/platform_impl/linux/wayland/window/shim.rs
+++ b/src/platform_impl/linux/wayland/window/shim.rs
@@ -20,7 +20,7 @@ use crate::platform_impl::wayland::event_loop::WinitState;
 use crate::platform_impl::wayland::seat::pointer::WinitPointer;
 use crate::platform_impl::wayland::seat::text_input::TextInputHandler;
 use crate::platform_impl::wayland::WindowId;
-use crate::window::{CursorIcon, UserAttentionType};
+use crate::window::{CursorIcon, Theme, UserAttentionType};
 
 /// A request to SCTK window from Winit window.
 #[derive(Debug, Clone)]
@@ -55,7 +55,7 @@ pub enum WindowRequest {
     Decorate(bool),
 
     /// Request decorations change.
-    CsdConfig(FrameConfig),
+    CsdThemeVariant(Theme),
 
     /// Make the window resizeable.
     Resizeable(bool),
@@ -422,7 +422,11 @@ pub fn handle_window_requests(winit_state: &mut WinitState) {
                     let window_update = window_updates.get_mut(window_id).unwrap();
                     window_update.refresh_frame = true;
                 }
-                WindowRequest::CsdConfig(config) => {
+                WindowRequest::CsdThemeVariant(theme) => {
+                    let config = match theme {
+                        Theme::Light => FrameConfig::light(),
+                        Theme::Dark => FrameConfig::dark(),
+                    };
                     window_handle.window.set_frame_config(config);
 
                     let window_update = window_updates.get_mut(window_id).unwrap();


### PR DESCRIPTION
Hi!
I wrote a simple CSD implementation for Smithay client toolkit, and I think it could be a good default for winit.
Here is winit running with those decorations:
|   |   |
|---|---|
|![active](https://i.imgur.com/WdO8e0i.png)|![inactive](https://i.imgur.com/MTFdSjK.png)|

Let me also answer questions that will most likely come up:
- `Why not libdecor?`
   - Using libdecor from Rust Wayland ecosystem is nowhere near completion, and in my opinion it will never be. And besides some initial tests with calling it from Rust, no one is actively working on it atm.
   - If I'm wrong and libdecor-rs will be a thing, then we can just drop my impl easily, so it's a win-win scenario.
- `Why  does it look like GTK/Adwaita?`
   - Mutter/Gnome is probably the only big compositor that does not support SSD, so I think it's a good idea to make it fit there, other DEs will render their own SSD anyway, so users of those will be happy anyway.
   - I think it just looks neutral, it's simple and minimal, so I doubt anyone will find this kind of design offensive.
- `Why does winit need a good default?`
  - Not all developers that use winit are well versed in Linux world, let alone know what Wayland is. So I believe that we have to have a good default, so we get a decent look, even if the developer of an app haven't spent time understanding what Wayland is and why it needs CSD.

> DISCLAIMER: Although I'm part of Smithay, this PR is just my private endavor, so nothing I say here should be taken as an opinion of Smithay as a whole, just as a random guy on the internet trying to make winit prettier.

closes: #1967