### PR TITLE
Revert "On Wayland, fix resize not propagating properly"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,6 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Replaced `EventLoopExtUnix` with `EventLoopBuilderExtUnix` (which also has renamed methods).
 - **Breaking:** The platform specific extensions for Windows `winit::platform::windows` have changed. All `HANDLE`-like types e.g. `HWND` and `HMENU` were converted from winapi types or `*mut c_void` to `isize`. This was done to be consistent with the type definitions in windows-sys and to not expose internal dependencies.
 - The internal bindings to the [Windows API](https://docs.microsoft.com/en-us/windows/) were changed from the unofficial [winapi](https://github.com/retep998/winapi-rs) bindings to the official Microsoft [windows-sys](https://github.com/microsoft/windows-rs) bindings.
-- On Wayland, fix resize and scale factor changes not being propagated properly.
 - On Wayland, fix polling during consecutive `EventLoop::run_return` invocations.
 - On Windows, fix race issue creating fullscreen windows with `WindowBuilder::with_fullscreen`
 - On Android, `virtual_keycode` for `KeyboardInput` events is now filled in where a suitable match is found.

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -24,7 +24,7 @@ use crate::platform_impl::EventLoopWindowTarget as PlatformEventLoopWindowTarget
 use super::env::{WindowingFeatures, WinitEnv};
 use super::output::OutputManager;
 use super::seat::SeatManager;
-use super::window::shim::{self, WindowRequest, WindowUpdate};
+use super::window::shim::{self, WindowUpdate};
 use super::{DeviceId, WindowId};
 
 mod proxy;
@@ -344,8 +344,7 @@ impl<T: 'static> EventLoop<T> {
             }
 
             // Process 'new' pending updates.
-            self.with_window_target(|window_target| {
-                let state = window_target.state.get_mut();
+            self.with_state(|state| {
                 window_updates.clear();
                 window_updates.extend(
                     state
@@ -357,8 +356,7 @@ impl<T: 'static> EventLoop<T> {
 
             for (window_id, window_update) in window_updates.iter_mut() {
                 if let Some(scale_factor) = window_update.scale_factor.map(|f| f as f64) {
-                    let mut physical_size = self.with_window_target(|window_target| {
-                        let state = window_target.state.get_mut();
+                    let mut physical_size = self.with_state(|state| {
                         let window_handle = state.window_map.get(window_id).unwrap();
                         let mut size = window_handle.size.lock().unwrap();
 
@@ -391,8 +389,7 @@ impl<T: 'static> EventLoop<T> {
                 }
 
                 if let Some(size) = window_update.size.take() {
-                    let physical_size = self.with_window_target(|window_target| {
-                        let state = window_target.state.get_mut();
+                    let physical_size = self.with_state(|state| {
                         let window_handle = state.window_map.get_mut(window_id).unwrap();
                         let mut window_size = window_handle.size.lock().unwrap();
 
@@ -417,15 +414,6 @@ impl<T: 'static> EventLoop<T> {
 
                         // Mark that refresh isn't required, since we've done it right now.
                         window_update.refresh_frame = false;
-
-                        // Queue request for redraw into the next iteration of the loop, since
-                        // resize and scale factor changes are double buffered.
-                        window_handle
-                            .pending_window_requests
-                            .lock()
-                            .unwrap()
-                            .push(WindowRequest::Redraw);
-                        window_target.event_loop_awakener.ping();
 
                         physical_size
                     });
@@ -463,8 +451,7 @@ impl<T: 'static> EventLoop<T> {
             // The purpose of the back buffer and that swap is to not hold borrow_mut when
             // we're doing callback to the user, since we can double borrow if the user decides
             // to create a window in one of those callbacks.
-            self.with_window_target(|window_target| {
-                let state = window_target.state.get_mut();
+            self.with_state(|state| {
                 std::mem::swap(
                     &mut event_sink_back_buffer,
                     &mut state.event_sink.window_events,
@@ -489,8 +476,7 @@ impl<T: 'static> EventLoop<T> {
             for (window_id, window_update) in window_updates.iter() {
                 // Handle refresh of the frame.
                 if window_update.refresh_frame {
-                    self.with_window_target(|window_target| {
-                        let state = window_target.state.get_mut();
+                    self.with_state(|state| {
                         let window_handle = state.window_map.get_mut(window_id).unwrap();
                         window_handle.window.refresh();
                         if !window_update.redraw_requested {
@@ -535,9 +521,9 @@ impl<T: 'static> EventLoop<T> {
         &self.window_target
     }
 
-    fn with_window_target<U, F: FnOnce(&mut EventLoopWindowTarget<T>) -> U>(&mut self, f: F) -> U {
+    fn with_state<U, F: FnOnce(&mut WinitState) -> U>(&mut self, f: F) -> U {
         let state = match &mut self.window_target.p {
-            PlatformEventLoopWindowTarget::Wayland(window_target) => window_target,
+            PlatformEventLoopWindowTarget::Wayland(window_target) => window_target.state.get_mut(),
             #[cfg(feature = "x11")]
             _ => unreachable!(),
         };


### PR DESCRIPTION
This reverts commit 78e5a395dac9604e851f781b6810247ead7928e3.

It was discovered that in some cases mesa will lock the back
buffer, e.g. when making context current, leading to resize
missing. Given that applications can restructure their rendering
to account for that, and that winit isn't limited to playing
nice with mesa reverting the original commit.


