### PR TITLE
Remove the deprecated `modifiers` field on several events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** Removed the deprecated `modifiers` field on the `CursorMoved`, `MouseWheel`, and `MouseInput` `WindowEvent`s, as well as on the `KeyboardInput` struct.
 - Added `WindowEvent::Occluded(bool)`, currently implemented on macOS and X11.
 - On X11, fix events for caps lock key not being sent
 - Build docs on `docs.rs` for iOS and Android as well.

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -7,7 +7,7 @@ fn main() {
     use simple_logger::SimpleLogger;
     use winit::{
         dpi::{PhysicalPosition, PhysicalSize, Position, Size},
-        event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+        event::{ElementState, Event, KeyboardInput, ModifiersState, VirtualKeyCode, WindowEvent},
         event_loop::EventLoop,
         window::{CursorGrabMode, CursorIcon, Fullscreen, WindowBuilder},
     };
@@ -29,6 +29,7 @@ fn main() {
 
         let (tx, rx) = mpsc::channel();
         window_senders.insert(window.id(), tx);
+        let mut modifiers = ModifiersState::default();
         thread::spawn(move || {
             while let Ok(event) = rx.recv() {
                 match event {
@@ -51,13 +52,14 @@ fn main() {
                             );
                         }
                     }
-                    #[allow(deprecated)]
+                    WindowEvent::ModifiersChanged(mod_state) => {
+                        modifiers = mod_state;
+                    }
                     WindowEvent::KeyboardInput {
                         input:
                             KeyboardInput {
                                 state: ElementState::Released,
                                 virtual_keycode: Some(key),
-                                modifiers,
                                 ..
                             },
                         ..

--- a/src/event.rs
+++ b/src/event.rs
@@ -298,8 +298,6 @@ pub enum WindowEvent<'a> {
         /// limited by the display area and it may have been transformed by the OS to implement effects such as cursor
         /// acceleration, it should not be used to implement non-cursor-like interactions such as 3D camera control.
         position: PhysicalPosition<f64>,
-        #[deprecated = "Deprecated in favor of WindowEvent::ModifiersChanged"]
-        modifiers: ModifiersState,
     },
 
     /// The cursor has entered the window.
@@ -313,8 +311,6 @@ pub enum WindowEvent<'a> {
         device_id: DeviceId,
         delta: MouseScrollDelta,
         phase: TouchPhase,
-        #[deprecated = "Deprecated in favor of WindowEvent::ModifiersChanged"]
-        modifiers: ModifiersState,
     },
 
     /// An mouse button press has been received.
@@ -322,8 +318,6 @@ pub enum WindowEvent<'a> {
         device_id: DeviceId,
         state: ElementState,
         button: MouseButton,
-        #[deprecated = "Deprecated in favor of WindowEvent::ModifiersChanged"]
-        modifiers: ModifiersState,
     },
 
     /// Touchpad pressure event.
@@ -407,15 +401,12 @@ impl Clone for WindowEvent<'static> {
             },
             Ime(preedit_state) => Ime(preedit_state.clone()),
             ModifiersChanged(modifiers) => ModifiersChanged(*modifiers),
-            #[allow(deprecated)]
             CursorMoved {
                 device_id,
                 position,
-                modifiers,
             } => CursorMoved {
                 device_id: *device_id,
                 position: *position,
-                modifiers: *modifiers,
             },
             CursorEntered { device_id } => CursorEntered {
                 device_id: *device_id,
@@ -423,29 +414,23 @@ impl Clone for WindowEvent<'static> {
             CursorLeft { device_id } => CursorLeft {
                 device_id: *device_id,
             },
-            #[allow(deprecated)]
             MouseWheel {
                 device_id,
                 delta,
                 phase,
-                modifiers,
             } => MouseWheel {
                 device_id: *device_id,
                 delta: *delta,
                 phase: *phase,
-                modifiers: *modifiers,
             },
-            #[allow(deprecated)]
             MouseInput {
                 device_id,
                 state,
                 button,
-                modifiers,
             } => MouseInput {
                 device_id: *device_id,
                 state: *state,
                 button: *button,
-                modifiers: *modifiers,
             },
             TouchpadPressure {
                 device_id,
@@ -499,41 +484,32 @@ impl<'a> WindowEvent<'a> {
             }),
             ModifiersChanged(modifiers) => Some(ModifiersChanged(modifiers)),
             Ime(event) => Some(Ime(event)),
-            #[allow(deprecated)]
             CursorMoved {
                 device_id,
                 position,
-                modifiers,
             } => Some(CursorMoved {
                 device_id,
                 position,
-                modifiers,
             }),
             CursorEntered { device_id } => Some(CursorEntered { device_id }),
             CursorLeft { device_id } => Some(CursorLeft { device_id }),
-            #[allow(deprecated)]
             MouseWheel {
                 device_id,
                 delta,
                 phase,
-                modifiers,
             } => Some(MouseWheel {
                 device_id,
                 delta,
                 phase,
-                modifiers,
             }),
-            #[allow(deprecated)]
             MouseInput {
                 device_id,
                 state,
                 button,
-                modifiers,
             } => Some(MouseInput {
                 device_id,
                 state,
                 button,
-                modifiers,
             }),
             TouchpadPressure {
                 device_id,
@@ -650,13 +626,6 @@ pub struct KeyboardInput {
     /// Use when the semantics of the key are more important than the physical location of the key, such as when
     /// implementing appropriate behavior for "page up."
     pub virtual_keycode: Option<VirtualKeyCode>,
-
-    /// Modifier keys active at the time of this input.
-    ///
-    /// This is tracked internally to avoid tracking errors arising from modifier key state changes when events from
-    /// this device are not being delivered to the application, e.g. due to keyboard focus being elsewhere.
-    #[deprecated = "Deprecated in favor of WindowEvent::ModifiersChanged"]
-    pub modifiers: ModifiersState,
 }
 
 /// Describes [input method](https://en.wikipedia.org/wiki/Input_method) events.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -440,7 +440,6 @@ impl<T: 'static> EventLoop<T> {
                                             KeyAction::Up => event::ElementState::Released,
                                             _ => event::ElementState::Released,
                                         };
-                                        #[allow(deprecated)]
                                         let event = event::Event::WindowEvent {
                                             window_id,
                                             event: event::WindowEvent::KeyboardInput {
@@ -451,7 +450,6 @@ impl<T: 'static> EventLoop<T> {
                                                     virtual_keycode: ndk_keycode_to_virtualkeycode(
                                                         key.key_code(),
                                                     ),
-                                                    modifiers: event::ModifiersState::default(),
                                                 },
                                                 is_synthetic: false,
                                             },

--- a/src/platform_impl/linux/wayland/seat/keyboard/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/keyboard/handlers.rs
@@ -71,7 +71,6 @@ pub(super) fn handle_keyboard(
             let virtual_keycode = keymap::keysym_to_vkey(keysym);
 
             event_sink.push_window_event(
-                #[allow(deprecated)]
                 WindowEvent::KeyboardInput {
                     device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                         DeviceId,
@@ -80,7 +79,6 @@ pub(super) fn handle_keyboard(
                         state,
                         scancode: rawkey,
                         virtual_keycode,
-                        modifiers: *inner.modifiers_state.borrow(),
                     },
                     is_synthetic: false,
                 },
@@ -112,7 +110,6 @@ pub(super) fn handle_keyboard(
             let virtual_keycode = keymap::keysym_to_vkey(keysym);
 
             event_sink.push_window_event(
-                #[allow(deprecated)]
                 WindowEvent::KeyboardInput {
                     device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                         DeviceId,
@@ -121,7 +118,6 @@ pub(super) fn handle_keyboard(
                         state: ElementState::Pressed,
                         scancode: rawkey,
                         virtual_keycode,
-                        modifiers: *inner.modifiers_state.borrow(),
                     },
                     is_synthetic: false,
                 },

--- a/src/platform_impl/linux/wayland/seat/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/mod.rs
@@ -131,7 +131,6 @@ impl SeatManagerInner {
                     &self.theme_manager,
                     &self.relative_pointer_manager,
                     &self.pointer_constraints,
-                    seat_info.modifiers_state.clone(),
                 ));
             }
         } else {

--- a/src/platform_impl/linux/wayland/seat/pointer/data.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/data.rs
@@ -9,18 +9,12 @@ use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_p
 use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_confined_pointer_v1::ZwpConfinedPointerV1;
 use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_locked_pointer_v1::ZwpLockedPointerV1;
 
-use crate::event::{ModifiersState, TouchPhase};
+use crate::event::TouchPhase;
 
 /// A data being used by pointer handlers.
 pub(super) struct PointerData {
     /// Winit's surface the pointer is currently over.
     pub surface: Option<WlSurface>,
-
-    /// Current modifiers state.
-    ///
-    /// This refers a state of modifiers from `WlKeyboard` on
-    /// the given seat.
-    pub modifiers_state: Rc<RefCell<ModifiersState>>,
 
     /// Pointer constraints.
     pub pointer_constraints: Option<Attached<ZwpPointerConstraintsV1>>,
@@ -43,7 +37,6 @@ impl PointerData {
         confined_pointer: Rc<RefCell<Option<ZwpConfinedPointerV1>>>,
         locked_pointer: Rc<RefCell<Option<ZwpLockedPointerV1>>>,
         pointer_constraints: Option<Attached<ZwpPointerConstraintsV1>>,
-        modifiers_state: Rc<RefCell<ModifiersState>>,
     ) -> Self {
         Self {
             surface: None,
@@ -51,7 +44,6 @@ impl PointerData {
             latest_enter_serial: Rc::new(Cell::new(0)),
             confined_pointer,
             locked_pointer,
-            modifiers_state,
             pointer_constraints,
             axis_data: AxisData::new(),
         }

--- a/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
@@ -85,7 +85,6 @@ pub(super) fn handle_pointer(
                         DeviceId,
                     )),
                     position,
-                    modifiers: *pointer_data.modifiers_state.borrow(),
                 },
                 window_id,
             );
@@ -143,7 +142,6 @@ pub(super) fn handle_pointer(
                         DeviceId,
                     )),
                     position,
-                    modifiers: *pointer_data.modifiers_state.borrow(),
                 },
                 window_id,
             );
@@ -180,7 +178,6 @@ pub(super) fn handle_pointer(
                     )),
                     state,
                     button,
