### PR TITLE
Explicitly specify minimum supported rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [stable, nightly]
+        rust_version: [1.57.0, stable, nightly]
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
@@ -103,7 +103,7 @@ jobs:
 
     - name: Lint with clippy
       shell: bash
-      if: (matrix.rust_version != 'nightly') && !contains(matrix.platform.options, '--no-default-features')
+      if: (matrix.rust_version == '1.57.0') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
 
     - name: Build with serde enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- The minimum supported Rust version was lowered to `1.57.0` and now explicitly tested.
+
 # 0.27.0 (2022-07-26)
 
 - On Windows, fix hiding a maximized window.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ your description of the issue as detailed as possible:
 
 When making a code contribution to winit, before opening your pull request, please make sure that:
 
+- your patch builds with Winit's minimal supported rust version - Rust 1.57.0.
 - you tested your modifications on all the platforms impacted, or if not possible detail which platforms
   were not tested, and what should be tested, so that a maintainer or another contributor can test them
 - you updated any relevant documentation in winit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 repository = "https://github.com/rust-windowing/winit"
 documentation = "https://docs.rs/winit"
 categories = ["gui"]
+rust-version = "1.57.0"
 
 [package.metadata.docs.rs]
 features = ["serde"]

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -59,12 +59,12 @@ fn main() {
                     }
                     VirtualKeyCode::F => {
                         let fullscreen = Some(Fullscreen::Exclusive(mode.clone()));
-                        println!("Setting mode: {fullscreen:?}");
+                        println!("Setting mode: {:?}", fullscreen);
                         window.set_fullscreen(fullscreen);
                     }
                     VirtualKeyCode::B => {
                         let fullscreen = Some(Fullscreen::Borderless(Some(monitor.clone())));
-                        println!("Setting mode: {fullscreen:?}");
+                        println!("Setting mode: {:?}", fullscreen);
                         window.set_fullscreen(fullscreen);
                     }
                     VirtualKeyCode::S => {

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -299,10 +299,11 @@ impl WindowExtUnix for Window {
     #[inline]
     #[cfg(feature = "wayland")]
     fn wayland_set_csd_theme(&self, theme: Theme) {
+        #[allow(clippy::single_match)]
         match self.window {
             LinuxWindow::Wayland(ref w) => w.set_csd_theme(theme),
             #[cfg(feature = "x11")]
-            _ => {}
+            _ => (),
         }
     }
 

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -793,7 +793,7 @@ pub unsafe fn handle_main_events_cleared() {
         return;
     }
     match this.state_mut() {
-        &mut AppStateImpl::ProcessingEvents { .. } => {}
+        AppStateImpl::ProcessingEvents { .. } => {}
         _ => bug!("`ProcessingRedraws` happened unexpectedly"),
     };
     drop(this);


### PR DESCRIPTION
This should help with distributing apps using winit.

Fixes #1075.

--

Will require a patch bump afterwards unfortunately.