### PR TITLE
Handle error cases in `MonitorHandle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Added `monitor::MonitorGone`.
+- **Breaking:** Changed the following methods to return `Result<T, MonitorGone>`, allowing handling errors that occur if the monitor disconnects:
+  - `MonitorHandle::name`
+  - `MonitorHandle::size`
+  - `MonitorHandle::position`
+  - `MonitorHandle::refresh_rate_millihertz`
+  - `MonitorHandle::scale_factor`
+  - `MonitorHandle::video_modes`
 - Add `Window::is_minimized`.
 - On X11, fix errors handled during `register_xlib_error_hook` invocation bleeding into winit.
 - Add `Window::has_focus`.

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -25,7 +25,11 @@ fn main() {
     println!("Monitor: {:?}", monitor.name());
 
     let mut mode_index = 0;
-    let mut mode = monitor.video_modes().next().expect("no mode found");
+    let mut mode = monitor
+        .video_modes()
+        .expect("monitor gone")
+        .next()
+        .expect("no mode found");
     println!("Mode: {}", mode);
 
     println!("Keys:");
@@ -78,16 +82,26 @@ fn main() {
                         println!("Monitor: {:?}", monitor.name());
 
                         mode_index = 0;
-                        mode = monitor.video_modes().next().expect("no mode found");
+                        mode = monitor
+                            .video_modes()
+                            .expect("monitor gone")
+                            .next()
+                            .expect("no mode found");
                         println!("Mode: {}", mode);
                     }
                     VirtualKeyCode::M => {
                         mode_index += 1;
-                        if let Some(m) = monitor.video_modes().nth(mode_index) {
+                        if let Some(m) =
+                            monitor.video_modes().expect("monitor gone").nth(mode_index)
+                        {
                             mode = m;
                         } else {
                             mode_index = 0;
-                            mode = monitor.video_modes().next().expect("no mode found");
+                            mode = monitor
+                                .video_modes()
+                                .expect("monitor gone")
+                                .next()
+                                .expect("no mode found");
                         }
                         println!("Mode: {}", mode);
                     }

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -1,13 +1,31 @@
 #![allow(clippy::single_match)]
+use std::thread;
+use std::time::Duration;
 
 use simple_logger::SimpleLogger;
-use winit::{event_loop::EventLoop, window::WindowBuilder};
+use winit::event_loop::EventLoop;
 
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    dbg!(window.available_monitors().collect::<Vec<_>>());
-    dbg!(window.primary_monitor());
+    println!("Primary monitor: {:#?}", event_loop.primary_monitor());
+
+    let mut monitors = event_loop.available_monitors().collect::<Vec<_>>();
+    println!("Monitor list: {:#?}", monitors);
+
+    loop {
+        let new_monitors = event_loop.available_monitors().collect::<Vec<_>>();
+        if new_monitors != monitors {
+            println!(
+                "Monitor list changed from {:#?} to {:#?}",
+                monitors, new_monitors
+            );
+            monitors = new_monitors;
+        }
+
+        // Sleep for the example; in practice, you should not need to listen
+        // for monitor changes.
+        thread::sleep(Duration::from_secs(1));
+    }
 }

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -24,7 +24,12 @@ fn main() {
             .build(&event_loop)
             .unwrap();
 
-        let mut video_modes: Vec<_> = window.current_monitor().unwrap().video_modes().collect();
+        let mut video_modes: Vec<_> = window
+            .current_monitor()
+            .unwrap()
+            .video_modes()
+            .unwrap()
+            .collect();
         let mut video_mode_id = 0usize;
 
         let (tx, rx) = mpsc::channel();
@@ -37,7 +42,12 @@ fn main() {
                         // was moved to an another monitor, so that the window
                         // appears on this monitor instead when we go fullscreen
                         let previous_video_mode = video_modes.get(video_mode_id).cloned();
-                        video_modes = window.current_monitor().unwrap().video_modes().collect();
+                        video_modes = window
+                            .current_monitor()
+                            .unwrap()
+                            .video_modes()
+                            .unwrap()
+                            .collect();
                         video_mode_id = video_mode_id.min(video_modes.len());
                         let video_mode = video_modes.get(video_mode_id);
 

--- a/examples/video_modes.rs
+++ b/examples/video_modes.rs
@@ -16,7 +16,7 @@ fn main() {
 
     println!("Listing available video modes:");
 
-    for mode in monitor.video_modes() {
+    for mode in monitor.video_modes().expect("monitor video modes") {
         println!("{}", mode);
     }
 }

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -83,6 +83,7 @@ fn main() {
                     let monitor = window.current_monitor().unwrap();
                     if let Some(mode) = monitor
                         .video_modes()
+                        .expect("monitor gone")
                         .max_by(|a, b| area(a.size()).cmp(&area(b.size())))
                     {
                         window.set_fullscreen(Some(Fullscreen::Exclusive(mode)));

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -3,7 +3,7 @@ use std::os::raw::c_void;
 
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
-    monitor::MonitorHandle,
+    monitor::{MonitorGone, MonitorHandle},
     window::{Window, WindowBuilder},
 };
 
@@ -278,18 +278,18 @@ impl<T> EventLoopBuilderExtMacOS for EventLoopBuilder<T> {
 /// Additional methods on [`MonitorHandle`] that are specific to MacOS.
 pub trait MonitorHandleExtMacOS {
     /// Returns the identifier of the monitor for Cocoa.
-    fn native_id(&self) -> u32;
+    fn native_id(&self) -> Result<u32, MonitorGone>;
     /// Returns a pointer to the NSScreen representing this monitor.
-    fn ns_screen(&self) -> Option<*mut c_void>;
+    fn ns_screen(&self) -> Result<*mut c_void, MonitorGone>;
 }
 
 impl MonitorHandleExtMacOS for MonitorHandle {
     #[inline]
-    fn native_id(&self) -> u32 {
-        self.inner.native_identifier()
+    fn native_id(&self) -> Result<u32, MonitorGone> {
+        Ok(self.inner.native_identifier())
     }
 
-    fn ns_screen(&self) -> Option<*mut c_void> {
+    fn ns_screen(&self) -> Result<*mut c_void, MonitorGone> {
         self.inner.ns_screen().map(|s| Id::as_ptr(&s) as _)
     }
 }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -2,7 +2,7 @@ use std::os::raw;
 
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
-    monitor::MonitorHandle,
+    monitor::{MonitorGone, MonitorHandle},
     window::{Window, WindowBuilder},
 };
 
@@ -133,12 +133,12 @@ impl WindowBuilderExtWayland for WindowBuilder {
 /// Additional methods on `MonitorHandle` that are specific to Wayland.
 pub trait MonitorHandleExtWayland {
     /// Returns the inner identifier of the monitor.
-    fn native_id(&self) -> u32;
+    fn native_id(&self) -> Result<u32, MonitorGone>;
 }
 
 impl MonitorHandleExtWayland for MonitorHandle {
     #[inline]
-    fn native_id(&self) -> u32 {
+    fn native_id(&self) -> Result<u32, MonitorGone> {
         self.inner.native_identifier()
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -4,7 +4,7 @@ use crate::{
     dpi::PhysicalSize,
     event::DeviceId,
     event_loop::EventLoopBuilder,
-    monitor::MonitorHandle,
+    monitor::{MonitorGone, MonitorHandle},
     platform_impl::WinIcon,
     window::{BadIcon, Icon, Window, WindowBuilder},
 };
@@ -275,21 +275,21 @@ impl WindowBuilderExtWindows for WindowBuilder {
 /// Additional methods on `MonitorHandle` that are specific to Windows.
 pub trait MonitorHandleExtWindows {
     /// Returns the name of the monitor adapter specific to the Win32 API.
-    fn native_id(&self) -> String;
+    fn native_id(&self) -> Result<String, MonitorGone>;
 
     /// Returns the handle of the monitor - `HMONITOR`.
-    fn hmonitor(&self) -> HMONITOR;
+    fn hmonitor(&self) -> Result<HMONITOR, MonitorGone>;
 }
 
 impl MonitorHandleExtWindows for MonitorHandle {
     #[inline]
-    fn native_id(&self) -> String {
+    fn native_id(&self) -> Result<String, MonitorGone> {
         self.inner.native_identifier()
     }
 
     #[inline]
-    fn hmonitor(&self) -> HMONITOR {
-        self.inner.hmonitor()
+    fn hmonitor(&self) -> Result<HMONITOR, MonitorGone> {
+        Ok(self.inner.hmonitor())
     }
 }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -3,7 +3,7 @@ use std::ptr;
 
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
-    monitor::MonitorHandle,
+    monitor::{MonitorGone, MonitorHandle},
     window::{Window, WindowBuilder},
 };
 
@@ -222,12 +222,12 @@ impl WindowBuilderExtX11 for WindowBuilder {
 /// Additional methods on `MonitorHandle` that are specific to X11.
 pub trait MonitorHandleExtX11 {
     /// Returns the inner identifier of the monitor.
-    fn native_id(&self) -> u32;
+    fn native_id(&self) -> Result<u32, MonitorGone>;
 }
 
 impl MonitorHandleExtX11 for MonitorHandle {
     #[inline]
-    fn native_id(&self) -> u32 {
+    fn native_id(&self) -> Result<u32, MonitorGone> {
         self.inner.native_identifier()
     }
 }

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -12,7 +12,7 @@ use objc2::rc::{Id, Shared};
 use super::uikit::{UIScreen, UIScreenMode};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    monitor::VideoMode as RootVideoMode,
+    monitor::{MonitorGone, VideoMode as RootVideoMode},
     platform_impl::platform::app_state,
 };
 
@@ -133,39 +133,41 @@ impl MonitorHandle {
 }
 
 impl Inner {
-    pub fn name(&self) -> Option<String> {
+    pub fn name(&self) -> Result<String, MonitorGone> {
         let main = UIScreen::main(MainThreadMarker::new().unwrap());
         if self.uiscreen == main {
-            Some("Primary".to_string())
+            Ok("Primary".to_string())
         } else if self.uiscreen == main.mirroredScreen() {
-            Some("Mirrored".to_string())
+            Ok("Mirrored".to_string())
         } else {
             UIScreen::screens(MainThreadMarker::new().unwrap())
                 .iter()
                 .position(|rhs| rhs == &*self.uiscreen)
                 .map(|idx| idx.to_string())
+                .ok_or_else(MonitorGone::new)
         }
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
+    pub fn size(&self) -> Result<PhysicalSize<u32>, MonitorGone> {
         let bounds = self.uiscreen.nativeBounds();
-        PhysicalSize::new(bounds.size.width as u32, bounds.size.height as u32)
+        // `nativeBounds` is measured in pixels
+        Ok(PhysicalSize::new(bounds.size.width, bounds.size.height).cast())
     }
 
-    pub fn position(&self) -> PhysicalPosition<i32> {
+    pub fn position(&self) -> Result<PhysicalPosition<i32>, MonitorGone> {
         let bounds = self.uiscreen.nativeBounds();
-        (bounds.origin.x as f64, bounds.origin.y as f64).into()
+        Ok(PhysicalPosition::new(bounds.origin.x, bounds.origin.y).cast())
     }
 
-    pub fn scale_factor(&self) -> f64 {
-        self.uiscreen.nativeScale() as f64
+    pub fn scale_factor(&self) -> Result<f64, MonitorGone> {
+        Ok(self.uiscreen.nativeScale() as f64)
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        Some(refresh_rate_millihertz(&self.uiscreen))
+    pub fn refresh_rate_millihertz(&self) -> Result<u32, MonitorGone> {
+        Ok(refresh_rate_millihertz(&self.uiscreen))
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+    pub fn video_modes(&self) -> Result<impl Iterator<Item = VideoMode>, MonitorGone> {
         // Use Ord impl of RootVideoMode
         let modes: BTreeSet<_> = self
             .uiscreen
@@ -181,7 +183,7 @@ impl Inner {
             })
             .collect();
 
-        modes.into_iter().map(|mode| mode.video_mode)
+        Ok(modes.into_iter().map(|mode| mode.video_mode))
     }
 }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -33,6 +33,7 @@ use crate::{
         ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
+    monitor::MonitorGone,
     window::{
         CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
         WindowButtons, WindowLevel,
@@ -225,38 +226,38 @@ macro_rules! x11_or_wayland {
 
 impl MonitorHandle {
     #[inline]
-    pub fn name(&self) -> Option<String> {
+    pub fn name(&self) -> Result<String, MonitorGone> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.name())
     }
 
     #[inline]
-    pub fn native_identifier(&self) -> u32 {
+    pub fn native_identifier(&self) -> Result<u32, MonitorGone> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.native_identifier())
     }
 
     #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
+    pub fn size(&self) -> Result<PhysicalSize<u32>, MonitorGone> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.size())
     }
 
     #[inline]
-    pub fn position(&self) -> PhysicalPosition<i32> {
+    pub fn position(&self) -> Result<PhysicalPosition<i32>, MonitorGone> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.position())
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn refresh_rate_millihertz(&self) -> Result<u32, MonitorGone> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.refresh_rate_millihertz())
     }
 
     #[inline]
-    pub fn scale_factor(&self) -> f64 {
-        x11_or_wayland!(match self; MonitorHandle(m) => m.scale_factor() as _)
+    pub fn scale_factor(&self) -> Result<f64, MonitorGone> {
+        x11_or_wayland!(match self; MonitorHandle(m) => m.scale_factor())
     }
 
     #[inline]
-    pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoMode>> {
-        x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
+    pub fn video_modes(&self) -> Result<Box<dyn Iterator<Item = VideoMode>>, MonitorGone> {
+        x11_or_wayland!(match self; MonitorHandle(m) => m.video_modes())
     }
 }
 

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -13,6 +13,7 @@ use super::{
 };
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
+    monitor::MonitorGone,
     platform_impl::{MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode},
 };
 
@@ -170,39 +171,41 @@ impl MonitorHandle {
         self.id == 0
     }
 
-    pub fn name(&self) -> Option<String> {
-        Some(self.name.clone())
+    pub fn name(&self) -> Result<String, MonitorGone> {
+        Ok(self.name.clone())
     }
 
     #[inline]
-    pub fn native_identifier(&self) -> u32 {
-        self.id as _
+    pub fn native_identifier(&self) -> Result<u32, MonitorGone> {
+        Ok(self.id as _)
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.dimensions.into()
+    pub fn size(&self) -> Result<PhysicalSize<u32>, MonitorGone> {
+        Ok(self.dimensions.into())
     }
 
-    pub fn position(&self) -> PhysicalPosition<i32> {
-        self.position.into()
+    pub fn position(&self) -> Result<PhysicalPosition<i32>, MonitorGone> {
+        Ok(self.position.into())
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        self.refresh_rate_millihertz
-    }
-
-    #[inline]
-    pub fn scale_factor(&self) -> f64 {
-        self.scale_factor
+    pub fn refresh_rate_millihertz(&self) -> Result<u32, MonitorGone> {
+        Ok(self.refresh_rate_millihertz.unwrap_or(0))
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoMode> {
+    pub fn scale_factor(&self) -> Result<f64, MonitorGone> {
+        Ok(self.scale_factor)
+    }
+
+    #[inline]
+    pub fn video_modes(&self) -> Result<Box<dyn Iterator<Item = PlatformVideoMode>>, MonitorGone> {
         let monitor = self.clone();
-        self.video_modes.clone().into_iter().map(move |mut x| {
-            x.monitor = Some(monitor.clone());
-            PlatformVideoMode::X(x)
-        })
+        Ok(Box::new(self.video_modes.clone().into_iter().map(
+            move |mut x| {
+                x.monitor = Some(monitor.clone());
+                PlatformVideoMode::X(x)
+            },
+        )))
     }
 }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -151,7 +151,9 @@ impl UnownedWindow {
                 })
                 .unwrap_or_else(|| monitors.swap_remove(0))
         };
-        let scale_factor = guessed_monitor.scale_factor();
+        let scale_factor = guessed_monitor
+            .scale_factor()
+            .expect("monitor window scale");
 
         info!("Guessed window scale factor: {}", scale_factor);
 
@@ -741,7 +743,8 @@ impl UnownedWindow {
 
                 let window_position = self.outer_position_physical();
                 self.shared_state_lock().restore_position = Some(window_position);
-                let monitor_origin: (i32, i32) = monitor.position().into();
+                let monitor_origin: (i32, i32) =
+                    monitor.position().expect("monitor position").into();
                 self.set_position_inner(monitor_origin.0, monitor_origin.1)
                     .queue();
                 Some(self.set_fullscreen_hint(true))

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -6,13 +6,15 @@ use core_foundation::{
     array::{CFArrayGetCount, CFArrayGetValueAtIndex},
     base::{CFRelease, TCFType},
     string::CFString,
+    uuid::CFUUIDRef,
 };
-use core_graphics::display::{CGDirectDisplayID, CGDisplay, CGDisplayBounds};
+use core_graphics::display::{CGDirectDisplayID, CGDisplay};
 use objc2::rc::{Id, Shared};
 
 use super::appkit::NSScreen;
 use super::ffi;
-use crate::dpi::{PhysicalPosition, PhysicalSize};
+use crate::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize};
+use crate::monitor::MonitorGone;
 
 #[derive(Clone)]
 pub struct VideoMode {
@@ -101,10 +103,7 @@ pub struct MonitorHandle(CGDirectDisplayID);
 // unique identifier that persists even across system reboots
 impl PartialEq for MonitorHandle {
     fn eq(&self, other: &Self) -> bool {
-        unsafe {
-            ffi::CGDisplayCreateUUIDFromDisplayID(self.0)
-                == ffi::CGDisplayCreateUUIDFromDisplayID(other.0)
-        }
+        self.uuid() == other.uuid()
     }
 }
 
@@ -118,18 +117,13 @@ impl PartialOrd for MonitorHandle {
 
 impl Ord for MonitorHandle {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        unsafe {
-            ffi::CGDisplayCreateUUIDFromDisplayID(self.0)
-                .cmp(&ffi::CGDisplayCreateUUIDFromDisplayID(other.0))
-        }
+        self.uuid().cmp(&other.uuid())
     }
 }
 
 impl std::hash::Hash for MonitorHandle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe {
-            ffi::CGDisplayCreateUUIDFromDisplayID(self.0).hash(state);
-        }
+        self.uuid().hash(state);
     }
 }
 
@@ -158,6 +152,7 @@ impl fmt::Debug for MonitorHandle {
             .field("position", &self.position())
             .field("scale_factor", &self.scale_factor())
             .field("refresh_rate_millihertz", &self.refresh_rate_millihertz())
+            .field("uuid", &self.uuid())
             .finish_non_exhaustive()
     }
 }
@@ -169,10 +164,14 @@ impl MonitorHandle {
 
     // TODO: Be smarter about this:
     // <https://github.com/glfw/glfw/blob/57cbded0760a50b9039ee0cb3f3c14f60145567c/src/cocoa_monitor.m#L44-L126>
-    pub fn name(&self) -> Option<String> {
+    pub fn name(&self) -> Result<String, MonitorGone> {
         let MonitorHandle(display_id) = *self;
         let screen_num = CGDisplay::new(display_id).model_number();
-        Some(format!("Monitor #{}", screen_num))
+        if screen_num == 0xFFFFFFFF {
+            Err(MonitorGone::new())
+        } else {
+            Ok(format!("Monitor #{}", screen_num))
+        }
     }
 
     #[inline]
@@ -180,58 +179,62 @@ impl MonitorHandle {
         self.0
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        let MonitorHandle(display_id) = *self;
-        let display = CGDisplay::new(display_id);
-        let height = display.pixels_high();
-        let width = display.pixels_wide();
-        PhysicalSize::from_logical::<_, f64>((width as f64, height as f64), self.scale_factor())
-    }
-
-    #[inline]
-    pub fn position(&self) -> PhysicalPosition<i32> {
-        let bounds = unsafe { CGDisplayBounds(self.native_identifier()) };
-        PhysicalPosition::from_logical::<_, f64>(
-            (bounds.origin.x as f64, bounds.origin.y as f64),
-            self.scale_factor(),
-        )
-    }
-
-    pub fn scale_factor(&self) -> f64 {
-        match self.ns_screen() {
-            Some(screen) => screen.backingScaleFactor() as f64,
-            None => 1.0, // default to 1.0 when we can't find the screen
+    pub fn size(&self) -> Result<PhysicalSize<u32>, MonitorGone> {
+        // Weirdly enough, even though these methods are named "pixels",
+        // they're not actually physical pixels, but rather a logical unit.
+        let width = self.display().pixels_wide();
+        let height = self.display().pixels_high();
+        if !self.display().is_online() {
+            return Err(MonitorGone::new());
         }
+        Ok(LogicalSize::new(width as u32, height as u32)
+            .to_physical(self.scale_factor().unwrap_or(1.0)))
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn position(&self) -> Result<PhysicalPosition<i32>, MonitorGone> {
+        let bounds = self.display().bounds();
+        if !self.display().is_online() {
+            return Err(MonitorGone::new());
+        }
+        Ok(LogicalPosition::new(bounds.origin.x, bounds.origin.y)
+            .to_physical::<i32>(self.scale_factor().unwrap_or(1.0)))
+    }
+
+    pub fn scale_factor(&self) -> Result<f64, MonitorGone> {
+        self.ns_screen()
+            .map(|screen| screen.backingScaleFactor() as f64)
+    }
+
+    pub fn refresh_rate_millihertz(&self) -> Result<u32, MonitorGone> {
         unsafe {
             let mut display_link = std::ptr::null_mut();
             if ffi::CVDisplayLinkCreateWithCGDisplay(self.0, &mut display_link)
                 != ffi::kCVReturnSuccess
             {
-                return None;
+                return Err(MonitorGone::new());
             }
             let time = ffi::CVDisplayLinkGetNominalOutputVideoRefreshPeriod(display_link);
             ffi::CVDisplayLinkRelease(display_link);
 
             // This value is indefinite if an invalid display link was specified
             if time.flags & ffi::kCVTimeIsIndefinite != 0 {
-                return None;
+                return Err(MonitorGone::new());
             }
 
-            Some((time.time_scale as i64 / time.time_value * 1000) as u32)
+            Ok((time.time_scale as i64 / time.time_value * 1000) as u32)
         }
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
-        let refresh_rate_millihertz = self.refresh_rate_millihertz().unwrap_or(0);
+    pub fn video_modes(&self) -> Result<impl Iterator<Item = VideoMode>, MonitorGone> {
+        let refresh_rate_millihertz = self.refresh_rate_millihertz()?;
         let monitor = self.clone();
 
         unsafe {
             let modes = {
                 let array = ffi::CGDisplayCopyAllDisplayModes(self.0, std::ptr::null());
-                assert!(!array.is_null(), "failed to get list of display modes");
+                if array.is_null() {
+                    return Err(MonitorGone::new());
+                }
                 let array_count = CFArrayGetCount(array);
                 let modes: Vec<_> = (0..array_count)
                     .map(move |i| {
@@ -244,13 +247,13 @@ impl MonitorHandle {
                 modes
             };
 
-            modes.into_iter().map(move |mode| {
-                let cg_refresh_rate_hertz = ffi::CGDisplayModeGetRefreshRate(mode).round() as i64;
+            Ok(modes.into_iter().map(move |mode| {
+                let cg_refresh_rate_hertz = ffi::CGDisplayModeGetRefreshRate(mode);
 
                 // CGDisplayModeGetRefreshRate returns 0.0 for any display that
                 // isn't a CRT
-                let refresh_rate_millihertz = if cg_refresh_rate_hertz > 0 {
-                    (cg_refresh_rate_hertz * 1000) as u32
+                let refresh_rate_millihertz = if cg_refresh_rate_hertz > 0.0 {
+                    (cg_refresh_rate_hertz * 1000.0).round() as u32
                 } else {
                     refresh_rate_millihertz
                 };
@@ -278,23 +281,37 @@ impl MonitorHandle {
                     monitor: monitor.clone(),
                     native_mode: NativeDisplayMode(mode),
                 }
-            })
+            }))
         }
     }
 
-    pub(crate) fn ns_screen(&self) -> Option<Id<NSScreen, Shared>> {
-        let uuid = unsafe { ffi::CGDisplayCreateUUIDFromDisplayID(self.0) };
-        NSScreen::screens()
-            .into_iter()
-            .find(|screen| {
-                let other_native_id = screen.display_id();
-                let other_uuid = unsafe {
-                    ffi::CGDisplayCreateUUIDFromDisplayID(other_native_id as CGDirectDisplayID)
-                };
-                uuid == other_uuid
-            })
-            .map(|screen| unsafe {
-                Id::retain(screen as *const NSScreen as *mut NSScreen).unwrap()
-            })
+    pub(crate) fn ns_screen(&self) -> Result<Id<NSScreen, Shared>, MonitorGone> {
+        if let Some(uuid) = self.uuid() {
+            NSScreen::screens()
+                .into_iter()
+                .find(|screen| Self::new(screen.display_id()).uuid() == Some(uuid))
+                .map(|screen: &NSScreen| unsafe {
+                    Id::retain(screen as *const NSScreen as *mut NSScreen).unwrap()
+                })
+                .ok_or_else(|| {
+                    warn!("could not find NSScreen corresponding to monitor");
+                    MonitorGone::new()
+                })
+        } else {
+            Err(MonitorGone::new())
+        }
+    }
+
+    fn uuid(&self) -> Option<CFUUIDRef> {
+        let ptr = unsafe { ffi::CGDisplayCreateUUIDFromDisplayID(self.0) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(ptr)
+        }
+    }
+
+    fn display(&self) -> CGDisplay {
+        CGDisplay::new(self.0)
     }
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -219,7 +219,7 @@ impl WinitWindow {
             let screen = match &attrs.fullscreen {
                 Some(Fullscreen::Borderless(Some(monitor)))
                 | Some(Fullscreen::Exclusive(VideoMode { monitor, .. })) => {
-                    monitor.ns_screen().or_else(NSScreen::main)
+                    monitor.ns_screen().ok().or_else(NSScreen::main)
                 }
                 Some(Fullscreen::Borderless(None)) => NSScreen::main(),
                 None => None,

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -3,6 +3,7 @@
 use std::str;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
+use crate::monitor::MonitorGone;
 
 pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
 mod event_loop;
@@ -192,37 +193,37 @@ pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub struct MonitorHandle;
 
 impl MonitorHandle {
-    pub fn name(&self) -> Option<String> {
-        Some("Redox Device".to_owned())
+    pub fn name(&self) -> Result<String, MonitorGone> {
+        Ok("Redox Device".to_owned())
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        PhysicalSize::new(0, 0) // TODO
+    pub fn size(&self) -> Result<PhysicalSize<u32>, MonitorGone> {
+        Ok(PhysicalSize::new(0, 0)) // TODO
     }
 
-    pub fn position(&self) -> PhysicalPosition<i32> {
-        (0, 0).into()
+    pub fn position(&self) -> Result<PhysicalPosition<i32>, MonitorGone> {
+        Ok((0, 0).into())
     }
 
-    pub fn scale_factor(&self) -> f64 {
-        1.0 // TODO
+    pub fn scale_factor(&self) -> Result<f64, MonitorGone> {
+        Ok(1.0) // TODO
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn refresh_rate_millihertz(&self) -> Result<u32, MonitorGone> {
         // FIXME no way to get real refresh rate for now.
-        None
+        Ok(60000)
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
-        let size = self.size().into();
+    pub fn video_modes(&self) -> Result<impl Iterator<Item = VideoMode>, MonitorGone> {
+        let size = self.size()?.into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(VideoMode {
+        Ok(std::iter::once(VideoMode {
             size,
             bit_depth: 32,
             refresh_rate_millihertz: 60000,
             monitor: self.clone(),
-        })
+        }))
     }
 }
 

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -41,7 +41,7 @@ impl Window {
         attrs: window::WindowAttributes,
         _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {
-        let scale = MonitorHandle.scale_factor();
+        let scale = MonitorHandle.scale_factor().expect("monitor scale factor");
 
         let (x, y) = if let Some(pos) = attrs.position {
             pos.to_physical::<i32>(scale).into()
@@ -151,7 +151,7 @@ impl Window {
 
     #[inline]
     pub fn scale_factor(&self) -> f64 {
-        MonitorHandle.scale_factor()
+        MonitorHandle.scale_factor().expect("monitor scale factor")
     }
 
     #[inline]

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -346,7 +346,7 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        Some(MonitorHandle)
+        None
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -1,54 +1,54 @@
 use crate::dpi::{PhysicalPosition, PhysicalSize};
+use crate::monitor::MonitorGone;
 
+// This is never constructed, so it is fine to leave as `unimplemented!()`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct MonitorHandle;
+pub struct MonitorHandle(());
 
 impl MonitorHandle {
-    pub fn scale_factor(&self) -> f64 {
-        1.0
+    pub fn scale_factor(&self) -> Result<f64, MonitorGone> {
+        unimplemented!()
     }
 
-    pub fn position(&self) -> PhysicalPosition<i32> {
-        PhysicalPosition { x: 0, y: 0 }
+    pub fn position(&self) -> Result<PhysicalPosition<i32>, MonitorGone> {
+        unimplemented!()
     }
 
-    pub fn name(&self) -> Option<String> {
-        None
+    pub fn name(&self) -> Result<String, MonitorGone> {
+        unimplemented!()
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        None
+    pub fn refresh_rate_millihertz(&self) -> Result<u32, MonitorGone> {
+        unimplemented!()
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        PhysicalSize {
-            width: 0,
-            height: 0,
-        }
+    pub fn size(&self) -> Result<PhysicalSize<u32>, MonitorGone> {
+        unimplemented!()
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
-        std::iter::empty()
+    pub fn video_modes(&self) -> Result<impl Iterator<Item = VideoMode>, MonitorGone> {
+        Ok(std::iter::empty())
     }
 }
 
+// This is never constructed, so it is fine to leave as `unimplemented!()`.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct VideoMode;
+pub struct VideoMode(());
 
 impl VideoMode {
     pub fn size(&self) -> PhysicalSize<u32> {
-        unimplemented!();
+        unimplemented!()
     }
 
     pub fn bit_depth(&self) -> u16 {
-        unimplemented!();
+        unimplemented!()
     }
 
     pub fn refresh_rate_millihertz(&self) -> u32 {
-        32000
+        unimplemented!()
     }
 
     pub fn monitor(&self) -> MonitorHandle {
-        MonitorHandle
+        unimplemented!()
     }
 }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -307,7 +307,7 @@ impl Window {
     #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.borrow().is_fullscreen() {
-            Some(Fullscreen::Borderless(Some(self.current_monitor_inner())))
+            Some(Fullscreen::Borderless(None))
         } else {
             None
         }
@@ -362,14 +362,8 @@ impl Window {
     }
 
     #[inline]
-    // Allow directly accessing the current monitor internally without unwrapping.
-    fn current_monitor_inner(&self) -> MonitorHandle {
-        MonitorHandle
-    }
-
-    #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
-        Some(self.current_monitor_inner())
+        None
     }
 
     #[inline]
@@ -379,7 +373,7 @@ impl Window {
 
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        Some(MonitorHandle)
+        None
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -614,8 +614,8 @@ impl Window {
                         Fullscreen::Borderless(None) => monitor::current_monitor(window.0),
                     };
 
-                    let position: (i32, i32) = monitor.position().into();
-                    let size: (u32, u32) = monitor.size().into();
+                    let position: (i32, i32) = monitor.position().expect("monitor position").into();
+                    let size: (u32, u32) = monitor.size().expect("monitor size").into();
 
                     unsafe {
                         SetWindowPos(


### PR DESCRIPTION
Part of https://github.com/rust-windowing/winit/issues/971.

Makes all `MonitorHandle` methods fallible. The same is not done for `VideoMode`, since they are just static blobs of data (rather than something queried dynamically) (but that might change in the future?).

- [ ] Tested on all platforms changed
  - [ ] Android
  - [x] iOS
  - [x] macOS
  - [ ] Wayland
  - [ ] Web
  - [ ] Windows
  - [ ] X11
  - [ ] Orbital
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

### Unresolved

I'm unsure what we should do in the case where some functionality isn't implemented yet? Is the correct thing to return a dummy value? Perhaps it would actually be better if we just panic with an `unimplemented!()`?

Though in any case I think this PR is an improvement over the status quo.