### PR TITLE
Add method to hook xlib error handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, add `with_prevent_default` and `with_focusable` to `WindowBuilderExtWebSys` to control whether events should be propagated.
 - On Windows, fix focus events being sent to inactive windows.
 - **Breaking**, update `raw-window-handle` to `v0.5` and implement `HasRawDisplayHandle` for `Window` and `EventLoopWindowTarget`.
+- On X11, add function `register_xlib_error_hook` into `winit::platform::unix` to subscribe for errors comming from Xlib.
 
 # 0.26.1 (2022-01-05)
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -19,7 +19,7 @@ use crate::{
 #[cfg(feature = "x11")]
 use crate::dpi::Size;
 #[cfg(feature = "x11")]
-use crate::platform_impl::x11::{ffi::XVisualInfo, XConnection};
+use crate::platform_impl::{x11::ffi::XVisualInfo, x11::XConnection, XLIB_ERROR_HOOKS};
 use crate::platform_impl::{
     ApplicationName, Backend, EventLoopWindowTarget as LinuxEventLoopWindowTarget,
     Window as LinuxWindow,
@@ -34,6 +34,29 @@ pub use crate::platform_impl::{x11::util::WindowType as XWindowType, XNotSupport
 
 #[cfg(feature = "wayland")]
 pub use crate::window::Theme;
+
+/// The first argument in the provided hook will be the pointer to XDisplay
+/// and the second one the pointer to XError. The return `bool` is an indicator
+/// whether error was handled by the callback.
+#[cfg(feature = "x11")]
+pub type XlibErrorHook =
+    Box<dyn Fn(*mut std::ffi::c_void, *mut std::ffi::c_void) -> bool + Send + Sync>;
+
+/// Hook to winit's xlib error handling callback.
+///
+/// This method is provided as a safe way to handle the errors comming from X11 when using xlib
+/// in external crates, like glutin for GLX access. Trying to handle errors by speculating with
+/// `XSetErrorHandler` is [`unsafe`].
+///
+/// [`unsafe`]: https://www.remlab.net/op/xlib.shtml
+#[inline]
+#[cfg(feature = "x11")]
+pub fn register_xlib_error_hook(hook: XlibErrorHook) {
+    // Append new hook.
+    unsafe {
+        XLIB_ERROR_HOOKS.lock().push(hook);
+    }
+}
 
 /// Additional methods on [`EventLoopWindowTarget`] that are specific to Unix.
 pub trait EventLoopWindowTargetExtUnix {


### PR DESCRIPTION
This should help glutin to handle errors coming from GLX
and provide multithreading access in a safe way.

Fixes #2378.
