### PR TITLE
Split `platform::unix` into `platform::x11` and `platform::wayland`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,14 +12,15 @@
 /src/platform/ios.rs                @francesca64
 /src/platform_impl/ios              @francesca64
 
-# Unix in general
-/src/platform/unix.rs               @kchibisov
+# Unix
 /src/platform_impl/linux/mod.rs     @kchibisov
 
 # Wayland
+/src/platform/wayland.rs            @kchibisov
 /src/platform_impl/linux/wayland    @kchibisov
 
 # X11
+/src/platform/x11.rs                @kchibisov
 /src/platform_impl/linux/x11        @kchibisov
 
 # macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - **Breaking:** Split the `platform::unix` module into `platform::x11` and `platform::wayland`. The extension types are similarly renamed.
+- **Breaking:**: Removed deprecated method `platform::unix::WindowExtUnix::is_ready`.
 - On macOS, fixed touch phase reporting when scrolling.
 - On X11, fix min, max and resize increment hints not persisting for resizable windows (e.g. on DPI change).
 - On Windows, respect min/max inner sizes when creating the window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** Split the `platform::unix` module into `platform::x11` and `platform::wayland`. The extension types are similarly renamed.
 - On macOS, fixed touch phase reporting when scrolling.
 - On X11, fix min, max and resize increment hints not persisting for resizable windows (e.g. on DPI change).
 - On Windows, respect min/max inner sizes when creating the window.

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,5 +1,3 @@
-#![cfg(any(target_os = "android"))]
-
 use crate::{
     event_loop::{EventLoop, EventLoopWindowTarget},
     window::{Window, WindowBuilder},

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "ios")]
-
 use std::os::raw::c_void;
 
 use crate::{

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "macos")]
-
 use std::os::raw::c_void;
 
 use crate::{

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -21,18 +21,32 @@ pub mod android;
 pub mod ios;
 #[cfg(target_os = "macos")]
 pub mod macos;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
+#[cfg(all(
+    feature = "wayland",
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )
 ))]
-pub mod unix;
+pub mod wayland;
 #[cfg(target_arch = "wasm32")]
 pub mod web;
 #[cfg(target_os = "windows")]
 pub mod windows;
+#[cfg(all(
+    feature = "x11",
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )
+))]
+pub mod x11;
 
 #[cfg(any(
     target_os = "windows",

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -15,11 +15,33 @@
 //!
 //! However only the module corresponding to the platform you're compiling to will be available.
 
+#[cfg(target_os = "android")]
 pub mod android;
+#[cfg(target_os = "ios")]
 pub mod ios;
+#[cfg(target_os = "macos")]
 pub mod macos;
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 pub mod unix;
+#[cfg(target_arch = "wasm32")]
 pub mod web;
+#[cfg(target_os = "windows")]
 pub mod windows;
 
