### PR TITLE
Reduce `WM_PAINT` messages of thread target window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Windows, added `WindowExtWindows::set_skip_taskbar` and `WindowBuilderExtWindows::with_skip_taskbar`.
 - On Windows, added `EventLoopBuilderExtWindows::with_msg_hook`.
 - On Windows, remove internally unique DC per window.
+- On Windows, reduce `WM_PAINT` messages of thread target window by calling `RedrawWindow` only when it needs to process the message.
 - On macOS, remove the need to call `set_ime_position` after moving the window.
 - Added `Window::is_visible`.
 - Added `Window::is_resizable`.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2175,10 +2175,6 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     }
     let userdata = Box::from_raw(userdata_ptr);
 
-    if msg != WM_PAINT {
-        RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
-    }
-
     let mut userdata_removed = false;
 
     // I decided to bind the closure to `callback` and pass it to catch_unwind rather than passing
@@ -2186,6 +2182,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     // the git blame and history would be preserved.
     let callback = || match msg {
         WM_NCDESTROY => {
+            RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
             super::set_window_long(window, GWL_USERDATA, 0);
             userdata_removed = true;
             0
@@ -2216,6 +2213,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         }
 
         WM_INPUT_DEVICE_CHANGE => {
+            RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
             let event = match wparam as u32 {
                 GIDC_ARRIVAL => DeviceEvent::Added,
                 GIDC_REMOVAL => DeviceEvent::Removed,
@@ -2236,6 +2234,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                 ElementState::{Pressed, Released},
                 MouseScrollDelta::LineDelta,
             };
+            RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
 
             if let Some(data) = raw_input::get_raw_input_data(lparam) {
                 let device_id = wrap_device_id(data.header.hDevice as u32);
@@ -2334,17 +2333,20 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         }
 
         _ if msg == *USER_EVENT_MSG_ID => {
+            RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
             if let Ok(event) = userdata.user_event_receiver.recv() {
                 userdata.send_event(Event::UserEvent(event));
             }
             0
         }
         _ if msg == *EXEC_MSG_ID => {
+            RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
             let mut function: ThreadExecFn = Box::from_raw(wparam as usize as *mut _);
             function();
             0
         }
         _ if msg == *PROCESS_NEW_EVENTS_MSG_ID => {
+            RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
             PostThreadMessageW(
                 userdata.event_loop_runner.wait_thread_id(),
                 *CANCEL_WAIT_UNTIL_MSG_ID,


### PR DESCRIPTION
Fixes #2367

Since there's no comment on the issue, I would like to open a PR and give it a try. Examples are working and we can still get nonstop messages with `ControlFlow::Poll` if we want.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
