### PR TITLE
Primarily use ButtonPress and ButtonRelease for mouse events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Fix on macOS `WindowBuilder::with_disallow_hidpi`, setting true or false by the user no matter the SO default value. 
 - `EventLoopBuilder::build` will now panic when the `EventLoop` is being created more than once.
 - Added `From<u64>` for `WindowId` and `From<WindowId>` for `u64`.
+- On X11, take mouse-events except motion from vanilla X11 instead of xinput2
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -438,8 +438,8 @@ impl UnownedWindow {
 
             // Select XInput2 events
             let mask = ffi::XI_MotionMask
-                    | ffi::XI_ButtonPressMask
-                    | ffi::XI_ButtonReleaseMask
+                    //| ffi::XI_ButtonPressMask
+                    //| ffi::XI_ButtonReleaseMask
                     //| ffi::XI_KeyPressMask
                     //| ffi::XI_KeyReleaseMask
                     | ffi::XI_EnterMask


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [x] ~~Created or updated an example program if it would help users understand this functionality~~
- [x] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~

(Sorry for the weird PR spam)

This change makes ButtonPresses like KeyPresses use regular events instead of XI-events which allows the scroll-button to be grabbed, the reason for wanting to do this is stated in https://github.com/rust-windowing/winit/issues/2359.

If I understood what's happening here correctly, and I might not have:
You cannot grab XI_Button events and still get regular Button events. XI uses motion for scrolling and doesn't count scrolling as a button press.
This leads to the problem where you can't grab scroll-keys as they aren't registered as being pressed when scrolling happens.

This change modifies that to make winit use regular ButtonPressEvents for scrolling and stops it listening for XI_Button events.
Interestingly there already was logic implemented for scrolling using buttons, but because XI doesn't count scrolling as buttons that logic was never activated, it's now used in the regular ButtonPress handling instead.

For extension devices not targeting the core-pointer scrolling behaviour should be the same, although that's hard to test.

Tested on x11 and now MouseWheel events only arrive if not grabbed. Additionally tested building glutin and then alacritty on top of this change and the problem is gone.