### PR TITLE
x11: Fix size hints being reset after a DPI change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On X11, fix min, max and resize increment hints not persisting for resizable windows (e.g. on DPI change).
 - On Windows, respect min/max inner sizes when creating the window.
 
 # 0.27.1 (2022-07-30)

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -371,14 +371,14 @@ impl UnownedWindow {
                     } else {
                         max_inner_size = Some(dimensions.into());
                         min_inner_size = Some(dimensions.into());
-
-                        let mut shared_state = window.shared_state.get_mut();
-                        shared_state.min_inner_size = window_attrs.min_inner_size;
-                        shared_state.max_inner_size = window_attrs.max_inner_size;
-                        shared_state.resize_increments = pl_attribs.resize_increments;
-                        shared_state.base_size = pl_attribs.base_size;
                     }
                 }
+
+                let mut shared_state = window.shared_state.get_mut();
+                shared_state.min_inner_size = min_inner_size.map(Into::into);
+                shared_state.max_inner_size = max_inner_size.map(Into::into);
+                shared_state.resize_increments = pl_attribs.resize_increments;
+                shared_state.base_size = pl_attribs.base_size;
 
                 let mut normal_hints = util::NormalHints::new(xconn);
                 normal_hints.set_position(position.map(|PhysicalPosition { x, y }| (x, y)));


### PR DESCRIPTION
I actually wanted to start working on #2020 almost a year after I created it, but in the process found this bug that when you move the window to another screen resize increments go poof

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
