### PR TITLE
Revert "ci: manually point ANDROID_NDK_ROOT to latest supplied version"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,6 @@ jobs:
         targets: ${{ matrix.platform.target }}
         components: clippy
 
-    - name: Setup NDK path
-      shell: bash
-      # "Temporary" workaround until https://github.com/actions/virtual-environments/issues/5879#issuecomment-1195156618
-      # gets looked into.
-      run: echo "ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME" >> $GITHUB_ENV
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
       run: sudo apt-get update && sudo apt-get install gcc-multilib


### PR DESCRIPTION
This reverts commit 4895a29e92a6fa9f7640558bd2676cdc48f66d8d.

GitHub Actions' runner-images readded this environment variable on my request [1] as it wasn't strictly related to the deprecated and removed `ndk-bundle` NDK release.  Back out of the workaround to keep CI scripts tidy.

[1]: https://github.com/actions/runner-images/issues/5879#issuecomment-1197811704
