### PR TITLE
Implement From<u64> for WindowId and vise-versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, add support for `Window::set_cursor_position`.
 - Fix on macOS `WindowBuilder::with_disallow_hidpi`, setting true or false by the user no matter the SO default value. 
 - `EventLoopBuilder::build` will now panic when the `EventLoop` is being created more than once.
+- Added `From<u64>` for `WindowId` and `From<WindowId>` for `u64`.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -627,6 +627,18 @@ impl WindowId {
     }
 }
 
+impl From<WindowId> for u64 {
+    fn from(_: WindowId) -> Self {
+        0
+    }
+}
+
+impl From<u64> for WindowId {
+    fn from(_: u64) -> Self {
+        Self
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DeviceId;
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -641,6 +641,20 @@ impl WindowId {
     }
 }
 
+impl From<WindowId> for u64 {
+    fn from(window_id: WindowId) -> Self {
+        window_id.window as u64
+    }
+}
+
+impl From<u64> for WindowId {
+    fn from(raw_id: u64) -> Self {
+        Self {
+            window: raw_id as _,
+        }
+    }
+}
+
 unsafe impl Send for WindowId {}
 unsafe impl Sync for WindowId {}
 

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -369,9 +369,7 @@ impl<T: 'static> EventLoop<T> {
 
                     sticky_exit_callback(
                         Event::WindowEvent {
-                            window_id: crate::window::WindowId(
-                                crate::platform_impl::WindowId::Wayland(*window_id),
-                            ),
+                            window_id: crate::window::WindowId(*window_id),
                             event: WindowEvent::ScaleFactorChanged {
                                 scale_factor,
                                 new_inner_size: &mut physical_size,
@@ -421,9 +419,7 @@ impl<T: 'static> EventLoop<T> {
                     if let Some(physical_size) = physical_size {
                         sticky_exit_callback(
                             Event::WindowEvent {
-                                window_id: crate::window::WindowId(
-                                    crate::platform_impl::WindowId::Wayland(*window_id),
-                                ),
+                                window_id: crate::window::WindowId(*window_id),
                                 event: WindowEvent::Resized(physical_size),
                             },
                             &self.window_target,
@@ -436,9 +432,7 @@ impl<T: 'static> EventLoop<T> {
                 if window_update.close_window {
                     sticky_exit_callback(
                         Event::WindowEvent {
-                            window_id: crate::window::WindowId(
-                                crate::platform_impl::WindowId::Wayland(*window_id),
-                            ),
+                            window_id: crate::window::WindowId(*window_id),
                             event: WindowEvent::CloseRequested,
                         },
                         &self.window_target,
@@ -488,9 +482,7 @@ impl<T: 'static> EventLoop<T> {
                 // Handle redraw request.
                 if window_update.redraw_requested {
                     sticky_exit_callback(
-                        Event::RedrawRequested(crate::window::WindowId(
-                            crate::platform_impl::WindowId::Wayland(*window_id),
-                        )),
+                        Event::RedrawRequested(crate::window::WindowId(*window_id)),
                         &self.window_target,
                         &mut control_flow,
                         &mut callback,

--- a/src/platform_impl/linux/wayland/event_loop/sink.rs
+++ b/src/platform_impl/linux/wayland/event_loop/sink.rs
@@ -1,7 +1,7 @@
 //! An event loop's sink to deliver events from the Wayland event callbacks.
 
 use crate::event::{DeviceEvent, DeviceId as RootDeviceId, Event, WindowEvent};
-use crate::platform_impl::platform::{DeviceId as PlatformDeviceId, WindowId as PlatformWindowId};
+use crate::platform_impl::platform::DeviceId as PlatformDeviceId;
 use crate::window::WindowId as RootWindowId;
 
 use super::{DeviceId, WindowId};
@@ -30,7 +30,7 @@ impl EventSink {
     pub fn push_window_event(&mut self, event: WindowEvent<'static>, window_id: WindowId) {
         self.window_events.push(Event::WindowEvent {
             event,
-            window_id: RootWindowId(PlatformWindowId::Wayland(window_id)),
+            window_id: RootWindowId(window_id),
         });
     }
 }

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -8,6 +8,7 @@
 
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
 
+pub use crate::platform_impl::platform::WindowId;
 pub use event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
 pub use output::{MonitorHandle, VideoMode};
 pub use window::Window;
@@ -27,16 +28,7 @@ impl DeviceId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(usize);
-
-impl WindowId {
-    pub const unsafe fn dummy() -> Self {
-        WindowId(0)
-    }
-}
-
 #[inline]
 fn make_wid(surface: &WlSurface) -> WindowId {
-    WindowId(surface.as_ref().c_ptr() as usize)
+    WindowId(surface.as_ref().c_ptr() as u64)
 }

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -59,7 +59,7 @@ impl<T: 'static> EventProcessor<T> {
         F: Fn(&Arc<UnownedWindow>) -> Ret,
     {
         let mut deleted = false;
-        let window_id = WindowId(window_id);
+        let window_id = WindowId(window_id as u64);
         let wt = get_xtarget(&self.target);
         let result = wt
             .windows
@@ -513,7 +513,7 @@ impl<T: 'static> EventProcessor<T> {
 
                 // In the event that the window's been destroyed without being dropped first, we
                 // cleanup again here.
-                wt.windows.borrow_mut().remove(&WindowId(window));
+                wt.windows.borrow_mut().remove(&WindowId(window as u64));
 
                 // Since all XIM stuff needs to happen from the same thread, we destroy the input
                 // context here instead of when dropping the window.
@@ -1213,11 +1213,7 @@ impl<T: 'static> EventProcessor<T> {
                                                 &*window.shared_state.lock(),
                                             );
 
-                                            let window_id = crate::window::WindowId(
-                                                crate::platform_impl::platform::WindowId::X(
-                                                    *window_id,
-                                                ),
-                                            );
+                                            let window_id = crate::window::WindowId(*window_id);
                                             let old_inner_size = PhysicalSize::new(width, height);
                                             let mut new_inner_size =
                                                 PhysicalSize::new(new_width, new_height);

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -53,7 +53,10 @@ use crate::{
     event_loop::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
-    platform_impl::{platform::sticky_exit_callback, PlatformSpecificWindowBuilderAttributes},
+    platform_impl::{
+        platform::{sticky_exit_callback, WindowId},
+        PlatformSpecificWindowBuilderAttributes,
+    },
     window::WindowAttributes,
 };
 
@@ -361,7 +364,7 @@ impl<T: 'static> EventLoop<T> {
                 }
 
                 for window_id in windows {
-                    let window_id = crate::window::WindowId(super::WindowId::X(window_id));
+                    let window_id = crate::window::WindowId(window_id);
                     sticky_exit_callback(
                         Event::RedrawRequested(window_id),
                         &this.target,
@@ -505,10 +508,7 @@ impl<T: 'static> EventLoop<T> {
                     target,
                     control_flow,
                     &mut |event, window_target, control_flow| {
-                        if let Event::RedrawRequested(crate::window::WindowId(
-                            super::WindowId::X(wid),
-                        )) = event
-                        {
+                        if let Event::RedrawRequested(crate::window::WindowId(wid)) = event {
                             wt.redraw_sender.sender.send(wid).unwrap();
                             wt.redraw_sender.waker.wake().unwrap();
                         } else {
@@ -610,15 +610,6 @@ impl<'a> Deref for DeviceInfo<'a> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(ffi::Window);
-
-impl WindowId {
-    pub const unsafe fn dummy() -> Self {
-        WindowId(0)
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId(c_int);
 
 impl DeviceId {
@@ -657,7 +648,7 @@ impl Drop for Window {
         let window = self.deref();
         let xconn = &window.xconn;
         unsafe {
-            (xconn.xlib.XDestroyWindow)(xconn.display, window.id().0);
+            (xconn.xlib.XDestroyWindow)(xconn.display, window.id().0 as ffi::Window);
             // If the window was somehow already destroyed, we'll get a `BadWindow` error, which we don't care about.
             let _ = xconn.check_errors();
         }
@@ -700,7 +691,7 @@ struct XExtension {
 }
 
 fn mkwid(w: ffi::Window) -> crate::window::WindowId {
-    crate::window::WindowId(crate::platform_impl::WindowId::X(WindowId(w)))
+    crate::window::WindowId(crate::platform_impl::platform::WindowId(w as u64))
 }
 fn mkdid(w: c_int) -> crate::event::DeviceId {
     crate::event::DeviceId(crate::platform_impl::DeviceId::X(DeviceId(w)))

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1496,14 +1496,14 @@ impl UnownedWindow {
 
     #[inline]
     pub fn id(&self) -> WindowId {
-        WindowId(self.xwindow)
+        WindowId(self.xwindow as u64)
     }
 
     #[inline]
     pub fn request_redraw(&self) {
         self.redraw_sender
             .sender
-            .send(WindowId(self.xwindow))
+            .send(WindowId(self.xwindow as u64))
             .unwrap();
         self.redraw_sender.waker.wake().unwrap();
     }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -58,6 +58,18 @@ impl WindowId {
     }
 }
 
+impl From<WindowId> for u64 {
+    fn from(window_id: WindowId) -> Self {
+        window_id.0 as u64
+    }
+}
+
+impl From<u64> for WindowId {
+    fn from(raw_id: u64) -> Self {
+        Self(raw_id as usize)
+    }
+}
+
 // Convert the `cocoa::base::id` associated with a window to a usize to use as a unique identifier
 // for the window.
 pub fn get_window_id(window_cocoa_id: id) -> WindowId {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -380,6 +380,18 @@ impl WindowId {
     }
 }
 
+impl From<WindowId> for u64 {
+    fn from(window_id: WindowId) -> Self {
+        window_id.0 as u64
+    }
+}
+
+impl From<u64> for WindowId {
+    fn from(raw_id: u64) -> Self {
+        Self(raw_id as u32)
+    }
+}
+
 #[derive(Default, Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub(crate) canvas: Option<backend::RawCanvasType>,

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -100,6 +100,18 @@ impl WindowId {
     }
 }
 
+impl From<WindowId> for u64 {
+    fn from(window_id: WindowId) -> Self {
+        window_id.0 as u64
+    }
+}
+
+impl From<u64> for WindowId {
+    fn from(raw_id: u64) -> Self {
+        Self(raw_id as HWND)
+    }
+}
+
 #[inline(always)]
 const fn get_xbutton_wparam(x: u32) -> u16 {
     loword(x)

--- a/src/window.rs
+++ b/src/window.rs
@@ -83,6 +83,18 @@ impl WindowId {
     }
 }
 
+impl From<WindowId> for u64 {
+    fn from(window_id: WindowId) -> Self {
+        window_id.into()
+    }
+}
+
+impl From<u64> for WindowId {
+    fn from(raw_id: u64) -> Self {
+        raw_id.into()
+    }
+}
+
 /// Object that allows building windows.
 #[derive(Clone, Default)]
 #[must_use]


### PR DESCRIPTION
This should help downstream applications to expose WindowId to the end
users via e.g. IPC to control particular windows in multi window
systems.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
