### PR TITLE
Windows: respect min/max sizes when creating the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows, respect min/max inner sizes when creating the window.
 - On Windows, fix hiding a maximized window.
 - On Android, `ndk-glue`'s `NativeWindow` lock is now held between `Event::Resumed` and `Event::Suspended`.
 - On Web, added `EventLoopExtWebSys` with a `spawn` method to start the event loop without throwing an exception.

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -511,6 +511,29 @@ impl Size {
             Size::Logical(size) => size.to_physical(scale_factor),
         }
     }
+
+    pub fn clamp<S: Into<Size>>(s1: S, s2: S, s3: S, scale_factor: f64) -> Size {
+        let (s1, s2, s3) = (
+            s1.into().to_physical::<f64>(scale_factor),
+            s2.into().to_physical::<f64>(scale_factor),
+            s3.into().to_physical::<f64>(scale_factor),
+        );
+
+        let clamp = |input: f64, min: f64, max: f64| {
+            if input < min {
+                min
+            } else if input > max {
+                max
+            } else {
+                input
+            }
+        };
+
+        let width = clamp(s1.width, s2.width, s3.width);
+        let height = clamp(s1.height, s2.height, s3.height);
+
+        PhysicalSize::new(width, height).into()
+    }
 }
 
 impl<P: Pixel> From<PhysicalSize<P>> for Size {

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -512,11 +512,11 @@ impl Size {
         }
     }
 
-    pub fn clamp<S: Into<Size>>(s1: S, s2: S, s3: S, scale_factor: f64) -> Size {
-        let (s1, s2, s3) = (
-            s1.into().to_physical::<f64>(scale_factor),
-            s2.into().to_physical::<f64>(scale_factor),
-            s3.into().to_physical::<f64>(scale_factor),
+    pub fn clamp<S: Into<Size>>(input: S, min: S, max: S, scale_factor: f64) -> Size {
+        let (input, min, max) = (
+            input.into().to_physical::<f64>(scale_factor),
+            min.into().to_physical::<f64>(scale_factor),
+            max.into().to_physical::<f64>(scale_factor),
         );
 
         let clamp = |input: f64, min: f64, max: f64| {
@@ -529,8 +529,8 @@ impl Size {
             }
         };
 
-        let width = clamp(s1.width, s2.width, s3.width);
-        let height = clamp(s1.height, s2.height, s3.height);
+        let width = clamp(input.width, min.width, max.width);
+        let height = clamp(input.height, min.height, max.height);
 
         PhysicalSize::new(width, height).into()
     }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -879,10 +879,17 @@ impl<'a, T: 'static> InitData<'a, T> {
             win.set_fullscreen(attributes.fullscreen);
             force_window_active(win.window.0);
         } else {
-            let dimensions = attributes
+            let size = attributes
                 .inner_size
                 .unwrap_or_else(|| PhysicalSize::new(800, 600).into());
-            win.set_inner_size(dimensions);
+            let max_size = attributes
+                .max_inner_size
+                .unwrap_or_else(|| PhysicalSize::new(f64::MAX, f64::MAX).into());
+            let min_size = attributes
+                .max_inner_size
+                .unwrap_or_else(|| PhysicalSize::new(0, 0).into());
+            let clamped_size = Size::clamp(size, min_size, max_size, win.scale_factor());
+            win.set_inner_size(clamped_size);
 
             if attributes.maximized {
                 // Need to set MAXIMIZED after setting `inner_size` as

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -886,7 +886,7 @@ impl<'a, T: 'static> InitData<'a, T> {
                 .max_inner_size
                 .unwrap_or_else(|| PhysicalSize::new(f64::MAX, f64::MAX).into());
             let min_size = attributes
-                .max_inner_size
+                .min_inner_size
                 .unwrap_or_else(|| PhysicalSize::new(0, 0).into());
             let clamped_size = Size::clamp(size, min_size, max_size, win.scale_factor());
             win.set_inner_size(clamped_size);


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
