### PR TITLE
Remove `core-video-sys` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,6 @@ core-foundation = "0.9"
 core-graphics = "0.22"
 dispatch = "0.2.0"
 
-[target.'cfg(target_os = "macos")'.dependencies.core-video-sys]
-version = "0.1.4"
-default_features = false
-features = ["display_link"]
-
 [target.'cfg(target_os = "windows")'.dependencies]
 parking_lot = "0.12"
 

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -221,3 +221,45 @@ extern "C" {
     pub fn CGDisplayModeRetain(mode: CGDisplayModeRef);
     pub fn CGDisplayModeRelease(mode: CGDisplayModeRef);
 }
+
+mod core_video {
+    use super::*;
+
+    #[link(name = "CoreVideo", kind = "framework")]
+    extern "C" {}
+
+    // CVBase.h
+
+    pub type CVTimeFlags = i32; // int32_t
+    pub const kCVTimeIsIndefinite: CVTimeFlags = 1 << 0;
+
+    #[repr(C)]
+    #[derive(Debug, Clone)]
+    pub struct CVTime {
+        pub time_value: i64, // int64_t
+        pub time_scale: i32, // int32_t
+        pub flags: i32,      // int32_t
+    }
+
+    // CVReturn.h
+
+    pub type CVReturn = i32; // int32_t
+    pub const kCVReturnSuccess: CVReturn = 0;
+
+    // CVDisplayLink.h
+
+    pub type CVDisplayLinkRef = *mut c_void;
+
+    extern "C" {
+        pub fn CVDisplayLinkCreateWithCGDisplay(
+            displayID: CGDirectDisplayID,
+            displayLinkOut: *mut CVDisplayLinkRef,
+        ) -> CVReturn;
+        pub fn CVDisplayLinkGetNominalOutputVideoRefreshPeriod(
+            displayLink: CVDisplayLinkRef,
+        ) -> CVTime;
+        pub fn CVDisplayLinkRelease(displayLink: CVDisplayLinkRef);
+    }
+}
+
+pub use core_video::*;

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -16,10 +16,6 @@ use core_foundation::{
     string::CFString,
 };
 use core_graphics::display::{CGDirectDisplayID, CGDisplay, CGDisplayBounds};
-use core_video_sys::{
-    kCVReturnSuccess, kCVTimeIsIndefinite, CVDisplayLinkCreateWithCGDisplay,
-    CVDisplayLinkGetNominalOutputVideoRefreshPeriod, CVDisplayLinkRelease,
-};
 
 #[derive(Clone)]
 pub struct VideoMode {
@@ -228,16 +224,16 @@ impl MonitorHandle {
         let cv_refresh_rate = unsafe {
             let mut display_link = std::ptr::null_mut();
             assert_eq!(
-                CVDisplayLinkCreateWithCGDisplay(self.0, &mut display_link),
-                kCVReturnSuccess
+                ffi::CVDisplayLinkCreateWithCGDisplay(self.0, &mut display_link),
+                ffi::kCVReturnSuccess
             );
-            let time = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(display_link);
-            CVDisplayLinkRelease(display_link);
+            let time = ffi::CVDisplayLinkGetNominalOutputVideoRefreshPeriod(display_link);
+            ffi::CVDisplayLinkRelease(display_link);
 
             // This value is indefinite if an invalid display link was specified
-            assert!(time.flags & kCVTimeIsIndefinite == 0);
+            assert!(time.flags & ffi::kCVTimeIsIndefinite == 0);
 
-            time.timeScale as i64 / time.timeValue
+            time.time_scale as i64 / time.time_value
         };
 
         let monitor = self.clone();


### PR DESCRIPTION
Hasn't been updated in over 2 years - many open PRs, seems abandoned. Is the cause of several duplicate dependencies in our dependency tree! At this point it's better to just bundle the tiny amount of functionality we need ourselves.

Fixes #1816.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
