### PR TITLE
Remove redundant steps from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,10 +86,6 @@ jobs:
       shell: bash
       run: cargo $CMD doc --no-deps --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES --document-private-items
 
-    - name: Build
-      shell: bash
-      run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
-
     - name: Build tests
       shell: bash
       run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
@@ -105,10 +101,6 @@ jobs:
       shell: bash
       if: (matrix.rust_version == '1.57.0') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
-
-    - name: Build with serde enabled
-      shell: bash
-      run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
 
     - name: Build tests with serde enabled
       shell: bash


### PR DESCRIPTION
Tests are already building the entire crate, so no need for a
separate builds slowing down the CI.
