### PR TITLE
On Wayland, fix `Window::request_redraw` being delayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Windows, respect min/max inner sizes when creating the window.
 - For backwards compatibility, `Window` now (additionally) implements the old version (`0.4`) of the `HasRawWindowHandle` trait
 - On Windows, added support for `EventLoopWindowTarget::set_device_event_filter`.
+- On Wayland, fix user requested `WindowEvent::RedrawRequested` being delayed by a frame.
 
 # 0.27.1 (2022-07-30)
 

--- a/src/platform_impl/linux/wayland/event_loop/state.rs
+++ b/src/platform_impl/linux/wayland/event_loop/state.rs
@@ -3,7 +3,9 @@
 use std::collections::HashMap;
 
 use super::EventSink;
-use crate::platform_impl::wayland::window::shim::{WindowHandle, WindowUpdate};
+use crate::platform_impl::wayland::window::shim::{
+    WindowCompositorUpdate, WindowHandle, WindowUserRequest,
+};
 use crate::platform_impl::wayland::WindowId;
 
 /// Wrapper to carry winit's state.
@@ -12,10 +14,14 @@ pub struct WinitState {
     /// event loop and forwarded downstream afterwards.
     pub event_sink: EventSink,
 
+    /// Window updates comming from the user requests. Those are separatelly dispatched right after
+    /// `MainEventsCleared`.
+    pub window_user_requests: HashMap<WindowId, WindowUserRequest>,
+
     /// Window updates, which are coming from SCTK or the compositor, which require
     /// calling back to the winit's downstream. They are handled right in the event loop,
     /// unlike the ones coming from buffers on the `WindowHandle`'s.
-    pub window_updates: HashMap<WindowId, WindowUpdate>,
+    pub window_compositor_updates: HashMap<WindowId, WindowCompositorUpdate>,
 
     /// Window map containing all SCTK windows. Since those windows aren't allowed
     /// to be sent to other threads, they live on the event loop's thread

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -30,7 +30,7 @@ use super::{EventLoopWindowTarget, WindowId};
 
 pub mod shim;
 
-use shim::{WindowHandle, WindowRequest, WindowUpdate};
+use shim::{WindowCompositorUpdate, WindowHandle, WindowRequest, WindowUserRequest};
 
 #[cfg(feature = "sctk-adwaita")]
 pub type WinitFrame = sctk_adwaita::AdwaitaFrame;
@@ -94,11 +94,20 @@ impl Window {
 
                 // Get the window that received the event.
                 let window_id = super::make_wid(&surface);
-                let mut window_update = winit_state.window_updates.get_mut(&window_id).unwrap();
+                let mut window_compositor_update = winit_state
+                    .window_compositor_updates
+                    .get_mut(&window_id)
+                    .unwrap();
+
+                // Mark that we need a frame refresh on the DPI change.
+                winit_state
+                    .window_user_requests
+                    .get_mut(&window_id)
+                    .unwrap()
+                    .refresh_frame = true;
 
                 // Set pending scale factor.
-                window_update.scale_factor = Some(scale);
-                window_update.redraw_requested = true;
+                window_compositor_update.scale_factor = Some(scale);
 
                 surface.set_buffer_scale(scale);
             })
@@ -128,11 +137,19 @@ impl Window {
                     use sctk::window::{Event, State};
 
                     let winit_state = dispatch_data.get::<WinitState>().unwrap();
-                    let mut window_update = winit_state.window_updates.get_mut(&window_id).unwrap();
+                    let mut window_compositor_update = winit_state
+                        .window_compositor_updates
+                        .get_mut(&window_id)
+                        .unwrap();
+
+                    let mut window_user_requests = winit_state
+                        .window_user_requests
+                        .get_mut(&window_id)
+                        .unwrap();
 
                     match event {
                         Event::Refresh => {
-                            window_update.refresh_frame = true;
+                            window_user_requests.refresh_frame = true;
                         }
                         Event::Configure { new_size, states } => {
                             let is_maximized = states.contains(&State::Maximized);
@@ -140,14 +157,13 @@ impl Window {
                             let is_fullscreen = states.contains(&State::Fullscreen);
                             fullscreen_clone.store(is_fullscreen, Ordering::Relaxed);
 
-                            window_update.refresh_frame = true;
-                            window_update.redraw_requested = true;
+                            window_user_requests.refresh_frame = true;
                             if let Some((w, h)) = new_size {
-                                window_update.size = Some(LogicalSize::new(w, h));
+                                window_compositor_update.size = Some(LogicalSize::new(w, h));
                             }
                         }
                         Event::Close => {
-                            window_update.close_window = true;
+                            window_compositor_update.close_window = true;
                         }
                     }
                 },
@@ -234,9 +250,9 @@ impl Window {
         let size = Arc::new(Mutex::new(LogicalSize::new(width, height)));
 
         // We should trigger redraw and commit the surface for the newly created window.
-        let mut window_update = WindowUpdate::new();
-        window_update.refresh_frame = true;
-        window_update.redraw_requested = true;
+        let mut window_user_request = WindowUserRequest::new();
+        window_user_request.refresh_frame = true;
+        window_user_request.redraw_requested = true;
 
         let window_id = super::make_wid(&surface);
         let window_requests = Arc::new(Mutex::new(Vec::with_capacity(64)));
@@ -262,9 +278,13 @@ impl Window {
             .event_sink
             .push_window_event(crate::event::WindowEvent::Focused(false), window_id);
 
+        // Add state for the window.
         winit_state
-            .window_updates
-            .insert(window_id, WindowUpdate::new());
+            .window_user_requests
+            .insert(window_id, window_user_request);
+        winit_state
+            .window_compositor_updates
+            .insert(window_id, WindowCompositorUpdate::new());
 
         let windowing_features = event_loop_window_target.windowing_features;
 


### PR DESCRIPTION
On Waylnad when asking for redraw before `MainEventsCleared`
would result for redraw being send on the next event loop tick,
which is not expectable given that it must be delivered on the same
event loop tick.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

--

Basically this change splits the inner hash map into multiple and handles them at different points of time. The requests the user is making are processed now right before `MainEventsCleared` as they should.