### PR TITLE
Allow changing resize increments after window creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.
+- Added `Window::resize_increments`/`Window::set_resize_increments` to update resize increments at runtime for X11/macOS.
 - macOS/iOS: Use `objc2` instead of `objc` internally.
 - **Breaking:** Bump MSRV from `1.57` to `1.60`.
 - **Breaking:** Split the `platform::unix` module into `platform::x11` and `platform::wayland`. The extension types are similarly renamed.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -177,7 +177,7 @@ Legend:
 |Window decorations               |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
 |Window decorations toggle        |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
 |Window resizing                  |✔️     |▢[#219]|✔️         |▢[#306]        |**N/A**|**N/A**|✔️        |
-|Window resize increments         |❌     |❌     |❌         |❌             |❌    |❌     |**N/A**|
+|Window resize increments         |❌     |✔️     |✔️         |❌             |**N/A**|**N/A**|**N/A**|
 |Window transparency              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|N/A        |
 |Window maximization              |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|
 |Window maximization toggle       |✔️     |✔️     |✔️         |✔️             |**N/A**|**N/A**|**N/A**|

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -1,0 +1,57 @@
+use log::debug;
+use simple_logger::SimpleLogger;
+use winit::{
+    dpi::LogicalSize,
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event_loop::EventLoop,
+    window::WindowBuilder,
+};
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_inner_size(LogicalSize::new(128.0, 128.0))
+        .with_resize_increments(LogicalSize::new(25.0, 25.0))
+        .build(&event_loop)
+        .unwrap();
+
+    let mut has_increments = true;
+
+    event_loop.run(move |event, _, control_flow| {
+        control_flow.set_wait();
+
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => control_flow.set_exit(),
+            Event::WindowEvent {
+                event:
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                virtual_keycode: Some(VirtualKeyCode::Space),
+                                state: ElementState::Released,
+                                ..
+                            },
+                        ..
+                    },
+                window_id,
+            } if window_id == window.id() => {
+                has_increments = !has_increments;
+
+                let new_increments = match window.resize_increments() {
+                    Some(_) => None,
+                    None => Some(LogicalSize::new(25.0, 25.0)),
+                };
+                debug!("Had increments: {}", new_increments.is_none());
+                window.set_resize_increments(new_increments);
+            }
+            Event::MainEventsCleared => window.request_redraw(),
+            _ => (),
+        }
+    });
+}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,7 +1,6 @@
 use std::os::raw::c_void;
 
 use crate::{
-    dpi::LogicalSize,
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
@@ -109,8 +108,6 @@ pub trait WindowBuilderExtMacOS {
     fn with_titlebar_buttons_hidden(self, titlebar_buttons_hidden: bool) -> WindowBuilder;
     /// Makes the window content appear behind the titlebar.
     fn with_fullsize_content_view(self, fullsize_content_view: bool) -> WindowBuilder;
-    /// Build window with `resizeIncrements` property. Values must not be 0.
-    fn with_resize_increments(self, increments: LogicalSize<f64>) -> WindowBuilder;
     fn with_disallow_hidpi(self, disallow_hidpi: bool) -> WindowBuilder;
     fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
 }
@@ -152,12 +149,6 @@ impl WindowBuilderExtMacOS for WindowBuilder {
     #[inline]
     fn with_fullsize_content_view(mut self, fullsize_content_view: bool) -> WindowBuilder {
         self.platform_specific.fullsize_content_view = fullsize_content_view;
-        self
-    }
-
-    #[inline]
-    fn with_resize_increments(mut self, increments: LogicalSize<f64>) -> WindowBuilder {
-        self.platform_specific.resize_increments = Some(increments);
         self
     }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -190,20 +190,6 @@ pub trait WindowBuilderExtX11 {
     /// Build window with `_GTK_THEME_VARIANT` hint set to the specified value. Currently only relevant on X11.
     fn with_gtk_theme_variant(self, variant: String) -> Self;
 
-    /// Build window with resize increment hint. Only implemented on X11.
-    ///
-    /// ```
-    /// # use winit::dpi::{LogicalSize, PhysicalSize};
-    /// # use winit::window::WindowBuilder;
-    /// # use winit::platform::x11::WindowBuilderExtX11;
-    /// // Specify the size in logical dimensions like this:
-    /// WindowBuilder::new().with_resize_increments(LogicalSize::new(400.0, 200.0));
-    ///
-    /// // Or specify the size in physical dimensions like this:
-    /// WindowBuilder::new().with_resize_increments(PhysicalSize::new(400, 200));
-    /// ```
-    fn with_resize_increments<S: Into<Size>>(self, increments: S) -> Self;
-
     /// Build window with base size hint. Only implemented on X11.
     ///
     /// ```
@@ -256,12 +242,6 @@ impl WindowBuilderExtX11 for WindowBuilder {
     #[inline]
     fn with_gtk_theme_variant(mut self, variant: String) -> Self {
         self.platform_specific.gtk_theme_variant = Some(variant);
-        self
-    }
-
-    #[inline]
-    fn with_resize_increments<S: Into<Size>>(mut self, increments: S) -> Self {
-        self.platform_specific.resize_increments = Some(increments.into());
         self
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -757,6 +757,12 @@ impl Window {
 
     pub fn set_max_inner_size(&self, _: Option<Size>) {}
 
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        None
+    }
+
+    pub fn set_resize_increments(&self, _increments: Option<Size>) {}
+
     pub fn set_title(&self, _title: &str) {}
 
     pub fn set_visible(&self, _visibility: bool) {}

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -154,6 +154,15 @@ impl Inner {
         warn!("`Window::set_max_inner_size` is ignored on iOS")
     }
 
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        None
+    }
+
+    #[inline]
+    pub fn set_resize_increments(&self, _increments: Option<Size>) {
+        warn!("`Window::set_resize_increments` is ignored on iOS")
+    }
+
     pub fn set_resizable(&self, _resizable: bool) {
         warn!("`Window::set_resizable` is ignored on iOS")
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -95,8 +95,6 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     #[cfg(feature = "x11")]
     pub screen_id: Option<i32>,
     #[cfg(feature = "x11")]
-    pub resize_increments: Option<Size>,
-    #[cfg(feature = "x11")]
     pub base_size: Option<Size>,
     #[cfg(feature = "x11")]
     pub override_redirect: bool,
@@ -116,8 +114,6 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             visual_infos: None,
             #[cfg(feature = "x11")]
             screen_id: None,
-            #[cfg(feature = "x11")]
-            resize_increments: None,
             #[cfg(feature = "x11")]
             base_size: None,
             #[cfg(feature = "x11")]
@@ -389,6 +385,16 @@ impl Window {
     #[inline]
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
         x11_or_wayland!(match self; Window(w) => w.set_max_inner_size(dimensions))
+    }
+
+    #[inline]
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        x11_or_wayland!(match self; Window(w) => w.resize_increments())
+    }
+
+    #[inline]
+    pub fn set_resize_increments(&self, increments: Option<Size>) {
+        x11_or_wayland!(match self; Window(w) => w.set_resize_increments(increments))
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -405,6 +405,16 @@ impl Window {
     }
 
     #[inline]
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        None
+    }
+
+    #[inline]
+    pub fn set_resize_increments(&self, _increments: Option<Size>) {
+        warn!("`set_resize_increments` is not implemented for Wayland");
+    }
+
+    #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         self.resizeable.store(resizable, Ordering::Relaxed);
         self.send_request(WindowRequest::Resizeable(resizable));

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -197,11 +197,17 @@ impl<'a> NormalHints<'a> {
     }
 
     pub fn get_position(&self) -> Option<(i32, i32)> {
-        if has_flag(self.size_hints.flags, ffi::PPosition) {
-            Some((self.size_hints.x as i32, self.size_hints.y as i32))
-        } else {
-            None
-        }
+        has_flag(self.size_hints.flags, ffi::PPosition)
+            .then(|| (self.size_hints.x as i32, self.size_hints.y as i32))
+    }
+
+    pub fn get_resize_increments(&self) -> Option<(u32, u32)> {
+        has_flag(self.size_hints.flags, ffi::PResizeInc).then(|| {
+            (
+                self.size_hints.width_inc as u32,
+                self.size_hints.height_inc as u32,
+            )
+        })
     }
 
     pub fn set_position(&mut self, position: Option<(i32, i32)>) {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -378,7 +378,7 @@ impl UnownedWindow {
                 let mut shared_state = window.shared_state.get_mut().unwrap();
                 shared_state.min_inner_size = min_inner_size.map(Into::into);
                 shared_state.max_inner_size = max_inner_size.map(Into::into);
-                shared_state.resize_increments = pl_attribs.resize_increments;
+                shared_state.resize_increments = window_attrs.resize_increments;
                 shared_state.base_size = pl_attribs.base_size;
 
                 let mut normal_hints = util::NormalHints::new(xconn);
@@ -387,7 +387,7 @@ impl UnownedWindow {
                 normal_hints.set_min_size(min_inner_size.map(Into::into));
                 normal_hints.set_max_size(max_inner_size.map(Into::into));
                 normal_hints.set_resize_increments(
-                    pl_attribs
+                    window_attrs
                         .resize_increments
                         .map(|size| size.to_physical::<u32>(scale_factor).into()),
                 );
@@ -1170,6 +1170,24 @@ impl UnownedWindow {
         let physical_dimensions =
             dimensions.map(|dimensions| dimensions.to_physical::<u32>(self.scale_factor()).into());
         self.set_max_inner_size_physical(physical_dimensions);
+    }
+
+    #[inline]
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        self.xconn
+            .get_normal_hints(self.xwindow)
+            .ok()
+            .and_then(|hints| hints.get_resize_increments())
+            .map(Into::into)
+    }
+
+    #[inline]
+    pub fn set_resize_increments(&self, increments: Option<Size>) {
+        self.shared_state_lock().resize_increments = increments;
+        let physical_increments =
+            increments.map(|increments| increments.to_physical::<u32>(self.scale_factor()).into());
+        self.update_normal_hints(|hints| hints.set_resize_increments(physical_increments))
+            .expect("Failed to call `XSetWMNormalHints`");
     }
 
     pub(crate) fn adjust_for_dpi(

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -242,10 +242,14 @@ fn create_window(
             }
 
             if let Some(increments) = pl_attrs.resize_increments {
-                let (x, y) = (increments.width, increments.height);
-                if x >= 1.0 && y >= 1.0 {
-                    let size = NSSize::new(x as CGFloat, y as CGFloat);
-                    ns_window.setResizeIncrements_(size);
+                let (w, h) = (increments.width, increments.height);
+                if w >= 1.0 && h >= 1.0 {
+                    let size = NSSize::new(w as CGFloat, h as CGFloat);
+                    // It was concluded (#2411) that there is never a use-case for
+                    // "outer" resize increments, hence we set "inner" ones here.
+                    // ("outer" in macOS being just resizeIncrements, and "inner" - contentResizeIncrements)
+                    // This is consistent with X11 size hints behavior
+                    ns_window.setContentResizeIncrements_(size);
                 }
             }
 
@@ -587,6 +591,28 @@ impl UnownedWindow {
             }));
             let scale_factor = self.scale_factor();
             set_max_inner_size(*self.ns_window, dimensions.to_logical(scale_factor));
+        }
+    }
+
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        let increments = unsafe { self.ns_window.contentResizeIncrements() };
+        let (x, y) = (increments.width, increments.height);
+        if x > 1.0 || y > 1.0 {
+            Some(LogicalSize::new(x, y).to_physical(self.scale_factor()))
+        } else {
+            None
+        }
+    }
+
+    pub fn set_resize_increments(&self, increments: Option<Size>) {
+        let size = increments
+            .map(|increments| {
+                let logical = increments.to_logical::<f64>(self.scale_factor());
+                NSSize::new(logical.width.max(1.0), logical.height.max(1.0))
+            })
+            .unwrap_or_else(|| NSSize::new(1.0, 1.0));
+        unsafe {
+            self.ns_window.setContentResizeIncrements_(size);
         }
     }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -154,6 +154,16 @@ impl Window {
     }
 
     #[inline]
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        None
+    }
+
+    #[inline]
+    pub fn set_resize_increments(&self, _increments: Option<Size>) {
+        // Intentionally a no-op: users can't resize canvas elements
+    }
+
+    #[inline]
     pub fn set_resizable(&self, _resizable: bool) {
         // Intentionally a no-op: users can't resize canvas elements
     }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -236,6 +236,14 @@ impl Window {
     }
 
     #[inline]
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        None
+    }
+
+    #[inline]
+    pub fn set_resize_increments(&self, _increments: Option<Size>) {}
+
+    #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         let window = self.window.clone();
         let window_state = Arc::clone(&self.window_state);

--- a/src/window.rs
+++ b/src/window.rs
@@ -134,6 +134,7 @@ pub(crate) struct WindowAttributes {
     pub decorations: bool,
     pub always_on_top: bool,
     pub window_icon: Option<Icon>,
+    pub resize_increments: Option<Size>,
 }
 
 impl Default for WindowAttributes {
@@ -153,6 +154,7 @@ impl Default for WindowAttributes {
             decorations: true,
             always_on_top: false,
             window_icon: None,
+            resize_increments: None,
         }
     }
 }
