### PR TITLE
Add `WindowBuilder::transparent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Build docs on `docs.rs` for iOS and Android as well.
 - **Breaking:** Removed the `WindowAttributes` struct, since all its functionality is accessible from `WindowBuilder`.
+- Added `WindowBuilder::transparent` getter to check if the user set `transparent` attribute.
 - On macOS, Fix emitting `Event::LoopDestroyed` on CMD+Q.
 - On macOS, fixed an issue where having multiple windows would prevent run_return from ever returning.
 - On Wayland, fix bug where the cursor wouldn't hide in GNOME.

--- a/src/window.rs
+++ b/src/window.rs
@@ -296,6 +296,12 @@ impl WindowBuilder {
         self
     }
 
+    /// Get whether the window will support transparency.
+    #[inline]
+    pub fn transparent(&self) -> bool {
+        self.window.transparent
+    }
+
     /// Sets whether the window should have a border, a title bar, etc.
     ///
     /// The default is `true`.


### PR DESCRIPTION
This is required to help hardware accelerated libraries like glutin
that accept WindowBuilder instead of RawWindowHandle, since the api
to access builder properties directly was removed.

Follow up to 44288f6.
