### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,13 +12,15 @@
 /src/platform/ios.rs                @francesca64
 /src/platform_impl/ios              @francesca64
 
-# Wayland
+# Unix in general
 /src/platform/unix.rs               @kchibisov
-/src/platform_impl/linux/wayland    @kchibisov
 /src/platform_impl/linux/mod.rs     @kchibisov
 
-# X11 (no maintainer)
-/src/platform_impl/linux/x11
+# Wayland
+/src/platform_impl/linux/wayland    @kchibisov
+
+# X11
+/src/platform_impl/linux/x11        @kchibisov
 
 # macOS
 /src/platform/macos.rs              @madsmtm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# Core maintainers:
+# - @msiglreith
+# - @kchibisov
+# - @madsmtm
+# - @maroider
+
+# Android
+/src/platform/android.rs            @msiglreith
+/src/platform_impl/android          @msiglreith
+
+# iOS
+/src/platform/ios.rs                @francesca64
+/src/platform_impl/ios              @francesca64
+
+# Wayland
+/src/platform/unix.rs               @kchibisov
+/src/platform_impl/linux/wayland    @kchibisov
+/src/platform_impl/linux/mod.rs     @kchibisov
+
+# X11 (no maintainer)
+/src/platform_impl/linux/x11
+
+# macOS
+/src/platform/macos.rs              @madsmtm
+/src/platform_impl/macos            @madsmtm
+
+# Web (no maintainer)
+/src/platform/web.rs
+/src/platform_impl/web
+
+# Windows
+/src/platform/windows.rs            @msiglreith
+/src/platform_impl/windows          @msiglreith

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,9 @@ Once your PR is deemed ready, the merging maintainer will take care of resolving
 
 ## Maintainers & Testers
 
-The current [list of testers and contributors](https://github.com/rust-windowing/winit/wiki/Testers-and-Contributors)
-can be found on the Wiki.
+The current maintainers is listed in the [CODEOWNERS](.github/CODEOWNERS) file.
 
-If you are interested in contributing or testing on a platform, please add yourself to that table!
+If you are interested in being pinged when testing is needed for a certain platform, please add yourself to the [Testers and Contributors](https://github.com/rust-windowing/winit/wiki/Testers-and-Contributors) table!
 
 ## Making a new release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Once your PR is deemed ready, the merging maintainer will take care of resolving
 
 ## Maintainers & Testers
 
-The current maintainers is listed in the [CODEOWNERS](.github/CODEOWNERS) file.
+The current maintainers are listed in the [CODEOWNERS](.github/CODEOWNERS) file.
 
 If you are interested in being pinged when testing is needed for a certain platform, please add yourself to the [Testers and Contributors](https://github.com/rust-windowing/winit/wiki/Testers-and-Contributors) table!
 

--- a/HALL_OF_CHAMPIONS.md
+++ b/HALL_OF_CHAMPIONS.md
@@ -15,9 +15,12 @@ future endeavors:
   vastly more sustainable era of winit.
 * [@goddessfreya]: For selflessly taking over maintainership of glutin, and her
   stellar dedication to improving both winit and glutin.
+* [@ArturKovacs]: For constently maintaining the macOS backend, and his
+  immense involvement in designing and implementing the new keyboard API.
 
 [@tomaka]: https://github.com/tomaka
 [@vberger]: https://github.com/vberger
 [@francesca64]: https://github.com/francesca64
 [@Osspial]: https://github.com/Osspial
 [@goddessfreya]: https://github.com/goddessfreya
+[@ArturKovacs]: https://github.com/ArturKovacs

--- a/HALL_OF_CHAMPIONS.md
+++ b/HALL_OF_CHAMPIONS.md
@@ -15,7 +15,7 @@ future endeavors:
   vastly more sustainable era of winit.
 * [@goddessfreya]: For selflessly taking over maintainership of glutin, and her
   stellar dedication to improving both winit and glutin.
-* [@ArturKovacs]: For constently maintaining the macOS backend, and his
+* [@ArturKovacs]: For consistently maintaining the macOS backend, and his
   immense involvement in designing and implementing the new keyboard API.
 
 [@tomaka]: https://github.com/tomaka


### PR DESCRIPTION
This makes it very clear when you're stepping down from the post as a maintainer, and makes it clear for users who is expected to review their PR.

The way it works is [detailed in the docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners), but in short, if edits are made to files specified here, the "code owner" will automatically be assigned as the reviewer.
An example: If I submitted a PR that edited `src/event.rs`, `src/platform/windows.rs` and `src/platform_impl/linux/wayland/output.rs`, `@msiglreith` and `@kchibisov` would automatically be marked as reviewers.