### PR TITLE
Properly remove window mouse event listeners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Remove the unstable `xlib_xconnection()` function from the private interface.
 - Added Orbital support for Redox OS
 - On X11, added `drag_resize_window` method.
+- On web, fix removal of mouse event listeners from the global object upon window distruction.
 
 # 0.27.5
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,6 +129,7 @@ features = [
     'DomRect',
     'Element',
     'Event',
+    "EventListenerOptions",
     'EventTarget',
     'FocusEvent',
     'HtmlCanvasElement',

--- a/src/platform_impl/web/web_sys/event_handle.rs
+++ b/src/platform_impl/web/web_sys/event_handle.rs
@@ -1,10 +1,11 @@
 use wasm_bindgen::{prelude::Closure, JsCast};
-use web_sys::{AddEventListenerOptions, EventTarget};
+use web_sys::{AddEventListenerOptions, EventListenerOptions, EventTarget};
 
 pub(super) struct EventListenerHandle<T: ?Sized> {
     target: EventTarget,
     event_type: &'static str,
     listener: Closure<T>,
+    options: EventListenerOptions
 }
 
 impl<T: ?Sized> EventListenerHandle<T> {
@@ -20,6 +21,7 @@ impl<T: ?Sized> EventListenerHandle<T> {
             target,
             event_type,
             listener,
+            options: EventListenerOptions::new()
         }
     }
 
@@ -44,6 +46,7 @@ impl<T: ?Sized> EventListenerHandle<T> {
             target,
             event_type,
             listener,
+            options: options.clone().unchecked_into()
         }
     }
 }
@@ -51,9 +54,10 @@ impl<T: ?Sized> EventListenerHandle<T> {
 impl<T: ?Sized> Drop for EventListenerHandle<T> {
     fn drop(&mut self) {
         self.target
-            .remove_event_listener_with_callback(
+            .remove_event_listener_with_callback_and_event_listener_options(
                 self.event_type,
                 self.listener.as_ref().unchecked_ref(),
+                &self.options
             )
             .unwrap_or_else(|e| {
                 web_sys::console::error_2(

--- a/src/platform_impl/web/web_sys/event_handle.rs
+++ b/src/platform_impl/web/web_sys/event_handle.rs
@@ -5,7 +5,7 @@ pub(super) struct EventListenerHandle<T: ?Sized> {
     target: EventTarget,
     event_type: &'static str,
     listener: Closure<T>,
-    options: EventListenerOptions
+    options: EventListenerOptions,
 }
 
 impl<T: ?Sized> EventListenerHandle<T> {
@@ -21,7 +21,7 @@ impl<T: ?Sized> EventListenerHandle<T> {
             target,
             event_type,
             listener,
-            options: EventListenerOptions::new()
+            options: EventListenerOptions::new(),
         }
     }
 
@@ -46,7 +46,7 @@ impl<T: ?Sized> EventListenerHandle<T> {
             target,
             event_type,
             listener,
-            options: options.clone().unchecked_into()
+            options: options.clone().unchecked_into(),
         }
     }
 }
@@ -57,7 +57,7 @@ impl<T: ?Sized> Drop for EventListenerHandle<T> {
             .remove_event_listener_with_callback_and_event_listener_options(
                 self.event_type,
                 self.listener.as_ref().unchecked_ref(),
-                &self.options
+                &self.options,
             )
             .unwrap_or_else(|e| {
                 web_sys::console::error_2(


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] [N/A] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] [N/A] Created or updated an example program if it would help users understand this functionality
- [ ] [N/A] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

The web backend for `winit` registers the `onmousedown`, `onmouseup`, and `onmousemove` events on the global Javascript window object. When the `winit` window is destroyed, however, these events are not properly removed. This is because the events are registered with the `capture: true`, but `capture: true` is not passed to the appropriate `removeEventListener` call. This PR updates the web backend to pass the event creation options to the event removal function. This prevents errors in which the Javascript runtime tries to invoke the event listener closures after they are destroyed.