### PR TITLE
Panic on multiple EventLoop instantiation, document why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** `Window::set_cursor_grab` now accepts `CursorGrabMode` to control grabbing behavior.
 - On Wayland, add support for `Window::set_cursor_position`.
 - Fix on macOS `WindowBuilder::with_disallow_hidpi`, setting true or false by the user no matter the SO default value. 
+- Panics if EventLoopBuilder is built twice in the same runtime and documented that that action it's unsupported
 
 # 0.26.1 (2022-01-05)
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -11,6 +11,7 @@ use instant::Instant;
 use std::marker::PhantomData;
 use std::ops::Deref;
 use std::{error, fmt};
+use once_cell::sync::OnceCell;
 
 use crate::{event::Event, monitor::MonitorHandle, platform_impl};
 
@@ -55,6 +56,8 @@ pub struct EventLoopBuilder<T: 'static> {
     _p: PhantomData<T>,
 }
 
+static EVENT_LOOP_CREATED: OnceCell<()> = OnceCell::new();
+
 impl EventLoopBuilder<()> {
     /// Start building a new event loop.
     #[inline]
@@ -76,8 +79,11 @@ impl<T> EventLoopBuilder<T> {
 
     /// Builds a new event loop.
     ///
-    /// ***For cross-platform compatibility, the [`EventLoop`] must be created on the main thread.***
-    /// Attempting to create the event loop on a different thread will panic. This restriction isn't
+    /// ***For cross-platform compatibility, the [`EventLoop`] must be created on the main thread,
+    /// and only once per application.***
+    ///
+    /// Attempting to create the event loop on a different thread, or multiple event loops in
+    /// the same application, will panic. This restriction isn't
     /// strictly necessary on all platforms, but is imposed to eliminate any nasty surprises when
     /// porting to platforms that require it. `EventLoopBuilderExt::any_thread` functions are exposed
     /// in the relevant [`platform`] module if the target platform supports creating an event loop on
@@ -95,6 +101,9 @@ impl<T> EventLoopBuilder<T> {
     /// [`platform`]: crate::platform
     #[inline]
     pub fn build(&mut self) -> EventLoop<T> {
+        if EVENT_LOOP_CREATED.set(()).is_err() {
+            panic!("Attempted to build an EventLoop twice in the same application which is unsupported.")
+        }
         // Certain platforms accept a mutable reference in their API.
         #[allow(clippy::unnecessary_mut_passed)]
         EventLoop {


### PR DESCRIPTION
- [ ] Tested on all platforms changed *(Only tested on x11, although this change is platform agnostic)*
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Since it was extremely easy to implement using existing dependencies I just made a prototype implementation that agressively fixes https://github.com/rust-windowing/winit/issues/2166. 

In the issue discussions were around just documenting it, or making it panic. I'm more for making it panic immediately since the problems can be hard to diagnose if they occur "naturally" such as in the report of a segfault, with other example in that same issue of SendErrors. Getting a segfault and tracking it down to EventLoopBuilder's docs will probably waste a lot of time for users.

I'm not ecstatic about having a static OnceCell to guard against double instantiation, but I can't think of any smoother solution 