### PR TITLE
Add touchpad magnify gesture support for Windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** On Windows, add support for two-finger touchpad magnification gesture with new event `WindowEvent::TouchpadMagnify`.
 - On Windows, fixed focus event emission on minimize.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
-- **Breaking:** On Windows, add support for two-finger touchpad magnification gesture with new event `WindowEvent::TouchpadMagnify`.
+- On Windows, added support for touchpad magnification gesture with `WindowEvent::TouchpadMagnify` event.
+- **Breaking:** On Windows the `WindowEvent::MouseWheel` event is no longer emitted during magnification gesture.
 - On Windows, fixed focus event emission on minimize.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -18,7 +18,7 @@ fn main() {
         r"
         Zoom is supported on both Windows and macOS,
         while rotation is only supported on Macos for now."
-        );
+    );
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -14,7 +14,11 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
-    println!("Only supported on macOS at the moment.");
+    println!(
+        r"
+        Zoom is supported on both Windows and macOS,
+        while rotation is only supported on Macos for now."
+        );
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;

--- a/src/event.rs
+++ b/src/event.rs
@@ -437,7 +437,7 @@ pub enum WindowEvent<'a> {
     ///
     /// ## Platform-specific
     ///
-    /// - Only available on **macOS**.
+    /// - Only available on **macOS** and **Windows**.
     TouchpadMagnify {
         device_id: DeviceId,
         delta: f64,


### PR DESCRIPTION
After seeing touchpad gestures implemented on macOS ( #2157 ), I looked for an implementation for Windows.

According to the microsfot documentation, there is a WM_GESTURE message that can be processed to support touchpad gestures. But at first I couldn't get one of these messages, then after searching, it seems that no one has implemented this message yet.

Then, in the microsoft doc, I saw this table https://bit.ly/3LDVdRd which describes how the gestures correspond to the existing messages, so based on that and on #2157, I implemented the zoom gesture.

What do you think about it ?
Thanks in advance.