### PR TITLE
[MacOS] Fix deadlock on maximizing window from event callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Android, upgrade `ndk` and `ndk-glue` dependencies to the recently released `0.7.0`.
 - All platforms can now be relied on to emit a `Resumed` event. Applications are recommended to lazily initialize graphics state and windows on first resume for portability.
 - **Breaking:**: Reverse horizontal scrolling sign in `MouseScrollDelta` to match the direction of vertical scrolling. A positive X value now means moving the content to the right. The meaning of vertical scrolling stays the same: a positive Y value means moving the content down.
+- On MacOS, fix deadlock when calling `set_maximized` from event loop.
 
 # 0.26.1 (2022-01-05)
 


### PR DESCRIPTION
This sadly undos #1901 again - cc: @xiaopengli89

The problem is that `handle_redraw` has no threading/re-entrance protection whatsoever - when calling `set_maximized` from within an event it will deadlock (which is ofc much worse than what #1901 tried to address)!

I ran into this when testing this egui PR https://github.com/emilk/egui/pull/2292

-----------
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
