### PR TITLE
Initial transition to `objc2`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- macOS/iOS: Use `objc2` instead of `objc` internally.
 - **Breaking:** Bump MSRV from `1.57` to `1.60`.
 - **Breaking:** Split the `platform::unix` module into `platform::x11` and `platform::wayland`. The extension types are similarly renamed.
 - **Breaking:**: Removed deprecated method `platform::unix::WindowExtUnix::is_ready`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,12 +62,14 @@ ndk = "0.7.0"
 ndk-glue = "0.7.0"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-objc = "0.2.7"
+objc = { version = "=0.3.0-beta.3", package = "objc2" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = "0.24"
-core-foundation = "0.9"
-core-graphics = "0.22"
+# Branch: objc2
+# TODO: Use non-git versions before we release
+cocoa = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "c770e620ba0766fc1d2a9f83327b0fee905eb5cb" }
+core-foundation = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "c770e620ba0766fc1d2a9f83327b0fee905eb5cb" }
+core-graphics = { git = "https://github.com/madsmtm/core-foundation-rs.git", rev = "c770e620ba0766fc1d2a9f83327b0fee905eb5cb" }
 dispatch = "0.2.0"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -9,7 +9,7 @@ use std::{
     time::Instant,
 };
 
-use objc::runtime::{BOOL, YES};
+use objc::runtime::{Object, BOOL, YES};
 use once_cell::sync::Lazy;
 
 use crate::{
@@ -582,7 +582,7 @@ pub unsafe fn did_finish_launching() {
             let _: () = msg_send![window, setScreen: screen];
             let _: () = msg_send![screen, release];
             let controller: id = msg_send![window, rootViewController];
-            let _: () = msg_send![window, setRootViewController:ptr::null::<()>()];
+            let _: () = msg_send![window, setRootViewController:ptr::null::<Object>()];
             let _: () = msg_send![window, setRootViewController: controller];
             let _: () = msg_send![window, makeKeyAndVisible];
         }

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -9,7 +9,7 @@ use std::{
     time::Instant,
 };
 
-use objc::runtime::{Object, BOOL, YES};
+use objc::runtime::Object;
 use once_cell::sync::Lazy;
 
 use crate::{
@@ -472,10 +472,7 @@ impl AppState {
 // retains window
 pub unsafe fn set_key_window(window: id) {
     bug_assert!(
-        {
-            let is_window: BOOL = msg_send![window, isKindOfClass: class!(UIWindow)];
-            is_window == YES
-        },
+        msg_send![window, isKindOfClass: class!(UIWindow)],
         "set_key_window called with an incorrect type"
     );
     let mut this = AppState::get_mut();
@@ -502,10 +499,7 @@ pub unsafe fn set_key_window(window: id) {
 // retains window
 pub unsafe fn queue_gl_or_metal_redraw(window: id) {
     bug_assert!(
-        {
-            let is_window: BOOL = msg_send![window, isKindOfClass: class!(UIWindow)];
-            is_window == YES
-        },
+        msg_send![window, isKindOfClass: class!(UIWindow)],
         "set_key_window called with an incorrect type"
     );
     let mut this = AppState::get_mut();
@@ -886,8 +880,11 @@ fn get_view_and_screen_frame(window_id: id) -> (id, CGRect) {
         let bounds: CGRect = msg_send![window_id, bounds];
         let screen: id = msg_send![window_id, screen];
         let screen_space: id = msg_send![screen, coordinateSpace];
-        let screen_frame: CGRect =
-            msg_send![window_id, convertRect:bounds toCoordinateSpace:screen_space];
+        let screen_frame: CGRect = msg_send![
+            window_id,
+            convertRect: bounds,
+            toCoordinateSpace: screen_space,
+        ];
         (view, screen_frame)
     }
 }
@@ -1019,7 +1016,7 @@ pub fn os_capabilities() -> OSCapabilities {
     static OS_CAPABILITIES: Lazy<OSCapabilities> = Lazy::new(|| {
         let version: NSOperatingSystemVersion = unsafe {
             let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
-            let atleast_ios_8: BOOL = msg_send![
+            let atleast_ios_8: bool = msg_send![
                 process_info,
                 respondsToSelector: sel!(operatingSystemVersion)
             ];
@@ -1030,10 +1027,7 @@ pub fn os_capabilities() -> OSCapabilities {
             // has been tested to not even run on macOS 10.15 - Xcode 8 might?
             //
             // The minimum required iOS version is likely to grow in the future.
-            assert!(
-                atleast_ios_8 == YES,
-                "`winit` requires iOS version 8 or greater"
-            );
+            assert!(atleast_ios_8, "`winit` requires iOS version 8 or greater");
             msg_send![process_info, operatingSystemVersion]
         };
         version.into()

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -9,6 +9,7 @@ use std::{
     time::Instant,
 };
 
+use objc::foundation::{NSInteger, NSUInteger};
 use objc::runtime::Object;
 use once_cell::sync::Lazy;
 
@@ -21,8 +22,8 @@ use crate::{
         ffi::{
             id, kCFRunLoopCommonModes, CFAbsoluteTimeGetCurrent, CFRelease, CFRunLoopAddTimer,
             CFRunLoopGetMain, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
-            CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CGRect, CGSize, NSInteger,
-            NSOperatingSystemVersion, NSUInteger,
+            CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CGRect, CGSize,
+            NSOperatingSystemVersion,
         },
     },
     window::WindowId as RootWindowId,

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -81,9 +81,10 @@ pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
 impl<T: 'static> EventLoop<T> {
     pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> EventLoop<T> {
+        assert_main_thread!("`EventLoop` can only be created on the main thread on iOS");
+
         static mut SINGLETON_INIT: bool = false;
         unsafe {
-            assert_main_thread!("`EventLoop` can only be created on the main thread on iOS");
             assert!(
                 !SINGLETON_INIT,
                 "Only one `EventLoop` is supported on iOS. \

--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -2,6 +2,7 @@
 
 use std::{convert::TryInto, ffi::CString, ops::BitOr, os::raw::*};
 
+use objc::foundation::{NSInteger, NSUInteger};
 use objc::{runtime::Object, Encode, Encoding};
 
 use crate::{
@@ -16,9 +17,6 @@ pub const nil: id = 0 as id;
 pub type CGFloat = f32;
 #[cfg(target_pointer_width = "64")]
 pub type CGFloat = f64;
-
-pub type NSInteger = isize;
-pub type NSUInteger = usize;
 
 #[repr(C)]
 #[derive(Clone, Debug)]

--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -28,11 +28,26 @@ pub struct NSOperatingSystemVersion {
     pub patch: NSInteger,
 }
 
+unsafe impl Encode for NSOperatingSystemVersion {
+    const ENCODING: Encoding = Encoding::Struct(
+        "NSOperatingSystemVersion",
+        &[
+            NSInteger::ENCODING,
+            NSInteger::ENCODING,
+            NSInteger::ENCODING,
+        ],
+    );
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CGPoint {
     pub x: CGFloat,
     pub y: CGFloat,
+}
+
+unsafe impl Encode for CGPoint {
+    const ENCODING: Encoding = Encoding::Struct("CGPoint", &[CGFloat::ENCODING, CGFloat::ENCODING]);
 }
 
 #[repr(C)]
@@ -51,6 +66,10 @@ impl CGSize {
     }
 }
 
+unsafe impl Encode for CGSize {
+    const ENCODING: Encoding = Encoding::Struct("CGSize", &[CGFloat::ENCODING, CGFloat::ENCODING]);
+}
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct CGRect {
@@ -65,18 +84,9 @@ impl CGRect {
 }
 
 unsafe impl Encode for CGRect {
-    fn encode() -> Encoding {
-        unsafe {
-            if cfg!(target_pointer_width = "32") {
-                Encoding::from_str("{CGRect={CGPoint=ff}{CGSize=ff}}")
-            } else if cfg!(target_pointer_width = "64") {
-                Encoding::from_str("{CGRect={CGPoint=dd}{CGSize=dd}}")
-            } else {
-                unimplemented!()
-            }
-        }
-    }
+    const ENCODING: Encoding = Encoding::Struct("CGRect", &[CGPoint::ENCODING, CGSize::ENCODING]);
 }
+
 #[derive(Debug)]
 #[allow(dead_code)]
 #[repr(isize)]
@@ -88,6 +98,10 @@ pub enum UITouchPhase {
     Cancelled,
 }
 
+unsafe impl Encode for UITouchPhase {
+    const ENCODING: Encoding = NSInteger::ENCODING;
+}
+
 #[derive(Debug, PartialEq, Eq)]
 #[allow(dead_code)]
 #[repr(isize)]
@@ -95,6 +109,10 @@ pub enum UIForceTouchCapability {
     Unknown = 0,
     Unavailable,
     Available,
+}
+
+unsafe impl Encode for UIForceTouchCapability {
+    const ENCODING: Encoding = NSInteger::ENCODING;
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -106,6 +124,10 @@ pub enum UITouchType {
     Pencil,
 }
 
+unsafe impl Encode for UITouchType {
+    const ENCODING: Encoding = NSInteger::ENCODING;
+}
+
 #[repr(C)]
 #[derive(Debug, Clone)]
 pub struct UIEdgeInsets {
@@ -115,14 +137,24 @@ pub struct UIEdgeInsets {
     pub right: CGFloat,
 }
 
+unsafe impl Encode for UIEdgeInsets {
+    const ENCODING: Encoding = Encoding::Struct(
+        "UIEdgeInsets",
+        &[
+            CGFloat::ENCODING,
+            CGFloat::ENCODING,
+            CGFloat::ENCODING,
+            CGFloat::ENCODING,
+        ],
+    );
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UIUserInterfaceIdiom(NSInteger);
 
 unsafe impl Encode for UIUserInterfaceIdiom {
-    fn encode() -> Encoding {
-        NSInteger::encode()
-    }
+    const ENCODING: Encoding = NSInteger::ENCODING;
 }
 
 impl UIUserInterfaceIdiom {
@@ -162,9 +194,7 @@ impl From<UIUserInterfaceIdiom> for Idiom {
 pub struct UIInterfaceOrientationMask(NSUInteger);
 
 unsafe impl Encode for UIInterfaceOrientationMask {
-    fn encode() -> Encoding {
-        NSUInteger::encode()
-    }
+    const ENCODING: Encoding = NSUInteger::ENCODING;
 }
 
 impl UIInterfaceOrientationMask {
@@ -213,9 +243,7 @@ impl UIInterfaceOrientationMask {
 pub struct UIRectEdge(NSUInteger);
 
 unsafe impl Encode for UIRectEdge {
-    fn encode() -> Encoding {
-        NSUInteger::encode()
-    }
+    const ENCODING: Encoding = NSUInteger::ENCODING;
 }
 
 impl From<ScreenEdge> for UIRectEdge {
@@ -241,9 +269,7 @@ impl From<UIRectEdge> for ScreenEdge {
 pub struct UIScreenOverscanCompensation(NSInteger);
 
 unsafe impl Encode for UIScreenOverscanCompensation {
-    fn encode() -> Encoding {
-        NSInteger::encode()
-    }
+    const ENCODING: Encoding = NSInteger::ENCODING;
 }
 
 #[allow(dead_code)]

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -63,8 +63,7 @@
 // window size/position.
 macro_rules! assert_main_thread {
     ($($t:tt)*) => {
-        let is_main_thread: ::objc::runtime::BOOL = msg_send!(class!(NSThread), isMainThread);
-        if is_main_thread == ::objc::runtime::NO {
+        if !::objc::foundation::is_main_thread() {
             panic!($($t)*);
         }
     };

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -4,12 +4,14 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use objc::foundation::{NSInteger, NSUInteger};
+
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform_impl::platform::{
         app_state,
-        ffi::{id, nil, CGFloat, CGRect, CGSize, NSInteger, NSUInteger},
+        ffi::{id, nil, CGFloat, CGRect, CGSize},
     },
 };
 

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -113,22 +113,14 @@ impl Deref for MonitorHandle {
     type Target = Inner;
 
     fn deref(&self) -> &Inner {
-        unsafe {
-            assert_main_thread!(
-                "`MonitorHandle` methods can only be run on the main thread on iOS"
-            );
-        }
+        assert_main_thread!("`MonitorHandle` methods can only be run on the main thread on iOS");
         &self.inner
     }
 }
 
 impl DerefMut for MonitorHandle {
     fn deref_mut(&mut self) -> &mut Inner {
-        unsafe {
-            assert_main_thread!(
-                "`MonitorHandle` methods can only be run on the main thread on iOS"
-            );
-        }
+        assert_main_thread!("`MonitorHandle` methods can only be run on the main thread on iOS");
         &mut self.inner
     }
 }
@@ -144,9 +136,7 @@ impl Clone for MonitorHandle {
 
 impl Drop for MonitorHandle {
     fn drop(&mut self) {
-        unsafe {
-            assert_main_thread!("`MonitorHandle` can only be dropped on the main thread on iOS");
-        }
+        assert_main_thread!("`MonitorHandle` can only be dropped on the main thread on iOS");
     }
 }
 
@@ -175,8 +165,8 @@ impl fmt::Debug for MonitorHandle {
 
 impl MonitorHandle {
     pub fn retained_new(uiscreen: id) -> MonitorHandle {
+        assert_main_thread!("`MonitorHandle` can only be cloned on the main thread on iOS");
         unsafe {
-            assert_main_thread!("`MonitorHandle` can only be cloned on the main thread on iOS");
             let _: id = msg_send![uiscreen, retain];
         }
         MonitorHandle {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -3,7 +3,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use objc::runtime::{Class, Object, BOOL, NO, YES};
+use objc::runtime::{Class, Object};
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, UiKitDisplayHandle, UiKitWindowHandle};
 
 use crate::{
@@ -51,14 +51,7 @@ impl Inner {
     }
 
     pub fn set_visible(&self, visible: bool) {
-        match visible {
-            true => unsafe {
-                let _: () = msg_send![self.window, setHidden: NO];
-            },
-            false => unsafe {
-                let _: () = msg_send![self.window, setHidden: YES];
-            },
-        }
+        unsafe { msg_send![self.window, setHidden: !visible] }
     }
 
     pub fn is_visible(&self) -> Option<bool> {
@@ -350,9 +343,7 @@ pub struct Window {
 
 impl Drop for Window {
     fn drop(&mut self) {
-        unsafe {
-            assert_main_thread!("`Window::drop` can only be run on the main thread on iOS");
-        }
+        assert_main_thread!("`Window::drop` can only be run on the main thread on iOS");
     }
 }
 
@@ -363,18 +354,14 @@ impl Deref for Window {
     type Target = Inner;
 
     fn deref(&self) -> &Inner {
-        unsafe {
-            assert_main_thread!("`Window` methods can only be run on the main thread on iOS");
-        }
+        assert_main_thread!("`Window` methods can only be run on the main thread on iOS");
         &self.inner
     }
 }
 
 impl DerefMut for Window {
     fn deref_mut(&mut self) -> &mut Inner {
-        unsafe {
-            assert_main_thread!("`Window` methods can only be run on the main thread on iOS");
-        }
+        assert_main_thread!("`Window` methods can only be run on the main thread on iOS");
         &mut self.inner
     }
 }
@@ -429,10 +416,9 @@ impl Window {
             let gl_or_metal_backed = {
                 let view_class: *const Class = msg_send![view, class];
                 let layer_class: *const Class = msg_send![view_class, layerClass];
-                let is_metal: BOOL =
-                    msg_send![layer_class, isSubclassOfClass: class!(CAMetalLayer)];
-                let is_gl: BOOL = msg_send![layer_class, isSubclassOfClass: class!(CAEAGLLayer)];
-                is_metal == YES || is_gl == YES
+                let is_metal = msg_send![layer_class, isSubclassOfClass: class!(CAMetalLayer)];
+                let is_gl = msg_send![layer_class, isSubclassOfClass: class!(CAEAGLLayer)];
+                is_metal || is_gl
             };
 
             let view_controller =
@@ -463,7 +449,7 @@ impl Window {
                 let screen: id = msg_send![window, screen];
                 let screen_space: id = msg_send![screen, coordinateSpace];
                 let screen_frame: CGRect =
-                    msg_send![view, convertRect:bounds toCoordinateSpace:screen_space];
+                    msg_send![view, convertRect: bounds, toCoordinateSpace: screen_space];
                 let size = crate::dpi::LogicalSize {
                     width: screen_frame.size.width as _,
                     height: screen_frame.size.height as _,
@@ -527,10 +513,9 @@ impl Inner {
 
     pub fn set_prefers_home_indicator_hidden(&self, hidden: bool) {
         unsafe {
-            let prefers_home_indicator_hidden = if hidden { YES } else { NO };
             let _: () = msg_send![
                 self.view_controller,
-                setPrefersHomeIndicatorAutoHidden: prefers_home_indicator_hidden
+                setPrefersHomeIndicatorAutoHidden: hidden,
             ];
         }
     }
@@ -547,11 +532,7 @@ impl Inner {
 
     pub fn set_prefers_status_bar_hidden(&self, hidden: bool) {
         unsafe {
-            let status_bar_hidden = if hidden { YES } else { NO };
-            let _: () = msg_send![
-                self.view_controller,
-                setPrefersStatusBarHidden: status_bar_hidden
-            ];
+            let _: () = msg_send![self.view_controller, setPrefersStatusBarHidden: hidden,];
         }
     }
 }
@@ -567,7 +548,11 @@ impl Inner {
         let screen: id = msg_send![self.window, screen];
         if !screen.is_null() {
             let screen_space: id = msg_send![screen, coordinateSpace];
-            msg_send![self.window, convertRect:rect toCoordinateSpace:screen_space]
+            msg_send![
+                self.window,
+                convertRect: rect,
+                toCoordinateSpace: screen_space,
+            ]
         } else {
             rect
         }
@@ -578,7 +563,11 @@ impl Inner {
         let screen: id = msg_send![self.window, screen];
         if !screen.is_null() {
             let screen_space: id = msg_send![screen, coordinateSpace];
-            msg_send![self.window, convertRect:rect fromCoordinateSpace:screen_space]
+            msg_send![
+                self.window,
+                convertRect: rect,
+                fromCoordinateSpace: screen_space,
+            ]
         } else {
             rect
         }

--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -5,7 +5,7 @@ use cocoa::{
     base::id,
 };
 use objc::{
-    declare::ClassDecl,
+    declare::ClassBuilder,
     runtime::{Class, Object, Sel},
 };
 use once_cell::sync::Lazy;
@@ -19,7 +19,7 @@ unsafe impl Sync for AppClass {}
 
 pub static APP_CLASS: Lazy<AppClass> = Lazy::new(|| unsafe {
     let superclass = class!(NSApplication);
-    let mut decl = ClassDecl::new("WinitApp", superclass).unwrap();
+    let mut decl = ClassBuilder::new("WinitApp", superclass).unwrap();
 
     decl.add_method(sel!(sendEvent:), send_event as extern "C" fn(_, _, _));
 

--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -21,10 +21,7 @@ pub static APP_CLASS: Lazy<AppClass> = Lazy::new(|| unsafe {
     let superclass = class!(NSApplication);
     let mut decl = ClassDecl::new("WinitApp", superclass).unwrap();
 
-    decl.add_method(
-        sel!(sendEvent:),
-        send_event as extern "C" fn(&Object, Sel, id),
-    );
+    decl.add_method(sel!(sendEvent:), send_event as extern "C" fn(_, _, _));
 
     AppClass(decl.register())
 });

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -27,16 +27,16 @@ pub static APP_DELEGATE_CLASS: Lazy<AppDelegateClass> = Lazy::new(|| unsafe {
     let superclass = class!(NSResponder);
     let mut decl = ClassDecl::new("WinitAppDelegate", superclass).unwrap();
 
-    decl.add_class_method(sel!(new), new as extern "C" fn(&Class, Sel) -> id);
-    decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
+    decl.add_class_method(sel!(new), new as extern "C" fn(_, _) -> _);
+    decl.add_method(sel!(dealloc), dealloc as extern "C" fn(_, _));
 
     decl.add_method(
         sel!(applicationDidFinishLaunching:),
-        did_finish_launching as extern "C" fn(&Object, Sel, id),
+        did_finish_launching as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(applicationWillTerminate:),
-        will_terminate as extern "C" fn(&Object, Sel, id),
+        will_terminate as extern "C" fn(_, _, _),
     );
 
     decl.add_ivar::<*mut c_void>(AUX_DELEGATE_STATE_NAME);

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -403,7 +403,7 @@ impl AppState {
             unsafe {
                 let app: id = NSApp();
 
-                autoreleasepool(|| {
+                autoreleasepool(|_| {
                     let _: () = msg_send![app, stop: nil];
                     // To stop event loop immediately, we need to post some event here.
                     post_dummy_event(app);

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -18,8 +18,9 @@ use cocoa::{
     foundation::NSSize,
 };
 use objc::{
+    foundation::is_main_thread,
     rc::autoreleasepool,
-    runtime::{Object, BOOL, NO, YES},
+    runtime::{Bool, Object},
 };
 use once_cell::sync::Lazy;
 
@@ -288,7 +289,7 @@ impl AppState {
             let ns_app = NSApp();
             window_activation_hack(ns_app);
             // TODO: Consider allowing the user to specify they don't want their application activated
-            ns_app.activateIgnoringOtherApps_(YES);
+            ns_app.activateIgnoringOtherApps_(Bool::YES.as_raw());
         };
         HANDLER.set_ready();
         HANDLER.waker().start();
@@ -361,16 +362,14 @@ impl AppState {
     }
 
     pub fn queue_event(wrapper: EventWrapper) {
-        let is_main_thread: BOOL = unsafe { msg_send!(class!(NSThread), isMainThread) };
-        if is_main_thread == NO {
+        if !is_main_thread() {
             panic!("Event queued from different thread: {:#?}", wrapper);
         }
         HANDLER.events().push_back(wrapper);
     }
 
     pub fn queue_events(mut wrappers: VecDeque<EventWrapper>) {
-        let is_main_thread: BOOL = unsafe { msg_send!(class!(NSThread), isMainThread) };
-        if is_main_thread == NO {
+        if !is_main_thread() {
             panic!("Events queued from different thread: {:#?}", wrappers);
         }
         HANDLER.events().append(&mut wrappers);
@@ -443,7 +442,7 @@ unsafe fn window_activation_hack(ns_app: id) {
         // And call `makeKeyAndOrderFront` if it was called on the window in `UnownedWindow::new`
         // This way we preserve the user's desired initial visiblity status
         // TODO: Also filter on the type/"level" of the window, and maybe other things?
-        if ns_window.isVisible() == YES {
+        if Bool::from_raw(ns_window.isVisible()).as_bool() {
             trace!("Activating visible window");
             ns_window.makeKeyAndOrderFront_(nil);
         } else {

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -161,7 +161,7 @@ impl<T> EventLoop<T> {
             aux_state.activation_policy = attributes.activation_policy;
             aux_state.default_menu = attributes.default_menu;
 
-            autoreleasepool(|| {
+            autoreleasepool(|_| {
                 let _: () = msg_send![app, setDelegate:*delegate];
             });
 
@@ -209,7 +209,7 @@ impl<T> EventLoop<T> {
 
         self._callback = Some(Rc::clone(&callback));
 
-        let exit_code = autoreleasepool(|| unsafe {
+        let exit_code = autoreleasepool(|_| unsafe {
             let app = NSApp();
             assert_ne!(app, nil);
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -14,9 +14,10 @@ use std::{
 use cocoa::{
     appkit::{NSApp, NSEventModifierFlags, NSEventSubtype, NSEventType::NSApplicationDefined},
     base::{id, nil},
-    foundation::{NSInteger, NSPoint, NSTimeInterval},
+    foundation::{NSPoint, NSTimeInterval},
 };
-use objc::{foundation::is_main_thread, rc::autoreleasepool};
+use objc::foundation::is_main_thread;
+use objc::rc::autoreleasepool;
 use raw_window_handle::{AppKitDisplayHandle, RawDisplayHandle};
 
 use crate::{
@@ -245,11 +246,11 @@ pub unsafe fn post_dummy_event(target: id) {
         location: NSPoint::new(0.0, 0.0)
         modifierFlags: NSEventModifierFlags::empty()
         timestamp: 0 as NSTimeInterval
-        windowNumber: 0 as NSInteger
+        windowNumber: 0isize
         context: nil
         subtype: NSEventSubtype::NSWindowExposedEventType
-        data1: 0 as NSInteger
-        data2: 0 as NSInteger
+        data1: 0isize
+        data2: 0isize
     ];
     let _: () = msg_send![target, postEvent: dummy_event, atStart: true];
 }

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -13,10 +13,10 @@ use std::{
 
 use cocoa::{
     appkit::{NSApp, NSEventModifierFlags, NSEventSubtype, NSEventType::NSApplicationDefined},
-    base::{id, nil, BOOL, NO, YES},
+    base::{id, nil},
     foundation::{NSInteger, NSPoint, NSTimeInterval},
 };
-use objc::rc::autoreleasepool;
+use objc::{foundation::is_main_thread, rc::autoreleasepool};
 use raw_window_handle::{AppKitDisplayHandle, RawDisplayHandle};
 
 use crate::{
@@ -144,8 +144,7 @@ impl Default for PlatformSpecificEventLoopAttributes {
 impl<T> EventLoop<T> {
     pub(crate) fn new(attributes: &PlatformSpecificEventLoopAttributes) -> Self {
         let delegate = unsafe {
-            let is_main_thread: BOOL = msg_send!(class!(NSThread), isMainThread);
-            if is_main_thread == NO {
+            if !is_main_thread() {
                 panic!("On macOS, `EventLoop` must be created on the main thread!");
             }
 
@@ -252,7 +251,7 @@ pub unsafe fn post_dummy_event(target: id) {
         data1: 0 as NSInteger
         data2: 0 as NSInteger
     ];
-    let _: () = msg_send![target, postEvent: dummy_event atStart: YES];
+    let _: () = msg_send![target, postEvent: dummy_event, atStart: true];
 }
 
 /// Catches panics that happen inside `f` and when a panic

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -18,31 +18,6 @@ use core_graphics::{
 
 pub const NSNotFound: NSInteger = NSInteger::max_value();
 
-#[repr(C)]
-pub struct NSRange {
-    pub location: NSUInteger,
-    pub length: NSUInteger,
-}
-
-impl NSRange {
-    #[inline]
-    pub fn new(location: NSUInteger, length: NSUInteger) -> NSRange {
-        NSRange { location, length }
-    }
-}
-
-unsafe impl objc::Encode for NSRange {
-    fn encode() -> objc::Encoding {
-        let encoding = format!(
-            // TODO: Verify that this is correct
-            "{{NSRange={}{}}}",
-            NSUInteger::encode().as_str(),
-            NSUInteger::encode().as_str(),
-        );
-        unsafe { objc::Encoding::from_str(&encoding) }
-    }
-}
-
 pub trait NSMutableAttributedString: Sized {
     unsafe fn alloc(_: Self) -> id {
         msg_send![class!(NSMutableAttributedString), alloc]

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -4,10 +4,7 @@
 
 use std::ffi::c_void;
 
-use cocoa::{
-    base::id,
-    foundation::{NSInteger, NSUInteger},
-};
+use cocoa::base::id;
 use core_foundation::{
     array::CFArrayRef, dictionary::CFDictionaryRef, string::CFStringRef, uuid::CFUUIDRef,
 };
@@ -15,6 +12,7 @@ use core_graphics::{
     base::CGError,
     display::{CGDirectDisplayID, CGDisplayConfigRef},
 };
+use objc::foundation::{NSInteger, NSUInteger};
 
 pub const NSNotFound: NSInteger = NSInteger::max_value();
 

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -13,7 +13,7 @@ struct KeyEquivalent<'a> {
 }
 
 pub fn initialize() {
-    autoreleasepool(|| unsafe {
+    autoreleasepool(|_| unsafe {
         let menubar = IdRef::new(NSMenu::new(nil));
         let app_menu_item = IdRef::new(NSMenuItem::new(nil));
         menubar.addItem_(*app_menu_item);

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -75,7 +75,7 @@ impl Window {
         attributes: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
-        let (window, _delegate) = autoreleasepool(|| UnownedWindow::new(attributes, pl_attribs))?;
+        let (window, _delegate) = autoreleasepool(|_| UnownedWindow::new(attributes, pl_attribs))?;
         Ok(Window { window, _delegate })
     }
 }

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -8,7 +8,6 @@ use crate::{
 use cocoa::{
     appkit::NSScreen,
     base::{id, nil},
-    foundation::NSUInteger,
 };
 use core_foundation::{
     array::{CFArrayGetCount, CFArrayGetValueAtIndex},
@@ -16,6 +15,7 @@ use core_foundation::{
     string::CFString,
 };
 use core_graphics::display::{CGDirectDisplayID, CGDisplay, CGDisplayBounds};
+use objc::foundation::NSUInteger;
 
 #[derive(Clone)]
 pub struct VideoMode {

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -229,7 +229,7 @@ pub unsafe fn set_title_async(ns_window: id, title: String) {
 pub unsafe fn close_async(ns_window: IdRef) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        autoreleasepool(move || {
+        autoreleasepool(move |_| {
             ns_window.close();
         });
     });

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -9,8 +9,9 @@ use cocoa::{
     foundation::{NSPoint, NSSize, NSString},
 };
 use dispatch::Queue;
+use objc::foundation::is_main_thread;
 use objc::rc::autoreleasepool;
-use objc::runtime::{BOOL, NO, YES};
+use objc::runtime::Bool;
 
 use crate::{
     dpi::LogicalSize,
@@ -55,8 +56,7 @@ pub unsafe fn set_style_mask_async(ns_window: id, ns_view: id, mask: NSWindowSty
     });
 }
 pub unsafe fn set_style_mask_sync(ns_window: id, ns_view: id, mask: NSWindowStyleMask) {
-    let is_main_thread: BOOL = msg_send!(class!(NSThread), isMainThread);
-    if is_main_thread != NO {
+    if is_main_thread() {
         set_style_mask(ns_window, ns_view, mask);
     } else {
         let ns_window = MainThreadSafe(ns_window);
@@ -97,7 +97,7 @@ pub unsafe fn set_level_async(ns_window: id, level: ffi::NSWindowLevel) {
 pub unsafe fn set_ignore_mouse_events(ns_window: id, ignore: bool) {
     let ns_window = MainThreadSafe(ns_window);
     Queue::main().exec_async(move || {
-        ns_window.setIgnoresMouseEvents_(if ignore { YES } else { NO });
+        ns_window.setIgnoresMouseEvents_(Bool::from(ignore).as_raw());
     });
 }
 
@@ -186,7 +186,7 @@ pub unsafe fn set_maximized_async(
                 } else {
                     shared_state_lock.saved_standard_frame()
                 };
-                ns_window.setFrame_display_(new_rect, NO);
+                ns_window.setFrame_display_(new_rect, Bool::NO.as_raw());
             }
         }
     });

--- a/src/platform_impl/macos/util/cursor.rs
+++ b/src/platform_impl/macos/util/cursor.rs
@@ -148,7 +148,7 @@ pub unsafe fn invisible_cursor() -> id {
         if *cursor_obj.borrow() == nil {
             // Create a cursor from `CURSOR_BYTES`
             let cursor_data: id = msg_send![class!(NSData),
-                dataWithBytesNoCopy:CURSOR_BYTES as *const [u8]
+                dataWithBytesNoCopy:CURSOR_BYTES.as_ptr()
                 length:CURSOR_BYTES.len()
                 freeWhenDone:NO
             ];

--- a/src/platform_impl/macos/util/cursor.rs
+++ b/src/platform_impl/macos/util/cursor.rs
@@ -3,7 +3,7 @@ use cocoa::{
     base::{id, nil},
     foundation::{NSDictionary, NSPoint, NSString},
 };
-use objc::{runtime::Sel, runtime::NO};
+use objc::runtime::Sel;
 use std::cell::RefCell;
 
 use crate::window::CursorIcon;
@@ -147,10 +147,11 @@ pub unsafe fn invisible_cursor() -> id {
     CURSOR_OBJECT.with(|cursor_obj| {
         if *cursor_obj.borrow() == nil {
             // Create a cursor from `CURSOR_BYTES`
-            let cursor_data: id = msg_send![class!(NSData),
-                dataWithBytesNoCopy:CURSOR_BYTES.as_ptr()
-                length:CURSOR_BYTES.len()
-                freeWhenDone:NO
+            let cursor_data: id = msg_send![
+                class!(NSData),
+                dataWithBytesNoCopy: CURSOR_BYTES.as_ptr(),
+                length: CURSOR_BYTES.len(),
+                freeWhenDone: false,
             ];
 
             let ns_image: id = msg_send![class!(NSImage), alloc];

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -9,7 +9,7 @@ use std::os::raw::c_uchar;
 use cocoa::{
     appkit::{CGFloat, NSApp, NSWindowStyleMask},
     base::{id, nil},
-    foundation::{NSPoint, NSRect, NSString, NSUInteger},
+    foundation::{NSPoint, NSRange, NSRect, NSString, NSUInteger},
 };
 use core_graphics::display::CGDisplay;
 use objc::runtime::{Class, Object, BOOL, NO};
@@ -28,7 +28,7 @@ where
     bitset & flag == flag
 }
 
-pub const EMPTY_RANGE: ffi::NSRange = ffi::NSRange {
+pub const EMPTY_RANGE: NSRange = NSRange {
     location: ffi::NSNotFound as NSUInteger,
     length: 0,
 };

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -9,9 +9,10 @@ use std::os::raw::c_uchar;
 use cocoa::{
     appkit::{CGFloat, NSApp, NSWindowStyleMask},
     base::{id, nil},
-    foundation::{NSPoint, NSRange, NSRect, NSString, NSUInteger},
+    foundation::{NSPoint, NSRect, NSString},
 };
 use core_graphics::display::CGDisplay;
+use objc::foundation::{NSRange, NSUInteger};
 use objc::runtime::{Class, Object};
 
 use crate::dpi::LogicalPosition;

--- a/src/platform_impl/macos/util/mod.rs
+++ b/src/platform_impl/macos/util/mod.rs
@@ -12,7 +12,7 @@ use cocoa::{
     foundation::{NSPoint, NSRange, NSRect, NSString, NSUInteger},
 };
 use core_graphics::display::CGDisplay;
-use objc::runtime::{Class, Object, BOOL, NO};
+use objc::runtime::{Class, Object};
 
 use crate::dpi::LogicalPosition;
 use crate::platform_impl::platform::ffi;
@@ -172,8 +172,8 @@ pub unsafe fn toggle_style_mask(window: id, view: id, mask: NSWindowStyleMask, o
 ///
 /// Safety: Assumes that `string` is an instance of `NSAttributedString` or `NSString`
 pub unsafe fn id_to_string_lossy(string: id) -> String {
-    let has_attr: BOOL = msg_send![string, isKindOfClass: class!(NSAttributedString)];
-    let characters = if has_attr != NO {
+    let has_attr = msg_send![string, isKindOfClass: class!(NSAttributedString)];
+    let characters = if has_attr {
         // This is a *mut NSAttributedString
         msg_send![string, string]
     } else {

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -12,7 +12,7 @@ use std::{
 use cocoa::{
     appkit::{NSApp, NSEvent, NSEventModifierFlags, NSEventPhase, NSView, NSWindow},
     base::{id, nil},
-    foundation::{NSInteger, NSPoint, NSRect, NSSize, NSString, NSUInteger},
+    foundation::{NSInteger, NSPoint, NSRange, NSRect, NSSize, NSString, NSUInteger},
 };
 use objc::{
     declare::ClassDecl,
@@ -165,169 +165,134 @@ unsafe impl Sync for ViewClass {}
 static VIEW_CLASS: Lazy<ViewClass> = Lazy::new(|| unsafe {
     let superclass = class!(NSView);
     let mut decl = ClassDecl::new("WinitView", superclass).unwrap();
-    decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
+    decl.add_method(sel!(dealloc), dealloc as extern "C" fn(_, _));
     decl.add_method(
         sel!(initWithWinit:),
-        init_with_winit as extern "C" fn(&Object, Sel, *mut c_void) -> id,
+        init_with_winit as extern "C" fn(_, _, _) -> _,
     );
     decl.add_method(
         sel!(viewDidMoveToWindow),
-        view_did_move_to_window as extern "C" fn(&Object, Sel),
+        view_did_move_to_window as extern "C" fn(_, _),
     );
-    decl.add_method(
-        sel!(drawRect:),
-        draw_rect as extern "C" fn(&Object, Sel, NSRect),
-    );
+    decl.add_method(sel!(drawRect:), draw_rect as extern "C" fn(_, _, _));
     decl.add_method(
         sel!(acceptsFirstResponder),
-        accepts_first_responder as extern "C" fn(&Object, Sel) -> BOOL,
+        accepts_first_responder as extern "C" fn(_, _) -> _,
     );
-    decl.add_method(
-        sel!(touchBar),
-        touch_bar as extern "C" fn(&Object, Sel) -> BOOL,
-    );
+    decl.add_method(sel!(touchBar), touch_bar as extern "C" fn(_, _) -> _);
     decl.add_method(
         sel!(resetCursorRects),
-        reset_cursor_rects as extern "C" fn(&Object, Sel),
+        reset_cursor_rects as extern "C" fn(_, _),
     );
 
     // ------------------------------------------------------------------
     // NSTextInputClient
     decl.add_method(
         sel!(hasMarkedText),
-        has_marked_text as extern "C" fn(&Object, Sel) -> BOOL,
+        has_marked_text as extern "C" fn(_, _) -> _,
     );
-    decl.add_method(
-        sel!(markedRange),
-        marked_range as extern "C" fn(&Object, Sel) -> NSRange,
-    );
+    decl.add_method(sel!(markedRange), marked_range as extern "C" fn(_, _) -> _);
     decl.add_method(
         sel!(selectedRange),
-        selected_range as extern "C" fn(&Object, Sel) -> NSRange,
+        selected_range as extern "C" fn(_, _) -> _,
     );
     decl.add_method(
         sel!(setMarkedText:selectedRange:replacementRange:),
-        set_marked_text as extern "C" fn(&mut Object, Sel, id, NSRange, NSRange),
+        set_marked_text as extern "C" fn(_, _, _, _, _),
     );
-    decl.add_method(sel!(unmarkText), unmark_text as extern "C" fn(&Object, Sel));
+    decl.add_method(sel!(unmarkText), unmark_text as extern "C" fn(_, _));
     decl.add_method(
         sel!(validAttributesForMarkedText),
-        valid_attributes_for_marked_text as extern "C" fn(&Object, Sel) -> id,
+        valid_attributes_for_marked_text as extern "C" fn(_, _) -> _,
     );
     decl.add_method(
         sel!(attributedSubstringForProposedRange:actualRange:),
-        attributed_substring_for_proposed_range
-            as extern "C" fn(&Object, Sel, NSRange, *mut c_void) -> id,
+        attributed_substring_for_proposed_range as extern "C" fn(_, _, _, _) -> _,
     );
     decl.add_method(
         sel!(insertText:replacementRange:),
-        insert_text as extern "C" fn(&Object, Sel, id, NSRange),
+        insert_text as extern "C" fn(_, _, _, _),
     );
     decl.add_method(
         sel!(characterIndexForPoint:),
-        character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> NSUInteger,
+        character_index_for_point as extern "C" fn(_, _, _) -> _,
     );
     decl.add_method(
         sel!(firstRectForCharacterRange:actualRange:),
-        first_rect_for_character_range
-            as extern "C" fn(&Object, Sel, NSRange, *mut c_void) -> NSRect,
+        first_rect_for_character_range as extern "C" fn(_, _, _, _) -> _,
     );
     decl.add_method(
         sel!(doCommandBySelector:),
-        do_command_by_selector as extern "C" fn(&Object, Sel, Sel),
+        do_command_by_selector as extern "C" fn(_, _, _),
     );
     // ------------------------------------------------------------------
 
-    decl.add_method(sel!(keyDown:), key_down as extern "C" fn(&Object, Sel, id));
-    decl.add_method(sel!(keyUp:), key_up as extern "C" fn(&Object, Sel, id));
-    decl.add_method(
-        sel!(flagsChanged:),
-        flags_changed as extern "C" fn(&Object, Sel, id),
-    );
-    decl.add_method(
-        sel!(insertTab:),
-        insert_tab as extern "C" fn(&Object, Sel, id),
-    );
+    decl.add_method(sel!(keyDown:), key_down as extern "C" fn(_, _, _));
+    decl.add_method(sel!(keyUp:), key_up as extern "C" fn(_, _, _));
+    decl.add_method(sel!(flagsChanged:), flags_changed as extern "C" fn(_, _, _));
+    decl.add_method(sel!(insertTab:), insert_tab as extern "C" fn(_, _, _));
     decl.add_method(
         sel!(insertBackTab:),
-        insert_back_tab as extern "C" fn(&Object, Sel, id),
+        insert_back_tab as extern "C" fn(_, _, _),
     );
-    decl.add_method(
-        sel!(mouseDown:),
-        mouse_down as extern "C" fn(&Object, Sel, id),
-    );
-    decl.add_method(sel!(mouseUp:), mouse_up as extern "C" fn(&Object, Sel, id));
+    decl.add_method(sel!(mouseDown:), mouse_down as extern "C" fn(_, _, _));
+    decl.add_method(sel!(mouseUp:), mouse_up as extern "C" fn(_, _, _));
     decl.add_method(
         sel!(rightMouseDown:),
-        right_mouse_down as extern "C" fn(&Object, Sel, id),
+        right_mouse_down as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(rightMouseUp:),
-        right_mouse_up as extern "C" fn(&Object, Sel, id),
+        right_mouse_up as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(otherMouseDown:),
-        other_mouse_down as extern "C" fn(&Object, Sel, id),
+        other_mouse_down as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(otherMouseUp:),
-        other_mouse_up as extern "C" fn(&Object, Sel, id),
+        other_mouse_up as extern "C" fn(_, _, _),
     );
-    decl.add_method(
-        sel!(mouseMoved:),
-        mouse_moved as extern "C" fn(&Object, Sel, id),
-    );
-    decl.add_method(
-        sel!(mouseDragged:),
-        mouse_dragged as extern "C" fn(&Object, Sel, id),
-    );
+    decl.add_method(sel!(mouseMoved:), mouse_moved as extern "C" fn(_, _, _));
+    decl.add_method(sel!(mouseDragged:), mouse_dragged as extern "C" fn(_, _, _));
     decl.add_method(
         sel!(rightMouseDragged:),
-        right_mouse_dragged as extern "C" fn(&Object, Sel, id),
+        right_mouse_dragged as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(otherMouseDragged:),
-        other_mouse_dragged as extern "C" fn(&Object, Sel, id),
+        other_mouse_dragged as extern "C" fn(_, _, _),
     );
-    decl.add_method(
-        sel!(mouseEntered:),
-        mouse_entered as extern "C" fn(&Object, Sel, id),
-    );
-    decl.add_method(
-        sel!(mouseExited:),
-        mouse_exited as extern "C" fn(&Object, Sel, id),
-    );
-    decl.add_method(
-        sel!(scrollWheel:),
-        scroll_wheel as extern "C" fn(&Object, Sel, id),
-    );
+    decl.add_method(sel!(mouseEntered:), mouse_entered as extern "C" fn(_, _, _));
+    decl.add_method(sel!(mouseExited:), mouse_exited as extern "C" fn(_, _, _));
+    decl.add_method(sel!(scrollWheel:), scroll_wheel as extern "C" fn(_, _, _));
     decl.add_method(
         sel!(magnifyWithEvent:),
-        magnify_with_event as extern "C" fn(&Object, Sel, id),
+        magnify_with_event as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(rotateWithEvent:),
-        rotate_with_event as extern "C" fn(&Object, Sel, id),
+        rotate_with_event as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(pressureChangeWithEvent:),
-        pressure_change_with_event as extern "C" fn(&Object, Sel, id),
+        pressure_change_with_event as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(_wantsKeyDownForEvent:),
-        wants_key_down_for_event as extern "C" fn(&Object, Sel, id) -> BOOL,
+        wants_key_down_for_event as extern "C" fn(_, _, _) -> _,
     );
     decl.add_method(
         sel!(cancelOperation:),
-        cancel_operation as extern "C" fn(&Object, Sel, id),
+        cancel_operation as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(frameDidChange:),
-        frame_did_change as extern "C" fn(&Object, Sel, id),
+        frame_did_change as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(acceptsFirstMouse:),
-        accepts_first_mouse as extern "C" fn(&Object, Sel, id) -> BOOL,
+        accepts_first_mouse as extern "C" fn(_, _, _) -> _,
     );
     decl.add_ivar::<*mut c_void>("winitState");
     decl.add_ivar::<id>("markedText");
@@ -364,7 +329,7 @@ extern "C" fn init_with_winit(this: &Object, _sel: Sel, state: *mut c_void) -> i
                 notification_center,
                 addObserver: this
                 selector: sel!(frameDidChange:)
-                name: frame_did_change_notification_name
+                name: *frame_did_change_notification_name
                 object: this
             ];
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -12,10 +12,11 @@ use std::{
 use cocoa::{
     appkit::{NSApp, NSEvent, NSEventModifierFlags, NSEventPhase, NSView, NSWindow},
     base::{id, nil},
-    foundation::{NSInteger, NSPoint, NSRange, NSRect, NSSize, NSString, NSUInteger},
+    foundation::{NSPoint, NSRect, NSSize, NSString},
 };
 use objc::{
     declare::ClassBuilder,
+    foundation::{NSInteger, NSRange, NSUInteger},
     runtime::{Bool, Class, Object, Protocol, Sel},
 };
 use once_cell::sync::Lazy;

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -141,7 +141,7 @@ fn create_window(
     attrs: &WindowAttributes,
     pl_attrs: &PlatformSpecificWindowBuilderAttributes,
 ) -> Option<IdRef> {
-    autoreleasepool(|| unsafe {
+    autoreleasepool(|_| unsafe {
         let screen = match attrs.fullscreen {
             Some(Fullscreen::Borderless(Some(RootMonitorHandle { inner: ref monitor })))
             | Some(Fullscreen::Exclusive(RootVideoMode {
@@ -239,10 +239,7 @@ fn create_window(
             }
 
             if attrs.always_on_top {
-                let _: () = msg_send![
-                    *ns_window,
-                    setLevel: ffi::NSWindowLevel::NSFloatingWindowLevel
-                ];
+                let _: () = msg_send![*ns_window, setLevel: ffi::kCGFloatingWindowLevelKey];
             }
 
             if let Some(increments) = pl_attrs.resize_increments {
@@ -284,11 +281,11 @@ static WINDOW_CLASS: Lazy<WindowClass> = Lazy::new(|| unsafe {
 
     decl.add_method(
         sel!(canBecomeMainWindow),
-        can_become_main_window as extern "C" fn(&Object, Sel) -> BOOL,
+        can_become_main_window as extern "C" fn(_, _) -> _,
     );
     decl.add_method(
         sel!(canBecomeKeyWindow),
-        can_become_key_window as extern "C" fn(&Object, Sel) -> BOOL,
+        can_become_key_window as extern "C" fn(_, _) -> _,
     );
     WindowClass(decl.register())
 });
@@ -998,10 +995,7 @@ impl UnownedWindow {
 
                 // Restore the normal window level following the Borderless fullscreen
                 // `CGShieldingWindowLevel() + 1` hack.
-                let _: () = msg_send![
-                    *self.ns_window,
-                    setLevel: ffi::NSWindowLevel::NSNormalWindowLevel
-                ];
+                let _: () = msg_send![*self.ns_window, setLevel: ffi::kCGBaseWindowLevelKey];
             },
             _ => {}
         };

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -42,12 +42,12 @@ use cocoa::{
         NSRequestUserAttentionType, NSScreen, NSView, NSWindow, NSWindowButton, NSWindowStyleMask,
     },
     base::{id, nil},
-    foundation::{NSDictionary, NSPoint, NSRect, NSSize, NSUInteger},
+    foundation::{NSDictionary, NSPoint, NSRect, NSSize},
 };
 use core_graphics::display::{CGDisplay, CGDisplayMode};
 use objc::{
     declare::ClassBuilder,
-    foundation::is_main_thread,
+    foundation::{is_main_thread, NSUInteger},
     rc::autoreleasepool,
     runtime::{Bool, Class, Object, Sel},
 };

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -139,90 +139,89 @@ static WINDOW_DELEGATE_CLASS: Lazy<WindowDelegateClass> = Lazy::new(|| unsafe {
     let superclass = class!(NSResponder);
     let mut decl = ClassDecl::new("WinitWindowDelegate", superclass).unwrap();
 
-    decl.add_method(sel!(dealloc), dealloc as extern "C" fn(&Object, Sel));
+    decl.add_method(sel!(dealloc), dealloc as extern "C" fn(_, _));
     decl.add_method(
         sel!(initWithWinit:),
-        init_with_winit as extern "C" fn(&Object, Sel, *mut c_void) -> id,
+        init_with_winit as extern "C" fn(_, _, _) -> _,
     );
 
     decl.add_method(
         sel!(windowShouldClose:),
-        window_should_close as extern "C" fn(&Object, Sel, id) -> BOOL,
+        window_should_close as extern "C" fn(_, _, _) -> _,
     );
     decl.add_method(
         sel!(windowWillClose:),
-        window_will_close as extern "C" fn(&Object, Sel, id),
+        window_will_close as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowDidResize:),
-        window_did_resize as extern "C" fn(&Object, Sel, id),
+        window_did_resize as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowDidMove:),
-        window_did_move as extern "C" fn(&Object, Sel, id),
+        window_did_move as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowDidChangeBackingProperties:),
-        window_did_change_backing_properties as extern "C" fn(&Object, Sel, id),
+        window_did_change_backing_properties as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowDidBecomeKey:),
-        window_did_become_key as extern "C" fn(&Object, Sel, id),
+        window_did_become_key as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowDidResignKey:),
-        window_did_resign_key as extern "C" fn(&Object, Sel, id),
+        window_did_resign_key as extern "C" fn(_, _, _),
     );
 
     decl.add_method(
         sel!(draggingEntered:),
-        dragging_entered as extern "C" fn(&Object, Sel, id) -> BOOL,
+        dragging_entered as extern "C" fn(_, _, _) -> _,
     );
     decl.add_method(
         sel!(prepareForDragOperation:),
-        prepare_for_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
+        prepare_for_drag_operation as extern "C" fn(_, _, _) -> _,
     );
     decl.add_method(
         sel!(performDragOperation:),
-        perform_drag_operation as extern "C" fn(&Object, Sel, id) -> BOOL,
+        perform_drag_operation as extern "C" fn(_, _, _) -> _,
     );
     decl.add_method(
         sel!(concludeDragOperation:),
-        conclude_drag_operation as extern "C" fn(&Object, Sel, id),
+        conclude_drag_operation as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(draggingExited:),
-        dragging_exited as extern "C" fn(&Object, Sel, id),
+        dragging_exited as extern "C" fn(_, _, _),
     );
 
     decl.add_method(
         sel!(window:willUseFullScreenPresentationOptions:),
-        window_will_use_fullscreen_presentation_options
-            as extern "C" fn(&Object, Sel, id, NSUInteger) -> NSUInteger,
+        window_will_use_fullscreen_presentation_options as extern "C" fn(_, _, _, _) -> _,
     );
     decl.add_method(
         sel!(windowDidEnterFullScreen:),
-        window_did_enter_fullscreen as extern "C" fn(&Object, Sel, id),
+        window_did_enter_fullscreen as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowWillEnterFullScreen:),
-        window_will_enter_fullscreen as extern "C" fn(&Object, Sel, id),
+        window_will_enter_fullscreen as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowDidExitFullScreen:),
-        window_did_exit_fullscreen as extern "C" fn(&Object, Sel, id),
+        window_did_exit_fullscreen as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowWillExitFullScreen:),
-        window_will_exit_fullscreen as extern "C" fn(&Object, Sel, id),
+        window_will_exit_fullscreen as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowDidFailToEnterFullScreen:),
-        window_did_fail_to_enter_fullscreen as extern "C" fn(&Object, Sel, id),
+        window_did_fail_to_enter_fullscreen as extern "C" fn(_, _, _),
     );
     decl.add_method(
         sel!(windowDidChangeOcclusionState:),
-        window_did_change_occlusion_state as extern "C" fn(&Object, Sel, id),
+        window_did_change_occlusion_state as extern "C" fn(_, _, _),
     );
 
     decl.add_ivar::<*mut c_void>("winitState");
@@ -268,7 +267,7 @@ extern "C" fn window_will_close(this: &Object, _: Sel, _: id) {
     trace_scope!("windowWillClose:");
     with_state(this, |state| unsafe {
         // `setDelegate:` retains the previous value and then autoreleases it
-        autoreleasepool(|| {
+        autoreleasepool(|_| {
             // Since El Capitan, we need to be careful that delegate methods can't
             // be called after the window closes.
             let _: () = msg_send![*state.ns_window, setDelegate: nil];

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -7,10 +7,10 @@ use std::{
 use cocoa::{
     appkit::{self, NSApplicationPresentationOptions, NSView, NSWindow, NSWindowOcclusionState},
     base::{id, nil},
-    foundation::NSUInteger,
 };
 use objc::{
     declare::ClassBuilder,
+    foundation::NSUInteger,
     rc::autoreleasepool,
     runtime::{Bool, Class, Object, Sel},
 };
@@ -477,7 +477,7 @@ extern "C" fn window_will_use_fullscreen_presentation_options(
                 options = (NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
                     | NSApplicationPresentationOptions::NSApplicationPresentationHideDock
                     | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar)
-                    .bits();
+                    .bits() as NSUInteger;
             }
         })
     });


### PR DESCRIPTION
Part of https://github.com/rust-windowing/winit/pull/2427.

Concrete improvements in `objc2` which can be seen in this PR:
- `msg_send!` can now return `bool` without special handling.
- Types in `msg_send!` are now required to be `Encode`. This helped catching a lot of undefined behaviour, which are fixed in https://github.com/rust-windowing/winit/pull/2138 and https://github.com/rust-windowing/winit/pull/2428.

Checklist:
- [x] Tested on all platforms changed
  - [x] macOS 10.14
  - [x] iOS simulator (can't get log output here though, so a bit harder)
  - [x] iOS 9.3.6 (iPad mini 1st gen)
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
