### PR TITLE
On Windows, fix reported cursor position.

### DIFF
--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -106,13 +106,13 @@ const fn get_xbutton_wparam(x: u32) -> u16 {
 }
 
 #[inline(always)]
-const fn get_x_lparam(x: u32) -> u16 {
-    loword(x)
+const fn get_x_lparam(x: u32) -> i16 {
+    loword(x) as _
 }
 
 #[inline(always)]
-const fn get_y_lparam(x: u32) -> u16 {
-    hiword(x)
+const fn get_y_lparam(x: u32) -> i16 {
+    hiword(x) as _
 }
 
 #[inline(always)]


### PR DESCRIPTION
When clicking and moving the cursor out of the window negative coordinates were not handled correctly.
Changelog entry not added as this occured during the `windows-sys` transition and shouldn't affect the latest release.


> Do not use the [LOWORD](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms632659(v=vs.85)) or [HIWORD](https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms632657(v=vs.85)) macros to extract the x- and y- coordinates of the cursor position because these macros return incorrect results on systems with multiple monitors. Systems with multiple monitors can have negative x- and y- coordinates, and LOWORD and HIWORD treat the coordinates as unsigned quantities.

The implementation now follows the original macro definition `#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))`.

Fixes https://github.com/rust-windowing/winit/issues/2310

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