-                    modifiers: *pointer_data.modifiers_state.borrow(),
                 },
                 window_id,
             );
@@ -214,7 +211,6 @@ pub(super) fn handle_pointer(
                         )),
                         delta: MouseScrollDelta::PixelDelta(delta),
                         phase: TouchPhase::Moved,
-                        modifiers: *pointer_data.modifiers_state.borrow(),
                     },
                     window_id,
                 );
@@ -276,7 +272,6 @@ pub(super) fn handle_pointer(
                     )),
                     delta: MouseScrollDelta::LineDelta(x, y),
                     phase: pointer_data.axis_data.axis_state,
-                    modifiers: *pointer_data.modifiers_state.borrow(),
                 }
             } else if let Some((x, y)) = axis_buffer {
                 let scale_factor = sctk::get_surface_scale_factor(surface) as f64;
@@ -288,7 +283,6 @@ pub(super) fn handle_pointer(
                     )),
                     delta: MouseScrollDelta::PixelDelta(delta),
                     phase: pointer_data.axis_data.axis_state,
-                    modifiers: *pointer_data.modifiers_state.borrow(),
                 }
             } else {
                 return;

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -16,7 +16,6 @@ use sctk::reexports::protocols::unstable::pointer_constraints::v1::client::zwp_l
 use sctk::seat::pointer::{ThemeManager, ThemedPointer};
 use sctk::window::Window;
 
-use crate::event::ModifiersState;
 use crate::platform_impl::wayland::event_loop::WinitState;
 use crate::platform_impl::wayland::window::WinitFrame;
 use crate::window::CursorIcon;
@@ -236,7 +235,6 @@ impl Pointers {
         theme_manager: &ThemeManager,
         relative_pointer_manager: &Option<Attached<ZwpRelativePointerManagerV1>>,
         pointer_constraints: &Option<Attached<ZwpPointerConstraintsV1>>,
-        modifiers_state: Rc<RefCell<ModifiersState>>,
     ) -> Self {
         let confined_pointer = Rc::new(RefCell::new(None));
         let locked_pointer = Rc::new(RefCell::new(None));
@@ -245,7 +243,6 @@ impl Pointers {
             confined_pointer.clone(),
             locked_pointer.clone(),
             pointer_constraints.clone(),
-            modifiers_state,
         )));
 
         let pointer_seat = seat.detach();

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -586,9 +586,6 @@ impl<T: 'static> EventProcessor<T> {
                         self.mod_keymap.get_modifier(xkev.keycode as ffi::KeyCode)
                     );
 
