### PR TITLE
Only build, but don't run tests in MSRV CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,15 +77,22 @@ jobs:
       shell: bash
       run: cargo $CMD doc --no-deps --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES --document-private-items
 
+    - name: Build crate
+      shell: bash
+      run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
+
     - name: Build tests
       shell: bash
+      if: matrix.rust_version != '1.60.0'
       run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
+
     - name: Run tests
       shell: bash
       if: (
         !contains(matrix.platform.target, 'android') &&
         !contains(matrix.platform.target, 'ios') &&
-        !contains(matrix.platform.target, 'wasm32'))
+        !contains(matrix.platform.target, 'wasm32') &&
+        matrix.rust_version != '1.60.0')
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
     - name: Lint with clippy
@@ -95,11 +102,13 @@ jobs:
 
     - name: Build tests with serde enabled
       shell: bash
+      if: matrix.rust_version != '1.60.0'
       run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
     - name: Run tests with serde enabled
       shell: bash
       if: (
         !contains(matrix.platform.target, 'android') &&
         !contains(matrix.platform.target, 'ios') &&
-        !contains(matrix.platform.target, 'wasm32'))
+        !contains(matrix.platform.target, 'wasm32') &&
+        matrix.rust_version != '1.60.0')
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Lint with clippy
       shell: bash
-      if: (matrix.rust_version == '1.60.0') && !contains(matrix.platform.options, '--no-default-features')
+      if: (matrix.rust_version == 'stable') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
 
     - name: Build tests with serde enabled

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -143,7 +143,7 @@ impl WinitPointer {
         *confined_pointer.borrow_mut() = Some(init_confined_pointer(
             pointer_constraints,
             surface,
-            &*self.pointer,
+            &self.pointer,
         ));
     }
 
@@ -177,7 +177,7 @@ impl WinitPointer {
         *locked_pointer.borrow_mut() = Some(init_locked_pointer(
             pointer_constraints,
             surface,
-            &*self.pointer,
+            &self.pointer,
         ));
     }
 
@@ -267,7 +267,7 @@ impl Pointers {
         let relative_pointer = relative_pointer_manager
             .as_ref()
             .map(|relative_pointer_manager| {
-                init_relative_pointer(relative_pointer_manager, &*pointer)
+                init_relative_pointer(relative_pointer_manager, &pointer)
             });
 
         Self {

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1228,7 +1228,7 @@ impl<T: 'static> EventProcessor<T> {
                                                 new_monitor.scale_factor,
                                                 width,
                                                 height,
-                                                &*window.shared_state_lock(),
+                                                &window.shared_state_lock(),
                                             );
 
                                             let window_id = crate::window::WindowId(*window_id);

--- a/src/platform_impl/linux/x11/ime/callbacks.rs
+++ b/src/platform_impl/linux/x11/ime/callbacks.rs
@@ -72,7 +72,8 @@ pub unsafe fn set_destroy_callback(
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names)]
 enum ReplaceImError {
-    MethodOpenFailed(PotentialInputMethods),
+    // Boxed to prevent large error type
+    MethodOpenFailed(Box<PotentialInputMethods>),
     ContextCreationFailed(ImeContextCreationError),
     SetDestroyCallbackFailed(XError),
 }
