### PR TITLE
Document `WindowEvent::Moved` OS support

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -324,7 +324,7 @@ pub enum WindowEvent<'a> {
     ///
     /// ## Platform-specific
     ///
-    /// - **Wayland:** Unsupported.
+    /// - **iOS / Android / Web / Wayland:** Unsupported.
     Moved(PhysicalPosition<i32>),
 
     /// The window has been requested to close.


### PR DESCRIPTION
Follow up to https://github.com/rust-windowing/winit/pull/2434.