### PR TITLE
examples/window_run_return: Enable on Android

### DIFF
--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -6,7 +6,8 @@
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "netbsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "android",
 ))]
 fn main() {
     use std::{thread::sleep, time::Duration};
@@ -57,7 +58,7 @@ fn main() {
     }
 }
 
-#[cfg(any(target_os = "ios", target_os = "android", target_arch = "wasm32"))]
+#[cfg(any(target_os = "ios", target_arch = "wasm32"))]
 fn main() {
     println!("This platform doesn't support run_return.");
 }


### PR DESCRIPTION
Android also supports `EventLoopExtRunReturn`.  The user will still have to follow the README to turn this example into a `cdylib` and add the `ndk_glue::main()` initialization attribute, though.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
