### PR TITLE
Reorganize EventLoopBuilder::build() platform documentation.

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -84,14 +84,14 @@ impl<T> EventLoopBuilder<T> {
     /// in the relevant `platform` module if the target platform supports creating an event loop on
     /// any thread.
     ///
-    /// Usage will result in display backend initialisation, this can be controlled on linux
-    /// using an environment variable `WINIT_UNIX_BACKEND`. Legal values are `x11` and `wayland`.
-    /// If it is not set, winit will try to connect to a wayland connection, and if it fails will
-    /// fallback on x11. If this variable is set with any other value, winit will panic.
+    /// Calling this function will result in display backend initialisation.
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS:** Can only be called on the main thread.
+    /// - **Linux:** Backend type can be controlled using an environment variable
+    ///   `WINIT_UNIX_BACKEND`. Legal values are `x11` and `wayland`.
+    ///   If it is not set, winit will try to connect to a Wayland connection, and if that fails,
+    ///   will fall back on X11. If this variable is set with any other value, winit will panic.
     #[inline]
     pub fn build(&mut self) -> EventLoop<T> {
         EventLoop {


### PR DESCRIPTION
This PR modifies documentation only; I tested it by viewing local `cargo doc` output.

Since there's a "Platform-specific" header, it makes sense to put the Linux-specific part under it. On the other hand, "Can only be called on the main thread." is true for all platforms, and documented in the preceding text, not just iOS, so there is no reason to call it out for iOS specifically.

A further improvement might be to describe the specific side-effects calling the function could have on non-Linux platforms (rather than just saying "display backend initialisation"), but I don't know of any to mention.
