### PR TITLE
Document `WindowEvent::Moved` as unsupported on Wayland

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -321,6 +321,10 @@ pub enum WindowEvent<'a> {
     Resized(PhysicalSize<u32>),
 
     /// The position of the window has changed. Contains the window's new position.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland:** Unsupported.
     Moved(PhysicalPosition<i32>),
 
     /// The window has been requested to close.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Wayland does not report the position of top-level windows to applications, so this event never gets emitted there.