### PR TITLE
Make the `EventLoopWindowTarget` passed to the `EventLoop::run` callback live for `'static`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- The `EventLoopWindowTarget` passed to the `EventLoop::run` callback now has a lifetime of `'static`.
+- The `EventLoopWindowTarget` passed to the `EventLoop::run_return` callback now lives for as long as the reference to the event loop.
 - Build docs on `docs.rs` for iOS and Android as well.
 - **Breaking:** Removed the `WindowAttributes` struct, since all its functionality is accessible from `WindowBuilder`.
 - Added `WindowBuilder::transparent` getter to check if the user set `transparent` attribute.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -271,7 +271,7 @@ impl<T> EventLoop<T> {
     #[inline]
     pub fn run<F>(self, event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<'_, T>, &'static EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.event_loop.run(event_handler)
     }

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -39,11 +39,11 @@ pub trait EventLoopExtRunReturn {
     ///
     /// - **Unix-alikes** (**X11** or **Wayland**): This function returns `1` upon disconnection from
     ///   the display server.
-    fn run_return<F>(&mut self, event_handler: F) -> i32
+    fn run_return<'a, F>(&'a mut self, event_handler: F) -> i32
     where
         F: FnMut(
             Event<'_, Self::UserEvent>,
-            &EventLoopWindowTarget<Self::UserEvent>,
+            &'a EventLoopWindowTarget<Self::UserEvent>,
             &mut ControlFlow,
         );
 }
@@ -51,11 +51,11 @@ pub trait EventLoopExtRunReturn {
 impl<T> EventLoopExtRunReturn for EventLoop<T> {
     type UserEvent = T;
 
-    fn run_return<F>(&mut self, event_handler: F) -> i32
+    fn run_return<'a, F>(&'a mut self, event_handler: F) -> i32
     where
         F: FnMut(
             Event<'_, Self::UserEvent>,
-            &EventLoopWindowTarget<Self::UserEvent>,
+            &'a EventLoopWindowTarget<Self::UserEvent>,
             &mut ControlFlow,
         ),
     {

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -82,13 +82,11 @@ impl<T> crate::platform_impl::EventLoop<T> {
         let this: &'static mut Self = unsafe { &mut *(&mut self as *mut Self) };
         // Note: we don't touch `callback` again if this unwinds, so it doesn't matter
         // if it's unwind safe.
-        let exit_code = match catch_unwind(AssertUnwindSafe(|| this.run_return(callback))) {
-            Ok(code) => code,
+        let exit_code = catch_unwind(AssertUnwindSafe(|| this.run_return(callback)))
             // 101 seems to be the status code Rust uses for panics.
             // Note: the panic message gets printed before unwinding, so we don't have to print it
             // ourselves.
-            Err(_) => 101,
-        };
+            .unwrap_or(101);
         process::exit(exit_code);
     }
 }

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -9,7 +9,10 @@
     target_os = "openbsd"
 ))]
 
-use std::{process, panic::{AssertUnwindSafe, catch_unwind}};
+use std::{
+    panic::{catch_unwind, AssertUnwindSafe},
+    process,
+};
 
 use crate::{
     event::Event,

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -271,15 +271,6 @@ impl<T: 'static> EventLoop<T> {
         }
     }
 
-    pub fn run<F>(mut self, event_handler: F) -> !
-    where
-        F: 'static
-            + FnMut(event::Event<'_, T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
-    {
-        let exit_code = self.run_return(event_handler);
-        ::std::process::exit(exit_code);
-    }
-
     pub fn run_return<F>(&mut self, mut event_handler: F) -> i32
     where
         F: FnMut(event::Event<'_, T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -271,16 +271,16 @@ impl<T: 'static> EventLoop<T> {
         }
     }
 
-    pub fn run_return<F>(&mut self, mut event_handler: F) -> i32
+    pub fn run_return<'a, F>(&'a mut self, mut event_handler: F) -> i32
     where
