### PR TITLE
On Windows and macOS, add API to enable/disable window controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows and MacOS, add API to enable/disable window controls (close, minimize, ...etc).
 - On Windows, fix focusing menubar when pressing `Alt`.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
-- On Windows and MacOS, add API to enable/disable window controls (close, minimize, ...etc).
+- On Windows and MacOS, add API to enable/disable window buttons (close, minimize, ...etc).
 - On Windows, fix focusing menubar when pressing `Alt`.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -1,0 +1,68 @@
+#![allow(clippy::single_match)]
+
+// This example is used by developers to test various window functions.
+
+use simple_logger::SimpleLogger;
+use winit::{
+    dpi::LogicalSize,
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event_loop::{DeviceEventFilter, EventLoop},
+    window::{WindowBuilder, WindowButtons},
+};
+
+fn main() {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_inner_size(LogicalSize::new(300.0, 300.0))
+        .build(&event_loop)
+        .unwrap();
+
+    eprintln!("Window Button keys:");
+    eprintln!("  (F) Toggle close button");
+    eprintln!("  (G) Toggle maximize button");
+    eprintln!("  (H) Toggle minimize button");
+
+    event_loop.set_device_event_filter(DeviceEventFilter::Never);
+
+    event_loop.run(move |event, _, control_flow| {
+        control_flow.set_wait();
+
+        match event {
+            Event::WindowEvent {
+                event:
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                virtual_keycode: Some(key),
+                                state: ElementState::Pressed,
+                                ..
+                            },
+                        ..
+                    },
+                ..
+            } => match key {
+                VirtualKeyCode::F => {
+                    let buttons = window.enabled_buttons();
+                    window.set_enabled_buttons(buttons ^ WindowButtons::CLOSE);
+                }
+                VirtualKeyCode::G => {
+                    let buttons = window.enabled_buttons();
+                    window.set_enabled_buttons(buttons ^ WindowButtons::MAXIMIZE);
+                }
+                VirtualKeyCode::H => {
+                    let buttons = window.enabled_buttons();
+                    window.set_enabled_buttons(buttons ^ WindowButtons::MINIMIZE);
+                }
+                _ => (),
+            },
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => control_flow.set_exit(),
+            _ => (),
+        }
+    });
+}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -771,6 +771,24 @@ impl Window {
         false
     }
 
+    pub fn set_minimizable(&self, _minimizable: bool) {}
+
+    pub fn is_minimizable(&self) -> bool {
+        false
+    }
+
+    pub fn set_maximizable(&self, _maximizable: bool) {}
+
+    pub fn is_maximizable(&self) -> bool {
+        false
+    }
+
+    pub fn set_closable(&self, _closable: bool) {}
+
+    pub fn is_closable(&self) -> bool {
+        false
+    }
+
     pub fn set_minimized(&self, _minimized: bool) {}
 
     pub fn set_maximized(&self, _maximized: bool) {}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -771,9 +771,9 @@ impl Window {
         false
     }
 
-    pub fn set_window_buttons(&self, _buttons: WindowButtons) {}
+    pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {}
 
