### PR TITLE
Disable default features in simple_logger, removes time dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ mint = { version = "0.5.6", optional = true }
 
 [dev-dependencies]
 image = { version = "0.24.0", default-features = false, features = ["png"] }
-simple_logger = "2.1.0"
+simple_logger = { version = "2.1.0", default_features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995


### PR DESCRIPTION
- [ ] Tested on all platforms changed
    - [x] Windows 10
    - [ ] iOS
    - [ ] Linux
    - [ ] Web
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users (N/A)
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior (N/A)
- [ ] Created or updated an example program if it would help users understand this functionality (N/A)
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented (N/A)

Fixes the incompatibility of the `time` crate with the specified MSRV 1.57 by disabling the `timestamps` feature in `simple_logger`.