### PR TITLE
windows: Use strict provenace for pointer casts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,8 @@ wayland-dlopen = ["sctk/dlopen", "wayland-client/dlopen"]
 wayland-csd-adwaita = ["sctk-adwaita", "sctk-adwaita/ab_glyph"]
 wayland-csd-adwaita-crossfont = ["sctk-adwaita", "sctk-adwaita/crossfont"]
 wayland-csd-adwaita-notitle = ["sctk-adwaita"]
-android-native-activity = [ "android-activity/native-activity" ]
-android-game-activity = [ "android-activity/game-activity" ]
+android-native-activity = ["android-activity/native-activity"]
+android-game-activity = ["android-activity/game-activity"]
 
 [build-dependencies]
 cfg_aliases = "0.1.1"
@@ -102,6 +102,9 @@ features = [
     "Win32_UI_TextServices",
     "Win32_UI_WindowsAndMessaging",
 ]
+
+[target.'cfg(target_os = "windows")'.dependencies]
+sptr = "0.3.2"
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 wayland-client = { version = "0.29.4", default_features = false,  features = ["use_system_lib"], optional = true }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -95,6 +95,7 @@ use crate::{
 };
 use runner::{EventLoopRunner, EventLoopRunnerShared};
 
+use super::strict;
 use super::window::set_skip_taskbar;
 
 type GetPointerFrameInfoHistory = unsafe extern "system" fn(
@@ -438,7 +439,9 @@ fn wait_thread(parent_thread_id: u32, msg_window_id: HWND) {
             }
 
             if msg.message == *WAIT_UNTIL_MSG_ID {
-                wait_until_opt = Some(*WaitUntilInstantBox::from_raw(msg.lParam as *mut _));
+                wait_until_opt = Some(*WaitUntilInstantBox::from_raw({
+                    strict::from_exposed_addr(msg.lParam as _)
+                }));
             } else if msg.message == *CANCEL_WAIT_UNTIL_MSG_ID {
                 wait_until_opt = None;
             }
@@ -557,7 +560,12 @@ impl EventLoopThreadExecutor {
 
                 let raw = Box::into_raw(boxed2);
 
-                let res = PostMessageW(self.target_window, *EXEC_MSG_ID, raw as usize, 0);
+                let res = PostMessageW(
+                    self.target_window,
+                    *EXEC_MSG_ID,
+                    strict::expose_addr(raw),
+                    0,
+                );
                 assert!(
                     res != false.into(),
                     "PostMessage failed; is the messages queue full?"
@@ -706,7 +714,13 @@ fn insert_event_target_window_data<T>(
     };
     let input_ptr = Box::into_raw(Box::new(userdata));
 
-    unsafe { super::set_window_long(thread_msg_target, GWL_USERDATA, input_ptr as isize) };
+    unsafe {
+        super::set_window_long(
+            thread_msg_target,
+            GWL_USERDATA,
+            strict::expose_addr(input_ptr) as isize,
+        )
+    };
 
     tx
 }
@@ -792,7 +806,7 @@ unsafe fn process_control_flow<T: 'static>(runner: &EventLoopRunner<T>) {
                 runner.wait_thread_id(),
                 *WAIT_UNTIL_MSG_ID,
                 0,
-                Box::into_raw(WaitUntilInstantBox::new(until)) as isize,
+                strict::expose_addr(Box::into_raw(WaitUntilInstantBox::new(until))) as isize,
             );
         }
         ControlFlow::ExitWithCode(_) => (),