-    pub fn window_buttons(&self) -> WindowButtons {
+    pub fn enabled_buttons(&self) -> WindowButtons {
         WindowButtons::all()
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -24,7 +24,7 @@ use crate::{
     error,
     event::{self, VirtualKeyCode},
     event_loop::{self, ControlFlow},
-    window::{self, CursorGrabMode, Theme},
+    window::{self, CursorGrabMode, Theme, WindowButtons},
 };
 
 static CONFIG: Lazy<RwLock<Configuration>> = Lazy::new(|| {
@@ -771,22 +771,10 @@ impl Window {
         false
     }
 
-    pub fn set_minimizable(&self, _minimizable: bool) {}
+    pub fn set_window_buttons(&self, _buttons: WindowButtons) {}
 
-    pub fn is_minimizable(&self) -> bool {
-        false
-    }
-
-    pub fn set_maximizable(&self, _maximizable: bool) {}
-
-    pub fn is_maximizable(&self) -> bool {
-        false
-    }
-
-    pub fn set_closable(&self, _closable: bool) {}
-
-    pub fn is_closable(&self) -> bool {
-        false
+    pub fn window_buttons(&self) -> WindowButtons {
+        WindowButtons::all()
     }
 
     pub fn set_minimized(&self, _minimized: bool) {}

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -172,6 +172,33 @@ impl Inner {
         false
     }
 
+    pub fn set_minimizable(&self, _minimizable: bool) {
+        warn!("`Window::set_minimizable` is ignored on iOS")
+    }
+
+    pub fn is_minimizable(&self) -> bool {
+        warn!("`Window::is_minimizable` is ignored on iOS");
+        false
+    }
+
+    pub fn set_maximizable(&self, _maximizable: bool) {
+        warn!("`Window::set_maximizable` is ignored on iOS")
+    }
+
+    pub fn is_maximizable(&self) -> bool {
+        warn!("`Window::is_maximizable` is ignored on iOS");
+        false
+    }
+
+    pub fn set_closable(&self, _closable: bool) {
+        warn!("`Window::set_closable` is ignored on iOS")
+    }
+
+    pub fn is_closable(&self) -> bool {
+        warn!("`Window::is_closable` is ignored on iOS");
+        false
+    }
+
     pub fn scale_factor(&self) -> f64 {
         unsafe {
             let hidpi: CGFloat = msg_send![self.view, contentScaleFactor];

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -23,7 +23,7 @@ use crate::{
         monitor, view, EventLoopWindowTarget, Fullscreen, MonitorHandle,
     },
     window::{
-        CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes,
+        CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
         WindowId as RootWindowId,
     },
 };
@@ -172,31 +172,15 @@ impl Inner {
         false
     }
 
-    pub fn set_minimizable(&self, _minimizable: bool) {
-        warn!("`Window::set_minimizable` is ignored on iOS")
+    #[inline]
+    pub fn set_window_buttons(&self, _buttons: WindowButtons) {
+        warn!("`Window::set_window_buttons` is ignored on iOS");
     }
 
-    pub fn is_minimizable(&self) -> bool {
-        warn!("`Window::is_minimizable` is ignored on iOS");
-        false
-    }
-
-    pub fn set_maximizable(&self, _maximizable: bool) {
-        warn!("`Window::set_maximizable` is ignored on iOS")
-    }
-
-    pub fn is_maximizable(&self) -> bool {
-        warn!("`Window::is_maximizable` is ignored on iOS");
-        false
-    }
-
-    pub fn set_closable(&self, _closable: bool) {
-        warn!("`Window::set_closable` is ignored on iOS")
-    }
-
-    pub fn is_closable(&self) -> bool {
-        warn!("`Window::is_closable` is ignored on iOS");
-        false
+    #[inline]
+    pub fn window_buttons(&self) -> WindowButtons {
+        warn!("`Window::window_buttons` is ignored on iOS");
+        WindowButtons::all()
     }
 
     pub fn scale_factor(&self) -> f64 {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -173,13 +173,13 @@ impl Inner {
     }
 
     #[inline]
-    pub fn set_window_buttons(&self, _buttons: WindowButtons) {
-        warn!("`Window::set_window_buttons` is ignored on iOS");
+    pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {
+        warn!("`Window::set_enabled_buttons` is ignored on iOS");
     }
 
     #[inline]
-    pub fn window_buttons(&self) -> WindowButtons {
-        warn!("`Window::window_buttons` is ignored on iOS");
+    pub fn enabled_buttons(&self) -> WindowButtons {
+        warn!("`Window::enabled_buttons` is ignored on iOS");
         WindowButtons::all()
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -39,7 +39,9 @@ use crate::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
-    window::{CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes},
+    window::{
+        CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
+    },
 };
 
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
@@ -404,32 +406,15 @@ impl Window {
     pub fn is_resizable(&self) -> bool {
         x11_or_wayland!(match self; Window(w) => w.is_resizable())
     }
+
     #[inline]
-    pub fn set_minimizable(&self, minimizable: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_minimizable(minimizable))
+    pub fn set_window_buttons(&self, buttons: WindowButtons) {
+        x11_or_wayland!(match self; Window(w) => w.set_window_buttons(buttons))
     }
 
     #[inline]
-    pub fn is_minimizable(&self) -> bool {
-        x11_or_wayland!(match self; Window(w) => w.is_minimizable())
-    }
-    #[inline]
-    pub fn set_maximizable(&self, maximizable: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_maximizable(maximizable))
-    }
-
-    #[inline]
-    pub fn is_maximizable(&self) -> bool {
-        x11_or_wayland!(match self; Window(w) => w.is_maximizable())
-    }
-    #[inline]
-    pub fn set_closable(&self, closable: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_closable(closable))
-    }
-
-    #[inline]
-    pub fn is_closable(&self) -> bool {
-        x11_or_wayland!(match self; Window(w) => w.is_closable())
+    pub fn window_buttons(&self) -> WindowButtons {
+        x11_or_wayland!(match self; Window(w) => w.window_buttons())
     }
 
     #[inline]

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -404,6 +404,33 @@ impl Window {
     pub fn is_resizable(&self) -> bool {
         x11_or_wayland!(match self; Window(w) => w.is_resizable())
     }
+    #[inline]
+    pub fn set_minimizable(&self, minimizable: bool) {
+        x11_or_wayland!(match self; Window(w) => w.set_minimizable(minimizable))
+    }
+
+    #[inline]
+    pub fn is_minimizable(&self) -> bool {
+        x11_or_wayland!(match self; Window(w) => w.is_minimizable())
+    }
+    #[inline]
+    pub fn set_maximizable(&self, maximizable: bool) {
+        x11_or_wayland!(match self; Window(w) => w.set_maximizable(maximizable))
+    }
+
+    #[inline]
+    pub fn is_maximizable(&self) -> bool {
+        x11_or_wayland!(match self; Window(w) => w.is_maximizable())
+    }
+    #[inline]
+    pub fn set_closable(&self, closable: bool) {
+        x11_or_wayland!(match self; Window(w) => w.set_closable(closable))
+    }
+
+    #[inline]
+    pub fn is_closable(&self) -> bool {
+        x11_or_wayland!(match self; Window(w) => w.is_closable())
+    }
 
     #[inline]
     pub fn set_cursor_icon(&self, cursor: CursorIcon) {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -408,13 +408,13 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_window_buttons(&self, buttons: WindowButtons) {
-        x11_or_wayland!(match self; Window(w) => w.set_window_buttons(buttons))
+    pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
+        x11_or_wayland!(match self; Window(w) => w.set_enabled_buttons(buttons))
     }
 
     #[inline]
-    pub fn window_buttons(&self) -> WindowButtons {
-        x11_or_wayland!(match self; Window(w) => w.window_buttons())
+    pub fn enabled_buttons(&self) -> WindowButtons {
+        x11_or_wayland!(match self; Window(w) => w.enabled_buttons())
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -422,7 +422,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_maximizable(&self, maximizable: bool) {}
+    pub fn set_maximizable(&self, _maximizable: bool) {}
 
     #[inline]
     pub fn is_maximizable(&self) -> bool {
@@ -430,7 +430,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_minimizable(&self, minimizable: bool) {}
+    pub fn set_minimizable(&self, _minimizable: bool) {}
 
     #[inline]
     pub fn is_minimizable(&self) -> bool {
@@ -438,7 +438,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_closable(&self, closable: bool) {}
+    pub fn set_closable(&self, _closable: bool) {}
 
     #[inline]
     pub fn is_closable(&self) -> bool {

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -422,6 +422,30 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_maximizable(&self, maximizable: bool) {}
+
+    #[inline]
+    pub fn is_maximizable(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    pub fn set_minimizable(&self, minimizable: bool) {}
+
+    #[inline]
+    pub fn is_minimizable(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    pub fn set_closable(&self, closable: bool) {}
+
+    #[inline]
+    pub fn is_closable(&self) -> bool {
+        true
+    }
+
+    #[inline]
     pub fn scale_factor(&self) -> u32 {
         // The scale factor from `get_surface_scale_factor` is always greater than zero, so
         // u32 conversion is safe.

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -18,7 +18,9 @@ use crate::platform_impl::{
     Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError,
     PlatformSpecificWindowBuilderAttributes as PlatformAttributes,
 };
-use crate::window::{CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes};
+use crate::window::{
+    CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
+};
 
 use super::env::WindowingFeatures;
 use super::event_loop::WinitState;
@@ -422,27 +424,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_maximizable(&self, _maximizable: bool) {}
+    pub fn set_window_buttons(&self, _buttons: WindowButtons) {}
 
     #[inline]
-    pub fn is_maximizable(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    pub fn set_minimizable(&self, _minimizable: bool) {}
-
-    #[inline]
-    pub fn is_minimizable(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    pub fn set_closable(&self, _closable: bool) {}
-
-    #[inline]
-    pub fn is_closable(&self) -> bool {
-        true
+    pub fn window_buttons(&self) -> WindowButtons {
+        WindowButtons::all()
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -424,10 +424,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_window_buttons(&self, _buttons: WindowButtons) {}
+    pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {}
 
     #[inline]
-    pub fn window_buttons(&self) -> WindowButtons {
+    pub fn enabled_buttons(&self) -> WindowButtons {
         WindowButtons::all()
     }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1261,10 +1261,10 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn set_window_buttons(&self, _buttons: WindowButtons) {}
+    pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {}
 
     #[inline]
-    pub fn window_buttons(&self) -> WindowButtons {
+    pub fn enabled_buttons(&self) -> WindowButtons {
         WindowButtons::all()
     }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -20,7 +20,9 @@ use crate::{
         Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError,
         PlatformSpecificWindowBuilderAttributes, VideoMode as PlatformVideoMode,
     },
-    window::{CursorGrabMode, CursorIcon, Icon, Theme, UserAttentionType, WindowAttributes},
+    window::{
+        CursorGrabMode, CursorIcon, Icon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
+    },
 };
 
 use super::{
@@ -1259,27 +1261,11 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn set_maximizable(&self, _maximizable: bool) {}
+    pub fn set_window_buttons(&self, _buttons: WindowButtons) {}
 
     #[inline]
-    pub fn is_maximizable(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    pub fn set_minimizable(&self, _minimizable: bool) {}
-
-    #[inline]
-    pub fn is_minimizable(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    pub fn set_closable(&self, _closable: bool) {}
-
-    #[inline]
-    pub fn is_closable(&self) -> bool {
-        true
+    pub fn window_buttons(&self) -> WindowButtons {
+        WindowButtons::all()
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1259,7 +1259,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn set_maximizable(&self, maximizable: bool) {}
+    pub fn set_maximizable(&self, _maximizable: bool) {}
 
     #[inline]
     pub fn is_maximizable(&self) -> bool {
@@ -1267,7 +1267,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn set_minimizable(&self, minimizable: bool) {}
+    pub fn set_minimizable(&self, _minimizable: bool) {}
 
     #[inline]
     pub fn is_minimizable(&self) -> bool {
@@ -1275,7 +1275,7 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn set_closable(&self, closable: bool) {}
+    pub fn set_closable(&self, _closable: bool) {}
 
     #[inline]
     pub fn is_closable(&self) -> bool {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1259,6 +1259,30 @@ impl UnownedWindow {
     }
 
     #[inline]
+    pub fn set_maximizable(&self, maximizable: bool) {}
+
+    #[inline]
+    pub fn is_maximizable(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    pub fn set_minimizable(&self, minimizable: bool) {}
+
+    #[inline]
+    pub fn is_minimizable(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    pub fn set_closable(&self, closable: bool) {}
+
+    #[inline]
+    pub fn is_closable(&self) -> bool {
+        true
+    }
+
+    #[inline]
     pub fn xlib_display(&self) -> *mut c_void {
         self.xconn.display as _
     }

--- a/src/platform_impl/macos/appkit/control.rs
+++ b/src/platform_impl/macos/appkit/control.rs
@@ -12,3 +12,13 @@ extern_class!(
         type Super = NSView;
     }
 );
+
+extern_methods!(
+    unsafe impl NSControl {
+        #[sel(setEnabled:)]
+        pub fn setEnabled(&self, enabled: bool);
+
+        #[sel(isEnabled)]
+        pub fn isEnabled(&self) -> bool;
+    }
+);

--- a/src/platform_impl/macos/appkit/control.rs
+++ b/src/platform_impl/macos/appkit/control.rs
@@ -1,5 +1,5 @@
 use objc2::foundation::NSObject;
-use objc2::{extern_class, ClassType};
+use objc2::{extern_class, extern_methods, ClassType};
 
 use super::{NSResponder, NSView};
 

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -170,6 +170,12 @@ extern_methods!(
         #[sel(isResizable)]
         pub fn isResizable(&self) -> bool;
 
+        #[sel(isMiniaturizable)]
+        pub fn isMiniaturizable(&self) -> bool;
+
+        #[sel(hasCloseBox)]
+        pub fn hasCloseBox(&self) -> bool;
+
         #[sel(isMiniaturized)]
         pub fn isMiniaturized(&self) -> bool;
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -651,8 +651,13 @@ impl WinitWindow {
             mask &= !NSWindowStyleMask::NSMiniaturizableWindowMask;
         }
 
-        self.set_style_mask_async(mask);
+        // This must happen before the button's "enabled" status has been set,
+        // hence we do it synchronously.
+        self.set_style_mask_sync(mask);
 
+        // We edit the button directly instead of using `NSResizableWindowMask`,
+        // since that mask also affect the resizability of the window (which is
+        // controllable by other means in `winit`).
         if let Some(button) = self.standardWindowButton(NSWindowButton::Zoom) {
             button.setEnabled(buttons.contains(WindowButtons::MAXIMIZE));
         }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -636,7 +636,7 @@ impl WinitWindow {
 
     #[inline]
     pub fn set_minimizable(&self, minimizable: bool) {
-        let mut mask = unsafe { self.ns_window.styleMask() };
+        let mut mask = self.styleMask();
         if minimizable {
             mask |= NSWindowStyleMask::NSMiniaturizableWindowMask;
         } else {
@@ -666,7 +666,7 @@ impl WinitWindow {
 
     #[inline]
     pub fn set_closable(&self, closable: bool) {
-        let mut mask = unsafe { self.ns_window.styleMask() };
+        let mut mask = self.styleMask();
         if closable {
             mask |= NSWindowStyleMask::NSClosableWindowMask;
         } else {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -267,11 +267,11 @@ impl WinitWindow {
                 masks &= !NSWindowStyleMask::NSResizableWindowMask;
             }
 
-            if !attrs.window_buttons.contains(WindowButtons::MINIMIZE) {
+            if !attrs.enabled_buttons.contains(WindowButtons::MINIMIZE) {
                 masks &= !NSWindowStyleMask::NSMiniaturizableWindowMask;
             }
 
-            if !attrs.window_buttons.contains(WindowButtons::CLOSE) {
+            if !attrs.enabled_buttons.contains(WindowButtons::CLOSE) {
                 masks &= !NSWindowStyleMask::NSClosableWindowMask;
             }
 
@@ -339,7 +339,7 @@ impl WinitWindow {
                     this.setLevel(NSWindowLevel::Floating);
                 }
 
-                if !attrs.window_buttons.contains(WindowButtons::MAXIMIZE) {
+                if !attrs.enabled_buttons.contains(WindowButtons::MAXIMIZE) {
                     if let Some(button) = this.standardWindowButton(NSWindowButton::Zoom) {
                         button.setEnabled(false);
                     }
@@ -635,7 +635,7 @@ impl WinitWindow {
     }
 
     #[inline]
-    pub fn set_window_buttons(&self, buttons: WindowButtons) {
+    pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
         let mut mask = self.styleMask();
 
         if buttons.contains(WindowButtons::CLOSE) {
@@ -658,7 +658,7 @@ impl WinitWindow {
     }
 
     #[inline]
-    pub fn window_buttons(&self) -> WindowButtons {
+    pub fn enabled_buttons(&self) -> WindowButtons {
         let mut buttons = WindowButtons::empty();
         if self.isMiniaturizable() {
             buttons |= WindowButtons::MINIMIZE;

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -172,6 +172,33 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_maximizable(&self, _maximizable: bool) {
+        // Intentionally a no-op: users can't maximize canvas elements
+    }
+
+    pub fn is_maximizable(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    pub fn set_minimizable(&self, _minimizable: bool) {
+        // Intentionally a no-op: users can't minmiize canvas elements
+    }
+
+    pub fn is_minimizable(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    pub fn set_closable(&self, _closable: bool) {
+        // Intentionally a no-op: users can't close canvas elements
+    }
+
+    pub fn is_closable(&self) -> bool {
+        true
+    }
+
+    #[inline]
     pub fn scale_factor(&self) -> f64 {
         super::backend::scale_factor()
     }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -3,7 +3,8 @@ use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
 use crate::event;
 use crate::icon::Icon;
 use crate::window::{
-    CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowId as RootWI,
+    CursorGrabMode, CursorIcon, Theme, UserAttentionType, WindowAttributes, WindowButtons,
+    WindowId as RootWI,
 };
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
@@ -172,30 +173,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_maximizable(&self, _maximizable: bool) {
-        // Intentionally a no-op: users can't maximize canvas elements
-    }
-
-    pub fn is_maximizable(&self) -> bool {
-        true
-    }
+    pub fn set_window_buttons(&self, _buttons: WindowButtons) {}
 
     #[inline]
-    pub fn set_minimizable(&self, _minimizable: bool) {
-        // Intentionally a no-op: users can't minmiize canvas elements
-    }
-
-    pub fn is_minimizable(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    pub fn set_closable(&self, _closable: bool) {
-        // Intentionally a no-op: users can't close canvas elements
-    }
-
-    pub fn is_closable(&self) -> bool {
-        true
+    pub fn window_buttons(&self) -> WindowButtons {
+        WindowButtons::all()
     }
 
     #[inline]

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -173,10 +173,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_window_buttons(&self, _buttons: WindowButtons) {}
+    pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {}
 
     #[inline]
-    pub fn window_buttons(&self) -> WindowButtons {
+    pub fn enabled_buttons(&self) -> WindowButtons {
         WindowButtons::all()
     }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1017,7 +1017,7 @@ where
     // WindowFlags::VISIBLE and MAXIMIZED are set down below after the window has been configured.
     window_flags.set(WindowFlags::RESIZABLE, attributes.resizable);
     // Will be changed later using `window.set_enabled_buttons` but we need to set a default here
-    // so the diffing later can work
+    // so the diffing later can work.
     window_flags.set(WindowFlags::CLOSABLE, true);
 
     let parent = match pl_attribs.parent {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -265,7 +265,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_window_buttons(&self, buttons: WindowButtons) {
+    pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
         let window = self.window.clone();
         let window_state = Arc::clone(&self.window_state);
 
@@ -288,7 +288,7 @@ impl Window {
         });
     }
 
-    pub fn window_buttons(&self) -> WindowButtons {
+    pub fn enabled_buttons(&self) -> WindowButtons {
         let mut buttons = WindowButtons::empty();
         let window_state = self.window_state_lock();
         if window_state.window_flags.contains(WindowFlags::MINIMIZABLE) {
@@ -943,7 +943,7 @@ impl<'a, T: 'static> InitData<'a, T> {
         // attribute is correctly applied.
         win.set_visible(attributes.visible);
 
-        win.set_window_buttons(attributes.window_buttons);
+        win.set_enabled_buttons(attributes.enabled_buttons);
 
         if attributes.fullscreen.is_some() {
             win.set_fullscreen(attributes.fullscreen);
@@ -1007,7 +1007,7 @@ where
     window_flags.set(WindowFlags::TRANSPARENT, attributes.transparent);
     // WindowFlags::VISIBLE and MAXIMIZED are set down below after the window has been configured.
     window_flags.set(WindowFlags::RESIZABLE, attributes.resizable);
-    // Will be changed later using `window.set_window_buttons` but we need to set a default here
+    // Will be changed later using `window.set_enabled_buttons` but we need to set a default here
     // so the diffing later can work
     window_flags.set(WindowFlags::CLOSABLE, true);
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -241,12 +241,7 @@ impl WindowFlags {
 
     pub fn to_window_styles(self) -> (WINDOW_STYLE, WINDOW_EX_STYLE) {
         // Required styles to properly support common window functionality like aero snap.
-        let mut style = WS_CAPTION
-            | WS_MINIMIZEBOX
-            | WS_BORDER
-            | WS_CLIPSIBLINGS
-            | WS_CLIPCHILDREN
-            | WS_SYSMENU;
+        let mut style = WS_CAPTION | WS_BORDER | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
         let mut style_ex = WS_EX_WINDOWEDGE | WS_EX_ACCEPTFILES;
 
         if self.contains(WindowFlags::RESIZABLE) {

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -350,17 +350,14 @@ impl WindowFlags {
         }
 
         if diff.contains(WindowFlags::CLOSABLE) || new.contains(WindowFlags::CLOSABLE) {
+            let flags = MF_BYCOMMAND
+                | new
+                    .contains(WindowFlags::CLOSABLE)
+                    .then(|| MF_ENABLED)
+                    .unwrap_or(MF_DISABLED);
+
             unsafe {
-                EnableMenuItem(
-                    GetSystemMenu(window, 0),
-                    SC_CLOSE,
-                    MF_BYCOMMAND
-                        | if new.contains(WindowFlags::CLOSABLE) {
-                            MF_ENABLED
-                        } else {
-                            MF_DISABLED
-                        },
-                );
+                EnableMenuItem(GetSystemMenu(window, 0), SC_CLOSE, flags);
             }
         }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -126,9 +126,7 @@ pub(crate) struct WindowAttributes {
     pub max_inner_size: Option<Size>,
     pub position: Option<Position>,
     pub resizable: bool,
-    pub maximizable: bool,
-    pub minimizable: bool,
-    pub closable: bool,
+    pub window_buttons: WindowButtons,
     pub title: String,
     pub fullscreen: Option<platform_impl::Fullscreen>,
     pub maximized: bool,
@@ -150,9 +148,7 @@ impl Default for WindowAttributes {
             max_inner_size: None,
             position: None,
             resizable: true,
-            minimizable: true,
-            maximizable: true,
-            closable: true,
+            window_buttons: WindowButtons::all(),
             title: "winit window".to_owned(),
             maximized: false,
             fullscreen: None,
@@ -248,36 +244,14 @@ impl WindowBuilder {
         self
     }
 
-    /// Sets whether the window is maximizable or not.
+    /// Sets the enabled window buttons.
     ///
-    /// The default is `true`.
+    /// The default is [`WindowButtons::all`]
     ///
-    /// See [`Window::set_maximizable`] for details.
+    /// See [`Window::set_window_buttons`] for details.
     #[inline]
-    pub fn with_maximizable(mut self, maximizable: bool) -> Self {
-        self.window.maximizable = maximizable;
-        self
-    }
-
-    /// Sets whether the window is minimizable or not.
-    ///
-    /// The default is `true`.
-    ///
-    /// See [`Window::set_minimizable`] for details.
-    #[inline]
-    pub fn with_minimizable(mut self, minimizable: bool) -> Self {
-        self.window.minimizable = minimizable;
-        self
-    }
-
-    /// Sets whether the window is closable or not.
-    ///
-    /// The default is `true`.
-    ///
-    /// See [`Window::set_closable`] for details.
-    #[inline]
-    pub fn with_closable(mut self, closable: bool) -> Self {
-        self.window.closable = closable;
+    pub fn with_window_buttons(mut self, buttons: WindowButtons) -> Self {
+        self.window.window_buttons = buttons;
         self
     }
 
@@ -771,70 +745,24 @@ impl Window {
         self.window.is_resizable()
     }
 
-    /// Sets whether the window is minimizable or not.
+    /// Sets the enabled window buttons.
     ///
     /// ## Platform-specific
     ///
     /// - **Wayland / X11:** Not implemented.
     /// - **Web / iOS / Android:** Unsupported.
-    #[inline]
-    pub fn set_minimizable(&self, minimizable: bool) {
-        self.window.set_minimizable(minimizable)
+    pub fn set_window_buttons(&self, buttons: WindowButtons) {
+        self.window.set_window_buttons(buttons)
     }
 
-    /// Gets the window's current minimizable state.
+    /// Gets the enabled window buttons.
     ///
     /// ## Platform-specific
     ///
-    /// - **Wayland / X11:** Not implemented.
-    /// - **Web / iOS / Android:** Unsupported.
-    #[inline]
-    pub fn is_minimizable(&self) -> bool {
-        self.window.is_minimizable()
-    }
-
-    /// Sets whether the window is maximizable or not.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Wayland / X11:** Not implemented.
-    /// - **Web / iOS / Android:** Unsupported.
-    #[inline]
-    pub fn set_maximizable(&self, maximizable: bool) {
-        self.window.set_maximizable(maximizable)
-    }
-
-    /// Gets the window's current maximizable state.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Wayland / X11:** Not implemented.
-    /// - **Web / iOS / Android:** Unsupported.
-    #[inline]
-    pub fn is_maximizable(&self) -> bool {
-        self.window.is_maximizable()
-    }
-
-    /// Sets whether the window is closable or not.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Wayland / X11:** Not implemented.
-    /// - **Web / iOS / Android:** Unsupported.
-    #[inline]
-    pub fn set_closable(&self, closable: bool) {
-        self.window.set_closable(closable)
-    }
-
-    /// Gets the window's current closable state.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Wayland / X11:** Not implemented.
-    /// - **Web / iOS / Android:** Unsupported.
-    #[inline]
-    pub fn is_closable(&self) -> bool {
-        self.window.is_closable()
+    /// - **Wayland / X11:** Not implemented. Always returns [`WindowButtons::all`].
+    /// - **Web / iOS / Android:** Unsupported. Always returns [`WindowButtons::all`].
+    pub fn window_buttons(&self) -> WindowButtons {
+        self.window.window_buttons()
     }
 
     /// Sets the window to minimized or back
@@ -1482,5 +1410,13 @@ pub enum UserAttentionType {
 impl Default for UserAttentionType {
     fn default() -> Self {
         UserAttentionType::Informational
+    }
+}
+
+bitflags! {
+    pub struct WindowButtons: u32 {
+        const CLOSE  = 1 << 0;
+        const MINIMIZE  = 1 << 1;
+        const MAXIMIZE  = 1 << 2;
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -126,6 +126,9 @@ pub(crate) struct WindowAttributes {
     pub max_inner_size: Option<Size>,
     pub position: Option<Position>,
     pub resizable: bool,
+    pub maximizable: bool,
+    pub minimizable: bool,
+    pub closable: bool,
     pub title: String,
     pub fullscreen: Option<platform_impl::Fullscreen>,
     pub maximized: bool,
@@ -147,6 +150,9 @@ impl Default for WindowAttributes {
             max_inner_size: None,
             position: None,
             resizable: true,
+            minimizable: true,
+            maximizable: true,
+            closable: true,
             title: "winit window".to_owned(),
             maximized: false,
             fullscreen: None,
@@ -239,6 +245,39 @@ impl WindowBuilder {
     #[inline]
     pub fn with_resizable(mut self, resizable: bool) -> Self {
         self.window.resizable = resizable;
+        self
+    }
+
+    /// Sets whether the window is maximizable or not.
+    ///
+    /// The default is `true`.
+    ///
+    /// See [`Window::set_maximizable`] for details.
+    #[inline]
+    pub fn with_maximizable(mut self, maximizable: bool) -> Self {
+        self.window.maximizable = maximizable;
+        self
+    }
+
+    /// Sets whether the window is minimizable or not.
+    ///
+    /// The default is `true`.
+    ///
+    /// See [`Window::set_minimizable`] for details.
+    #[inline]
+    pub fn with_minimizable(mut self, minimizable: bool) -> Self {
+        self.window.minimizable = minimizable;
+        self
+    }
+
+    /// Sets whether the window is closable or not.
+    ///
+    /// The default is `true`.
+    ///
+    /// See [`Window::set_closable`] for details.
+    #[inline]
+    pub fn with_closable(mut self, closable: bool) -> Self {
+        self.window.closable = closable;
         self
     }
 
@@ -730,6 +769,72 @@ impl Window {
     #[inline]
     pub fn is_resizable(&self) -> bool {
         self.window.is_resizable()
+    }
+
+    /// Sets whether the window is minimizable or not.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland / X11:** Not implemented.
+    /// - **Web / iOS / Android:** Unsupported.
+    #[inline]
+    pub fn set_minimizable(&self, minimizable: bool) {
+        self.window.set_minimizable(minimizable)
+    }
+
+    /// Gets the window's current minimizable state.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland / X11:** Not implemented.
+    /// - **Web / iOS / Android:** Unsupported.
+    #[inline]
+    pub fn is_minimizable(&self) -> bool {
+        self.window.is_minimizable()
+    }
+
+    /// Sets whether the window is maximizable or not.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland / X11:** Not implemented.
+    /// - **Web / iOS / Android:** Unsupported.
+    #[inline]
+    pub fn set_maximizable(&self, maximizable: bool) {
+        self.window.set_maximizable(maximizable)
+    }
+
+    /// Gets the window's current maximizable state.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland / X11:** Not implemented.
+    /// - **Web / iOS / Android:** Unsupported.
+    #[inline]
+    pub fn is_maximizable(&self) -> bool {
+        self.window.is_maximizable()
+    }
+
+    /// Sets whether the window is closable or not.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland / X11:** Not implemented.
+    /// - **Web / iOS / Android:** Unsupported.
+    #[inline]
+    pub fn set_closable(&self, closable: bool) {
+        self.window.set_closable(closable)
+    }
+
+    /// Gets the window's current closable state.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland / X11:** Not implemented.
+    /// - **Web / iOS / Android:** Unsupported.
+    #[inline]
+    pub fn is_closable(&self) -> bool {
+        self.window.is_closable()
     }
 
     /// Sets the window to minimized or back

--- a/src/window.rs
+++ b/src/window.rs
@@ -126,7 +126,7 @@ pub(crate) struct WindowAttributes {
     pub max_inner_size: Option<Size>,
     pub position: Option<Position>,
     pub resizable: bool,
-    pub window_buttons: WindowButtons,
+    pub enabled_buttons: WindowButtons,
     pub title: String,
     pub fullscreen: Option<platform_impl::Fullscreen>,
     pub maximized: bool,
@@ -148,7 +148,7 @@ impl Default for WindowAttributes {
             max_inner_size: None,
             position: None,
             resizable: true,
-            window_buttons: WindowButtons::all(),
+            enabled_buttons: WindowButtons::all(),
             title: "winit window".to_owned(),
             maximized: false,
             fullscreen: None,
@@ -248,10 +248,10 @@ impl WindowBuilder {
     ///
     /// The default is [`WindowButtons::all`]
     ///
-    /// See [`Window::set_window_buttons`] for details.
+    /// See [`Window::set_enabled_buttons`] for details.
     #[inline]
-    pub fn with_window_buttons(mut self, buttons: WindowButtons) -> Self {
-        self.window.window_buttons = buttons;
+    pub fn with_enabled_buttons(mut self, buttons: WindowButtons) -> Self {
+        self.window.enabled_buttons = buttons;
         self
     }
 
@@ -751,8 +751,8 @@ impl Window {
     ///
     /// - **Wayland / X11:** Not implemented.
     /// - **Web / iOS / Android:** Unsupported.
-    pub fn set_window_buttons(&self, buttons: WindowButtons) {
-        self.window.set_window_buttons(buttons)
+    pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
+        self.window.set_enabled_buttons(buttons)
     }
 
     /// Gets the enabled window buttons.
@@ -761,8 +761,8 @@ impl Window {
     ///
     /// - **Wayland / X11:** Not implemented. Always returns [`WindowButtons::all`].
     /// - **Web / iOS / Android:** Unsupported. Always returns [`WindowButtons::all`].
-    pub fn window_buttons(&self) -> WindowButtons {
-        self.window.window_buttons()
+    pub fn enabled_buttons(&self) -> WindowButtons {
+        self.window.enabled_buttons()
     }
 
     /// Sets the window to minimized or back


### PR DESCRIPTION
- [X] Tested on all platforms changed
	- [X] Windows
	- [x] macOS
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Porting https://github.com/tauri-apps/tao/commit/a50fd867b3df033dff077f5320b4b7037b04e454