### PR TITLE
macOS Add background color for Window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Added `Window::set_ime_allowed` supported on desktop platforms.
 - **Breaking:** IME input on desktop platforms won't be received unless it's explicitly allowed via `Window::set_ime_allowed` and new `WindowEvent::Ime` events are handled.
 - On macOS, `WindowEvent::Resized` is now emitted in `frameDidChange` instead of `windowDidResize`.
+- On macOS, add `WindowExtMacOS::set_background_color` and  `WindowBuilderExtMacOS::with_background_color`.
 
 # 0.26.1 (2022-01-05)
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -128,6 +128,7 @@ If your PR makes notable changes to Winit's features, please update this section
 * Hidden titlebar
 * Hidden titlebar buttons
 * Full-size content view
+* Background color of window and titlebar
 
 ### Unix
 * Window urgency

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -38,6 +38,13 @@ pub trait WindowExtMacOS {
 
     /// Sets whether or not the window has shadow.
     fn set_has_shadow(&self, has_shadow: bool);
+
+    /// Sets the background color of the window and the title bar
+    /// using sRGB colors.
+    ///
+    /// If the title bar is not transparent,
+    /// it will appear darker than this color.
+    fn set_background_color(&self, red: u8, green: u8, blue: u8, alpha: u8);
 }
 
 impl WindowExtMacOS for Window {
@@ -69,6 +76,11 @@ impl WindowExtMacOS for Window {
     #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
         self.window.set_has_shadow(has_shadow)
+    }
+
+    #[inline]
+    fn set_background_color(&self, red: u8, green: u8, blue: u8, alpha: u8) {
+        self.window.set_background_color(red, green, blue, alpha)
     }
 }
 
@@ -117,6 +129,12 @@ pub trait WindowBuilderExtMacOS {
     fn with_resize_increments(self, increments: LogicalSize<f64>) -> WindowBuilder;
     fn with_disallow_hidpi(self, disallow_hidpi: bool) -> WindowBuilder;
     fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
+    /// Sets the background color of the window and the title bar,
+    /// using sRGB colors.
+    ///
+    /// If the title bar is not transparent,
+    /// it will appear darker than this color.
+    fn with_background_color(self, red: u8, green: u8, blue: u8, alpha: u8) -> WindowBuilder;
 }
 
 impl WindowBuilderExtMacOS for WindowBuilder {
@@ -174,6 +192,12 @@ impl WindowBuilderExtMacOS for WindowBuilder {
     #[inline]
     fn with_has_shadow(mut self, has_shadow: bool) -> WindowBuilder {
         self.platform_specific.has_shadow = has_shadow;
+        self
+    }
+
+    #[inline]
+    fn with_background_color(mut self, red: u8, green: u8, blue: u8, alpha: u8) -> WindowBuilder {
+        self.platform_specific.background_color = Some((red, green, blue, alpha));
         self
     }
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -74,6 +74,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub resize_increments: Option<LogicalSize<f64>>,
     pub disallow_hidpi: bool,
     pub has_shadow: bool,
+    pub background_color: Option<(u8, u8, u8, u8)>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -89,6 +90,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             resize_increments: None,
             disallow_hidpi: false,
             has_shadow: true,
+            background_color: None,
         }
     }
 }
@@ -238,6 +240,18 @@ fn create_window(
             if attrs.position.is_none() {
                 ns_window.center();
             }
+
+            if let Some((r, g, b, a)) = pl_attrs.background_color {
+                let color = NSColor::colorWithSRGBRed_green_blue_alpha_(
+                    nil,
+                    r as f64 / 255f64,
+                    g as f64 / 255f64,
+                    b as f64 / 255f64,
+                    a as f64 / 255f64,
+                );
+                ns_window.setBackgroundColor_(color);
+            }
+
             ns_window
         })
     })
@@ -1240,6 +1254,20 @@ impl WindowExtMacOS for UnownedWindow {
             self.ns_window
                 .setHasShadow_(if has_shadow { YES } else { NO })
         }
+    }
+
+    #[inline]
+    fn set_background_color(&self, red: u8, green: u8, blue: u8, alpha: u8) {
+        autoreleasepool(|| unsafe {
+            let ns_background = NSColor::colorWithSRGBRed_green_blue_alpha_(
+                nil,
+                red as f64 / 255f64,
+                green as f64 / 255f64,
+                blue as f64 / 255f64,
+                alpha as f64 / 255f64,
+            );
+            self.ns_window.setBackgroundColor_(ns_background);
+        })
     }
 }
 


### PR DESCRIPTION
Changing the background color on macOS is most useful for
changing the title bar color, as the content of the window will most likely be overwritten by the user.

- Add `WindowExtMacOS::set_background_color`
- Add `WindowBuilderExtMacOS::with_background_color`

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] ~Created or updated an example program if it would help users understand this functionality~
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Only changing the background color using new functionality (the title bar is also affected by this a bit):

<img width="368" alt="grafik" src="https://user-images.githubusercontent.com/5594651/172052069-4a89cac2-4d44-417a-ad12-cfeb4d1b37da.png">

Changing the background color and making the title bar transparent:

<img width="368" alt="grafik" src="https://user-images.githubusercontent.com/5594651/172052059-2979189d-d946-46b4-8ecb-2bfaf48bd299.png">

