### PR TITLE
Update `sctk-adwaita`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
     env:
       RUST_BACKTRACE: 1
       CARGO_INCREMENTAL: 0
-      PKG_CONFIG_ALLOW_CROSS: 1
       RUSTFLAGS: "-C debuginfo=0 --deny warnings"
       OPTIONS: ${{ matrix.platform.options }}
       FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
@@ -72,12 +71,9 @@ jobs:
       # "Temporary" workaround until https://github.com/actions/virtual-environments/issues/5879#issuecomment-1195156618
       # gets looked into.
       run: echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
-    - name: Install Linux dependencies
-      if: (matrix.platform.os == 'ubuntu-latest')
-      run: sudo apt-get update && sudo apt-get install pkg-config cmake libfreetype6-dev libfontconfig1-dev
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
-      run: sudo dpkg --add-architecture i386 && sudo apt-get update && sudo apt-get install g++-multilib gcc-multilib libfreetype6-dev:i386 libfontconfig1-dev:i386
+      run: sudo apt-get update && sudo apt-get install gcc-multilib
     - name: Install cargo-apk
       if: contains(matrix.platform.target, 'android')
       run: cargo install cargo-apk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Windows, added `WindowExtWindows::set_undecorated_shadow` and `WindowBuilderExtWindows::with_undecorated_shadow` to draw the drop shadow behind a borderless window.
 - On Windows, fixed default window features (ie snap, animations, shake, etc.) when decorations are disabled.
 - On macOS, add support for two-finger touchpad magnification and rotation gestures with new events `WindowEvent::TouchpadMagnify` and `WindowEvent::TouchpadRotate`.
+- On Wayland, `wayland-csd-adwaita` now uses `ab_glyph` instead of `crossfont` to render the title for decorations.
+- On Wayland, a new `wayland-csd-adwaita-crossfont` feature was added to use `crossfont` instead of `ab_glyph` for decorations.
 
 # 0.27.2 (2022-8-12)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
 wayland = ["wayland-client", "wayland-protocols", "sctk"]
 wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
 wayland-csd-adwaita = ["sctk-adwaita", "sctk-adwaita/ab_glyph"]
+wayland-csd-adwaita-crossfont = ["sctk-adwaita", "sctk-adwaita/crossfont"]
 wayland-csd-adwaita-notitle = ["sctk-adwaita"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 x11 = ["x11-dl", "mio", "percent-encoding", "parking_lot"]
 wayland = ["wayland-client", "wayland-protocols", "sctk"]
 wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
-wayland-csd-adwaita = ["sctk-adwaita", "sctk-adwaita/title"]
+wayland-csd-adwaita = ["sctk-adwaita", "sctk-adwaita/ab_glyph"]
 wayland-csd-adwaita-notitle = ["sctk-adwaita"]
 
 [dependencies]
@@ -105,7 +105,7 @@ features = [
 wayland-client = { version = "0.29.4", default_features = false,  features = ["use_system_lib"], optional = true }
 wayland-protocols = { version = "0.29.4", features = [ "staging_protocols"], optional = true }
 sctk = { package = "smithay-client-toolkit", version = "0.16.0", default_features = false, features = ["calloop"],  optional = true }
-sctk-adwaita = { version = "0.4.1", optional = true }
+sctk-adwaita = { version = "0.5.1", default_features = false, optional = true }
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 percent-encoding = { version = "2.0", optional = true }


### PR DESCRIPTION
`sctk-adwaita` now uses [`ab_glyph`](https://crates.io/crates/ab_glyph) instead of [`crossfont`](https://crates.io/crates/crossfont). As far as I can tell this isn't a breaking change.

I'm not sure if some users would prefer `crossfont` over `ab_glyph`. Alternatively we could add another crate feature for that? I think it would have been better to remove `wayland-csd-adwaita-notitle` and add `wayland-csd-adwaita-ab-glyph` and `wayland-csd-adwaita-crossfont` instead, but it's too late for that now.

Fixes #2373.