@@ -330,6 +332,17 @@ impl WindowBuilder {
     #[inline]
     pub fn with_window_icon(mut self, window_icon: Option<Icon>) -> Self {
         self.window.window_icon = window_icon;
+        self
+    }
+
+    /// Build window with resize increments hint.
+    ///
+    /// The default is `None`.
+    ///
+    /// See [`Window::set_resize_increments`] for details.
+    #[inline]
+    pub fn with_resize_increments<S: Into<Size>>(mut self, resize_increments: S) -> Self {
+        self.window.resize_increments = Some(resize_increments.into());
         self
     }
 
@@ -603,6 +616,32 @@ impl Window {
     #[inline]
     pub fn set_max_inner_size<S: Into<Size>>(&self, max_size: Option<S>) {
         self.window.set_max_inner_size(max_size.map(|s| s.into()))
+    }
+
+    /// Returns window resize increments if any were set.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / Wayland / Windows:** Always returns [`None`].
+    #[inline]
+    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        self.window.resize_increments()
+    }
+
+    /// Sets window resize increments.
+    ///
+    /// This is a niche constraint hint usually employed by terminal emulators
+    /// and other apps that need "blocky" resizes.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** Increments are converted to logical size and then macOS rounds them to whole numbers.
+    /// - **Wayland / Windows:** Not implemented.
+    /// - **iOS / Android / Web:** Unsupported.
+    #[inline]
+    pub fn set_resize_increments<S: Into<Size>>(&self, increments: Option<S>) {
+        self.window
+            .set_resize_increments(increments.map(Into::into))
     }
 }
 


### PR DESCRIPTION
Pretty basic "I hope it works" implementation, only tested on X11, can test on a mac in a few days.

Once this is reviewed->merged->released I hope to finally make Alacritty _not suck_, heh

~The branch is based on the #2410 because I kept moving the test window to the other screen, I'll rebase once it's merged,~ done

~Currently this is a draft to run your CI and to get reviews.~ should be ready

Closes #2020

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
