### PR TITLE
Add `refresh_rate` for `MonitorHandle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Fix on macOS `WindowBuilder::with_disallow_hidpi`, setting true or false by the user no matter the SO default value. 
 - `EventLoopBuilder::build` will now panic when the `EventLoop` is being created more than once.
 - Added `From<u64>` for `WindowId` and `From<WindowId>` for `u64`.
+- Added `MonitorHandle::refresh_rate_millihertz` to get monitor's refresh rate.
+- **Breaking**, Replaced `VideoMode::refresh_rate` with `VideoMode::refresh_rate_millihertz` providing better precision.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -39,8 +39,8 @@ impl Ord for VideoMode {
         self.monitor().cmp(&other.monitor()).then(
             size.cmp(&other_size)
                 .then(
-                    self.refresh_rate()
-                        .cmp(&other.refresh_rate())
+                    self.refresh_rate_millihertz()
+                        .cmp(&other.refresh_rate_millihertz())
                         .then(self.bit_depth().cmp(&other.bit_depth())),
                 )
                 .reverse(),
@@ -68,12 +68,10 @@ impl VideoMode {
         self.video_mode.bit_depth()
     }
 
-    /// Returns the refresh rate of this video mode. **Note**: the returned
-    /// refresh rate is an integer approximation, and you shouldn't rely on this
-    /// value to be exact.
+    /// Returns the refresh rate of this video mode in mHz.
     #[inline]
-    pub fn refresh_rate(&self) -> u16 {
-        self.video_mode.refresh_rate()
+    pub fn refresh_rate_millihertz(&self) -> u32 {
+        self.video_mode.refresh_rate_millihertz()
     }
 
     /// Returns the monitor that this video mode is valid for. Each monitor has
@@ -88,10 +86,10 @@ impl std::fmt::Display for VideoMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}x{} @ {} Hz ({} bpp)",
+            "{}x{} @ {} mHz ({} bpp)",
             self.size().width,
             self.size().height,
-            self.refresh_rate(),
+            self.refresh_rate_millihertz(),
             self.bit_depth()
         )
     }
@@ -139,6 +137,15 @@ impl MonitorHandle {
     #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         self.inner.position()
+    }
+
+    /// The monitor refresh rate used by the system.
+    ///
+    /// When using exclusive fullscreen, the refresh rate of the [`VideoMode`] that was used to
+    /// enter fullscreen should be used instead.
+    #[inline]
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        self.inner.refresh_rate_millihertz()
     }
 
     /// Returns the scale factor that can be used to map logical pixels to physical pixels, and vice versa.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -857,6 +857,11 @@ impl MonitorHandle {
             .unwrap_or(1.0)
     }
 
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        // FIXME no way to get real refrsh rate for now.
+        None
+    }
+
     pub fn video_modes(&self) -> impl Iterator<Item = monitor::VideoMode> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
@@ -865,7 +870,7 @@ impl MonitorHandle {
             video_mode: VideoMode {
                 size,
                 bit_depth: 32,
-                refresh_rate: 60,
+                refresh_rate_millihertz: 60000,
                 monitor: self.clone(),
             },
         })
@@ -876,7 +881,7 @@ impl MonitorHandle {
 pub struct VideoMode {
     size: (u32, u32),
     bit_depth: u16,
-    refresh_rate: u16,
+    refresh_rate_millihertz: u32,
     monitor: MonitorHandle,
 }
 
@@ -889,8 +894,8 @@ impl VideoMode {
         self.bit_depth
     }
 
-    pub fn refresh_rate(&self) -> u16 {
-        self.refresh_rate
+    pub fn refresh_rate_millihertz(&self) -> u32 {
+        self.refresh_rate_millihertz
     }
 
     pub fn monitor(&self) -> monitor::MonitorHandle {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -257,6 +257,11 @@ impl MonitorHandle {
     }
 
     #[inline]
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        x11_or_wayland!(match self; MonitorHandle(m) => m.refresh_rate_millihertz())
+    }
+
+    #[inline]
     pub fn scale_factor(&self) -> f64 {
         x11_or_wayland!(match self; MonitorHandle(m) => m.scale_factor() as f64)
     }
@@ -287,8 +292,8 @@ impl VideoMode {
     }
 
     #[inline]
-    pub fn refresh_rate(&self) -> u16 {
-        x11_or_wayland!(match self; VideoMode(m) => m.refresh_rate())
+    pub fn refresh_rate_millihertz(&self) -> u32 {
+        x11_or_wayland!(match self; VideoMode(m) => m.refresh_rate_millihertz())
     }
 
     #[inline]

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -17,6 +17,10 @@ impl MonitorHandle {
         None
     }
 
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        None
+    }
+
     pub fn size(&self) -> PhysicalSize<u32> {
         PhysicalSize {
             width: 0,
@@ -41,8 +45,8 @@ impl VideoMode {
         unimplemented!();
     }
 
-    pub fn refresh_rate(&self) -> u16 {
-        32
+    pub fn refresh_rate_millihertz(&self) -> u32 {
+        32000
     }
 
     pub fn monitor(&self) -> RootMonitorHandle {

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -9,8 +9,8 @@ use windows_sys::Win32::{
     Graphics::Gdi::{
         EnumDisplayMonitors, EnumDisplaySettingsExW, GetMonitorInfoW, MonitorFromPoint,
         MonitorFromWindow, DEVMODEW, DM_BITSPERPEL, DM_DISPLAYFREQUENCY, DM_PELSHEIGHT,
-        DM_PELSWIDTH, HDC, HMONITOR, MONITORINFO, MONITORINFOEXW, MONITOR_DEFAULTTONEAREST,
-        MONITOR_DEFAULTTOPRIMARY,
+        DM_PELSWIDTH, ENUM_CURRENT_SETTINGS, HDC, HMONITOR, MONITORINFO, MONITORINFOEXW,
+        MONITOR_DEFAULTTONEAREST, MONITOR_DEFAULTTOPRIMARY,
     },
 };
 
@@ -29,7 +29,7 @@ use crate::{
 pub struct VideoMode {
     pub(crate) size: (u32, u32),
     pub(crate) bit_depth: u16,
-    pub(crate) refresh_rate: u16,
+    pub(crate) refresh_rate_millihertz: u32,
     pub(crate) monitor: MonitorHandle,
     // DEVMODEW is huge so we box it to avoid blowing up the size of winit::window::Fullscreen
     pub(crate) native_video_mode: Box<DEVMODEW>,
@@ -39,7 +39,7 @@ impl PartialEq for VideoMode {
     fn eq(&self, other: &Self) -> bool {
         self.size == other.size
             && self.bit_depth == other.bit_depth
-            && self.refresh_rate == other.refresh_rate
+            && self.refresh_rate_millihertz == other.refresh_rate_millihertz
             && self.monitor == other.monitor
     }
 }
@@ -50,7 +50,7 @@ impl std::hash::Hash for VideoMode {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.size.hash(state);
         self.bit_depth.hash(state);
-        self.refresh_rate.hash(state);
+        self.refresh_rate_millihertz.hash(state);
         self.monitor.hash(state);
     }
 }
@@ -60,7 +60,7 @@ impl std::fmt::Debug for VideoMode {
         f.debug_struct("VideoMode")
             .field("size", &self.size)
             .field("bit_depth", &self.bit_depth)
-            .field("refresh_rate", &self.refresh_rate)
+            .field("refresh_rate_millihertz", &self.refresh_rate_millihertz)
             .field("monitor", &self.monitor)
             .finish()
     }
@@ -75,8 +75,8 @@ impl VideoMode {
         self.bit_depth
     }
 
-    pub fn refresh_rate(&self) -> u16 {
-        self.refresh_rate
+    pub fn refresh_rate_millihertz(&self) -> u32 {
+        self.refresh_rate_millihertz
     }
 
     pub fn monitor(&self) -> RootMonitorHandle {
@@ -193,6 +193,23 @@ impl MonitorHandle {
     }
 
     #[inline]
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        let monitor_info = get_monitor_info(self.0).unwrap();
+        let device_name = monitor_info.szDevice.as_ptr();
+        unsafe {
+            let mut mode: DEVMODEW = mem::zeroed();
+            mode.dmSize = mem::size_of_val(&mode) as u16;
+            if EnumDisplaySettingsExW(device_name, ENUM_CURRENT_SETTINGS, &mut mode, 0)
+                == false.into()
+            {
+                None
+            } else {
+                Some(mode.dmDisplayFrequency * 1000)
+            }
+        }
+    }
+
+    #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         let rc_monitor = get_monitor_info(self.0).unwrap().monitorInfo.rcMonitor;
         PhysicalPosition {
@@ -233,7 +250,7 @@ impl MonitorHandle {
                     video_mode: VideoMode {
                         size: (mode.dmPelsWidth, mode.dmPelsHeight),
                         bit_depth: mode.dmBitsPerPel as u16,
-                        refresh_rate: mode.dmDisplayFrequency as u16,
+                        refresh_rate_millihertz: mode.dmDisplayFrequency as u32 * 1000,
                         monitor: self.clone(),
                         native_video_mode: Box::new(mode),
                     },


### PR DESCRIPTION
This also alters `VideoMode::refresh_rate` to return u32 which is a
monitor refresh rate in mHz.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
