### PR TITLE
Add `Window::title` getter on Windows and macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows and macOS, Add `Window::title` getter.
 - On Windows, fix focusing menubar when pressing `Alt`.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
-- On Windows and macOS, Add `Window::title` getter.
+- On Windows and macOS, add `Window::title` to query the current window title.
 - On Windows, fix focusing menubar when pressing `Alt`.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -856,6 +856,10 @@ impl Window {
     pub fn theme(&self) -> Option<Theme> {
         None
     }
+
+    pub fn title(&self) -> String {
+        String::new()
+    }
 }
 
 #[derive(Default, Clone, Debug)]

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -347,6 +347,11 @@ impl Inner {
         warn!("`Window::theme` is ignored on iOS");
         None
     }
+
+    pub fn title(&self) -> String {
+        warn!("`Window::title` is ignored on iOS");
+        String::new()
+    }
 }
 
 pub struct Window {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -589,6 +589,11 @@ impl Window {
     pub fn theme(&self) -> Option<Theme> {
         x11_or_wayland!(match self; Window(window) => window.theme())
     }
+
+    #[inline]
+    pub fn title(&self) -> String {
+        x11_or_wayland!(match self; Window(window) => window.title())
+    }
 }
 
 /// Hooks for X11 errors.

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -624,6 +624,11 @@ impl Window {
     pub fn theme(&self) -> Option<Theme> {
         None
     }
+
+    #[inline]
+    pub fn title(&self) -> String {
+        String::new()
+    }
 }
 
 impl Drop for Window {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1551,4 +1551,9 @@ impl UnownedWindow {
     pub fn theme(&self) -> Option<Theme> {
         None
     }
+
+    #[inline]
+    pub fn title(&self) -> String {
+        String::new()
+    }
 }

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -143,6 +143,10 @@ extern_methods!(
         #[sel(setTitle:)]
         pub fn setTitle(&self, title: &NSString);
 
+        pub fn title_(&self) -> Id<NSString, Shared> {
+            unsafe { msg_send_id![self, title] }
+        }
+
         #[sel(setReleasedWhenClosed:)]
         pub fn setReleasedWhenClosed(&self, val: bool);
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1115,6 +1115,11 @@ impl WinitWindow {
         let state = self.shared_state.lock().unwrap();
         state.current_theme
     }
+
+    #[inline]
+    pub fn title(&self) -> String {
+        self.title_().to_string()
+    }
 }
 
 impl WindowExtMacOS for WinitWindow {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -378,6 +378,11 @@ impl Window {
     pub fn theme(&self) -> Option<Theme> {
         None
     }
+
+    #[inline]
+    pub fn title(&self) -> String {
+        String::new()
+    }
 }
 
 impl Drop for Window {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -701,7 +701,7 @@ impl Window {
     #[inline]
     pub fn title(&self) -> String {
         let len = unsafe { GetWindowTextLengthW(self.window.0) };
-        let mut buf = vec![0; len as usize];
+        let mut buf = vec![0; (len + 1) as usize];
         unsafe { GetWindowTextW(self.window.0, buf.as_mut_ptr(), len) };
         String::from_utf16_lossy(&buf[..(len - 1) as _])
     }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -703,7 +703,7 @@ impl Window {
         let len = unsafe { GetWindowTextLengthW(self.window.0) };
         let mut buf = vec![0; (len + 1) as usize];
         unsafe { GetWindowTextW(self.window.0, buf.as_mut_ptr(), len) };
-        String::from_utf16_lossy(&buf[..(len - 1) as _])
+        String::from_utf16_lossy(&buf[..len as _])
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -40,13 +40,13 @@ use windows_sys::Win32::{
         },
         WindowsAndMessaging::{
             CreateWindowExW, FlashWindowEx, GetClientRect, GetCursorPos, GetForegroundWindow,
-            GetSystemMetrics, GetWindowPlacement, IsWindowVisible, LoadCursorW, PeekMessageW,
-            PostMessageW, RegisterClassExW, SetCursor, SetCursorPos, SetForegroundWindow,
-            SetWindowPlacement, SetWindowPos, SetWindowTextW, CS_HREDRAW, CS_VREDRAW,
-            CW_USEDEFAULT, FLASHWINFO, FLASHW_ALL, FLASHW_STOP, FLASHW_TIMERNOFG, FLASHW_TRAY,
-            GWLP_HINSTANCE, HTCAPTION, MAPVK_VK_TO_VSC, NID_READY, PM_NOREMOVE, SM_DIGITIZER,
-            SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, WM_NCLBUTTONDOWN,
-            WNDCLASSEXW,
+            GetSystemMetrics, GetWindowPlacement, GetWindowTextLengthW, GetWindowTextW,
+            IsWindowVisible, LoadCursorW, PeekMessageW, PostMessageW, RegisterClassExW, SetCursor,
+            SetCursorPos, SetForegroundWindow, SetWindowPlacement, SetWindowPos, SetWindowTextW,
+            CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, FLASHWINFO, FLASHW_ALL, FLASHW_STOP,
+            FLASHW_TIMERNOFG, FLASHW_TRAY, GWLP_HINSTANCE, HTCAPTION, MAPVK_VK_TO_VSC, NID_READY,
+            PM_NOREMOVE, SM_DIGITIZER, SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOSIZE,
+            SWP_NOZORDER, WM_NCLBUTTONDOWN, WNDCLASSEXW,
         },
     },
 };
@@ -696,6 +696,14 @@ impl Window {
     #[inline]
     pub fn theme(&self) -> Option<Theme> {
         Some(self.window_state_lock().current_theme)
+    }
+
+    #[inline]
+    pub fn title(&self) -> String {
+        let len = unsafe { GetWindowTextLengthW(self.window.0) };
+        let mut buf = vec![0; len as usize];
+        unsafe { GetWindowTextW(self.window.0, buf.as_mut_ptr(), len) };
+        String::from_utf16_lossy(&buf[..(len - 1) as _])
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -700,10 +700,10 @@ impl Window {
 
     #[inline]
     pub fn title(&self) -> String {
-        let len = unsafe { GetWindowTextLengthW(self.window.0) };
-        let mut buf = vec![0; (len + 1) as usize];
+        let len = unsafe { GetWindowTextLengthW(self.window.0) } + 1;
+        let mut buf = vec![0; len as usize];
         unsafe { GetWindowTextW(self.window.0, buf.as_mut_ptr(), len) };
-        String::from_utf16_lossy(&buf[..len as _])
+        util::decode_wide(&buf).to_string_lossy().to_string()
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -957,7 +957,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / x11 / Wayland / Web:** Unsupported. Always return an empty string.
+    /// - **iOS / Android / x11 / Wayland / Web:** Unsupported. Always returns an empty string.
     #[inline]
     pub fn title(&self) -> String {
         self.window.title()

--- a/src/window.rs
+++ b/src/window.rs
@@ -952,6 +952,16 @@ impl Window {
     pub fn theme(&self) -> Option<Theme> {
         self.window.theme()
     }
+
+    /// Gets the current title of the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / x11 / Wayland / Web:** Unsupported.
+    #[inline]
+    pub fn title(&self) -> String {
+        self.window.title()
+    }
 }
 
 /// Cursor functions.

--- a/src/window.rs
+++ b/src/window.rs
@@ -957,7 +957,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / x11 / Wayland / Web:** Unsupported.
+    /// - **iOS / Android / x11 / Wayland / Web:** Unsupported. Always return an empty string.
     #[inline]
     pub fn title(&self) -> String {
         self.window.title()


### PR DESCRIPTION
- [x] Tested on all platforms changed
	- [x] macOS 
	- [X] Windows
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Porting https://github.com/tauri-apps/tao/commit/c50529b3ee453c73acf36bd7e1cd7c14669951f3