### PR TITLE
Initial Xbox Gamepad support

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -829,6 +829,16 @@ pub struct KeyboardInput {
     pub modifiers: ModifiersState,
 }
 
+// Describes a gamepad input event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct GamepadInput {
+    // Identifies physical button pressed
+    pub button: ButtonId,
+
+    pub state: ElementState,
+}
+
 /// Describes [input method](https://en.wikipedia.org/wiki/Input_method) events.
 ///
 /// This is also called a "composition event".


### PR DESCRIPTION
Initial change for #2506 which in the future hopefuly will introduce Xbox platform based on Win32/WinRT APIs which are not under NDA.

> **Note** [`Windows.Gaming.Input`](https://learn.microsoft.com/en-us/uwp/api/windows.gaming.input?view=winrt-22621) API depends on focused window and [`Gamepad`](https://learn.microsoft.com/en-us/uwp/api/windows.gaming.input.gamepad?view=winrt-22621) module provides Xbox specific metadata such as assigned users, which is required for upstream console compatibility.

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
