### PR TITLE
On Android, use `HasRawWindowHandle` directly from the `ndk` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ image = { version = "0.24.0", default-features = false, features = ["png"] }
 simple_logger = "2.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-ndk = "0.6"
-ndk-sys = "0.3"
-ndk-glue = "0.6"
+# Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995
+ndk = { git = "https://github.com/rust-windowing/android-ndk-rs", rev = "7e33384" }
+ndk-glue = { git = "https://github.com/rust-windowing/android-ndk-rs", rev = "7e33384" }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -13,7 +13,7 @@ use ndk::{
 };
 use ndk_glue::{Event, Rect};
 use once_cell::sync::Lazy;
-use raw_window_handle::{AndroidNdkHandle, RawWindowHandle};
+use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
@@ -786,13 +786,11 @@ impl Window {
     }
 
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut handle = AndroidNdkHandle::empty();
         if let Some(native_window) = ndk_glue::native_window().as_ref() {
-            handle.a_native_window = unsafe { native_window.ptr().as_mut() as *mut _ as *mut _ }
+            native_window.raw_window_handle()
         } else {
             panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
-        };
-        RawWindowHandle::AndroidNdk(handle)
+        }
     }
 
     pub fn config(&self) -> Configuration {


### PR DESCRIPTION
The `ndk` crate now implements [`HasRawWindowHandle` directly on `NativeWindow`], relieving the burden on `winit` to carry the same implementation details.

[`HasRawWindowHandle` directly on `NativeWindow`]: https://github.com/rust-windowing/android-ndk-rs/pull/274

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

---

This PR is also being opened to discuss how we should proceed with up and coming `ndk` (+ `ndk_glue`) changes that are not yet published. I'd like to coordinate the next (which is going to be breaking) release of those crates with `winit` so that we're not unnecessarily creating a desync in the ecosystem (https://github.com/rust-windowing/winit/issues/1995). That'd require Android PRs to remain open until `winit` eventually starts the `0.27` cycle and I decide when and where to make the cut and publish the `ndk`. Alternatives are:

- Make preview/alpha/beta releases for `ndk`+`ndk_glue`;
- Use git references in the `patch` section: this doesn't carry over to user-crates having a `git` reference on `winit`, allowing only local development;
- Temporarily replace these crates with `git` dependencies: this prevents `winit` from making release before the Android crates are released;
- (Repeating what was mentioned above: leaving dependent Android PRs open and merging them in at the last moment, when an `ndk` release is made).

I'm sure similar issues might have come up with other crates, bar the "coordinate a release" bit.
