### PR TITLE
Android: avoid deadlocks while handling UserEvent

### DIFF
--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -257,7 +257,7 @@ macro_rules! call_event_handler {
 
 impl<T: 'static> EventLoop<T> {
     pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> Self {
-        let (sender, receiver) = mpsc::channel();
+        let (user_events_sender, user_events_receiver) = mpsc::channel();
         Self {
             window_target: event_loop::EventLoopWindowTarget {
                 p: EventLoopWindowTarget {
@@ -265,8 +265,8 @@ impl<T: 'static> EventLoop<T> {
                 },
                 _marker: std::marker::PhantomData,
             },
-            user_events_sender: sender,
-            user_events_receiver: receiver,
+            user_events_sender,
+            user_events_receiver,
             first_event: None,
             start_cause: event::StartCause::Init,
             looper: ThreadLooper::for_thread().unwrap(),


### PR DESCRIPTION
Calling `EventLoopProxy::send_event` while handling a UserEvent event would cause a deadlock.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

edit: restored original PR template