### PR TITLE
macOS: Fix overridden fullscreen selectors

### DIFF
--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -221,9 +221,9 @@ declare_class!(
         }
 
         /// Invoked when before enter fullscreen
-        #[sel(windowWillEnterFullscreen:)]
+        #[sel(windowWillEnterFullScreen:)]
         fn window_will_enter_fullscreen(&self, _: Option<&Object>) {
-            trace_scope!("windowWillEnterFullscreen:");
+            trace_scope!("windowWillEnterFullScreen:");
 
             let mut shared_state = self
                 .window
@@ -287,9 +287,9 @@ declare_class!(
         }
 
         /// Invoked when entered fullscreen
-        #[sel(windowDidEnterFullscreen:)]
+        #[sel(windowDidEnterFullScreen:)]
         fn window_did_enter_fullscreen(&mut self, _: Option<&Object>) {
-            trace_scope!("windowDidEnterFullscreen:");
+            trace_scope!("windowDidEnterFullScreen:");
             *self.initial_fullscreen = false;
             let mut shared_state = self.window.lock_shared_state("window_did_enter_fullscreen");
             shared_state.in_fullscreen_transition = false;
@@ -301,9 +301,9 @@ declare_class!(
         }
 
         /// Invoked when exited fullscreen
-        #[sel(windowDidExitFullscreen:)]
+        #[sel(windowDidExitFullScreen:)]
         fn window_did_exit_fullscreen(&self, _: Option<&Object>) {
-            trace_scope!("windowDidExitFullscreen:");
+            trace_scope!("windowDidExitFullScreen:");
 
             self.window.restore_state_from_fullscreen();
             let mut shared_state = self.window.lock_shared_state("window_did_exit_fullscreen");
@@ -331,9 +331,9 @@ declare_class!(
         /// due to being in the midst of handling some other animation or user gesture.
         /// This method indicates that there was an error, and you should clean up any
         /// work you may have done to prepare to enter full-screen mode.
-        #[sel(windowDidFailToEnterFullscreen:)]
+        #[sel(windowDidFailToEnterFullScreen:)]
         fn window_did_fail_to_enter_fullscreen(&self, _: Option<&Object>) {
-            trace_scope!("windowDidFailToEnterFullscreen:");
+            trace_scope!("windowDidFailToEnterFullScreen:");
             let mut shared_state = self
                 .window
                 .lock_shared_state("window_did_fail_to_enter_fullscreen");


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/2520

These were incorrectly named (`Fullscreen` instead of `FullScreen`, notice the big "S").

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
  - Introduced in https://github.com/rust-windowing/winit/pull/2458 which has not been released yet, so no need to note this in the changelog.
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
