### PR TITLE
macos: Send CapsLock keyboard events

### DIFF
--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -222,6 +222,7 @@ pub fn code_to_key(code: KeyCode, scancode: u16) -> Key {
         KeyCode::ShiftRight => Key::Shift,
         KeyCode::AltRight => Key::Alt,
         KeyCode::ControlRight => Key::Control,
+        KeyCode::CapsLock => Key::CapsLock,
 
         KeyCode::NumLock => Key::NumLock,
         KeyCode::AudioVolumeUp => Key::AudioVolumeUp,
@@ -417,6 +418,7 @@ impl KeyCodeExtScancode for KeyCode {
             KeyCode::SuperRight => Some(0x36),
             KeyCode::SuperLeft => Some(0x37),
             KeyCode::ShiftLeft => Some(0x38),
+            KeyCode::CapsLock => Some(0x39),
             KeyCode::AltLeft => Some(0x3a),
             KeyCode::ControlLeft => Some(0x3b),
             KeyCode::ShiftRight => Some(0x3c),


### PR DESCRIPTION
On macOS, no `WindowEvent` is sent when CapsLock is pressed.

Actually there is a trick: only the CapsLock state change is sent by macOS, not the state of the keyboard key. The press/release cycle is simulated to fake the presses.

Checklist

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
