### PR TITLE
Fix embedded NULs in C wide strings returned from Windows API

### DIFF
--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -1,10 +1,7 @@
 use std::{
     collections::{BTreeSet, VecDeque},
-    ffi::OsString,
     hash::Hash,
-    io, mem,
-    os::windows::prelude::OsStringExt,
-    ptr,
+    io, mem, ptr,
 };
 
 use windows_sys::Win32::{
@@ -17,6 +14,7 @@ use windows_sys::Win32::{
     },
 };
 
+use super::util::decode_wide;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
@@ -169,7 +167,7 @@ impl MonitorHandle {
     pub fn name(&self) -> Option<String> {
         let monitor_info = get_monitor_info(self.0).unwrap();
         Some(
-            OsString::from_wide(&monitor_info.szDevice)
+            decode_wide(&monitor_info.szDevice)
                 .to_string_lossy()
                 .to_string(),
         )

--- a/src/platform_impl/windows/raw_input.rs
+++ b/src/platform_impl/windows/raw_input.rs
@@ -1,7 +1,5 @@
 use std::{
-    ffi::OsString,
     mem::{self, size_of},
-    os::windows::prelude::OsStringExt,
     ptr,
 };
 
@@ -129,7 +127,7 @@ pub fn get_raw_input_device_name(handle: HANDLE) -> Option<String> {
 
     unsafe { name.set_len(minimum_size as _) };
 
-    OsString::from_wide(&name).into_string().ok()
+    util::decode_wide(&name).into_string().ok()
 }
 
 pub fn register_raw_input_devices(devices: &[RAWINPUTDEVICE]) -> bool {

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -1,10 +1,10 @@
 use std::{
-    ffi::{c_void, OsStr},
+    ffi::{c_void, OsStr, OsString},
     io,
     iter::once,
     mem,
     ops::BitAnd,
-    os::windows::prelude::OsStrExt,
+    os::windows::prelude::{OsStrExt, OsStringExt},
     ptr,
     sync::atomic::{AtomicBool, Ordering},
 };
@@ -35,6 +35,14 @@ use crate::{dpi::PhysicalSize, window::CursorIcon};
 
 pub fn encode_wide(string: impl AsRef<OsStr>) -> Vec<u16> {
     string.as_ref().encode_wide().chain(once(0)).collect()
+}
+
+pub fn decode_wide(mut wide_c_string: &[u16]) -> OsString {
+    if let Some(null_pos) = wide_c_string.iter().position(|c| *c == 0) {
+        wide_c_string = &wide_c_string[..null_pos];
+    }
+
+    OsString::from_wide(wide_c_string)
 }
 
 pub fn has_flag<T>(bitset: T, flag: T) -> bool


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [ ] ~Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users~
  - This change fixes an error introduced in b222dde83504e402d51fa40a3c78dee40cb2ee5f, which hasn't been included in a release yet
- [ ] ~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- [ ] ~Created or updated an example program if it would help users understand this functionality~
- [ ] ~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~
