### PR TITLE
linux: Send scancode instead of keycodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }
 parking_lot = { version = "0.12.0", optional = true }
 libc = "0.2.64"
+keycode = "0.3.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web_sys]
 package = "web-sys"


### PR DESCRIPTION
X11 sends Linux keycodes that only match scancodes on a limited
part of the keys. For example for extended scancodes, the values
don't match.

showkey command can display a mapping:
- https://linux.die.net/man/1/showkey
- https://github.com/legionus/kbd/blob/master/src/showkey.c

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
