### PR TITLE
Make `EventLoopProxy` `Sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- `EventLoopProxy` now implements `Sync` as well as `Send`.
+- `EventLoopProxy` now implements `Send` on WebAssembly.
 - Build docs on `docs.rs` for iOS and Android as well.
 - **Breaking:** Removed the `WindowAttributes` struct, since all its functionality is accessible from `WindowBuilder`.
 - Added `WindowBuilder::transparent` getter to check if the user set `transparent` attribute.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,8 +136,10 @@ features = [
     'WheelEvent'
 ]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
-version = "0.2.45"
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2.45"
+wasm-bindgen-futures = "0.4.31"
+async-channel = "1.6.1"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 console_log = "0.2"

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -154,7 +154,8 @@ pub struct EventLoopProxy<T> {
 
 unsafe impl<T: Send> Send for EventLoopProxy<T> {}
 // Looking at the source code for `CFRunLoopSourceSignal` (https://github.com/opensource-apple/CF/blob/3cc41a76b1491f50813e28a4ec09954ffa359e6f/CFRunLoop.c#L3418-L3425),
-// it locks the source before doing anything, so I think it should be fine to use from behind a reference.
+// it locks the source before doing anything, so I think it should be fine to
+// use from behind a reference.
 //
 // `SyncSender` is already `Sync`, so that's not an issue.
 unsafe impl<T: Send> Sync for EventLoopProxy<T> {}

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -82,7 +82,7 @@ pub struct EventLoop<T: 'static> {
     pending_user_events: Rc<RefCell<Vec<T>>>,
 
     /// Sender of user events.
-    user_events_sender: calloop::channel::Sender<T>,
+    user_events_sender: calloop::channel::SyncSender<T>,
 
     /// Dispatcher of Wayland events.
     pub wayland_dispatcher: WinitDispatcher,
@@ -139,7 +139,7 @@ impl<T: 'static> EventLoop<T> {
         // A source of user events.
         let pending_user_events = Rc::new(RefCell::new(Vec::new()));
         let pending_user_events_clone = pending_user_events.clone();
-        let (user_events_sender, user_events_channel) = calloop::channel::channel();
+        let (user_events_sender, user_events_channel) = calloop::channel::sync_channel(10);
 
         // User events channel.
         event_loop

--- a/src/platform_impl/linux/wayland/event_loop/proxy.rs
+++ b/src/platform_impl/linux/wayland/event_loop/proxy.rs
@@ -2,13 +2,13 @@
 
 use std::sync::mpsc::SendError;
 
-use sctk::reexports::calloop::channel::Sender;
+use sctk::reexports::calloop::channel::SyncSender;
 
 use crate::event_loop::EventLoopClosed;
 
 /// A handle that can be sent across the threads and used to wake up the `EventLoop`.
 pub struct EventLoopProxy<T: 'static> {
-    user_events_sender: Sender<T>,
+    user_events_sender: SyncSender<T>,
 }
 
 impl<T: 'static> Clone for EventLoopProxy<T> {
@@ -20,7 +20,7 @@ impl<T: 'static> Clone for EventLoopProxy<T> {
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn new(user_events_sender: Sender<T>) -> Self {
+    pub fn new(user_events_sender: SyncSender<T>) -> Self {
         Self { user_events_sender }
     }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -32,7 +32,7 @@ use std::{
     ptr,
     rc::Rc,
     slice,
-    sync::mpsc::{Receiver, Sender, TryRecvError, SyncSender},
+    sync::mpsc::{Receiver, Sender, SyncSender, TryRecvError},
     sync::{mpsc, Arc, Weak},
     time::{Duration, Instant},
 };

--- a/src/platform_impl/web/event_loop/proxy.rs
+++ b/src/platform_impl/web/event_loop/proxy.rs
@@ -1,26 +1,27 @@
-use super::runner;
-use crate::event::Event;
+use async_channel::{Sender, TrySendError};
+
 use crate::event_loop::EventLoopClosed;
 
 pub struct EventLoopProxy<T: 'static> {
-    runner: runner::Shared<T>,
+    pub sender: Sender<T>,
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn new(runner: runner::Shared<T>) -> Self {
-        Self { runner }
-    }
-
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
-        self.runner.send_event(Event::UserEvent(event));
-        Ok(())
+        match self.sender.try_send(event) {
+            Ok(()) => Ok(()),
+            Err(TrySendError::Closed(val)) => Err(EventLoopClosed(val)),
+            // Note: `async-channel` has no way to block on sending something,
+            // so this is our only option for making this synchronous.
+            Err(TrySendError::Full(_)) => unreachable!("`EventLoopProxy` channels are unbounded"),
+        }
     }
 }
 
 impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
         Self {
-            runner: self.runner.clone(),
+            sender: self.sender.clone(),
         }
     }
 }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -35,7 +35,7 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     pub fn proxy(&self) -> EventLoopProxy<T> {
-        EventLoopProxy::new(self.runner.clone())
+        self.runner.create_proxy()
     }
 
     pub fn run(&self, event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>) {

--- a/tests/send_objects.rs
+++ b/tests/send_objects.rs
@@ -1,7 +1,6 @@
 #[allow(dead_code)]
 fn needs_send<T: Send>() {}
 
-#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn event_loop_proxy_send() {
     #[allow(dead_code)]

--- a/tests/sync_object.rs
+++ b/tests/sync_object.rs
@@ -3,6 +3,16 @@ fn needs_sync<T: Sync>() {}
 
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
+fn event_loop_proxy_sync() {
+    #[allow(dead_code)]
+    fn is_send<T: 'static + Send>() {
+        // ensures that `winit::EventLoopProxy` implements `Sync`
+        needs_sync::<winit::event_loop::EventLoopProxy<T>>();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
 fn window_sync() {
     // ensures that `winit::Window` implements `Sync`
     needs_sync::<winit::window::Window>();

--- a/tests/sync_object.rs
+++ b/tests/sync_object.rs
@@ -1,7 +1,6 @@
 #[allow(dead_code)]
 fn needs_sync<T: Sync>() {}
 
-#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn event_loop_proxy_sync() {
     #[allow(dead_code)]


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [ ] ~~Created or updated an example program if it would help users understand this functionality~~
- [ ] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~

Previously, `EventLoopProxy` was `Send` but not `Sync`. The only reason for this that I could see was that `mpsc::Sender` wasn't `Sync`; however, the alternative `mpsc::SyncSender` is, so I've switched to using that instead.

It's not named that because it implements `Sync`;  the difference is that `SyncSender` has a fixed-size buffer and will block if its buffer is full, whereas `Sender` will never block. For the size of the buffer, I've just arbitrarily picked 10; I've got no idea what would be optimal.

The reason I think it needs to implement `Sync` is for the sake of #1199. In an executor which polls futures within the event loop, the best way I can think of to implement `Waker` is by sending an event through `EventLoopProxy` to wake up the event loop; however, `Waker` is `Send` and `Sync`, so `EventLoopProxy` also has to be `Send` and `Sync` for a `Waker` implementation to use it.

~~On the web, `EventLoopProxy` is neither `Send` nor `Sync`. This could be fixed, but would be much more complicated and isn't needed for the async use case - on the web, `wasm_bindgen_futures::spawn_local` could just be used instead, so a custom `Waker` implementation isn't needed.~~