### PR TITLE
[MacOS] Replace NSTrackingRect with NSTrackingArea

### DIFF
--- a/src/platform_impl/macos/appkit/mod.rs
+++ b/src/platform_impl/macos/appkit/mod.rs
@@ -25,10 +25,10 @@ mod pasteboard;
 mod responder;
 mod screen;
 mod text_input_context;
+mod tracking_area;
 mod version;
 mod view;
 mod window;
-mod tracking_area;
 
 pub(crate) use self::appearance::NSAppearance;
 pub(crate) use self::application::{
@@ -51,13 +51,13 @@ pub(crate) use self::responder::NSResponder;
 #[allow(unused_imports)]
 pub(crate) use self::screen::{NSDeviceDescriptionKey, NSScreen};
 pub(crate) use self::text_input_context::NSTextInputContext;
+pub(crate) use self::tracking_area::{NSTrackingArea, NSTrackingAreaOptions};
 pub(crate) use self::version::NSAppKitVersion;
-pub(crate) use self::view::{NSTrackingRectTag, NSView};
+pub(crate) use self::view::NSView;
 pub(crate) use self::window::{
     NSBackingStoreType, NSWindow, NSWindowButton, NSWindowLevel, NSWindowOcclusionState,
     NSWindowOrderingMode, NSWindowSharingType, NSWindowStyleMask, NSWindowTitleVisibility,
 };
-pub(crate) use self::tracking_area::NSTrackingArea;
 
 #[link(name = "AppKit", kind = "framework")]
 extern "C" {}

--- a/src/platform_impl/macos/appkit/mod.rs
+++ b/src/platform_impl/macos/appkit/mod.rs
@@ -28,6 +28,7 @@ mod text_input_context;
 mod version;
 mod view;
 mod window;
+mod tracking_area;
 
 pub(crate) use self::appearance::NSAppearance;
 pub(crate) use self::application::{
@@ -56,6 +57,7 @@ pub(crate) use self::window::{
     NSBackingStoreType, NSWindow, NSWindowButton, NSWindowLevel, NSWindowOcclusionState,
     NSWindowOrderingMode, NSWindowSharingType, NSWindowStyleMask, NSWindowTitleVisibility,
 };
+pub(crate) use self::tracking_area::NSTrackingArea;
 
 #[link(name = "AppKit", kind = "framework")]
 extern "C" {}

--- a/src/platform_impl/macos/appkit/tracking_area.rs
+++ b/src/platform_impl/macos/appkit/tracking_area.rs
@@ -4,7 +4,8 @@ use std::ptr;
 use objc2::foundation::{NSObject, NSRect};
 use objc2::ffi::NSUInteger;
 use objc2::runtime::Object;
-use objc2::{extern_class, ClassType, extern_methods, Encoding, Encode};
+use objc2::{extern_class, ClassType, extern_methods, msg_send_id};
+use objc2::rc::{Id, Shared};
 
 use super::{NSView};
 
@@ -13,31 +14,53 @@ extern_class!(
     pub(crate) struct NSTrackingArea;
 
     unsafe impl ClassType for NSTrackingArea {
-        #[inherits(NSObject)]
-        type Super = NSView;
+        type Super = NSObject;
     }
 );
-unsafe impl Encode for NSTrackingArea {
-    const ENCODING: Encoding = Encoding::Class;
-}
+
 extern_methods!(
     unsafe impl NSTrackingArea {
-        #[sel(initWithRect:options:owner:userInfo:)]
-        unsafe fn inner_initWithRect(
+
+        pub fn inner_initWithRect(
+            rect: NSRect,
             options: NSUInteger,
             owner: &Object,
-            rect: NSRect,
             user_info: *mut c_void,
-        ) -> NSTrackingArea;
+        ) -> Option<Id<NSTrackingArea, Shared>> {
+            unsafe {
+                let cls = msg_send_id![Self::class(), alloc];
+                msg_send_id![cls, initWithRect: rect, options: options, owner: owner, userInfo: user_info]
+            }
+        }
 
-        pub fn initWithRect(&self,options: NSUInteger, rect: NSRect) -> Option<NSTrackingArea> {
+        pub fn initWithRect(
+            rect: NSRect,
+            options: NSUInteger,
+            owner: &Object
+        ) -> Option<Id<NSTrackingArea, Shared>> {
             //SAFETY: Return none if options are invalid. userInfo is NULL, so it is valid.
             if options & 0xF0 == 0 || options & 0x7 == 0 {
                 return None
             }
-            Some(unsafe {
-                Self::inner_initWithRect(options, self, rect, ptr::null_mut())
-            })
+            unsafe {
+                Self::inner_initWithRect(rect, options, owner, ptr::null_mut())
+            }
         }
     }
 );
+
+// See https://developer.apple.com/documentation/appkit/nstrackingareaoptions?language=objc
+bitflags! {
+    pub struct NSTrackingAreaOptions: NSUInteger {
+        const NSTrackingMouseEnteredAndExited = 1 << 0;
+        const NSTrackingMouseMoved = 1 << 2;
+        const NSTrackingCursorUpdate = 1 << 3;
+        const NSTrackingActiveWhenFirstResponder = 1 << 4;
+        const NSTrackingActiveInKeyWindow = 1 << 5;
+        const NSTrackingActiveInActiveApp = 1 << 6;
+        const NSTrackingActiveAlways = 1 << 7;
+        const NSTrackingAssumeInside = 1 << 8;
+        const NSTrackingInVisibleRect = 1 << 9;
+        const NSTrackingEnabledDuringMouseDrag = 1 << 10;
+    }
+}

--- a/src/platform_impl/macos/appkit/tracking_area.rs
+++ b/src/platform_impl/macos/appkit/tracking_area.rs
@@ -1,0 +1,43 @@
+use std::ffi::c_void;
+use std::ptr;
+
+use objc2::foundation::{NSObject, NSRect};
+use objc2::ffi::NSUInteger;
+use objc2::runtime::Object;
+use objc2::{extern_class, ClassType, extern_methods, Encoding, Encode};
+
+use super::{NSView};
+
+extern_class!(
+    #[derive(Debug, PartialEq, Eq, Hash)]
+    pub(crate) struct NSTrackingArea;
+
+    unsafe impl ClassType for NSTrackingArea {
+        #[inherits(NSObject)]
+        type Super = NSView;
+    }
+);
+unsafe impl Encode for NSTrackingArea {
+    const ENCODING: Encoding = Encoding::Class;
+}
+extern_methods!(
+    unsafe impl NSTrackingArea {
+        #[sel(initWithRect:options:owner:userInfo:)]
+        unsafe fn inner_initWithRect(
+            options: NSUInteger,
+            owner: &Object,
+            rect: NSRect,
+            user_info: *mut c_void,
+        ) -> NSTrackingArea;
+
+        pub fn initWithRect(&self,options: NSUInteger, rect: NSRect) -> Option<NSTrackingArea> {
+            //SAFETY: Return none if options are invalid. userInfo is NULL, so it is valid.
+            if options & 0xF0 == 0 || options & 0x7 == 0 {
+                return None
+            }
+            Some(unsafe {
+                Self::inner_initWithRect(options, self, rect, ptr::null_mut())
+            })
+        }
+    }
+);

--- a/src/platform_impl/macos/appkit/view.rs
+++ b/src/platform_impl/macos/appkit/view.rs
@@ -1,14 +1,10 @@
-use std::ffi::c_void;
-use std::num::NonZeroIsize;
-use std::ptr;
-
 use objc2::foundation::{NSObject, NSPoint, NSRect};
 use objc2::rc::{Id, Shared};
-use objc2::runtime::Object;
 use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
-use objc2::ffi::NSUInteger;
 
-use super::{NSCursor, NSResponder, NSTextInputContext, NSWindow, NSTrackingArea};
+use super::{
+    NSCursor, NSResponder, NSTextInputContext, NSTrackingArea, NSTrackingAreaOptions, NSWindow,
+};
 
 extern_class!(
     #[derive(Debug, PartialEq, Eq, Hash)]
@@ -69,32 +65,19 @@ extern_methods!(
         #[sel(setPostsFrameChangedNotifications:)]
         pub fn setPostsFrameChangedNotifications(&mut self, value: bool);
 
-        #[sel(removeTrackingRect:)]
-        pub fn removeTrackingRect(&self, tag: NSTrackingRectTag);
-
-        #[sel(addTrackingRect:owner:userData:assumeInside:)]
-        unsafe fn inner_addTrackingRect(
-            &self,
-            rect: NSRect,
-            owner: &Object,
-            user_data: *mut c_void,
-            assume_inside: bool,
-        ) -> Option<NSTrackingRectTag>;
-
-        pub fn add_tracking_rect(&self, rect: NSRect, assume_inside: bool) -> NSTrackingRectTag {
-            // SAFETY: The user data is NULL, so it is valid
-            unsafe { self.inner_addTrackingRect(rect, self, ptr::null_mut(), assume_inside) }
-                .expect("failed creating tracking rect")
-        }
-
-       #[sel(addTrackingArea:)]
+        #[sel(addTrackingArea:)]
         pub fn addTrackingArea(&self, area: &NSTrackingArea);
 
         #[sel(removeTrackingArea:)]
         pub fn removeTrackingArea(&self, area: &NSTrackingArea);
 
-        pub fn init_and_add_tracking_area(&self, options: NSUInteger, rect: NSRect) -> Id<NSTrackingArea, Shared> {
-            let tracking_area = NSTrackingArea::initWithRect(rect, options, self).expect("failed to create tracking area");
+        pub fn init_and_add_tracking_area(
+            &self,
+            options: NSTrackingAreaOptions,
+            rect: NSRect,
+        ) -> Id<NSTrackingArea, Shared> {
+            let tracking_area = NSTrackingArea::initWithRect(rect, options, self)
+                .expect("failed to create tracking area");
             self.addTrackingArea(&tracking_area);
             tracking_area
         }
@@ -107,6 +90,3 @@ extern_methods!(
         pub fn setHidden(&self, hidden: bool);
     }
 );
-
-/// <https://developer.apple.com/documentation/appkit/nstrackingrecttag?language=objc>
-pub type NSTrackingRectTag = NonZeroIsize; // NSInteger, but non-zero!

--- a/src/platform_impl/macos/appkit/view.rs
+++ b/src/platform_impl/macos/appkit/view.rs
@@ -7,7 +7,7 @@ use objc2::rc::{Id, Shared};
 use objc2::runtime::Object;
 use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
 
-use super::{NSCursor, NSResponder, NSTextInputContext, NSWindow};
+use super::{NSCursor, NSResponder, NSTextInputContext, NSWindow, NSTrackingArea};
 
 extern_class!(
     #[derive(Debug, PartialEq, Eq, Hash)]
@@ -85,6 +85,12 @@ extern_methods!(
             unsafe { self.inner_addTrackingRect(rect, self, ptr::null_mut(), assume_inside) }
                 .expect("failed creating tracking rect")
         }
+
+       #[sel(addTrackingArea:)]
+        pub fn addTrackingArea(&self, area: NSTrackingArea);
+
+        #[sel(removeTrackingArea:)]
+        pub fn removeTrackingArea(&self, area: NSTrackingArea);
 
         #[sel(addCursorRect:cursor:)]
         // NSCursor safe to take by shared reference since it is already immutable

--- a/src/platform_impl/macos/appkit/view.rs
+++ b/src/platform_impl/macos/appkit/view.rs
@@ -6,6 +6,7 @@ use objc2::foundation::{NSObject, NSPoint, NSRect};
 use objc2::rc::{Id, Shared};
 use objc2::runtime::Object;
 use objc2::{extern_class, extern_methods, msg_send_id, ClassType};
+use objc2::ffi::NSUInteger;
 
 use super::{NSCursor, NSResponder, NSTextInputContext, NSWindow, NSTrackingArea};
 
@@ -87,10 +88,16 @@ extern_methods!(
         }
 
        #[sel(addTrackingArea:)]
-        pub fn addTrackingArea(&self, area: NSTrackingArea);
+        pub fn addTrackingArea(&self, area: &NSTrackingArea);
 
         #[sel(removeTrackingArea:)]
-        pub fn removeTrackingArea(&self, area: NSTrackingArea);
+        pub fn removeTrackingArea(&self, area: &NSTrackingArea);
+
+        pub fn init_and_add_tracking_area(&self, options: NSUInteger, rect: NSRect) -> Id<NSTrackingArea, Shared> {
+            let tracking_area = NSTrackingArea::initWithRect(rect, options, self).expect("failed to create tracking area");
+            self.addTrackingArea(&tracking_area);
+            tracking_area
+        }
 
         #[sel(addCursorRect:cursor:)]
         // NSCursor safe to take by shared reference since it is already immutable

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -12,9 +12,9 @@ use objc2::runtime::{Object, Sel};
 use objc2::{class, declare_class, msg_send, msg_send_id, sel, ClassType};
 
 use super::appkit::{
-    NSApp, NSCursor, NSEvent, NSEventModifierFlags, NSEventPhase, NSResponder, NSTrackingRectTag,
-    NSView,
+    NSApp, NSCursor, NSEvent, NSEventModifierFlags, NSEventPhase, NSResponder, NSView,
 };
+use crate::platform_impl::platform::appkit::{NSTrackingArea, NSTrackingAreaOptions};
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     event::{
@@ -33,7 +33,6 @@ use crate::{
     },
     window::WindowId,
 };
-use crate::platform_impl::platform::appkit::NSTrackingArea;
 
 #[derive(Debug)]
 pub struct CursorState {
@@ -206,7 +205,12 @@ declare_class!(
 
             let rect = self.visibleRect();
             //let tracking_area = self.add_tracking_rect(rect, false);
-            let tracking_area = self.init_and_add_tracking_area(0x1 | 0x2 | 0x40, rect);
+            let tracking_area = self.init_and_add_tracking_area(
+                NSTrackingAreaOptions::NSTrackingMouseEnteredAndExited
+                    | NSTrackingAreaOptions::NSTrackingMouseMoved
+                    | NSTrackingAreaOptions::NSTrackingActiveAlways,
+                rect,
+            );
             self.state.tracking_area = Some(tracking_area);
         }
 
@@ -217,7 +221,12 @@ declare_class!(
                 self.removeTrackingArea(&tracking_area);
             }
             let rect = self.visibleRect();
-            let tracking_area = self.init_and_add_tracking_area(0x1 | 0x2 | 0x40, rect);
+            let tracking_area = self.init_and_add_tracking_area(
+                NSTrackingAreaOptions::NSTrackingMouseEnteredAndExited
+                    | NSTrackingAreaOptions::NSTrackingMouseMoved
+                    | NSTrackingAreaOptions::NSTrackingActiveAlways,
+                rect,
+            );
             self.state.tracking_area = Some(tracking_area);
 
             // Emit resize event here rather than from windowDidResize because:

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -12,9 +12,9 @@ use objc2::runtime::{Object, Sel};
 use objc2::{class, declare_class, msg_send, msg_send_id, sel, ClassType};
 
 use super::appkit::{
-    NSApp, NSCursor, NSEvent, NSEventModifierFlags, NSEventPhase, NSResponder, NSView,
+    NSApp, NSCursor, NSEvent, NSEventModifierFlags, NSEventPhase, NSResponder, NSTrackingArea,
+    NSTrackingAreaOptions, NSView,
 };
-use crate::platform_impl::platform::appkit::{NSTrackingArea, NSTrackingAreaOptions};
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     event::{


### PR DESCRIPTION
This PR updates winit's macOS implementation to use NSTrackingArea instead of TrackingRects. These have [more features](https://developer.apple.com/documentation/appkit/nstrackingareaoptions?language=objc) than TrackingRects, which could be used to implement some of the cursor-related features that aren't currently implemented for macOS. 

I'm pretty inexperienced when it comes to working with big codebases, and am happy to hear any advice/requested changes.

- [ X] Tested on all platforms changed
(no user-facing changes)