### PR TITLE
feat(x11): Add Window::drag_resize_window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, `RedrawRequested` not emitted during resize.
 - **Breaking:** Remove the unstable `xlib_xconnection()` function from the private interface.
 - Added Orbital support for Redox OS
+- On X11, added `drag_resize_window` method.
 
 # 0.27.5
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -215,6 +215,7 @@ Legend:
 |Gamepad/Joystick events |❌[#804] |❌      |❌       |❌          |❌    |❌     |❓        |**N/A** |
 |Device movement events  |❓        |❓       |❓       |❓           |❌    |❌     |❓        |**N/A** |
 |Drag window with cursor |✔️       |✔️      |✔️       |✔️          |**N/A**|**N/A**|**N/A**   |**N/A** |
+|Resize with cursor      |❌         |❌       |✔️       |❌       |**N/A**|**N/A**|**N/A**   |**N/A** |
 
 ### Pending API Reworks
 Changes in the API that have been agreed upon but aren't implemented across all platforms.

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -1,0 +1,141 @@
+//! Demonstrates capability to create in-app draggable regions for client-side decoration support.
+
+use simple_logger::SimpleLogger;
+use winit::{
+    event::{
+        ElementState, Event, KeyboardInput, MouseButton, StartCause, VirtualKeyCode, WindowEvent,
+    },
+    event_loop::{ControlFlow, EventLoop},
+    window::{CursorIcon, ResizeDirection, WindowBuilder},
+};
+
+const BORDER: f64 = 8.0;
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_inner_size(winit::dpi::LogicalSize::new(600.0, 400.0))
+        .with_min_inner_size(winit::dpi::LogicalSize::new(400.0, 200.0))
+        .with_decorations(false)
+        .build(&event_loop)
+        .unwrap();
+
+    let mut border = false;
+    let mut cursor_location = None;
+
+    event_loop.run(move |event, _, control_flow| match event {
+        Event::NewEvents(StartCause::Init) => {
+            eprintln!("Press 'B' to toggle borderless")
+        }
+        Event::WindowEvent { event, .. } => match event {
+            WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+            WindowEvent::CursorMoved { position, .. } => {
+                if !window.is_decorated() {
+                    let new_location =
+                        cursor_resize_direction(window.inner_size(), position, BORDER);
+
+                    if new_location != cursor_location {
+                        cursor_location = new_location;
+                        window.set_cursor_icon(cursor_direction_icon(cursor_location))
+                    }
+                }
+            }
+
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Left,
+                ..
+            } => {
+                if let Some(dir) = cursor_location {
+                    let _res = window.drag_resize_window(dir);
+                }
+            }
+            WindowEvent::KeyboardInput {
+                input:
+                    KeyboardInput {
+                        state: ElementState::Released,
+                        virtual_keycode: Some(VirtualKeyCode::B),
+                        ..
+                    },
+                ..
+            } => {
+                border = !border;
+                window.set_decorations(border);
+            }
+            _ => (),
+        },
+        _ => (),
+    });
+}
+
+fn cursor_direction_icon(resize_direction: Option<ResizeDirection>) -> CursorIcon {
+    match resize_direction {
+        Some(resize_direction) => match resize_direction {
+            ResizeDirection::East => CursorIcon::EResize,
+            ResizeDirection::North => CursorIcon::NResize,
+            ResizeDirection::NorthEast => CursorIcon::NeResize,
+            ResizeDirection::NorthWest => CursorIcon::NwResize,
+            ResizeDirection::South => CursorIcon::SResize,
+            ResizeDirection::SouthEast => CursorIcon::SeResize,
+            ResizeDirection::SouthWest => CursorIcon::SwResize,
+            ResizeDirection::West => CursorIcon::WResize,
+        },
+        None => CursorIcon::Default,
+    }
+}
+
+fn cursor_resize_direction(
+    win_size: winit::dpi::PhysicalSize<u32>,
+    position: winit::dpi::PhysicalPosition<f64>,
+    border_size: f64,
+) -> Option<ResizeDirection> {
+    enum XDirection {
+        West,
+        East,
+        Default,
+    }
+
+    enum YDirection {
+        North,
+        South,
+        Default,
+    }
+
+    let xdir = if position.x < border_size {
+        XDirection::West
+    } else if position.x > (win_size.width as f64 - border_size) {
+        XDirection::East
+    } else {
+        XDirection::Default
+    };
+
+    let ydir = if position.y < border_size {
+        YDirection::North
+    } else if position.y > (win_size.height as f64 - border_size) {
+        YDirection::South
+    } else {
+        YDirection::Default
+    };
+
+    Some(match xdir {
+        XDirection::West => match ydir {
+            YDirection::North => ResizeDirection::NorthWest,
+            YDirection::South => ResizeDirection::SouthWest,
+            YDirection::Default => ResizeDirection::West,
+        },
+
+        XDirection::East => match ydir {
+            YDirection::North => ResizeDirection::NorthEast,
+            YDirection::South => ResizeDirection::SouthEast,
+            YDirection::Default => ResizeDirection::East,
+        },
+
+        XDirection::Default => match ydir {
+            YDirection::North => ResizeDirection::North,
+            YDirection::South => ResizeDirection::South,
+            YDirection::Default => return None,
+        },
+    })
+}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     error,
     event::{self, StartCause, VirtualKeyCode},
     event_loop::{self, ControlFlow, EventLoopWindowTarget as RootELW},
