### PR TITLE
Wayland: Use sctk-adwaita 0.5.1 auto theme selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** On macOS, add support for two-finger touchpad magnification and rotation gestures with new events `WindowEvent::TouchpadMagnify` and `WindowEvent::TouchpadRotate`.
 - On Wayland, `wayland-csd-adwaita` now uses `ab_glyph` instead of `crossfont` to render the title for decorations.
 - On Wayland, a new `wayland-csd-adwaita-crossfont` feature was added to use `crossfont` instead of `ab_glyph` for decorations.
+- On Wayland, if not otherwise specified use upstream automatic CSD theme selection.
 
 # 0.27.2 (2022-8-12)
 

--- a/src/platform/unix.rs
+++ b/src/platform/unix.rs
@@ -212,6 +212,8 @@ pub trait WindowExtUnix {
     ///
     /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
     /// Possible values for env variable are: "dark" and light"
+    ///
+    /// When unspecified a theme is automatically selected.
     #[cfg(feature = "wayland")]
     fn wayland_set_csd_theme(&self, config: Theme);
 
@@ -349,6 +351,8 @@ pub trait WindowBuilderExtUnix {
     ///
     /// You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
     /// Possible values for env variable are: "dark" and light"
+    ///
+    /// When unspecified a theme is automatically selected.
     #[cfg(feature = "wayland")]
     fn with_wayland_csd_theme(self, theme: Theme) -> Self;
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -170,16 +170,15 @@ impl Window {
             )
             .map_err(|_| os_error!(OsError::WaylandMisc("failed to create window.")))?;
 
+        // Set CSD frame config from theme if specified,
+        // otherwise use upstream automatic selection.
         #[cfg(feature = "sctk-adwaita")]
-        {
-            // Set CSD frame config from theme if specified,
-            // otherwise use upstream automatic selection.
-            if let Some(theme) = platform_attributes
-                .csd_theme
-                .or_else(|| std::env::var(WAYLAND_CSD_THEME_ENV_VAR).try_into().ok())
-            {
-                window.set_frame_config(theme.into());
-            }
+        if let Some(theme) = platform_attributes.csd_theme.or_else(|| {
+            std::env::var(WAYLAND_CSD_THEME_ENV_VAR)
+                .ok()
+                .and_then(|s| s.as_str().try_into().ok())
+        }) {
+            window.set_frame_config(theme.into());
         }
 
         // Set decorations.
@@ -652,12 +651,5 @@ impl TryFrom<&str> for Theme {
         } else {
             Err(())
         }
-    }
-}
-impl TryFrom<Result<String, std::env::VarError>> for Theme {
-    type Error = ();
-
-    fn try_from(env: Result<String, std::env::VarError>) -> Result<Self, Self::Error> {
-        env.map_err(|_| ())?.as_str().try_into()
     }
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -174,12 +174,10 @@ impl Window {
         {
             // Set CSD frame config from theme if specified,
             // otherwise use upstream automatic selection.
-            if let Some(theme) = platform_attributes.csd_theme.or_else(|| {
-                std::env::var(WAYLAND_CSD_THEME_ENV_VAR)
-                    .ok()?
-                    .try_into()
-                    .ok()
-            }) {
+            if let Some(theme) = platform_attributes
+                .csd_theme
+                .or_else(|| std::env::var(WAYLAND_CSD_THEME_ENV_VAR).try_into().ok())
+            {
                 window.set_frame_config(theme.into());
             }
         }
@@ -637,16 +635,16 @@ impl From<Theme> for sctk_adwaita::FrameConfig {
     }
 }
 
-impl TryFrom<String> for Theme {
+impl TryFrom<&str> for Theme {
     type Error = ();
 
     /// ```
     /// use winit::window::Theme;
     ///
-    /// assert_eq!(String::from("dark").try_into(), Ok(Theme::Dark));
-    /// assert_eq!(String::from("lIghT").try_into(), Ok(Theme::Light));
+    /// assert_eq!("dark".try_into(), Ok(Theme::Dark));
+    /// assert_eq!("lIghT".try_into(), Ok(Theme::Light));
     /// ```
-    fn try_from(theme: String) -> Result<Self, Self::Error> {
+    fn try_from(theme: &str) -> Result<Self, Self::Error> {
         if theme.eq_ignore_ascii_case("dark") {
             Ok(Self::Dark)
         } else if theme.eq_ignore_ascii_case("light") {
@@ -654,5 +652,12 @@ impl TryFrom<String> for Theme {
         } else {
             Err(())
         }
+    }
+}
+impl TryFrom<Result<String, std::env::VarError>> for Theme {
+    type Error = ();
+
+    fn try_from(env: Result<String, std::env::VarError>) -> Result<Self, Self::Error> {
+        env.map_err(|_| ())?.as_str().try_into()
     }
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -170,18 +170,17 @@ impl Window {
             )
             .map_err(|_| os_error!(OsError::WaylandMisc("failed to create window.")))?;
 
-        // Set CSD frame config from theme if specified
         #[cfg(feature = "sctk-adwaita")]
         {
-            let theme = platform_attributes.csd_theme.or_else(|| {
-                match std::env::var(WAYLAND_CSD_THEME_ENV_VAR) {
-                    Ok(t) if t.eq_ignore_ascii_case("dark") => Some(Theme::Dark),
-                    Ok(t) if t.eq_ignore_ascii_case("light") => Some(Theme::Light),
-                    _ => None,
-                }
-            });
-            // If not specified use upstream default (automatically selects theme)
-            if let Some(theme) = theme {
+            // Set CSD frame config from theme if specified,
+            // otherwise use upstream automatic selection.
+            if let Some(theme) = platform_attributes.csd_theme.or_else(|| {
+                std::env::var(WAYLAND_CSD_THEME_ENV_VAR)
+                    .ok()?
+                    .as_str()
+                    .try_into()
+                    .ok()
+            }) {
                 window.set_frame_config(theme.into());
             }
         }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -177,7 +177,6 @@ impl Window {
             if let Some(theme) = platform_attributes.csd_theme.or_else(|| {
                 std::env::var(WAYLAND_CSD_THEME_ENV_VAR)
                     .ok()?
-                    .as_str()
                     .try_into()
                     .ok()
             }) {
@@ -634,6 +633,26 @@ impl From<Theme> for sctk_adwaita::FrameConfig {
         match theme {
             Theme::Light => sctk_adwaita::FrameConfig::light(),
             Theme::Dark => sctk_adwaita::FrameConfig::dark(),
+        }
+    }
+}
+
+impl TryFrom<String> for Theme {
+    type Error = ();
+
+    /// ```
+    /// use winit::window::Theme;
+    ///
+    /// assert_eq!(String::from("dark").try_into(), Ok(Theme::Dark));
+    /// assert_eq!(String::from("lIghT").try_into(), Ok(Theme::Light));
+    /// ```
+    fn try_from(theme: String) -> Result<Self, Self::Error> {
+        if theme.eq_ignore_ascii_case("dark") {
+            Ok(Self::Dark)
+        } else if theme.eq_ignore_ascii_case("light") {
+            Ok(Self::Light)
+        } else {
+            Err(())
         }
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1282,26 +1282,6 @@ pub enum Theme {
     Dark,
 }
 
-impl TryFrom<&str> for Theme {
-    type Error = ();
-
-    /// ```
-    /// use winit::window::Theme;
-    ///
-    /// assert_eq!("dark".try_into(), Ok(Theme::Dark));
-    /// assert_eq!("lIghT".try_into(), Ok(Theme::Light));
-    /// ```
-    fn try_from(theme: &str) -> Result<Self, Self::Error> {
-        if theme.eq_ignore_ascii_case("dark") {
-            Ok(Self::Dark)
-        } else if theme.eq_ignore_ascii_case("light") {
-            Ok(Self::Light)
-        } else {
-            Err(())
-        }
-    }
-}
-
 /// ## Platform-specific
 ///
 /// - **X11:** Sets the WM's `XUrgencyHint`. No distinction between [`Critical`] and [`Informational`].

--- a/src/window.rs
+++ b/src/window.rs
@@ -1282,6 +1282,26 @@ pub enum Theme {
     Dark,
 }
 
+impl TryFrom<&str> for Theme {
+    type Error = ();
+
+    /// ```
+    /// use winit::window::Theme;
+    ///
+    /// assert_eq!("dark".try_into(), Ok(Theme::Dark));
+    /// assert_eq!("lIghT".try_into(), Ok(Theme::Light));
+    /// ```
+    fn try_from(theme: &str) -> Result<Self, Self::Error> {
+        if theme.eq_ignore_ascii_case("dark") {
+            Ok(Self::Dark)
+        } else if theme.eq_ignore_ascii_case("light") {
+            Ok(Self::Light)
+        } else {
+            Err(())
+        }
+    }
+}
+
 /// ## Platform-specific
 ///
 /// - **X11:** Sets the WM's `XUrgencyHint`. No distinction between [`Critical`] and [`Informational`].


### PR DESCRIPTION
On Wayland, if not otherwise specified use upstream automatic CSD theme selection.

This is available in [sctk-adwaita 0.5.1](https://github.com/PolyMeilex/sctk-adwaita/blob/master/CHANGELOG.md#051), ~so this PR requires #2438~

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- ~[ ] Created or updated an example program if it would help users understand this functionality~
- ~[ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~
