### PR TITLE
Fix runloop entry

### DIFF
--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -10,10 +10,9 @@ use std::{
 use core_foundation::base::{CFIndex, CFRelease};
 use core_foundation::runloop::{
     kCFRunLoopAfterWaiting, kCFRunLoopBeforeWaiting, kCFRunLoopCommonModes, kCFRunLoopDefaultMode,
-    kCFRunLoopEntry, kCFRunLoopExit, CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddSource,
-    CFRunLoopGetMain, CFRunLoopObserverCreate, CFRunLoopObserverRef, CFRunLoopSourceContext,
-    CFRunLoopSourceCreate, CFRunLoopSourceInvalidate, CFRunLoopSourceRef, CFRunLoopSourceSignal,
-    CFRunLoopWakeUp,
+    kCFRunLoopExit, CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddSource, CFRunLoopGetMain,
+    CFRunLoopObserverCreate, CFRunLoopObserverRef, CFRunLoopSourceContext, CFRunLoopSourceCreate,
+    CFRunLoopSourceInvalidate, CFRunLoopSourceRef, CFRunLoopSourceSignal, CFRunLoopWakeUp,
 };
 use objc2::runtime::Object;
 use objc2::{class, msg_send, ClassType};
@@ -236,7 +235,6 @@ fn setup_control_flow_observers() {
                 #[allow(non_upper_case_globals)]
                 match activity {
                     kCFRunLoopAfterWaiting => app_state::handle_wakeup_transition(),
-                    kCFRunLoopEntry => unimplemented!(), // not expected to ever happen
                     _ => unreachable!(),
                 }
             }
@@ -288,7 +286,7 @@ fn setup_control_flow_observers() {
 
         let begin_observer = CFRunLoopObserverCreate(
             ptr::null_mut(),
-            kCFRunLoopEntry | kCFRunLoopAfterWaiting,
+            kCFRunLoopAfterWaiting,
             1, // repeat = true
             CFIndex::min_value(),
             control_flow_begin_handler,

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -15,8 +15,8 @@ use crate::platform_impl::platform::{
 use core_foundation::base::{CFIndex, CFOptionFlags, CFRelease};
 use core_foundation::date::CFAbsoluteTimeGetCurrent;
 use core_foundation::runloop::{
-    kCFRunLoopAfterWaiting, kCFRunLoopBeforeWaiting, kCFRunLoopCommonModes, kCFRunLoopEntry,
-    kCFRunLoopExit, CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddTimer, CFRunLoopGetMain,
+    kCFRunLoopAfterWaiting, kCFRunLoopBeforeWaiting, kCFRunLoopCommonModes, kCFRunLoopExit,
+    CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddTimer, CFRunLoopGetMain,
     CFRunLoopObserverCallBack, CFRunLoopObserverContext, CFRunLoopObserverCreate,
     CFRunLoopObserverRef, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
     CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate,
@@ -57,7 +57,6 @@ extern "C" fn control_flow_begin_handler(
                     AppState::wakeup(panic_info);
                     //trace!("Completed `CFRunLoopAfterWaiting`");
                 }
-                kCFRunLoopEntry => unimplemented!(), // not expected to ever happen
                 _ => unreachable!(),
             }
         });
@@ -126,7 +125,7 @@ pub fn setup_control_flow_observers(panic_info: Weak<PanicInfo>) {
         };
         let run_loop = RunLoop::get();
         run_loop.add_observer(
-            kCFRunLoopEntry | kCFRunLoopAfterWaiting,
+            kCFRunLoopAfterWaiting,
             CFIndex::min_value(),
             control_flow_begin_handler,
             &mut context as *mut _,


### PR DESCRIPTION
Introduced in https://github.com/rust-windowing/winit/pull/2479; turns out the definitions were not entirely equal, the `kCFRunLoopEntry` that we were using previously was defined as `0` while the correct value is `1` (which meant the `unimplemented!()` branch suddenly started triggering)

- [x] Tested on all platforms changed
