### PR TITLE
Make defenition of vectors compatible with math libs.

### DIFF
--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -167,6 +167,7 @@ pub fn validate_scale_factor(scale_factor: f64) -> bool {
 /// implementation is provided which does the rounding for you.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(C)]
 pub struct LogicalPosition<P> {
     pub x: P,
     pub y: P,
@@ -246,6 +247,7 @@ impl<P: Pixel> From<LogicalPosition<P>> for mint::Point2<P> {
 /// A position represented in physical pixels.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(C)]
 pub struct PhysicalPosition<P> {
     pub x: P,
     pub y: P,
@@ -325,6 +327,7 @@ impl<P: Pixel> From<PhysicalPosition<P>> for mint::Point2<P> {
 /// A size represented in logical pixels.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(C)]
 pub struct LogicalSize<P> {
     pub width: P,
     pub height: P,
@@ -407,6 +410,7 @@ impl<P: Pixel> From<LogicalSize<P>> for mint::Vector2<P> {
 /// A size represented in physical pixels.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[repr(C)]
 pub struct PhysicalSize<P> {
     pub width: P,
     pub height: P,


### PR DESCRIPTION
Adding reprt(C) make definition of vectors of winit compatible with definition of vectors in math libs.
Most math libs define vector with reprt(C).

Enhancment #2270.

- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I can add all that.