### PR TITLE
Add Windows opt-in function for device events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - On Windows, respect min/max inner sizes when creating the window.
+- **Breaking:** On Windows, device events are now ignored for unfocused windows by default, use `EventLoopWindowTarget::set_device_event_filter` to set the filter level.
 
 # 0.27.1 (2022-07-30)
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -323,7 +323,7 @@ impl<T> EventLoopWindowTarget<T> {
     ///
     /// ## Platform-specific
     ///
-    /// - **Wayland / Windows / macOS / iOS / Android / Web:** Unsupported.
+    /// - **Wayland / macOS / iOS / Android / Web:** Unsupported.
     ///
     /// [`DeviceEvent`]: crate::event::DeviceEvent
     pub fn set_device_event_filter(&self, _filter: DeviceEventFilter) {
@@ -332,7 +332,8 @@ impl<T> EventLoopWindowTarget<T> {
             target_os = "dragonfly",
             target_os = "freebsd",
             target_os = "netbsd",
-            target_os = "openbsd"
+            target_os = "openbsd",
+            target_os = "windows"
         ))]
         self.p.set_device_event_filter(_filter);
     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -77,7 +77,9 @@ use windows_sys::Win32::{
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{DeviceEvent, Event, Force, Ime, KeyboardInput, Touch, TouchPhase, WindowEvent},
-    event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootELW},
+    event_loop::{
+        ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
+    },
     monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         dark_mode::try_theme,
@@ -207,7 +209,10 @@ impl<T: 'static> EventLoop<T> {
 
         let thread_msg_sender =
             insert_event_target_window_data::<T>(thread_msg_target, runner_shared.clone());
-        raw_input::register_all_mice_and_keyboards_for_raw_input(thread_msg_target);
+        raw_input::register_all_mice_and_keyboards_for_raw_input(
+            thread_msg_target,
+            Default::default(),
+        );
 
         EventLoop {
             thread_msg_sender,
@@ -321,6 +326,10 @@ impl<T> EventLoopWindowTarget<T> {
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::Windows(WindowsDisplayHandle::empty())
+    }
+
+    pub fn set_device_event_filter(&self, filter: DeviceEventFilter) {
+        raw_input::register_all_mice_and_keyboards_for_raw_input(self.thread_msg_target, filter);
     }
 }
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
   - [ ] Windows <8.1
   - [ ] Windows 8.1
   - [ ] Windows 10 (<21H2)
   - [x] Windows 10 (21H2)
   - [ ] Windows 11
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality (N/A - already included in `window_debug.rs`)
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented (N/A)

Addresses (#1634) on Windows.

An attempt at doing for Windows what #2195 did for X11. Device events are by default only listened to on the focused window and need to be manually opted into via `EventLoop::set_device_event_filter`.

This appears to work in a very simple test application on Windows 10 21H2. I didn't see a list of supported Windows versions, in any case I'm not able to test other ones.