### PR TITLE
On macOS,  add `EventLoopBuilderExtMacOS::with_activate_ignoring_other_apps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On MacOS, add `EventLoopBuilderExtMacOS::with_activate_ignoring_other_apps`.
 - On Windows, fix icons specified on `WindowBuilder` not taking effect for windows created after the first one.
 - On Windows and macOS, add `Window::title` to query the current window title.
 - On Windows, fix focusing menubar when pressing `Alt`.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -218,6 +218,12 @@ pub trait EventLoopBuilderExtMacOS {
     /// # }
     /// ```
     fn with_default_menu(&mut self, enable: bool) -> &mut Self;
+
+    /// Used to prevent the application from automatically activating when launched if
+    /// another application is already active
+    ///
+    /// The default behavior is to ignore other applications and activate when launched.
+    fn with_activate_ignoring_other_apps(&mut self, ignore: bool) -> &mut Self;
 }
 
 impl<T> EventLoopBuilderExtMacOS for EventLoopBuilder<T> {
@@ -230,6 +236,12 @@ impl<T> EventLoopBuilderExtMacOS for EventLoopBuilder<T> {
     #[inline]
     fn with_default_menu(&mut self, enable: bool) -> &mut Self {
         self.platform_specific.default_menu = enable;
+        self
+    }
+
+    #[inline]
+    fn with_activate_ignoring_other_apps(&mut self, ignore: bool) -> &mut Self {
+        self.platform_specific.activate_ignoring_other_apps = ignore;
         self
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -220,7 +220,7 @@ pub trait EventLoopBuilderExtMacOS {
     fn with_default_menu(&mut self, enable: bool) -> &mut Self;
 
     /// Used to prevent the application from automatically activating when launched if
-    /// another application is already active
+    /// another application is already active.
     ///
     /// The default behavior is to ignore other applications and activate when launched.
     fn with_activate_ignoring_other_apps(&mut self, ignore: bool) -> &mut Self;

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -11,6 +11,7 @@ declare_class!(
     pub(super) struct ApplicationDelegate {
         activation_policy: NSApplicationActivationPolicy,
         default_menu: bool,
+        activate_ignoring_other_apps: bool,
     }
 
     unsafe impl ClassType for ApplicationDelegate {
@@ -36,7 +37,11 @@ declare_class!(
         #[sel(applicationDidFinishLaunching:)]
         fn did_finish_launching(&self, _sender: *const Object) {
             trace_scope!("applicationDidFinishLaunching:");
-            AppState::launched(*self.activation_policy, *self.default_menu);
+            AppState::launched(
+                *self.activation_policy,
+                *self.default_menu,
+                *self.activate_ignoring_other_apps,
+            );
         }
 
         #[sel(applicationWillTerminate:)]
@@ -52,12 +57,14 @@ impl ApplicationDelegate {
     pub(super) fn new(
         activation_policy: NSApplicationActivationPolicy,
         default_menu: bool,
+        activate_ignoring_other_apps: bool,
     ) -> Id<Self, Shared> {
         unsafe {
             msg_send_id![
                 msg_send_id![Self::class(), alloc],
                 initWithActivationPolicy: activation_policy,
                 defaultMenu: default_menu,
+                activateIgnoringOtherApps: activate_ignoring_other_apps,
             ]
         }
     }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -272,7 +272,11 @@ impl AppState {
         }
     }
 
-    pub fn launched(activation_policy: NSApplicationActivationPolicy, create_default_menu: bool) {
+    pub fn launched(
+        activation_policy: NSApplicationActivationPolicy,
+        create_default_menu: bool,
+        activate_ignoring_other_apps: bool,
+    ) {
         let app = NSApp();
         // We need to delay setting the activation policy and activating the app
         // until `applicationDidFinishLaunching` has been called. Otherwise the
@@ -281,7 +285,7 @@ impl AppState {
 
         window_activation_hack(&app);
         // TODO: Consider allowing the user to specify they don't want their application activated
-        app.activateIgnoringOtherApps(true);
+        app.activateIgnoringOtherApps(activate_ignoring_other_apps);
 
         HANDLER.set_ready();
         HANDLER.waker().start();

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -284,7 +284,6 @@ impl AppState {
         app.setActivationPolicy(activation_policy);
 
         window_activation_hack(&app);
-        // TODO: Consider allowing the user to specify they don't want their application activated
         app.activateIgnoringOtherApps(activate_ignoring_other_apps);
 
         HANDLER.set_ready();

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -124,6 +124,7 @@ pub struct EventLoop<T: 'static> {
 pub(crate) struct PlatformSpecificEventLoopAttributes {
     pub(crate) activation_policy: ActivationPolicy,
     pub(crate) default_menu: bool,
+    pub(crate) activate_ignoring_other_apps: bool,
 }
 
 impl Default for PlatformSpecificEventLoopAttributes {
@@ -131,6 +132,7 @@ impl Default for PlatformSpecificEventLoopAttributes {
         Self {
             activation_policy: Default::default(), // Regular
             default_menu: true,
+            activate_ignoring_other_apps: true,
         }
     }
 }
@@ -154,7 +156,11 @@ impl<T> EventLoop<T> {
             ActivationPolicy::Accessory => NSApplicationActivationPolicyAccessory,
             ActivationPolicy::Prohibited => NSApplicationActivationPolicyProhibited,
         };
-        let delegate = ApplicationDelegate::new(activation_policy, attributes.default_menu);
+        let delegate = ApplicationDelegate::new(
+            activation_policy,
+            attributes.default_menu,
+            attributes.activate_ignoring_other_apps,
+        );
 
         autoreleasepool(|_| {
             app.setDelegate(&delegate);


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Port of https://github.com/tauri-apps/tao/commit/d2c6a91c4588bab460ef5924b10cfb224c1336c6