-                    let modifiers = self.device_mod_state.modifiers();
-
-                    #[allow(deprecated)]
                     callback(Event::WindowEvent {
                         window_id,
                         event: WindowEvent::KeyboardInput {
@@ -597,7 +594,6 @@ impl<T: 'static> EventProcessor<T> {
                                 state,
                                 scancode,
                                 virtual_keycode,
-                                modifiers,
                             },
                             is_synthetic: false,
                         },
@@ -681,7 +677,6 @@ impl<T: 'static> EventProcessor<T> {
                                     device_id,
                                     state,
                                     button: Left,
-                                    modifiers,
                                 },
                             }),
                             ffi::Button2 => callback(Event::WindowEvent {
@@ -690,7 +685,6 @@ impl<T: 'static> EventProcessor<T> {
                                     device_id,
                                     state,
                                     button: Middle,
-                                    modifiers,
                                 },
                             }),
                             ffi::Button3 => callback(Event::WindowEvent {
@@ -699,7 +693,6 @@ impl<T: 'static> EventProcessor<T> {
                                     device_id,
                                     state,
                                     button: Right,
-                                    modifiers,
                                 },
                             }),
 
@@ -720,7 +713,6 @@ impl<T: 'static> EventProcessor<T> {
                                                 _ => unreachable!(),
                                             },
                                             phase: TouchPhase::Moved,
-                                            modifiers,
                                         },
                                     });
                                 }
@@ -732,7 +724,6 @@ impl<T: 'static> EventProcessor<T> {
                                     device_id,
                                     state,
                                     button: Other(x as u16),
-                                    modifiers,
                                 },
                             }),
                         }
