### PR TITLE
Removed once_cell usage where possible now that Mutex::new and RwLock…

### DIFF
--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -39,7 +39,7 @@ static CONFIG: Lazy<RwLock<Configuration>> = Lazy::new(|| {
 //
 // This allows us to inject event into the event loop without going through `ndk-glue` and
 // calling unsafe function that should only be called by Android.
-static INTERNAL_EVENT: Lazy<RwLock<Option<InternalEvent>>> = Lazy::new(|| RwLock::new(None));
+static INTERNAL_EVENT: RwLock<Option<InternalEvent>> = RwLock::new(None);
 
 enum InternalEvent {
     RedrawRequested,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -590,8 +590,7 @@ impl Window {
 
 /// Hooks for X11 errors.
 #[cfg(feature = "x11")]
-pub(crate) static mut XLIB_ERROR_HOOKS: Lazy<Mutex<Vec<XlibErrorHook>>> =
-    Lazy::new(|| Mutex::new(Vec::new()));
+pub(crate) static mut XLIB_ERROR_HOOKS: Mutex<Vec<XlibErrorHook>> = Mutex::new(Vec::new());
 
 #[cfg(feature = "x11")]
 unsafe extern "C" fn x_error_callback(

--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -7,11 +7,9 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use once_cell::sync::Lazy;
-
 use super::{ffi, util, XConnection, XError};
 
-static GLOBAL_LOCK: Lazy<Mutex<()>> = Lazy::new(Default::default);
+static GLOBAL_LOCK: Mutex<()> = Mutex::new(());
 
 unsafe fn open_im(xconn: &Arc<XConnection>, locale_modifiers: &CStr) -> Option<ffi::XIM> {
     let _lock = GLOBAL_LOCK.lock();

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -2,8 +2,6 @@ use std::os::raw::*;
 use std::slice;
 use std::sync::Mutex;
 
-use once_cell::sync::Lazy;
-
 use super::{
     ffi::{
         RRCrtc, RRCrtcChangeNotifyMask, RRMode, RROutputPropertyNotifyMask,
@@ -20,7 +18,7 @@ use crate::{
 // Used for testing. This should always be committed as false.
 const DISABLE_MONITOR_LIST_CACHING: bool = false;
 
-static MONITORS: Lazy<Mutex<Option<Vec<MonitorHandle>>>> = Lazy::new(Mutex::default);
+static MONITORS: Mutex<Option<Vec<MonitorHandle>>> = Mutex::new(None);
 
 pub fn invalidate_cached_monitor_list() -> Option<Vec<MonitorHandle>> {
     // We update this lazily.

--- a/src/platform_impl/linux/x11/util/wm.rs
+++ b/src/platform_impl/linux/x11/util/wm.rs
@@ -1,13 +1,11 @@
 use std::sync::Mutex;
 
-use once_cell::sync::Lazy;
-
 use super::*;
 
 // This info is global to the window manager.
-static SUPPORTED_HINTS: Lazy<Mutex<Vec<ffi::Atom>>> =
-    Lazy::new(|| Mutex::new(Vec::with_capacity(0)));
-static WM_NAME: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
+static SUPPORTED_HINTS: Mutex<Vec<ffi::Atom>> = Mutex::new(Vec::new());
+
+static WM_NAME: Mutex<Option<String>> = Mutex::new(None);
 
 pub fn hint_is_supported(hint: ffi::Atom) -> bool {
     (*SUPPORTED_HINTS.lock().unwrap()).contains(&hint)


### PR DESCRIPTION
…:new are const fns

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
