### PR TITLE
iOS: fix accidentally flipped assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
-- On iOS, fix accidentally flipped assertion in `EventLoop::run` to ensure `UIApplication` shared singleton must not exist already.
 - **Breaking:** On Web, touch input no longer fires `WindowEvent::Cursor*`, `WindowEvent::MouseInput`, or `DeviceEvent::MouseMotion` like other platforms, but instead it fires `WindowEvent::Touch`.
 - **Breaking:** Removed platform specific `WindowBuilder::with_parent` API in favor of `WindowBuilder::with_parent_window`.
 - On Windows, retain `WS_MAXIMIZE` window style when un-minimizing a maximized window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On iOS, fix accidentally flipped assertion in `EventLoop::run` to ensure `UIApplication` shared singleton must not exist already.
 - **Breaking:** On Web, touch input no longer fires `WindowEvent::Cursor*`, `WindowEvent::MouseInput`, or `DeviceEvent::MouseMotion` like other platforms, but instead it fires `WindowEvent::Touch`.
 - **Breaking:** Removed platform specific `WindowBuilder::with_parent` API in favor of `WindowBuilder::with_parent_window`.
 - On Windows, retain `WS_MAXIMIZE` window style when un-minimizing a maximized window.

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -114,7 +114,9 @@ impl<T: 'static> EventLoop<T> {
         F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         unsafe {
-            let _application = UIApplication::shared(MainThreadMarker::new().unwrap()).expect(
+            let application = UIApplication::shared(MainThreadMarker::new().unwrap());
+            assert!(
+                application.is_none(),
                 "\
                 `EventLoop` cannot be `run` after a call to `UIApplicationMain` on iOS\n\
                  Note: `EventLoop::run` calls `UIApplicationMain` on iOS",


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] [N/A] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] [N/A] Created or updated an example program if it would help users understand this functionality
- [ ] [N/A] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Commit `ee88e38f` introduced changes to add safe abstraction over UIApplication (among other objc types). However, the assertion that the `UIApplication` shared instance should be `null` got accidentally flipped (was comparing the shared instance to null, became checking that shared instance is `Some`). This broke `winit` based iOS apps.

This PR reverses that assertion and make `winit` based iOS apps run again.