### PR TITLE
Avoid infinite recursion about WindowId conversion

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -85,13 +85,13 @@ impl WindowId {
 
 impl From<WindowId> for u64 {
     fn from(window_id: WindowId) -> Self {
-        window_id.into()
+        window_id.0.into()
     }
 }
 
 impl From<u64> for WindowId {
     fn from(raw_id: u64) -> Self {
-        raw_id.into()
+        Self(raw_id.into())
     }
 }
 


### PR DESCRIPTION
These conversion methods call itself recursively so using it occurs stack overflow.

Found using `Windowid::from(u64)` in a work on https://github.com/rust-windowing/winit/pull/2246. You can see a stack overflow with this PR's commit https://github.com/rust-windowing/winit/pull/2246/commits/7a04d4073ef75fe739a0553d1d09dbb359022d2d with `cargo run --example child_window`.

- [ ] Tested on all platforms changed
    - It'll be checked in CI 
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
    - It's a bugfix so it will not change any features
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
    - same as above
- [x] Created or updated an example program if it would help users understand this functionality
    - same as above
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
    - same as above
