### PR TITLE
Make raw-window-handle 0.4 optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, `wayland-csd-adwaita` now uses `ab_glyph` instead of `crossfont` to render the title for decorations.
 - On Wayland, a new `wayland-csd-adwaita-crossfont` feature was added to use `crossfont` instead of `ab_glyph` for decorations.
 - On Wayland, if not otherwise specified use upstream automatic CSD theme selection.
+- `raw-window-handle` 0.4 support was made optional behind the `raw_window_handle_04` feature.
 
 # 0.27.3
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ targets = [
 ]
 
 [features]
-default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
+default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita", "raw_window_handle_04"]
 x11 = ["x11-dl", "mio", "percent-encoding"]
 wayland = ["wayland-client", "wayland-protocols", "sctk"]
 wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
@@ -48,7 +48,7 @@ once_cell = "1.12"
 log = "0.4"
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 raw_window_handle = { package = "raw-window-handle", version = "0.5" }
-raw_window_handle_04 = { package = "raw-window-handle", version = "0.4.3" }
+raw_window_handle_04 = { package = "raw-window-handle", version = "0.4.3", optional = true }
 bitflags = "1"
 mint = { version = "0.5.6", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 * `x11` (enabled by default): On Unix platform, compiles with the X11 backend
 * `wayland` (enabled by default): On Unix platform, compiles with the Wayland backend
 * `mint`: Enables mint (math interoperability standard types) conversions.
+* `raw_window_handle_04` (enabled by default): Enables support for `raw-window-handle` 0.4
 
 ### Platform-specific usage
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1109,6 +1109,8 @@ unsafe impl HasRawDisplayHandle for Window {
         self.window.raw_display_handle()
     }
 }
+
+#[cfg(feature = "raw_window_handle_04")]
 unsafe impl raw_window_handle_04::HasRawWindowHandle for Window {
     /// Returns a [`raw_window_handle_04::RawWindowHandle`] for the Window
     ///


### PR DESCRIPTION
The motivation for this PR is to remove multiple crate versions from the dependency graph for the [`clippy::multiple_crate_versions`](https://rust-lang.github.io/rust-clippy/master/#multiple_crate_versions) lint. I saw that raw-window-handle 0.4 support is slated for removal in 0.28, so it's fine if you'd rather wait until then.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented