### PR TITLE
[macOS] remove old dialog fix that seems to be superceded by https://github.c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Added new `WindowEvent::Ime` supported on desktop platforms.
 - Added `Window::set_ime_allowed` supported on desktop platforms.
 - **Breaking:** IME input on desktop platforms won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::Ime` events are handled.
+- On macOS, fixed an issue where having multiple windows would prevent run_return from ever returning.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -127,7 +127,6 @@ impl<T> EventHandler for EventLoopHandler<T> {
 struct Handler {
     ready: AtomicBool,
     in_callback: AtomicBool,
-    dialog_is_closing: AtomicBool,
     control_flow: Mutex<ControlFlow>,
     control_flow_prev: Mutex<ControlFlow>,
     start_time: Mutex<Option<Instant>>,
@@ -261,8 +260,6 @@ impl Handler {
         }
     }
 }
-
-pub static INTERRUPT_EVENT_LOOP_EXIT: AtomicBool = AtomicBool::new(false);
 
 pub enum AppState {}
 
@@ -403,40 +400,12 @@ impl AppState {
         if HANDLER.should_exit() {
             unsafe {
                 let app: id = NSApp();
-                let windows: id = msg_send![app, windows];
-                let window_count: usize = msg_send![windows, count];
 
-                let dialog_open = if window_count > 1 {
-                    let dialog: id = msg_send![windows, lastObject];
-                    let is_main_window: BOOL = msg_send![dialog, isMainWindow];
-                    let is_visible: BOOL = msg_send![dialog, isVisible];
-                    is_visible != NO && is_main_window == NO
-                } else {
-                    false
-                };
-
-                let dialog_is_closing = HANDLER.dialog_is_closing.load(Ordering::SeqCst);
                 autoreleasepool(|| {
-                    if !INTERRUPT_EVENT_LOOP_EXIT.load(Ordering::SeqCst)
-                        && !dialog_open
-                        && !dialog_is_closing
-                    {
-                        let () = msg_send![app, stop: nil];
-                        // To stop event loop immediately, we need to post some event here.
-                        post_dummy_event(app);
-                    }
+                    let () = msg_send![app, stop: nil];
+                    // To stop event loop immediately, we need to post some event here.
+                    post_dummy_event(app);
                 });
-
-                if window_count > 0 {
-                    let window: id = msg_send![windows, firstObject];
-                    let window_has_focus: BOOL = msg_send![window, isKeyWindow];
-                    if !dialog_open && window_has_focus != NO && dialog_is_closing {
-                        HANDLER.dialog_is_closing.store(false, Ordering::SeqCst);
-                    }
-                    if dialog_open {
-                        HANDLER.dialog_is_closing.store(true, Ordering::SeqCst);
-                    }
-                }
             };
         }
         HANDLER.update_start_time();

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -20,7 +20,6 @@ use crate::{
     platform::macos::WindowExtMacOS,
     platform_impl::platform::{
         app_state::AppState,
-        app_state::INTERRUPT_EVENT_LOOP_EXIT,
         ffi,
         monitor::{self, MonitorHandle, VideoMode},
         util::{self, IdRef},
@@ -907,8 +906,6 @@ impl UnownedWindow {
         let mut shared_state_lock = self.lock_shared_state("set_fullscreen");
         shared_state_lock.fullscreen = fullscreen.clone();
 
-        INTERRUPT_EVENT_LOOP_EXIT.store(true, Ordering::SeqCst);
-
         match (&old_fullscreen, &fullscreen) {
             (&None, &Some(_)) => unsafe {
                 util::toggle_full_screen_async(
@@ -978,7 +975,7 @@ impl UnownedWindow {
                     setLevel: ffi::NSWindowLevel::NSNormalWindowLevel
                 ];
             },
-            _ => INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst),
+            _ => {}
         };
     }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -1,7 +1,7 @@
 use std::{
     f64,
     os::raw::c_void,
-    sync::{atomic::Ordering, Arc, Weak},
+    sync::{Arc, Weak},
 };
 
 use cocoa::{
@@ -20,7 +20,6 @@ use crate::{
     event::{Event, ModifiersState, WindowEvent},
     platform_impl::platform::{
         app_state::AppState,
-        app_state::INTERRUPT_EVENT_LOOP_EXIT,
         event::{EventProxy, EventWrapper},
         util::{self, IdRef},
         view::ViewState,
@@ -422,8 +421,6 @@ extern "C" fn dragging_exited(this: &Object, _: Sel, _: id) {
 extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
     trace_scope!("windowWillEnterFullscreen:");
 
-    INTERRUPT_EVENT_LOOP_EXIT.store(true, Ordering::SeqCst);
-
     with_state(this, |state| {
         state.with_window(|window| {
             let mut shared_state = window.lock_shared_state("window_will_enter_fullscreen");
@@ -452,8 +449,6 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
 /// Invoked when before exit fullscreen
 extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
     trace_scope!("windowWillExitFullScreen:");
-
-    INTERRUPT_EVENT_LOOP_EXIT.store(true, Ordering::SeqCst);
 
     with_state(this, |state| {
         state.with_window(|window| {
@@ -498,8 +493,6 @@ extern "C" fn window_will_use_fullscreen_presentation_options(
 /// Invoked when entered fullscreen
 extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
     trace_scope!("windowDidEnterFullscreen:");
-    INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst);
-
     with_state(this, |state| {
         state.initial_fullscreen = false;
         state.with_window(|window| {
@@ -517,7 +510,6 @@ extern "C" fn window_did_enter_fullscreen(this: &Object, _: Sel, _: id) {
 /// Invoked when exited fullscreen
 extern "C" fn window_did_exit_fullscreen(this: &Object, _: Sel, _: id) {
     trace_scope!("windowDidExitFullscreen:");
-    INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst);
 
     with_state(this, |state| {
         state.with_window(|window| {


### PR DESCRIPTION
…om/rust-windowing/winit/pull/2027/files

It appears that an [old fix](https://github.com/rust-windowing/winit/pull/1581) for having multiple windows opening (in particular a native file dialog) broke `EventLoop::run_return` on macOS. In particular, this PR prevented the EventLoop from exiting if more than one window was open.

Since then, a [more general fix](https://github.com/rust-windowing/winit/pull/2027) has been released that prevents running the EventLoop re-entrant-ly.

This PR essentially manually reverts #1581, fixing EventLoop::run_return on macOS when multiple windows are open.

- [x] Tested on all platforms changed
  - tested with `rfd` file dialog winit example 
  - also tested multiple windows being open and returning from EventLoop::run_return
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
~- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
~- [ ] Created or updated an example program if it would help users understand this functionality~
~- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~

This PR fixes https://github.com/rust-windowing/winit/issues/2284