### PR TITLE
Pen and pressure support for Windows and Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Added support for digital pen information in `WindowEvent::Touch`.
+- On Windows and Android, implemented digital pen information.
+- On Android, implemented touch pressure.
 - On Windows, fix hiding a maximized window.
 - On Android, `ndk-glue`'s `NativeWindow` lock is now held between `Event::Resumed` and `Event::Suspended`.
 - On Web, added `EventLoopExtWebSys` with a `spawn` method to start the event loop without throwing an exception.
@@ -206,7 +209,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On macOS, fix inverted horizontal scroll.
 - **Breaking:** `current_monitor` now returns `Option<MonitorHandle>`.
 - **Breaking:** `primary_monitor` now returns `Option<MonitorHandle>`.
-- On macOS, updated core-* dependencies and cocoa.
+- On macOS, updated core-\* dependencies and cocoa.
 - Bump `parking_lot` to 0.11
 - On Android, bump `ndk`, `ndk-sys` and `ndk-glue` to 0.2. Checkout the new ndk-glue main proc attribute.
 - On iOS, fixed starting the app in landscape where the view still had portrait dimensions.
@@ -248,7 +251,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Windows, fix `WindowBuilder::with_maximized` being ignored.
 - On Android, minimal platform support.
 - On iOS, touch positions are now properly converted to physical pixels.
-- On macOS, updated core-* dependencies and cocoa
+- On macOS, updated core-\* dependencies and cocoa
 
 # 0.22.1 (2020-04-16)
 
@@ -435,7 +438,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - On X11, non-resizable windows now have maximize explicitly disabled.
 - On Windows, support paths longer than MAX_PATH (260 characters) in `WindowEvent::DroppedFile`
-and `WindowEvent::HoveredFile`.
+  and `WindowEvent::HoveredFile`.
 - On Mac, implement `DeviceEvent::Button`.
 - Change `Event::Suspended(true / false)` to `Event::Suspended` and `Event::Resumed`.
 - On X11, fix sanity check which checks that a monitor's reported width and height (in millimeters) are non-zero when calculating the DPI factor.
@@ -777,20 +780,20 @@ _Yanked_
 - Added event `WindowEvent::HiDPIFactorChanged`.
 - Added method `MonitorId::get_hidpi_factor`.
 - Deprecated `get_inner_size_pixels` and `get_inner_size_points` methods of `Window` in favor of
-`get_inner_size`.
+  `get_inner_size`.
 - **Breaking:** `EventsLoop` is `!Send` and `!Sync` because of platform-dependant constraints,
   but `Window`, `WindowId`, `DeviceId` and `MonitorId` guaranteed to be `Send`.
 - `MonitorId::get_position` now returns `(i32, i32)` instead of `(u32, u32)`.
 - Rewrite of the wayland backend to use wayland-client-0.11
 - Support for dead keys on wayland for keyboard utf8 input
 - Monitor enumeration on Windows is now implemented using `EnumDisplayMonitors` instead of
-`EnumDisplayDevices`. This changes the value returned by `MonitorId::get_name()`.
+  `EnumDisplayDevices`. This changes the value returned by `MonitorId::get_name()`.
 - On Windows added `MonitorIdExt::hmonitor` method
 - Impl `Clone` for `EventsLoopProxy`
 - `EventsLoop::get_primary_monitor()` on X11 will fallback to any available monitor if no primary is found
 - Support for touch event on wayland
 - `WindowEvent`s `MouseMoved`, `MouseEntered`, and `MouseLeft` have been renamed to
-`CursorMoved`, `CursorEntered`, and `CursorLeft`.
+  `CursorMoved`, `CursorEntered`, and `CursorLeft`.
 - New `DeviceEvent`s added, `MouseMotion` and `MouseWheel`.
 - Send `CursorMoved` event after `CursorEntered` and `Focused` events.
 - Add support for `ModifiersState`, `MouseMove`, `MouseInput`, `MouseMotion` for emscripten backend.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -204,7 +204,8 @@ Legend:
 |Cursor icon             |✔️       |✔️      |✔️       |✔️           |**N/A**|**N/A**|✔️        |
 |Cursor hittest          |✔️       |✔️      |❌       |✔️           |**N/A**|**N/A**|❌        |
 |Touch events            |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |
