### PR TITLE
Support not applying an activation policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On iOS, send `RedrawEventsCleared` even if there are no redraw events, consistent with other platforms.
 - **Breaking:** Replaced `Window::with_app_id` and `Window::with_class` with `Window::with_name` on `WindowBuilderExtUnix`.
 - On Wayland and X11, fix window not resizing with `Window::set_inner_size` after calling `Window:set_resizable(false)`.
+- A new `ActivationPolicy::None` variant can be used to not set an activation policy. This variant may be useful for system tray only applications not wanting a dock icon.
+
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -81,6 +81,11 @@ pub enum ActivationPolicy {
     Accessory,
     /// Corresponds to `NSApplicationActivationPolicyProhibited`.
     Prohibited,
+    /// Does not set an activation policy.
+    ///
+    /// This is useful for apps that wish to have a system tray but no
+    /// dock icon.
+    None,
 }
 
 impl Default for ActivationPolicy {

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -488,10 +488,16 @@ fn apply_activation_policy(app_delegate: &Object) {
         // until `applicationDidFinishLaunching` has been called. Otherwise the
         // menu bar is initially unresponsive on macOS 10.15.
         let act_pol = get_aux_state_mut(app_delegate).activation_policy;
-        ns_app.setActivationPolicy_(match act_pol {
+
+        let policy = match act_pol {
+            ActivationPolicy::None => {
+                return;
+            }
             ActivationPolicy::Regular => NSApplicationActivationPolicyRegular,
             ActivationPolicy::Accessory => NSApplicationActivationPolicyAccessory,
             ActivationPolicy::Prohibited => NSApplicationActivationPolicyProhibited,
-        });
+        };
+
+        ns_app.setActivationPolicy_(policy);
     }
 }


### PR DESCRIPTION
This commit introduces an `ActivationPolicy::None` variant that
enables us to skip the call to `NSApp::setActivationPolicy()` at
application startup time.

I needed this functionality in order to author a system tray only
application - one that has a menu in the system tray but not an icon
in the dock.

If you apply an activation policy, the app icon appears in the dock,
even if your bundle uses `LSUIElement = true` in its Info.plist.
Interestingly, if you run the same executable outside the context
of an app bundle and don't set an activation policy, I can never get
focus to work in text elements. So it looks like apps in the wild
will need to conditionally define the activation policy at run-time
depending on whether they are run from a bundle or not.

Arguably the proper way to model "no activation policy" would be to
use `Option<T>`. I chose not to do this so I didn't break the API.
But if you want me to refactor to use `Option<T>`, I could do that.

- [ ] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
