### PR TITLE
Windows: apply skip taskbar state when taskbar is restarted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows, apply skip taskbar state when taskbar is restarted.
 - On Android, `ndk-glue`'s `NativeWindow` lock is now held between `Event::Resumed` and `Event::Suspended`.
 - On Web, added `EventLoopExtWebSys` with a `spawn` method to start the event loop without throwing an exception.
 - Added `WindowEvent::Occluded(bool)`, currently implemented on macOS and X11.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
-- On Windows, apply skip taskbar state when taskbar is restarted.
 - On Android, `ndk-glue`'s `NativeWindow` lock is now held between `Event::Resumed` and `Event::Suspended`.
 - On Web, added `EventLoopExtWebSys` with a `spawn` method to start the event loop without throwing an exception.
 - Added `WindowEvent::Occluded(bool)`, currently implemented on macOS and X11.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -613,7 +613,7 @@ pub static SET_RETAIN_STATE_ON_SIZE_MSG_ID: Lazy<u32> =
 static THREAD_EVENT_TARGET_WINDOW_CLASS: Lazy<Vec<u16>> =
     Lazy::new(|| util::encode_wide("Winit Thread Event Target"));
 /// When the taskbar is created, it registers a message with the "TaskbarCreated" string and then broadcasts this message to all top-level windows
-/// https://docs.microsoft.com/en-us/windows/win32/shell/taskbar#taskbar-creation-notification
+/// <https://docs.microsoft.com/en-us/windows/win32/shell/taskbar#taskbar-creation-notification>
 pub static TASKBAR_CREATED: Lazy<u32> =
     Lazy::new(|| unsafe { RegisterWindowMessageA("TaskbarCreated\0".as_ptr()) });
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -680,39 +680,8 @@ impl Window {
 
     #[inline]
     pub fn set_skip_taskbar(&self, skip: bool) {
-        com_initialized();
-        unsafe {
-            TASKBAR_LIST.with(|task_bar_list_ptr| {
-                let mut task_bar_list = task_bar_list_ptr.get();
-
-                if task_bar_list.is_null() {
-                    let hr = CoCreateInstance(
-                        &CLSID_TaskbarList,
-                        ptr::null_mut(),
-                        CLSCTX_ALL,
-                        &IID_ITaskbarList,
-                        &mut task_bar_list as *mut _ as *mut _,
-                    );
-
-                    let hr_init = (*(*task_bar_list).lpVtbl).HrInit;
-
-                    if hr != S_OK || hr_init(task_bar_list.cast()) != S_OK {
-                        // In some old windows, the taskbar object could not be created, we just ignore it
-                        return;
-                    }
-                    task_bar_list_ptr.set(task_bar_list)
-                }
-
-                task_bar_list = task_bar_list_ptr.get();
-                if skip {
-                    let delete_tab = (*(*task_bar_list).lpVtbl).DeleteTab;
-                    delete_tab(task_bar_list, self.window.0);
-                } else {
-                    let add_tab = (*(*task_bar_list).lpVtbl).AddTab;
-                    add_tab(task_bar_list, self.window.0);
-                }
-            });
-        }
+        self.window_state.lock().skip_taskbar = skip;
+        unsafe { set_skip_taskbar(self.hwnd(), skip) };
     }
 
     #[inline]
@@ -1097,6 +1066,40 @@ unsafe fn taskbar_mark_fullscreen(handle: HWND, fullscreen: bool) {
         let mark_fullscreen_window = (*(*task_bar_list2).lpVtbl).MarkFullscreenWindow;
         mark_fullscreen_window(task_bar_list2, handle, if fullscreen { 1 } else { 0 });
     })
+}
+
+pub(crate) unsafe fn set_skip_taskbar(hwnd: HWND, skip: bool) {
+    com_initialized();
+    TASKBAR_LIST.with(|task_bar_list_ptr| {
+        let mut task_bar_list = task_bar_list_ptr.get();
+
+        if task_bar_list.is_null() {
+            let hr = CoCreateInstance(
+                &CLSID_TaskbarList,
+                ptr::null_mut(),
+                CLSCTX_ALL,
+                &IID_ITaskbarList,
+                &mut task_bar_list as *mut _ as *mut _,
+            );
+
+            let hr_init = (*(*task_bar_list).lpVtbl).HrInit;
+
+            if hr != S_OK || hr_init(task_bar_list.cast()) != S_OK {
+                // In some old windows, the taskbar object could not be created, we just ignore it
+                return;
+            }
+            task_bar_list_ptr.set(task_bar_list)
+        }
+
+        task_bar_list = task_bar_list_ptr.get();
+        if skip {
+            let delete_tab = (*(*task_bar_list).lpVtbl).DeleteTab;
+            delete_tab(task_bar_list, hwnd);
+        } else {
+            let add_tab = (*(*task_bar_list).lpVtbl).AddTab;
+            add_tab(task_bar_list, hwnd);
+        }
+    });
 }
 
 unsafe fn force_window_active(handle: HWND) {

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -49,6 +49,8 @@ pub struct WindowState {
     // Used by WM_NCACTIVATE, WM_SETFOCUS and WM_KILLFOCUS
     pub is_active: bool,
     pub is_focused: bool,
+
+    pub skip_taskbar: bool,
 }
 
 #[derive(Clone)]
@@ -152,6 +154,8 @@ impl WindowState {
 
             is_active: false,
             is_focused: false,
+
+            skip_taskbar: false,
         }
     }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
