### PR TITLE
m: Remove xlib_xconnection from public interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** On Android, switched to using [`android-activity`](https://github.com/rib/android-activity) crate as a glue layer instead of [`ndk-glue`](https://github.com/rust-windowing/android-ndk-rs/tree/master/ndk-glue). See [README.md#Android](https://github.com/rust-windowing/winit#Android) for more details. ([#2444](https://github.com/rust-windowing/winit/pull/2444))
 - **Breaking:** Removed support for `raw-window-handle` version `0.4`
 - On Wayland, `RedrawRequested` not emitted during resize.
+- **Breaking:** Remove the unstable `xlib_xconnection()` function from the private interface.
 
 # 0.27.5
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -116,7 +116,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
 }
 
 #[cfg(x11_platform)]
-pub static X11_BACKEND: Lazy<Mutex<Result<Arc<XConnection>, XNotSupported>>> =
+pub(crate) static X11_BACKEND: Lazy<Mutex<Result<Arc<XConnection>, XNotSupported>>> =
     Lazy::new(|| Mutex::new(XConnection::new(Some(x_error_callback)).map(Arc::new)));
 
 #[derive(Debug, Clone)]
@@ -142,7 +142,7 @@ impl fmt::Display for OsError {
     }
 }
 
-pub enum Window {
+pub(crate) enum Window {
     #[cfg(x11_platform)]
     X(x11::Window),
     #[cfg(wayland_platform)]

--- a/src/platform_impl/linux/x11/dnd.rs
+++ b/src/platform_impl/linux/x11/dnd.rs
@@ -11,8 +11,7 @@ use percent_encoding::percent_decode;
 use super::{ffi, util, XConnection, XError};
 
 #[derive(Debug)]
-pub struct DndAtoms {
-    pub aware: ffi::Atom,
+pub(crate) struct DndAtoms {
     pub enter: ffi::Atom,
     pub leave: ffi::Atom,
     pub drop: ffi::Atom,
@@ -29,7 +28,6 @@ pub struct DndAtoms {
 impl DndAtoms {
     pub fn new(xconn: &Arc<XConnection>) -> Result<Self, XError> {
         let names = [
-            b"XdndAware\0".as_ptr() as *mut c_char,
             b"XdndEnter\0".as_ptr() as *mut c_char,
             b"XdndLeave\0".as_ptr() as *mut c_char,
             b"XdndDrop\0".as_ptr() as *mut c_char,
@@ -44,18 +42,17 @@ impl DndAtoms {
         ];
         let atoms = unsafe { xconn.get_atoms(&names) }?;
         Ok(DndAtoms {
-            aware: atoms[0],
-            enter: atoms[1],
-            leave: atoms[2],
-            drop: atoms[3],
-            position: atoms[4],
-            status: atoms[5],
-            action_private: atoms[6],
-            selection: atoms[7],
-            finished: atoms[8],
-            type_list: atoms[9],
-            uri_list: atoms[10],
-            none: atoms[11],
+            enter: atoms[0],
+            leave: atoms[1],
+            drop: atoms[2],
+            position: atoms[3],
+            status: atoms[4],
+            action_private: atoms[5],
+            selection: atoms[6],
+            finished: atoms[7],
+            type_list: atoms[8],
+            uri_list: atoms[9],
+            none: atoms[10],
         })
     }
 }
@@ -87,7 +84,7 @@ impl From<io::Error> for DndDataParseError {
     }
 }
 
-pub struct Dnd {
+pub(crate) struct Dnd {
     xconn: Arc<XConnection>,
     pub atoms: DndAtoms,
     // Populated by XdndEnter event handler

--- a/src/platform_impl/linux/x11/ime/callbacks.rs
+++ b/src/platform_impl/linux/x11/ime/callbacks.rs
@@ -8,7 +8,7 @@ use super::{
     input_method::PotentialInputMethods,
 };
 
-pub unsafe fn xim_set_callback(
+pub(crate) unsafe fn xim_set_callback(
     xconn: &Arc<XConnection>,
     xim: ffi::XIM,
     field: *const c_char,
@@ -26,7 +26,7 @@ pub unsafe fn xim_set_callback(
 // * This is called per locale modifier, not per input method opened with that locale modifier.
 // * Trying to set this for multiple locale modifiers causes problems, i.e. one of the rebuilt
 //   input contexts would always silently fail to use the input method.
-pub unsafe fn set_instantiate_callback(
+pub(crate) unsafe fn set_instantiate_callback(
     xconn: &Arc<XConnection>,
     client_data: ffi::XPointer,
 ) -> Result<(), XError> {
@@ -41,7 +41,7 @@ pub unsafe fn set_instantiate_callback(
     xconn.check_errors()
 }
 
-pub unsafe fn unset_instantiate_callback(
+pub(crate) unsafe fn unset_instantiate_callback(
     xconn: &Arc<XConnection>,
     client_data: ffi::XPointer,
 ) -> Result<(), XError> {
@@ -56,7 +56,7 @@ pub unsafe fn unset_instantiate_callback(
     xconn.check_errors()
 }
 
-pub unsafe fn set_destroy_callback(
+pub(crate) unsafe fn set_destroy_callback(
     xconn: &Arc<XConnection>,
     im: ffi::XIM,
     inner: &ImeInner,

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -201,7 +201,7 @@ pub struct ImeContext {
 }
 
 impl ImeContext {
-    pub unsafe fn new(
+    pub(crate) unsafe fn new(
         xconn: &Arc<XConnection>,
         im: ffi::XIM,
         style: Style,
@@ -323,14 +323,14 @@ impl ImeContext {
         (!ic.is_null()).then(|| ic)
     }
 
-    pub fn focus(&self, xconn: &Arc<XConnection>) -> Result<(), XError> {
+    pub(crate) fn focus(&self, xconn: &Arc<XConnection>) -> Result<(), XError> {
         unsafe {
             (xconn.xlib.XSetICFocus)(self.ic);
         }
         xconn.check_errors()
     }
 
-    pub fn unfocus(&self, xconn: &Arc<XConnection>) -> Result<(), XError> {
+    pub(crate) fn unfocus(&self, xconn: &Arc<XConnection>) -> Result<(), XError> {
         unsafe {
             (xconn.xlib.XUnsetICFocus)(self.ic);
         }
@@ -346,7 +346,7 @@ impl ImeContext {
     // window and couldn't be changed.
     //
     // For me see: https://bugs.freedesktop.org/show_bug.cgi?id=1580.
-    pub fn set_spot(&mut self, xconn: &Arc<XConnection>, x: c_short, y: c_short) {
+    pub(crate) fn set_spot(&mut self, xconn: &Arc<XConnection>, x: c_short, y: c_short) {
         if !self.is_allowed() || self.ic_spot.x == x && self.ic_spot.y == y {
             return;
         }

--- a/src/platform_impl/linux/x11/ime/inner.rs
+++ b/src/platform_impl/linux/x11/ime/inner.rs
@@ -8,17 +8,17 @@ use super::{
 };
 use crate::platform_impl::platform::x11::ime::ImeEventSender;
 
-pub unsafe fn close_im(xconn: &Arc<XConnection>, im: ffi::XIM) -> Result<(), XError> {
+pub(crate) unsafe fn close_im(xconn: &Arc<XConnection>, im: ffi::XIM) -> Result<(), XError> {
     (xconn.xlib.XCloseIM)(im);
     xconn.check_errors()
 }
 
-pub unsafe fn destroy_ic(xconn: &Arc<XConnection>, ic: ffi::XIC) -> Result<(), XError> {
+pub(crate) unsafe fn destroy_ic(xconn: &Arc<XConnection>, ic: ffi::XIC) -> Result<(), XError> {
     (xconn.xlib.XDestroyIC)(ic);
     xconn.check_errors()
 }
 
-pub struct ImeInner {
+pub(crate) struct ImeInner {
     pub xconn: Arc<XConnection>,
     pub im: Option<InputMethod>,
     pub potential_input_methods: PotentialInputMethods,
@@ -33,7 +33,7 @@ pub struct ImeInner {
 }
 
 impl ImeInner {
-    pub fn new(
+    pub(crate) fn new(
         xconn: Arc<XConnection>,
         potential_input_methods: PotentialInputMethods,
         event_sender: ImeEventSender,

--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -263,7 +263,7 @@ impl PotentialInputMethod {
 // By logging this struct, you get a sequential listing of every locale modifier tried, where it
 // came from, and if it succeeded.
 #[derive(Debug, Clone)]
-pub struct PotentialInputMethods {
+pub(crate) struct PotentialInputMethods {
     // On correctly configured systems, the XMODIFIERS environment variable tells us everything we
     // need to know.
     xmodifiers: Option<PotentialInputMethod>,

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -45,13 +45,13 @@ pub enum ImeRequest {
 }
 
 #[derive(Debug)]
-pub enum ImeCreationError {
+pub(crate) enum ImeCreationError {
     // Boxed to prevent large error type
     OpenFailure(Box<PotentialInputMethods>),
     SetDestroyCallbackFailed(XError),
 }
 
-pub struct Ime {
+pub(crate) struct Ime {
     xconn: Arc<XConnection>,
     // The actual meat of this struct is boxed away, since it needs to have a fixed location in
     // memory so we can pass a pointer to it around.

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -10,11 +10,13 @@ pub mod util;
 mod window;
 mod xdisplay;
 
-pub use self::{
+pub(crate) use self::{
     monitor::{MonitorHandle, VideoMode},
     window::UnownedWindow,
-    xdisplay::{XConnection, XError, XNotSupported},
+    xdisplay::XConnection,
 };
+
+pub use self::xdisplay::{XError, XNotSupported};
 
 use std::{
     cell::{Cell, RefCell},
@@ -135,7 +137,7 @@ impl<T: 'static> Clone for EventLoopProxy<T> {
 }
 
 impl<T: 'static> EventLoop<T> {
-    pub fn new(xconn: Arc<XConnection>) -> EventLoop<T> {
+    pub(crate) fn new(xconn: Arc<XConnection>) -> EventLoop<T> {
         let root = unsafe { (xconn.xlib.XDefaultRootWindow)(xconn.display) };
 
         let wm_delete_window = unsafe { xconn.get_atom_unchecked(b"WM_DELETE_WINDOW\0") };
@@ -538,7 +540,7 @@ pub(crate) fn get_xtarget<T>(target: &RootELW<T>) -> &EventLoopWindowTarget<T> {
 impl<T> EventLoopWindowTarget<T> {
     /// Returns the `XConnection` of this events loop.
     #[inline]
-    pub fn x_connection(&self) -> &Arc<XConnection> {
+    pub(crate) fn x_connection(&self) -> &Arc<XConnection> {
         &self.xconn
     }
 
@@ -627,12 +629,13 @@ impl<'a> Deref for DeviceInfo<'a> {
 pub struct DeviceId(c_int);
 
 impl DeviceId {
+    #[allow(unused)]
     pub const unsafe fn dummy() -> Self {
         DeviceId(0)
     }
 }
 
-pub struct Window(Arc<UnownedWindow>);
+pub(crate) struct Window(Arc<UnownedWindow>);
 
 impl Deref for Window {
     type Target = UnownedWindow;

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -185,7 +185,7 @@ impl MwmHints {
     }
 }
 
-pub struct NormalHints<'a> {
+pub(crate) struct NormalHints<'a> {
     size_hints: XSmartPointer<'a, ffi::XSizeHints>,
 }
 
@@ -194,11 +194,6 @@ impl<'a> NormalHints<'a> {
         NormalHints {
             size_hints: xconn.alloc_size_hints(),
         }
-    }
-
-    pub fn get_position(&self) -> Option<(i32, i32)> {
-        has_flag(self.size_hints.flags, ffi::PPosition)
-            .then(|| (self.size_hints.x, self.size_hints.y))
     }
 
     pub fn get_resize_increments(&self) -> Option<(u32, u32)> {

--- a/src/platform_impl/linux/x11/util/memory.rs
+++ b/src/platform_impl/linux/x11/util/memory.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use super::*;
 
-pub struct XSmartPointer<'a, T> {
+pub(crate) struct XSmartPointer<'a, T> {
     xconn: &'a XConnection,
     pub ptr: *mut T,
 }

--- a/src/platform_impl/linux/x11/util/mod.rs
+++ b/src/platform_impl/linux/x11/util/mod.rs
@@ -17,9 +17,11 @@ mod window_property;
 mod wm;
 
 pub use self::{
-    atom::*, client_msg::*, format::*, geometry::*, hint::*, icon::*, input::*, memory::*,
-    randr::*, window_property::*, wm::*,
+    atom::*, client_msg::*, format::*, geometry::*, hint::*, icon::*, input::*, randr::*,
+    window_property::*, wm::*,
 };
+
+pub(crate) use self::memory::*;
 
 use std::{
     mem::{self, MaybeUninit},
@@ -48,7 +50,7 @@ where
 }
 
 #[must_use = "This request was made asynchronously, and is still in the output buffer. You must explicitly choose to either `.flush()` (empty the output buffer, sending the request now) or `.queue()` (wait to send the request, allowing you to continue to add more requests without additional round-trips). For more information, see the documentation for `util::flush_requests`."]
-pub struct Flusher<'a> {
+pub(crate) struct Flusher<'a> {
     xconn: &'a XConnection,
 }
 

--- a/src/platform_impl/linux/x11/util/modifiers.rs
+++ b/src/platform_impl/linux/x11/util/modifiers.rs
@@ -26,13 +26,13 @@ pub enum Modifier {
 }
 
 #[derive(Debug, Default)]
-pub struct ModifierKeymap {
+pub(crate) struct ModifierKeymap {
     // Maps keycodes to modifiers
     keys: HashMap<ffi::KeyCode, Modifier>,
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct ModifierKeyState {
+pub(crate) struct ModifierKeyState {
     // Contains currently pressed modifier keys and their corresponding modifiers
     keys: HashMap<ffi::KeyCode, Modifier>,
     state: ModifiersState,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -101,11 +101,11 @@ impl SharedState {
 unsafe impl Send for UnownedWindow {}
 unsafe impl Sync for UnownedWindow {}
 
-pub struct UnownedWindow {
-    pub xconn: Arc<XConnection>, // never changes
-    xwindow: ffi::Window,        // never changes
-    root: ffi::Window,           // never changes
-    screen_id: i32,              // never changes
+pub(crate) struct UnownedWindow {
+    pub(crate) xconn: Arc<XConnection>, // never changes
+    xwindow: ffi::Window,               // never changes
+    root: ffi::Window,                  // never changes
+    screen_id: i32,                     // never changes
     cursor: Mutex<CursorIcon>,
     cursor_grabbed_mode: Mutex<CursorGrabMode>,
     #[allow(clippy::mutex_atomic)]
@@ -1297,11 +1297,6 @@ impl UnownedWindow {
     #[inline]
     pub fn xlib_screen_id(&self) -> c_int {
         self.screen_id
-    }
-
-    #[inline]
-    pub fn xlib_xconnection(&self) -> Arc<XConnection> {
-        Arc::clone(&self.xconn)
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -5,16 +5,13 @@ use crate::window::CursorIcon;
 use super::ffi;
 
 /// A connection to an X server.
-pub struct XConnection {
+pub(crate) struct XConnection {
     pub xlib: ffi::Xlib,
     /// Exposes XRandR functions from version < 1.5
     pub xrandr: ffi::Xrandr_2_2_0,
-    /// Exposes XRandR functions from version = 1.5
-    pub xrandr_1_5: Option<ffi::Xrandr>,
     pub xcursor: ffi::Xcursor,
     pub xinput2: ffi::XInput2,
     pub xlib_xcb: ffi::Xlib_xcb,
-    pub xrender: ffi::Xrender,
     pub display: *mut ffi::Display,
     pub x11_fd: c_int,
     pub latest_error: Mutex<Option<XError>>,
@@ -33,10 +30,8 @@ impl XConnection {
         let xlib = ffi::Xlib::open()?;
         let xcursor = ffi::Xcursor::open()?;
         let xrandr = ffi::Xrandr_2_2_0::open()?;
-        let xrandr_1_5 = ffi::Xrandr::open().ok();
         let xinput2 = ffi::XInput2::open()?;
         let xlib_xcb = ffi::Xlib_xcb::open()?;
-        let xrender = ffi::Xrender::open()?;
 
         unsafe { (xlib.XInitThreads)() };
         unsafe { (xlib.XSetErrorHandler)(error_handler) };
@@ -56,11 +51,9 @@ impl XConnection {
         Ok(XConnection {
             xlib,
             xrandr,
-            xrandr_1_5,
             xcursor,
             xinput2,
             xlib_xcb,
-            xrender,
             display,
             x11_fd: fd,
             latest_error: Mutex::new(None),
@@ -77,12 +70,6 @@ impl XConnection {
         } else {
             Ok(())
         }
-    }
-
-    /// Ignores any previous error.
-    #[inline]
-    pub fn ignore_error(&self) {
-        *self.latest_error.lock().unwrap() = None;
     }
 }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR removes the `xlib_xconnection()` function from the `platform::x11` module. This was previously used by `glutin`, but is not used anymore. Removing this lets me make some types in the `platform_impl::x11` module `pub(crate)`, which makes it easier to identify what's being used and what isn't.