### PR TITLE
Update raw-window-handle to v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking**, Replaced `VideoMode::refresh_rate` with `VideoMode::refresh_rate_millihertz` providing better precision.
 - On Web, add `with_prevent_default` and `with_focusable` to `WindowBuilderExtWebSys` to control whether events should be propagated.
 - On Windows, fix focus events being sent to inactive windows.
+- **Breaking**, update `raw-window-handle` to `v0.5` and implement `HasRawDisplayHandle` for `Window` and `EventLoopWindowTarget`.
 
 # 0.26.1 (2022-01-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 once_cell = "1.12"
 log = "0.4"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
-raw-window-handle = "0.4.2"
+raw-window-handle = "0.5.0"
 bitflags = "1"
 mint = { version = "0.5.6", optional = true }
 
@@ -55,8 +55,8 @@ simple_logger = "2.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995
-ndk = { git = "https://github.com/rust-windowing/android-ndk-rs", rev = "a0c5e99" }
-ndk-glue = { git = "https://github.com/rust-windowing/android-ndk-rs", rev = "a0c5e99" }
+ndk = { git = "https://github.com/rust-windowing/android-ndk-rs", rev = "814be08" }
+ndk-glue = { git = "https://github.com/rust-windowing/android-ndk-rs", rev = "814be08" }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -13,6 +13,7 @@ use std::{error, fmt};
 
 use instant::Instant;
 use once_cell::sync::OnceCell;
+use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
 
 use crate::{event::Event, monitor::MonitorHandle, platform_impl};
 
@@ -334,6 +335,13 @@ impl<T> EventLoopWindowTarget<T> {
             target_os = "openbsd"
         ))]
         self.p.set_device_event_filter(_filter);
