### PR TITLE
windows: Use correct value for mouse wheel delta

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2272,7 +2272,8 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
                     let mouse_button_flags = mouse.Anonymous.Anonymous.usButtonFlags;
 
                     if util::has_flag(mouse_button_flags as u32, RI_MOUSE_WHEEL) {
-                        let delta = mouse_button_flags as i16 as f32 / WHEEL_DELTA as f32;
+                        let delta = mouse.Anonymous.Anonymous.usButtonData as i16 as f32
+                            / WHEEL_DELTA as f32;
                         userdata.send_event(Event::DeviceEvent {
                             device_id,
                             event: MouseWheel {


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

During the switch to windows-sys, it looks like we unintentionally started using `usButtonFlags` instead of `usButtonData` for this event.

Original winapi version: `usButtonData` is used for the delta
https://github.com/rust-windowing/winit/blob/f3f6f1008a5891ed0c9e5e8f26568f8f2d49f164/src/platform_impl/windows/event_loop.rs#L2155-L2164
After switch to windows-sys: `usButtonFlags` is used for the delta
https://github.com/rust-windowing/winit/blob/b222dde83504e402d51fa40a3c78dee40cb2ee5f/src/platform_impl/windows/event_loop.rs#L2153-L2163