### PR TITLE
android: depend on android-activity 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ simple_logger = { version = "2.1.0", default_features = false }
 [target.'cfg(target_os = "android")'.dependencies]
 # Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995
 ndk = "0.7.0"
-android-activity = "0.4.0-beta.1"
+android-activity = "0.4.0"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 objc2 = "=0.3.0-beta.3"


### PR DESCRIPTION
This simply bumps the android-activity dependency from `0.4.0-beta.1` to `0.4.0` since `0.4` was release https://crates.io/crates/android-activity (https://github.com/rib/android-activity/pull/39)
