### PR TITLE
examples/multiwindow.rs: ignore synthetic key press events

### DIFF
--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use simple_logger::SimpleLogger;
 use winit::{
-    event::{ElementState, Event, KeyboardInput, WindowEvent},
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
     event_loop::EventLoop,
     window::Window,
 };
@@ -16,8 +16,11 @@ fn main() {
     let mut windows = HashMap::new();
     for _ in 0..3 {
         let window = Window::new(&event_loop).unwrap();
+        println!("Opened a new window: {:?}", window.id());
         windows.insert(window.id(), window);
     }
+
+    println!("Press N to open a new window.");
 
     event_loop.run(move |event, event_loop, control_flow| {
         control_flow.set_wait();
@@ -39,11 +42,14 @@ fn main() {
                         input:
                             KeyboardInput {
                                 state: ElementState::Pressed,
+                                virtual_keycode: Some(VirtualKeyCode::N),
                                 ..
                             },
+                        is_synthetic: false,
                         ..
                     } => {
                         let window = Window::new(event_loop).unwrap();
+                        println!("Opened a new window: {:?}", window.id());
                         windows.insert(window.id(), window);
                     }
                     _ => (),


### PR DESCRIPTION
Fixes #2349. Tested on X11; I don't think the rest is relevant.

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
