### PR TITLE
feat(event loop): Add a function to ControlFlow for waiting on a Duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** On Android, switched to using [`android-activity`](https://github.com/rib/android-activity) crate as a glue layer instead of [`ndk-glue`](https://github.com/rust-windowing/android-ndk-rs/tree/master/ndk-glue). See [README.md#Android](https://github.com/rust-windowing/winit#Android) for more details. ([#2444](https://github.com/rust-windowing/winit/pull/2444))
 - **Breaking:** Removed support for `raw-window-handle` version `0.4`
 - On Wayland, `RedrawRequested` not emitted during resize.
+- Add a `set_wait_timeout` function to `ControlFlow` to allow waiting for a `Duration`.
 - **Breaking:** Remove the unstable `xlib_xconnection()` function from the private interface.
 - Added Orbital support for Redox OS
 - On X11, added `drag_resize_window` method.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -11,7 +11,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::{error, fmt};
 
-use instant::Instant;
+use instant::{Duration, Instant};
 use once_cell::sync::OnceCell;
 use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
 
@@ -163,8 +163,10 @@ pub enum ControlFlow {
     ///   example when the scaling of the page has changed. This should be treated as an implementation
     ///   detail which should not be relied on.
     Poll,
+
     /// When the current loop iteration finishes, suspend the thread until another event arrives.
     Wait,
+
     /// When the current loop iteration finishes, suspend the thread until either another event
     /// arrives or the given time is reached.
     ///
@@ -174,6 +176,7 @@ pub enum ControlFlow {
     ///
     /// [`Poll`]: Self::Poll
     WaitUntil(Instant),
+
     /// Send a [`LoopDestroyed`] event and stop the event loop. This variant is *sticky* - once set,
     /// `control_flow` cannot be changed from `ExitWithCode`, and any future attempts to do so will
     /// result in the `control_flow` parameter being reset to `ExitWithCode`.
@@ -219,6 +222,20 @@ impl ControlFlow {
     /// [`WaitUntil`]: Self::WaitUntil
     pub fn set_wait_until(&mut self, instant: Instant) {
         *self = Self::WaitUntil(instant);
+    }
+
+    /// Sets this to wait until a timeout has expired.
+    ///
+    /// In most cases, this is set to [`WaitUntil`]. However, if the timeout overflows, it is
+    /// instead set to [`Wait`].
+    ///
+    /// [`WaitUntil`]: Self::WaitUntil
+    /// [`Wait`]: Self::Wait
+    pub fn set_wait_timeout(&mut self, timeout: Duration) {
+        match Instant::now().checked_add(timeout) {
+            Some(instant) => self.set_wait_until(instant),
+            None => self.set_wait(),
+        }
     }
 
     /// Sets this to [`ExitWithCode`]`(code)`.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR adds a `set_wait_timeout` function to compliment the `set_wait_until` function on `EventLoop`. It basically just adds the timeout to `Instant::now()` and uses that in `set_wait_until`.