### PR TITLE
Remove `parking_lot` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Removed `parking_lot` dependency.
 - On Windows, added `WindowExtWindows::set_undecorated_shadow` and `WindowBuilderExtWindows::with_undecorated_shadow` to draw the drop shadow behind a borderless window.
 - On Windows, fixed default window features (ie snap, animations, shake, etc.) when decorations are disabled.
 - **Breaking:** On macOS, add support for two-finger touchpad magnification and rotation gestures with new events `WindowEvent::TouchpadMagnify` and `WindowEvent::TouchpadRotate`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ targets = [
 
 [features]
 default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
-x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
+x11 = ["x11-dl", "mio", "percent-encoding"]
 wayland = ["wayland-client", "wayland-protocols", "sctk"]
 wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
 wayland-csd-adwaita = ["sctk-adwaita", "sctk-adwaita/ab_glyph"]
@@ -69,9 +69,6 @@ cocoa = "0.24"
 core-foundation = "0.9"
 core-graphics = "0.22"
 dispatch = "0.2.0"
-
-[target.'cfg(target_os = "windows")'.dependencies]
-parking_lot = "0.12"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 version = "0.36"
@@ -110,7 +107,6 @@ sctk-adwaita = { version = "0.5.1", default_features = false, optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }
-parking_lot = { version = "0.12.0", optional = true }
 libc = "0.2.64"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.web_sys]

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -56,7 +56,7 @@ pub type XlibErrorHook =
 pub fn register_xlib_error_hook(hook: XlibErrorHook) {
     // Append new hook.
     unsafe {
-        XLIB_ERROR_HOOKS.lock().push(hook);
+        XLIB_ERROR_HOOKS.lock().unwrap().push(hook);
     }
 }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -14,12 +14,15 @@ use std::error::Error;
 
 use std::{collections::VecDeque, env, fmt};
 #[cfg(feature = "x11")]
-use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Arc};
+use std::{
+    ffi::CStr,
+    mem::MaybeUninit,
+    os::raw::*,
+    sync::{Arc, Mutex},
+};
 
 #[cfg(feature = "x11")]
 use once_cell::sync::Lazy;
-#[cfg(feature = "x11")]
-use parking_lot::Mutex;
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 
 #[cfg(feature = "x11")]
