### PR TITLE
ci: manually point ANDROID_NDK_ROOT to latest supplied version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,11 @@ jobs:
         targets: ${{ matrix.platform.target }}
         components: clippy
 
+    - name: Setup NDK path
+      shell: bash
+      # "Temporary" workaround until https://github.com/actions/virtual-environments/issues/5879#issuecomment-1195156618
+      # gets looked into.
+      run: echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
     - name: Install Linux dependencies
       if: (matrix.platform.os == 'ubuntu-latest')
       run: sudo apt-get update && sudo apt-get install pkg-config cmake libfreetype6-dev libfontconfig1-dev


### PR DESCRIPTION
It seems the symlink to `ndk-bundle` and this environment variable pointing to it have been removed to prevent the sdkmanager from failing, when finding the SDK setup to be in an "indeterminate" state.  It is now up to the users themselves to install an NDK through that tool or point the right variables to a preinstalled "latest" NDK.

https://github.com/actions/virtual-environments/issues/2689
https://github.com/actions/virtual-environments/issues/5879
https://github.com/actions/virtual-environments/pull/5926

---

Draft because I'm still waiting for confirmation that the removal of this env var is intended, instead of just pointing it to the latest LTS release _without going through a symlink_ to match previous behaviour.
