### PR TITLE
Make `winit` completely platform-agnostic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,14 +12,15 @@
 /src/platform/ios.rs                @francesca64
 /src/platform_impl/ios              @francesca64
 
-# Unix in general
-/src/platform/unix.rs               @kchibisov
+# Unix
 /src/platform_impl/linux/mod.rs     @kchibisov
 
 # Wayland
+/src/platform/wayland.rs            @kchibisov
 /src/platform_impl/linux/wayland    @kchibisov
 
 # X11
+/src/platform/x11.rs                @kchibisov
 /src/platform_impl/linux/x11        @kchibisov
 
 # macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** Split the `platform::unix` module into `platform::x11` and `platform::wayland`. The extension types are similarly renamed.
 - On macOS, fixed touch phase reporting when scrolling.
 - On X11, fix min, max and resize increment hints not persisting for resizable windows (e.g. on DPI change).
 - On Windows, respect min/max inner sizes when creating the window.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -312,7 +312,9 @@ impl<T> EventLoopWindowTarget<T> {
     /// **Wayland:** Always returns `None`.
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        self.p.primary_monitor()
+        self.p
+            .primary_monitor()
+            .map(|inner| MonitorHandle { inner })
     }
 
     /// Change [`DeviceEvent`] filter mode.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,14 +149,17 @@ extern crate bitflags;
 #[macro_use]
 extern crate objc;
 
-pub mod dpi;
 #[macro_use]
 pub mod error;
+
+#[macro_use]
+mod platform_impl;
+
+pub mod dpi;
 pub mod event;
 pub mod event_loop;
 mod icon;
 pub mod monitor;
-mod platform_impl;
 pub mod window;
 
 pub mod platform;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -169,6 +169,8 @@ impl MonitorHandle {
     /// - **Web:** Always returns an empty iterator
     #[inline]
     pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
-        self.inner.video_modes()
+        self.inner
+            .video_modes()
+            .map(|video_mode| VideoMode { video_mode })
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -78,7 +78,9 @@ impl VideoMode {
     /// a separate set of valid video modes.
     #[inline]
     pub fn monitor(&self) -> MonitorHandle {
-        self.video_mode.monitor()
+        MonitorHandle {
+            inner: self.video_mode.monitor(),
+        }
     }
 }
 

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,5 +1,3 @@
-#![cfg(any(target_os = "android"))]
-
 use crate::{
     event_loop::{EventLoop, EventLoopWindowTarget},
     window::{Window, WindowBuilder},

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "ios")]
-
 use std::os::raw::c_void;
 
 use crate::{

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -257,7 +257,9 @@ impl MonitorHandleExtIOS for MonitorHandle {
 
     #[inline]
     fn preferred_video_mode(&self) -> VideoMode {
-        self.inner.preferred_video_mode()
+        VideoMode {
+            video_mode: self.inner.preferred_video_mode(),
+        }
     }
 }
 

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -1,7 +1,7 @@
 use std::os::raw::c_void;
 
 use crate::{
-    event_loop::EventLoop,
+    event_loop::{EventLoop, InnerEventLoop},
     monitor::{MonitorHandle, VideoMode},
     window::{Window, WindowBuilder},
 };
@@ -14,7 +14,9 @@ pub trait EventLoopExtIOS {
 
 impl<T: 'static> EventLoopExtIOS for EventLoop<T> {
     fn idiom(&self) -> Idiom {
-        self.event_loop.idiom()
+        platform!(match &self.event_loop {
+            InnerEventLoop::__Platform__(this) => this.idiom(),
+        })
     }
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "macos")]
-
 use std::os::raw::c_void;
 
 use crate::{

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -2,7 +2,7 @@ use std::os::raw::c_void;
 
 use crate::{
     dpi::LogicalSize,
-    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{EventLoopBuilder, EventLoopWindowTarget, InnerEventLoopWindowTarget},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };
@@ -263,10 +263,18 @@ pub trait EventLoopWindowTargetExtMacOS {
 
 impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
     fn hide_application(&self) {
-        self.p.hide_application()
+        platform!(match &self.p {
+            InnerEventLoopWindowTarget::__Platform__(this) => {
+                this.hide_application()
+            }
+        })
     }
 
     fn hide_other_applications(&self) {
-        self.p.hide_other_applications()
+        platform!(match &self.p {
+            InnerEventLoopWindowTarget::__Platform__(this) => {
+                this.hide_other_applications()
+            }
+        })
     }
 }

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -21,18 +21,32 @@ pub mod android;
 pub mod ios;
 #[cfg(target_os = "macos")]
 pub mod macos;
-#[cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
+#[cfg(all(
+    feature = "wayland",
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )
 ))]
-pub mod unix;
+pub mod wayland;
 #[cfg(target_arch = "wasm32")]
 pub mod web;
 #[cfg(target_os = "windows")]
 pub mod windows;
+#[cfg(all(
+    feature = "x11",
+    any(
+        target_os = "linux",
+        target_os = "dragonfly",
+        target_os = "freebsd",
+        target_os = "netbsd",
+        target_os = "openbsd",
+    )
+))]
+pub mod x11;
 
 #[cfg(any(
     target_os = "windows",

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -15,11 +15,33 @@
 //!
 //! However only the module corresponding to the platform you're compiling to will be available.
 
+#[cfg(target_os = "android")]
 pub mod android;
+#[cfg(target_os = "ios")]
 pub mod ios;
+#[cfg(target_os = "macos")]
 pub mod macos;
+#[cfg(any(
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 pub mod unix;
+#[cfg(target_arch = "wasm32")]
 pub mod web;
+#[cfg(target_os = "windows")]
 pub mod windows;
 
