### PR TITLE
Update cargo-run-wasm

### DIFF
--- a/run-wasm/Cargo.toml
+++ b/run-wasm/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cargo-run-wasm = "0.1.0"
+cargo-run-wasm = "0.2.0"

--- a/run-wasm/src/main.rs
+++ b/run-wasm/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    cargo_run_wasm::run_wasm();
+    cargo_run_wasm::run_wasm_with_css("body { margin: 0px; }");
 }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR updates cargo-run-wasm to the latest release.

A common request I have received is to remove the `<h1></h1>` from the page and give easy access to custom css.
To accommodate that I have reworked the API a little and changed the format of the page.
I have used the `body { margin: 0px; }` css which is the recommended default css to use as with `cargo run-wasm` as it gives the wasm app more space to work with by removing the pointless margin.