### PR TITLE
Remove myself from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # Core maintainers:
 # - @msiglreith
-# - @francesca64
 # - @kchibisov
 # - @madsmtm
 # - @maroider
@@ -10,8 +9,8 @@
 /src/platform_impl/android          @msiglreith
 
 # iOS
-/src/platform/ios.rs                @francesca64 @madsmtm
-/src/platform_impl/ios              @francesca64 @madsmtm
+/src/platform/ios.rs                @madsmtm
+/src/platform_impl/ios              @madsmtm
 
 # Unix
 /src/platform_impl/linux/mod.rs     @kchibisov


### PR DESCRIPTION
I fortunately don't work in mobile dev anymore!

Additionally, the [Admins wiki page](https://github.com/rust-windowing/winit/wiki/Admins) is out of date, since there a bunch of more responsive people to ping now.