-    window::{self, CursorGrabMode, Theme, WindowButtons, WindowLevel},
+    window::{self, CursorGrabMode, ResizeDirection, Theme, WindowButtons, WindowLevel},
 };
 
 fn ndk_keycode_to_virtualkeycode(keycode: Keycode) -> Option<event::VirtualKeyCode> {
@@ -1016,6 +1016,15 @@ impl Window {
     pub fn set_cursor_visible(&self, _: bool) {}
 
     pub fn drag_window(&self) -> Result<(), error::ExternalError> {
+        Err(error::ExternalError::NotSupported(
+            error::NotSupportedError::new(),
+        ))
+    }
+
+    pub fn drag_resize_window(
+        &self,
+        _direction: ResizeDirection,
+    ) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(
             error::NotSupportedError::new(),
         ))

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -26,8 +26,8 @@ use crate::{
         monitor, EventLoopWindowTarget, Fullscreen, MonitorHandle,
     },
     window::{
-        CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
-        WindowId as RootWindowId, WindowLevel,
+        CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
+        WindowButtons, WindowId as RootWindowId, WindowLevel,
     },
 };
 
@@ -197,6 +197,10 @@ impl Inner {
     }
 
     pub fn drag_window(&self) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -34,8 +34,8 @@ use crate::{
     },
     icon::Icon,
     window::{
-        CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
-        WindowLevel,
+        CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
+        WindowButtons, WindowLevel,
     },
 };
 
@@ -422,6 +422,11 @@ impl Window {
     #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         x11_or_wayland!(match self; Window(window) => window.drag_window())
+    }
+
+    #[inline]
+    pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+        x11_or_wayland!(match self; Window(window) => window.drag_resize_window(direction))
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -19,7 +19,8 @@ use crate::platform_impl::{
     PlatformSpecificWindowBuilderAttributes as PlatformAttributes,
 };
 use crate::window::{
-    CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
+    CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
+    WindowButtons,
 };
 
 use super::env::WindowingFeatures;
@@ -558,6 +559,11 @@ impl Window {
         self.send_request(WindowRequest::DragWindow);
 
         Ok(())
+    }
+
+    #[inline]
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/util/wm.rs
+++ b/src/platform_impl/linux/x11/util/wm.rs
@@ -4,6 +4,17 @@ use once_cell::sync::Lazy;
 
 use super::*;
 