@@ -88,7 +89,7 @@ unsafe fn replace_im(inner: *mut ImeInner) -> Result<(), ReplaceImError> {
         let is_fallback = new_im.is_fallback();
         (
             new_im.ok().ok_or_else(|| {
-                ReplaceImError::MethodOpenFailed((*inner).potential_input_methods.clone())
+                ReplaceImError::MethodOpenFailed(Box::new((*inner).potential_input_methods.clone()))
             })?,
             is_fallback,
         )

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -46,7 +46,8 @@ pub enum ImeRequest {
 
 #[derive(Debug)]
 pub enum ImeCreationError {
-    OpenFailure(PotentialInputMethods),
+    // Boxed to prevent large error type
+    OpenFailure(Box<PotentialInputMethods>),
     SetDestroyCallbackFailed(XError),
 }
 
@@ -90,7 +91,7 @@ impl Ime {
         if let Some(input_method) = input_method.ok() {
             inner.is_fallback = is_fallback;
             unsafe {
-                let result = set_destroy_callback(&xconn, input_method.im, &*inner)
+                let result = set_destroy_callback(&xconn, input_method.im, &inner)
                     .map_err(ImeCreationError::SetDestroyCallbackFailed);
                 if result.is_err() {
                     let _ = close_im(&xconn, input_method.im);
@@ -100,7 +101,9 @@ impl Ime {
             inner.im = Some(input_method);
             Ok(Ime { xconn, inner })
         } else {
-            Err(ImeCreationError::OpenFailure(inner.potential_input_methods))
+            Err(ImeCreationError::OpenFailure(Box::new(
+                inner.potential_input_methods,
+            )))
         }
     }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -644,7 +644,7 @@ impl Deref for Window {
     type Target = UnownedWindow;
     #[inline]
     fn deref(&self) -> &UnownedWindow {
-        &*self.0
+        &self.0
     }
 }
 

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -46,9 +46,8 @@ impl XConnection {
         if let Ok(res) = ::std::ffi::CStr::from_ptr(resource_manager_str).to_str() {
             let name: &str = "Xft.dpi:\t";
             for pair in res.split('\n') {
-                if pair.starts_with(&name) {
-                    let res = &pair[name.len()..];
-                    return f64::from_str(res).ok();
+                if let Some(stripped) = pair.strip_prefix(name) {
+                    return f64::from_str(stripped).ok();
                 }
             }
         }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -196,7 +196,7 @@ impl Handler {
         if let Some(ref mut callback) = *self.callback.lock().unwrap() {
             match wrapper {
                 EventWrapper::StaticEvent(event) => {
-                    callback.handle_nonuser_event(event, &mut *self.control_flow.lock().unwrap())
+                    callback.handle_nonuser_event(event, &mut self.control_flow.lock().unwrap())
                 }
                 EventWrapper::EventProxy(proxy) => self.handle_proxy(proxy, callback),
             }
@@ -205,7 +205,7 @@ impl Handler {
 
     fn handle_user_events(&self) {
         if let Some(ref mut callback) = *self.callback.lock().unwrap() {
-            callback.handle_user_events(&mut *self.control_flow.lock().unwrap());
+            callback.handle_user_events(&mut self.control_flow.lock().unwrap());
         }
     }
 
@@ -226,7 +226,7 @@ impl Handler {
             },
         };
 
-        callback.handle_nonuser_event(event, &mut *self.control_flow.lock().unwrap());
+        callback.handle_nonuser_event(event, &mut self.control_flow.lock().unwrap());
 
         let physical_size = *new_inner_size;
         let logical_size = physical_size.to_logical(scale_factor);

--- a/src/platform_impl/macos/menu.rs
+++ b/src/platform_impl/macos/menu.rs
@@ -19,14 +19,14 @@ pub fn initialize() {
     let process_name = NSProcessInfo::process_info().process_name();
 
     // About menu item
-    let about_item_title = ns_string!("About ").concat(&*process_name);
+    let about_item_title = ns_string!("About ").concat(&process_name);
     let about_item = menu_item(&about_item_title, sel!(orderFrontStandardAboutPanel:), None);
 
     // Seperator menu item
     let sep_first = NSMenuItem::separatorItem();
 
     // Hide application menu item
-    let hide_item_title = ns_string!("Hide ").concat(&*process_name);
+    let hide_item_title = ns_string!("Hide ").concat(&process_name);
     let hide_item = menu_item(
         &hide_item_title,
         sel!(hide:),
@@ -57,7 +57,7 @@ pub fn initialize() {
     let sep = NSMenuItem::separatorItem();
 
     // Quit application menu item
-    let quit_item_title = ns_string!("Quit ").concat(&*process_name);
+    let quit_item_title = ns_string!("Quit ").concat(&process_name);
     let quit_item = menu_item(
         &quit_item_title,
         sel!(terminate:),

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -74,7 +74,7 @@ impl Deref for Window {
     type Target = WinitWindow;
     #[inline]
     fn deref(&self) -> &Self::Target {
-        &*self.window
+        &self.window
     }
 }
 

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -45,7 +45,7 @@ pub(crate) fn set_style_mask_async(window: &NSWindow, mask: NSWindowStyleMask) {
     // TODO(madsmtm): Remove this 'static hack!
     let window = unsafe { MainThreadSafe(mem::transmute::<&NSWindow, &'static NSWindow>(window)) };
     Queue::main().exec_async(move || {
-        set_style_mask(*window, mask);
+        set_style_mask(&window, mask);
     });
 }
 pub(crate) fn set_style_mask_sync(window: &NSWindow, mask: NSWindowStyleMask) {
@@ -54,7 +54,7 @@ pub(crate) fn set_style_mask_sync(window: &NSWindow, mask: NSWindowStyleMask) {
     } else {
         let window = MainThreadSafe(window);
         Queue::main().exec_sync(move || {
-            set_style_mask(*window, mask);
+            set_style_mask(&window, mask);
         })
     }
 }
@@ -111,13 +111,13 @@ pub(crate) fn toggle_full_screen_async(
             let required =
                 NSWindowStyleMask::NSTitledWindowMask | NSWindowStyleMask::NSResizableWindowMask;
             if !curr_mask.contains(required) {
-                set_style_mask(*window, required);
+                set_style_mask(&window, required);
                 if let Some(shared_state) = shared_state.upgrade() {
                     let mut shared_state_lock = SharedStateMutexGuard::new(
                         shared_state.lock().unwrap(),
                         "toggle_full_screen_callback",
                     );
-                    (*shared_state_lock).saved_style = Some(curr_mask);
+                    shared_state_lock.saved_style = Some(curr_mask);
                 }
             }
         }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -733,7 +733,7 @@ impl WinitWindow {
         shared_state_lock.fullscreen = None;
 
         let maximized = shared_state_lock.maximized;
-        let mask = self.saved_style(&mut *shared_state_lock);
+        let mask = self.saved_style(&mut shared_state_lock);
 
         drop(shared_state_lock);
 
@@ -1191,7 +1191,7 @@ impl WindowExtMacOS for WinitWindow {
 
             true
         } else {
-            let new_mask = self.saved_style(&mut *shared_state_lock);
+            let new_mask = self.saved_style(&mut shared_state_lock);
             self.set_style_mask_async(new_mask);
             shared_state_lock.is_simple_fullscreen = false;
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -15,6 +15,8 @@ use std::{
 
 pub struct Shared<T: 'static>(Rc<Execution<T>>);
 
+pub(super) type EventHandler<T> = dyn FnMut(Event<'_, T>, &mut ControlFlow);
+
 impl<T> Clone for Shared<T> {
     fn clone(&self) -> Self {
         Shared(self.0.clone())
@@ -54,11 +56,11 @@ impl<T: 'static> RunnerEnum<T> {
 
 struct Runner<T: 'static> {
     state: State,
-    event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>,
+    event_handler: Box<EventHandler<T>>,
 }
 
 impl<T: 'static> Runner<T> {
-    pub fn new(event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>) -> Self {
+    pub fn new(event_handler: Box<EventHandler<T>>) -> Self {
         Runner {
             state: State::Init,
             event_handler,
@@ -123,7 +125,7 @@ impl<T: 'static> Shared<T> {
     // Set the event callback to use for the event loop runner
     // This the event callback is a fairly thin layer over the user-provided callback that closes
     // over a RootEventLoopWindowTarget reference
-    pub fn set_listener(&self, event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>) {
+    pub fn set_listener(&self, event_handler: Box<EventHandler<T>>) {
         {
             let mut runner = self.0.runner.borrow_mut();
             assert!(matches!(*runner, RunnerEnum::Pending));

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -14,7 +14,6 @@ use crate::event::{
     DeviceEvent, DeviceId as RootDeviceId, ElementState, Event, KeyboardInput, TouchPhase,
     WindowEvent,
 };
-use crate::event_loop::ControlFlow;
 use crate::window::{Theme, WindowId as RootWindowId};
 
 pub struct EventLoopWindowTarget<T: 'static> {
@@ -40,7 +39,7 @@ impl<T> EventLoopWindowTarget<T> {
         EventLoopProxy::new(self.runner.clone())
     }
 
-    pub fn run(&self, event_handler: Box<dyn FnMut(Event<'_, T>, &mut ControlFlow)>) {
+    pub fn run(&self, event_handler: Box<runner::EventHandler<T>>) {
         self.runner.set_listener(event_handler);
         let runner = self.runner.clone();
         self.runner.set_on_scale_change(move |arg| {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -249,7 +249,7 @@ impl Window {
         } else {
             self.canvas
                 .borrow()
-                .set_attribute("cursor", *self.previous_pointer.borrow());
+                .set_attribute("cursor", &self.previous_pointer.borrow());
         }
     }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -492,11 +492,11 @@ fn dur2timeout(dur: Duration) -> u32 {
         .checked_mul(1000)
         .and_then(|ms| ms.checked_add((dur.subsec_nanos() as u64) / 1_000_000))
         .and_then(|ms| {
-            ms.checked_add(if dur.subsec_nanos() % 1_000_000 > 0 {
-                1
+            if dur.subsec_nanos() % 1_000_000 > 0 {
+                ms.checked_add(1)
             } else {
-                0
-            })
+                Some(ms)
+            }
         })
         .map(|ms| {
             if ms > u32::MAX as u64 {
@@ -1547,7 +1547,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         WM_LBUTTONDOWN => {
             use crate::event::{ElementState::Pressed, MouseButton::Left, WindowEvent::MouseInput};
 
-            capture_mouse(window, &mut *userdata.window_state_lock());
+            capture_mouse(window, &mut userdata.window_state_lock());
 
             update_modifiers(window, userdata);
 
@@ -1589,7 +1589,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Pressed, MouseButton::Right, WindowEvent::MouseInput,
             };
 
-            capture_mouse(window, &mut *userdata.window_state_lock());
+            capture_mouse(window, &mut userdata.window_state_lock());
 
             update_modifiers(window, userdata);
 
@@ -1631,7 +1631,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Pressed, MouseButton::Middle, WindowEvent::MouseInput,
             };
 
-            capture_mouse(window, &mut *userdata.window_state_lock());
+            capture_mouse(window, &mut userdata.window_state_lock());
 
             update_modifiers(window, userdata);
 
@@ -1674,7 +1674,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
             let xbutton = super::get_xbutton_wparam(wparam as u32);
 
-            capture_mouse(window, &mut *userdata.window_state_lock());
+            capture_mouse(window, &mut userdata.window_state_lock());
 
             update_modifiers(window, userdata);
 
@@ -2155,6 +2155,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     // The direction to nudge the window in to get the window onto the monitor with
                     // the new DPI factor. We calculate this by seeing which monitor edges are
                     // shared and nudging away from the wrong monitor based on those.
+                    #[allow(clippy::bool_to_int_with_if)]
                     let delta_nudge_to_dpi_monitor = (
                         if wrong_monitor_rect.left == new_monitor_rect.right {
                             -1
@@ -2210,7 +2211,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
             let preferred_theme = userdata.window_state_lock().preferred_theme;
 
-            if preferred_theme == None {
+            if preferred_theme.is_none() {
                 let new_theme = try_theme(window, preferred_theme);
                 let mut window_state = userdata.window_state_lock();
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1116,7 +1116,7 @@ unsafe fn taskbar_mark_fullscreen(handle: HWND, fullscreen: bool) {
 
         task_bar_list2 = task_bar_list2_ptr.get();
         let mark_fullscreen_window = (*(*task_bar_list2).lpVtbl).MarkFullscreenWindow;
-        mark_fullscreen_window(task_bar_list2, handle, if fullscreen { 1 } else { 0 });
+        mark_fullscreen_window(task_bar_list2, handle, fullscreen.into());
     })
 }
 


### PR DESCRIPTION
Since the MSRV of development dependencies can easily be bumped without it affecting the MSRV of the published version of `winit`.

Done because the `image` crate now has an MSRV of 1.61: https://github.com/image-rs/image/commit/11492233cd59fc0e2701ab12cd00607e9bbf125c