### PR TITLE
On Windows, improve support for undecorated windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - On Windows, respect min/max inner sizes when creating the window.
+- On Windows, added `WindowExtWindows::set_undecorated_shadow` and `WindowBuilderExtWindows::with_undecorated_shadow` to draw the drop shadow behind a borderless window.
+- On Windows, fixed default window features (ie snap, animations, shake, etc.) when decorations are disabled.
 
 # 0.27.1 (2022-07-30)
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -143,6 +143,11 @@ pub trait WindowExtWindows {
 
     /// Whether to show or hide the window icon in the taskbar.
     fn set_skip_taskbar(&self, skip: bool);
+
+    /// Shows or hides the background drop shadow for undecorated windows.
+    ///
+    /// Enabling the shadow causes a thin 1px line to appear on the top of the window.
+    fn set_undecorated_shadow(&self, shadow: bool);
 }
 
 impl WindowExtWindows for Window {
@@ -174,6 +179,11 @@ impl WindowExtWindows for Window {
     #[inline]
     fn set_skip_taskbar(&self, skip: bool) {
         self.window.set_skip_taskbar(skip)
+    }
+
+    #[inline]
+    fn set_undecorated_shadow(&self, shadow: bool) {
+        self.window.set_undecorated_shadow(shadow)
     }
 }
 
@@ -229,6 +239,12 @@ pub trait WindowBuilderExtWindows {
 
     /// Whether show or hide the window icon in the taskbar.
     fn with_skip_taskbar(self, skip: bool) -> WindowBuilder;
+
+    /// Shows or hides the background drop shadow for undecorated windows.
+    ///
+    /// The shadow is hidden by default.
+    /// Enabling the shadow causes a thin 1px line to appear on the top of the window.
+    fn with_undecorated_shadow(self, shadow: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExtWindows for WindowBuilder {
@@ -277,6 +293,12 @@ impl WindowBuilderExtWindows for WindowBuilder {
     #[inline]
     fn with_skip_taskbar(mut self, skip: bool) -> WindowBuilder {
         self.platform_specific.skip_taskbar = skip;
+        self
+    }
+
+    #[inline]
+    fn with_undecorated_shadow(mut self, shadow: bool) -> WindowBuilder {
+        self.platform_specific.decoration_shadow = shadow;
         self
     }
 }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -16,7 +16,10 @@ use crate::{
     dpi::PhysicalSize,
     event::{Event, StartCause, WindowEvent},
     event_loop::ControlFlow,
-    platform_impl::platform::util,
+    platform_impl::platform::{
+        event_loop::{WindowData, GWL_USERDATA},
+        get_window_long,
+    },
     window::WindowId,
 };
 
@@ -434,11 +437,13 @@ impl<T> BufferedEvent<T> {
                         new_inner_size: &mut new_inner_size,
                     },
                 });
-                util::set_inner_size_physical(
-                    (window_id.0).0,
-                    new_inner_size.width as _,
-                    new_inner_size.height as _,
-                );
+
+                let window_flags = unsafe {
+                    let userdata =
+                        get_window_long(window_id.0.into(), GWL_USERDATA) as *mut WindowData<T>;
+                    (*userdata).window_state.lock().window_flags
+                };
+                window_flags.set_size((window_id.0).0, new_inner_size);
             }
         }
     }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -36,6 +36,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub drag_and_drop: bool,
     pub preferred_theme: Option<Theme>,
     pub skip_taskbar: bool,
+    pub decoration_shadow: bool,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -48,6 +49,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             drag_and_drop: true,
             preferred_theme: None,
             skip_taskbar: false,
+            decoration_shadow: false,
         }
     }
 }
