### PR TITLE
wayland: Clear preedit if there is no pending preedit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, a new `wayland-csd-adwaita-crossfont` feature was added to use `crossfont` instead of `ab_glyph` for decorations.
 - On Wayland, if not otherwise specified use upstream automatic CSD theme selection.
 - On Windows, fixed ALT+Space shortcut to open window menu.
+- On Wayland, fixed `Ime::Preedit` not being sent on IME reset.
 
 # 0.27.2 (2022-8-12)
 

--- a/src/platform_impl/linux/wayland/seat/text_input/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/text_input/handlers.rs
@@ -92,15 +92,21 @@ pub(super) fn handle_text_input(
                 event_sink.push_window_event(WindowEvent::Ime(Ime::Commit(text)), window_id);
             }
 
-            // Push preedit string we've got after latest commit.
-            if let Some(preedit) = inner.pending_preedit.take() {
-                let cursor_range = preedit
-                    .cursor_begin
-                    .map(|b| (b, preedit.cursor_end.unwrap_or(b)));
+            // Always send preedit on `Done` events.
+            let (text, range) = inner
+                .pending_preedit
+                .take()
+                .map(|preedit| {
+                    let cursor_range = preedit
+                        .cursor_begin
+                        .map(|b| (b, preedit.cursor_end.unwrap_or(b)));
 
-                let event = Ime::Preedit(preedit.text, cursor_range);
-                event_sink.push_window_event(WindowEvent::Ime(event), window_id);
-            }
+                    (preedit.text, cursor_range)
+                })
+                .unwrap_or_default();
+
+            let event = Ime::Preedit(text, range);
+            event_sink.push_window_event(WindowEvent::Ime(event), window_id);
         }
         _ => (),
     }


### PR DESCRIPTION
Fix #2478

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