-        F: FnMut(event::Event<'_, T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(event::Event<'_, T>, &'a event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         let mut control_flow = ControlFlow::default();
 
         'event_loop: loop {
             call_event_handler!(
                 event_handler,
-                self.window_target(),
+                &self.window_target,
                 control_flow,
                 event::Event::NewEvents(self.start_cause)
             );
@@ -293,7 +293,7 @@ impl<T: 'static> EventLoop<T> {
                     Event::WindowCreated => {
                         call_event_handler!(
                             event_handler,
-                            self.window_target(),
+                            &self.window_target,
                             control_flow,
                             event::Event::Resumed
                         );
@@ -303,7 +303,7 @@ impl<T: 'static> EventLoop<T> {
                     Event::WindowDestroyed => {
                         call_event_handler!(
                             event_handler,
-                            self.window_target(),
+                            &self.window_target,
                             control_flow,
                             event::Event::Suspended
                         );
@@ -328,7 +328,7 @@ impl<T: 'static> EventLoop<T> {
                             };
                             call_event_handler!(
                                 event_handler,
-                                self.window_target(),
+                                &self.window_target,
                                 control_flow,
                                 event
                             );
@@ -337,7 +337,7 @@ impl<T: 'static> EventLoop<T> {
                     Event::WindowHasFocus => {
                         call_event_handler!(
                             event_handler,
-                            self.window_target(),
+                            &self.window_target,
                             control_flow,
                             event::Event::WindowEvent {
                                 window_id: window::WindowId(WindowId),
@@ -348,7 +348,7 @@ impl<T: 'static> EventLoop<T> {
                     Event::WindowLostFocus => {
                         call_event_handler!(
                             event_handler,
-                            self.window_target(),
+                            &self.window_target,
                             control_flow,
                             event::Event::WindowEvent {
                                 window_id: window::WindowId(WindowId),
@@ -418,7 +418,7 @@ impl<T: 'static> EventLoop<T> {
                                                 };
                                                 call_event_handler!(
                                                     event_handler,
-                                                    self.window_target(),
+                                                    &self.window_target,
                                                     control_flow,
                                                     event
                                                 );
@@ -449,7 +449,7 @@ impl<T: 'static> EventLoop<T> {
                                         };
                                         call_event_handler!(
                                             event_handler,
-                                            self.window_target(),
+                                            &self.window_target,
                                             control_flow,
                                             event
                                         );
@@ -465,7 +465,7 @@ impl<T: 'static> EventLoop<T> {
                     while let Some(event) = user_queue.pop_front() {
                         call_event_handler!(
                             event_handler,
-                            self.window_target(),
+                            &self.window_target,
                             control_flow,
                             event::Event::UserEvent(event)
                         );
@@ -479,7 +479,7 @@ impl<T: 'static> EventLoop<T> {
 
             call_event_handler!(
                 event_handler,
-                self.window_target(),
+                &self.window_target,
                 control_flow,
                 event::Event::MainEventsCleared
             );
@@ -490,17 +490,17 @@ impl<T: 'static> EventLoop<T> {
                     window_id: window::WindowId(WindowId),
                     event: event::WindowEvent::Resized(size),
                 };
-                call_event_handler!(event_handler, self.window_target(), control_flow, event);
+                call_event_handler!(event_handler, &self.window_target, control_flow, event);
             }
 
             if redraw && self.running {
                 let event = event::Event::RedrawRequested(window::WindowId(WindowId));
-                call_event_handler!(event_handler, self.window_target(), control_flow, event);
+                call_event_handler!(event_handler, &self.window_target, control_flow, event);
             }
 
             call_event_handler!(
                 event_handler,
-                self.window_target(),
+                &self.window_target,
                 control_flow,
                 event::Event::RedrawEventsCleared
             );

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -710,9 +710,9 @@ impl<T: 'static> EventLoop<T> {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.create_proxy(); as EventLoopProxy)
     }
 
-    pub fn run_return<F>(&mut self, callback: F) -> i32
+    pub fn run_return<'a, F>(&'a mut self, callback: F) -> i32
     where
-        F: FnMut(crate::event::Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(crate::event::Event<'_, T>, &'a RootELW<T>, &mut ControlFlow),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_return(callback))
     }
@@ -791,13 +791,13 @@ impl<T> EventLoopWindowTarget<T> {
     }
 }
 
-fn sticky_exit_callback<T, F>(
+fn sticky_exit_callback<'a, T, F>(
     evt: Event<'_, T>,
-    target: &RootELW<T>,
+    target: &'a RootELW<T>,
     control_flow: &mut ControlFlow,
     callback: &mut F,
 ) where
-    F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+    F: FnMut(Event<'_, T>, &'a RootELW<T>, &mut ControlFlow),
 {
     // make ControlFlow::ExitWithCode sticky by providing a dummy
     // control flow reference if it is already ExitWithCode.

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -717,13 +717,6 @@ impl<T: 'static> EventLoop<T> {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_return(callback))
     }
 
-    pub fn run<F>(self, callback: F) -> !
-    where
-        F: 'static + FnMut(crate::event::Event<'_, T>, &RootELW<T>, &mut ControlFlow),
-    {
-        x11_or_wayland!(match self; EventLoop(evlp) => evlp.run(callback))
-    }
-
     pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget<T> {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.window_target())
     }

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -6,7 +6,7 @@ use std::{
     mem,
     os::raw::c_void,
     panic::{catch_unwind, resume_unwind, RefUnwindSafe, UnwindSafe},
-    process, ptr,
+    ptr,
     rc::{Rc, Weak},
     sync::mpsc,
 };

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -223,14 +223,6 @@ impl<T: 'static> EventLoop<T> {
         &self.window_target
     }
 
-    pub fn run<F>(mut self, event_handler: F) -> !
-    where
-        F: 'static + FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
-    {
-        let exit_code = self.run_return(event_handler);
-        ::std::process::exit(exit_code);
-    }
-
     pub fn run_return<F>(&mut self, mut event_handler: F) -> i32
     where
         F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -223,9 +223,9 @@ impl<T: 'static> EventLoop<T> {
         &self.window_target
     }
 
-    pub fn run_return<F>(&mut self, mut event_handler: F) -> i32
+    pub fn run_return<'a, F>(&'a mut self, mut event_handler: F) -> i32
     where
-        F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(Event<'_, T>, &'a RootELW<T>, &mut ControlFlow),
     {
         let event_loop_windows_ref = &self.window_target;
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~ this is purely a signature change, so no extra docs are needed on top.
- [ ] ~~Created or updated an example program if it would help users understand this functionality~~
- [ ] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~

This PR changes the signature of `EventLoop::run` to make the `EventLoopWindowTarget` passed to the callback live for `'static`, and changes the signature of `EventLoop::run_return` to make the `EventLoopWindowTarget` live for as long as the reference to the event loop.

The main motivation for this is writing an async executor on top of winit (ref #1199). Such an executor needs to pass an `EventLoopWindowTarget` to the future to create windows with, which then needs to live for the entirety of the future (i.e., `'static`).

This plus #2294 should make it possible to write an async executor on top of winit.