### PR TITLE
Bump windows-sys version to 0.36

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ features = ["display_link"]
 parking_lot = "0.12"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
-version = "0.33"
+version = "0.36"
 features = [
     "Win32_Devices_HumanInterfaceDevice",
     "Win32_Foundation",


### PR DESCRIPTION
`windows-sys:0.36` should become a common version in ecosystem and be our target for the upcoming release.https://github.com/rust-windowing/winit/issues/2234#issuecomment-1114332780

`parking_lot` did a patch release for their `core` create which will automatically pull in the 0.36 version, so there are not multiple `windows-sys` version in the dependency tree.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
