### PR TITLE
On Wayland, fix invalid offsets being sent in Preedit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, if not otherwise specified use upstream automatic CSD theme selection.
 - On X11, added `WindowExtX11::with_parent` to create child windows.
 - On X11, fixed IME crashing during reload.
+- On Wayland, fix byte offset in `Ime::Preedit` pointing to invalid bytes.
 
 # 0.27.3
 

--- a/src/platform_impl/linux/wayland/seat/text_input/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/text_input/handlers.rs
@@ -68,9 +68,14 @@ pub(super) fn handle_text_input(
             cursor_begin,
             cursor_end,
         } => {
-            let cursor_begin = usize::try_from(cursor_begin).ok();
-            let cursor_end = usize::try_from(cursor_end).ok();
             let text = text.unwrap_or_default();
+            let cursor_begin = usize::try_from(cursor_begin)
+                .ok()
+                .and_then(|idx| text.is_char_boundary(idx).then(|| idx));
+            let cursor_end = usize::try_from(cursor_end)
+                .ok()
+                .and_then(|idx| text.is_char_boundary(idx).then(|| idx));
+
             inner.pending_preedit = Some(Preedit {
                 text,
                 cursor_begin,


### PR DESCRIPTION
Even when the protocol explicitly tells to send proper UTF-8 boundaries for cursor, some IMEs don't do that, so sanity check them before sending downstream.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
