### PR TITLE
macOS: Fix ApplicationDelegate::init

### DIFF
--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -20,16 +20,18 @@ declare_class!(
     }
 
     unsafe impl ApplicationDelegate {
-        #[sel(initWithActivationPolicy:defaultMenu:)]
+        #[sel(initWithActivationPolicy:defaultMenu:activateIgnoringOtherApps:)]
         fn init(
             &mut self,
             activation_policy: NSApplicationActivationPolicy,
             default_menu: bool,
+            activate_ignoring_other_apps: bool,
         ) -> Option<&mut Self> {
             let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
             this.map(|this| {
                 *this.activation_policy = activation_policy;
                 *this.default_menu = default_menu;
+                *this.activate_ignoring_other_apps = activate_ignoring_other_apps;
                 this
             })
         }


### PR DESCRIPTION
Accidentally introduced in #2551, because I forgot to actually test the thing...

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
