### PR TITLE
Fix panic in current_monitor_inner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Removed `WindowBuilderExtWindows::with_theme` and `WindowBuilderExtWayland::with_wayland_csd_theme` in favour of `WindowBuilder::with_theme`.
 - **Breaking:** Removed `WindowExtWindows::theme` in favour of `Window::theme`.
 - Enabled `doc_auto_cfg` when generating docs on docs.rs for feature labels.
-- macOS: Return `None` instead of panic when getting monitor fails
+- On macOS, fix panic when getting current monitor without any monitor attached.
 
 # 0.27.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Removed `WindowBuilderExtWindows::with_theme` and `WindowBuilderExtWayland::with_wayland_csd_theme` in favour of `WindowBuilder::with_theme`.
 - **Breaking:** Removed `WindowExtWindows::theme` in favour of `Window::theme`.
 - Enabled `doc_auto_cfg` when generating docs on docs.rs for feature labels.
+- macOS: Return `None` instead of panic when getting monitor fails
 
 # 0.27.5
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -805,7 +805,11 @@ impl WinitWindow {
             let new_screen = match fullscreen {
                 Fullscreen::Borderless(Some(monitor)) => monitor.clone(),
                 Fullscreen::Borderless(None) => {
-                    self.current_monitor_inner().expect("expected screen")
+                    if let Some(monitor) = self.current_monitor_inner() {
+                        monitor
+                    } else {
+                        return;
+                    }
                 }
                 Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
             }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -804,7 +804,9 @@ impl WinitWindow {
         if let Some(ref fullscreen) = fullscreen {
             let new_screen = match fullscreen {
                 Fullscreen::Borderless(Some(monitor)) => monitor.clone(),
-                Fullscreen::Borderless(None) => self.current_monitor_inner(),
+                Fullscreen::Borderless(None) => {
+                    self.current_monitor_inner().expect("expected screen")
+                }
                 Fullscreen::Exclusive(video_mode) => video_mode.monitor(),
             }
             .ns_screen()
@@ -1067,14 +1069,14 @@ impl WinitWindow {
 
     #[inline]
     // Allow directly accessing the current monitor internally without unwrapping.
-    pub(crate) fn current_monitor_inner(&self) -> MonitorHandle {
-        let display_id = self.screen().expect("expected screen").display_id();
-        MonitorHandle::new(display_id)
+    pub(crate) fn current_monitor_inner(&self) -> Option<MonitorHandle> {
+        let display_id = self.screen()?.display_id();
+        Some(MonitorHandle::new(display_id))
     }
 
     #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
-        Some(self.current_monitor_inner())
+        self.current_monitor_inner()
     }
 
     #[inline]

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -242,7 +242,7 @@ declare_class!(
                 // Otherwise, we must've reached fullscreen by the user clicking
                 // on the green fullscreen button. Update state!
                 None => {
-                    let current_monitor = Some(self.window.current_monitor_inner());
+                    let current_monitor = self.window.current_monitor_inner();
                     shared_state.fullscreen = Some(Fullscreen::Borderless(current_monitor))
                 }
             }


### PR DESCRIPTION
- [x] Tested on all platforms changed

```
panic:  uncaught panic: "expected screen" at .cargo/git/checkouts/winit-560a7c8630e332ba/a8d2a7e/src/platform_impl/macos/window.rs:1071:40
```