@@ -103,6 +105,12 @@ impl WindowId {
 impl From<WindowId> for u64 {
     fn from(window_id: WindowId) -> Self {
         window_id.0 as u64
+    }
+}
+
+impl From<WindowId> for HWND {
+    fn from(window_id: WindowId) -> Self {
+        window_id.0
     }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -201,7 +201,7 @@ impl Window {
     #[inline]
     pub fn set_inner_size(&self, size: Size) {
         let scale_factor = self.scale_factor();
-        let physical_size = size.to_physical::<u32>(scale_factor).into();
+        let physical_size = size.to_physical::<u32>(scale_factor);
 
         let window_state = Arc::clone(&self.window_state);
         let window = self.window.clone();
@@ -254,7 +254,7 @@ impl Window {
     /// Returns the `hwnd` of this window.
     #[inline]
     pub fn hwnd(&self) -> HWND {
-        self.window.0.into()
+        self.window.0
     }
 
     #[inline]

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    dpi::{PhysicalPosition, Size},
+    dpi::{PhysicalPosition, PhysicalSize, Size},
     event::ModifiersState,
     icon::Icon,
     platform_impl::platform::{event_loop, util},
@@ -11,14 +11,15 @@ use windows_sys::Win32::{
     Foundation::{HWND, RECT},
     Graphics::Gdi::InvalidateRgn,
     UI::WindowsAndMessaging::{
-        SendMessageW, SetWindowLongW, SetWindowPos, ShowWindow, GWL_EXSTYLE, GWL_STYLE,
-        HWND_NOTOPMOST, HWND_TOPMOST, SWP_ASYNCWINDOWPOS, SWP_FRAMECHANGED, SWP_NOACTIVATE,
-        SWP_NOMOVE, SWP_NOSIZE, SWP_NOZORDER, SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE,
-        SW_SHOW, WINDOWPLACEMENT, WINDOW_EX_STYLE, WINDOW_STYLE, WS_BORDER, WS_CAPTION, WS_CHILD,
-        WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_LAYERED,
-        WS_EX_LEFT, WS_EX_NOREDIRECTIONBITMAP, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_EX_WINDOWEDGE,
-        WS_MAXIMIZE, WS_MAXIMIZEBOX, WS_MINIMIZE, WS_MINIMIZEBOX, WS_OVERLAPPED,
-        WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SIZEBOX, WS_SYSMENU, WS_VISIBLE,
+        AdjustWindowRectEx, GetMenu, GetWindowLongW, SendMessageW, SetWindowLongW, SetWindowPos,
+        ShowWindow, GWL_EXSTYLE, GWL_STYLE, HWND_NOTOPMOST, HWND_TOPMOST, SWP_ASYNCWINDOWPOS,
+        SWP_FRAMECHANGED, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOREPOSITION, SWP_NOSIZE, SWP_NOZORDER,
+        SW_HIDE, SW_MAXIMIZE, SW_MINIMIZE, SW_RESTORE, SW_SHOW, WINDOWPLACEMENT, WINDOW_EX_STYLE,
+        WINDOW_STYLE, WS_BORDER, WS_CAPTION, WS_CHILD, WS_CLIPCHILDREN, WS_CLIPSIBLINGS,
+        WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_LAYERED, WS_EX_NOREDIRECTIONBITMAP,
+        WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_EX_WINDOWEDGE, WS_MAXIMIZE, WS_MAXIMIZEBOX,
+        WS_MINIMIZE, WS_MINIMIZEBOX, WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SIZEBOX, WS_SYSMENU,
+        WS_VISIBLE,
     },
 };
 
@@ -76,36 +77,39 @@ bitflags! {
 bitflags! {
     pub struct WindowFlags: u32 {
         const RESIZABLE      = 1 << 0;
-        const DECORATIONS    = 1 << 1;
-        const VISIBLE        = 1 << 2;
-        const ON_TASKBAR     = 1 << 3;
-        const ALWAYS_ON_TOP  = 1 << 4;
-        const NO_BACK_BUFFER = 1 << 5;
-        const TRANSPARENT    = 1 << 6;
-        const CHILD          = 1 << 7;
-        const MAXIMIZED      = 1 << 8;
-        const POPUP          = 1 << 14;
+        const VISIBLE        = 1 << 1;
+        const ON_TASKBAR     = 1 << 2;
+        const ALWAYS_ON_TOP  = 1 << 3;
+        const NO_BACK_BUFFER = 1 << 4;
+        const TRANSPARENT    = 1 << 5;
+        const CHILD          = 1 << 6;
+        const MAXIMIZED      = 1 << 7;
+        const POPUP          = 1 << 8;
 
         /// Marker flag for fullscreen. Should always match `WindowState::fullscreen`, but is
         /// included here to make masking easier.
         const MARKER_EXCLUSIVE_FULLSCREEN = 1 << 9;
-        const MARKER_BORDERLESS_FULLSCREEN = 1 << 13;
+        const MARKER_BORDERLESS_FULLSCREEN = 1 << 10;
 
         /// The `WM_SIZE` event contains some parameters that can effect the state of `WindowFlags`.
         /// In most cases, it's okay to let those parameters change the state. However, when we're
         /// running the `WindowFlags::apply_diff` function, we *don't* want those parameters to
         /// effect our stored state, because the purpose of `apply_diff` is to update the actual
         /// window's state to match our stored state. This controls whether to accept those changes.
-        const MARKER_RETAIN_STATE_ON_SIZE = 1 << 10;
+        const MARKER_RETAIN_STATE_ON_SIZE = 1 << 11;
 
-        const MARKER_IN_SIZE_MOVE = 1 << 11;
+        const MARKER_IN_SIZE_MOVE = 1 << 12;
 
-        const MINIMIZED = 1 << 12;
+        const MINIMIZED = 1 << 13;
 
-        const IGNORE_CURSOR_EVENT = 1 << 15;
+        const IGNORE_CURSOR_EVENT = 1 << 14;
+
+        /// Fully decorated window (incl. caption, border and drop shadow).
+        const MARKER_DECORATIONS = 1 << 15;
+        /// Drop shadow for undecorated windows.
+        const MARKER_UNDECORATED_SHADOW = 1 << 16;
 
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits;
-        const NO_DECORATIONS_AND_MASK = !WindowFlags::RESIZABLE.bits;
     }
 }
 
@@ -228,21 +232,21 @@ impl WindowFlags {
         if self.contains(WindowFlags::MARKER_EXCLUSIVE_FULLSCREEN) {
             self |= WindowFlags::EXCLUSIVE_FULLSCREEN_OR_MASK;
         }
-        if !self.contains(WindowFlags::DECORATIONS) {
-            self &= WindowFlags::NO_DECORATIONS_AND_MASK;
-        }
         self
     }
 
     pub fn to_window_styles(self) -> (WINDOW_STYLE, WINDOW_EX_STYLE) {
-        let (mut style, mut style_ex) = (WS_OVERLAPPED, WS_EX_LEFT);
+        // Required styles to properly support common window functionality like aero snap.
+        let mut style = WS_CAPTION
+            | WS_MINIMIZEBOX
+            | WS_BORDER
+            | WS_CLIPSIBLINGS
+            | WS_CLIPCHILDREN
+            | WS_SYSMENU;
+        let mut style_ex = WS_EX_WINDOWEDGE | WS_EX_ACCEPTFILES;
 
         if self.contains(WindowFlags::RESIZABLE) {
             style |= WS_SIZEBOX | WS_MAXIMIZEBOX;
-        }
-        if self.contains(WindowFlags::DECORATIONS) {
-            style |= WS_CAPTION | WS_MINIMIZEBOX | WS_BORDER;
-            style_ex = WS_EX_WINDOWEDGE;
         }
         if self.contains(WindowFlags::VISIBLE) {
             style |= WS_VISIBLE;
@@ -271,9 +275,6 @@ impl WindowFlags {
         if self.contains(WindowFlags::IGNORE_CURSOR_EVENT) {
             style_ex |= WS_EX_TRANSPARENT | WS_EX_LAYERED;
         }
-
-        style |= WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
-        style_ex |= WS_EX_ACCEPTFILES;
 
         if self.intersects(
             WindowFlags::MARKER_EXCLUSIVE_FULLSCREEN | WindowFlags::MARKER_BORDERLESS_FULLSCREEN,
@@ -379,11 +380,69 @@ impl WindowFlags {
             }
         }
     }
+
+    pub fn adjust_rect(self, hwnd: HWND, mut rect: RECT) -> Result<RECT, io::Error> {
+        unsafe {
+            let mut style = GetWindowLongW(hwnd, GWL_STYLE) as u32;
+            let style_ex = GetWindowLongW(hwnd, GWL_EXSTYLE) as u32;
+
+            // Frameless style implemented by manually overriding the non-client area in `WM_NCCALCSIZE`.
+            if !self.contains(WindowFlags::MARKER_DECORATIONS) {
+                style &= !(WS_CAPTION | WS_SIZEBOX);
+            }
+
+            util::win_to_err({
+                let b_menu = GetMenu(hwnd) != 0;
+                if let (Some(get_dpi_for_window), Some(adjust_window_rect_ex_for_dpi)) = (
+                    *util::GET_DPI_FOR_WINDOW,
+                    *util::ADJUST_WINDOW_RECT_EX_FOR_DPI,
+                ) {
+                    let dpi = get_dpi_for_window(hwnd);
+                    adjust_window_rect_ex_for_dpi(&mut rect, style, b_menu.into(), style_ex, dpi)
+                } else {
+                    AdjustWindowRectEx(&mut rect, style, b_menu.into(), style_ex)
+                }
+            })?;
+            Ok(rect)
+        }
+    }
+
+    pub fn adjust_size(self, hwnd: HWND, size: PhysicalSize<u32>) -> PhysicalSize<u32> {
+        let (width, height): (u32, u32) = size.into();
+        let rect = RECT {
+            left: 0,
+            right: width as i32,
+            top: 0,
+            bottom: height as i32,
+        };
+        let rect = self.adjust_rect(hwnd, rect).unwrap_or(rect);
+
+        let outer_x = (rect.right - rect.left).abs();
+        let outer_y = (rect.top - rect.bottom).abs();
+
+        PhysicalSize::new(outer_x as _, outer_y as _)
+    }
+
+    pub fn set_size(self, hwnd: HWND, size: PhysicalSize<u32>) {
+        unsafe {
+            let (width, height): (u32, u32) = self.adjust_size(hwnd, size).into();
+            SetWindowPos(
+                hwnd,
+                0,
+                0,
+                0,
+                width as _,
+                height as _,
+                SWP_ASYNCWINDOWPOS | SWP_NOZORDER | SWP_NOREPOSITION | SWP_NOMOVE | SWP_NOACTIVATE,
+            );
+            InvalidateRgn(hwnd, 0, false.into());
+        }
+    }
 }
 
 impl CursorFlags {
     fn refresh_os_cursor(self, window: HWND) -> Result<(), io::Error> {
-        let client_rect = util::get_client_rect(window)?;
+        let client_rect = util::WindowArea::Inner.get_rect(window)?;
 
         if util::is_focused(window) {
             let cursor_clip = match self.contains(CursorFlags::GRABBED) {


### PR DESCRIPTION
Alternative PR to https://github.com/rust-windowing/winit/pull/1891

- Add an option to add the drop shadow for borderless windows. This also will result in the compositor to correctly identify the window to draw the rounded corners on Windows 11. Unfortunately shows an black 1px line on top of the window.. overall just sad state of legacy stuff piled up and the compositor isn't very helpful either ):
- Support for Shake, Snap, Alt-Print, etc features which a normal window can do. This is derived by the window styles. To not show the non-client area we just spread the client area to cover it (mostly)

Non-client area hit control https://github.com/rust-windowing/winit/issues/2413 would be needed as next stop to properly emulate resize borders (not in the dropshadow tho..) and other functionality like dragging for the shake feature.

- [x] Tested on all platforms changed: Windows 10, Windows 11 VM
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented