### PR TITLE
Bump MSRV to 1.60

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: [1.57.0, stable, nightly]
+        rust_version: ['1.60.0', stable, nightly]
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
@@ -95,7 +95,7 @@ jobs:
 
     - name: Lint with clippy
       shell: bash
-      if: (matrix.rust_version == '1.57.0') && !contains(matrix.platform.options, '--no-default-features')
+      if: (matrix.rust_version == '1.60.0') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
 
     - name: Build tests with serde enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** Bump MSRV from `1.57` to `1.60`.
 - **Breaking:** Split the `platform::unix` module into `platform::x11` and `platform::wayland`. The extension types are similarly renamed.
 - **Breaking:**: Removed deprecated method `platform::unix::WindowExtUnix::is_ready`.
 - Removed `parking_lot` dependency.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ your description of the issue as detailed as possible:
 
 When making a code contribution to winit, before opening your pull request, please make sure that:
 
-- your patch builds with Winit's minimal supported rust version - Rust 1.57.0.
+- your patch builds with Winit's minimal supported rust version - Rust 1.60.
 - you tested your modifications on all the platforms impacted, or if not possible detail which platforms
   were not tested, and what should be tested, so that a maintainer or another contributor can test them
 - you updated any relevant documentation in winit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/rust-windowing/winit"
 documentation = "https://docs.rs/winit"
 categories = ["gui"]
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 
 [package.metadata.docs.rs]
 features = ["serde"]

--- a/src/platform_impl/linux/x11/dnd.rs
+++ b/src/platform_impl/linux/x11/dnd.rs
@@ -188,7 +188,7 @@ impl Dnd {
             .get_property(window, self.atoms.selection, self.atoms.uri_list)
     }
 
-    pub fn parse_data(&self, data: &mut Vec<c_uchar>) -> Result<Vec<PathBuf>, DndDataParseError> {
+    pub fn parse_data(&self, data: &mut [c_uchar]) -> Result<Vec<PathBuf>, DndDataParseError> {
         if !data.is_empty() {
             let mut path_list = Vec::new();
             let decoded = percent_decode(data).decode_utf8()?.into_owned();


### PR DESCRIPTION
- 1.58 needed by https://github.com/rust-windowing/winit/pull/2444
- 1.60 needed by https://github.com/rust-windowing/winit/pull/2452

Since `objc2` uses [new cargo features](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features), it is not possible to compile the dependency on 1.57, even if this is done on a platform which shouldn't need that dependency (this _could_ be reverted, but I'd rather avoid doing so, as it is a bit of a usability regression when you want to use its cargo features).

I recognize that distributions will need to have caught up with 1.60 before we can really do this, but maybe we can do this now, and then time our next breaking release of `winit` with that?

- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

CC @Lokathor @chrisduerr @kchibisov @rib