+    }
+}
+
+unsafe impl<T> HasRawDisplayHandle for EventLoopWindowTarget<T> {
+    /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
+    fn raw_display_handle(&self) -> RawDisplayHandle {
+        self.p.raw_display_handle()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,9 +98,9 @@
 //! # Drawing on the window
 //!
 //! Winit doesn't directly provide any methods for drawing on a [`Window`]. However it allows you to
-//! retrieve the raw handle of the window (see the [`platform`] module and/or the
-//! [`raw_window_handle`] method), which in turn allows you to create an
-//! OpenGL/Vulkan/DirectX/Metal/etc. context that can be used to render graphics.
+//! retrieve the raw handle of the window and display (see the [`platform`] module and/or the
+//! [`raw_window_handle`] and [`raw_display_handle`] methods), which in turn allows
+//!  you to create an OpenGL/Vulkan/DirectX/Metal/etc. context that can be used to render graphics.
 //!
 //! Note that many platforms will display garbage data in the window's client area if the
 //! application doesn't render anything to the window by the time the desktop compositor is ready to
@@ -129,6 +129,7 @@
 //! [`LoopDestroyed`]: event::Event::LoopDestroyed
 //! [`platform`]: platform
 //! [`raw_window_handle`]: ./window/struct.Window.html#method.raw_window_handle
+//! [`raw_display_handle`]: ./window/struct.Window.html#method.raw_display_handle
 
 #![deny(rust_2018_idioms)]
 #![deny(rustdoc::broken_intra_doc_links)]

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -14,7 +14,9 @@ use ndk::{
 };
 use ndk_glue::{Event, LockReadGuard, Rect};
 use once_cell::sync::Lazy;
-use raw_window_handle::{HasRawWindowHandle, RawWindowHandle};
+use raw_window_handle::{
+    AndroidDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+};
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
@@ -639,6 +641,10 @@ impl<T: 'static> EventLoopWindowTarget<T> {
         v.push_back(MonitorHandle);
         v
     }
+
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::Android(AndroidDisplayHandle::empty())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -827,6 +833,10 @@ impl Window {
         } else {
             panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
         }
+    }
+
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::Android(AndroidDisplayHandle::empty())
     }
 
     pub fn config(&self) -> Configuration {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -7,6 +7,8 @@ use std::{
     sync::mpsc::{self, Receiver, Sender},
 };
 
+use raw_window_handle::{RawDisplayHandle, UiKitDisplayHandle};
+
 use crate::{
     dpi::LogicalSize,
     event::Event,
@@ -62,6 +64,10 @@ impl<T: 'static> EventLoopWindowTarget<T> {
         let monitor = unsafe { monitor::main_uiscreen() };
 
         Some(RootMonitorHandle { inner: monitor })
+    }
+
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::UiKit(UiKitDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -1,10 +1,10 @@
-use raw_window_handle::{RawWindowHandle, UiKitHandle};
 use std::{
     collections::VecDeque,
     ops::{Deref, DerefMut},
 };
 
 use objc::runtime::{Class, Object, BOOL, NO, YES};
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle, UiKitDisplayHandle, UiKitWindowHandle};
 
 use crate::{
     dpi::{self, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size},
@@ -332,11 +332,15 @@ impl Inner {
     }
 
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut handle = UiKitHandle::empty();
-        handle.ui_window = self.window as _;
-        handle.ui_view = self.view as _;
-        handle.ui_view_controller = self.view_controller as _;
-        RawWindowHandle::UiKit(handle)
+        let mut window_handle = UiKitWindowHandle::empty();
+        window_handle.ui_window = self.window as _;
+        window_handle.ui_view = self.view as _;
+        window_handle.ui_view_controller = self.view_controller as _;
+        RawWindowHandle::UiKit(window_handle)
+    }
+
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::UiKit(UiKitDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -6,6 +6,8 @@ use std::process;
 use std::rc::Rc;
 use std::time::{Duration, Instant};
 
+use raw_window_handle::{RawDisplayHandle, WaylandDisplayHandle};
+
 use sctk::reexports::client::protocol::wl_compositor::WlCompositor;
 use sctk::reexports::client::protocol::wl_shm::WlShm;
 use sctk::reexports::client::Display;
@@ -69,6 +71,14 @@ pub struct EventLoopWindowTarget<T> {
     pub theme_manager: ThemeManager,
 
     _marker: std::marker::PhantomData<T>,
+}
+
+impl<T> EventLoopWindowTarget<T> {
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        let mut display_handle = WaylandDisplayHandle::empty();
+        display_handle.display = self.display.get_display_ptr() as *mut _;
+        RawDisplayHandle::Wayland(display_handle)
+    }
 }
 
 pub struct EventLoop<T: 'static> {

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -7,7 +7,9 @@ use sctk::reexports::client::Display;
 
 use sctk::reexports::calloop;
 
-use raw_window_handle::WaylandHandle;
+use raw_window_handle::{
+    RawDisplayHandle, RawWindowHandle, WaylandDisplayHandle, WaylandWindowHandle,
+};
 use sctk::window::Decorations;
 
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
@@ -579,11 +581,17 @@ impl Window {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> WaylandHandle {
-        let mut handle = WaylandHandle::empty();
-        handle.display = self.display.get_display_ptr() as *mut _;
-        handle.surface = self.surface.as_ref().c_ptr() as *mut _;
-        handle
+    pub fn raw_window_handle(&self) -> RawWindowHandle {
+        let mut window_handle = WaylandWindowHandle::empty();
+        window_handle.surface = self.surface.as_ref().c_ptr() as *mut _;
+        RawWindowHandle::Wayland(window_handle)
+    }
+
+    #[inline]
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        let mut display_handle = WaylandDisplayHandle::empty();
+        display_handle.display = self.display.get_display_ptr() as *mut _;
+        RawDisplayHandle::Wayland(display_handle)
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -40,6 +40,7 @@ use std::{
 use libc::{self, setlocale, LC_CTYPE};
 
 use mio::{unix::SourceFd, Events, Interest, Poll, Token, Waker};
+use raw_window_handle::{RawDisplayHandle, XlibDisplayHandle};
 
 use self::{
     dnd::{Dnd, DndState},
@@ -557,6 +558,14 @@ impl<T> EventLoopWindowTarget<T> {
         self.xconn
             .select_xinput_events(self.root, ffi::XIAllMasterDevices, mask)
             .queue();
+    }
+
+    pub fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
+        let mut display_handle = XlibDisplayHandle::empty();
+        display_handle.display = self.xconn.display as *mut _;
+        display_handle.screen =
+            unsafe { (self.xconn.xlib.XDefaultScreen)(self.xconn.display as *mut _) };
+        RawDisplayHandle::Xlib(display_handle)
     }
 }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1,4 +1,3 @@
-use raw_window_handle::XlibHandle;
 use std::{
     cmp, env,
     ffi::CString,
@@ -8,10 +7,11 @@ use std::{
     ptr, slice,
     sync::Arc,
 };
-use x11_dl::xlib::TrueColor;
 
 use libc;
 use parking_lot::Mutex;
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle, XlibDisplayHandle, XlibWindowHandle};
+use x11_dl::xlib::TrueColor;
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
@@ -1509,10 +1509,17 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> XlibHandle {
-        let mut handle = XlibHandle::empty();
-        handle.window = self.xlib_window();
-        handle.display = self.xlib_display();
-        handle
+    pub fn raw_window_handle(&self) -> RawWindowHandle {
+        let mut window_handle = XlibWindowHandle::empty();
+        window_handle.window = self.xlib_window();
+        RawWindowHandle::Xlib(window_handle)
+    }
+
+    #[inline]
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        let mut display_handle = XlibDisplayHandle::empty();
+        display_handle.display = self.xlib_display();
+        display_handle.screen = self.screen_id;
+        RawDisplayHandle::Xlib(display_handle)
     }
 }

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -17,6 +17,7 @@ use cocoa::{
     foundation::{NSInteger, NSPoint, NSTimeInterval},
 };
 use objc::rc::autoreleasepool;
+use raw_window_handle::{AppKitDisplayHandle, RawDisplayHandle};
 
 use crate::{
     event::Event,
@@ -86,6 +87,11 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
         let monitor = monitor::primary_monitor();
         Some(RootMonitorHandle { inner: monitor })
+    }
+
+    #[inline]
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::AppKit(AppKitDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1,4 +1,3 @@
-use raw_window_handle::{AppKitHandle, RawWindowHandle};
 use std::{
     collections::VecDeque,
     convert::TryInto,
@@ -8,6 +7,10 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex, MutexGuard, Weak,
     },
+};
+
+use raw_window_handle::{
+    AppKitDisplayHandle, AppKitWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 
 use crate::{
@@ -1144,10 +1147,15 @@ impl UnownedWindow {
 
     #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut handle = AppKitHandle::empty();
-        handle.ns_window = *self.ns_window as *mut _;
-        handle.ns_view = *self.ns_view as *mut _;
-        RawWindowHandle::AppKit(handle)
+        let mut window_handle = AppKitWindowHandle::empty();
+        window_handle.ns_window = *self.ns_window as *mut _;
+        window_handle.ns_view = *self.ns_view as *mut _;
+        RawWindowHandle::AppKit(window_handle)
+    }
+
+    #[inline]
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::AppKit(AppKitDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -1,3 +1,10 @@
+use std::cell::RefCell;
+use std::clone::Clone;
+use std::collections::{vec_deque::IntoIter as VecDequeIter, VecDeque};
+use std::rc::Rc;
+
+use raw_window_handle::{RawDisplayHandle, WebDisplayHandle};
+
 use super::{
     super::monitor::MonitorHandle, backend, device::DeviceId, proxy::EventLoopProxy, runner,
     window::WindowId,
@@ -10,10 +17,6 @@ use crate::event::{
 use crate::event_loop::ControlFlow;
 use crate::monitor::MonitorHandle as RootMH;
 use crate::window::{Theme, WindowId as RootWindowId};
-use std::cell::RefCell;
-use std::clone::Clone;
-use std::collections::{vec_deque::IntoIter as VecDequeIter, VecDeque};
-use std::rc::Rc;
 
 pub struct EventLoopWindowTarget<T: 'static> {
     pub(crate) runner: runner::Shared<T>,
@@ -278,5 +281,9 @@ impl<T> EventLoopWindowTarget<T> {
         Some(RootMH {
             inner: MonitorHandle,
         })
+    }
+
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::Web(WebDisplayHandle::empty())
     }
 }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -7,7 +7,7 @@ use crate::window::{
     CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWI,
 };
 
-use raw_window_handle::{RawWindowHandle, WebHandle};
+use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
 
 use super::{backend, monitor::MonitorHandle, EventLoopWindowTarget};
 
@@ -359,9 +359,14 @@ impl Window {
 
     #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut handle = WebHandle::empty();
-        handle.id = self.id.0;
-        RawWindowHandle::Web(handle)
+        let mut window_handle = WebWindowHandle::empty();
+        window_handle.id = self.id.0;
+        RawWindowHandle::Web(window_handle)
+    }
+
+    #[inline]
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::Web(WebDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2,8 +2,6 @@
 
 mod runner;
 
-use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 use std::{
     cell::Cell,
     collections::VecDeque,
@@ -18,6 +16,10 @@ use std::{
     thread,
     time::{Duration, Instant},
 };
+
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use raw_window_handle::{RawDisplayHandle, WindowsDisplayHandle};
 
 use windows_sys::Win32::{
     Devices::HumanInterfaceDevice::MOUSE_MOVE_RELATIVE,
@@ -313,6 +315,10 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
         let monitor = monitor::primary_monitor();
         Some(RootMonitorHandle { inner: monitor })
+    }
+
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::Windows(WindowsDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1,7 +1,9 @@
 #![cfg(target_os = "windows")]
 
 use parking_lot::Mutex;
-use raw_window_handle::{RawWindowHandle, Win32Handle};
+use raw_window_handle::{
+    RawDisplayHandle, RawWindowHandle, Win32WindowHandle, WindowsDisplayHandle,
+};
 use std::{
     cell::Cell,
     ffi::c_void,
@@ -260,10 +262,15 @@ impl Window {
 
     #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut handle = Win32Handle::empty();
-        handle.hwnd = self.window.0 as *mut _;
-        handle.hinstance = self.hinstance() as *mut _;
-        RawWindowHandle::Win32(handle)
+        let mut window_handle = Win32WindowHandle::empty();
+        window_handle.hwnd = self.window.0 as *mut _;
+        window_handle.hinstance = self.hinstance() as *mut _;
+        RawWindowHandle::Win32(window_handle)
+    }
+
+    #[inline]
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::Windows(WindowsDisplayHandle::empty())
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,6 +1,10 @@
 //! The [`Window`] struct and associated types.
 use std::fmt;
 
+use raw_window_handle::{
+    HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+};
+
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError},
@@ -1032,8 +1036,7 @@ impl Window {
         self.window.primary_monitor()
     }
 }
-
-unsafe impl raw_window_handle::HasRawWindowHandle for Window {
+unsafe impl HasRawWindowHandle for Window {
     /// Returns a [`raw_window_handle::RawWindowHandle`] for the Window
     ///
     /// ## Platform-specific
@@ -1049,8 +1052,18 @@ unsafe impl raw_window_handle::HasRawWindowHandle for Window {
     ///
     /// [`Event::Resumed`]: crate::event::Event::Resumed
     /// [`Event::Suspended`]: crate::event::Event::Suspended
-    fn raw_window_handle(&self) -> raw_window_handle::RawWindowHandle {
+    fn raw_window_handle(&self) -> RawWindowHandle {
         self.window.raw_window_handle()
+    }
+}
+
+unsafe impl HasRawDisplayHandle for Window {
+    /// Returns a [`raw_window_handle::RawDisplayHandle`] used by the [`EventLoop`] that
+    /// created a window.
+    ///
+    /// [`EventLoop`]: crate::event_loop::EventLoop
+    fn raw_display_handle(&self) -> RawDisplayHandle {
+        self.window.raw_display_handle()
     }
 }
 


### PR DESCRIPTION
This updates raw-window-handle to v0.5.0. The change is breaking
and removes the old `HasRawWindowHandle` trait implementation,
but that's intentional given that internal structs got renamed.
