### PR TITLE
Add myself as iOS co-maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Core maintainers:
 # - @msiglreith
+# - @francesca64
 # - @kchibisov
 # - @madsmtm
 # - @maroider
@@ -9,8 +10,8 @@
 /src/platform_impl/android          @msiglreith
 
 # iOS
-/src/platform/ios.rs                @francesca64
-/src/platform_impl/ios              @francesca64
+/src/platform/ios.rs                @francesca64 @madsmtm
+/src/platform_impl/ios              @francesca64 @madsmtm
 
 # Unix in general
 /src/platform/unix.rs               @kchibisov


### PR DESCRIPTION
Hey @francesca64, you noted in https://github.com/rust-windowing/winit/pull/2428#issuecomment-1229605279 that you no longer have access to iOS devices (also sorry to hear you're unemployed if you're affected by that in other ways!).

I'm quite proficient in Objective-C at this point, and have access to an iOS device I can test on, and while that is of course very far from "knowing" UIKit, I think it would make sense for me to take on co-responsibility of the iOS platform. I'll probably be limiting myself to stuff relating to Objective-C to begin with, e.g. I wouldn't really feel comfortable tackling https://github.com/rust-windowing/winit/pull/2144.