### PR TITLE
Note the platform versions that `winit` supports

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,10 +1,10 @@
 # Winit Scope
 
 Winit aims to expose an interface that abstracts over window creation and input handling, and can
-be used to create both games and applications. It supports the main graphical platforms:
+be used to create both games and applications. It supports the following main graphical platforms:
 - Desktop
-  - Windows
-  - macOS
+  - Windows 7+ (10+ is tested regularly)
+  - macOS 10.7+ (10.14+ is tested regularly)
   - Unix
     - via X11
     - via Wayland


### PR DESCRIPTION
Currently only macOS and Windows, since I somewhat know how versioning works there. Missing iOS and Android! Would it make sense to do a similar thing for Wayland and X11?

I think we should do something similar for WASM, but unsure how, maybe it should be as verbose as specifying each browser an the version that it is expected to work on?

Spawned by https://github.com/rust-windowing/winit/pull/2409#issuecomment-1207266938.