### PR TITLE
On Wayland send Focused(false) for new window

### DIFF
--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -254,6 +254,12 @@ impl Window {
 
         winit_state.window_map.insert(window_id, window_handle);
 
+        // On Wayland window doesn't have Focus by default and it'll get it later on. So be
+        // explicit here.
+        winit_state
+            .event_sink
+            .push_window_event(crate::event::WindowEvent::Focused(false), window_id);
+
         winit_state
             .window_updates
             .insert(window_id, WindowUpdate::new());


### PR DESCRIPTION
On Wayland winit will always get an explicit focused event from the
system and will transfer it downstream. So send focused false to enforce
it.

--

This doesn't affect the end users, since they'll have explicit event and shouldn't make any assumption like if I documented that window is unfocused by default.
