### PR TITLE
bugfix: Ensure all free unixes can build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ features = [
     "Win32_UI_WindowsAndMessaging",
 ]
 
-[target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
+[target.'cfg(all(unix, not(any(target_os = "redox", target_arch = "wasm32", target_os = "android", target_os = "ios", target_os = "macos"))))'.dependencies]
 libc = "0.2.64"
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 percent-encoding = { version = "2.0", optional = true }


### PR DESCRIPTION
- [ ] Tested on all platforms changed (I only noticed this when trying to build on illumos, I'm not sure what else is affected).
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

#2586 added `cfg` aliases, but these aliases don't match up with the `Cargo.toml` configuration, especially when it comes to `free_unix`. This PR aligns the `Cargo.toml` configuration with `build.rs`.