+#[cfg(any(
+    target_os = "windows",
+    target_os = "macos",
+    target_os = "android",
+    target_os = "linux",
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 pub mod run_return;

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -1,14 +1,3 @@
-#![cfg(any(
-    target_os = "windows",
-    target_os = "macos",
-    target_os = "android",
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-
 use crate::{
     event::Event,
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use crate::{
     event::Event,
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
@@ -40,7 +42,7 @@ pub trait EventLoopExtRunReturn {
 impl<T> EventLoopExtRunReturn for EventLoop<T> {
     type UserEvent = T;
 
-    fn run_return<F>(&mut self, event_handler: F) -> i32
+    fn run_return<F>(&mut self, mut event_handler: F) -> i32
     where
         F: FnMut(
             Event<'_, Self::UserEvent>,
@@ -48,6 +50,11 @@ impl<T> EventLoopExtRunReturn for EventLoop<T> {
             &mut ControlFlow,
         ),
     {
-        self.event_loop.run_return(event_handler)
+        let window_target = &self.window_target;
+        let platform_window_target = Rc::clone(&self.window_target.p);
+        self.event_loop.run_return(
+            move |event, control_flow| event_handler(event, window_target, control_flow),
+            platform_window_target,
+        )
     }
 }

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -1,11 +1,3 @@
-#![cfg(any(
-    target_os = "linux",
-    target_os = "dragonfly",
-    target_os = "freebsd",
-    target_os = "netbsd",
-    target_os = "openbsd"
-))]
-
 use std::os::raw;
 #[cfg(feature = "x11")]
 use std::{ptr, sync::Arc};

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -37,10 +37,8 @@ impl<T> EventLoopWindowTargetExtWayland for EventLoopWindowTarget<T> {
 
     #[inline]
     fn wayland_display(&self) -> Option<*mut raw::c_void> {
-        match self.p {
-            LinuxEventLoopWindowTarget::Wayland(ref p) => {
-                Some(p.display().get_display_ptr() as *mut _)
-            }
+        match &*self.p {
+            LinuxEventLoopWindowTarget::Wayland(p) => Some(p.display().get_display_ptr() as *mut _),
             #[cfg(feature = "x11")]
             _ => None,
         }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -1,0 +1,186 @@
+use std::os::raw;
+
+use crate::{
+    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    monitor::MonitorHandle,
+    window::{Window, WindowBuilder},
+};
+
+use crate::platform_impl::{
+    ApplicationName, Backend, EventLoopWindowTarget as LinuxEventLoopWindowTarget,
+    Window as LinuxWindow,
+};
+
+pub use crate::window::Theme;
+
+/// Additional methods on [`EventLoopWindowTarget`] that are specific to Wayland.
+pub trait EventLoopWindowTargetExtWayland {
+    /// True if the [`EventLoopWindowTarget`] uses Wayland.
+    fn is_wayland(&self) -> bool;
+
+    /// Returns a pointer to the `wl_display` object of wayland that is used by this
+    /// [`EventLoopWindowTarget`].
+    ///
+    /// Returns `None` if the [`EventLoop`] doesn't use wayland (if it uses xlib for example).
+    ///
+    /// The pointer will become invalid when the winit [`EventLoop`] is destroyed.
+    ///
+    /// [`EventLoop`]: crate::event_loop::EventLoop
+    fn wayland_display(&self) -> Option<*mut raw::c_void>;
+}
+
+impl<T> EventLoopWindowTargetExtWayland for EventLoopWindowTarget<T> {
+    #[inline]
+    fn is_wayland(&self) -> bool {
+        self.p.is_wayland()
+    }
+
+    #[inline]
+    fn wayland_display(&self) -> Option<*mut raw::c_void> {
+        match self.p {
+            LinuxEventLoopWindowTarget::Wayland(ref p) => {
+                Some(p.display().get_display_ptr() as *mut _)
+            }
+            #[cfg(feature = "x11")]
+            _ => None,
+        }
+    }
+}
+
+/// Additional methods on [`EventLoopBuilder`] that are specific to Wayland.
+pub trait EventLoopBuilderExtWayland {
+    /// Force using Wayland.
+    fn with_wayland(&mut self) -> &mut Self;
+
+    /// Whether to allow the event loop to be created off of the main thread.
+    ///
+    /// By default, the window is only allowed to be created on the main
+    /// thread, to make platform compatibility easier.
+    fn with_any_thread(&mut self, any_thread: bool) -> &mut Self;
+}
+
+impl<T> EventLoopBuilderExtWayland for EventLoopBuilder<T> {
+    #[inline]
+    fn with_wayland(&mut self) -> &mut Self {
+        self.platform_specific.forced_backend = Some(Backend::Wayland);
+        self
+    }
+
+    #[inline]
+    fn with_any_thread(&mut self, any_thread: bool) -> &mut Self {
+        self.platform_specific.any_thread = any_thread;
+        self
+    }
+}
+
+/// Additional methods on [`Window`] that are specific to Wayland.
+pub trait WindowExtWayland {
+    /// Returns a pointer to the `wl_surface` object of wayland that is used by this window.
+    ///
+    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
+    ///
+    /// The pointer will become invalid when the [`Window`] is destroyed.
+    fn wayland_surface(&self) -> Option<*mut raw::c_void>;
+
+    /// Returns a pointer to the `wl_display` object of wayland that is used by this window.
+    ///
+    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
+    ///
+    /// The pointer will become invalid when the [`Window`] is destroyed.
+    fn wayland_display(&self) -> Option<*mut raw::c_void>;
+
+    /// Updates [`Theme`] of window decorations.
+    ///
+    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+    /// Possible values for env variable are: "dark" and light"
+    fn wayland_set_csd_theme(&self, config: Theme);
+
+    /// Check if the window is ready for drawing
+    ///
+    /// It is a remnant of a previous implementation detail for the
+    /// wayland backend, and is no longer relevant.
+    ///
+    /// Always return `true`.
+    #[deprecated]
+    fn is_ready(&self) -> bool;
+}
+
+impl WindowExtWayland for Window {
+    #[inline]
+    fn wayland_surface(&self) -> Option<*mut raw::c_void> {
+        match self.window {
+            LinuxWindow::Wayland(ref w) => Some(w.surface().as_ref().c_ptr() as *mut _),
+            #[cfg(feature = "x11")]
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn wayland_display(&self) -> Option<*mut raw::c_void> {
+        match self.window {
+            LinuxWindow::Wayland(ref w) => Some(w.display().get_display_ptr() as *mut _),
+            #[cfg(feature = "x11")]
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn wayland_set_csd_theme(&self, theme: Theme) {
+        #[allow(clippy::single_match)]
+        match self.window {
+            LinuxWindow::Wayland(ref w) => w.set_csd_theme(theme),
+            #[cfg(feature = "x11")]
+            _ => (),
+        }
+    }
+
+    #[inline]
+    fn is_ready(&self) -> bool {
+        true
+    }
+}
+
+/// Additional methods on [`WindowBuilder`] that are specific to Wayland.
+pub trait WindowBuilderExtWayland {
+    /// Build window with the given application ID.
+    ///
+    /// This should match the `.desktop` file destributed with your program.
+    ///
+    /// For details about application ID conventions, see the
+    /// [Desktop Entry Spec](https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#desktop-file-id)
+    fn with_application_id(self, application_id: impl Into<String>) -> Self;
+
+    /// Build window with certain decoration [`Theme`]
+    ///
+    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
+    /// Possible values for env variable are: "dark" and light"
+    fn with_wayland_csd_theme(self, theme: Theme) -> Self;
+}
+
+impl WindowBuilderExtWayland for WindowBuilder {
+    #[inline]
+    fn with_application_id(mut self, application_id: impl Into<String>) -> Self {
+        self.platform_specific.name =
+            Some(ApplicationName::new(application_id.into(), String::new()));
+        self
+    }
+
+    #[inline]
+    fn with_wayland_csd_theme(mut self, theme: Theme) -> Self {
+        self.platform_specific.csd_theme = Some(theme);
+        self
+    }
+}
+
+/// Additional methods on `MonitorHandle` that are specific to Wayland.
+pub trait MonitorHandleExtWayland {
+    /// Returns the inner identifier of the monitor.
+    fn native_id(&self) -> u32;
+}
+
+impl MonitorHandleExtWayland for MonitorHandle {
+    #[inline]
+    fn native_id(&self) -> u32 {
+        self.inner.native_identifier()
+    }
+}

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -1,5 +1,3 @@
-#![cfg(target_arch = "wasm32")]
-
 //! The web target does not automatically insert the canvas element object into the web page, to
 //! allow end users to determine how the page should be laid out. Use the [`WindowExtWebSys`] trait
 //! to retrieve the canvas from the Window. Alternatively, use the [`WindowBuilderExtWebSys`] trait

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -8,6 +8,8 @@ use crate::event::Event;
 use crate::event_loop::ControlFlow;
 use crate::event_loop::EventLoop;
 use crate::event_loop::EventLoopWindowTarget;
+use crate::event_loop::InnerEventLoop;
+use crate::event_loop::InnerEventLoopWindowTarget;
 use crate::window::WindowBuilder;
 
 use web_sys::HtmlCanvasElement;
@@ -90,7 +92,11 @@ impl<T> EventLoopExtWebSys for EventLoop<T> {
             event_loop,
             ..
         } = self;
-        let platform_window_target = Rc::clone(&window_target.p);
+        let (event_loop, platform_window_target) = match (event_loop, &window_target.p) {
+            (InnerEventLoop::Web(event_loop), InnerEventLoopWindowTarget::Web(window_target)) => {
+                (event_loop, Rc::clone(&window_target))
+            }
+        };
 
         event_loop.spawn(
             move |event, control_flow| event_handler(event, &window_target, control_flow),

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "windows")]
-
 use std::{ffi::c_void, path::Path};
 
 use crate::{

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -58,8 +58,8 @@ impl<T> EventLoopWindowTargetExtX11 for EventLoopWindowTarget<T> {
 
     #[inline]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
-        match self.p {
-            LinuxEventLoopWindowTarget::X(ref e) => Some(e.x_connection().clone()),
+        match &*self.p {
+            LinuxEventLoopWindowTarget::X(e) => Some(e.x_connection().clone()),
             #[cfg(feature = "wayland")]
             _ => None,
         }

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -1,5 +1,4 @@
 use std::os::raw;
-#[cfg(feature = "x11")]
 use std::{ptr, sync::Arc};
 
 use crate::{
@@ -8,31 +7,22 @@ use crate::{
     window::{Window, WindowBuilder},
 };
 
-#[cfg(feature = "x11")]
 use crate::dpi::Size;
-#[cfg(feature = "x11")]
-use crate::platform_impl::{x11::ffi::XVisualInfo, x11::XConnection, XLIB_ERROR_HOOKS};
 use crate::platform_impl::{
-    ApplicationName, Backend, EventLoopWindowTarget as LinuxEventLoopWindowTarget,
-    Window as LinuxWindow,
+    x11::ffi::XVisualInfo, x11::XConnection, ApplicationName, Backend,
+    EventLoopWindowTarget as LinuxEventLoopWindowTarget, Window as LinuxWindow, XLIB_ERROR_HOOKS,
 };
 
 // TODO: stupid hack so that glutin can do its work
 #[doc(hidden)]
-#[cfg(feature = "x11")]
 pub use crate::platform_impl::x11;
-#[cfg(feature = "x11")]
 pub use crate::platform_impl::{x11::util::WindowType as XWindowType, XNotSupported};
-
-#[cfg(feature = "wayland")]
-pub use crate::window::Theme;
 
 /// The first argument in the provided hook will be the pointer to `XDisplay`
 /// and the second one the pointer to [`XErrorEvent`]. The returned `bool` is an
 /// indicator whether the error was handled by the callback.
 ///
 /// [`XErrorEvent`]: https://linux.die.net/man/3/xerrorevent
-#[cfg(feature = "x11")]
 pub type XlibErrorHook =
     Box<dyn Fn(*mut std::ffi::c_void, *mut std::ffi::c_void) -> bool + Send + Sync>;
 
@@ -44,7 +34,6 @@ pub type XlibErrorHook =
 ///
 /// [`unsafe`]: https://www.remlab.net/op/xlib.shtml
 #[inline]
-#[cfg(feature = "x11")]
 pub fn register_xlib_error_hook(hook: XlibErrorHook) {
     // Append new hook.
     unsafe {
@@ -52,47 +41,22 @@ pub fn register_xlib_error_hook(hook: XlibErrorHook) {
     }
 }
 
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to Unix.
-pub trait EventLoopWindowTargetExtUnix {
-    /// True if the [`EventLoopWindowTarget`] uses Wayland.
-    #[cfg(feature = "wayland")]
-    fn is_wayland(&self) -> bool;
-
+/// Additional methods on [`EventLoopWindowTarget`] that are specific to X11.
+pub trait EventLoopWindowTargetExtX11 {
     /// True if the [`EventLoopWindowTarget`] uses X11.
-    #[cfg(feature = "x11")]
     fn is_x11(&self) -> bool;
 
     #[doc(hidden)]
-    #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>>;
-
-    /// Returns a pointer to the `wl_display` object of wayland that is used by this
-    /// [`EventLoopWindowTarget`].
-    ///
-    /// Returns `None` if the [`EventLoop`] doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the winit [`EventLoop`] is destroyed.
-    ///
-    /// [`EventLoop`]: crate::event_loop::EventLoop
-    #[cfg(feature = "wayland")]
-    fn wayland_display(&self) -> Option<*mut raw::c_void>;
 }
 
-impl<T> EventLoopWindowTargetExtUnix for EventLoopWindowTarget<T> {
+impl<T> EventLoopWindowTargetExtX11 for EventLoopWindowTarget<T> {
     #[inline]
-    #[cfg(feature = "wayland")]
-    fn is_wayland(&self) -> bool {
-        self.p.is_wayland()
-    }
-
-    #[inline]
-    #[cfg(feature = "x11")]
     fn is_x11(&self) -> bool {
         !self.p.is_wayland()
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.p {
             LinuxEventLoopWindowTarget::X(ref e) => Some(e.x_connection().clone()),
@@ -100,29 +64,12 @@ impl<T> EventLoopWindowTargetExtUnix for EventLoopWindowTarget<T> {
             _ => None,
         }
     }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn wayland_display(&self) -> Option<*mut raw::c_void> {
-        match self.p {
-            LinuxEventLoopWindowTarget::Wayland(ref p) => {
-                Some(p.display().get_display_ptr() as *mut _)
-            }
-            #[cfg(feature = "x11")]
-            _ => None,
-        }
-    }
 }
 
-/// Additional methods on [`EventLoopBuilder`] that are specific to Unix.
-pub trait EventLoopBuilderExtUnix {
+/// Additional methods on [`EventLoopBuilder`] that are specific to X11.
+pub trait EventLoopBuilderExtX11 {
     /// Force using X11.
-    #[cfg(feature = "x11")]
     fn with_x11(&mut self) -> &mut Self;
-
-    /// Force using Wayland.
-    #[cfg(feature = "wayland")]
-    fn with_wayland(&mut self) -> &mut Self;
 
     /// Whether to allow the event loop to be created off of the main thread.
     ///
@@ -131,18 +78,10 @@ pub trait EventLoopBuilderExtUnix {
     fn with_any_thread(&mut self, any_thread: bool) -> &mut Self;
 }
 
-impl<T> EventLoopBuilderExtUnix for EventLoopBuilder<T> {
+impl<T> EventLoopBuilderExtX11 for EventLoopBuilder<T> {
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_x11(&mut self) -> &mut Self {
         self.platform_specific.forced_backend = Some(Backend::X);
-        self
-    }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn with_wayland(&mut self) -> &mut Self {
-        self.platform_specific.forced_backend = Some(Backend::Wayland);
         self
     }
 
@@ -153,12 +92,11 @@ impl<T> EventLoopBuilderExtUnix for EventLoopBuilder<T> {
     }
 }
 
-/// Additional methods on [`Window`] that are specific to Unix.
-pub trait WindowExtUnix {
+/// Additional methods on [`Window`] that are specific to X11.
+pub trait WindowExtX11 {
     /// Returns the ID of the [`Window`] xlib object that is used by this window.
     ///
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
-    #[cfg(feature = "x11")]
     fn xlib_window(&self) -> Option<raw::c_ulong>;
 
     /// Returns a pointer to the `Display` object of xlib that is used by this window.
@@ -166,14 +104,11 @@ pub trait WindowExtUnix {
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
     ///
     /// The pointer will become invalid when the [`Window`] is destroyed.
-    #[cfg(feature = "x11")]
     fn xlib_display(&self) -> Option<*mut raw::c_void>;
 
-    #[cfg(feature = "x11")]
     fn xlib_screen_id(&self) -> Option<raw::c_int>;
 
     #[doc(hidden)]
-    #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>>;
 
     /// This function returns the underlying `xcb_connection_t` of an xlib `Display`.
@@ -181,31 +116,7 @@ pub trait WindowExtUnix {
     /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
     ///
     /// The pointer will become invalid when the [`Window`] is destroyed.
-    #[cfg(feature = "x11")]
     fn xcb_connection(&self) -> Option<*mut raw::c_void>;
-
-    /// Returns a pointer to the `wl_surface` object of wayland that is used by this window.
-    ///
-    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    #[cfg(feature = "wayland")]
-    fn wayland_surface(&self) -> Option<*mut raw::c_void>;
-
-    /// Returns a pointer to the `wl_display` object of wayland that is used by this window.
-    ///
-    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    #[cfg(feature = "wayland")]
-    fn wayland_display(&self) -> Option<*mut raw::c_void>;
-
-    /// Updates [`Theme`] of window decorations.
-    ///
-    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
-    /// Possible values for env variable are: "dark" and light"
-    #[cfg(feature = "wayland")]
-    fn wayland_set_csd_theme(&self, config: Theme);
 
     /// Check if the window is ready for drawing
     ///
@@ -217,9 +128,8 @@ pub trait WindowExtUnix {
     fn is_ready(&self) -> bool;
 }
 
-impl WindowExtUnix for Window {
+impl WindowExtX11 for Window {
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_window(&self) -> Option<raw::c_ulong> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xlib_window()),
@@ -229,7 +139,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_display(&self) -> Option<*mut raw::c_void> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xlib_display()),
@@ -239,7 +148,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_screen_id(&self) -> Option<raw::c_int> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xlib_screen_id()),
@@ -249,7 +157,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xlib_xconnection(&self) -> Option<Arc<XConnection>> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xlib_xconnection()),
@@ -259,7 +166,6 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn xcb_connection(&self) -> Option<*mut raw::c_void> {
         match self.window {
             LinuxWindow::X(ref w) => Some(w.xcb_connection()),
@@ -269,56 +175,20 @@ impl WindowExtUnix for Window {
     }
 
     #[inline]
-    #[cfg(feature = "wayland")]
-    fn wayland_surface(&self) -> Option<*mut raw::c_void> {
-        match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.surface().as_ref().c_ptr() as *mut _),
-            #[cfg(feature = "x11")]
-            _ => None,
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn wayland_display(&self) -> Option<*mut raw::c_void> {
-        match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.display().get_display_ptr() as *mut _),
-            #[cfg(feature = "x11")]
-            _ => None,
-        }
-    }
-
-    #[inline]
-    #[cfg(feature = "wayland")]
-    fn wayland_set_csd_theme(&self, theme: Theme) {
-        #[allow(clippy::single_match)]
-        match self.window {
-            LinuxWindow::Wayland(ref w) => w.set_csd_theme(theme),
-            #[cfg(feature = "x11")]
-            _ => (),
-        }
-    }
-
-    #[inline]
     fn is_ready(&self) -> bool {
         true
     }
 }
 
-/// Additional methods on [`WindowBuilder`] that are specific to Unix.
-pub trait WindowBuilderExtUnix {
-    #[cfg(feature = "x11")]
+/// Additional methods on [`WindowBuilder`] that are specific to X11.
+pub trait WindowBuilderExtX11 {
     fn with_x11_visual<T>(self, visual_infos: *const T) -> Self;
 
-    #[cfg(feature = "x11")]
     fn with_x11_screen(self, screen_id: i32) -> Self;
 
     /// Build window with the given `general` and `instance` names.
     ///
-    /// On Wayland, the `general` name sets an application ID, which should match the `.desktop`
-    /// file destributed with your program. The `instance` is a `no-op`.
-    ///
-    /// On X11, the `general` sets general class of `WM_CLASS(STRING)`, while `instance` set the
+    /// The `general` sets general class of `WM_CLASS(STRING)`, while `instance` set the
     /// instance part of it. The resulted property looks like `WM_CLASS(STRING) = "general", "instance"`.
     ///
     /// For details about application ID conventions, see the
@@ -326,37 +196,26 @@ pub trait WindowBuilderExtUnix {
     fn with_name(self, general: impl Into<String>, instance: impl Into<String>) -> Self;
 
     /// Build window with override-redirect flag; defaults to false. Only relevant on X11.
-    #[cfg(feature = "x11")]
     fn with_override_redirect(self, override_redirect: bool) -> Self;
 
     /// Build window with `_NET_WM_WINDOW_TYPE` hints; defaults to `Normal`. Only relevant on X11.
-    #[cfg(feature = "x11")]
     fn with_x11_window_type(self, x11_window_type: Vec<XWindowType>) -> Self;
 
     /// Build window with `_GTK_THEME_VARIANT` hint set to the specified value. Currently only relevant on X11.
-    #[cfg(feature = "x11")]
     fn with_gtk_theme_variant(self, variant: String) -> Self;
-
-    /// Build window with certain decoration [`Theme`]
-    ///
-    /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
-    /// Possible values for env variable are: "dark" and light"
-    #[cfg(feature = "wayland")]
-    fn with_wayland_csd_theme(self, theme: Theme) -> Self;
 
     /// Build window with resize increment hint. Only implemented on X11.
     ///
     /// ```
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
     /// # use winit::window::WindowBuilder;
-    /// # use winit::platform::unix::WindowBuilderExtUnix;
+    /// # use winit::platform::x11::WindowBuilderExtX11;
     /// // Specify the size in logical dimensions like this:
     /// WindowBuilder::new().with_resize_increments(LogicalSize::new(400.0, 200.0));
     ///
     /// // Or specify the size in physical dimensions like this:
     /// WindowBuilder::new().with_resize_increments(PhysicalSize::new(400, 200));
     /// ```
-    #[cfg(feature = "x11")]
     fn with_resize_increments<S: Into<Size>>(self, increments: S) -> Self;
 
     /// Build window with base size hint. Only implemented on X11.
@@ -364,20 +223,18 @@ pub trait WindowBuilderExtUnix {
     /// ```
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
     /// # use winit::window::WindowBuilder;
-    /// # use winit::platform::unix::WindowBuilderExtUnix;
+    /// # use winit::platform::x11::WindowBuilderExtX11;
     /// // Specify the size in logical dimensions like this:
     /// WindowBuilder::new().with_base_size(LogicalSize::new(400.0, 200.0));
     ///
     /// // Or specify the size in physical dimensions like this:
     /// WindowBuilder::new().with_base_size(PhysicalSize::new(400, 200));
     /// ```
-    #[cfg(feature = "x11")]
     fn with_base_size<S: Into<Size>>(self, base_size: S) -> Self;
 }
 
-impl WindowBuilderExtUnix for WindowBuilder {
+impl WindowBuilderExtX11 for WindowBuilder {
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_x11_visual<T>(mut self, visual_infos: *const T) -> Self {
         {
             self.platform_specific.visual_infos =
@@ -387,7 +244,6 @@ impl WindowBuilderExtUnix for WindowBuilder {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_x11_screen(mut self, screen_id: i32) -> Self {
         self.platform_specific.screen_id = Some(screen_id);
         self
@@ -400,55 +256,43 @@ impl WindowBuilderExtUnix for WindowBuilder {
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_override_redirect(mut self, override_redirect: bool) -> Self {
         self.platform_specific.override_redirect = override_redirect;
         self
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_x11_window_type(mut self, x11_window_types: Vec<XWindowType>) -> Self {
         self.platform_specific.x11_window_types = x11_window_types;
         self
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_gtk_theme_variant(mut self, variant: String) -> Self {
         self.platform_specific.gtk_theme_variant = Some(variant);
         self
     }
 
     #[inline]
-    #[cfg(feature = "wayland")]
-    fn with_wayland_csd_theme(mut self, theme: Theme) -> Self {
-        self.platform_specific.csd_theme = Some(theme);
-        self
-    }
-
-    #[inline]
-    #[cfg(feature = "x11")]
     fn with_resize_increments<S: Into<Size>>(mut self, increments: S) -> Self {
         self.platform_specific.resize_increments = Some(increments.into());
         self
     }
 
     #[inline]
-    #[cfg(feature = "x11")]
     fn with_base_size<S: Into<Size>>(mut self, base_size: S) -> Self {
         self.platform_specific.base_size = Some(base_size.into());
         self
     }
 }
 
-/// Additional methods on `MonitorHandle` that are specific to Linux.
-pub trait MonitorHandleExtUnix {
+/// Additional methods on `MonitorHandle` that are specific to X11.
+pub trait MonitorHandleExtX11 {
     /// Returns the inner identifier of the monitor.
     fn native_id(&self) -> u32;
 }
 
-impl MonitorHandleExtUnix for MonitorHandle {
+impl MonitorHandleExtX11 for MonitorHandle {
     #[inline]
     fn native_id(&self) -> u32 {
         self.inner.native_identifier()

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -901,17 +901,15 @@ impl MonitorHandle {
         None
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = monitor::VideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(monitor::VideoMode {
-            video_mode: VideoMode {
-                size,
-                bit_depth: 32,
-                refresh_rate_millihertz: 60000,
-                monitor: self.clone(),
-            },
+        std::iter::once(VideoMode {
+            size,
+            bit_depth: 32,
+            refresh_rate_millihertz: 60000,
+            monitor: self.clone(),
         })
     }
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -261,9 +261,7 @@ macro_rules! call_event_handler {
 }
 
 impl<T: 'static> EventLoop<T> {
-    pub(crate) fn new(
-        _: &PlatformSpecificEventLoopAttributes,
-    ) -> (Self, EventLoopWindowTarget<T>) {
+    pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> (Self, EventLoopWindowTarget<T>) {
         let (user_events_sender, user_events_receiver) = mpsc::channel();
         (
             Self {

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -18,6 +18,7 @@ use raw_window_handle::{
     AndroidDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 
+use super::Fullscreen;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error,
@@ -683,7 +684,7 @@ impl DeviceId {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PlatformSpecificWindowBuilderAttributes;
 
-pub struct Window;
+pub(crate) struct Window;
 
 impl Window {
     pub(crate) fn new<T: 'static>(
@@ -772,11 +773,11 @@ impl Window {
         false
     }
 
-    pub fn set_fullscreen(&self, _monitor: Option<window::Fullscreen>) {
+    pub fn set_fullscreen(&self, _monitor: Option<Fullscreen>) {
         warn!("Cannot set fullscreen on Android");
     }
 
-    pub fn fullscreen(&self) -> Option<window::Fullscreen> {
+    pub fn fullscreen(&self) -> Option<Fullscreen> {
         None
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -23,7 +23,6 @@ use crate::{
     error,
     event::{self, VirtualKeyCode},
     event_loop::{self, ControlFlow},
-    monitor,
     window::{self, CursorGrabMode},
 };
 
@@ -636,10 +635,8 @@ pub struct EventLoopWindowTarget<T: 'static> {
 }
 
 impl<T: 'static> EventLoopWindowTarget<T> {
-    pub fn primary_monitor(&self) -> Option<monitor::MonitorHandle> {
-        Some(monitor::MonitorHandle {
-            inner: MonitorHandle,
-        })
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
@@ -702,10 +699,8 @@ impl Window {
         WindowId
     }
 
-    pub fn primary_monitor(&self) -> Option<monitor::MonitorHandle> {
-        Some(monitor::MonitorHandle {
-            inner: MonitorHandle,
-        })
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
@@ -714,10 +709,8 @@ impl Window {
         v
     }
 
-    pub fn current_monitor(&self) -> Option<monitor::MonitorHandle> {
-        Some(monitor::MonitorHandle {
-            inner: MonitorHandle,
-        })
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     pub fn scale_factor(&self) -> f64 {
@@ -935,9 +928,7 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> monitor::MonitorHandle {
-        monitor::MonitorHandle {
-            inner: self.monitor.clone(),
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        self.monitor.clone()
     }
 }

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -15,7 +15,6 @@ use crate::{
     event_loop::{
         ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootEventLoopWindowTarget,
     },
-    monitor::MonitorHandle as RootMonitorHandle,
     platform::ios::Idiom,
 };
 
@@ -59,11 +58,11 @@ impl<T: 'static> EventLoopWindowTarget<T> {
         unsafe { monitor::uiscreens() }
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         // guaranteed to be on main thread
         let monitor = unsafe { monitor::main_uiscreen() };
 
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -87,6 +87,7 @@ pub(crate) use self::{
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},
 };
 
+pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -227,7 +227,7 @@ impl Inner {
         Some(refresh_rate_millihertz(self.uiscreen))
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         let mut modes = BTreeSet::new();
         unsafe {
             let available_modes: id = msg_send![self.uiscreen, availableModes];
@@ -235,13 +235,14 @@ impl Inner {
 
             for i in 0..available_mode_count {
                 let mode: id = msg_send![available_modes, objectAtIndex: i];
+                // Use Ord impl of RootVideoMode
                 modes.insert(RootVideoMode {
                     video_mode: VideoMode::retained_new(self.uiscreen, mode),
                 });
             }
         }
 
-        modes.into_iter()
+        modes.into_iter().map(|mode| mode.video_mode)
     }
 }
 
@@ -275,12 +276,10 @@ impl Inner {
         self.uiscreen
     }
 
-    pub fn preferred_video_mode(&self) -> RootVideoMode {
+    pub fn preferred_video_mode(&self) -> VideoMode {
         unsafe {
             let mode: id = msg_send![self.uiscreen, preferredMode];
-            RootVideoMode {
-                video_mode: VideoMode::retained_new(self.uiscreen, mode),
-            }
+            VideoMode::retained_new(self.uiscreen, mode)
         }
     }
 }

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::VideoMode as RootVideoMode,
     platform_impl::platform::{
         app_state,
         ffi::{id, nil, CGFloat, CGRect, CGSize, NSInteger, NSUInteger},
@@ -84,10 +84,8 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: self.monitor.clone(),
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        self.monitor.clone()
     }
 }
 

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -8,7 +8,6 @@ use objc::{
 use crate::{
     dpi::PhysicalPosition,
     event::{DeviceId as RootDeviceId, Event, Force, Touch, TouchPhase, WindowEvent},
-    platform::ios::MonitorHandleExtIOS,
     platform_impl::platform::{
         app_state::{self, OSCapabilities},
         event_loop::{self, EventProxy, EventWrapper},
@@ -17,9 +16,9 @@ use crate::{
             UIRectEdge, UITouchPhase, UITouchType,
         },
         window::PlatformSpecificWindowBuilderAttributes,
-        DeviceId,
+        DeviceId, Fullscreen,
     },
-    window::{Fullscreen, WindowAttributes, WindowId as RootWindowId},
+    window::{WindowAttributes, WindowId as RootWindowId},
 };
 
 macro_rules! add_property {
@@ -524,7 +523,7 @@ pub(crate) unsafe fn create_window(
     match window_attributes.fullscreen {
         Some(Fullscreen::Exclusive(ref video_mode)) => {
             let uiscreen = video_mode.monitor().ui_screen() as id;
-            let _: () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode.0];
+            let _: () = msg_send![uiscreen, setCurrentMode: video_mode.screen_mode.0];
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
         Some(Fullscreen::Borderless(ref monitor)) => {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -223,9 +223,10 @@ impl Inner {
                         msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode.0];
                     uiscreen
                 }
-                Some(Fullscreen::Borderless(monitor)) => monitor
-                    .unwrap_or_else(|| self.current_monitor_inner())
-                    .ui_screen() as id,
+                Some(Fullscreen::Borderless(Some(monitor))) => monitor.ui_screen() as id,
+                Some(Fullscreen::Borderless(None)) => {
+                    self.current_monitor_inner().ui_screen() as id
+                }
                 None => {
                     warn!("`Window::set_fullscreen(None)` ignored on iOS");
                     return;
@@ -254,7 +255,7 @@ impl Inner {
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         unsafe {
             let monitor = self.current_monitor_inner();
-            let uiscreen = monitor.inner.ui_screen();
+            let uiscreen = monitor.ui_screen();
             let screen_space_bounds = self.screen_frame();
             let screen_bounds: CGRect = msg_send![uiscreen, bounds];
 
@@ -264,7 +265,9 @@ impl Inner {
                 && screen_space_bounds.size.width == screen_bounds.size.width
                 && screen_space_bounds.size.height == screen_bounds.size.height
             {
-                Some(Fullscreen::Borderless(Some(monitor)))
+                Some(Fullscreen::Borderless(Some(RootMonitorHandle {
+                    inner: monitor,
+                })))
             } else {
                 None
             }
@@ -305,16 +308,14 @@ impl Inner {
     }
 
     // Allow directly accessing the current monitor internally without unwrapping.
-    fn current_monitor_inner(&self) -> RootMonitorHandle {
+    fn current_monitor_inner(&self) -> MonitorHandle {
         unsafe {
             let uiscreen: id = msg_send![self.window, screen];
-            RootMonitorHandle {
-                inner: MonitorHandle::retained_new(uiscreen),
-            }
+            MonitorHandle::retained_new(uiscreen)
         }
     }
 
-    pub fn current_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
         Some(self.current_monitor_inner())
     }
 
@@ -322,9 +323,9 @@ impl Inner {
         unsafe { monitor::uiscreens() }
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = unsafe { monitor::main_uiscreen() };
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 
     pub fn id(&self) -> WindowId {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -38,7 +38,6 @@ use crate::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
-    monitor::MonitorHandle as RootMonitorHandle,
     window::{CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
 };
 
@@ -299,7 +298,7 @@ impl VideoMode {
     }
 
     #[inline]
-    pub fn monitor(&self) -> RootMonitorHandle {
+    pub fn monitor(&self) -> MonitorHandle {
         x11_or_wayland!(match self; VideoMode(m) => m.monitor())
     }
 }
@@ -522,21 +521,17 @@ impl Window {
     }
 
     #[inline]
-    pub fn current_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
         match self {
             #[cfg(feature = "x11")]
             Window::X(ref window) => {
                 let current_monitor = MonitorHandle::X(window.current_monitor());
-                Some(RootMonitorHandle {
-                    inner: current_monitor,
-                })
+                Some(current_monitor)
             }
             #[cfg(feature = "wayland")]
             Window::Wayland(ref window) => {
                 let current_monitor = MonitorHandle::Wayland(window.current_monitor()?);
-                Some(RootMonitorHandle {
-                    inner: current_monitor,
-                })
+                Some(current_monitor)
             }
         }
     }
@@ -560,14 +555,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         match self {
             #[cfg(feature = "x11")]
             Window::X(ref window) => {
                 let primary_monitor = MonitorHandle::X(window.primary_monitor());
-                Some(RootMonitorHandle {
-                    inner: primary_monitor,
-                })
+                Some(primary_monitor)
             }
             #[cfg(feature = "wayland")]
             Window::Wayland(ref window) => window.primary_monitor(),
@@ -804,16 +797,14 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         match *self {
             #[cfg(feature = "wayland")]
             EventLoopWindowTarget::Wayland(ref evlp) => evlp.primary_monitor(),
             #[cfg(feature = "x11")]
             EventLoopWindowTarget::X(ref evlp) => {
                 let primary_monitor = MonitorHandle::X(evlp.x_connection().primary_monitor());
-                Some(RootMonitorHandle {
-                    inner: primary_monitor,
-                })
+                Some(primary_monitor)
             }
         }
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -38,7 +38,7 @@ use crate::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::MonitorHandle as RootMonitorHandle,
     window::{CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
 };
 
@@ -269,7 +269,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> Box<dyn Iterator<Item = RootVideoMode>> {
+    pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoMode>> {
         x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
     }
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -27,7 +27,7 @@ pub use self::x11::XNotSupported;
 #[cfg(feature = "x11")]
 use self::x11::{ffi::XVisualInfo, util::WindowType as XWindowType, XConnection, XError};
 #[cfg(feature = "x11")]
-use crate::platform::unix::XlibErrorHook;
+use crate::platform::x11::XlibErrorHook;
 #[cfg(feature = "wayland")]
 use crate::window::Theme;
 use crate::{

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -38,9 +38,10 @@ use crate::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
-    window::{CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
+    window::{CursorGrabMode, CursorIcon, UserAttentionType, WindowAttributes},
 };
 
+pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 
 #[cfg(feature = "wayland")]
@@ -448,12 +449,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn fullscreen(&self) -> Option<Fullscreen> {
+    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         x11_or_wayland!(match self; Window(w) => w.fullscreen())
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
+    pub(crate) fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
         x11_or_wayland!(match self; Window(w) => w.set_fullscreen(monitor))
     }
 

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -8,7 +8,6 @@ use sctk::environment::Environment;
 use sctk::output::OutputStatusListener;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform_impl::platform::{
     MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode,
 };
@@ -224,10 +223,8 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: PlatformMonitorHandle::Wayland(self.monitor.clone()),
-        }
+    pub fn monitor(&self) -> PlatformMonitorHandle {
+        PlatformMonitorHandle::Wayland(self.monitor.clone())
     }
 }
 
@@ -243,7 +240,7 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<PlatformMonitorHandle> {
         // There's no primary monitor on Wayland.
         None
     }

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -8,7 +8,7 @@ use sctk::environment::Environment;
 use sctk::output::OutputStatusListener;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
+use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform_impl::platform::{
     MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode,
 };
@@ -183,19 +183,19 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoMode> {
         let modes = sctk::output::with_output_info(&self.proxy, |info| info.modes.clone())
             .unwrap_or_default();
 
         let monitor = self.clone();
 
-        modes.into_iter().map(move |mode| RootVideoMode {
-            video_mode: PlatformVideoMode::Wayland(VideoMode {
+        modes.into_iter().map(move |mode| {
+            PlatformVideoMode::Wayland(VideoMode {
                 size: (mode.dimensions.0 as u32, mode.dimensions.1 as u32).into(),
                 refresh_rate_millihertz: mode.refresh_rate as u32,
                 bit_depth: 32,
                 monitor: monitor.clone(),
-            }),
+            })
         })
     }
 }

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -8,6 +8,7 @@ use sctk::environment::Environment;
 use sctk::output::OutputStatusListener;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
+use crate::event_loop::DeviceEventFilter;
 use crate::platform_impl::platform::{
     MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode,
 };
@@ -244,4 +245,7 @@ impl<T> EventLoopWindowTarget<T> {
         // There's no primary monitor on Wayland.
         None
     }
+
+    #[inline]
+    pub fn set_device_event_filter(&self, _filter: DeviceEventFilter) {}
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -571,7 +571,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<PlatformMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         None
     }
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -205,12 +205,11 @@ impl Window {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor =
-                    monitor.and_then(|RootMonitorHandle { inner: monitor }| match monitor {
-                        PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
-                        #[cfg(feature = "x11")]
-                        PlatformMonitorHandle::X(_) => None,
-                    });
+                let monitor = monitor.and_then(|monitor| match monitor.inner {
+                    PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
+                    #[cfg(feature = "x11")]
+                    PlatformMonitorHandle::X(_) => None,
+                });
 
                 window.set_fullscreen(monitor.as_ref());
             }
@@ -462,12 +461,11 @@ impl Window {
                 return;
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor =
-                    monitor.and_then(|RootMonitorHandle { inner: monitor }| match monitor {
-                        PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
-                        #[cfg(feature = "x11")]
-                        PlatformMonitorHandle::X(_) => None,
-                    });
+                let monitor = monitor.and_then(|monitor| match monitor.inner {
+                    PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
+                    #[cfg(feature = "x11")]
+                    PlatformMonitorHandle::X(_) => None,
+                });
 
                 WindowRequest::Fullscreen(monitor)
             }
@@ -576,7 +574,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<PlatformMonitorHandle> {
         None
     }
 

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::{MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode},
 };
 
@@ -199,13 +199,11 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoMode> {
         let monitor = self.clone();
         self.video_modes.clone().into_iter().map(move |mut x| {
             x.monitor = Some(monitor.clone());
-            RootVideoMode {
-                video_mode: PlatformVideoMode::X(x),
-            }
+            PlatformVideoMode::X(x)
         })
     }
 }

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -13,7 +13,6 @@ use super::{
 };
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::{MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode},
 };
 
@@ -53,10 +52,8 @@ impl VideoMode {
     }
 
     #[inline]
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: PlatformMonitorHandle::X(self.monitor.clone().unwrap()),
-        }
+    pub fn monitor(&self) -> PlatformMonitorHandle {
+        PlatformMonitorHandle::X(self.monitor.clone().unwrap())
     }
 }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -22,7 +22,6 @@ use raw_window_handle::{AppKitDisplayHandle, RawDisplayHandle};
 use crate::{
     event::Event,
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootWindowTarget},
-    monitor::MonitorHandle as RootMonitorHandle,
     platform::macos::ActivationPolicy,
     platform_impl::{
         get_aux_state_mut,
@@ -84,9 +83,9 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = monitor::primary_monitor();
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 
     #[inline]

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -32,6 +32,7 @@ use crate::{
 };
 use objc::rc::autoreleasepool;
 
+pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -3,7 +3,7 @@ use std::{collections::VecDeque, fmt};
 use super::{ffi, util};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::MonitorHandle as RootMonitorHandle,
 };
 use cocoa::{
     appkit::NSScreen,
@@ -237,7 +237,7 @@ impl MonitorHandle {
         }
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         let refresh_rate_millihertz = self.refresh_rate_millihertz().unwrap_or(0);
         let monitor = self.clone();
 
@@ -282,7 +282,7 @@ impl MonitorHandle {
                     unimplemented!()
                 };
 
-                let video_mode = VideoMode {
+                VideoMode {
                     size: (
                         ffi::CGDisplayModeGetPixelWidth(mode) as u32,
                         ffi::CGDisplayModeGetPixelHeight(mode) as u32,
@@ -291,9 +291,7 @@ impl MonitorHandle {
                     bit_depth,
                     monitor: monitor.clone(),
                     native_mode: NativeDisplayMode(mode),
-                };
-
-                RootVideoMode { video_mode }
+                }
             })
         }
     }

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -1,10 +1,7 @@
 use std::{collections::VecDeque, fmt};
 
 use super::{ffi, util};
-use crate::{
-    dpi::{PhysicalPosition, PhysicalSize},
-    monitor::MonitorHandle as RootMonitorHandle,
-};
+use crate::dpi::{PhysicalPosition, PhysicalSize};
 use cocoa::{
     appkit::NSScreen,
     base::{id, nil},
@@ -91,10 +88,8 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: self.monitor.clone(),
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        self.monitor.clone()
     }
 }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -19,15 +19,15 @@ use once_cell::sync::Lazy;
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     event::{Event, ModifiersState, WindowEvent},
-    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         app_state::AppState,
         event::{EventProxy, EventWrapper},
         util::{self, IdRef},
         view::ViewState,
         window::{get_window_id, UnownedWindow},
+        Fullscreen,
     },
-    window::{Fullscreen, WindowId},
+    window::WindowId,
 };
 
 pub struct WindowDelegateState {
@@ -434,9 +434,7 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
                 // Otherwise, we must've reached fullscreen by the user clicking
                 // on the green fullscreen button. Update state!
                 None => {
-                    let current_monitor = Some(RootMonitorHandle {
-                        inner: window.current_monitor_inner(),
-                    });
+                    let current_monitor = Some(window.current_monitor_inner());
                     shared_state.fullscreen = Some(Fullscreen::Borderless(current_monitor))
                 }
             }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -19,6 +19,7 @@ use once_cell::sync::Lazy;
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     event::{Event, ModifiersState, WindowEvent},
+    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         app_state::AppState,
         event::{EventProxy, EventWrapper},
@@ -433,7 +434,9 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
                 // Otherwise, we must've reached fullscreen by the user clicking
                 // on the green fullscreen button. Update state!
                 None => {
-                    let current_monitor = Some(window.current_monitor_inner());
+                    let current_monitor = Some(RootMonitorHandle {
+                        inner: window.current_monitor_inner(),
+                    });
                     shared_state.fullscreen = Some(Fullscreen::Borderless(current_monitor))
                 }
             }

--- a/src/platform_impl/macros.rs
+++ b/src/platform_impl/macros.rs
@@ -1,0 +1,275 @@
+//! TODO!
+//!
+//! Yeah... This is complex!
+
+macro_rules! platform {
+    // Declare enums
+    {
+        $(#[$m:meta])*
+        $v:vis enum $($t:tt)*
+    } => {
+        __platform_parse_until_curly_bracket! {
+            (__platform_enum_out)
+            ($(#[$m])* $v enum)
+            ()
+            ($($t)*)
+        }
+    };
+
+    // Match on those enums
+    (
+        $(use $import:ident::__Platform__;)?
+        match $($t:tt)*
+    ) => {
+        __platform_parse_until_curly_bracket! {
+            (__platform_match_parse_inner)
+            ($(use $import::__Platform__;)? match)
+            ()
+            ($($t)*)
+        }
+    };
+}
+
+macro_rules! __platform_parse_until_curly_bracket {
+    {($macro_out:ident) ($($prefix:tt)*) ($($item:tt)*) ({ $($body:tt)* })} => {
+        $macro_out! {
+            $($prefix)* ($($item)*) {
+                $($body)*
+            }
+        }
+    };
+    {($macro_out:ident) ($($prefix:tt)*) ($($item:tt)*) ($t:tt $($rest:tt)*)} => {
+        __platform_parse_until_curly_bracket! {
+            ($macro_out) ($($prefix)*) ($($item)* $t) ($($rest)*)
+        }
+    };
+}
+
+macro_rules! __platform_parse_until_fat_arrow {
+    {($macro_out:ident) ($($prefix:tt)*) ($($item:tt)*) (=> $($body:tt)*)} => {
+        $macro_out! {
+            $($prefix)* {
+                ($($item)*) => $($body)*
+            }
+        }
+    };
+    {($macro_out:ident) ($($prefix:tt)*) ($($item:tt)*) ($t:tt $($rest:tt)*)} => {
+        __platform_parse_until_fat_arrow! {
+            ($macro_out) ($($prefix)*) ($($item)* $t) ($($rest)*)
+        }
+    };
+}
+
+macro_rules! __platform_enum_out {
+    (
+        $(#[$m:meta])* $v:vis enum ($($enum:tt)*) {
+            __Platform__$(($($t:tt)+))? $(,)?
+        }
+    ) => {
+        $(#[$m])*
+        $v enum $($enum)* {
+            #[cfg(target_os = "ios")]
+            Ios$((__platform_impl_replace!((platform_impl) () ($($t)+))))?,
+
+            #[cfg(target_os = "macos")]
+            Macos$((__platform_impl_replace!((platform_impl) () ($($t)+))))?,
+
+            #[cfg(all(
+                feature = "x11",
+                any(
+                    target_os = "linux",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                ),
+            ))]
+            X11$((__platform_impl_replace!((platform_impl::x11) () ($($t)+))))?,
+
+            #[cfg(all(
+                feature = "wayland",
+                any(
+                    target_os = "linux",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                ),
+            ))]
+            Wayland$((__platform_impl_replace!((platform_impl::wayland) () ($($t)+))))?,
+
+            #[cfg(target_os = "windows")]
+            Windows$((__platform_impl_replace!((platform_impl) () ($($t)+))))?,
+
+            #[cfg(target_arch = "wasm32")]
+            Web$((__platform_impl_replace!((platform_impl) () ($($t)+))))?,
+
+            #[cfg(target_os = "android")]
+            Android$((__platform_impl_replace!((platform_impl) () ($($t)+))))?,
+        }
+    };
+}
+
+macro_rules! __platform_match_parse_inner {
+    (
+        $(use $import:ident::__Platform__;)?
+        match ($item:expr) {
+            $($t:tt)*
+        }
+    ) => {
+        __platform_parse_until_fat_arrow! {
+            (__platform_match_out)
+            ($(use $import::__Platform__;)? match ($item))
+            ()
+            ($($t)*)
+        }
+    };
+}
+
+macro_rules! __platform_match_out {
+    (
+        $(use $import:ident::__Platform__;)?
+        match ($item:expr) {
+            ($($p:tt)*) => $x:expr
+            $(, _ => $fallback:expr)? $(,)?
+        }
+    ) => {
+        match $item {
+            #[cfg(target_os = "ios")]
+            __platform_pattern_replace!((Ios) () ($($p)+)) => {
+                $(use $import::Ios as __Platform__;)?
+                $x
+            }
+
+            #[cfg(target_os = "macos")]
+            __platform_pattern_replace!((Macos) () ($($p)+)) => {
+                $(use $import::Macos as __Platform__;)?
+                $x
+            }
+
+            #[cfg(all(
+                feature = "x11",
+                any(
+                    target_os = "linux",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                ),
+            ))]
+            __platform_pattern_replace!((X11) () ($($p)+)) => {
+                $(use $import::X11 as __Platform__;)?
+                $x
+            }
+
+            #[cfg(all(
+                feature = "wayland",
+                any(
+                    target_os = "linux",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                ),
+            ))]
+            __platform_pattern_replace!((Wayland) () ($($p)+)) => {
+                $(use $import::Wayland as __Platform__;)?
+                $x
+            }
+
+            #[cfg(target_os = "windows")]
+            __platform_pattern_replace!((Windows) () ($($p)+)) => {
+                $(use $import::Windows as __Platform__;)?
+                $x
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            __platform_pattern_replace!((Web) () ($($p)+)) => {
+                $(use $import::Web as __Platform__;)?
+                $x
+            }
+
+            #[cfg(target_os = "android")]
+            __platform_pattern_replace!((Android) () ($($p)+)) => {
+                $(use $import::Android as __Platform__;)?
+                $x
+            }
+
+            $(
+                #[allow(unreachable_patterns)]
+                _ => $fallback
+            )?
+        }
+    };
+}
+
+/// Replace __Platform__ with the specified path
+macro_rules! __platform_pattern_replace {
+    {($($path:tt)*) ($($output:tt)*) (__Platform__ $($rest:tt)*)} => {
+        __platform_pattern_replace! {
+            ($($path)*)
+            ($($output)* $($path)*)
+            ($($rest)*)
+        }
+    };
+    // Recurse into parentheses
+    {($($path:tt)*) ($($output:tt)*) (( $($rest:tt)* ))} => {
+        __platform_pattern_replace_in_group! {
+            ($($path)*)
+            ($($output)*)
+            ()
+            ()
+            ($($rest)*)
+        }
+    };
+    {($($path:tt)*) ($($output:tt)*) ($t:tt $($rest:tt)*)} => {
+        __platform_pattern_replace! {
+            ($($path)*)
+            ($($output)* $t)
+            ($($rest)*)
+        }
+    };
+    {($($path:tt)*) ($($output:tt)*) ()} => {
+        $($output)*
+    };
+}
+
+macro_rules! __platform_pattern_replace_in_group {
+    {($($path:tt)*) ($($output:tt)*) ($($parsed:tt)*) ($($item:tt)*) ($(,)?)} => {
+        $($output)* (
+            $($parsed)*
+            __platform_pattern_replace!(($($path)*) () ($($item)*))
+        )
+    };
+    {($($path:tt)*) ($($output:tt)*) ($($parsed:tt)*) ($($item:tt)*) (, $($rest:tt)*)} => {
+        __platform_pattern_replace_in_group! {
+            ($($path)*) ($($output)*) ($($parsed)* __platform_pattern_replace!(($($path)*) () ($($item)*)), ) () ($($rest)*)
+        }
+    };
+    {($($path:tt)*) ($($output:tt)*) ($($parsed:tt)*) ($($item:tt)*) ($t:tt $($rest:tt)*)} => {
+        __platform_pattern_replace_in_group! {
+            ($($path)*) ($($output)*) ($($parsed)*) ($($item)* $t) ($($rest)*)
+        }
+    };
+}
+
+/// Replace platform_impl::__platform__ with the specified path
+macro_rules! __platform_impl_replace {
+    {($($path:tt)*) ($($output:tt)*) (platform_impl::__platform__ $($rest:tt)*)} => {
+        __platform_impl_replace! {
+            ($($path)*)
+            ($($output)* $($path)*)
+            ($($rest)*)
+        }
+    };
+    {($($path:tt)*) ($($output:tt)*) ($t:tt $($rest:tt)*)} => {
+        __platform_impl_replace! {
+            ($($path)*)
+            ($($output)* $t)
+            ($($rest)*)
+        }
+    };
+    {($($path:tt)*) ($($output:tt)*) ()} => {
+        $($output)*
+    };
+}

--- a/src/platform_impl/macros.rs
+++ b/src/platform_impl/macros.rs
@@ -45,21 +45,6 @@ macro_rules! __platform_parse_until_curly_bracket {
     };
 }
 
-macro_rules! __platform_parse_until_fat_arrow {
-    {($macro_out:ident) ($($prefix:tt)*) ($($item:tt)*) (=> $($body:tt)*)} => {
-        $macro_out! {
-            $($prefix)* {
-                ($($item)*) => $($body)*
-            }
-        }
-    };
-    {($macro_out:ident) ($($prefix:tt)*) ($($item:tt)*) ($t:tt $($rest:tt)*)} => {
-        __platform_parse_until_fat_arrow! {
-            ($macro_out) ($($prefix)*) ($($item)* $t) ($($rest)*)
-        }
-    };
-}
-
 macro_rules! __platform_enum_out {
     (
         $(#[$m:meta])* $v:vis enum ($($enum:tt)*) {
@@ -114,35 +99,18 @@ macro_rules! __platform_match_parse_inner {
     (
         $(use $import:ident::__Platform__;)?
         match ($item:expr) {
-            $($t:tt)*
-        }
-    ) => {
-        __platform_parse_until_fat_arrow! {
-            (__platform_match_out)
-            ($(use $import::__Platform__;)? match ($item))
-            ()
-            ($($t)*)
-        }
-    };
-}
-
-macro_rules! __platform_match_out {
-    (
-        $(use $import:ident::__Platform__;)?
-        match ($item:expr) {
-            ($($p:tt)*) => $x:expr
-            $(, _ => $fallback:expr)? $(,)?
+            $enum:ident::__Platform__$(($p:pat))? => $x:expr $(,)?
         }
     ) => {
         match $item {
             #[cfg(target_os = "ios")]
-            __platform_pattern_replace!((Ios) () ($($p)+)) => {
+            $enum::Ios$(($p))? => {
                 $(use $import::Ios as __Platform__;)?
                 $x
             }
 
             #[cfg(target_os = "macos")]
-            __platform_pattern_replace!((Macos) () ($($p)+)) => {
+            $enum::Macos$(($p))? => {
                 $(use $import::Macos as __Platform__;)?
                 $x
             }
@@ -157,7 +125,7 @@ macro_rules! __platform_match_out {
                     target_os = "openbsd",
                 ),
             ))]
-            __platform_pattern_replace!((X11) () ($($p)+)) => {
+            $enum::X11$(($p))? => {
                 $(use $import::X11 as __Platform__;)?
                 $x
             }
@@ -172,83 +140,117 @@ macro_rules! __platform_match_out {
                     target_os = "openbsd",
                 ),
             ))]
-            __platform_pattern_replace!((Wayland) () ($($p)+)) => {
+            $enum::Wayland$(($p))? => {
                 $(use $import::Wayland as __Platform__;)?
                 $x
             }
 
             #[cfg(target_os = "windows")]
-            __platform_pattern_replace!((Windows) () ($($p)+)) => {
+            $enum::Windows$(($p))? => {
                 $(use $import::Windows as __Platform__;)?
                 $x
             }
 
             #[cfg(target_arch = "wasm32")]
-            __platform_pattern_replace!((Web) () ($($p)+)) => {
+            $enum::Web$(($p))? => {
                 $(use $import::Web as __Platform__;)?
                 $x
             }
 
             #[cfg(target_os = "android")]
-            __platform_pattern_replace!((Android) () ($($p)+)) => {
+            $enum::Android$(($p))? => {
+                $(use $import::Android as __Platform__;)?
+                $x
+            }
+        }
+    };
+    // If no comma after expression
+    (
+        $(use $import:ident::__Platform__;)?
+        match ($item:expr) {
+            ($($enum:ident::__Platform__$(($p:pat))?),+ $(,)?) => { $($x:tt)* }
+            _ => $fallback:expr $(,)?
+        }
+    ) => {
+        __platform_match_parse_inner!(
+            $(use $import::__Platform__;)?
+            match ($item) {
+                ($($enum::__Platform__$(($p))?),+) => { $($x)* },
+                _ => $fallback,
+            }
+        )
+    };
+    // Usual case
+    (
+        $(use $import:ident::__Platform__;)?
+        match ($item:expr) {
+            ($($enum:ident::__Platform__$(($p:pat))?),+ $(,)?) => $x:expr,
+            _ => $fallback:expr $(,)?
+        }
+    ) => {
+        match $item {
+            #[cfg(target_os = "ios")]
+            ($($enum::Ios$(($p))?),+) => {
+                $(use $import::Ios as __Platform__;)?
+                $x
+            }
+
+            #[cfg(target_os = "macos")]
+            ($($enum::Macos$(($p))?),+) => {
+                $(use $import::Macos as __Platform__;)?
+                $x
+            }
+
+            #[cfg(all(
+                feature = "x11",
+                any(
+                    target_os = "linux",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                ),
+            ))]
+            ($($enum::X11$(($p))?),+) => {
+                $(use $import::X11 as __Platform__;)?
+                $x
+            }
+
+            #[cfg(all(
+                feature = "wayland",
+                any(
+                    target_os = "linux",
+                    target_os = "dragonfly",
+                    target_os = "freebsd",
+                    target_os = "netbsd",
+                    target_os = "openbsd",
+                ),
+            ))]
+            ($($enum::Wayland$(($p))?),+) => {
+                $(use $import::Wayland as __Platform__;)?
+                $x
+            }
+
+            #[cfg(target_os = "windows")]
+            ($($enum::Windows$(($p))?),+) => {
+                $(use $import::Windows as __Platform__;)?
+                $x
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            ($($enum::Web$(($p))?),+) => {
+                $(use $import::Web as __Platform__;)?
+                $x
+            }
+
+            #[cfg(target_os = "android")]
+            ($($enum::Android$(($p))?),+) => {
                 $(use $import::Android as __Platform__;)?
                 $x
             }
 
-            $(
-                #[allow(unreachable_patterns)]
-                _ => $fallback
-            )?
-        }
-    };
-}
-
-/// Replace __Platform__ with the specified path
-macro_rules! __platform_pattern_replace {
-    {($($path:tt)*) ($($output:tt)*) (__Platform__ $($rest:tt)*)} => {
-        __platform_pattern_replace! {
-            ($($path)*)
-            ($($output)* $($path)*)
-            ($($rest)*)
-        }
-    };
-    // Recurse into parentheses
-    {($($path:tt)*) ($($output:tt)*) (( $($rest:tt)* ))} => {
-        __platform_pattern_replace_in_group! {
-            ($($path)*)
-            ($($output)*)
-            ()
-            ()
-            ($($rest)*)
-        }
-    };
-    {($($path:tt)*) ($($output:tt)*) ($t:tt $($rest:tt)*)} => {
-        __platform_pattern_replace! {
-            ($($path)*)
-            ($($output)* $t)
-            ($($rest)*)
-        }
-    };
-    {($($path:tt)*) ($($output:tt)*) ()} => {
-        $($output)*
-    };
-}
-
-macro_rules! __platform_pattern_replace_in_group {
-    {($($path:tt)*) ($($output:tt)*) ($($parsed:tt)*) ($($item:tt)*) ($(,)?)} => {
-        $($output)* (
-            $($parsed)*
-            __platform_pattern_replace!(($($path)*) () ($($item)*))
-        )
-    };
-    {($($path:tt)*) ($($output:tt)*) ($($parsed:tt)*) ($($item:tt)*) (, $($rest:tt)*)} => {
-        __platform_pattern_replace_in_group! {
-            ($($path)*) ($($output)*) ($($parsed)* __platform_pattern_replace!(($($path)*) () ($($item)*)), ) () ($($rest)*)
-        }
-    };
-    {($($path:tt)*) ($($output:tt)*) ($($parsed:tt)*) ($($item:tt)*) ($t:tt $($rest:tt)*)} => {
-        __platform_pattern_replace_in_group! {
-            ($($path)*) ($($output)*) ($($parsed)*) ($($item)* $t) ($($rest)*)
+            #[allow(unreachable_patterns)]
+            _ => $fallback
         }
     };
 }

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -61,6 +61,7 @@ impl From<Fullscreen> for RootFullscreen {
 }
 
 platform! {
+    #[allow(dead_code)]
     #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
     #[non_exhaustive]
     pub(crate) enum Platform {

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -1,6 +1,9 @@
 use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
 use crate::window::Fullscreen as RootFullscreen;
 
+#[macro_use]
+mod macros;
+
 #[cfg(target_os = "windows")]
 #[path = "windows/mod.rs"]
 mod platform;
@@ -54,6 +57,14 @@ impl From<Fullscreen> for RootFullscreen {
             }
             Fullscreen::Borderless(None) => Self::Borderless(None),
         }
+    }
+}
+
+platform! {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    #[non_exhaustive]
+    pub(crate) enum Platform {
+        __Platform__, // Replaced by macro
     }
 }
 

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -1,4 +1,5 @@
-pub use self::platform::*;
+use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
+use crate::window::Fullscreen as RootFullscreen;
 
 #[cfg(target_os = "windows")]
 #[path = "windows/mod.rs"]
@@ -24,6 +25,37 @@ mod platform;
 #[cfg(target_arch = "wasm32")]
 #[path = "web/mod.rs"]
 mod platform;
+
+pub use self::platform::*;
+
+/// Helper for converting between platform-specific and generic VideoMode/MonitorHandle
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Fullscreen {
+    Exclusive(VideoMode),
+    Borderless(Option<MonitorHandle>),
+}
+
+impl From<RootFullscreen> for Fullscreen {
+    fn from(f: RootFullscreen) -> Self {
+        match f {
+            RootFullscreen::Exclusive(mode) => Self::Exclusive(mode.video_mode),
+            RootFullscreen::Borderless(Some(handle)) => Self::Borderless(Some(handle.inner)),
+            RootFullscreen::Borderless(None) => Self::Borderless(None),
+        }
+    }
+}
+
+impl From<Fullscreen> for RootFullscreen {
+    fn from(f: Fullscreen) -> Self {
+        match f {
+            Fullscreen::Exclusive(video_mode) => Self::Exclusive(RootVideoMode { video_mode }),
+            Fullscreen::Borderless(Some(inner)) => {
+                Self::Borderless(Some(RootMonitorHandle { inner }))
+            }
+            Fullscreen::Borderless(None) => Self::Borderless(None),
+        }
+    }
+}
 
 #[cfg(all(
     not(target_os = "ios"),

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -15,7 +15,6 @@ use crate::event::{
     WindowEvent,
 };
 use crate::event_loop::ControlFlow;
-use crate::monitor::MonitorHandle as RootMH;
 use crate::window::{Theme, WindowId as RootWindowId};
 
 pub struct EventLoopWindowTarget<T: 'static> {
@@ -277,10 +276,8 @@ impl<T> EventLoopWindowTarget<T> {
         VecDeque::new().into_iter()
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMH> {
-        Some(RootMH {
-            inner: MonitorHandle,
-        })
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -34,6 +34,7 @@ pub(crate) use self::event_loop::{
 pub use self::monitor::{MonitorHandle, VideoMode};
 pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId};
 
+pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 #[derive(Clone, Copy)]

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -1,5 +1,4 @@
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::MonitorHandle as RootMonitorHandle;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MonitorHandle;
@@ -49,9 +48,7 @@ impl VideoMode {
         32000
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: MonitorHandle,
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        MonitorHandle
     }
 }

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -1,5 +1,5 @@
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
+use crate::monitor::MonitorHandle as RootMonitorHandle;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MonitorHandle;
@@ -28,7 +28,7 @@ impl MonitorHandle {
         }
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         std::iter::empty()
     }
 }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -2,14 +2,13 @@ use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
 use crate::event;
 use crate::icon::Icon;
-use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::window::{
-    CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWI,
+    CursorGrabMode, CursorIcon, UserAttentionType, WindowAttributes, WindowId as RootWI,
 };
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
 
-use super::{backend, monitor::MonitorHandle, EventLoopWindowTarget};
+use super::{backend, monitor::MonitorHandle, EventLoopWindowTarget, Fullscreen};
 
 use std::cell::{Ref, RefCell};
 use std::collections::vec_deque::IntoIter as VecDequeIter;
@@ -271,19 +270,17 @@ impl Window {
     }
 
     #[inline]
-    pub fn fullscreen(&self) -> Option<Fullscreen> {
+    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.borrow().is_fullscreen() {
-            Some(Fullscreen::Borderless(Some(RootMonitorHandle {
-                inner: self.current_monitor_inner(),
-            })))
+            Some(Fullscreen::Borderless(Some(self.current_monitor_inner())))
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
-        if monitor.is_some() {
+    pub(crate) fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
+        if fullscreen.is_some() {
             self.canvas.borrow().request_fullscreen();
         } else if self.canvas.borrow().is_fullscreen() {
             backend::exit_fullscreen();

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -2,7 +2,7 @@ use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
 use crate::event;
 use crate::icon::Icon;
-use crate::monitor::MonitorHandle as RootMH;
+use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::window::{
     CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWI,
 };
@@ -273,7 +273,9 @@ impl Window {
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.borrow().is_fullscreen() {
-            Some(Fullscreen::Borderless(Some(self.current_monitor_inner())))
+            Some(Fullscreen::Borderless(Some(RootMonitorHandle {
+                inner: self.current_monitor_inner(),
+            })))
         } else {
             None
         }
@@ -329,14 +331,12 @@ impl Window {
 
     #[inline]
     // Allow directly accessing the current monitor internally without unwrapping.
-    fn current_monitor_inner(&self) -> RootMH {
-        RootMH {
-            inner: MonitorHandle,
-        }
+    fn current_monitor_inner(&self) -> MonitorHandle {
+        MonitorHandle
     }
 
     #[inline]
-    pub fn current_monitor(&self) -> Option<RootMH> {
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
         Some(self.current_monitor_inner())
     }
 
@@ -346,10 +346,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMH> {
-        Some(RootMH {
-            inner: MonitorHandle,
-        })
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     #[inline]

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -80,7 +80,6 @@ use crate::{
     event_loop::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
-    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         dark_mode::try_theme,
         dpi::{become_dpi_aware, dpi_to_scale_factor},
@@ -319,9 +318,9 @@ impl<T> EventLoopWindowTarget<T> {
         monitor::available_monitors()
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = monitor::primary_monitor();
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -90,9 +90,9 @@ use crate::{
         raw_input, util,
         window::InitData,
         window_state::{CursorFlags, ImeState, WindowFlags, WindowState},
-        wrap_device_id, WindowId, DEVICE_ID,
+        wrap_device_id, Fullscreen, WindowId, DEVICE_ID,
     },
-    window::{Fullscreen, WindowId as RootWindowId},
+    window::WindowId as RootWindowId,
 };
 use runner::{EventLoopRunner, EventLoopRunnerShared};
 
@@ -1081,7 +1081,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                             if new_monitor != 0
                                 && fullscreen_monitor
                                     .as_ref()
-                                    .map(|monitor| new_monitor != monitor.inner.hmonitor())
+                                    .map(|monitor| new_monitor != monitor.hmonitor())
                                     .unwrap_or(true)
                             {
                                 if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor)
@@ -1092,13 +1092,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                                     window_pos.cx = new_monitor_rect.right - new_monitor_rect.left;
                                     window_pos.cy = new_monitor_rect.bottom - new_monitor_rect.top;
                                 }
-                                *fullscreen_monitor = Some(crate::monitor::MonitorHandle {
-                                    inner: MonitorHandle::new(new_monitor),
-                                });
+                                *fullscreen_monitor = Some(MonitorHandle::new(new_monitor));
                             }
                         }
                         Fullscreen::Exclusive(ref video_mode) => {
-                            let old_monitor = video_mode.video_mode.monitor.hmonitor();
+                            let old_monitor = video_mode.monitor.hmonitor();
                             if let Ok(old_monitor_info) = monitor::get_monitor_info(old_monitor) {
                                 let old_monitor_rect = old_monitor_info.monitorInfo.rcMonitor;
                                 window_pos.x = old_monitor_rect.left;

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use self::{
 };
 
 pub use self::icon::WinIcon as PlatformIcon;
+pub(self) use super::Fullscreen;
 
 use crate::event::DeviceId as RootDeviceId;
 use crate::icon::Icon;

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -224,7 +224,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         // EnumDisplaySettingsExW can return duplicate values (or some of the
         // fields are probably changing, but we aren't looking at those fields
         // anyway), so we're using a BTreeSet deduplicate
@@ -246,6 +246,7 @@ impl MonitorHandle {
                     (DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY) as u32;
                 assert!(has_flag(mode.dmFields, REQUIRED_FIELDS));
 
+                // Use Ord impl of RootVideoMode
                 modes.insert(RootVideoMode {
                     video_mode: VideoMode {
                         size: (mode.dmPelsWidth, mode.dmPelsHeight),
@@ -258,6 +259,6 @@ impl MonitorHandle {
             }
         }
 
-        modes.into_iter()
+        modes.into_iter().map(|mode| mode.video_mode)
     }
 }

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -17,7 +17,7 @@ use windows_sys::Win32::{
 use super::util::decode_wide;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::VideoMode as RootVideoMode,
     platform_impl::platform::{
         dpi::{dpi_to_scale_factor, get_monitor_dpi},
         util::has_flag,
@@ -79,10 +79,8 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: self.monitor.clone(),
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        self.monitor.clone()
     }
 }
 
@@ -136,9 +134,9 @@ impl Window {
         available_monitors()
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = primary_monitor();
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -69,13 +69,13 @@ use crate::{
         monitor::{self, MonitorHandle},
         util,
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
-        Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
+        Fullscreen, Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
-    window::{CursorGrabMode, CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes},
+    window::{CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes},
 };
 
 /// The Win32 implementation of the main `Window` object.
-pub struct Window {
+pub(crate) struct Window {
     /// Main handle for the window.
     window: WindowWrapper,
 
@@ -448,12 +448,12 @@ impl Window {
             match (&old_fullscreen, &fullscreen) {
                 (_, Some(Fullscreen::Exclusive(video_mode))) => {
                     let monitor = video_mode.monitor();
-                    let monitor_info = monitor::get_monitor_info(monitor.inner.hmonitor()).unwrap();
+                    let monitor_info = monitor::get_monitor_info(monitor.hmonitor()).unwrap();
 
                     let res = unsafe {
                         ChangeDisplaySettingsExW(
                             monitor_info.szDevice.as_ptr(),
-                            &*video_mode.video_mode.native_video_mode,
+                            &*video_mode.native_video_mode,
                             0,
                             CDS_FULLSCREEN,
                             ptr::null(),
@@ -532,8 +532,8 @@ impl Window {
                     window_state.lock().saved_window = Some(SavedWindow { placement });
 
                     let monitor = match &fullscreen {
-                        Fullscreen::Exclusive(video_mode) => video_mode.monitor().inner,
-                        Fullscreen::Borderless(Some(monitor)) => monitor.inner.clone(),
+                        Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
+                        Fullscreen::Borderless(Some(monitor)) => monitor.clone(),
                         Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
                     };
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -56,7 +56,6 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
     icon::Icon,
-    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         dark_mode::try_theme,
         definitions::{
@@ -67,7 +66,8 @@ use crate::{
         event_loop::{self, EventLoopWindowTarget, DESTROY_MSG_ID},
         icon::{self, IconType},
         ime::ImeContext,
-        monitor, util,
+        monitor::{self, MonitorHandle},
+        util,
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
         Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
@@ -532,11 +532,9 @@ impl Window {
                     window_state.lock().saved_window = Some(SavedWindow { placement });
 
                     let monitor = match &fullscreen {
-                        Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
-                        Fullscreen::Borderless(Some(monitor)) => monitor.clone(),
-                        Fullscreen::Borderless(None) => RootMonitorHandle {
-                            inner: monitor::current_monitor(window.0),
-                        },
+                        Fullscreen::Exclusive(video_mode) => video_mode.monitor().inner,
+                        Fullscreen::Borderless(Some(monitor)) => monitor.inner.clone(),
+                        Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
                     };
 
                     let position: (i32, i32) = monitor.position().into();
@@ -602,10 +600,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn current_monitor(&self) -> Option<RootMonitorHandle> {
-        Some(RootMonitorHandle {
-            inner: monitor::current_monitor(self.hwnd()),
-        })
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
+        Some(monitor::current_monitor(self.hwnd()))
     }
 
     #[inline]

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -2,8 +2,8 @@ use crate::{
     dpi::{PhysicalPosition, Size},
     event::ModifiersState,
     icon::Icon,
-    platform_impl::platform::{event_loop, util},
-    window::{CursorIcon, Fullscreen, Theme, WindowAttributes},
+    platform_impl::platform::{event_loop, util, Fullscreen},
+    window::{CursorIcon, Theme, WindowAttributes},
 };
 use parking_lot::MutexGuard;
 use std::io;
@@ -23,7 +23,7 @@ use windows_sys::Win32::{
 };
 
 /// Contains information about states and the window that the callback is going to use.
-pub struct WindowState {
+pub(crate) struct WindowState {
     pub mouse: MouseProperties,
 
     /// Used by `WM_GETMINMAXINFO`.

--- a/src/window.rs
+++ b/src/window.rs
@@ -127,7 +127,7 @@ pub(crate) struct WindowAttributes {
     pub position: Option<Position>,
     pub resizable: bool,
     pub title: String,
-    pub fullscreen: Option<Fullscreen>,
+    pub fullscreen: Option<platform_impl::Fullscreen>,
     pub maximized: bool,
     pub visible: bool,
     pub transparent: bool,
@@ -256,7 +256,7 @@ impl WindowBuilder {
     /// See [`Window::set_fullscreen`] for details.
     #[inline]
     pub fn with_fullscreen(mut self, fullscreen: Option<Fullscreen>) -> Self {
-        self.window.fullscreen = fullscreen;
+        self.window.fullscreen = fullscreen.map(|f| f.into());
         self
     }
 
@@ -727,7 +727,7 @@ impl Window {
     /// - **Android:** Unsupported.
     #[inline]
     pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
-        self.window.set_fullscreen(fullscreen)
+        self.window.set_fullscreen(fullscreen.map(|f| f.into()))
     }
 
     /// Gets the window's current fullscreen state.
@@ -739,7 +739,7 @@ impl Window {
     /// - **Wayland:** Can return `Borderless(None)` when there are no monitors.
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
-        self.window.fullscreen()
+        self.window.fullscreen().map(|f| f.into())
     }
 
     /// Turn window decorations on or off.

--- a/src/window.rs
+++ b/src/window.rs
@@ -999,7 +999,9 @@ impl Window {
     /// **iOS:** Can only be called on the main thread.
     #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
-        self.window.current_monitor()
+        self.window
+            .current_monitor()
+            .map(|inner| MonitorHandle { inner })
     }
 
     /// Returns the list of all the monitors available on the system.
@@ -1033,7 +1035,9 @@ impl Window {
     /// [`EventLoopWindowTarget::primary_monitor`]: crate::event_loop::EventLoopWindowTarget::primary_monitor
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        self.window.primary_monitor()
+        self.window
+            .primary_monitor()
+            .map(|inner| MonitorHandle { inner })
     }
 }
 unsafe impl HasRawWindowHandle for Window {


### PR DESCRIPTION
Builds upon: https://github.com/rust-windowing/winit/pull/2421.
Related: https://github.com/rust-windowing/winit/issues/2093

A great thing about `winit` is how it supports a varied number of different platforms. I would like to make it even easier to add support for new platforms. Possible examples include: Mac Catalyst, GNUStep, X11 on macOS, SwiftUI, GTK, KMS/DRM, WinRT, and whatever new thing that vendors may decide we should start using.

We already have code in `src/platform_impl/linux/mod.rs` to handle the fact that both X11 and Wayland can be present on the same target. While some of the above examples can be bolted on to that existing system, I really feel we need a generic way to handle the cases where more than one platform may be available on a specific target. This PR is an attempt at that.

The basic idea is to take the `x11_or_wayland!` macro, extend it a bit, and then handle delegation to the desired platform at the top level instead (e.g. inside `src/event_loop.rs`, `src/window.rs`, ...).

I haven't implemented this everywhere yet, wanted to get some feedback first, but compare `src/platform_impl/linux/mod.rs` and `src/event_loop.rs` in commit [`e74b801`](https://github.com/rust-windowing/winit/pull/2430/commits/e74b8012b1359cffad81312cd050749e630790be) to get a feel for what this would look like.

In the end, we would end up with the following directory structure:
```
src/platform_impl/
    android/
    ios/
    macos/
    unix/utils.rs // Shared utility functions between Unix platforms, if needed
    wayland/
    web/
    windows/
    x11/
    mod.rs
```

(This would also make Wayland and X11 feel a lot less like second-class citizens).

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation
