### PR TITLE
On macOS, fix `WindowEvent::Destroyed` isn't emitted 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On macOS, fix `WindowEvent::Destroyed` isn't emitted when the window is dropped.
 - On Windows, fix focusing menubar when pressing `Alt`.
 - On MacOS, made `accepts_first_mouse` configurable.
 - Migrated `WindowBuilderExtUnix::with_resize_increments` to `WindowBuilder`.

--- a/src/event.rs
+++ b/src/event.rs
@@ -331,6 +331,9 @@ pub enum WindowEvent<'a> {
     CloseRequested,
 
     /// The window has been destroyed.
+    ///
+    /// However, it won't get emitted if the window is closed by the event loop set to exit.
+    /// Use [`Event::LoopDestroyed`] to check such behaviour instead.
     Destroyed,
 
     /// A file has been dropped into the window.

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -57,7 +57,7 @@ pub(crate) struct Window {
 impl Drop for Window {
     fn drop(&mut self) {
         // Ensure the window is closed
-        util::close_async(Id::into_super(self.window.clone()));
+        util::close_async(self.window.clone());
     }
 }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -51,13 +51,13 @@ pub(crate) const DEVICE_ID: RootDeviceId = RootDeviceId(DeviceId);
 pub(crate) struct Window {
     pub(crate) window: Id<WinitWindow, Shared>,
     // We keep this around so that it doesn't get dropped until the window does.
-    _delegate: Id<WinitWindowDelegate, Shared>,
+    pub(crate) delegate: Id<WinitWindowDelegate, Shared>,
 }
 
 impl Drop for Window {
     fn drop(&mut self) {
         // Ensure the window is closed
-        util::close_async(self.window.clone());
+        util::close_async(self.delegate.clone());
     }
 }
 
@@ -84,8 +84,8 @@ impl Window {
         attributes: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
-        let (window, _delegate) = autoreleasepool(|_| WinitWindow::new(attributes, pl_attribs))?;
-        Ok(Window { window, _delegate })
+        let (window, delegate) = autoreleasepool(|_| WinitWindow::new(attributes, pl_attribs))?;
+        Ok(Window { window, delegate })
     }
 }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -25,7 +25,7 @@ use crate::{
 declare_class!(
     #[derive(Debug)]
     pub(crate) struct WinitWindowDelegate {
-        window: IvarDrop<Id<WinitWindow, Shared>>,
+        pub(crate) window: IvarDrop<Id<WinitWindow, Shared>>,
 
         // TODO: It's possible for delegate methods to be called asynchronously,
         // causing data races / `RefCell` panics.


### PR DESCRIPTION
It seems `windowWillClose` can only be called when `windowShouldClose` returns true.
So the `WindowEvent::Destroyed` is never called when the window is dropped.
This PR add another queue event when the window is dropped during Drop trait is called.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