@@ -595,11 +598,11 @@ unsafe extern "C" fn x_error_callback(
     display: *mut x11::ffi::Display,
     event: *mut x11::ffi::XErrorEvent,
 ) -> c_int {
-    let xconn_lock = X11_BACKEND.lock();
+    let xconn_lock = X11_BACKEND.lock().unwrap();
     if let Ok(ref xconn) = *xconn_lock {
         // Call all the hooks.
         let mut error_handled = false;
-        for hook in XLIB_ERROR_HOOKS.lock().iter() {
+        for hook in XLIB_ERROR_HOOKS.lock().unwrap().iter() {
             error_handled |= hook(display as *mut _, event as *mut _);
         }
 
@@ -626,7 +629,7 @@ unsafe extern "C" fn x_error_callback(
             error!("X11 error: {:#?}", error);
         }
 
-        *xconn.latest_error.lock() = Some(error);
+        *xconn.latest_error.lock().unwrap() = Some(error);
     }
     // Fun fact: this return value is completely ignored.
     0
@@ -729,7 +732,7 @@ impl<T: 'static> EventLoop<T> {
 
     #[cfg(feature = "x11")]
     fn new_x11_any_thread() -> Result<EventLoop<T>, XNotSupported> {
-        let xconn = match X11_BACKEND.lock().as_ref() {
+        let xconn = match X11_BACKEND.lock().unwrap().as_ref() {
             Ok(xconn) => xconn.clone(),
             Err(err) => return Err(err.clone()),
         };

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -2,8 +2,6 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc, slice, sync::Arc};
 
 use libc::{c_char, c_int, c_long, c_uint, c_ulong};
 
-use parking_lot::MutexGuard;
-
 use super::{
     events, ffi, get_xtarget, mkdid, mkwid, monitor, util, Device, DeviceId, DeviceInfo, Dnd,
     DndState, GenericEventCookie, ImeReceiver, ScrollOrientation, UnownedWindow, WindowId,
@@ -351,9 +349,9 @@ impl<T: 'static> EventProcessor<T> {
                     let new_inner_size = (xev.width as u32, xev.height as u32);
                     let new_inner_position = (xev.x as i32, xev.y as i32);
 
-                    let mut shared_state_lock = window.shared_state.lock();
-
                     let (mut resized, moved) = {
+                        let mut shared_state_lock = window.shared_state_lock();
+
                         let resized =
                             util::maybe_change(&mut shared_state_lock.size, new_inner_size);
                         let moved = if is_synthetic {
@@ -380,7 +378,13 @@ impl<T: 'static> EventProcessor<T> {
                         (resized, moved)
                     };
 
-                    let new_outer_position = if moved || shared_state_lock.position.is_none() {
+                    let position = window.shared_state_lock().position;
+
+                    let new_outer_position = if let (Some(position), false) = (position, moved) {
+                        position
+                    } else {
+                        let mut shared_state_lock = window.shared_state_lock();
+
                         // We need to convert client area position to window position.
                         let frame_extents = shared_state_lock
                             .frame_extents
@@ -395,21 +399,21 @@ impl<T: 'static> EventProcessor<T> {
                         let outer = frame_extents
                             .inner_pos_to_outer(new_inner_position.0, new_inner_position.1);
                         shared_state_lock.position = Some(outer);
+
+                        // Unlock shared state to prevent deadlock in callback below
+                        drop(shared_state_lock);
+
                         if moved {
-                            // Temporarily unlock shared state to prevent deadlock
-                            MutexGuard::unlocked(&mut shared_state_lock, || {
-                                callback(Event::WindowEvent {
-                                    window_id,
-                                    event: WindowEvent::Moved(outer.into()),
-                                });
+                            callback(Event::WindowEvent {
+                                window_id,
+                                event: WindowEvent::Moved(outer.into()),
                             });
                         }
                         outer
-                    } else {
-                        shared_state_lock.position.unwrap()
                     };
 
                     if is_synthetic {
+                        let mut shared_state_lock = window.shared_state_lock();
                         // If we don't use the existing adjusted value when available, then the user can screw up the
                         // resizing by dragging across monitors *without* dropping the window.
                         let (width, height) = shared_state_lock
@@ -441,15 +445,15 @@ impl<T: 'static> EventProcessor<T> {
                             let old_inner_size = PhysicalSize::new(width, height);
                             let mut new_inner_size = PhysicalSize::new(new_width, new_height);
 
-                            // Temporarily unlock shared state to prevent deadlock
-                            MutexGuard::unlocked(&mut shared_state_lock, || {
-                                callback(Event::WindowEvent {
-                                    window_id,
-                                    event: WindowEvent::ScaleFactorChanged {
-                                        scale_factor: new_scale_factor,
-                                        new_inner_size: &mut new_inner_size,
-                                    },
-                                });
+                            // Unlock shared state to prevent deadlock in callback below
+                            drop(shared_state_lock);
+
+                            callback(Event::WindowEvent {
+                                window_id,
+                                event: WindowEvent::ScaleFactorChanged {
+                                    scale_factor: new_scale_factor,
+                                    new_inner_size: &mut new_inner_size,
+                                },
                             });
 
                             if new_inner_size != old_inner_size {
@@ -457,13 +461,16 @@ impl<T: 'static> EventProcessor<T> {
                                     new_inner_size.width,
                                     new_inner_size.height,
                                 );
-                                shared_state_lock.dpi_adjusted = Some(new_inner_size.into());
+                                window.shared_state_lock().dpi_adjusted =
+                                    Some(new_inner_size.into());
                                 // if the DPI factor changed, force a resize event to ensure the logical
                                 // size is computed with the right DPI factor
                                 resized = true;
                             }
                         }
                     }
+
+                    let mut shared_state_lock = window.shared_state_lock();
 
                     // This is a hack to ensure that the DPI adjusted resize is actually applied on all WMs. KWin
                     // doesn't need this, but Xfwm does. The hack should not be run on other WMs, since tiling
@@ -478,10 +485,10 @@ impl<T: 'static> EventProcessor<T> {
                         }
                     }
 
-                    if resized {
-                        // Drop the shared state lock to prevent deadlock
-                        drop(shared_state_lock);
+                    // Unlock shared state to prevent deadlock in callback below
+                    drop(shared_state_lock);
 
+                    if resized {
                         callback(Event::WindowEvent {
                             window_id,
                             event: WindowEvent::Resized(new_inner_size.into()),
@@ -747,7 +754,7 @@ impl<T: 'static> EventProcessor<T> {
                         update_modifiers!(modifiers, None);
 
                         let cursor_moved = self.with_window(xev.event, |window| {
-                            let mut shared_state_lock = window.shared_state.lock();
+                            let mut shared_state_lock = window.shared_state_lock();
                             util::maybe_change(&mut shared_state_lock.cursor_pos, new_cursor_pos)
                         });
                         if cursor_moved == Some(true) {
@@ -1215,7 +1222,7 @@ impl<T: 'static> EventProcessor<T> {
                                                 new_monitor.scale_factor,
                                                 width,
                                                 height,
-                                                &*window.shared_state.lock(),
+                                                &*window.shared_state_lock(),
                                             );
 
                                             let window_id = crate::window::WindowId(*window_id);

--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -4,11 +4,10 @@ use std::{
     fmt,
     os::raw::c_char,
     ptr,
-    sync::Arc,
+    sync::{Arc, Mutex},
 };
 
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 
 use super::{ffi, util, XConnection, XError};
 

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -1,8 +1,8 @@
 use std::os::raw::*;
 use std::slice;
+use std::sync::Mutex;
 
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 
 use super::{
     ffi::{
@@ -24,7 +24,7 @@ static MONITORS: Lazy<Mutex<Option<Vec<MonitorHandle>>>> = Lazy::new(Mutex::defa
 
 pub fn invalidate_cached_monitor_list() -> Option<Vec<MonitorHandle>> {
     // We update this lazily.
-    (*MONITORS.lock()).take()
+    (*MONITORS.lock().unwrap()).take()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -293,7 +293,7 @@ impl XConnection {
     }
 
     pub fn available_monitors(&self) -> Vec<MonitorHandle> {
-        let mut monitors_lock = MONITORS.lock();
+        let mut monitors_lock = MONITORS.lock().unwrap();
         (*monitors_lock)
             .as_ref()
             .cloned()

--- a/src/platform_impl/linux/x11/util/atom.rs
+++ b/src/platform_impl/linux/x11/util/atom.rs
@@ -3,10 +3,10 @@ use std::{
     ffi::{CStr, CString},
     fmt::Debug,
     os::raw::*,
+    sync::Mutex,
 };
 
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 
 use super::*;
 
@@ -17,7 +17,7 @@ static ATOM_CACHE: Lazy<Mutex<AtomCache>> = Lazy::new(|| Mutex::new(HashMap::wit
 impl XConnection {
     pub fn get_atom<T: AsRef<CStr> + Debug>(&self, name: T) -> ffi::Atom {
         let name = name.as_ref();
-        let mut atom_cache_lock = ATOM_CACHE.lock();
+        let mut atom_cache_lock = ATOM_CACHE.lock().unwrap();
         let cached_atom = (*atom_cache_lock).get(name).cloned();
         if let Some(atom) = cached_atom {
             atom

--- a/src/platform_impl/linux/x11/util/cursor.rs
+++ b/src/platform_impl/linux/x11/util/cursor.rs
@@ -7,6 +7,7 @@ impl XConnection {
         let cursor = *self
             .cursor_cache
             .lock()
+            .unwrap()
             .entry(cursor)
             .or_insert_with(|| self.get_cursor(cursor));
 

--- a/src/platform_impl/linux/x11/util/wm.rs
+++ b/src/platform_impl/linux/x11/util/wm.rs
@@ -1,5 +1,6 @@
+use std::sync::Mutex;
+
 use once_cell::sync::Lazy;
-use parking_lot::Mutex;
 
 use super::*;
 
@@ -9,11 +10,11 @@ static SUPPORTED_HINTS: Lazy<Mutex<Vec<ffi::Atom>>> =
 static WM_NAME: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
 
 pub fn hint_is_supported(hint: ffi::Atom) -> bool {
-    (*SUPPORTED_HINTS.lock()).contains(&hint)
+    (*SUPPORTED_HINTS.lock().unwrap()).contains(&hint)
 }
 
 pub fn wm_name_is_one_of(names: &[&str]) -> bool {
-    if let Some(ref name) = *WM_NAME.lock() {
+    if let Some(ref name) = *WM_NAME.lock().unwrap() {
         names.contains(&name.as_str())
     } else {
         false
@@ -22,8 +23,8 @@ pub fn wm_name_is_one_of(names: &[&str]) -> bool {
 
 impl XConnection {
     pub fn update_cached_wm_info(&self, root: ffi::Window) {
-        *SUPPORTED_HINTS.lock() = self.get_supported_hints(root);
-        *WM_NAME.lock() = self.get_wm_name(root);
+        *SUPPORTED_HINTS.lock().unwrap() = self.get_supported_hints(root);
+        *WM_NAME.lock().unwrap() = self.get_wm_name(root);
     }
 
     fn get_supported_hints(&self, root: ffi::Window) -> Vec<ffi::Atom> {

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -1,7 +1,4 @@
-use std::{collections::HashMap, error::Error, fmt, os::raw::c_int, ptr};
-
-use libc;
-use parking_lot::Mutex;
+use std::{collections::HashMap, error::Error, fmt, os::raw::c_int, ptr, sync::Mutex};
 
 use crate::window::CursorIcon;
 
@@ -74,7 +71,7 @@ impl XConnection {
     /// Checks whether an error has been triggered by the previous function calls.
     #[inline]
     pub fn check_errors(&self) -> Result<(), XError> {
-        let error = self.latest_error.lock().take();
+        let error = self.latest_error.lock().unwrap().take();
         if let Some(error) = error {
             Err(error)
         } else {
@@ -85,7 +82,7 @@ impl XConnection {
     /// Ignores any previous error.
     #[inline]
     pub fn ignore_error(&self) {
-        *self.latest_error.lock() = None;
+        *self.latest_error.lock().unwrap() = None;
     }
 }
 

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -441,7 +441,7 @@ impl<T> BufferedEvent<T> {
                 let window_flags = unsafe {
                     let userdata =
                         get_window_long(window_id.0.into(), GWL_USERDATA) as *mut WindowData<T>;
-                    (*userdata).window_state.lock().window_flags
+                    (*userdata).window_state_lock().window_flags
                 };
                 window_flags.set_size((window_id.0).0, new_inner_size);
             }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -5,8 +5,8 @@ use crate::{
     platform_impl::platform::{event_loop, util},
     window::{CursorIcon, Fullscreen, Theme, WindowAttributes},
 };
-use parking_lot::MutexGuard;
 use std::io;
+use std::sync::MutexGuard;
 use windows_sys::Win32::{
     Foundation::{HWND, RECT},
     Graphics::Gdi::InvalidateRgn,


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/650.

`std`'s `Mutex` has [recently improved a lot](https://blog.rust-lang.org/2022/06/30/Rust-1.62.0.html#thinner-faster-mutexes-on-linux), so there's not really a performance argument for keeping i any more. Also means we won't have to use the same `windows-sys` version as `parking_lot`

Dependency tree (Windows):
```
// Before
winit v0.27.1
├── bitflags v1.3.2
├── instant v0.1.12
│   └── cfg-if v1.0.0
├── log v0.4.17
│   └── cfg-if v1.0.0
├── once_cell v1.13.0
├── parking_lot v0.12.1
│   ├── lock_api v0.4.7
│   │   └── scopeguard v1.1.0
│   │   [build-dependencies]
│   │   └── autocfg v1.1.0
│   └── parking_lot_core v0.9.3
│       ├── cfg-if v1.0.0
│       ├── smallvec v1.9.0
│       └── windows-sys v0.36.1
│           └── windows_x86_64_gnu v0.36.1
├── raw-window-handle v0.5.0
│   └── cty v0.2.2
└── windows-sys v0.36.1 (*)

// After
winit v0.27.1
├── bitflags v1.3.2
├── instant v0.1.12
│   └── cfg-if v1.0.0
├── log v0.4.17
│   └── cfg-if v1.0.0
├── once_cell v1.13.0
├── raw-window-handle v0.5.0
│   └── cty v0.2.2
└── windows-sys v0.36.1
    └── windows_x86_64_gnu v0.36.1
```

Dependency tree (X11):
```
// Before
winit v0.27.1
├── bitflags v1.3.2
├── instant v0.1.12
│   └── cfg-if v1.0.0
├── libc v0.2.129
├── log v0.4.17
│   └── cfg-if v1.0.0
├── mio v0.8.4
│   ├── libc v0.2.129
│   └── log v0.4.17 (*)
├── once_cell v1.13.0
├── parking_lot v0.12.1
│   ├── lock_api v0.4.7
│   │   └── scopeguard v1.1.0
│   │   [build-dependencies]
│   │   └── autocfg v1.1.0
│   └── parking_lot_core v0.9.3
│       ├── cfg-if v1.0.0
│       ├── libc v0.2.129
│       └── smallvec v1.9.0
├── percent-encoding v2.1.0
├── raw-window-handle v0.5.0
│   └── cty v0.2.2
└── x11-dl v2.20.0
    ├── lazy_static v1.4.0
    └── libc v0.2.129
    [build-dependencies]
    └── pkg-config v0.3.25

// After
winit v0.27.1
├── bitflags v1.3.2
├── instant v0.1.12
│   └── cfg-if v1.0.0
├── libc v0.2.129
├── log v0.4.17
│   └── cfg-if v1.0.0
├── mio v0.8.4
│   ├── libc v0.2.129
│   └── log v0.4.17 (*)
├── once_cell v1.13.0
├── percent-encoding v2.1.0
├── raw-window-handle v0.5.0
│   └── cty v0.2.2
└── x11-dl v2.20.0
    ├── lazy_static v1.4.0
    └── libc v0.2.129
    [build-dependencies]
    └── pkg-config v0.3.25
```

- [ ] Tested on all platforms changed
  - Nope, please test this!
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
