### PR TITLE
Winit version 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+# 0.28.0
+
 - Add `Window::has_focus`.
 - On Windows, fix `Window::set_minimized(false)` not working for windows minimized by `Win + D` hotkey.
 - **Breaking:** On Web, touch input no longer fires `WindowEvent::Cursor*`, `WindowEvent::MouseInput`, or `DeviceEvent::MouseMotion` like other platforms, but instead it fires `WindowEvent::Touch`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.27.5"
+version = "0.28.0"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-winit = "0.27.5"
+winit = "0.28.0"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
## Patches that left

Some of the patches that might be worth merging for `0.28.0`:

- [x] https://github.com/rust-windowing/winit/pull/2626
- [x] ~https://github.com/rust-windowing/winit/pull/2615~ Will take more design work, so let's not block on this one
- [x] https://github.com/rust-windowing/winit/pull/2632 (web, so can't review, cc @maroider ?)
- [x] https://github.com/rust-windowing/winit/pull/2613 (not sure)
- [x] https://github.com/rust-windowing/winit/pull/2605 (bevy)
- [x] https://github.com/rust-windowing/winit/pull/2585 (awaits macOS)
- [x] https://github.com/rust-windowing/winit/pull/2576 (macOS patch about Option as Alt)
- [x] https://github.com/rust-windowing/winit/pull/2369 (fractional scaling on Wayland)
- [x] https://github.com/rust-windowing/winit/pull/2636 (required for egui)
- [x] https://github.com/rust-windowing/winit/pull/2639 (regression on master)
- [x] https://github.com/rust-windowing/winit/pull/2584

If I've missed something or you want some bug to be fixed for `v0.28.0` let me know.

Be aware that the next major release after the `0.28.0`(`0.29.0`) will contain the new Wayland backend (updated to new wayland-rs) and likely new X11 backend(mixture of Xlib + Xcb, instead of raw xlib).

--
CC of some main downstream consumers(if you're not interested in getting notified about release planning in winit let me know, so I won't even CC you again).

- `bevy`: @alice-i-cecile, @cart
- `egui`/`eframe`: @emilk
- `iced`: @hecrj
- `ggez`: @PSteinhaus
- `tauri` : @amrbashir
- `nannou`: @mitchmindtree

If you have some issues with winit that you want fixed for 0.28.0 let me know while we're in release preparation stage, so I include them and try to look into.

Also would you prefer if winit had `rc` period or you're fine with the current policy with `patch` fixes right away, given that winit don't really have breaking changes. Initially
we decided to not do `rc` releases, since it's easier to iterate and propagate the update without them, given that majority unlikely to use them and it's better to know that something broke if you push the update.