### PR TITLE
Windows, emit `ReceivedCharacter` on system keybinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows, emit `ReceivedCharacter` events on system keybindings.
 - On Windows, fixed focus event emission on minimize.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -65,7 +65,7 @@ use windows_sys::Win32::{
             WM_MOUSEWHEEL, WM_NCACTIVATE, WM_NCCALCSIZE, WM_NCCREATE, WM_NCDESTROY,
             WM_NCLBUTTONDOWN, WM_PAINT, WM_POINTERDOWN, WM_POINTERUP, WM_POINTERUPDATE,
             WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE,
-            WM_SYSCOMMAND, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_TOUCH, WM_WINDOWPOSCHANGED,
+            WM_SYSCHAR, WM_SYSCOMMAND, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_TOUCH, WM_WINDOWPOSCHANGED,
             WM_WINDOWPOSCHANGING, WM_XBUTTONDOWN, WM_XBUTTONUP, WNDCLASSEXW, WS_EX_LAYERED,
             WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TRANSPARENT, WS_OVERLAPPED, WS_POPUP,
             WS_VISIBLE,
@@ -1186,7 +1186,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             0
         }
 
-        WM_CHAR => {
+        WM_CHAR | WM_SYSCHAR => {
             use crate::event::WindowEvent::ReceivedCharacter;
             use std::char;
             let is_high_surrogate = (0xD800..=0xDBFF).contains(&wparam);
@@ -1217,7 +1217,18 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 }
             }
 
-            0
+            // todo(msiglreith):
+            //   Ideally, `WM_SYSCHAR` shouldn't emit a `ReceivedChar` event
+            //   indicating user text input. As we lack dedicated support
+            //   accelerators/keybindings these events will be additionally
+            //   emitted for downstream users.
+            //   This means certain key combinations (ie Alt + Space) will
+            //   trigger the default system behavior **and** emit a char event.
+            if msg == WM_SYSCHAR {
+                DefWindowProcW(window, msg, wparam, lparam)
+            } else {
+                0
+            }
         }
 
         WM_MENUCHAR => (MNC_CLOSE << 16) as isize,


### PR DESCRIPTION
Workaround for https://github.com/rust-windowing/winit/issues/2504 to support keybinding based on `ReceivedCharacter`. I currently don't see a possibility for a clean solution in the short run without API changes (extra fields or keybinding api)

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
