### PR TITLE
Fix hiding cursor hiding on wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Wayland, fix bug where the cursor wouldn't hide in GNOME.
 - On macOS, Windows, and Wayland, add `set_cursor_hittest` to let the window ignore mouse events.
 - On Windows, added `WindowExtWindows::set_skip_taskbar` and `WindowBuilderExtWindows::with_skip_taskbar`.
 - On Windows, added `EventLoopBuilderExtWindows::with_msg_hook`.

--- a/src/platform_impl/linux/wayland/seat/pointer/data.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/data.rs
@@ -26,8 +26,11 @@ pub(super) struct PointerData {
 
     pub confined_pointer: Rc<RefCell<Option<ZwpConfinedPointerV1>>>,
 
-    /// A latest event serial.
+    /// Latest observed serial in pointer events.
     pub latest_serial: Rc<Cell<u32>>,
+
+    /// Latest observed serial in pointer enter events.
+    pub latest_enter_serial: Rc<Cell<u32>>,
 
     /// The currently accumulated axis data on a pointer.
     pub axis_data: AxisData,
@@ -42,6 +45,7 @@ impl PointerData {
         Self {
             surface: None,
             latest_serial: Rc::new(Cell::new(0)),
+            latest_enter_serial: Rc::new(Cell::new(0)),
             confined_pointer,
             modifiers_state,
             pointer_constraints,

--- a/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
@@ -42,6 +42,7 @@ pub(super) fn handle_pointer(
             ..
         } => {
             pointer_data.latest_serial.replace(serial);
+            pointer_data.latest_enter_serial.replace(serial);
 
             let window_id = wayland::make_wid(&surface);
             if !winit_state.window_map.contains_key(&window_id) {
@@ -61,6 +62,7 @@ pub(super) fn handle_pointer(
                 confined_pointer: Rc::downgrade(&pointer_data.confined_pointer),
                 pointer_constraints: pointer_data.pointer_constraints.clone(),
                 latest_serial: pointer_data.latest_serial.clone(),
+                latest_enter_serial: pointer_data.latest_enter_serial.clone(),
                 seat,
             };
             window_handle.pointer_entered(winit_pointer);
@@ -104,6 +106,7 @@ pub(super) fn handle_pointer(
                 confined_pointer: Rc::downgrade(&pointer_data.confined_pointer),
                 pointer_constraints: pointer_data.pointer_constraints.clone(),
                 latest_serial: pointer_data.latest_serial.clone(),
+                latest_enter_serial: pointer_data.latest_enter_serial.clone(),
                 seat,
             };
             window_handle.pointer_left(winit_pointer);


### PR DESCRIPTION
Fixes #2273.

The underlying method for hiding the cursor (setting its texuture to
NULL) is [`wayland_client::protocol::wl_pointer::WlPointer::set_cursor()`](https://docs.rs/wayland-client/0.29.4/wayland_client/protocol/wl_pointer/struct.WlPointer.html#method.set_cursor).
This method expects a serial number of the last **enter** event.

Right now, `latest_event` is any latest pointer event. It gets used by
the call to [`set_cursor()`](https://github.com/rust-windowing/winit/blob/ea09d1d10e59f7b44dedfd18a9170a01a4930768/src/platform_impl/linux/wayland/seat/pointer/mod.rs#L56-L116) and also to [`start_interactive_move()`](https://github.com/rust-windowing/winit/blob/ea09d1d10e59f7b44dedfd18a9170a01a4930768/src/platform_impl/linux/wayland/seat/pointer/mod.rs#L153-L155). While
`set_cursor()` expects the latest enter event, `start_interactive_move()`
expects the very latest serial from any event. Thus we need to track
both.

After this change, both serials are tracked and the appropriate is used
in the call into smithay-client-toolkit.

Tested on sway and gnome (on sway it already worked before the change).

See also #2273.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users **none: bugfix**
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior **none: bugfix**
- [x] Created or updated an example program if it would help users understand this functionality **none: bugfix**
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented **none: bugfix**
