### PR TITLE
Allow introspection of WindowBuilder default values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On macOS, fix the mouse buttons other than left/right/middle being reported as middle.
 - On Wayland, support fractional scaling via the wp-fractional-scale protocol.
 - On web, fix removal of mouse event listeners from the global object upon window distruction.
+- Add WindowAttributes getter to WindowBuilder to allow introspection of default values.
 
 # 0.27.5
 

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -455,7 +455,7 @@ impl WinitUIWindow {
 
         this.setRootViewController(Some(view_controller));
 
-        match window_attributes.fullscreen {
+        match window_attributes.fullscreen.clone().map(Into::into) {
             Some(Fullscreen::Exclusive(ref video_mode)) => {
                 let monitor = video_mode.monitor();
                 let screen = monitor.ui_screen();

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -416,7 +416,8 @@ impl Window {
         // TODO: transparency, visible
 
         let main_screen = UIScreen::main(mtm);
-        let screen = match window_attributes.fullscreen {
+        let fullscreen = window_attributes.fullscreen.clone().map(Into::into);
+        let screen = match fullscreen {
             Some(Fullscreen::Exclusive(ref video_mode)) => video_mode.monitor.ui_screen(),
             Some(Fullscreen::Borderless(Some(ref monitor))) => monitor.ui_screen(),
             Some(Fullscreen::Borderless(None)) | None => &main_screen,

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -240,7 +240,7 @@ impl Window {
         window.set_title(attributes.title);
 
         // Set fullscreen/maximized if so was requested.
-        match attributes.fullscreen {
+        match attributes.fullscreen.map(Into::into) {
             Some(Fullscreen::Exclusive(_)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland")
             }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -484,7 +484,8 @@ impl UnownedWindow {
                 window.set_maximized_inner(window_attrs.maximized).queue();
             }
             if window_attrs.fullscreen.is_some() {
-                if let Some(flusher) = window.set_fullscreen_inner(window_attrs.fullscreen.clone())
+                if let Some(flusher) =
+                    window.set_fullscreen_inner(window_attrs.fullscreen.clone().map(Into::into))
                 {
                     flusher.queue()
                 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -217,7 +217,7 @@ impl WinitWindow {
         }
 
         let this = autoreleasepool(|_| {
-            let screen = match &attrs.fullscreen {
+            let screen = match attrs.fullscreen.clone().map(Into::into) {
                 Some(Fullscreen::Borderless(Some(monitor)))
                 | Some(Fullscreen::Exclusive(VideoMode { monitor, .. })) => {
                     monitor.ns_screen().or_else(NSScreen::main)
@@ -459,7 +459,7 @@ impl WinitWindow {
         let delegate = WinitWindowDelegate::new(&this, attrs.fullscreen.is_some());
 
         // Set fullscreen mode after we setup everything
-        this.set_fullscreen(attrs.fullscreen);
+        this.set_fullscreen(attrs.fullscreen.map(Into::into));
 
         // Setting the window as key has to happen *after* we set the fullscreen
         // state, since otherwise we'll briefly see the window at normal size

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1011,7 +1011,7 @@ impl<'a, T: 'static> InitData<'a, T> {
         win.set_enabled_buttons(attributes.enabled_buttons);
 
         if attributes.fullscreen.is_some() {
-            win.set_fullscreen(attributes.fullscreen);
+            win.set_fullscreen(attributes.fullscreen.map(Into::into));
             force_window_active(win.window.0);
         } else {
             let size = attributes

--- a/src/window.rs
+++ b/src/window.rs
@@ -120,7 +120,7 @@ impl fmt::Debug for WindowBuilder {
 
 /// Attributes to use when creating a window.
 #[derive(Debug, Clone)]
-pub(crate) struct WindowAttributes {
+pub struct WindowAttributes {
     pub inner_size: Option<Size>,
     pub min_inner_size: Option<Size>,
     pub max_inner_size: Option<Size>,
@@ -128,7 +128,7 @@ pub(crate) struct WindowAttributes {
     pub resizable: bool,
     pub enabled_buttons: WindowButtons,
     pub title: String,
-    pub fullscreen: Option<platform_impl::Fullscreen>,
+    pub fullscreen: Option<Fullscreen>,
     pub maximized: bool,
     pub visible: bool,
     pub transparent: bool,
@@ -174,6 +174,11 @@ impl WindowBuilder {
     #[inline]
     pub fn new() -> Self {
         Default::default()
+    }
+
+    /// Get the current window attributes.
+    pub fn window_attributes(&self) -> &WindowAttributes {
+        &self.window
     }
 
     /// Requests the window to be of specific dimensions.
@@ -279,7 +284,7 @@ impl WindowBuilder {
     /// See [`Window::set_fullscreen`] for details.
     #[inline]
     pub fn with_fullscreen(mut self, fullscreen: Option<Fullscreen>) -> Self {
-        self.window.fullscreen = fullscreen.map(|f| f.into());
+        self.window.fullscreen = fullscreen;
         self
     }
 


### PR DESCRIPTION
Makes WindowAttributes public and add window_attributes() getter to WindowBuilder.

In version 0.27, the WindowAttributes struct was made private, but this removed the ability to introspect the default WindowBuilder values.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