@@ -758,7 +749,6 @@ impl<T: 'static> EventProcessor<T> {
                                 event: CursorMoved {
                                     device_id,
                                     position,
-                                    modifiers,
                                 },
                             });
                         } else if cursor_moved.is_none() {
@@ -805,7 +795,6 @@ impl<T: 'static> EventProcessor<T> {
                                                     }
                                                 },
                                                 phase: TouchPhase::Moved,
-                                                modifiers,
                                             },
                                         });
                                     } else {
@@ -866,18 +855,12 @@ impl<T: 'static> EventProcessor<T> {
                             // This needs to only be done after confirming the window still exists,
                             // since otherwise we risk getting a `BadWindow` error if the window was
                             // dropped with queued events.
-                            let modifiers = wt
-                                .xconn
-                                .query_pointer(xev.event, xev.deviceid)
-                                .expect("Failed to query pointer device")
-                                .get_modifier_state();
 
                             callback(Event::WindowEvent {
                                 window_id,
                                 event: CursorMoved {
                                     device_id,
                                     position,
-                                    modifiers,
                                 },
                             });
                         }
@@ -943,7 +926,6 @@ impl<T: 'static> EventProcessor<T> {
                                 event: CursorMoved {
                                     device_id: mkdid(pointer_id),
                                     position,
-                                    modifiers,
                                 },
                             });
 
@@ -1007,7 +989,6 @@ impl<T: 'static> EventProcessor<T> {
                         };
                         if self.window_exists(xev.event) {
                             let id = xev.detail as u64;
-                            let modifiers = self.device_mod_state.modifiers();
                             let location =
                                 PhysicalPosition::new(xev.event_x as f64, xev.event_y as f64);
 
@@ -1020,7 +1001,6 @@ impl<T: 'static> EventProcessor<T> {
                                     event: WindowEvent::CursorMoved {
                                         device_id: mkdid(util::VIRTUAL_CORE_POINTER),
                                         position: location.cast(),
-                                        modifiers,
                                     },
                                 });
                             }
@@ -1125,14 +1105,12 @@ impl<T: 'static> EventProcessor<T> {
                         let virtual_keycode = events::keysym_to_element(keysym as c_uint);
                         let modifiers = self.device_mod_state.modifiers();
 
-                        #[allow(deprecated)]
                         callback(Event::DeviceEvent {
                             device_id,
                             event: DeviceEvent::Key(KeyboardInput {
                                 scancode: scancode as u32,
                                 virtual_keycode,
                                 state,
-                                modifiers,
                             }),
                         });
 
@@ -1315,7 +1293,6 @@ impl<T: 'static> EventProcessor<T> {
         F: FnMut(Event<'_, T>),
     {
         let device_id = mkdid(util::VIRTUAL_CORE_KEYBOARD);
-        let modifiers = device_mod_state.modifiers();
 
         // Update modifiers state and emit key events based on which keys are currently pressed.
         for keycode in wt
@@ -1336,7 +1313,6 @@ impl<T: 'static> EventProcessor<T> {
                 );
             }
 
