### PR TITLE
Prevent null dereference on X11 with bad locale

### DIFF
--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -103,7 +103,14 @@ extern "C" fn preedit_draw_callback(
         if xim_text.encoding_is_wchar > 0 {
             return;
         }
-        let new_text = unsafe { CStr::from_ptr(xim_text.string.multi_byte) };
+
+        let new_text = unsafe { xim_text.string.multi_byte };
+
+        if new_text.is_null() {
+            return;
+        }
+
+        let new_text = unsafe { CStr::from_ptr(new_text) };
 
         String::from(new_text.to_str().expect("Invalid UTF-8 String from IME"))
             .chars()


### PR DESCRIPTION
Based on https://github.com/rust-windowing/winit/pull/2067