### PR TITLE
Make `set_device_event_filter` non-mut

### DIFF
--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -6,7 +6,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::{LogicalSize, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
-    event_loop::EventLoop,
+    event_loop::{DeviceEventFilter, EventLoop},
     window::{Fullscreen, WindowBuilder},
 };
 
@@ -31,6 +31,8 @@ fn main() {
 
     let mut minimized = false;
     let mut visible = true;
+
+    event_loop.set_device_event_filter(DeviceEventFilter::Never);
 
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -306,7 +306,7 @@ impl<T> EventLoopWindowTarget<T> {
     /// - **Wayland / Windows / macOS / iOS / Android / Web**: Unsupported.
     ///
     /// [`DeviceEvent`]: crate::event::DeviceEvent
-    pub fn set_device_event_filter(&mut self, _filter: DeviceEventFilter) {
+    pub fn set_device_event_filter(&self, _filter: DeviceEventFilter) {
         #[cfg(any(
             target_os = "linux",
             target_os = "dragonfly",

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -788,12 +788,12 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn set_device_event_filter(&mut self, _filter: DeviceEventFilter) {
+    pub fn set_device_event_filter(&self, _filter: DeviceEventFilter) {
         match *self {
             #[cfg(feature = "wayland")]
             EventLoopWindowTarget::Wayland(_) => (),
             #[cfg(feature = "x11")]
-            EventLoopWindowTarget::X(ref mut evlp) => evlp.set_device_event_filter(_filter),
+            EventLoopWindowTarget::X(ref evlp) => evlp.set_device_event_filter(_filter),
         }
     }
 }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -23,7 +23,7 @@ pub use self::{
 };
 
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::{HashMap, HashSet},
     ffi::CStr,
     mem::{self, MaybeUninit},
@@ -108,7 +108,7 @@ pub struct EventLoopWindowTarget<T> {
     ime: RefCell<Ime>,
     windows: RefCell<HashMap<WindowId, Weak<UnownedWindow>>>,
     redraw_sender: WakeSender<WindowId>,
-    device_event_filter: DeviceEventFilter,
+    device_event_filter: Cell<DeviceEventFilter>,
     _marker: ::std::marker::PhantomData<T>,
 }
 
@@ -536,14 +536,14 @@ impl<T> EventLoopWindowTarget<T> {
         &self.xconn
     }
 
-    pub fn set_device_event_filter(&mut self, filter: DeviceEventFilter) {
-        self.device_event_filter = filter;
+    pub fn set_device_event_filter(&self, filter: DeviceEventFilter) {
+        self.device_event_filter.set(filter);
     }
 
     /// Update the device event filter based on window focus.
     pub fn update_device_event_filter(&self, focus: bool) {
-        let filter_events = self.device_event_filter == DeviceEventFilter::Never
-            || (self.device_event_filter == DeviceEventFilter::Unfocused && !focus);
+        let filter_events = self.device_event_filter.get() == DeviceEventFilter::Never
+            || (self.device_event_filter.get() == DeviceEventFilter::Unfocused && !focus);
 
         let mut mask = 0;
         if !filter_events {


### PR DESCRIPTION
Commit f10a984 added `EventLoopWindowTarget::set_device_event_filter`
with for a mutable reference, however most winit APIs work with
immutable references, so altering API to play nicely with existing APIs.

This also disables device event filtering on debug example.

cc @chrisduerr 
