### PR TITLE
macOS disallow_highdpi will set explicity the value to avoid the SO value by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Implemented `Eq` for `Fullscreen`, `Theme`, and `UserAttentionType`.
 - **Breaking:** `Window::set_cursor_grab` now accepts `CursorGrabMode` to control grabbing behavior.
 - On Wayland, add support for `Window::set_cursor_position`.
+- Fix on macOS `WindowBuilder::with_disallow_hidpi`, setting true o false by the user no matter the SO default value. 
 
 # 0.26.1 (2022-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Implemented `Eq` for `Fullscreen`, `Theme`, and `UserAttentionType`.
 - **Breaking:** `Window::set_cursor_grab` now accepts `CursorGrabMode` to control grabbing behavior.
 - On Wayland, add support for `Window::set_cursor_position`.
-- Fix on macOS `WindowBuilder::with_disallow_hidpi`, setting true o false by the user no matter the SO default value. 
+- Fix on macOS `WindowBuilder::with_disallow_hidpi`, setting true or false by the user no matter the SO default value. 
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -100,8 +100,13 @@ unsafe fn create_view(
 ) -> Option<(IdRef, Weak<Mutex<CursorState>>)> {
     let (ns_view, cursor_state) = new_view(ns_window);
     ns_view.non_nil().map(|ns_view| {
+        // The default value of `setWantsBestResolutionOpenGLSurface_` was `false` until
+        // macos 10.14 and `true` after 10.5, we should set it to `YES` o `NO` to avoid
+        // always the default system value in favour of the user's code
         if !pl_attribs.disallow_hidpi {
             ns_view.setWantsBestResolutionOpenGLSurface_(YES);
+        } else {
+            ns_view.setWantsBestResolutionOpenGLSurface_(NO);
         }
 
         // On Mojave, views automatically become layer-backed shortly after being added to


### PR DESCRIPTION
Hi! I just made a simple change to how the `disallow_highdpi`option behaves. 

The default value of `setWantsBestResolutionOpenGLSurface_` was `false` until macos 10.14 and `true` after 10.5, we should set it to `YES` o `NO` to avoid always the default system value in favour of the user's code.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
