### PR TITLE
Release version 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Removed `WindowBuilderExtWindows::with_theme` and `WindowBuilderExtWayland::with_wayland_csd_theme` in favour of `WindowBuilder::with_theme`.
 - **Breaking:** Removed `WindowExtWindows::theme` in favour of `Window::theme`.
 - Enabled `doc_auto_cfg` when generating docs on docs.rs for feature labels.
-- **Breaking:** On Android, switched to using [`android-activity`](https://github.com/rib/android-activity) crate as a glue layer instead of [`ndk-glue](https://github.com/rust-windowing/android-ndk-rs/tree/master/ndk-glue). See [README.md#Android](https://github.com/rust-windowing/winit#Android) for more details. ([#2444](https://github.com/rust-windowing/winit/pull/2444))
+- **Breaking:** On Android, switched to using [`android-activity`](https://github.com/rib/android-activity) crate as a glue layer instead of [`ndk-glue`](https://github.com/rust-windowing/android-ndk-rs/tree/master/ndk-glue). See [README.md#Android](https://github.com/rust-windowing/winit#Android) for more details. ([#2444](https://github.com/rust-windowing/winit/pull/2444))
 
 # 0.27.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+# 0.28.0
+
 - On Windows, retain `WS_MAXIMIZE` window style when un-minimizing a maximized window.
 - On Windows, fix left mouse button release event not being sent after `Window::drag_window`.
 - On macOS, run most actions on the main thread, which is strictly more correct, but might make multithreaded applications block slightly more.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.27.5"
+version = "0.28.0"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-winit = "0.27.5"
+winit = "0.28.0"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
The changelog is getting larger, and it was indirectly requested in https://github.com/rust-windowing/winit/pull/2157#issuecomment-1360370469 that we do a new release soon; so let's start the discussion of what that would entail.

See also [the milestone](https://github.com/rust-windowing/winit/milestone/8).

Tagging major library consumers, to ask what their timelines on releases are (so that we can somewhat coordinate on them, like, if you're planning a release on a specific date, we could try to release 0.28 shortly before that) (do tell me if I should tag someone else too in the future):
- `bevy`: @alice-i-cecile, @cart
- `egui`/`eframe`: @emilk
- `iced`: @hecrj
- `ggez`: @PSteinhaus