-            #[allow(deprecated)]
             callback(Event::WindowEvent {
                 window_id,
                 event: WindowEvent::KeyboardInput {
@@ -1345,7 +1321,6 @@ impl<T: 'static> EventProcessor<T> {
                         scancode,
                         state,
                         virtual_keycode,
-                        modifiers,
                     },
                     is_synthetic: true,
                 },

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -287,14 +287,12 @@ pub unsafe fn modifier_event(
 
         let scancode = get_scancode(ns_event);
         let virtual_keycode = scancode_to_keycode(scancode);
-        #[allow(deprecated)]
         Some(WindowEvent::KeyboardInput {
             device_id: DEVICE_ID,
             input: KeyboardInput {
                 state,
                 scancode: scancode as _,
                 virtual_keycode,
-                modifiers: event_mods(ns_event),
             },
             is_synthetic: false,
         })

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -769,7 +769,6 @@ extern "C" fn key_down(this: &Object, _sel: Sel, event: id) {
 
         let preedit_related = was_in_preedit || now_in_preedit;
         if !preedit_related || state.forward_key_to_app || !state.ime_allowed {
-            #[allow(deprecated)]
             let window_event = Event::WindowEvent {
                 window_id,
                 event: WindowEvent::KeyboardInput {
@@ -778,7 +777,6 @@ extern "C" fn key_down(this: &Object, _sel: Sel, event: id) {
                         state: ElementState::Pressed,
                         scancode,
                         virtual_keycode,
-                        modifiers: event_mods(event),
                     },
                     is_synthetic: false,
                 },
@@ -809,7 +807,6 @@ extern "C" fn key_up(this: &Object, _sel: Sel, event: id) {
 
         // We want to send keyboard input when we are not currently in preedit
         if state.ime_state != ImeState::Preedit {
-            #[allow(deprecated)]
             let window_event = Event::WindowEvent {
                 window_id: WindowId(get_window_id(state.ns_window)),
                 event: WindowEvent::KeyboardInput {
@@ -818,7 +815,6 @@ extern "C" fn key_up(this: &Object, _sel: Sel, event: id) {
                         state: ElementState::Released,
                         scancode,
                         virtual_keycode,
-                        modifiers: event_mods(event),
                     },
                     is_synthetic: false,
                 },
@@ -929,7 +925,6 @@ extern "C" fn cancel_operation(this: &Object, _sel: Sel, _sender: id) {
 
         update_potentially_stale_modifiers(state, event);
 
-        #[allow(deprecated)]
         let window_event = Event::WindowEvent {
             window_id: WindowId(get_window_id(state.ns_window)),
             event: WindowEvent::KeyboardInput {
@@ -938,7 +933,6 @@ extern "C" fn cancel_operation(this: &Object, _sel: Sel, _sender: id) {
                     state: ElementState::Pressed,
                     scancode: scancode as _,
                     virtual_keycode,
-                    modifiers: event_mods(event),
                 },
                 is_synthetic: false,
             },
@@ -961,7 +955,6 @@ fn mouse_click(this: &Object, event: id, button: MouseButton, button_state: Elem
                 device_id: DEVICE_ID,
                 state: button_state,
                 button,
-                modifiers: event_mods(event),
             },
         };
 
@@ -1040,7 +1033,6 @@ fn mouse_motion(this: &Object, event: id) {
             event: WindowEvent::CursorMoved {
                 device_id: DEVICE_ID,
                 position: logical_position.to_physical(state.get_scale_factor()),
-                modifiers: event_mods(event),
             },
         };
 
@@ -1142,7 +1134,6 @@ extern "C" fn scroll_wheel(this: &Object, _sel: Sel, event: id) {
                 device_id: DEVICE_ID,
                 delta,
                 phase,
-                modifiers: event_mods(event),
             },
         };
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -72,8 +72,7 @@ impl<T> EventLoopWindowTarget<T> {
         });
 
         let runner = self.runner.clone();
-        canvas.on_keyboard_press(move |scancode, virtual_keycode, modifiers| {
-            #[allow(deprecated)]
+        canvas.on_keyboard_press(move |scancode, virtual_keycode| {
             runner.send_event(Event::WindowEvent {
                 window_id: RootWindowId(id),
                 event: WindowEvent::KeyboardInput {
@@ -82,7 +81,6 @@ impl<T> EventLoopWindowTarget<T> {
                         scancode,
                         state: ElementState::Pressed,
                         virtual_keycode,
-                        modifiers,
                     },
                     is_synthetic: false,
                 },
@@ -90,8 +88,7 @@ impl<T> EventLoopWindowTarget<T> {
         });
 
         let runner = self.runner.clone();
-        canvas.on_keyboard_release(move |scancode, virtual_keycode, modifiers| {
-            #[allow(deprecated)]
+        canvas.on_keyboard_release(move |scancode, virtual_keycode| {
             runner.send_event(Event::WindowEvent {
                 window_id: RootWindowId(id),
                 event: WindowEvent::KeyboardInput {
@@ -100,7 +97,6 @@ impl<T> EventLoopWindowTarget<T> {
                         scancode,
                         state: ElementState::Released,
                         virtual_keycode,
-                        modifiers,
                     },
                     is_synthetic: false,
                 },
@@ -136,13 +132,12 @@ impl<T> EventLoopWindowTarget<T> {
         });
 
         let runner = self.runner.clone();
-        canvas.on_cursor_move(move |pointer_id, position, delta, modifiers| {
+        canvas.on_cursor_move(move |pointer_id, position, delta| {
             runner.send_event(Event::WindowEvent {
                 window_id: RootWindowId(id),
                 event: WindowEvent::CursorMoved {
                     device_id: RootDeviceId(DeviceId(pointer_id)),
                     position,
-                    modifiers,
                 },
             });
             runner.send_event(Event::DeviceEvent {
@@ -154,7 +149,7 @@ impl<T> EventLoopWindowTarget<T> {
         });
 
         let runner = self.runner.clone();
-        canvas.on_mouse_press(move |pointer_id, position, button, modifiers| {
+        canvas.on_mouse_press(move |pointer_id, position, button| {
             // A mouse down event may come in without any prior CursorMoved events,
             // therefore we should send a CursorMoved event to make sure that the
             // user code has the correct cursor position.
@@ -164,7 +159,6 @@ impl<T> EventLoopWindowTarget<T> {
                     event: WindowEvent::CursorMoved {
                         device_id: RootDeviceId(DeviceId(pointer_id)),
                         position,
-                        modifiers,
                     },
                 })
                 .chain(std::iter::once(Event::WindowEvent {
@@ -173,34 +167,31 @@ impl<T> EventLoopWindowTarget<T> {
                         device_id: RootDeviceId(DeviceId(pointer_id)),
                         state: ElementState::Pressed,
                         button,
-                        modifiers,
                     },
                 })),
             );
         });
 
         let runner = self.runner.clone();
-        canvas.on_mouse_release(move |pointer_id, button, modifiers| {
+        canvas.on_mouse_release(move |pointer_id, button| {
             runner.send_event(Event::WindowEvent {
                 window_id: RootWindowId(id),
                 event: WindowEvent::MouseInput {
                     device_id: RootDeviceId(DeviceId(pointer_id)),
                     state: ElementState::Released,
                     button,
-                    modifiers,
                 },
             });
         });
 
         let runner = self.runner.clone();
-        canvas.on_mouse_wheel(move |pointer_id, delta, modifiers| {
+        canvas.on_mouse_wheel(move |pointer_id, delta| {
             runner.send_event(Event::WindowEvent {
                 window_id: RootWindowId(id),
                 event: WindowEvent::MouseWheel {
                     device_id: RootDeviceId(DeviceId(pointer_id)),
                     delta,
                     phase: TouchPhase::Moved,
-                    modifiers,
                 },
             });
         });

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -3,7 +3,7 @@ use super::event_handle::EventListenerHandle;
 use super::media_query_handle::MediaQueryListHandle;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
-use crate::event::{ModifiersState, MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode};
+use crate::event::{MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode};
 use crate::platform_impl::{OsError, PlatformSpecificWindowBuilderAttributes};
 
 use std::cell::RefCell;
@@ -150,24 +150,20 @@ impl Canvas {
 
     pub fn on_keyboard_release<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(ScanCode, Option<VirtualKeyCode>, ModifiersState),
+        F: 'static + FnMut(ScanCode, Option<VirtualKeyCode>),
     {
         self.on_keyboard_release = Some(self.common.add_user_event(
             "keyup",
             move |event: KeyboardEvent| {
                 event.prevent_default();
-                handler(
-                    event::scan_code(&event),
-                    event::virtual_key_code(&event),
-                    event::keyboard_modifiers(&event),
-                );
+                handler(event::scan_code(&event), event::virtual_key_code(&event));
             },
         ));
     }
 
     pub fn on_keyboard_press<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(ScanCode, Option<VirtualKeyCode>, ModifiersState),
+        F: 'static + FnMut(ScanCode, Option<VirtualKeyCode>),
     {
         self.on_keyboard_press = Some(self.common.add_user_event(
             "keydown",
@@ -183,11 +179,7 @@ impl Canvas {
                 if !is_key_string || is_shortcut_modifiers {
                     event.prevent_default();
                 }
-                handler(
-                    event::scan_code(&event),
-                    event::virtual_key_code(&event),
-                    event::keyboard_modifiers(&event),
-                );
+                handler(event::scan_code(&event), event::virtual_key_code(&event));
             },
         ));
     }
@@ -233,7 +225,7 @@ impl Canvas {
 
     pub fn on_mouse_release<F>(&mut self, handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, MouseButton),
     {
         match &mut self.mouse_state {
             MouseState::HasPointerEvent(h) => h.on_mouse_release(&self.common, handler),
@@ -243,7 +235,7 @@ impl Canvas {
 
     pub fn on_mouse_press<F>(&mut self, handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton),
     {
         match &mut self.mouse_state {
             MouseState::HasPointerEvent(h) => h.on_mouse_press(&self.common, handler),
@@ -253,7 +245,7 @@ impl Canvas {
 
     pub fn on_cursor_move<F>(&mut self, handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>),
     {
         match &mut self.mouse_state {
             MouseState::HasPointerEvent(h) => h.on_cursor_move(&self.common, handler),
@@ -263,12 +255,12 @@ impl Canvas {
 
     pub fn on_mouse_wheel<F>(&mut self, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseScrollDelta, ModifiersState),
+        F: 'static + FnMut(i32, MouseScrollDelta),
     {
         self.on_mouse_wheel = Some(self.common.add_event("wheel", move |event: WheelEvent| {
             event.prevent_default();
             if let Some(delta) = event::mouse_scroll_delta(&event) {
-                handler(0, delta, event::mouse_modifiers(&event));
+                handler(0, delta);
             }
         }));
     }

--- a/src/platform_impl/web/web_sys/canvas/mouse_handler.rs
+++ b/src/platform_impl/web/web_sys/canvas/mouse_handler.rs
@@ -1,7 +1,7 @@
 use super::event;
 use super::EventListenerHandle;
 use crate::dpi::PhysicalPosition;
-use crate::event::{ModifiersState, MouseButton};
+use crate::event::MouseButton;
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -75,7 +75,7 @@ impl MouseHandler {
 
     pub fn on_mouse_release<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, MouseButton),
     {
         let on_mouse_leave_handler = self.on_mouse_leave_handler.clone();
         let mouse_capture_state = self.mouse_capture_state.clone();
@@ -99,11 +99,7 @@ impl MouseHandler {
                     MouseCaptureState::Captured => {}
                 }
                 event.stop_propagation();
-                handler(
-                    0,
-                    event::mouse_button(&event),
-                    event::mouse_modifiers(&event),
-                );
+                handler(0, event::mouse_button(&event));
                 if event
                     .target()
                     .map_or(false, |target| target != EventTarget::from(canvas))
@@ -126,7 +122,7 @@ impl MouseHandler {
 
     pub fn on_mouse_press<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton),
     {
         let mouse_capture_state = self.mouse_capture_state.clone();
         let canvas = canvas_common.raw.clone();
@@ -155,7 +151,6 @@ impl MouseHandler {
                     0,
                     event::mouse_position(&event).to_physical(super::super::scale_factor()),
                     event::mouse_button(&event),
-                    event::mouse_modifiers(&event),
                 );
             },
         ));
@@ -163,7 +158,7 @@ impl MouseHandler {
 
     pub fn on_cursor_move<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>),
     {
         let mouse_capture_state = self.mouse_capture_state.clone();
         let canvas = canvas_common.raw.clone();
@@ -198,7 +193,6 @@ impl MouseHandler {
                             0,
                             mouse_pos.to_physical(super::super::scale_factor()),
                             mouse_delta.to_physical(super::super::scale_factor()),
-                            event::mouse_modifiers(&event),
                         );
                     }
                 }

--- a/src/platform_impl/web/web_sys/canvas/pointer_handler.rs
+++ b/src/platform_impl/web/web_sys/canvas/pointer_handler.rs
@@ -1,7 +1,7 @@
 use super::event;
 use super::EventListenerHandle;
 use crate::dpi::PhysicalPosition;
-use crate::event::{ModifiersState, MouseButton};
+use crate::event::MouseButton;
 
 use web_sys::PointerEvent;
 
@@ -51,23 +51,19 @@ impl PointerHandler {
 
     pub fn on_mouse_release<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, MouseButton),
     {
         self.on_pointer_release = Some(canvas_common.add_user_event(
             "pointerup",
             move |event: PointerEvent| {
-                handler(
-                    event.pointer_id(),
-                    event::mouse_button(&event),
-                    event::mouse_modifiers(&event),
-                );
+                handler(event.pointer_id(), event::mouse_button(&event));
             },
         ));
     }
 
     pub fn on_mouse_press<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton),
     {
         let canvas = canvas_common.raw.clone();
         self.on_pointer_press = Some(canvas_common.add_user_event(
@@ -77,7 +73,6 @@ impl PointerHandler {
                     event.pointer_id(),
                     event::mouse_position(&event).to_physical(super::super::scale_factor()),
                     event::mouse_button(&event),
-                    event::mouse_modifiers(&event),
                 );
 
                 // Error is swallowed here since the error would occur every time the mouse is
@@ -90,7 +85,7 @@ impl PointerHandler {
 
     pub fn on_cursor_move<F>(&mut self, canvas_common: &super::Common, mut handler: F)
     where
-        F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>, ModifiersState),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>),
     {
         self.on_cursor_move = Some(canvas_common.add_event(
             "pointermove",
@@ -99,7 +94,6 @@ impl PointerHandler {
                     event.pointer_id(),
                     event::mouse_position(&event).to_physical(super::super::scale_factor()),
                     event::mouse_delta(&event).to_physical(super::super::scale_factor()),
-                    event::mouse_modifiers(&event),
                 );
             },
         ));

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -1,5 +1,5 @@
 use crate::dpi::LogicalPosition;
-use crate::event::{ModifiersState, MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode};
+use crate::event::{MouseButton, MouseScrollDelta, ScanCode, VirtualKeyCode};
 
 use std::convert::TryInto;
 use web_sys::{HtmlCanvasElement, KeyboardEvent, MouseEvent, WheelEvent};
@@ -11,15 +11,6 @@ pub fn mouse_button(event: &MouseEvent) -> MouseButton {
         2 => MouseButton::Right,
         i => MouseButton::Other((i - 3).try_into().expect("very large mouse button value")),
     }
-}
-
-pub fn mouse_modifiers(event: &MouseEvent) -> ModifiersState {
-    let mut m = ModifiersState::empty();
-    m.set(ModifiersState::SHIFT, event.shift_key());
-    m.set(ModifiersState::CTRL, event.ctrl_key());
-    m.set(ModifiersState::ALT, event.alt_key());
-    m.set(ModifiersState::LOGO, event.meta_key());
-    m
 }
 
 pub fn mouse_position(event: &MouseEvent) -> LogicalPosition<f64> {
@@ -229,15 +220,6 @@ pub fn virtual_key_code(event: &KeyboardEvent) -> Option<VirtualKeyCode> {
         "Yen" => VirtualKeyCode::Yen,
         _ => return None,
     })
-}
-
-pub fn keyboard_modifiers(event: &KeyboardEvent) -> ModifiersState {
-    let mut m = ModifiersState::empty();
-    m.set(ModifiersState::SHIFT, event.shift_key());
-    m.set(ModifiersState::CTRL, event.ctrl_key());
-    m.set(ModifiersState::ALT, event.alt_key());
-    m.set(ModifiersState::LOGO, event.meta_key());
-    m
 }
 
 pub fn codepoint(event: &KeyboardEvent) -> char {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1273,7 +1273,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     event: CursorMoved {
                         device_id: DEVICE_ID,
                         position,
-                        modifiers: event::get_key_mods(),
                     },
                 });
             }
@@ -1315,7 +1314,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     delta: LineDelta(0.0, value),
                     phase: TouchPhase::Moved,
-                    modifiers: event::get_key_mods(),
                 },
             });
 
@@ -1337,7 +1335,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     delta: LineDelta(value, 0.0),
                     phase: TouchPhase::Moved,
-                    modifiers: event::get_key_mods(),
                 },
             });
 
@@ -1352,7 +1349,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 if let Some((scancode, vkey)) = process_key_params(wparam, lparam) {
                     update_modifiers(window, userdata);
 
-                    #[allow(deprecated)]
                     userdata.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: WindowEvent::KeyboardInput {
@@ -1361,7 +1357,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                                 state: Pressed,
                                 scancode,
                                 virtual_keycode: vkey,
-                                modifiers: event::get_key_mods(),
                             },
                             is_synthetic: false,
                         },
@@ -1384,7 +1379,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
             if let Some((scancode, vkey)) = process_key_params(wparam, lparam) {
                 update_modifiers(window, userdata);
 
-                #[allow(deprecated)]
                 userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
@@ -1393,7 +1387,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                             state: Released,
                             scancode,
                             virtual_keycode: vkey,
-                            modifiers: event::get_key_mods(),
                         },
                         is_synthetic: false,
                     },
@@ -1415,7 +1408,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     state: Pressed,
                     button: Left,
-                    modifiers: event::get_key_mods(),
                 },
             });
             0
@@ -1436,7 +1428,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     state: Released,
                     button: Left,
-                    modifiers: event::get_key_mods(),
                 },
             });
             0
@@ -1457,7 +1448,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     state: Pressed,
                     button: Right,
-                    modifiers: event::get_key_mods(),
                 },
             });
             0
@@ -1478,7 +1468,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     state: Released,
                     button: Right,
-                    modifiers: event::get_key_mods(),
                 },
             });
             0
@@ -1499,7 +1488,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     state: Pressed,
                     button: Middle,
-                    modifiers: event::get_key_mods(),
                 },
             });
             0
@@ -1520,7 +1508,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     state: Released,
                     button: Middle,
-                    modifiers: event::get_key_mods(),
                 },
             });
             0
@@ -1542,7 +1529,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     state: Pressed,
                     button: Other(xbutton),
-                    modifiers: event::get_key_mods(),
                 },
             });
             0
@@ -1564,7 +1550,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     device_id: DEVICE_ID,
                     state: Released,
                     button: Other(xbutton),
-                    modifiers: event::get_key_mods(),
                 },
             });
             0
@@ -1778,7 +1763,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
                 update_modifiers(window, userdata);
 
-                #[allow(deprecated)]
                 userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
@@ -1787,7 +1771,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                             scancode,
                             virtual_keycode,
                             state: Released,
-                            modifiers: event::get_key_mods(),
                         },
                         is_synthetic: true,
                     },
@@ -1812,7 +1795,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 let scancode = MapVirtualKeyA(windows_keycode as u32, MAPVK_VK_TO_VSC);
                 let virtual_keycode = event::vkey_to_winit_vkey(windows_keycode);
 
-                #[allow(deprecated)]
                 userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: WindowEvent::KeyboardInput {
@@ -1821,7 +1803,6 @@ unsafe fn public_window_callback_inner<T: 'static>(
                             scancode,
                             virtual_keycode,
                             state: Released,
-                            modifiers: event::get_key_mods(),
                         },
                         is_synthetic: true,
                     },
@@ -2315,14 +2296,12 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                         {
                             let virtual_keycode = vkey_to_winit_vkey(vkey);
 
-                            #[allow(deprecated)]
                             userdata.send_event(Event::DeviceEvent {
                                 device_id,
                                 event: Key(KeyboardInput {
                                     scancode,
                                     state,
                                     virtual_keycode,
-                                    modifiers: event::get_key_mods(),
                                 }),
                             });
                         }


### PR DESCRIPTION
It looks like the Web backend doesn't emit ModifiersChanged events at all right now. This has to be resolved before including this change upstream. I've elected to leave "modifier-querying" code in-place for now in order to avoid accidentally introducing any regressions.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
