### PR TITLE
On X11, fix errors bleeding from hooks handling them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On X11, fix errors handled during `register_xlib_error_hook` invocation bleeding into winit.
 - Add `Window::has_focus`.
 - On Windows, fix `Window::set_minimized(false)` not working for windows minimized by `Win + D` hotkey.
 - **Breaking:** On Web, touch input no longer fires `WindowEvent::Cursor*`, `WindowEvent::MouseInput`, or `DeviceEvent::MouseMotion` like other platforms, but instead it fires `WindowEvent::Touch`.

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -24,9 +24,13 @@ pub type XlibErrorHook =
 
 /// Hook to winit's xlib error handling callback.
 ///
-/// This method is provided as a safe way to handle the errors comming from X11 when using xlib
-/// in external crates, like glutin for GLX access. Trying to handle errors by speculating with
-/// `XSetErrorHandler` is [`unsafe`].
+/// This method is provided as a safe way to handle the errors comming from X11
+/// when using xlib in external crates, like glutin for GLX access. Trying to
+/// handle errors by speculating with `XSetErrorHandler` is [`unsafe`].
+///
+/// **Be aware that your hook is always invoked and returning `true` from it will
+/// prevent `winit` from getting the error itself. It's wise to always return
+/// `false` if you're not initiated the `Sync`.**
 ///
 /// [`unsafe`]: https://www.remlab.net/op/xlib.shtml
 #[inline]

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -653,9 +653,9 @@ unsafe extern "C" fn x_error_callback(
         // Don't log error.
         if !error_handled {
             error!("X11 error: {:#?}", error);
+            // XXX only update the error, if it wasn't handled by any of the hooks.
+            *xconn.latest_error.lock().unwrap() = Some(error);
         }
-
-        *xconn.latest_error.lock().unwrap() = Some(error);
     }
     // Fun fact: this return value is completely ignored.
     0


### PR DESCRIPTION
This commit fixes it, by not updating the `latest_error` when any of the hooks handled the error, otherwise it'd interfere with the winit's error checking.

