### PR TITLE
Fix menubar focus using `Alt` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows, fix focusing menubar when pressing `Alt`.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.
 - Added `Window::resize_increments`/`Window::set_resize_increments` to update resize increments at runtime for X11/macOS.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1537,7 +1537,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     },
                 });
             }
-            0
+            if msg == WM_SYSKEYUP {
+                DefWindowProcW(window, msg, wparam, lparam)
+            } else {
+                0
+            }
         }
 
         WM_LBUTTONDOWN => {


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I am not sure if this is the right fix or not because I am not familiar with the keyboard handling in winit and win32 in general and I actually found this fix by trial and error with keyboard related handling branches.

1. winit@[92fdf5ba](https://github.com/rust-windowing/winit/commit/92fdf5ba85f920262a61cee4590f4a11ad5738d1)
	![image](https://user-images.githubusercontent.com/48618675/196778580-85d7bea9-b2ae-4c16-aa59-9506383aadbe.png)

2. PR@[985000e1](https://github.com/rust-windowing/winit/pull/2521/commits/985000e11170cda6a30585142e1688793734c8cd)
	![image](https://user-images.githubusercontent.com/48618675/196784125-3cd734f9-8e4b-4901-beef-e3eb582692c2.png)