### PR TITLE
[Windows] Avoid GetModuleHandle(NULL)

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -27,10 +27,7 @@ use windows_sys::Win32::{
         RDW_INTERNALPAINT, SC_SCREENSAVE,
     },
     Media::{timeBeginPeriod, timeEndPeriod, timeGetDevCaps, TIMECAPS, TIMERR_NOERROR},
-    System::{
-        LibraryLoader::GetModuleHandleW, Ole::RevokeDragDrop, Threading::GetCurrentThreadId,
-        WindowsProgramming::INFINITE,
-    },
+    System::{Ole::RevokeDragDrop, Threading::GetCurrentThreadId, WindowsProgramming::INFINITE},
     UI::{
         Controls::{HOVER_DEFAULT, WM_MOUSELEAVE},
         Input::{
@@ -647,7 +644,7 @@ fn create_event_target_window<T: 'static>() -> HWND {
             lpfnWndProc: Some(thread_event_target_callback::<T>),
             cbClsExtra: 0,
             cbWndExtra: 0,
-            hInstance: GetModuleHandleW(ptr::null()),
+            hInstance: util::get_instance_handle(),
             hIcon: 0,
             hCursor: 0, // must be null in order for cursor state to work properly
             hbrBackground: 0,
@@ -681,7 +678,7 @@ fn create_event_target_window<T: 'static>() -> HWND {
             0,
             0,
             0,
-            GetModuleHandleW(ptr::null()),
+            util::get_instance_handle(),
             ptr::null(),
         );
 

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -1,10 +1,9 @@
-use std::{fmt, io, mem, path::Path, ptr, sync::Arc};
+use std::{fmt, io, mem, path::Path, sync::Arc};
 
 use windows_sys::{
     core::PCWSTR,
     Win32::{
         Foundation::HWND,
-        System::LibraryLoader::GetModuleHandleW,
         UI::WindowsAndMessaging::{
             CreateIcon, DestroyIcon, LoadImageW, SendMessageW, HICON, ICON_BIG, ICON_SMALL,
             IMAGE_ICON, LR_DEFAULTSIZE, LR_LOADFROMFILE, WM_SETICON,
@@ -111,7 +110,7 @@ impl WinIcon {
         let (width, height) = size.map(Into::into).unwrap_or((0, 0));
         let handle = unsafe {
             LoadImageW(
-                GetModuleHandleW(ptr::null()),
+                util::get_instance_handle(),
                 resource_id as PCWSTR,
                 IMAGE_ICON,
                 width as i32,

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -220,7 +220,7 @@ pub fn get_instance_handle() -> HINSTANCE {
         static __ImageBase: IMAGE_DOS_HEADER;
     }
 
-    unsafe { &__ImageBase as *const IMAGE_DOS_HEADER as _ }
+    unsafe { &__ImageBase as *const _ as _ }
 }
 
 impl CursorIcon {

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -12,11 +12,11 @@ use std::{
 use windows_sys::{
     core::{HRESULT, PCWSTR},
     Win32::{
-        Foundation::{BOOL, HWND, RECT, HINSTANCE},
+        Foundation::{BOOL, HINSTANCE, HWND, RECT},
         Graphics::Gdi::{ClientToScreen, InvalidateRgn, HMONITOR},
         System::{
             LibraryLoader::{GetProcAddress, LoadLibraryA},
-            SystemServices::IMAGE_DOS_HEADER
+            SystemServices::IMAGE_DOS_HEADER,
         },
         UI::{
             HiDpi::{DPI_AWARENESS_CONTEXT, MONITOR_DPI_TYPE, PROCESS_DPI_AWARENESS},

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -12,9 +12,12 @@ use std::{
 use windows_sys::{
     core::{HRESULT, PCWSTR},
     Win32::{
-        Foundation::{BOOL, HWND, RECT},
+        Foundation::{BOOL, HWND, RECT, HINSTANCE},
         Graphics::Gdi::{ClientToScreen, InvalidateRgn, HMONITOR},
-        System::LibraryLoader::{GetProcAddress, LoadLibraryA},
+        System::{
+            LibraryLoader::{GetProcAddress, LoadLibraryA},
+            SystemServices::IMAGE_DOS_HEADER
+        },
         UI::{
             HiDpi::{DPI_AWARENESS_CONTEXT, MONITOR_DPI_TYPE, PROCESS_DPI_AWARENESS},
             Input::KeyboardAndMouse::GetActiveWindow,
@@ -203,6 +206,21 @@ pub fn get_desktop_rect() -> RECT {
 
 pub fn is_focused(window: HWND) -> bool {
     window == unsafe { GetActiveWindow() }
+}
+
+pub fn get_instance_handle() -> HINSTANCE {
+    // Gets the instance handle by taking the address of the
+    // pseudo-variable created by the microsoft linker:
+    // https://devblogs.microsoft.com/oldnewthing/20041025-00/?p=37483
+
+    // This is preferred over GetModuleHandle(NULL) because it also works in DLLs:
+    // https://stackoverflow.com/questions/21718027/getmodulehandlenull-vs-hinstance
+
+    extern "C" {
+        static __ImageBase: IMAGE_DOS_HEADER;
+    }
+
+    unsafe { &__ImageBase as *const IMAGE_DOS_HEADER as _ }
 }
 
 impl CursorIcon {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -26,7 +26,6 @@ use windows_sys::Win32::{
         Com::{
             CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_APARTMENTTHREADED,
         },
-        LibraryLoader::GetModuleHandleW,
         Ole::{OleInitialize, RegisterDragDrop},
     },
     UI::{
@@ -974,7 +973,7 @@ where
         CW_USEDEFAULT,
         parent.unwrap_or(0),
         pl_attribs.menu.unwrap_or(0),
-        GetModuleHandleW(ptr::null()),
+        util::get_instance_handle(),
         &mut initdata as *mut _ as *mut _,
     );
 
@@ -1013,7 +1012,7 @@ unsafe fn register_window_class<T: 'static>(
         lpfnWndProc: Some(super::event_loop::public_window_callback::<T>),
         cbClsExtra: 0,
         cbWndExtra: 0,
-        hInstance: GetModuleHandleW(ptr::null()),
+        hInstance: util::get_instance_handle(),
         hIcon: h_icon,
         hCursor: 0, // must be null in order for cursor state to work properly
         hbrBackground: 0,


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #2300.

winit's GetModuleHandle(NULL) [returns an invalid instance handle if it were to be used inside of a DLL or other non-executable target](https://stackoverflow.com/questions/21718027/getmodulehandlenull-vs-hinstance).. Using the [pseudo-variable of the microsoft linker](https://devblogs.microsoft.com/oldnewthing/20041025-00/?p=37483) not only reduces work, but also works reliably inside both DLLs and executables. More info is inside the issue.

The documentation states that this only works with the microsoft linker, I've tested it using both the stable-GNU and stable-MSVC toolchain and it both seems to work, which suggests that on windows the microsoft linker is always used. 