### PR TITLE
Fix value in `MouseButton::Other` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Windows, fix the value in `MouseButton::Other`.
 - On Windows, fix icons specified on `WindowBuilder` not taking effect for windows created after the first one.
 - On Windows and macOS, add `Window::title` to query the current window title.
 - On Windows, fix focusing menubar when pressing `Alt`.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -120,7 +120,7 @@ impl From<u64> for WindowId {
 
 #[inline(always)]
 const fn get_xbutton_wparam(x: u32) -> u16 {
-    loword(x)
+    hiword(x)
 }
 
 #[inline(always)]


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/2562 and probably fixes https://github.com/rust-windowing/winit/issues/2563.

This was a mistake in https://github.com/rust-windowing/winit/pull/2057.

We used `winapi`'s [`GET_XBUTTON_WPARAM`](https://docs.rs/winapi/0.3.9/src/winapi/um/winuser.rs.html#1297-1299) before which is using `HIWORD` instead of `LOWORD`.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
