### PR TITLE
On Windows, fix icons specified on `WindowBuilder` not taking effect for windows created after the first one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows, fix icons specified on `WindowBuilder` not taking effect for windows created after the first one.
 - On Windows, fix focusing menubar when pressing `Alt`.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1036,7 +1036,7 @@ where
 unsafe fn register_window_class<T: 'static>() -> Vec<u16> {
     let class_name = util::encode_wide("Window Class");
 
-    use windows_sys::Win32::UI::WindowsAndMessaging::COLOR_WINDOWFRAME;
+    use windows_sys::Win32::Graphics::Gdi::COLOR_WINDOWFRAME;
     let class = WNDCLASSEXW {
         cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
         style: CS_HREDRAW | CS_VREDRAW,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -794,8 +794,6 @@ impl<'a, T: 'static> InitData<'a, T> {
         let window_state = {
             let window_state = WindowState::new(
                 &self.attributes,
-                // Will be set later in on_create
-                None,
                 scale_factor,
                 current_theme,
                 self.attributes.preferred_theme,

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -123,7 +123,6 @@ pub enum ImeState {
 impl WindowState {
     pub(crate) fn new(
         attributes: &WindowAttributes,
-        taskbar_icon: Option<Icon>,
         scale_factor: f64,
         current_theme: Theme,
         preferred_theme: Option<Theme>,
@@ -140,7 +139,7 @@ impl WindowState {
             max_size: attributes.max_inner_size,
 
             window_icon: attributes.window_icon.clone(),
-            taskbar_icon,
+            taskbar_icon: None,
 
             saved_window: None,
             scale_factor,


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
