### PR TITLE
On Windows, fix left mouse button release event not being sent after `Window::drag_window`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows, fix left mouse button release event not being sent after `Window::drag_window`
 - On Windows, fix icons specified on `WindowBuilder` not taking effect for windows created after the first one.
 - On Windows and macOS, add `Window::title` to query the current window title.
 - On Windows, fix focusing menubar when pressing `Alt`.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1006,9 +1006,13 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         WM_EXITSIZEMOVE => {
-            userdata
-                .window_state_lock()
-                .set_window_flags_in_place(|f| f.remove(WindowFlags::MARKER_IN_SIZE_MOVE));
+            let mut state = userdata.window_state_lock();
+            if state.dragging {
+                state.dragging = false;
+                PostMessageW(window, WM_LBUTTONUP, 0, lparam);
+            }
+
+            state.set_window_flags_in_place(|f| f.remove(WindowFlags::MARKER_IN_SIZE_MOVE));
             0
         }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -376,6 +376,9 @@ impl Window {
                 y: points.y as i16,
             };
             ReleaseCapture();
+
+            self.window_state_lock().dragging = true;
+
             PostMessageW(
                 self.hwnd(),
                 WM_NCLBUTTONDOWN,

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -51,6 +51,8 @@ pub(crate) struct WindowState {
     pub is_active: bool,
     pub is_focused: bool,
 
+    pub dragging: bool,
+
     pub skip_taskbar: bool,
 }
 
@@ -156,6 +158,8 @@ impl WindowState {
 
             is_active: false,
             is_focused: false,
+
+            dragging: false,
 
             skip_taskbar: false,
         }


### PR DESCRIPTION
This is a dupe for #2200 because I'm bad at git.
After tricking windows into thinking we are pressing on `HTCAPTION`, we would not get `WM_NCLBUTTONUP`, thus creating unexpected behavior in `winit` dependent projects (https://github.com/emilk/egui/issues/1245#issue-1134534176, https://github.com/bevyengine/bevy/issues/4394, https://github.com/tauri-apps/tauri/issues/3811)
Some debugging after it appears that `wine` have different logic that `winapi` (for context see [this](https://matrix.to/#/!DGpLzJTRzBDTwZiogk:matrix.org/$8hlJG0C6Eiorsj0suXpUr5IOXx0if1nhIfPRHoMwZI8?via=matrix.org&via=libera.chat))

With event tracing we can see that the most suitable event triggered on every drag is `WM_EXITSIZEMOVE`([docs](https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-exitsizemove)):
![image](https://user-images.githubusercontent.com/47575622/154812898-9f1b1b3b-ef6c-4e59-bdca-f2579e43a4fb.png)

- Fixes: https://github.com/rust-windowing/winit/issues/2192