-|Touch pressure          |✔️       |❌      |❌       |❌          |❌    |✔️     |❌        |
+|Touch pressure          |✔️       |❌      |❌       |❌          |✔️    |✔️     |❌        |
+|Pen information         |✔️       |❌      |❌       |❌          |✔️    |❌     |❓        |
 |Multitouch              |✔️       |❌      |✔️       |✔️          |✔️    |✔️     |❌        |
 |Keyboard events         |✔️       |✔️      |✔️       |✔️          |❓     |❌     |✔️        |
 |Drag & Drop             |▢[#720]  |▢[#720] |▢[#720]  |❌[#306]    |**N/A**|**N/A**|❓        |

--- a/src/event.rs
+++ b/src/event.rs
@@ -765,10 +765,35 @@ pub struct Touch {
     ///
     /// ## Platform-specific
     ///
-    /// - Only available on **iOS** 9.0+ and **Windows** 8+.
+    /// - Only available on **iOS** 9.0+, **Android** and **Windows** 8+.
     pub force: Option<Force>,
+    /// Describes an press with a digital pen. Is `None` if the Touch event was not triggered
+    /// by a digital pen
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Only available on **Android** and **Windows** 8+.
+    pub pen_state: Option<PenState>,
     /// Unique identifier of a finger.
     pub id: u64,
+}
+
+/// Describes the physical state of a digital pen
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PenState {
+    /// The clockwise rotation of the pointer normalized in a range of 0 to 359.
+    /// Defaults to 0 if not available on platform.
+    pub rotation: f64,
+    /// The angle of tilt of the pointer in a range of -90 to +90 for each axis,
+    /// with a positive value indicating a tilt to the right or towards the user.
+    /// Defaults to (0, 0) if not available on platform.
+    pub tilt: (f64, f64),
+    /// The barrel button is pressed.
+    pub barrel: bool,
+    /// The pen is inverted.
+    pub inverted: bool,
+    /// The eraser button is pressed.
+    pub eraser: bool,
 }
 
 /// Describes the force of a touch event

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -273,6 +273,7 @@ unsafe fn get_view_class(root_view_class: &'static Class) -> &'static Class {
                             location: physical_location,
                             force,
                             phase,
+                            pen_state: None,
                         }),
                     }));
                 }

--- a/src/platform_impl/linux/wayland/seat/touch/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/touch/handlers.rs
@@ -38,6 +38,7 @@ pub(super) fn handle_touch(
                     )),
                     phase: TouchPhase::Started,
                     location: position.to_physical(scale_factor),
+                    pen_state: None,
                     force: None, // TODO
                     id: id as u64,
                 }),
@@ -71,6 +72,7 @@ pub(super) fn handle_touch(
                     )),
                     phase: TouchPhase::Ended,
                     location,
+                    pen_state: None,
                     force: None, // TODO
                     id: id as u64,
                 }),
@@ -96,6 +98,7 @@ pub(super) fn handle_touch(
                     )),
                     phase: TouchPhase::Moved,
                     location,
+                    pen_state: None,
                     force: None, // TODO
                     id: id as u64,
                 }),
@@ -116,6 +119,7 @@ pub(super) fn handle_touch(
                         )),
                         phase: TouchPhase::Cancelled,
                         location,
+                        pen_state: None,
                         force: None, // TODO
                         id: touch_point.id as u64,
                     }),

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1032,6 +1032,7 @@ impl<T: 'static> EventProcessor<T> {
                                     phase,
                                     location,
                                     force: None, // TODO
+                                    pen_state: None,
                                     id,
                                 }),
                             })


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

### About the TODO for getToolType:

My PR for the ndk repo [#323](https://github.com/rust-windowing/android-ndk-rs/pull/323) needs to go through before this can be implemented.
Using the event source worked reliably on my devices so this workaround should be good for now.

This relates to #99 