### PR TITLE
Bump `ndk` and `ndk-glue` dependencies to stable `0.7.0` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Windows, fix focus events being sent to inactive windows.
 - **Breaking**, update `raw-window-handle` to `v0.5` and implement `HasRawDisplayHandle` for `Window` and `EventLoopWindowTarget`.
 - On X11, add function `register_xlib_error_hook` into `winit::platform::unix` to subscribe for errors comming from Xlib.
+- On Android, upgrade `ndk` and `ndk-glue` dependencies to the recently released `0.7.0`.
 
 # 0.26.1 (2022-01-05)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,8 +55,8 @@ simple_logger = "2.1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995
-ndk = { git = "https://github.com/rust-windowing/android-ndk-rs", rev = "814be08" }
-ndk-glue = { git = "https://github.com/rust-windowing/android-ndk-rs", rev = "814be08" }
+ndk = "0.7.0"
+ndk-glue = "0.7.0"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc = "0.2.7"

--- a/README.md
+++ b/README.md
@@ -101,16 +101,16 @@ book].
 
 This library makes use of the [ndk-rs](https://github.com/rust-windowing/android-ndk-rs) crates, refer to that repo for more documentation.
 
-The `ndk_glue` version needs to match the version used by `winit`. Otherwise, the application will not start correctly as `ndk_glue`'s internal NativeActivity static is not the same due to version mismatch.
+The `ndk-glue` version needs to match the version used by `winit`. Otherwise, the application will not start correctly as `ndk-glue`'s internal `NativeActivity` static is not the same due to version mismatch.
 
-`ndk_glue` <-> `winit` version comparison compatibility:
+`winit` compatibility table with `ndk-glue`:
 
-| winit |       ndk_glue       |
+| winit |       ndk-glue       |
 | :---: | :------------------: |
-| 0.24  | `ndk_glue = "0.2.0"` |
-| 0.25  | `ndk_glue = "0.3.0"` |
-| 0.26  | `ndk_glue = "0.5.0"` |
-| 0.27  | `ndk_glue = "0.6.0"` |
+| 0.24  | `ndk-glue = "0.2.0"` |
+| 0.25  | `ndk-glue = "0.3.0"` |
+| 0.26  | `ndk-glue = "0.5.0"` |
+| 0.27  | `ndk-glue = "0.7.0"` |
 
 Running on an Android device needs a dynamic system library, add this to Cargo.toml:
 


### PR DESCRIPTION
Closes #1995
