### PR TITLE
Simplify internal type construction

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -312,7 +312,9 @@ impl<T> EventLoopWindowTarget<T> {
     /// **Wayland:** Always returns `None`.
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        self.p.primary_monitor()
+        self.p
+            .primary_monitor()
+            .map(|inner| MonitorHandle { inner })
     }
 
     /// Change [`DeviceEvent`] filter mode.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -169,6 +169,8 @@ impl MonitorHandle {
     /// - **Web:** Always returns an empty iterator
     #[inline]
     pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
-        self.inner.video_modes()
+        self.inner
+            .video_modes()
+            .map(|video_mode| VideoMode { video_mode })
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -78,7 +78,9 @@ impl VideoMode {
     /// a separate set of valid video modes.
     #[inline]
     pub fn monitor(&self) -> MonitorHandle {
-        self.video_mode.monitor()
+        MonitorHandle {
+            inner: self.video_mode.monitor(),
+        }
     }
 }
 

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -257,7 +257,9 @@ impl MonitorHandleExtIOS for MonitorHandle {
 
     #[inline]
     fn preferred_video_mode(&self) -> VideoMode {
-        self.inner.preferred_video_mode()
+        VideoMode {
+            video_mode: self.inner.preferred_video_mode(),
+        }
     }
 }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -23,7 +23,6 @@ use crate::{
     error,
     event::{self, VirtualKeyCode},
     event_loop::{self, ControlFlow},
-    monitor,
     window::{self, CursorGrabMode},
 };
 
@@ -636,10 +635,8 @@ pub struct EventLoopWindowTarget<T: 'static> {
 }
 
 impl<T: 'static> EventLoopWindowTarget<T> {
