### PR TITLE
Specify minimum supported version for RWH 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, if not otherwise specified use upstream automatic CSD theme selection.
 - On Windows, fixed ALT+Space shortcut to open window menu.
 - On Wayland, fixed `Ime::Preedit` not being sent on IME reset.
+- Fixed unbound version specified for `raw-window-handle` leading to compilation failures.
 
 # 0.27.2 (2022-8-12)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ once_cell = "1.12"
 log = "0.4"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 raw_window_handle = { package = "raw-window-handle", version = "0.5" }
-raw_window_handle_04 = { package = "raw-window-handle", version = "0.4" }
+raw_window_handle_04 = { package = "raw-window-handle", version = "0.4.3" }
 bitflags = "1"
 mint = { version = "0.5.6", optional = true }
 


### PR DESCRIPTION
Winit uses raw-window-handle of version 0.4.3,
but only 0.4.0 was specified.