+// https://specifications.freedesktop.org/wm-spec/latest/ar01s04.html#idm46075117309248
+pub const MOVERESIZE_TOPLEFT: isize = 0;
+pub const MOVERESIZE_TOP: isize = 1;
+pub const MOVERESIZE_TOPRIGHT: isize = 2;
+pub const MOVERESIZE_RIGHT: isize = 3;
+pub const MOVERESIZE_BOTTOMRIGHT: isize = 4;
+pub const MOVERESIZE_BOTTOM: isize = 5;
+pub const MOVERESIZE_BOTTOMLEFT: isize = 6;
+pub const MOVERESIZE_LEFT: isize = 7;
+pub const MOVERESIZE_MOVE: isize = 8;
+
 // This info is global to the window manager.
 static SUPPORTED_HINTS: Lazy<Mutex<Vec<ffi::Atom>>> =
     Lazy::new(|| Mutex::new(Vec::with_capacity(0)));

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -32,8 +32,8 @@ use crate::{
         Fullscreen, OsError,
     },
     window::{
-        CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
-        WindowId as RootWindowId, WindowLevel,
+        CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
+        WindowButtons, WindowId as RootWindowId, WindowLevel,
     },
 };
 use core_graphics::display::{CGDisplay, CGPoint};
@@ -782,6 +782,11 @@ impl WinitWindow {
         let event = NSApp().currentEvent();
         self.performWindowDragWithEvent(event.as_deref());
         Ok(())
+    }
+
+    #[inline]
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -349,6 +349,16 @@ impl Window {
     }
 
     #[inline]
+    pub fn drag_resize_window(
+        &self,
+        _direction: window::ResizeDirection,
+    ) -> Result<(), error::ExternalError> {
+        Err(error::ExternalError::NotSupported(
+            error::NotSupportedError::new(),
+        ))
+    }
+
+    #[inline]
     pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(
             error::NotSupportedError::new(),

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -3,8 +3,8 @@ use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
 use crate::event;
 use crate::icon::Icon;
 use crate::window::{
-    CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
-    WindowId as RootWI, WindowLevel,
+    CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
+    WindowButtons, WindowId as RootWI, WindowLevel,
 };
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
@@ -264,6 +264,11 @@ impl Window {
 
     #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    }
+
+    #[inline]
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -72,8 +72,8 @@ use crate::{
         Fullscreen, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
     window::{
-        CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
-        WindowLevel,
+        CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
+        WindowButtons, WindowLevel,
     },
 };
 
@@ -430,6 +430,11 @@ impl Window {
         }
 
         Ok(())
+    }
+
+    #[inline]
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
+        Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1159,6 +1159,19 @@ impl Window {
         self.window.drag_window()
     }
 
+    /// Resizes the window with the left mouse button until the button is released.
+    ///
+    /// There's no guarantee that this will work unless the left mouse button was pressed
+    /// immediately before this function is called.
+    ///
+    /// ## Platform-specific
+    ///
+    /// Only X11 is supported at this time.
+    #[inline]
+    pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+        self.window.drag_resize_window(direction)
+    }
+
     /// Modifies whether the window catches cursor events.
     ///
     /// If `true`, the window will catch the cursor events. If `false`, events are passed through
@@ -1350,6 +1363,35 @@ pub enum CursorIcon {
 impl Default for CursorIcon {
     fn default() -> Self {
         CursorIcon::Default
+    }
+}
+
+/// Defines the orientation that a window resize will be performed.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ResizeDirection {
+    East,
+    North,
+    NorthEast,
+    NorthWest,
+    South,
+    SouthEast,
+    SouthWest,
+    West,
+}
+
+impl From<ResizeDirection> for CursorIcon {
+    fn from(direction: ResizeDirection) -> Self {
+        use ResizeDirection::*;
+        match direction {
+            East => CursorIcon::EResize,
+            North => CursorIcon::NResize,
+            NorthEast => CursorIcon::NeResize,
+            NorthWest => CursorIcon::NwResize,
+            South => CursorIcon::SResize,
+            SouthEast => CursorIcon::SeResize,
+            SouthWest => CursorIcon::SwResize,
+            West => CursorIcon::WResize,
+        }
     }
 }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Implements functionality required to resolve #725 for X11. Uses the example from #2003. Only supports X11 on Linux for now. Wayland support will require a future release of sctk with the additional protocol added to the API. And there's some substantial changes in sctk at the moment so upgrading this library will be a bit of a chore. Code from #2003 for Windows support could be added on top of this.