### PR TITLE
adds support for fn set_suspend_callback

### DIFF
--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -13,7 +13,9 @@ pub trait EventLoopExtAndroid {}
 impl<T> EventLoopExtAndroid for EventLoop<T> {}
 
 /// Additional methods on `EventLoopWindowTarget` that are specific to Android.
-pub trait EventLoopWindowTargetExtAndroid {}
+pub trait EventLoopWindowTargetExtAndroid {
+    fn set_suspend_callback(&self, _cb: Option<Box<dyn Fn(bool) -> ()>>) {}
+}
 
 /// Additional methods on `Window` that are specific to Android.
 pub trait WindowExtAndroid {


### PR DESCRIPTION
Fix for https://github.com/rust-windowing/glutin/issues/1307 but I still don´t know what to put into the implementation of `set_suspend_callback`. It looks like this repo had this but now does not have it anymore, and I couldn't find the implementation for it. What should I put there? At least it compiles now


- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
