### PR TITLE
Bump sctk-adwaita to 0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ features = [
 wayland-client = { version = "0.29.4", default_features = false,  features = ["use_system_lib"], optional = true }
 wayland-protocols = { version = "0.29.4", features = [ "staging_protocols"], optional = true }
 sctk = { package = "smithay-client-toolkit", version = "0.16.0", default_features = false, features = ["calloop"],  optional = true }
-sctk-adwaita = { version = "0.4.0", optional = true }
+sctk-adwaita = { version = "0.4.1", optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -72,7 +72,7 @@ extern "C" fn dealloc(this: &Object, _: Sel) {
         let state_ptr: *mut c_void = *(this.get_ivar(AUX_DELEGATE_STATE_NAME));
         // As soon as the box is constructed it is immediately dropped, releasing the underlying
         // memory
-        Box::from_raw(state_ptr as *mut RefCell<AuxDelegateState>);
+        drop(Box::from_raw(state_ptr as *mut RefCell<AuxDelegateState>));
     }
 }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -210,7 +210,7 @@ impl<T> EventLoop<T> {
             // A bit of juggling with the callback references to make sure
             // that `self.callback` is the only owner of the callback.
             let weak_cb: Weak<_> = Rc::downgrade(&callback);
-            mem::drop(callback);
+            drop(callback);
 
             AppState::set_callback(weak_cb, Rc::clone(&self.window_target));
             let _: () = msg_send![app, run];

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -325,7 +325,7 @@ extern "C" fn dealloc(this: &Object, _sel: Sel) {
         let marked_text: id = *this.get_ivar("markedText");
         let _: () = msg_send![marked_text, release];
         let state: *mut c_void = *this.get_ivar("winitState");
-        Box::from_raw(state as *mut ViewState);
+        drop(Box::from_raw(state as *mut ViewState));
     }
 }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -241,7 +241,7 @@ fn with_state<F: FnOnce(&mut WindowDelegateState) -> T, T>(this: &Object, callba
 
 extern "C" fn dealloc(this: &Object, _sel: Sel) {
     with_state(this, |state| unsafe {
-        Box::from_raw(state as *mut WindowDelegateState);
+        drop(Box::from_raw(state as *mut WindowDelegateState));
     });
 }
 

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -80,7 +80,7 @@ impl FileDropHandler {
         let count = drop_handler.refcount.fetch_sub(1, Ordering::Release) - 1;
         if count == 0 {
             // Destroy the underlying data
-            Box::from_raw(drop_handler as *mut FileDropHandlerData);
+            drop(Box::from_raw(drop_handler as *mut FileDropHandlerData));
         }
         count as u32
     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -923,7 +923,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
     };
 
     if userdata_removed && recurse_depth == 0 {
-        Box::from_raw(userdata_ptr);
+        drop(Box::from_raw(userdata_ptr));
     }
 
     result
@@ -2154,7 +2154,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
                 if window_state.current_theme != new_theme {
                     window_state.current_theme = new_theme;
-                    mem::drop(window_state);
+                    drop(window_state);
                     userdata.send_event(Event::WindowEvent {
                         window_id: RootWindowId(WindowId(window)),
                         event: ThemeChanged(new_theme),
@@ -2413,7 +2413,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         .catch_unwind(callback)
         .unwrap_or(-1);
     if userdata_removed {
-        mem::drop(userdata);
+        drop(userdata);
     } else {
         Box::into_raw(userdata);
     }


### PR DESCRIPTION
This should force the use of system libraries for Fontconfig
and freetype instead of building them with cmake if missing.

Fixes #2373.