-    pub fn primary_monitor(&self) -> Option<monitor::MonitorHandle> {
-        Some(monitor::MonitorHandle {
-            inner: MonitorHandle,
-        })
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
@@ -702,10 +699,8 @@ impl Window {
         WindowId
     }
 
-    pub fn primary_monitor(&self) -> Option<monitor::MonitorHandle> {
-        Some(monitor::MonitorHandle {
-            inner: MonitorHandle,
-        })
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
@@ -714,10 +709,8 @@ impl Window {
         v
     }
 
-    pub fn current_monitor(&self) -> Option<monitor::MonitorHandle> {
-        Some(monitor::MonitorHandle {
-            inner: MonitorHandle,
-        })
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     pub fn scale_factor(&self) -> f64 {
@@ -941,9 +934,7 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> monitor::MonitorHandle {
-        monitor::MonitorHandle {
-            inner: self.monitor.clone(),
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        self.monitor.clone()
     }
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -18,7 +18,7 @@ use raw_window_handle::{
     AndroidDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 
-use super::Fullscreen;
+use crate::platform_impl::Fullscreen;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error,

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -907,17 +907,15 @@ impl MonitorHandle {
         None
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = monitor::VideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(monitor::VideoMode {
-            video_mode: VideoMode {
-                size,
-                bit_depth: 32,
-                refresh_rate_millihertz: 60000,
-                monitor: self.clone(),
-            },
+        std::iter::once(VideoMode {
+            size,
+            bit_depth: 32,
+            refresh_rate_millihertz: 60000,
+            monitor: self.clone(),
         })
     }
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -18,6 +18,7 @@ use raw_window_handle::{
     AndroidDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 
+use super::Fullscreen;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error,
@@ -683,7 +684,7 @@ impl DeviceId {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PlatformSpecificWindowBuilderAttributes;
 
-pub struct Window;
+pub(crate) struct Window;
 
 impl Window {
     pub(crate) fn new<T: 'static>(
@@ -778,11 +779,11 @@ impl Window {
         false
     }
 
-    pub fn set_fullscreen(&self, _monitor: Option<window::Fullscreen>) {
+    pub fn set_fullscreen(&self, _monitor: Option<Fullscreen>) {
         warn!("Cannot set fullscreen on Android");
     }
 
-    pub fn fullscreen(&self) -> Option<window::Fullscreen> {
+    pub fn fullscreen(&self) -> Option<Fullscreen> {
         None
     }
 

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -24,7 +24,6 @@ use crate::{
     event_loop::{
         ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootEventLoopWindowTarget,
     },
-    monitor::MonitorHandle as RootMonitorHandle,
     platform::ios::Idiom,
 };
 
@@ -60,11 +59,11 @@ impl<T: 'static> EventLoopWindowTarget<T> {
         unsafe { monitor::uiscreens() }
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         // guaranteed to be on main thread
         let monitor = unsafe { monitor::main_uiscreen() };
 
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -87,6 +87,7 @@ pub(crate) use self::{
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},
 };
 
+pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -87,8 +87,8 @@ pub(crate) use self::{
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},
 };
 
-pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
+pub(self) use crate::platform_impl::Fullscreen;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId {

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -220,7 +220,7 @@ impl Inner {
         Some(refresh_rate_millihertz(self.uiscreen))
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         let mut modes = BTreeSet::new();
         unsafe {
             let available_modes: id = msg_send![self.uiscreen, availableModes];
@@ -228,13 +228,14 @@ impl Inner {
 
             for i in 0..available_mode_count {
                 let mode: id = msg_send![available_modes, objectAtIndex: i];
+                // Use Ord impl of RootVideoMode
                 modes.insert(RootVideoMode {
                     video_mode: VideoMode::retained_new(self.uiscreen, mode),
                 });
             }
         }
 
-        modes.into_iter()
+        modes.into_iter().map(|mode| mode.video_mode)
     }
 }
 
@@ -268,12 +269,10 @@ impl Inner {
         self.uiscreen
     }
 
-    pub fn preferred_video_mode(&self) -> RootVideoMode {
+    pub fn preferred_video_mode(&self) -> VideoMode {
         unsafe {
             let mode: id = msg_send![self.uiscreen, preferredMode];
-            RootVideoMode {
-                video_mode: VideoMode::retained_new(self.uiscreen, mode),
-            }
+            VideoMode::retained_new(self.uiscreen, mode)
         }
     }
 }

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -9,7 +9,7 @@ use objc2::{class, msg_send};
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::VideoMode as RootVideoMode,
     platform_impl::platform::{
         app_state,
         ffi::{id, nil, CGFloat, CGRect, CGSize},
@@ -87,10 +87,8 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: self.monitor.clone(),
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        self.monitor.clone()
     }
 }
 

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -9,7 +9,6 @@ use super::uikit::{UIResponder, UIViewController, UIWindow};
 use crate::{
     dpi::PhysicalPosition,
     event::{DeviceId as RootDeviceId, Event, Force, Touch, TouchPhase, WindowEvent},
-    platform::ios::MonitorHandleExtIOS,
     platform_impl::platform::{
         app_state,
         event_loop::{self, EventProxy, EventWrapper},
@@ -18,9 +17,9 @@ use crate::{
             UIRectEdge, UITouchPhase, UITouchType,
         },
         window::PlatformSpecificWindowBuilderAttributes,
-        DeviceId,
+        DeviceId, Fullscreen,
     },
-    window::{Fullscreen, WindowAttributes, WindowId as RootWindowId},
+    window::{WindowAttributes, WindowId as RootWindowId},
 };
 
 // requires main thread
@@ -464,7 +463,7 @@ pub(crate) unsafe fn create_window(
     match window_attributes.fullscreen {
         Some(Fullscreen::Exclusive(ref video_mode)) => {
             let uiscreen = video_mode.monitor().ui_screen() as id;
-            let _: () = msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode.0];
+            let _: () = msg_send![uiscreen, setCurrentMode: video_mode.screen_mode.0];
             msg_send![window, setScreen:video_mode.monitor().ui_screen()]
         }
         Some(Fullscreen::Borderless(ref monitor)) => {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -12,8 +12,7 @@ use crate::{
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
     event::{Event, WindowEvent},
     icon::Icon,
-    monitor::MonitorHandle as RootMonitorHandle,
-    platform::ios::{MonitorHandleExtIOS, ScreenEdge, ValidOrientations},
+    platform::ios::{ScreenEdge, ValidOrientations},
     platform_impl::platform::{
         app_state,
         event_loop::{self, EventProxy, EventWrapper},
@@ -21,11 +20,10 @@ use crate::{
             id, CGFloat, CGPoint, CGRect, CGSize, UIEdgeInsets, UIInterfaceOrientationMask,
             UIRectEdge, UIScreenOverscanCompensation,
         },
-        monitor, view, EventLoopWindowTarget, MonitorHandle,
+        monitor, view, EventLoopWindowTarget, Fullscreen, MonitorHandle,
     },
     window::{
-        CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes,
-        WindowId as RootWindowId,
+        CursorGrabMode, CursorIcon, UserAttentionType, WindowAttributes, WindowId as RootWindowId,
     },
 };
 
@@ -217,13 +215,12 @@ impl Inner {
         false
     }
 
-    pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
+    pub(crate) fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
         unsafe {
             let uiscreen = match monitor {
                 Some(Fullscreen::Exclusive(video_mode)) => {
-                    let uiscreen = video_mode.video_mode.monitor.ui_screen() as id;
-                    let _: () =
-                        msg_send![uiscreen, setCurrentMode: video_mode.video_mode.screen_mode.0];
+                    let uiscreen = video_mode.monitor.ui_screen() as id;
+                    let _: () = msg_send![uiscreen, setCurrentMode: video_mode.screen_mode.0];
                     uiscreen
                 }
                 Some(Fullscreen::Borderless(Some(monitor))) => monitor.ui_screen() as id,
@@ -255,7 +252,7 @@ impl Inner {
         }
     }
 
-    pub fn fullscreen(&self) -> Option<Fullscreen> {
+    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         unsafe {
             let monitor = self.current_monitor_inner();
             let uiscreen = monitor.ui_screen();
@@ -268,9 +265,7 @@ impl Inner {
                 && screen_space_bounds.size.width == screen_bounds.size.width
                 && screen_space_bounds.size.height == screen_bounds.size.height
             {
-                Some(Fullscreen::Borderless(Some(RootMonitorHandle {
-                    inner: monitor,
-                })))
+                Some(Fullscreen::Borderless(Some(monitor)))
             } else {
                 None
             }
@@ -396,10 +391,8 @@ impl Window {
 
         unsafe {
             let screen = match window_attributes.fullscreen {
-                Some(Fullscreen::Exclusive(ref video_mode)) => {
-                    video_mode.video_mode.monitor.ui_screen() as id
-                }
-                Some(Fullscreen::Borderless(Some(ref monitor))) => monitor.inner.ui_screen(),
+                Some(Fullscreen::Exclusive(ref video_mode)) => video_mode.monitor.ui_screen() as id,
+                Some(Fullscreen::Borderless(Some(ref monitor))) => monitor.ui_screen(),
                 Some(Fullscreen::Borderless(None)) | None => {
                     monitor::main_uiscreen().ui_screen() as id
                 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -41,7 +41,7 @@ use crate::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::MonitorHandle as RootMonitorHandle,
     window::{CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
 };
 
@@ -268,7 +268,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> Box<dyn Iterator<Item = RootVideoMode>> {
+    pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoMode>> {
         x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
     }
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -44,8 +44,8 @@ use crate::{
     window::{CursorGrabMode, CursorIcon, UserAttentionType, WindowAttributes},
 };
 
-pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
+pub(self) use crate::platform_impl::Fullscreen;
 
 #[cfg(feature = "wayland")]
 pub mod wayland;

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -41,7 +41,6 @@ use crate::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
-    monitor::MonitorHandle as RootMonitorHandle,
     window::{CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
 };
 
@@ -298,7 +297,7 @@ impl VideoMode {
     }
 
     #[inline]
-    pub fn monitor(&self) -> RootMonitorHandle {
+    pub fn monitor(&self) -> MonitorHandle {
         x11_or_wayland!(match self; VideoMode(m) => m.monitor())
     }
 }
@@ -531,21 +530,17 @@ impl Window {
     }
 
     #[inline]
-    pub fn current_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
         match self {
             #[cfg(feature = "x11")]
             Window::X(ref window) => {
                 let current_monitor = MonitorHandle::X(window.current_monitor());
-                Some(RootMonitorHandle {
-                    inner: current_monitor,
-                })
+                Some(current_monitor)
             }
             #[cfg(feature = "wayland")]
             Window::Wayland(ref window) => {
                 let current_monitor = MonitorHandle::Wayland(window.current_monitor()?);
-                Some(RootMonitorHandle {
-                    inner: current_monitor,
-                })
+                Some(current_monitor)
             }
         }
     }
@@ -569,14 +564,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         match self {
             #[cfg(feature = "x11")]
             Window::X(ref window) => {
                 let primary_monitor = MonitorHandle::X(window.primary_monitor());
-                Some(RootMonitorHandle {
-                    inner: primary_monitor,
-                })
+                Some(primary_monitor)
             }
             #[cfg(feature = "wayland")]
             Window::Wayland(ref window) => window.primary_monitor(),
@@ -813,16 +806,14 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         match *self {
             #[cfg(feature = "wayland")]
             EventLoopWindowTarget::Wayland(ref evlp) => evlp.primary_monitor(),
             #[cfg(feature = "x11")]
             EventLoopWindowTarget::X(ref evlp) => {
                 let primary_monitor = MonitorHandle::X(evlp.x_connection().primary_monitor());
-                Some(RootMonitorHandle {
-                    inner: primary_monitor,
-                })
+                Some(primary_monitor)
             }
         }
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -41,9 +41,10 @@ use crate::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
-    window::{CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes},
+    window::{CursorGrabMode, CursorIcon, UserAttentionType, WindowAttributes},
 };
 
+pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 
 #[cfg(feature = "wayland")]
@@ -457,12 +458,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn fullscreen(&self) -> Option<Fullscreen> {
+    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         x11_or_wayland!(match self; Window(w) => w.fullscreen())
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
+    pub(crate) fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
         x11_or_wayland!(match self; Window(w) => w.set_fullscreen(monitor))
     }
 

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -8,7 +8,6 @@ use sctk::environment::Environment;
 use sctk::output::OutputStatusListener;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform_impl::platform::{
     MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode,
 };
@@ -224,10 +223,8 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: PlatformMonitorHandle::Wayland(self.monitor.clone()),
-        }
+    pub fn monitor(&self) -> PlatformMonitorHandle {
+        PlatformMonitorHandle::Wayland(self.monitor.clone())
     }
 }
 
@@ -243,7 +240,7 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<PlatformMonitorHandle> {
         // There's no primary monitor on Wayland.
         None
     }

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -8,7 +8,7 @@ use sctk::environment::Environment;
 use sctk::output::OutputStatusListener;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
+use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform_impl::platform::{
     MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode,
 };
@@ -183,19 +183,19 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoMode> {
         let modes = sctk::output::with_output_info(&self.proxy, |info| info.modes.clone())
             .unwrap_or_default();
 
         let monitor = self.clone();
 
-        modes.into_iter().map(move |mode| RootVideoMode {
-            video_mode: PlatformVideoMode::Wayland(VideoMode {
+        modes.into_iter().map(move |mode| {
+            PlatformVideoMode::Wayland(VideoMode {
                 size: (mode.dimensions.0 as u32, mode.dimensions.1 as u32).into(),
                 refresh_rate_millihertz: mode.refresh_rate as u32,
                 bit_depth: 32,
                 monitor: monitor.clone(),
-            }),
+            })
         })
     }
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -467,9 +467,7 @@ impl Window {
     #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         if self.fullscreen.load(Ordering::Relaxed) {
-            let current_monitor = self
-                .current_monitor()
-                .map(|monitor| PlatformMonitorHandle::Wayland(monitor));
+            let current_monitor = self.current_monitor().map(PlatformMonitorHandle::Wayland);
 
             Some(Fullscreen::Borderless(current_monitor))
         } else {

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -218,12 +218,11 @@ impl Window {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor =
-                    monitor.and_then(|RootMonitorHandle { inner: monitor }| match monitor {
-                        PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
-                        #[cfg(feature = "x11")]
-                        PlatformMonitorHandle::X(_) => None,
-                    });
+                let monitor = monitor.and_then(|monitor| match monitor.inner {
+                    PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
+                    #[cfg(feature = "x11")]
+                    PlatformMonitorHandle::X(_) => None,
+                });
 
                 window.set_fullscreen(monitor.as_ref());
             }
@@ -489,12 +488,11 @@ impl Window {
                 return;
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor =
-                    monitor.and_then(|RootMonitorHandle { inner: monitor }| match monitor {
-                        PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
-                        #[cfg(feature = "x11")]
-                        PlatformMonitorHandle::X(_) => None,
-                    });
+                let monitor = monitor.and_then(|monitor| match monitor.inner {
+                    PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
+                    #[cfg(feature = "x11")]
+                    PlatformMonitorHandle::X(_) => None,
+                });
 
                 WindowRequest::Fullscreen(monitor)
             }
@@ -603,7 +601,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<PlatformMonitorHandle> {
         None
     }
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -14,14 +14,11 @@ use sctk::window::Decorations;
 
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
-use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform_impl::{
-    MonitorHandle as PlatformMonitorHandle, OsError,
+    Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError,
     PlatformSpecificWindowBuilderAttributes as PlatformAttributes,
 };
-use crate::window::{
-    CursorGrabMode, CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes,
-};
+use crate::window::{CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes};
 
 use super::env::WindowingFeatures;
 use super::event_loop::WinitState;
@@ -218,7 +215,7 @@ impl Window {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland")
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor = monitor.and_then(|monitor| match monitor.inner {
+                let monitor = monitor.and_then(|monitor| match monitor {
                     PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
                     #[cfg(feature = "x11")]
                     PlatformMonitorHandle::X(_) => None,
@@ -468,11 +465,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn fullscreen(&self) -> Option<Fullscreen> {
+    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         if self.fullscreen.load(Ordering::Relaxed) {
-            let current_monitor = self.current_monitor().map(|monitor| RootMonitorHandle {
-                inner: PlatformMonitorHandle::Wayland(monitor),
-            });
+            let current_monitor = self
+                .current_monitor()
+                .map(|monitor| PlatformMonitorHandle::Wayland(monitor));
 
             Some(Fullscreen::Borderless(current_monitor))
         } else {
@@ -481,14 +478,14 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
+    pub(crate) fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         let fullscreen_request = match fullscreen {
             Some(Fullscreen::Exclusive(_)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland");
                 return;
             }
             Some(Fullscreen::Borderless(monitor)) => {
-                let monitor = monitor.and_then(|monitor| match monitor.inner {
+                let monitor = monitor.and_then(|monitor| match monitor {
                     PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
                     #[cfg(feature = "x11")]
                     PlatformMonitorHandle::X(_) => None,

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::{MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode},
 };
 
@@ -199,13 +199,11 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoMode> {
         let monitor = self.clone();
         self.video_modes.clone().into_iter().map(move |mut x| {
             x.monitor = Some(monitor.clone());
-            RootVideoMode {
-                video_mode: PlatformVideoMode::X(x),
-            }
+            PlatformVideoMode::X(x)
         })
     }
 }

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -13,7 +13,6 @@ use super::{
 };
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::{MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode},
 };
 
@@ -53,10 +52,8 @@ impl VideoMode {
     }
 
     #[inline]
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: PlatformMonitorHandle::X(self.monitor.clone().unwrap()),
-        }
+    pub fn monitor(&self) -> PlatformMonitorHandle {
+        PlatformMonitorHandle::X(self.monitor.clone().unwrap())
     }
 }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -15,13 +15,12 @@ use x11_dl::xlib::TrueColor;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
     platform_impl::{
         x11::{ime::ImeContextCreationError, MonitorHandle as X11MonitorHandle},
-        MonitorHandle as PlatformMonitorHandle, OsError, PlatformSpecificWindowBuilderAttributes,
-        VideoMode as PlatformVideoMode,
+        Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError,
+        PlatformSpecificWindowBuilderAttributes, VideoMode as PlatformVideoMode,
     },
-    window::{CursorGrabMode, CursorIcon, Fullscreen, Icon, UserAttentionType, WindowAttributes},
+    window::{CursorGrabMode, CursorIcon, Icon, UserAttentionType, WindowAttributes},
 };
 
 use super::{
@@ -40,9 +39,9 @@ pub struct SharedState {
     pub is_decorated: bool,
     pub last_monitor: X11MonitorHandle,
     pub dpi_adjusted: Option<(u32, u32)>,
-    pub fullscreen: Option<Fullscreen>,
+    pub(crate) fullscreen: Option<Fullscreen>,
     // Set when application calls `set_fullscreen` when window is not visible
-    pub desired_fullscreen: Option<Option<Fullscreen>>,
+    pub(crate) desired_fullscreen: Option<Option<Fullscreen>>,
     // Used to restore position after exiting fullscreen
     pub restore_position: Option<(i32, i32)>,
     // Used to restore video mode after exiting fullscreen
@@ -638,17 +637,10 @@ impl UnownedWindow {
             // fullscreen, so we can restore it upon exit, as XRandR does not
             // provide a mechanism to set this per app-session or restore this
             // to the desktop video mode as macOS and Windows do
-            (
-                &None,
-                &Some(Fullscreen::Exclusive(RootVideoMode {
-                    video_mode: PlatformVideoMode::X(ref video_mode),
-                })),
-            )
+            (&None, &Some(Fullscreen::Exclusive(PlatformVideoMode::X(ref video_mode))))
             | (
                 &Some(Fullscreen::Borderless(_)),
-                &Some(Fullscreen::Exclusive(RootVideoMode {
-                    video_mode: PlatformVideoMode::X(ref video_mode),
-                })),
+                &Some(Fullscreen::Exclusive(PlatformVideoMode::X(ref video_mode))),
             ) => {
                 let monitor = video_mode.monitor.as_ref().unwrap();
                 shared_state_lock.desktop_video_mode =
@@ -679,12 +671,12 @@ impl UnownedWindow {
             }
             Some(fullscreen) => {
                 let (video_mode, monitor) = match fullscreen {
-                    Fullscreen::Exclusive(RootVideoMode {
-                        video_mode: PlatformVideoMode::X(ref video_mode),
-                    }) => (Some(video_mode), video_mode.monitor.clone().unwrap()),
-                    Fullscreen::Borderless(Some(RootMonitorHandle {
-                        inner: PlatformMonitorHandle::X(monitor),
-                    })) => (None, monitor),
+                    Fullscreen::Exclusive(PlatformVideoMode::X(ref video_mode)) => {
+                        (Some(video_mode), video_mode.monitor.clone().unwrap())
+                    }
+                    Fullscreen::Borderless(Some(PlatformMonitorHandle::X(monitor))) => {
+                        (None, monitor)
+                    }
                     Fullscreen::Borderless(None) => (None, self.current_monitor()),
                     #[cfg(feature = "wayland")]
                     _ => unreachable!(),
@@ -737,7 +729,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn fullscreen(&self) -> Option<Fullscreen> {
+    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         let shared_state = self.shared_state_lock();
 
         shared_state
@@ -747,7 +739,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
+    pub(crate) fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         if let Some(flusher) = self.set_fullscreen_inner(fullscreen) {
             flusher
                 .sync()

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -25,7 +25,6 @@ use super::appkit::{NSApp, NSApplicationActivationPolicy, NSEvent};
 use crate::{
     event::Event,
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootWindowTarget},
-    monitor::MonitorHandle as RootMonitorHandle,
     platform::macos::ActivationPolicy,
     platform_impl::platform::{
         app::WinitApplication,
@@ -83,9 +82,9 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = monitor::primary_monitor();
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 
     #[inline]

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 use objc2::rc::{autoreleasepool, Id, Shared};
 
+pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -33,8 +33,8 @@ use crate::{
 };
 use objc2::rc::{autoreleasepool, Id, Shared};
 
-pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
+pub(self) use crate::platform_impl::Fullscreen;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -10,10 +10,7 @@ use objc2::rc::{Id, Shared};
 
 use super::appkit::NSScreen;
 use super::ffi;
-use crate::{
-    dpi::{PhysicalPosition, PhysicalSize},
-    monitor::MonitorHandle as RootMonitorHandle,
-};
+use crate::dpi::{PhysicalPosition, PhysicalSize};
 
 #[derive(Clone)]
 pub struct VideoMode {
@@ -89,10 +86,8 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: self.monitor.clone(),
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        self.monitor.clone()
     }
 }
 

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -12,7 +12,7 @@ use super::appkit::NSScreen;
 use super::ffi;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::MonitorHandle as RootMonitorHandle,
 };
 
 #[derive(Clone)]
@@ -234,7 +234,7 @@ impl MonitorHandle {
         }
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         let refresh_rate_millihertz = self.refresh_rate_millihertz().unwrap_or(0);
         let monitor = self.clone();
 
@@ -279,7 +279,7 @@ impl MonitorHandle {
                     unimplemented!()
                 };
 
-                let video_mode = VideoMode {
+                VideoMode {
                     size: (
                         ffi::CGDisplayModeGetPixelWidth(mode) as u32,
                         ffi::CGDisplayModeGetPixelHeight(mode) as u32,
@@ -288,9 +288,7 @@ impl MonitorHandle {
                     bit_depth,
                     monitor: monitor.clone(),
                     native_mode: NativeDisplayMode(mode),
-                };
-
-                RootVideoMode { video_mode }
+                }
             })
         }
     }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -12,14 +12,14 @@ use super::appkit::{
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     event::{Event, ModifiersState, WindowEvent},
-    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         app_state::AppState,
         event::{EventProxy, EventWrapper},
         util,
         window::WinitWindow,
+        Fullscreen,
     },
-    window::{Fullscreen, WindowId},
+    window::WindowId,
 };
 
 declare_class!(
@@ -226,9 +226,7 @@ declare_class!(
                 // Otherwise, we must've reached fullscreen by the user clicking
                 // on the green fullscreen button. Update state!
                 None => {
-                    let current_monitor = Some(RootMonitorHandle {
-                        inner: self.window.current_monitor_inner(),
-                    });
+                    let current_monitor = Some(self.window.current_monitor_inner());
                     shared_state.fullscreen = Some(Fullscreen::Borderless(current_monitor))
                 }
             }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -12,6 +12,7 @@ use super::appkit::{
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     event::{Event, ModifiersState, WindowEvent},
+    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         app_state::AppState,
         event::{EventProxy, EventWrapper},
@@ -225,7 +226,9 @@ declare_class!(
                 // Otherwise, we must've reached fullscreen by the user clicking
                 // on the green fullscreen button. Update state!
                 None => {
-                    let current_monitor = Some(self.window.current_monitor_inner());
+                    let current_monitor = Some(RootMonitorHandle {
+                        inner: self.window.current_monitor_inner(),
+                    });
                     shared_state.fullscreen = Some(Fullscreen::Borderless(current_monitor))
                 }
             }

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -1,4 +1,5 @@
-pub use self::platform::*;
+use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
+use crate::window::Fullscreen as RootFullscreen;
 
 #[cfg(target_os = "windows")]
 #[path = "windows/mod.rs"]
@@ -24,6 +25,37 @@ mod platform;
 #[cfg(target_arch = "wasm32")]
 #[path = "web/mod.rs"]
 mod platform;
+
+pub use self::platform::*;
+
+/// Helper for converting between platform-specific and generic VideoMode/MonitorHandle
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum Fullscreen {
+    Exclusive(VideoMode),
+    Borderless(Option<MonitorHandle>),
+}
+
+impl From<RootFullscreen> for Fullscreen {
+    fn from(f: RootFullscreen) -> Self {
+        match f {
+            RootFullscreen::Exclusive(mode) => Self::Exclusive(mode.video_mode),
+            RootFullscreen::Borderless(Some(handle)) => Self::Borderless(Some(handle.inner)),
+            RootFullscreen::Borderless(None) => Self::Borderless(None),
+        }
+    }
+}
+
+impl From<Fullscreen> for RootFullscreen {
+    fn from(f: Fullscreen) -> Self {
+        match f {
+            Fullscreen::Exclusive(video_mode) => Self::Exclusive(RootVideoMode { video_mode }),
+            Fullscreen::Borderless(Some(inner)) => {
+                Self::Borderless(Some(RootMonitorHandle { inner }))
+            }
+            Fullscreen::Borderless(None) => Self::Borderless(None),
+        }
+    }
+}
 
 #[cfg(all(
     not(target_os = "ios"),

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -15,7 +15,6 @@ use crate::event::{
     WindowEvent,
 };
 use crate::event_loop::ControlFlow;
-use crate::monitor::MonitorHandle as RootMH;
 use crate::window::{Theme, WindowId as RootWindowId};
 
 pub struct EventLoopWindowTarget<T: 'static> {
@@ -283,10 +282,8 @@ impl<T> EventLoopWindowTarget<T> {
         VecDeque::new().into_iter()
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMH> {
-        Some(RootMH {
-            inner: MonitorHandle,
-        })
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -34,8 +34,8 @@ pub(crate) use self::event_loop::{
 pub use self::monitor::{MonitorHandle, VideoMode};
 pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId};
 
-pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
+pub(self) use crate::platform_impl::Fullscreen;
 
 #[derive(Clone, Copy)]
 pub(crate) struct ScaleChangeArgs {

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -34,6 +34,7 @@ pub(crate) use self::event_loop::{
 pub use self::monitor::{MonitorHandle, VideoMode};
 pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId};
 
+pub(self) use super::Fullscreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 #[derive(Clone, Copy)]

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -1,5 +1,4 @@
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::MonitorHandle as RootMonitorHandle;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MonitorHandle;
@@ -49,9 +48,7 @@ impl VideoMode {
         32000
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: MonitorHandle,
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        MonitorHandle
     }
 }

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -1,5 +1,5 @@
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
+use crate::monitor::MonitorHandle as RootMonitorHandle;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct MonitorHandle;
@@ -28,7 +28,7 @@ impl MonitorHandle {
         }
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         std::iter::empty()
     }
 }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -2,7 +2,7 @@ use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
 use crate::event;
 use crate::icon::Icon;
-use crate::monitor::MonitorHandle as RootMH;
+use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::window::{
     CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWI,
 };
@@ -283,7 +283,9 @@ impl Window {
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.borrow().is_fullscreen() {
-            Some(Fullscreen::Borderless(Some(self.current_monitor_inner())))
+            Some(Fullscreen::Borderless(Some(RootMonitorHandle {
+                inner: self.current_monitor_inner(),
+            })))
         } else {
             None
         }
@@ -339,14 +341,12 @@ impl Window {
 
     #[inline]
     // Allow directly accessing the current monitor internally without unwrapping.
-    fn current_monitor_inner(&self) -> RootMH {
-        RootMH {
-            inner: MonitorHandle,
-        }
+    fn current_monitor_inner(&self) -> MonitorHandle {
+        MonitorHandle
     }
 
     #[inline]
-    pub fn current_monitor(&self) -> Option<RootMH> {
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
         Some(self.current_monitor_inner())
     }
 
@@ -356,10 +356,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<RootMH> {
-        Some(RootMH {
-            inner: MonitorHandle,
-        })
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        Some(MonitorHandle)
     }
 
     #[inline]

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -2,14 +2,13 @@ use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
 use crate::event;
 use crate::icon::Icon;
-use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::window::{
-    CursorGrabMode, CursorIcon, Fullscreen, UserAttentionType, WindowAttributes, WindowId as RootWI,
+    CursorGrabMode, CursorIcon, UserAttentionType, WindowAttributes, WindowId as RootWI,
 };
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
 
-use super::{backend, monitor::MonitorHandle, EventLoopWindowTarget};
+use super::{backend, monitor::MonitorHandle, EventLoopWindowTarget, Fullscreen};
 
 use std::cell::{Ref, RefCell};
 use std::collections::vec_deque::IntoIter as VecDequeIter;
@@ -281,19 +280,17 @@ impl Window {
     }
 
     #[inline]
-    pub fn fullscreen(&self) -> Option<Fullscreen> {
+    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.borrow().is_fullscreen() {
-            Some(Fullscreen::Borderless(Some(RootMonitorHandle {
-                inner: self.current_monitor_inner(),
-            })))
+            Some(Fullscreen::Borderless(Some(self.current_monitor_inner())))
         } else {
             None
         }
     }
 
     #[inline]
-    pub fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
-        if monitor.is_some() {
+    pub(crate) fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
+        if fullscreen.is_some() {
             self.canvas.borrow().request_fullscreen();
         } else if self.canvas.borrow().is_fullscreen() {
             backend::exit_fullscreen();

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -89,9 +89,9 @@ use crate::{
         raw_input, util,
         window::InitData,
         window_state::{CursorFlags, ImeState, WindowFlags, WindowState},
-        wrap_device_id, WindowId, DEVICE_ID,
+        wrap_device_id, Fullscreen, WindowId, DEVICE_ID,
     },
-    window::{Fullscreen, WindowId as RootWindowId},
+    window::WindowId as RootWindowId,
 };
 use runner::{EventLoopRunner, EventLoopRunnerShared};
 
@@ -1110,7 +1110,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                             if new_monitor != 0
                                 && fullscreen_monitor
                                     .as_ref()
-                                    .map(|monitor| new_monitor != monitor.inner.hmonitor())
+                                    .map(|monitor| new_monitor != monitor.hmonitor())
                                     .unwrap_or(true)
                             {
                                 if let Ok(new_monitor_info) = monitor::get_monitor_info(new_monitor)
@@ -1121,13 +1121,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                                     window_pos.cx = new_monitor_rect.right - new_monitor_rect.left;
                                     window_pos.cy = new_monitor_rect.bottom - new_monitor_rect.top;
                                 }
-                                *fullscreen_monitor = Some(crate::monitor::MonitorHandle {
-                                    inner: MonitorHandle::new(new_monitor),
-                                });
+                                *fullscreen_monitor = Some(MonitorHandle::new(new_monitor));
                             }
                         }
                         Fullscreen::Exclusive(ref video_mode) => {
-                            let old_monitor = video_mode.video_mode.monitor.hmonitor();
+                            let old_monitor = video_mode.monitor.hmonitor();
                             if let Ok(old_monitor_info) = monitor::get_monitor_info(old_monitor) {
                                 let old_monitor_rect = old_monitor_info.monitorInfo.rcMonitor;
                                 window_pos.x = old_monitor_rect.left;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -79,7 +79,6 @@ use crate::{
     event_loop::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
-    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         dark_mode::try_theme,
         dpi::{become_dpi_aware, dpi_to_scale_factor},
@@ -322,9 +321,9 @@ impl<T> EventLoopWindowTarget<T> {
         monitor::available_monitors()
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = monitor::primary_monitor();
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use self::{
 };
 
 pub use self::icon::WinIcon as PlatformIcon;
+pub(self) use super::Fullscreen;
 
 use crate::event::DeviceId as RootDeviceId;
 use crate::icon::Icon;

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -15,7 +15,7 @@ pub(crate) use self::{
 };
 
 pub use self::icon::WinIcon as PlatformIcon;
-pub(self) use super::Fullscreen;
+pub(self) use crate::platform_impl::Fullscreen;
 
 use crate::event::DeviceId as RootDeviceId;
 use crate::icon::Icon;

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -224,7 +224,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = RootVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         // EnumDisplaySettingsExW can return duplicate values (or some of the
         // fields are probably changing, but we aren't looking at those fields
         // anyway), so we're using a BTreeSet deduplicate
@@ -246,6 +246,7 @@ impl MonitorHandle {
                     (DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY) as u32;
                 assert!(has_flag(mode.dmFields, REQUIRED_FIELDS));
 
+                // Use Ord impl of RootVideoMode
                 modes.insert(RootVideoMode {
                     video_mode: VideoMode {
                         size: (mode.dmPelsWidth, mode.dmPelsHeight),
@@ -258,6 +259,6 @@ impl MonitorHandle {
             }
         }
 
-        modes.into_iter()
+        modes.into_iter().map(|mode| mode.video_mode)
     }
 }

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -17,7 +17,7 @@ use windows_sys::Win32::{
 use super::util::decode_wide;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode},
+    monitor::VideoMode as RootVideoMode,
     platform_impl::platform::{
         dpi::{dpi_to_scale_factor, get_monitor_dpi},
         util::has_flag,
@@ -79,10 +79,8 @@ impl VideoMode {
         self.refresh_rate_millihertz
     }
 
-    pub fn monitor(&self) -> RootMonitorHandle {
-        RootMonitorHandle {
-            inner: self.monitor.clone(),
-        }
+    pub fn monitor(&self) -> MonitorHandle {
+        self.monitor.clone()
     }
 }
 
@@ -136,9 +134,9 @@ impl Window {
         available_monitors()
     }
 
-    pub fn primary_monitor(&self) -> Option<RootMonitorHandle> {
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = primary_monitor();
-        Some(RootMonitorHandle { inner: monitor })
+        Some(monitor)
     }
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -68,13 +68,13 @@ use crate::{
         monitor::{self, MonitorHandle},
         util,
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
-        Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
+        Fullscreen, Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
-    window::{CursorGrabMode, CursorIcon, Fullscreen, Theme, UserAttentionType, WindowAttributes},
+    window::{CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes},
 };
 
 /// The Win32 implementation of the main `Window` object.
-pub struct Window {
+pub(crate) struct Window {
     /// Main handle for the window.
     window: WindowWrapper,
 
@@ -463,12 +463,12 @@ impl Window {
             match (&old_fullscreen, &fullscreen) {
                 (_, Some(Fullscreen::Exclusive(video_mode))) => {
                     let monitor = video_mode.monitor();
-                    let monitor_info = monitor::get_monitor_info(monitor.inner.hmonitor()).unwrap();
+                    let monitor_info = monitor::get_monitor_info(monitor.hmonitor()).unwrap();
 
                     let res = unsafe {
                         ChangeDisplaySettingsExW(
                             monitor_info.szDevice.as_ptr(),
-                            &*video_mode.video_mode.native_video_mode,
+                            &*video_mode.native_video_mode,
                             0,
                             CDS_FULLSCREEN,
                             ptr::null(),
@@ -547,8 +547,8 @@ impl Window {
                     window_state.lock().unwrap().saved_window = Some(SavedWindow { placement });
 
                     let monitor = match &fullscreen {
-                        Fullscreen::Exclusive(video_mode) => video_mode.monitor().inner,
-                        Fullscreen::Borderless(Some(monitor)) => monitor.inner.clone(),
+                        Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
+                        Fullscreen::Borderless(Some(monitor)) => monitor.clone(),
                         Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
                     };
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -55,7 +55,6 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
     icon::Icon,
-    monitor::MonitorHandle as RootMonitorHandle,
     platform_impl::platform::{
         dark_mode::try_theme,
         definitions::{
@@ -66,7 +65,8 @@ use crate::{
         event_loop::{self, EventLoopWindowTarget, DESTROY_MSG_ID},
         icon::{self, IconType},
         ime::ImeContext,
-        monitor, util,
+        monitor::{self, MonitorHandle},
+        util,
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
         Parent, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
@@ -547,11 +547,9 @@ impl Window {
                     window_state.lock().unwrap().saved_window = Some(SavedWindow { placement });
 
                     let monitor = match &fullscreen {
-                        Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
-                        Fullscreen::Borderless(Some(monitor)) => monitor.clone(),
-                        Fullscreen::Borderless(None) => RootMonitorHandle {
-                            inner: monitor::current_monitor(window.0),
-                        },
+                        Fullscreen::Exclusive(video_mode) => video_mode.monitor().inner,
+                        Fullscreen::Borderless(Some(monitor)) => monitor.inner.clone(),
+                        Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
                     };
 
                     let position: (i32, i32) = monitor.position().into();
@@ -619,10 +617,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn current_monitor(&self) -> Option<RootMonitorHandle> {
-        Some(RootMonitorHandle {
-            inner: monitor::current_monitor(self.hwnd()),
-        })
+    pub fn current_monitor(&self) -> Option<MonitorHandle> {
+        Some(monitor::current_monitor(self.hwnd()))
     }
 
     #[inline]

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -2,8 +2,8 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Size},
     event::ModifiersState,
     icon::Icon,
-    platform_impl::platform::{event_loop, util},
-    window::{CursorIcon, Fullscreen, Theme, WindowAttributes},
+    platform_impl::platform::{event_loop, util, Fullscreen},
+    window::{CursorIcon, Theme, WindowAttributes},
 };
 use std::io;
 use std::sync::MutexGuard;
@@ -24,7 +24,7 @@ use windows_sys::Win32::{
 };
 
 /// Contains information about states and the window that the callback is going to use.
-pub struct WindowState {
+pub(crate) struct WindowState {
     pub mouse: MouseProperties,
 
     /// Used by `WM_GETMINMAXINFO`.

--- a/src/window.rs
+++ b/src/window.rs
@@ -1038,7 +1038,9 @@ impl Window {
     /// **iOS:** Can only be called on the main thread.
     #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
-        self.window.current_monitor()
+        self.window
+            .current_monitor()
+            .map(|inner| MonitorHandle { inner })
     }
 
     /// Returns the list of all the monitors available on the system.
@@ -1072,7 +1074,9 @@ impl Window {
     /// [`EventLoopWindowTarget::primary_monitor`]: crate::event_loop::EventLoopWindowTarget::primary_monitor
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        self.window.primary_monitor()
+        self.window
+            .primary_monitor()
+            .map(|inner| MonitorHandle { inner })
     }
 }
 unsafe impl HasRawWindowHandle for Window {

--- a/src/window.rs
+++ b/src/window.rs
@@ -127,7 +127,7 @@ pub(crate) struct WindowAttributes {
     pub position: Option<Position>,
     pub resizable: bool,
     pub title: String,
-    pub fullscreen: Option<Fullscreen>,
+    pub fullscreen: Option<platform_impl::Fullscreen>,
     pub maximized: bool,
     pub visible: bool,
     pub transparent: bool,
@@ -258,7 +258,7 @@ impl WindowBuilder {
     /// See [`Window::set_fullscreen`] for details.
     #[inline]
     pub fn with_fullscreen(mut self, fullscreen: Option<Fullscreen>) -> Self {
-        self.window.fullscreen = fullscreen;
+        self.window.fullscreen = fullscreen.map(|f| f.into());
         self
     }
 
@@ -766,7 +766,7 @@ impl Window {
     /// - **Android:** Unsupported.
     #[inline]
     pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
-        self.window.set_fullscreen(fullscreen)
+        self.window.set_fullscreen(fullscreen.map(|f| f.into()))
     }
 
     /// Gets the window's current fullscreen state.
@@ -778,7 +778,7 @@ impl Window {
     /// - **Wayland:** Can return `Borderless(None)` when there are no monitors.
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
-        self.window.fullscreen()
+        self.window.fullscreen().map(|f| f.into())
     }
 
     /// Turn window decorations on or off.


### PR DESCRIPTION
Change things internally such that platform implementations don't have to import `Fullscreen`, `MonitorHandle` and `VideoMode` from the top-level crate.

- [ ] Tested on all platforms changed
  - This is really a "it compiles, it works" change, but have tested on macOS and iOS