### PR TITLE
Fix warnings on nightly rust

### DIFF
--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -70,7 +70,6 @@ impl<T> EventLoopWindowTargetExtUnix for EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    #[doc(hidden)]
     #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.p {
@@ -221,7 +220,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[doc(hidden)]
     #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.window {


### PR DESCRIPTION
This was causing CI to fail: https://github.com/rust-windowing/winit/runs/6506026326