@@ -905,12 +919,12 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
 
     let userdata_ptr = match (userdata, msg) {
         (0, WM_NCCREATE) => {
-            let createstruct = &mut *(lparam as *mut CREATESTRUCTW);
+            let createstruct = &mut *(strict::invalid::<CREATESTRUCTW>(lparam as usize));
             let initdata = &mut *(createstruct.lpCreateParams as *mut InitData<'_, T>);
 
             let result = match initdata.on_nccreate(window) {
                 Some(userdata) => {
-                    super::set_window_long(window, GWL_USERDATA, userdata as _);
+                    super::set_window_long(window, GWL_USERDATA, userdata);
                     DefWindowProcW(window, msg, wparam, lparam)
                 }
                 None => -1, // failed to create the window
@@ -922,7 +936,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
         // but we'll make window creation fail here just in case.
         (0, WM_CREATE) => return -1,
         (_, WM_CREATE) => {
-            let createstruct = &mut *(lparam as *mut CREATESTRUCTW);
+            let createstruct = &mut *(strict::invalid::<CREATESTRUCTW>(lparam as usize));
             let initdata = createstruct.lpCreateParams;
             let initdata = &mut *(initdata as *mut InitData<'_, T>);
 
@@ -930,7 +944,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
             return DefWindowProcW(window, msg, wparam, lparam);
         }
         (0, _) => return DefWindowProcW(window, msg, wparam, lparam),
-        _ => userdata as *mut WindowData<T>,
+        _ => strict::from_exposed_addr::<WindowData<T>>(userdata as _),
     };
 
     let (result, userdata_removed, recurse_depth) = {
@@ -990,7 +1004,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             // ahead of the window surface. Currently, there seems no option to achieve this
             // with the Windows API.
             if window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW) {
-                let params = &mut *(lparam as *mut NCCALCSIZE_PARAMS);
+                let params = &mut *(strict::invalid::<NCCALCSIZE_PARAMS>(lparam as usize));
                 params.rgrc[0].top += 1;
                 params.rgrc[0].bottom += 1;
             }
@@ -1070,7 +1084,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         WM_WINDOWPOSCHANGING => {
             let mut window_state = userdata.window_state_lock();
             if let Some(ref mut fullscreen) = window_state.fullscreen {
-                let window_pos = &mut *(lparam as *mut WINDOWPOS);
+                let window_pos = &mut *(strict::invalid::<WINDOWPOS>(lparam as usize));
                 let new_rect = RECT {
                     left: window_pos.x,
                     top: window_pos.y,
@@ -1973,7 +1987,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         WM_GETMINMAXINFO => {
-            let mmi = lparam as *mut MINMAXINFO;
+            let mmi = strict::invalid::<MINMAXINFO>(lparam as usize);
 
             let window_state = userdata.window_state_lock();
             let window_flags = window_state.window_flags;
@@ -2031,7 +2045,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
 
             // New size as suggested by Windows.
-            let suggested_rect = *(lparam as *const RECT);
+            let suggested_rect = *(strict::invalid::<RECT>(lparam as usize));
 
             // The window rect provided is the window's outer size, not it's inner size. However,
             // win32 doesn't provide an `UnadjustWindowRectEx` function to get the client rect from
@@ -2262,7 +2276,10 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
-    let userdata_ptr = super::get_window_long(window, GWL_USERDATA) as *mut ThreadMsgTargetData<T>;
+    let userdata_ptr = strict::from_exposed_addr::<ThreadMsgTargetData<T>>(super::get_window_long(
+        window,
+        GWL_USERDATA,
+    ) as usize);
     if userdata_ptr.is_null() {
         // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE` and
         // `WM_CREATE`.
@@ -2436,7 +2453,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             0
         }
         _ if msg == *EXEC_MSG_ID => {
-            let mut function: ThreadExecFn = Box::from_raw(wparam as *mut _);
+            let mut function: ThreadExecFn = Box::from_raw(strict::from_exposed_addr(wparam as _));
             function();
             0
         }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -12,6 +12,7 @@ use windows_sys::Win32::{
     Graphics::Gdi::{RedrawWindow, RDW_INTERNALPAINT},
 };
 
+use super::strict;
 use crate::{
     dpi::PhysicalSize,
     event::{Event, StartCause, WindowEvent},
@@ -439,8 +440,10 @@ impl<T> BufferedEvent<T> {
                 });
 
                 let window_flags = unsafe {
-                    let userdata =
-                        get_window_long(window_id.0.into(), GWL_USERDATA) as *mut WindowData<T>;
+                    let userdata: *mut WindowData<T> =
+                        strict::from_exposed_addr(
+                            get_window_long(window_id.0.into(), GWL_USERDATA) as _,
+                        );
                     (*userdata).window_state_lock().window_flags
                 };
                 window_flags.set_size((window_id.0).0, new_inner_size);

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -12,7 +12,6 @@ use windows_sys::Win32::{
     Graphics::Gdi::{RedrawWindow, RDW_INTERNALPAINT},
 };
 
-use super::strict;
 use crate::{
     dpi::PhysicalSize,
     event::{Event, StartCause, WindowEvent},
@@ -440,10 +439,9 @@ impl<T> BufferedEvent<T> {
                 });
 
                 let window_flags = unsafe {
-                    let userdata: *mut WindowData<T> =
-                        strict::from_exposed_addr(
-                            get_window_long(window_id.0.into(), GWL_USERDATA) as _,
-                        );
+                    let userdata: *mut WindowData<T> = sptr::from_exposed_addr_mut(
+                        get_window_long(window_id.0.into(), GWL_USERDATA) as _,
+                    );
                     (*userdata).window_state_lock().window_flags
                 };
                 window_flags.set_size((window_id.0).0, new_inner_size);

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -170,38 +170,3 @@ mod monitor;
 mod raw_input;
 mod window;
 mod window_state;
-
-mod strict {
-    //! Strict provenance polyfill for Windows.
-    //!
-    //! Once the `strict_provenance` feature is stabilized, replace this module with functions
-    //! from the standard library.
-
-    use std::mem::transmute;
-
-    /// Get the address of a pointer.
-    pub(crate) fn addr<T>(ptr: *mut T) -> usize {
-        // SAFETY: To be replaced with the equivalent from the standard library.
-        unsafe { transmute(ptr) }
-    }
-
-    /// Expose the address of the pointer.
-    ///
-    /// The result semantically carries the provenance information of the pointer.
-    pub(crate) fn expose_addr<T>(ptr: *mut T) -> usize {
-        // SAFETY: To be replaced with the equivalent from the standard library.
-        unsafe { transmute(ptr) }
-    }
-
-    /// Create a new, invalid pointer from an address.
-    pub(crate) fn invalid<T>(addr: usize) -> *mut T {
-        // SAFETY: To be replaced with the equivalent from the standard library.
-        unsafe { transmute(addr) }
-    }
-
-    /// Create a new pointer from a previously exposed address.
-    pub(crate) fn from_exposed_addr<T>(addr: usize) -> *mut T {
-        // SAFETY: To be replaced with the equivalent from the standard library.
-        unsafe { transmute(addr) }
-    }
-}

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -170,3 +170,38 @@ mod monitor;
 mod raw_input;
 mod window;
 mod window_state;
+
+mod strict {
+    //! Strict provenance polyfill for Windows.
+    //!
+    //! Once the `strict_provenance` feature is stabilized, replace this module with functions
+    //! from the standard library.
+
+    use std::mem::transmute;
+
+    /// Get the address of a pointer.
+    pub(crate) fn addr<T>(ptr: *mut T) -> usize {
+        // SAFETY: To be replaced with the equivalent from the standard library.
+        unsafe { transmute(ptr) }
+    }
+
+    /// Expose the address of the pointer.
+    ///
+    /// The result semantically carries the provenance information of the pointer.
+    pub(crate) fn expose_addr<T>(ptr: *mut T) -> usize {
+        // SAFETY: To be replaced with the equivalent from the standard library.
+        unsafe { transmute(ptr) }
+    }
+
+    /// Create a new, invalid pointer from an address.
+    pub(crate) fn invalid<T>(addr: usize) -> *mut T {
+        // SAFETY: To be replaced with the equivalent from the standard library.
+        unsafe { transmute(addr) }
+    }
+
+    /// Create a new pointer from a previously exposed address.
+    pub(crate) fn from_exposed_addr<T>(addr: usize) -> *mut T {
+        // SAFETY: To be replaced with the equivalent from the standard library.
+        unsafe { transmute(addr) }
+    }
+}

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -9,6 +9,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
+use super::strict;
 use once_cell::sync::Lazy;
 use windows_sys::{
     core::{HRESULT, PCWSTR},
@@ -147,7 +148,8 @@ pub fn get_instance_handle() -> HINSTANCE {
         static __ImageBase: IMAGE_DOS_HEADER;
     }
 
-    unsafe { &__ImageBase as *const _ as _ }
+    strict::addr(unsafe { &__ImageBase as *const IMAGE_DOS_HEADER as *mut IMAGE_DOS_HEADER })
+        as HINSTANCE
 }
 
 impl CursorIcon {

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -9,7 +9,6 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use super::strict;
 use once_cell::sync::Lazy;
 use windows_sys::{
     core::{HRESULT, PCWSTR},
@@ -137,6 +136,8 @@ pub fn is_focused(window: HWND) -> bool {
 }
 
 pub fn get_instance_handle() -> HINSTANCE {
+    use sptr::Strict;
+
     // Gets the instance handle by taking the address of the
     // pseudo-variable created by the microsoft linker:
     // https://devblogs.microsoft.com/oldnewthing/20041025-00/?p=37483
@@ -148,7 +149,7 @@ pub fn get_instance_handle() -> HINSTANCE {
         static __ImageBase: IMAGE_DOS_HEADER;
     }
 
-    strict::addr(unsafe { &__ImageBase as *const IMAGE_DOS_HEADER as *mut IMAGE_DOS_HEADER })
+    Strict::addr(unsafe { &__ImageBase as *const IMAGE_DOS_HEADER as *mut IMAGE_DOS_HEADER })
         as HINSTANCE
 }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Rust is planning on phasing out ptr-to-usize and usize-to-ptr conversions in the future, and only allowing them through methods that explicitly preserve provenance. See rust-lang/rust#95228 for more information. As these kinds of casts are most prevalent in the Windows implementation of `winit`, I've implemented this there.

I'm not too familiar with this codebase, so please tell me if there's anything I've missed.