+#[cfg(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "android",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 pub mod run_return;

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -1,14 +1,3 @@
-#![cfg(any(
-    target_os = "windows",
-    target_os = "macos",
-    target_os = "android",
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-
 use crate::{
     event::Event,
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -1,11 +1,3 @@
-#![cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-
 use std::os::raw;
 #[cfg(feature = "x11")]
 use std::{ptr, sync::Arc};

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -142,13 +142,14 @@ impl WindowExtWayland for Window {
 
 /// Additional methods on [`WindowBuilder`] that are specific to Wayland.
 pub trait WindowBuilderExtWayland {
-    /// Build window with the given application ID.
+    /// Build window with the given name.
     ///
-    /// This should match the `.desktop` file destributed with your program.
+    /// The `general` name sets an application ID, which should match the `.desktop`
+    /// file destributed with your program. The `instance` is a `no-op`.
     ///
     /// For details about application ID conventions, see the
     /// [Desktop Entry Spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id)
-    fn with_application_id(self, application_id: impl Into<String>) -> Self;
+    fn with_name(self, general: impl Into<String>, instance: impl Into<String>) -> Self;
 
     /// Build window with certain decoration [`Theme`]
     ///
@@ -159,9 +160,8 @@ pub trait WindowBuilderExtWayland {
 
 impl WindowBuilderExtWayland for WindowBuilder {
     #[inline]
-    fn with_application_id(mut self, application_id: impl Into<String>) -> Self {
-        self.platform_specific.name =
-            Some(ApplicationName::new(application_id.into(), String::new()));
+    fn with_name(self, general: impl Into<String>, instance: impl Into<String>) -> Self {
+        self.platform_specific.name = Some(ApplicationName::new(general.into(), instance.into()));
         self
     }
 

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -1,0 +1,186 @@
+use std::os::raw;
+
+use crate::{
+    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    monitor::MonitorHandle,
+    window::{Window, WindowBuilder},
+};
+
+use crate::platform_impl::{
+    ApplicationName, Backend, EventLoopWindowTarget as LinuxEventLoopWindowTarget,
+    Window as LinuxWindow,
+};
+
+pub use crate::window::Theme;
+
+/// Additional methods on [`EventLoopWindowTarget`] that are specific to Wayland.
+pub trait EventLoopWindowTargetExtWayland {
+    /// True if the [`EventLoopWindowTarget`] uses Wayland.
+    fn is_wayland(&self) -> bool;
+
+    /// Returns a pointer to the `wl_display` object of wayland that is used by this
+    /// [`EventLoopWindowTarget`].
+    ///
+    /// Returns `None` if the [`EventLoop`] doesn't use wayland (if it uses xlib for example).
+    ///
+    /// The pointer will become invalid when the winit [`EventLoop`] is destroyed.
+    ///
+    /// [`EventLoop`]: crate::event_loop::EventLoop
+    fn wayland_display(&self) -> Option<*mut raw::c_void>;
+}
+
+impl<T> EventLoopWindowTargetExtWayland for EventLoopWindowTarget<T> {
+    #[inline]
+    fn is_wayland(&self) -> bool {
+        self.p.is_wayland()
+    }
+
+    #[inline]
+    fn wayland_display(&self) -> Option<*mut raw::c_void> {
+        match self.p {
+            LinuxEventLoopWindowTarget::Wayland(ref p) => {
+                Some(p.display().get_display_ptr() as *mut _)
+            }
+            #[cfg(feature = "x11")]
+            _ => None,
+        }
+    }
+}
+
+/// Additional methods on [`EventLoopBuilder`] that are specific to Wayland.
+pub trait EventLoopBuilderExtWayland {
+    /// Force using Wayland.
+    fn with_wayland(&mut self) -> &mut Self;
+
+    /// Whether to allow the event loop to be created off of the main thread.
+    ///
+    /// By default, the window is only allowed to be created on the main
+    /// thread, to make platform compatibility easier.
+    fn with_any_thread(&mut self, any_thread: bool) -> &mut Self;
+}
+
+impl<T> EventLoopBuilderExtWayland for EventLoopBuilder<T> {
+    #[inline]
+    fn with_wayland(&mut self) -> &mut Self {
+        self.platform_specific.forced_backend = Some(Backend::Wayland);
+        self
+    }
+
+    #[inline]
+    fn with_any_thread(&mut self, any_thread: bool) -> &mut Self {
+        self.platform_specific.any_thread = any_thread;
+        self
+    }
+}
+
+/// Additional methods on [`Window`] that are specific to Wayland.
+pub trait WindowExtWayland {
+    /// Returns a pointer to the `wl_surface` object of wayland that is used by this window.
+    ///
+    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
+    ///
+    /// The pointer will become invalid when the [`Window`] is destroyed.
+    fn wayland_surface(&self) -> Option<*mut raw::c_void>;
+
+    /// Returns a pointer to the `wl_display` object of wayland that is used by this window.
+    ///
+    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
+    ///
+    /// The pointer will become invalid when the [`Window`] is destroyed.
+    fn wayland_display(&self) -> Option<*mut raw::c_void>;
+
+    /// Updates [`Theme`] of window decorations.
+    ///
+    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+    /// Possible values for env variable are: "dark" and light"
+    fn wayland_set_csd_theme(&self, config: Theme);
+
+    /// Check if the window is ready for drawing
+    ///
+    /// It is a remnant of a previous implementation detail for the
+    /// wayland backend, and is no longer relevant.
+    ///
+    /// Always return `true`.
+    #[deprecated]
+    fn is_ready(&self) -> bool;
+}
+
+impl WindowExtWayland for Window {
+    #[inline]
+    fn wayland_surface(&self) -> Option<*mut raw::c_void> {
+        match self.window {
+            LinuxWindow::Wayland(ref w) => Some(w.surface().as_ref().c_ptr() as *mut _),
+            #[cfg(feature = "x11")]
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn wayland_display(&self) -> Option<*mut raw::c_void> {
+        match self.window {
+            LinuxWindow::Wayland(ref w) => Some(w.display().get_display_ptr() as *mut _),
+            #[cfg(feature = "x11")]
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn wayland_set_csd_theme(&self, theme: Theme) {
+        #[allow(clippy::single_match)]
+        match self.window {
+            LinuxWindow::Wayland(ref w) => w.set_csd_theme(theme),
+            #[cfg(feature = "x11")]
+            _ => (),
+        }
+    }
+
+    #[inline]
+    fn is_ready(&self) -> bool {
+        true
+    }
+}
+
+/// Additional methods on [`WindowBuilder`] that are specific to Wayland.
+pub trait WindowBuilderExtWayland {
+    /// Build window with the given application ID.
+    ///
+    /// This should match the `.desktop` file destributed with your program.
+    ///
+    /// For details about application ID conventions, see the
+    /// [Desktop Entry Spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id)
+    fn with_application_id(self, application_id: impl Into<String>) -> Self;
+
+    /// Build window with certain decoration [`Theme`]
+    ///
+    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+    /// Possible values for env variable are: "dark" and light"
+    fn with_wayland_csd_theme(self, theme: Theme) -> Self;
+}
+
+impl WindowBuilderExtWayland for WindowBuilder {
+    #[inline]
+    fn with_application_id(mut self, application_id: impl Into<String>) -> Self {
+        self.platform_specific.name =
+            Some(ApplicationName::new(application_id.into(), String::new()));
+        self
+    }
+
+    #[inline]
+    fn with_wayland_csd_theme(mut self, theme: Theme) -> Self {
+        self.platform_specific.csd_theme = Some(theme);
+        self
+    }
+}
+
+/// Additional methods on `MonitorHandle` that are specific to Wayland.
+pub trait MonitorHandleExtWayland {
+    /// Returns the inner identifier of the monitor.
+    fn native_id(&self) -> u32;
+}
+
+impl MonitorHandleExtWayland for MonitorHandle {
+    #[inline]
+    fn native_id(&self) -> u32 {
+        self.inner.native_identifier()
+    }
+}

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -150,7 +150,7 @@ pub trait WindowBuilderExtWayland {
 
 impl WindowBuilderExtWayland for WindowBuilder {
     #[inline]
-    fn with_name(self, general: impl Into<String>, instance: impl Into<String>) -> Self {
+    fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
         self.platform_specific.name = Some(ApplicationName::new(general.into(), instance.into()));
         self
     }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -94,15 +94,6 @@ pub trait WindowExtWayland {
     /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
     /// Possible values for env variable are: "dark" and light"
     fn wayland_set_csd_theme(&self, config: Theme);
-
-    /// Check if the window is ready for drawing
-    ///
-    /// It is a remnant of a previous implementation detail for the
-    /// wayland backend, and is no longer relevant.
-    ///
-    /// Always return `true`.
-    #[deprecated]
-    fn is_ready(&self) -> bool;
 }
 
 impl WindowExtWayland for Window {
@@ -132,11 +123,6 @@ impl WindowExtWayland for Window {
             #[cfg(feature = "x11")]
             _ => (),
         }
-    }
-
-    #[inline]
-    fn is_ready(&self) -> bool {
-        true
     }
 }
 

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -1,5 +1,3 @@
-#![cfg(target_arch = "wasm32")]
-
 //! The web target does not automatically insert the canvas element object into the web page, to
 //! allow end users to determine how the page should be laid out. Use the [`WindowExtWebSys`] trait
 //! to retrieve the canvas from the Window. Alternatively, use the [`WindowBuilderExtWebSys`] trait

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "windows")]
-
 use std::{ffi::c_void, path::Path};
 
 use crate::{

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -1,5 +1,4 @@
 use std::os::raw;
-#[cfg(feature = "x11")]
 use std::{ptr, sync::Arc};
 
 use crate::{
@@ -8,31 +7,22 @@ use crate::{
     window::{Window, WindowBuilder},
 };
 
-#[cfg(feature = "x11")]
 use crate::dpi::Size;
-#[cfg(feature = "x11")]
-use crate::platform_impl::{x11::ffi::XVisualInfo, x11::XConnection, XLIB_ERROR_HOOKS};
 use crate::platform_impl::{
-    ApplicationName, Backend, EventLoopWindowTarget as LinuxEventLoopWindowTarget,
-    Window as LinuxWindow,
+    x11::ffi::XVisualInfo, x11::XConnection, ApplicationName, Backend,
+    EventLoopWindowTarget as LinuxEventLoopWindowTarget, Window as LinuxWindow, XLIB_ERROR_HOOKS,
 };
 
 // TODO: stupid hack so that glutin can do its work
 #[doc(hidden)]
-#[cfg(feature = "x11")]
 pub use crate::platform_impl::x11;
-#[cfg(feature = "x11")]
 pub use crate::platform_impl::{x11::util::WindowType as XWindowType, XNotSupported};
-
-#[cfg(feature = "wayland")]
-pub use crate::window::Theme;
 
 /// The first argument in the provided hook will be the pointer to `XDisplay`
 /// and the second one the pointer to [`XErrorEvent`]. The returned `bool` is an
 /// indicator whether the error was handled by the callback.
 ///
 /// [`XErrorEvent`]: https://linux.die.net/man/3/xerrorevent
-#[cfg(feature = "x11")]
 pub type XlibErrorHook =
     Box<dyn Fn(*mut std::ffi::c_void, *mut std::ffi::c_void) -> bool + Send + Sync>;
 
@@ -44,7 +34,6 @@ pub type XlibErrorHook =
 ///
 /// [`unsafe`]: https://www.remlab.net/op/xlib.shtml
 #[inline]
-#[cfg(feature = "x11")]
 pub fn register_xlib_error_hook(hook: XlibErrorHook) {
     // Append new hook.
     unsafe {
@@ -52,47 +41,22 @@ pub fn register_xlib_error_hook(hook: XlibErrorHook) {
     }
 }
 
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to Unix.
-pub trait EventLoopWindowTargetExtUnix {
-    /// True if the [`EventLoopWindowTarget`] uses Wayland.
-    #[cfg(feature = "wayland")]
-    fn is_wayland(&self) -> bool;
-
+/// Additional methods on [`EventLoopWindowTarget`] that are specific to X11.
+pub trait EventLoopWindowTargetExtX11 {
     /// True if the [`EventLoopWindowTarget`] uses X11.
-    #[cfg(feature = "x11")]
     fn is_x11(&self) -> bool;
 
     #[doc(hidden)]
-    #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>>;
-
-    /// Returns a pointer to the `wl_display` object of wayland that is used by this
-    /// [`EventLoopWindowTarget`].
-    ///
-    /// Returns `None` if the [`EventLoop`] doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the winit [`EventLoop`] is destroyed.
-    ///
-    /// [`EventLoop`]: crate::event_loop::EventLoop
-    #[cfg(feature = "wayland")]
-    fn wayland_display(&self) -> Option<*mut raw::c_void>;
 }
 
-impl<T> EventLoopWindowTargetExtUnix for EventLoopWindowTarget<T> {
+impl<T> EventLoopWindowTargetExtX11 for EventLoopWindowTarget<T> {
     #[inline]
-    #[cfg(feature = "wayland")]
-    fn is_wayland(&self) -> bool {
-        self.p.is_wayland()
-    }
-
-    #[inline]
-    #[cfg(feature = "x11")]
     fn is_x11(&self) -> bool {
         !self.p.is_wayland()
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.p {
             LinuxEventLoopWindowTarget::X(ref e) => Some(e.x_connection().clone()),
@@ -100,29 +64,12 @@ impl<T> EventLoopWindowTargetExtUnix for EventLoopWindowTarget<T> {
             _ => None,
         }
     }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn wayland_display(&self) -> Option<*mut raw::c_void> {
-        match self.p {
-            LinuxEventLoopWindowTarget::Wayland(ref p) => {
-                Some(p.display().get_display_ptr() as *mut _)
-            }
-            #[cfg(feature = "x11")]
-            _ => None,
-        }
-    }
 }
 
-/// Additional methods on [`EventLoopBuilder`] that are specific to Unix.
-pub trait EventLoopBuilderExtUnix {
+/// Additional methods on [`EventLoopBuilder`] that are specific to X11.
+pub trait EventLoopBuilderExtX11 {
     /// Force using X11.
-    #[cfg(feature = "x11")]
     fn with_x11(&mut self) -> &mut Self;
-
-    /// Force using Wayland.
-    #[cfg(feature = "wayland")]
-    fn with_wayland(&mut self) -> &mut Self;
 
     /// Whether to allow the event loop to be created off of the main thread.
     ///
@@ -131,18 +78,10 @@ pub trait EventLoopBuilderExtUnix {
     fn with_any_thread(&mut self, any_thread: bool) -> &mut Self;
 }
 
-impl<T> EventLoopBuilderExtUnix for EventLoopBuilder<T> {
+impl<T> EventLoopBuilderExtX11 for EventLoopBuilder<T> {
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_x11(&mut self) -> &mut Self {
         self.platform_specific.forced_backend = Some(Backend::X);
-        self
-    }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn with_wayland(&mut self) -> &mut Self {
-        self.platform_specific.forced_backend = Some(Backend::Wayland);
         self
     }
 
@@ -153,12 +92,11 @@ impl<T> EventLoopBuilderExtUnix for EventLoopBuilder<T> {
     }
 }
 
-/// Additional methods on [`Window`] that are specific to Unix.
-pub trait WindowExtUnix {
+/// Additional methods on [`Window`] that are specific to X11.
+pub trait WindowExtX11 {
     /// Returns the ID of the [`Window`] xlib object that is used by this window.
     ///
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
-    #[cfg(feature = "x11")]
     fn xlib_window(&self) -> Option<raw::c_ulong>;
 
     /// Returns a pointer to the `Display` object of xlib that is used by this window.
@@ -166,14 +104,11 @@ pub trait WindowExtUnix {
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
     ///
     /// The pointer will become invalid when the [`Window`] is destroyed.
-    #[cfg(feature = "x11")]
     fn xlib_display(&self) -> Option<*mut raw::c_void>;
 
-    #[cfg(feature = "x11")]
     fn xlib_screen_id(&self) -> Option<raw::c_int>;
 
     #[doc(hidden)]
-    #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>>;
 
     /// This function returns the underlying `xcb_connection_t` of an xlib `Display`.
@@ -181,31 +116,7 @@ pub trait WindowExtUnix {
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
     ///
     /// The pointer will become invalid when the [`Window`] is destroyed.
-    #[cfg(feature = "x11")]
     fn xcb_connection(&self) -> Option<*mut raw::c_void>;
-
-    /// Returns a pointer to the `wl_surface` object of wayland that is used by this window.
-    ///
-    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    #[cfg(feature = "wayland")]
-    fn wayland_surface(&self) -> Option<*mut raw::c_void>;
-
-    /// Returns a pointer to the `wl_display` object of wayland that is used by this window.
-    ///
-    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    #[cfg(feature = "wayland")]
-    fn wayland_display(&self) -> Option<*mut raw::c_void>;
-
-    /// Updates [`Theme`] of window decorations.
-    ///
-    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
-    /// Possible values for env variable are: "dark" and light"
-    #[cfg(feature = "wayland")]
-    fn wayland_set_csd_theme(&self, config: Theme);
 
     /// Check if the window is ready for drawing
     ///
@@ -217,9 +128,8 @@ pub trait WindowExtUnix {
     fn is_ready(&self) -> bool;
 }
 
-impl WindowExtUnix for Window {
+impl WindowExtX11 for Window {
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_window(&self) -> Option<raw::c_ulong> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xlib_window()),
@@ -229,7 +139,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_display(&self) -> Option<*mut raw::c_void> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xlib_display()),
@@ -239,7 +148,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_screen_id(&self) -> Option<raw::c_int> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xlib_screen_id()),
@@ -249,7 +157,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xlib_xconnection()),
@@ -259,7 +166,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xcb_connection(&self) -> Option<*mut raw::c_void> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xcb_connection()),
@@ -269,56 +175,20 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "wayland")]
-    fn wayland_surface(&self) -> Option<*mut raw::c_void> {
-        match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.surface().as_ref().c_ptr() as *mut _),
-            #[cfg(feature = "x11")]
-            _ => None,
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn wayland_display(&self) -> Option<*mut raw::c_void> {
-        match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.display().get_display_ptr() as *mut _),
-            #[cfg(feature = "x11")]
-            _ => None,
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn wayland_set_csd_theme(&self, theme: Theme) {
-        #[allow(clippy::single_match)]
-        match self.window {
-            LinuxWindow::Wayland(ref w) => w.set_csd_theme(theme),
-            #[cfg(feature = "x11")]
-            _ => (),
-        }
-    }
-
-    #[inline]
     fn is_ready(&self) -> bool {
         true
     }
 }
 
-/// Additional methods on [`WindowBuilder`] that are specific to Unix.
-pub trait WindowBuilderExtUnix {
-    #[cfg(feature = "x11")]
+/// Additional methods on [`WindowBuilder`] that are specific to X11.
+pub trait WindowBuilderExtX11 {
     fn with_x11_visual<T>(self, visual_infos: *const T) -> Self;
 
-    #[cfg(feature = "x11")]
     fn with_x11_screen(self, screen_id: i32) -> Self;
 
     /// Build window with the given `general` and `instance` names.
     ///
-    /// On Wayland, the `general` name sets an application ID, which should match the `.desktop`
-    /// file destributed with your program. The `instance` is a `no-op`.
-    ///
-    /// On X11, the `general` sets general class of `WM_CLASS(STRING)`, while `instance` set the
+    /// The `general` sets general class of `WM_CLASS(STRING)`, while `instance` set the
     /// instance part of it. The resulted property looks like `WM_CLASS(STRING) = "general", "instance"`.
     ///
     /// For details about application ID conventions, see the
@@ -326,37 +196,26 @@ pub trait WindowBuilderExtUnix {
     fn with_name(self, general: impl Into<String>, instance: impl Into<String>) -> Self;
 
     /// Build window with override-redirect flag; defaults to false. Only relevant on X11.
-    #[cfg(feature = "x11")]
     fn with_override_redirect(self, override_redirect: bool) -> Self;
 
     /// Build window with `_NET_WM_WINDOW_TYPE` hints; defaults to `Normal`. Only relevant on X11.
-    #[cfg(feature = "x11")]
     fn with_x11_window_type(self, x11_window_type: Vec<XWindowType>) -> Self;
 
     /// Build window with `_GTK_THEME_VARIANT` hint set to the specified value. Currently only relevant on X11.
-    #[cfg(feature = "x11")]
     fn with_gtk_theme_variant(self, variant: String) -> Self;
-
-    /// Build window with certain decoration [`Theme`]
-    ///
-    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
-    /// Possible values for env variable are: "dark" and light"
-    #[cfg(feature = "wayland")]
-    fn with_wayland_csd_theme(self, theme: Theme) -> Self;
 
     /// Build window with resize increment hint. Only implemented on X11.
     ///
     /// ```
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
     /// # use winit::window::WindowBuilder;
-    /// # use winit::platform::unix::WindowBuilderExtUnix;
+    /// # use winit::platform::x11::WindowBuilderExtX11;
     /// // Specify the size in logical dimensions like this:
     /// WindowBuilder::new().with_resize_increments(LogicalSize::new(400.0, 200.0));
     ///
     /// // Or specify the size in physical dimensions like this:
     /// WindowBuilder::new().with_resize_increments(PhysicalSize::new(400, 200));
     /// ```
-    #[cfg(feature = "x11")]
     fn with_resize_increments<S: Into<Size>>(self, increments: S) -> Self;
 
     /// Build window with base size hint. Only implemented on X11.
@@ -364,20 +223,18 @@ pub trait WindowBuilderExtUnix {
     /// ```
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
     /// # use winit::window::WindowBuilder;
-    /// # use winit::platform::unix::WindowBuilderExtUnix;
+    /// # use winit::platform::x11::WindowBuilderExtX11;
     /// // Specify the size in logical dimensions like this:
     /// WindowBuilder::new().with_base_size(LogicalSize::new(400.0, 200.0));
     ///
     /// // Or specify the size in physical dimensions like this:
     /// WindowBuilder::new().with_base_size(PhysicalSize::new(400, 200));
     /// ```
-    #[cfg(feature = "x11")]
     fn with_base_size<S: Into<Size>>(self, base_size: S) -> Self;
 }
 
-impl WindowBuilderExtUnix for WindowBuilder {
+impl WindowBuilderExtX11 for WindowBuilder {
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_x11_visual<T>(mut self, visual_infos: *const T) -> Self {
         {
             self.platform_specific.visual_infos =
@@ -387,7 +244,6 @@ impl WindowBuilderExtUnix for WindowBuilder {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_x11_screen(mut self, screen_id: i32) -> Self {
         self.platform_specific.screen_id = Some(screen_id);
         self
@@ -400,55 +256,43 @@ impl WindowBuilderExtUnix for WindowBuilder {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_override_redirect(mut self, override_redirect: bool) -> Self {
         self.platform_specific.override_redirect = override_redirect;
         self
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_x11_window_type(mut self, x11_window_types: Vec<XWindowType>) -> Self {
         self.platform_specific.x11_window_types = x11_window_types;
         self
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_gtk_theme_variant(mut self, variant: String) -> Self {
         self.platform_specific.gtk_theme_variant = Some(variant);
         self
     }
 
     #[inline]
-    #[cfg(feature = "wayland")]
-    fn with_wayland_csd_theme(mut self, theme: Theme) -> Self {
-        self.platform_specific.csd_theme = Some(theme);
-        self
-    }
-
-    #[inline]
-    #[cfg(feature = "x11")]
     fn with_resize_increments<S: Into<Size>>(mut self, increments: S) -> Self {
         self.platform_specific.resize_increments = Some(increments.into());
         self
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_base_size<S: Into<Size>>(mut self, base_size: S) -> Self {
         self.platform_specific.base_size = Some(base_size.into());
         self
     }
 }
 
-/// Additional methods on `MonitorHandle` that are specific to Linux.
-pub trait MonitorHandleExtUnix {
+/// Additional methods on `MonitorHandle` that are specific to X11.
+pub trait MonitorHandleExtX11 {
     /// Returns the inner identifier of the monitor.
     fn native_id(&self) -> u32;
 }
 
-impl MonitorHandleExtUnix for MonitorHandle {
+impl MonitorHandleExtX11 for MonitorHandle {
     #[inline]
     fn native_id(&self) -> u32 {
         self.inner.native_identifier()

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -117,15 +117,6 @@ pub trait WindowExtX11 {
     ///
     /// The pointer will become invalid when the [`Window`] is destroyed.
     fn xcb_connection(&self) -> Option<*mut raw::c_void>;
-
-    /// Check if the window is ready for drawing
-    ///
-    /// It is a remnant of a previous implementation detail for the
-    /// wayland backend, and is no longer relevant.
-    ///
-    /// Always return `true`.
-    #[deprecated]
-    fn is_ready(&self) -> bool;
 }
 
 impl WindowExtX11 for Window {
@@ -172,11 +163,6 @@ impl WindowExtX11 for Window {
             #[cfg(feature = "wayland")]
             _ => None,
         }
-    }
-
-    #[inline]
-    fn is_ready(&self) -> bool {
-        true
     }
 }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -27,7 +27,7 @@ pub use self::x11::XNotSupported;
 #[cfg(feature = "x11")]
 use self::x11::{ffi::XVisualInfo, util::WindowType as XWindowType, XConnection, XError};
 #[cfg(feature = "x11")]
-use crate::platform::unix::XlibErrorHook;
+use crate::platform::x11::XlibErrorHook;
 #[cfg(feature = "wayland")]
 use crate::window::Theme;
 use crate::{


### PR DESCRIPTION
There were basically no overlap between the platform-specific extensions in these, so it made little sense to keep them in the same file!

Will gladly rename the functions as well, e.g. `wayland_set_csd_theme -> set_csd_theme`?

~Blocked-ish on #2420~