### PR TITLE
Migrate from lazy_static to once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ wayland-csd-adwaita-notitle = ["sctk-adwaita"]
 
 [dependencies]
 instant = { version = "0.1", features = ["wasm-bindgen"] }
-lazy_static = "1"
+once_cell = "1.12"
 log = "0.4"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 raw-window-handle = "0.4.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,9 +135,6 @@
 
 #[allow(unused_imports)]
 #[macro_use]
-extern crate lazy_static;
-#[allow(unused_imports)]
-#[macro_use]
 extern crate log;
 #[cfg(feature = "serde")]
 #[macro_use]

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -1,12 +1,11 @@
 #![cfg(target_os = "android")]
 
-use crate::{
-    dpi::{PhysicalPosition, PhysicalSize, Position, Size},
-    error,
-    event::{self, VirtualKeyCode},
-    event_loop::{self, ControlFlow},
-    monitor, window,
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex, RwLock},
+    time::{Duration, Instant},
 };
+
 use ndk::{
     configuration::Configuration,
     event::{InputEvent, KeyAction, Keycode, MotionAction},
@@ -15,10 +14,13 @@ use ndk::{
 use ndk_glue::{Event, Rect};
 use once_cell::sync::Lazy;
 use raw_window_handle::{AndroidNdkHandle, RawWindowHandle};
-use std::{
-    collections::VecDeque,
-    sync::{Arc, Mutex, RwLock},
-    time::{Duration, Instant},
+
+use crate::{
+    dpi::{PhysicalPosition, PhysicalSize, Position, Size},
+    error,
+    event::{self, VirtualKeyCode},
+    event_loop::{self, ControlFlow},
+    monitor, window,
 };
 
 static CONFIG: Lazy<RwLock<Configuration>> = Lazy::new(|| {

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -13,6 +13,7 @@ use ndk::{
     looper::{ForeignLooper, Poll, ThreadLooper},
 };
 use ndk_glue::{Event, Rect};
+use once_cell::sync::Lazy;
 use raw_window_handle::{AndroidNdkHandle, RawWindowHandle};
 use std::{
     collections::VecDeque,
@@ -20,19 +21,19 @@ use std::{
     time::{Duration, Instant},
 };
 
-lazy_static! {
-    static ref CONFIG: RwLock<Configuration> = RwLock::new(Configuration::from_asset_manager(
+static CONFIG: Lazy<RwLock<Configuration>> = Lazy::new(|| {
+    RwLock::new(Configuration::from_asset_manager(
         #[allow(deprecated)] // TODO: rust-windowing/winit#2196
-        &ndk_glue::native_activity().asset_manager()
-    ));
-    // If this is `Some()` a `Poll::Wake` is considered an `EventSource::Internal` with the event
-    // contained in the `Option`. The event is moved outside of the `Option` replacing it with a
-    // `None`.
-    //
-    // This allows us to inject event into the event loop without going through `ndk-glue` and
-    // calling unsafe function that should only be called by Android.
-    static ref INTERNAL_EVENT: RwLock<Option<InternalEvent>> = RwLock::new(None);
-}
+        &ndk_glue::native_activity().asset_manager(),
+    ))
+});
+// If this is `Some()` a `Poll::Wake` is considered an `EventSource::Internal` with the event
+// contained in the `Option`. The event is moved outside of the `Option` replacing it with a
+// `None`.
+//
+// This allows us to inject event into the event loop without going through `ndk-glue` and
+// calling unsafe function that should only be called by Android.
+static INTERNAL_EVENT: Lazy<RwLock<Option<InternalEvent>>> = Lazy::new(|| RwLock::new(None));
 
 enum InternalEvent {
     RedrawRequested,

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -1,5 +1,6 @@
 #![deny(unused_results)]
 
+use once_cell::sync::Lazy;
 use std::{
     cell::{RefCell, RefMut},
     collections::HashSet,
@@ -1016,29 +1017,27 @@ impl NSOperatingSystemVersion {
 }
 
 pub fn os_capabilities() -> OSCapabilities {
-    lazy_static! {
-        static ref OS_CAPABILITIES: OSCapabilities = {
-            let version: NSOperatingSystemVersion = unsafe {
-                let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
-                let atleast_ios_8: BOOL = msg_send![
-                    process_info,
-                    respondsToSelector: sel!(operatingSystemVersion)
-                ];
-                // winit requires atleast iOS 8 because no one has put the time into supporting earlier os versions.
-                // Older iOS versions are increasingly difficult to test. For example, Xcode 11 does not support
-                // debugging on devices with an iOS version of less than 8. Another example, in order to use an iOS
-                // simulator older than iOS 8, you must download an older version of Xcode (<9), and at least Xcode 7
-                // has been tested to not even run on macOS 10.15 - Xcode 8 might?
-                //
-                // The minimum required iOS version is likely to grow in the future.
-                assert!(
-                    atleast_ios_8 == YES,
-                    "`winit` requires iOS version 8 or greater"
-                );
-                msg_send![process_info, operatingSystemVersion]
-            };
-            version.into()
+    static OS_CAPABILITIES: Lazy<OSCapabilities> = Lazy::new(|| {
+        let version: NSOperatingSystemVersion = unsafe {
+            let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
+            let atleast_ios_8: BOOL = msg_send![
+                process_info,
+                respondsToSelector: sel!(operatingSystemVersion)
+            ];
+            // winit requires atleast iOS 8 because no one has put the time into supporting earlier os versions.
+            // Older iOS versions are increasingly difficult to test. For example, Xcode 11 does not support
+            // debugging on devices with an iOS version of less than 8. Another example, in order to use an iOS
+            // simulator older than iOS 8, you must download an older version of Xcode (<9), and at least Xcode 7
+            // has been tested to not even run on macOS 10.15 - Xcode 8 might?
+            //
+            // The minimum required iOS version is likely to grow in the future.
+            assert!(
+                atleast_ios_8 == YES,
+                "`winit` requires iOS version 8 or greater"
+            );
+            msg_send![process_info, operatingSystemVersion]
         };
-    }
+        version.into()
+    });
     OS_CAPABILITIES.clone()
 }

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -1,6 +1,5 @@
 #![deny(unused_results)]
 
-use once_cell::sync::Lazy;
 use std::{
     cell::{RefCell, RefMut},
     collections::HashSet,
@@ -11,6 +10,7 @@ use std::{
 };
 
 use objc::runtime::{BOOL, YES};
+use once_cell::sync::Lazy;
 
 use crate::{
     dpi::LogicalSize,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -14,8 +14,6 @@ use crate::window::Theme;
 #[cfg(feature = "wayland")]
 use std::error::Error;
 
-#[cfg(feature = "x11")]
-use once_cell::sync::Lazy;
 use std::{collections::VecDeque, env, fmt};
 #[cfg(feature = "x11")]
 use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Arc};
@@ -23,6 +21,8 @@ use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Arc};
 #[cfg(feature = "x11")]
 use parking_lot::Mutex;
 use raw_window_handle::RawWindowHandle;
+#[cfg(feature = "x11")]
+use once_cell::sync::Lazy;
 
 #[cfg(feature = "x11")]
 pub use self::x11::XNotSupported;

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -19,10 +19,10 @@ use std::{collections::VecDeque, env, fmt};
 use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Arc};
 
 #[cfg(feature = "x11")]
+use once_cell::sync::Lazy;
+#[cfg(feature = "x11")]
 use parking_lot::Mutex;
 use raw_window_handle::RawWindowHandle;
-#[cfg(feature = "x11")]
-use once_cell::sync::Lazy;
 
 #[cfg(feature = "x11")]
 pub use self::x11::XNotSupported;

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -14,6 +14,8 @@ use crate::window::Theme;
 #[cfg(feature = "wayland")]
 use std::error::Error;
 
+#[cfg(feature = "x11")]
+use once_cell::sync::Lazy;
 use std::{collections::VecDeque, env, fmt};
 #[cfg(feature = "x11")]
 use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Arc};
@@ -133,10 +135,8 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
 }
 
 #[cfg(feature = "x11")]
-lazy_static! {
-    pub static ref X11_BACKEND: Mutex<Result<Arc<XConnection>, XNotSupported>> =
-        Mutex::new(XConnection::new(Some(x_error_callback)).map(Arc::new));
-}
+pub static X11_BACKEND: Lazy<Mutex<Result<Arc<XConnection>, XNotSupported>>> =
+    Lazy::new(|| Mutex::new(XConnection::new(Some(x_error_callback)).map(Arc::new)));
 
 #[derive(Debug, Clone)]
 pub enum OsError {

--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -1,5 +1,3 @@
-use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 use std::{
     env,
     ffi::{CStr, CString, IntoStringError},
@@ -8,6 +6,9 @@ use std::{
     ptr,
     sync::Arc,
 };
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 
 use super::{ffi, util, XConnection, XError};
 

--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -1,3 +1,5 @@
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use std::{
     env,
     ffi::{CStr, CString, IntoStringError},
@@ -7,13 +9,9 @@ use std::{
     sync::Arc,
 };
 
-use parking_lot::Mutex;
-
 use super::{ffi, util, XConnection, XError};
 
-lazy_static! {
-    static ref GLOBAL_LOCK: Mutex<()> = Default::default();
-}
+static GLOBAL_LOCK: Lazy<Mutex<()>> = Lazy::new(Default::default);
 
 unsafe fn open_im(xconn: &Arc<XConnection>, locale_modifiers: &CStr) -> Option<ffi::XIM> {
     let _lock = GLOBAL_LOCK.lock();

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -14,13 +14,12 @@ use crate::{
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform_impl::{MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode},
 };
+use once_cell::sync::Lazy;
 
 // Used for testing. This should always be committed as false.
 const DISABLE_MONITOR_LIST_CACHING: bool = false;
 
-lazy_static! {
-    static ref MONITORS: Mutex<Option<Vec<MonitorHandle>>> = Mutex::default();
-}
+static MONITORS: Lazy<Mutex<Option<Vec<MonitorHandle>>>> = Lazy::new(Mutex::default);
 
 pub fn invalidate_cached_monitor_list() -> Option<Vec<MonitorHandle>> {
     // We update this lazily.

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -1,6 +1,7 @@
 use std::os::raw::*;
 
 use parking_lot::Mutex;
+use once_cell::sync::Lazy;
 
 use super::{
     ffi::{
@@ -14,7 +15,6 @@ use crate::{
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform_impl::{MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode},
 };
-use once_cell::sync::Lazy;
 
 // Used for testing. This should always be committed as false.
 const DISABLE_MONITOR_LIST_CACHING: bool = false;

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -1,7 +1,7 @@
 use std::os::raw::*;
 
-use parking_lot::Mutex;
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 
 use super::{
     ffi::{

--- a/src/platform_impl/linux/x11/util/atom.rs
+++ b/src/platform_impl/linux/x11/util/atom.rs
@@ -1,3 +1,5 @@
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use std::{
     collections::HashMap,
     ffi::{CStr, CString},
@@ -5,15 +7,11 @@ use std::{
     os::raw::*,
 };
 
-use parking_lot::Mutex;
-
 use super::*;
 
 type AtomCache = HashMap<CString, ffi::Atom>;
 
-lazy_static! {
-    static ref ATOM_CACHE: Mutex<AtomCache> = Mutex::new(HashMap::with_capacity(2048));
-}
+static ATOM_CACHE: Lazy<Mutex<AtomCache>> = Lazy::new(|| Mutex::new(HashMap::with_capacity(2048)));
 
 impl XConnection {
     pub fn get_atom<T: AsRef<CStr> + Debug>(&self, name: T) -> ffi::Atom {

--- a/src/platform_impl/linux/x11/util/atom.rs
+++ b/src/platform_impl/linux/x11/util/atom.rs
@@ -1,11 +1,12 @@
-use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 use std::{
     collections::HashMap,
     ffi::{CStr, CString},
     fmt::Debug,
     os::raw::*,
 };
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 
 use super::*;
 

--- a/src/platform_impl/linux/x11/util/wm.rs
+++ b/src/platform_impl/linux/x11/util/wm.rs
@@ -1,7 +1,7 @@
 use parking_lot::Mutex;
+use once_cell::sync::Lazy;
 
 use super::*;
-use once_cell::sync::Lazy;
 
 // This info is global to the window manager.
 static SUPPORTED_HINTS: Lazy<Mutex<Vec<ffi::Atom>>> =

--- a/src/platform_impl/linux/x11/util/wm.rs
+++ b/src/platform_impl/linux/x11/util/wm.rs
@@ -1,5 +1,5 @@
-use parking_lot::Mutex;
 use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 
 use super::*;
 

--- a/src/platform_impl/linux/x11/util/wm.rs
+++ b/src/platform_impl/linux/x11/util/wm.rs
@@ -1,12 +1,12 @@
 use parking_lot::Mutex;
 
 use super::*;
+use once_cell::sync::Lazy;
 
 // This info is global to the window manager.
-lazy_static! {
-    static ref SUPPORTED_HINTS: Mutex<Vec<ffi::Atom>> = Mutex::new(Vec::with_capacity(0));
-    static ref WM_NAME: Mutex<Option<String>> = Mutex::new(None);
-}
+static SUPPORTED_HINTS: Lazy<Mutex<Vec<ffi::Atom>>> =
+    Lazy::new(|| Mutex::new(Vec::with_capacity(0)));
+static WM_NAME: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
 
 pub fn hint_is_supported(hint: ffi::Atom) -> bool {
     (*SUPPORTED_HINTS.lock()).contains(&hint)

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,4 +1,7 @@
-use crate::{platform::macos::ActivationPolicy, platform_impl::platform::app_state::AppState};
+use std::{
+    cell::{RefCell, RefMut},
+    os::raw::c_void,
+};
 
 use cocoa::base::id;
 use objc::{
@@ -6,10 +9,8 @@ use objc::{
     runtime::{Class, Object, Sel},
 };
 use once_cell::sync::Lazy;
-use std::{
-    cell::{RefCell, RefMut},
-    os::raw::c_void,
-};
+
+use crate::{platform::macos::ActivationPolicy, platform_impl::platform::app_state::AppState};
 
 static AUX_DELEGATE_STATE_NAME: &str = "auxState";
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -12,6 +12,16 @@ use std::{
     time::Instant,
 };
 
+use cocoa::{
+    appkit::{NSApp, NSApplication, NSWindow},
+    base::{id, nil},
+    foundation::NSSize,
+};
+use objc::{
+    rc::autoreleasepool,
+    runtime::{Object, BOOL, NO, YES},
+};
+
 use crate::{
     dpi::LogicalSize,
     event::{Event, StartCause, WindowEvent},
@@ -29,15 +39,6 @@ use crate::{
         },
     },
     window::WindowId,
-};
-use cocoa::{
-    appkit::{NSApp, NSApplication, NSWindow},
-    base::{id, nil},
-    foundation::NSSize,
-};
-use objc::{
-    rc::autoreleasepool,
-    runtime::{Object, BOOL, NO, YES},
 };
 use once_cell::sync::Lazy;
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -12,16 +12,6 @@ use std::{
     time::Instant,
 };
 
-use cocoa::{
-    appkit::{NSApp, NSApplication, NSWindow},
-    base::{id, nil},
-    foundation::NSSize,
-};
-use objc::{
-    rc::autoreleasepool,
-    runtime::{Object, BOOL, NO, YES},
-};
-
 use crate::{
     dpi::LogicalSize,
     event::{Event, StartCause, WindowEvent},
@@ -40,10 +30,18 @@ use crate::{
     },
     window::WindowId,
 };
+use cocoa::{
+    appkit::{NSApp, NSApplication, NSWindow},
+    base::{id, nil},
+    foundation::NSSize,
+};
+use objc::{
+    rc::autoreleasepool,
+    runtime::{Object, BOOL, NO, YES},
+};
+use once_cell::sync::Lazy;
 
-lazy_static! {
-    static ref HANDLER: Handler = Default::default();
-}
+static HANDLER: Lazy<Handler> = Lazy::new(Default::default);
 
 impl<'a, Never> Event<'a, Never> {
     fn userify<T: 'static>(self) -> Event<'a, T> {

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -21,6 +21,7 @@ use objc::{
     rc::autoreleasepool,
     runtime::{Object, BOOL, NO, YES},
 };
+use once_cell::sync::Lazy;
 
 use crate::{
     dpi::LogicalSize,
@@ -40,7 +41,6 @@ use crate::{
     },
     window::WindowId,
 };
-use once_cell::sync::Lazy;
 
 static HANDLER: Lazy<Handler> = Lazy::new(Default::default);
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -1,13 +1,3 @@
-use cocoa::{
-    appkit::{NSApp, NSEvent, NSEventModifierFlags, NSEventPhase, NSView, NSWindow},
-    base::{id, nil},
-    foundation::{NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger},
-};
-use objc::{
-    declare::ClassDecl,
-    runtime::{Class, Object, Protocol, Sel, BOOL, NO, YES},
-};
-use once_cell::sync::Lazy;
 use std::{
     boxed::Box,
     collections::VecDeque,
@@ -18,6 +8,17 @@ use std::{
         Arc, Mutex, Weak,
     },
 };
+
+use cocoa::{
+    appkit::{NSApp, NSEvent, NSEventModifierFlags, NSEventPhase, NSView, NSWindow},
+    base::{id, nil},
+    foundation::{NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger},
+};
+use objc::{
+    declare::ClassDecl,
+    runtime::{Class, Object, Protocol, Sel, BOOL, NO, YES},
+};
+use once_cell::sync::Lazy;
 
 use crate::{
     dpi::{LogicalPosition, LogicalSize},

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -1,3 +1,13 @@
+use cocoa::{
+    appkit::{NSApp, NSEvent, NSEventModifierFlags, NSEventPhase, NSView, NSWindow},
+    base::{id, nil},
+    foundation::{NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger},
+};
+use objc::{
+    declare::ClassDecl,
+    runtime::{Class, Object, Protocol, Sel, BOOL, NO, YES},
+};
+use once_cell::sync::Lazy;
 use std::{
     boxed::Box,
     collections::VecDeque,
@@ -7,16 +17,6 @@ use std::{
         atomic::{compiler_fence, Ordering},
         Arc, Mutex, Weak,
     },
-};
-
-use cocoa::{
-    appkit::{NSApp, NSEvent, NSEventModifierFlags, NSEventPhase, NSView, NSWindow},
-    base::{id, nil},
-    foundation::{NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger},
-};
-use objc::{
-    declare::ClassDecl,
-    runtime::{Class, Object, Protocol, Sel, BOOL, NO, YES},
 };
 
 use crate::{
@@ -155,173 +155,171 @@ struct ViewClass(*const Class);
 unsafe impl Send for ViewClass {}
 unsafe impl Sync for ViewClass {}
 
-lazy_static! {
-    static ref VIEW_CLASS: ViewClass = unsafe {
-        let superclass = class!(NSView);
-        let mut decl = ClassDecl::new("WinitView", superclass).unwrap();
-        decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
-        decl.add_method(
-            sel!(initWithWinit:),
-            init_with_winit as extern "C" fn(&Object, Sel, *mut c_void) -> id,
-        );
-        decl.add_method(
-            sel!(viewDidMoveToWindow),
-            view_did_move_to_window as extern "C" fn(&Object, Sel),
-        );
-        decl.add_method(
-            sel!(drawRect:),
-            draw_rect as extern "C" fn(&Object, Sel, NSRect),
-        );
-        decl.add_method(
-            sel!(acceptsFirstResponder),
-            accepts_first_responder as extern "C" fn(&Object, Sel) -> BOOL,
-        );
-        decl.add_method(
-            sel!(touchBar),
-            touch_bar as extern "C" fn(&Object, Sel) -> BOOL,
-        );
-        decl.add_method(
-            sel!(resetCursorRects),
-            reset_cursor_rects as extern "C" fn(&Object, Sel),
-        );
+static VIEW_CLASS: Lazy<ViewClass> = Lazy::new(|| unsafe {
+    let superclass = class!(NSView);
+    let mut decl = ClassDecl::new("WinitView", superclass).unwrap();
+    decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
+    decl.add_method(
+        sel!(initWithWinit:),
+        init_with_winit as extern "C" fn(&Object, Sel, *mut c_void) -> id,
+    );
+    decl.add_method(
+        sel!(viewDidMoveToWindow),
+        view_did_move_to_window as extern "C" fn(&Object, Sel),
+    );
+    decl.add_method(
+        sel!(drawRect:),
+        draw_rect as extern "C" fn(&Object, Sel, NSRect),
+    );
+    decl.add_method(
+        sel!(acceptsFirstResponder),
+        accepts_first_responder as extern "C" fn(&Object, Sel) -> BOOL,
+    );
+    decl.add_method(
+        sel!(touchBar),
+        touch_bar as extern "C" fn(&Object, Sel) -> BOOL,
+    );
+    decl.add_method(
+        sel!(resetCursorRects),
+        reset_cursor_rects as extern "C" fn(&Object, Sel),
+    );
 
-        // ------------------------------------------------------------------
-        // NSTextInputClient
-        decl.add_method(
-            sel!(hasMarkedText),
-            has_marked_text as extern "C" fn(&Object, Sel) -> BOOL,
-        );
-        decl.add_method(
-            sel!(markedRange),
-            marked_range as extern "C" fn(&Object, Sel) -> NSRange,
-        );
-        decl.add_method(
-            sel!(selectedRange),
-            selected_range as extern "C" fn(&Object, Sel) -> NSRange,
-        );
-        decl.add_method(
-            sel!(setMarkedText:selectedRange:replacementRange:),
-            set_marked_text as extern "C" fn(&mut Object, Sel, id, NSRange, NSRange),
-        );
-        decl.add_method(sel!(unmarkText), unmark_text as extern "C" fn(&Object, Sel));
-        decl.add_method(
-            sel!(validAttributesForMarkedText),
-            valid_attributes_for_marked_text as extern "C" fn(&Object, Sel) -> id,
-        );
-        decl.add_method(
-            sel!(attributedSubstringForProposedRange:actualRange:),
-            attributed_substring_for_proposed_range
-                as extern "C" fn(&Object, Sel, NSRange, *mut c_void) -> id,
-        );
-        decl.add_method(
-            sel!(insertText:replacementRange:),
-            insert_text as extern "C" fn(&Object, Sel, id, NSRange),
-        );
-        decl.add_method(
-            sel!(characterIndexForPoint:),
-            character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> NSUInteger,
-        );
-        decl.add_method(
-            sel!(firstRectForCharacterRange:actualRange:),
-            first_rect_for_character_range
-                as extern "C" fn(&Object, Sel, NSRange, *mut c_void) -> NSRect,
-        );
-        decl.add_method(
-            sel!(doCommandBySelector:),
-            do_command_by_selector as extern "C" fn(&Object, Sel, Sel),
-        );
-        // ------------------------------------------------------------------
+    // ------------------------------------------------------------------
+    // NSTextInputClient
+    decl.add_method(
+        sel!(hasMarkedText),
+        has_marked_text as extern "C" fn(&Object, Sel) -> BOOL,
+    );
+    decl.add_method(
+        sel!(markedRange),
+        marked_range as extern "C" fn(&Object, Sel) -> NSRange,
+    );
+    decl.add_method(
+        sel!(selectedRange),
+        selected_range as extern "C" fn(&Object, Sel) -> NSRange,
+    );
+    decl.add_method(
+        sel!(setMarkedText:selectedRange:replacementRange:),
+        set_marked_text as extern "C" fn(&mut Object, Sel, id, NSRange, NSRange),
+    );
+    decl.add_method(sel!(unmarkText), unmark_text as extern "C" fn(&Object, Sel));
+    decl.add_method(
+        sel!(validAttributesForMarkedText),
+        valid_attributes_for_marked_text as extern "C" fn(&Object, Sel) -> id,
+    );
+    decl.add_method(
+        sel!(attributedSubstringForProposedRange:actualRange:),
+        attributed_substring_for_proposed_range
+            as extern "C" fn(&Object, Sel, NSRange, *mut c_void) -> id,
+    );
+    decl.add_method(
+        sel!(insertText:replacementRange:),
+        insert_text as extern "C" fn(&Object, Sel, id, NSRange),
+    );
+    decl.add_method(
+        sel!(characterIndexForPoint:),
+        character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> NSUInteger,
+    );
+    decl.add_method(
+        sel!(firstRectForCharacterRange:actualRange:),
+        first_rect_for_character_range
+            as extern "C" fn(&Object, Sel, NSRange, *mut c_void) -> NSRect,
+    );
+    decl.add_method(
+        sel!(doCommandBySelector:),
+        do_command_by_selector as extern "C" fn(&Object, Sel, Sel),
+    );
+    // ------------------------------------------------------------------
 
-        decl.add_method(sel!(keyDown:), key_down as extern "C" fn(&Object, Sel, id));
-        decl.add_method(sel!(keyUp:), key_up as extern "C" fn(&Object, Sel, id));
-        decl.add_method(
-            sel!(flagsChanged:),
-            flags_changed as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(insertTab:),
-            insert_tab as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(insertBackTab:),
-            insert_back_tab as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(mouseDown:),
-            mouse_down as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(sel!(mouseUp:), mouse_up as extern "C" fn(&Object, Sel, id));
-        decl.add_method(
-            sel!(rightMouseDown:),
-            right_mouse_down as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(rightMouseUp:),
-            right_mouse_up as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(otherMouseDown:),
-            other_mouse_down as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(otherMouseUp:),
-            other_mouse_up as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(mouseMoved:),
-            mouse_moved as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(mouseDragged:),
-            mouse_dragged as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(rightMouseDragged:),
-            right_mouse_dragged as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(otherMouseDragged:),
-            other_mouse_dragged as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(mouseEntered:),
-            mouse_entered as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(mouseExited:),
-            mouse_exited as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(scrollWheel:),
-            scroll_wheel as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(pressureChangeWithEvent:),
-            pressure_change_with_event as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(_wantsKeyDownForEvent:),
-            wants_key_down_for_event as extern "C" fn(&Object, Sel, id) -> BOOL,
-        );
-        decl.add_method(
-            sel!(cancelOperation:),
-            cancel_operation as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(frameDidChange:),
-            frame_did_change as extern "C" fn(&Object, Sel, id),
-        );
-        decl.add_method(
-            sel!(acceptsFirstMouse:),
-            accepts_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
-        );
-        decl.add_ivar::<*mut c_void>("winitState");
-        decl.add_ivar::<id>("markedText");
-        let protocol = Protocol::get("NSTextInputClient").unwrap();
-        decl.add_protocol(protocol);
-        ViewClass(decl.register())
-    };
-}
+    decl.add_method(sel!(keyDown:), key_down as extern "C" fn(&Object, Sel, id));
+    decl.add_method(sel!(keyUp:), key_up as extern "C" fn(&Object, Sel, id));
+    decl.add_method(
+        sel!(flagsChanged:),
+        flags_changed as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(insertTab:),
+        insert_tab as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(insertBackTab:),
+        insert_back_tab as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(mouseDown:),
+        mouse_down as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(sel!(mouseUp:), mouse_up as extern "C" fn(&Object, Sel, id));
+    decl.add_method(
+        sel!(rightMouseDown:),
+        right_mouse_down as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(rightMouseUp:),
+        right_mouse_up as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(otherMouseDown:),
+        other_mouse_down as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(otherMouseUp:),
+        other_mouse_up as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(mouseMoved:),
+        mouse_moved as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(mouseDragged:),
+        mouse_dragged as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(rightMouseDragged:),
+        right_mouse_dragged as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(otherMouseDragged:),
+        other_mouse_dragged as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(mouseEntered:),
+        mouse_entered as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(mouseExited:),
+        mouse_exited as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(scrollWheel:),
+        scroll_wheel as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(pressureChangeWithEvent:),
+        pressure_change_with_event as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(_wantsKeyDownForEvent:),
+        wants_key_down_for_event as extern "C" fn(&Object, Sel, id) -> BOOL,
+    );
+    decl.add_method(
+        sel!(cancelOperation:),
+        cancel_operation as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(frameDidChange:),
+        frame_did_change as extern "C" fn(&Object, Sel, id),
+    );
+    decl.add_method(
+        sel!(acceptsFirstMouse:),
+        accepts_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
+    );
+    decl.add_ivar::<*mut c_void>("winitState");
+    decl.add_ivar::<id>("markedText");
+    let protocol = Protocol::get("NSTextInputClient").unwrap();
+    decl.add_protocol(protocol);
+    ViewClass(decl.register())
+});
 
 extern "C" fn dealloc(this: &Object, _sel: Sel) {
     unsafe {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1,3 +1,15 @@
+use raw_window_handle::{AppKitHandle, RawWindowHandle};
+use std::{
+    collections::VecDeque,
+    convert::TryInto,
+    f64, ops,
+    os::raw::c_void,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, MutexGuard, Weak,
+    },
+};
+
 use crate::{
     dpi::{
         LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size, Size::Logical,
@@ -36,17 +48,6 @@ use objc::{
     runtime::{Class, Object, Sel, BOOL, NO, YES},
 };
 use once_cell::sync::Lazy;
-use raw_window_handle::{AppKitHandle, RawWindowHandle};
-use std::{
-    collections::VecDeque,
-    convert::TryInto,
-    f64, ops,
-    os::raw::c_void,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex, MutexGuard, Weak,
-    },
-};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(pub usize);

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -1,3 +1,9 @@
+use std::{
+    f64,
+    os::raw::c_void,
+    sync::{atomic::Ordering, Arc, Weak},
+};
+
 use cocoa::{
     appkit::{self, NSApplicationPresentationOptions, NSView, NSWindow},
     base::{id, nil},
@@ -9,11 +15,6 @@ use objc::{
     runtime::{Class, Object, Sel, BOOL, NO, YES},
 };
 use once_cell::sync::Lazy;
-use std::{
-    f64,
-    os::raw::c_void,
-    sync::{atomic::Ordering, Arc, Weak},
-};
 
 use crate::{
     dpi::{LogicalPosition, LogicalSize},

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -1,7 +1,7 @@
+use once_cell::sync::Lazy;
 /// This is a simple implementation of support for Windows Dark Mode,
 /// which is inspired by the solution in https://github.com/ysc3839/win32-darkmode
 use std::{ffi::c_void, ptr};
-
 use windows_sys::{
     core::PCSTR,
     Win32::{
@@ -22,47 +22,45 @@ use crate::window::Theme;
 
 use super::util;
 
-lazy_static! {
-    static ref WIN10_BUILD_VERSION: Option<u32> = {
-        type RtlGetVersion = unsafe extern "system" fn (*mut OSVERSIONINFOW) -> NTSTATUS;
-        let handle = get_function!("ntdll.dll", RtlGetVersion);
+static WIN10_BUILD_VERSION: Lazy<Option<u32>> = Lazy::new(|| {
+    type RtlGetVersion = unsafe extern "system" fn(*mut OSVERSIONINFOW) -> NTSTATUS;
+    let handle = get_function!("ntdll.dll", RtlGetVersion);
 
-        if let Some(rtl_get_version) = handle {
-            unsafe {
-                let mut vi = OSVERSIONINFOW {
-                    dwOSVersionInfoSize: 0,
-                    dwMajorVersion: 0,
-                    dwMinorVersion: 0,
-                    dwBuildNumber: 0,
-                    dwPlatformId: 0,
-                    szCSDVersion: [0; 128],
-                };
+    if let Some(rtl_get_version) = handle {
+        unsafe {
+            let mut vi = OSVERSIONINFOW {
+                dwOSVersionInfoSize: 0,
+                dwMajorVersion: 0,
+                dwMinorVersion: 0,
+                dwBuildNumber: 0,
+                dwPlatformId: 0,
+                szCSDVersion: [0; 128],
+            };
 
-                let status = (rtl_get_version)(&mut vi);
+            let status = (rtl_get_version)(&mut vi);
 
-                if status >= 0 && vi.dwMajorVersion == 10 && vi.dwMinorVersion == 0 {
-                    Some(vi.dwBuildNumber)
-                } else {
-                    None
-                }
+            if status >= 0 && vi.dwMajorVersion == 10 && vi.dwMinorVersion == 0 {
+                Some(vi.dwBuildNumber)
+            } else {
+                None
             }
-        } else {
-            None
         }
-    };
+    } else {
+        None
+    }
+});
 
-    static ref DARK_MODE_SUPPORTED: bool = {
-        // We won't try to do anything for windows versions < 17763
-        // (Windows 10 October 2018 update)
-        match *WIN10_BUILD_VERSION {
-            Some(v) => v >= 17763,
-            None => false
-        }
-    };
+static DARK_MODE_SUPPORTED: Lazy<bool> = Lazy::new(|| {
+    // We won't try to do anything for windows versions < 17763
+    // (Windows 10 October 2018 update)
+    match *WIN10_BUILD_VERSION {
+        Some(v) => v >= 17763,
+        None => false,
+    }
+});
 
-    static ref DARK_THEME_NAME: Vec<u16> = util::encode_wide("DarkMode_Explorer");
-    static ref LIGHT_THEME_NAME: Vec<u16> = util::encode_wide("");
-}
+static DARK_THEME_NAME: Lazy<Vec<u16>> = Lazy::new(|| util::encode_wide("DarkMode_Explorer"));
+static LIGHT_THEME_NAME: Lazy<Vec<u16>> = Lazy::new(|| util::encode_wide(""));
 
 /// Attempt to set a theme on a window, if necessary.
 /// Returns the theme that was picked
@@ -113,10 +111,8 @@ fn set_dark_mode_for_window(hwnd: HWND, is_dark_mode: bool) -> bool {
         cbData: usize,
     }
 
-    lazy_static! {
-        static ref SET_WINDOW_COMPOSITION_ATTRIBUTE: Option<SetWindowCompositionAttribute> =
-            get_function!("user32.dll", SetWindowCompositionAttribute);
-    }
+    static SET_WINDOW_COMPOSITION_ATTRIBUTE: Lazy<Option<SetWindowCompositionAttribute>> =
+        Lazy::new(|| get_function!("user32.dll", SetWindowCompositionAttribute));
 
     if let Some(set_window_composition_attribute) = *SET_WINDOW_COMPOSITION_ATTRIBUTE {
         unsafe {
@@ -144,23 +140,19 @@ fn should_use_dark_mode() -> bool {
 
 fn should_apps_use_dark_mode() -> bool {
     type ShouldAppsUseDarkMode = unsafe extern "system" fn() -> bool;
-    lazy_static! {
-        static ref SHOULD_APPS_USE_DARK_MODE: Option<ShouldAppsUseDarkMode> = {
-            unsafe {
-                const UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL: PCSTR = 132 as PCSTR;
+    static SHOULD_APPS_USE_DARK_MODE: Lazy<Option<ShouldAppsUseDarkMode>> = Lazy::new(|| unsafe {
+        const UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL: PCSTR = 132 as PCSTR;
 
-                let module = LoadLibraryA("uxtheme.dll\0".as_ptr());
+        let module = LoadLibraryA("uxtheme.dll\0".as_ptr());
 
-                if module == 0 {
-                    return None;
-                }
+        if module == 0 {
+            return None;
+        }
 
-                let handle = GetProcAddress(module, UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL);
+        let handle = GetProcAddress(module, UXTHEME_SHOULDAPPSUSEDARKMODE_ORDINAL);
 
-                handle.map(|handle| std::mem::transmute(handle))
-            }
-        };
-    }
+        handle.map(|handle| std::mem::transmute(handle))
+    });
 
     SHOULD_APPS_USE_DARK_MODE
         .map(|should_apps_use_dark_mode| unsafe { (should_apps_use_dark_mode)() })

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -1,7 +1,8 @@
-use once_cell::sync::Lazy;
 /// This is a simple implementation of support for Windows Dark Mode,
 /// which is inspired by the solution in https://github.com/ysc3839/win32-darkmode
 use std::{ffi::c_void, ptr};
+
+use once_cell::sync::Lazy;
 use windows_sys::{
     core::PCSTR,
     Win32::{

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -9,6 +9,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
+use once_cell::sync::Lazy;
 use windows_sys::{
     core::{HRESULT, PCWSTR},
     Win32::{
@@ -298,19 +299,17 @@ pub type AdjustWindowRectExForDpi = unsafe extern "system" fn(
     dpi: u32,
 ) -> BOOL;
 
-lazy_static! {
-    pub static ref GET_DPI_FOR_WINDOW: Option<GetDpiForWindow> =
-        get_function!("user32.dll", GetDpiForWindow);
-    pub static ref ADJUST_WINDOW_RECT_EX_FOR_DPI: Option<AdjustWindowRectExForDpi> =
-        get_function!("user32.dll", AdjustWindowRectExForDpi);
-    pub static ref GET_DPI_FOR_MONITOR: Option<GetDpiForMonitor> =
-        get_function!("shcore.dll", GetDpiForMonitor);
-    pub static ref ENABLE_NON_CLIENT_DPI_SCALING: Option<EnableNonClientDpiScaling> =
-        get_function!("user32.dll", EnableNonClientDpiScaling);
-    pub static ref SET_PROCESS_DPI_AWARENESS_CONTEXT: Option<SetProcessDpiAwarenessContext> =
-        get_function!("user32.dll", SetProcessDpiAwarenessContext);
-    pub static ref SET_PROCESS_DPI_AWARENESS: Option<SetProcessDpiAwareness> =
-        get_function!("shcore.dll", SetProcessDpiAwareness);
-    pub static ref SET_PROCESS_DPI_AWARE: Option<SetProcessDPIAware> =
-        get_function!("user32.dll", SetProcessDPIAware);
-}
+pub static GET_DPI_FOR_WINDOW: Lazy<Option<GetDpiForWindow>> =
+    Lazy::new(|| get_function!("user32.dll", GetDpiForWindow));
+pub static ADJUST_WINDOW_RECT_EX_FOR_DPI: Lazy<Option<AdjustWindowRectExForDpi>> =
+    Lazy::new(|| get_function!("user32.dll", AdjustWindowRectExForDpi));
+pub static GET_DPI_FOR_MONITOR: Lazy<Option<GetDpiForMonitor>> =
+    Lazy::new(|| get_function!("shcore.dll", GetDpiForMonitor));
+pub static ENABLE_NON_CLIENT_DPI_SCALING: Lazy<Option<EnableNonClientDpiScaling>> =
+    Lazy::new(|| get_function!("user32.dll", EnableNonClientDpiScaling));
+pub static SET_PROCESS_DPI_AWARENESS_CONTEXT: Lazy<Option<SetProcessDpiAwarenessContext>> =
+    Lazy::new(|| get_function!("user32.dll", SetProcessDpiAwarenessContext));
+pub static SET_PROCESS_DPI_AWARENESS: Lazy<Option<SetProcessDpiAwareness>> =
+    Lazy::new(|| get_function!("shcore.dll", SetProcessDpiAwareness));
+pub static SET_PROCESS_DPI_AWARE: Lazy<Option<SetProcessDPIAware>> =
+    Lazy::new(|| get_function!("user32.dll", SetProcessDPIAware));


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

## Motivation
`lazy_static!`, while a declarative macro, is a macro nonetheless. It can add quite a bit of additional compilation time cost. `once_cell::sync::Lazy` does the same thing with generics, and can be used more flexibly (i.e. non-static lazily initialized values), and has been [proposed to be added to `std`](https://github.com/rust-lang/rust/issues/74465).

I'm trying to reduce the compile time and dependency tree complexity of a dependent project: [bevy](https://bevyengine.org), which is using winit. `lazy_static` and `once_cell` are both in our dependency tree and both end up doing the same thing.

## Solution
Migrate to `once_cell`.

---

I don't think any of the changes here are user visible beyond the dependency in the tree, and should work as-is on all of them, but I could be wrong.