### PR TITLE
Add `Window::set_transparent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Remove the unstable `xlib_xconnection()` function from the private interface.
 - Added Orbital support for Redox OS
 - On X11, added `drag_resize_window` method.
+- Added `Window::set_transparent` to provide a hint about transparency of the window on Wayland and macOS.
 
 # 0.27.5
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -947,6 +947,8 @@ impl Window {
 
     pub fn set_title(&self, _title: &str) {}
 
+    pub fn set_transparent(&self, _transparent: bool) {}
+
     pub fn set_visible(&self, _visibility: bool) {}
 
     pub fn is_visible(&self) -> Option<bool> {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -43,6 +43,10 @@ impl Inner {
         debug!("`Window::set_title` is ignored on iOS")
     }
 
+    pub fn set_transparent(&self, _transparent: bool) {
+        debug!("`Window::set_transparent` is ignored on iOS")
+    }
+
     pub fn set_visible(&self, visible: bool) {
         self.window.setHidden(!visible)
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -325,6 +325,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_transparent(&self, transparent: bool) {
+        x11_or_wayland!(match self; Window(w) => w.set_transparent(transparent));
+    }
+
+    #[inline]
     pub fn set_visible(&self, visible: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_visible(visible))
     }

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -431,6 +431,9 @@ impl<T: 'static> EventLoop<T> {
                         window_handle.window.resize(size.width, size.height);
                         window_handle.window.refresh();
 
+                        // Update the opaque region.
+                        window_handle.set_transparent(window_handle.transparent.get());
+
                         // Mark that refresh isn't required, since we've done it right now.
                         state
                             .window_user_requests

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -261,6 +261,9 @@ impl Window {
             window_requests.clone(),
         );
 
+        // Set opaque region.
+        window_handle.set_transparent(attributes.transparent);
+
         // Set resizable state, so we can determine how to handle `Window::set_inner_size`.
         window_handle.is_resizable.set(attributes.resizable);
 
@@ -330,6 +333,11 @@ impl Window {
     #[inline]
     pub fn set_title(&self, title: &str) {
         self.send_request(WindowRequest::Title(title.to_owned()));
+    }
+
+    #[inline]
+    pub fn set_transparent(&self, transparent: bool) {
+        self.send_request(WindowRequest::Transparent(transparent));
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -903,6 +903,9 @@ impl UnownedWindow {
             .expect("Failed to set window title");
     }
 
+    #[inline]
+    pub fn set_transparent(&self, _transparent: bool) {}
+
     fn set_decorations_inner(&self, decorations: bool) -> util::Flusher<'_> {
         self.shared_state_lock().is_decorated = decorations;
         let mut hints = self.xconn.get_motif_hints(self.xwindow);

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -506,6 +506,10 @@ impl WinitWindow {
         util::set_title_sync(self, title);
     }
 
+    pub fn set_transparent(&self, transparent: bool) {
+        self.setOpaque(!transparent)
+    }
+
     pub fn set_visible(&self, visible: bool) {
         match visible {
             true => util::make_key_and_order_front_sync(self),

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -241,6 +241,9 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_transparent(&self, _transparent: bool) {}
+
+    #[inline]
     pub fn set_visible(&self, _visibility: bool) {}
 
     #[inline]

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -87,6 +87,8 @@ impl Window {
         self.canvas.borrow().set_attribute("alt", title);
     }
 
+    pub fn set_transparent(&self, _transparent: bool) {}
+
     pub fn set_visible(&self, _visible: bool) {
         // Intentionally a no-op
     }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -113,6 +113,8 @@ impl Window {
         }
     }
 
+    pub fn set_transparent(&self, _transparent: bool) {}
+
     #[inline]
     pub fn set_visible(&self, visible: bool) {
         let window = self.window.clone();

--- a/src/window.rs
+++ b/src/window.rs
@@ -306,7 +306,9 @@ impl WindowBuilder {
     /// Sets whether the background of the window should be transparent.
     ///
     /// If this is `true`, writing colors with alpha values different than
-    /// `1.0` will produce a transparent window.
+    /// `1.0` will produce a transparent window. On some platforms this
+    /// is more of a hint for the system and you'd still have the alpha
+    /// buffer. To control it see [`Window::set_transparent`].
     ///
     /// The default is `false`.
     #[inline]
@@ -733,6 +735,23 @@ impl Window {
     #[inline]
     pub fn set_title(&self, title: &str) {
         self.window.set_title(title)
+    }
+
+    /// Change the window transparency state.
+    ///
+    /// This is just a hint that may not change anything about
+    /// the window transparency, however doing a missmatch between
+    /// the content of your window and this hint may result in
+    /// visual artifacts.
+    ///
+    /// The default value follows the [`WindowBuilder::with_transparent`].
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Windows / X11 / Web / iOS / Android:** Unsupported.
+    #[inline]
+    pub fn set_transparent(&self, transparent: bool) {
+        self.window.set_transparent(transparent)
     }
 
     /// Modifies the window's visibility.

--- a/src/window.rs
+++ b/src/window.rs
@@ -748,7 +748,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **Windows / X11 / Web / iOS / Android:** Unsupported.
+    /// - **Windows / X11 / Web / iOS / Android / Orbital:** Unsupported.
     #[inline]
     pub fn set_transparent(&self, transparent: bool) {
         self.window.set_transparent(transparent)


### PR DESCRIPTION
Provide a hint to system compositor whether the window is opaque or not. Only implemented on macOS and Wayland for now.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

