### PR TITLE
implement pen for X11

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -976,8 +976,36 @@ pub struct Touch {
     ///
     /// - Only available on **iOS** 9.0+ and **Windows** 8+.
     pub force: Option<Force>,
+
+
+    /// Describes an press with a digital pen. Is `None` if the Touch event was not triggered
+    /// by a digital pen
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Only available on **Android** and **Windows** 8+.
+    pub pen_state: Option<PenState>,
+
     /// Unique identifier of a finger.
     pub id: u64,
+}
+
+/// Describes the physical state of a digital pen
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct PenState {
+    /// The clockwise rotation of the pointer normalized in a range of 0 to 359.
+    /// Defaults to 0 if not available on platform.
+    pub rotation: f64,
+    /// The angle of tilt of the pointer in a range of -90 to +90 for each axis,
+    /// with a positive value indicating a tilt to the right or towards the user.
+    /// Defaults to (0, 0) if not available on platform.
+    pub tilt: (f64, f64),
+    /// The barrel button is pressed.
+    pub barrel: bool,
+    /// The pen is inverted.
+    pub inverted: bool,
+    /// The eraser button is pressed.
+    pub eraser: bool,
 }
 
 /// Describes the force of a touch event

--- a/src/platform_impl/linux/wayland/seat/touch/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/touch/handlers.rs
@@ -40,6 +40,7 @@ pub(super) fn handle_touch(
                     phase: TouchPhase::Started,
                     location: position.to_physical(scale_factor),
                     force: None, // TODO
+                    pen_state: None,
                     id: id as u64,
                 }),
                 window_id,
@@ -78,6 +79,7 @@ pub(super) fn handle_touch(
                     phase: TouchPhase::Ended,
                     location,
                     force: None, // TODO
+                    pen_state: None,
                     id: id as u64,
                 }),
                 window_id,
@@ -108,6 +110,7 @@ pub(super) fn handle_touch(
                     phase: TouchPhase::Moved,
                     location,
                     force: None, // TODO
+                    pen_state: None,
                     id: id as u64,
                 }),
                 window_id,
@@ -133,6 +136,7 @@ pub(super) fn handle_touch(
                         phase: TouchPhase::Cancelled,
                         location,
                         force: None, // TODO
+                        pen_state: None,
                         id: touch_point.id as u64,
                     }),
                     window_id,

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -4,12 +4,13 @@ use libc::{c_char, c_int, c_long, c_uint, c_ulong};
 
 use super::{
     events, ffi, get_xtarget, mkdid, mkwid, monitor, util, Device, DeviceId, DeviceInfo, Dnd,
-    DndState, GenericEventCookie, ImeReceiver, ScrollOrientation, UnownedWindow, WindowId,
-    XExtension,
+    DndState, GenericEventCookie, ImeReceiver, PenAtoms, ScrollOrientation, UnownedWindow,
+    ValuatorInfo, WindowId, XExtension,
 };
 
 use util::modifiers::{ModifierKeyState, ModifierKeymap};
 
+use crate::event::{PenState, Touch};
 use crate::platform_impl::platform::x11::ime::{ImeEvent, ImeEventReceiver, ImeRequest};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
@@ -39,15 +40,90 @@ pub(super) struct EventProcessor<T: 'static> {
     // Currently focused window belonging to this process
     pub(super) active_window: Option<ffi::Window>,
     pub(super) is_composing: bool,
+    pub(super) pen_status: PenStatus,
+}
+
+#[derive(Default)]
+pub(super) struct PenStatus {
+    pub(super) pen_down: bool,
+    pub(super) barrel_down: bool,
+    pub(super) eraser_down: bool,
+}
+
+fn handle_pen_event<T: 'static, F>(
+    devices: &HashMap<DeviceId, Device>,
+    pen_status: &mut PenStatus,
+    xev: &ffi::XIDeviceEvent,
+    mut callback: F,
+) where
+    F: FnMut(Event<'_, T>),
+{
+    if let Some(Device { pen: Some(pen), .. }) = devices.get(&DeviceId(xev.sourceid)) {
+        let position = PhysicalPosition::new(xev.event_x, xev.event_y);
+        let value = xev.valuators.values;
+        let mask =
+            unsafe { slice::from_raw_parts(xev.valuators.mask, xev.valuators.mask_len as usize) };
+
+        let get_value = |vi: &ValuatorInfo| -> f64 {
+            match ffi::XIMaskIsSet(mask, vi.axis) {
+                true => unsafe { *value.offset(vi.axis as isize) },
+                _ => 0.,
+            }
+        };
+
+        let pressure =
+            (get_value(&pen.pressure) - pen.pressure.min) / (pen.pressure.max - pen.pressure.min);
+        let tilt_x = pen.tilt_x.as_ref().map(get_value).unwrap_or(0.);
+        let tilt_y = pen.tilt_y.as_ref().map(get_value).unwrap_or(0.);
+        let phase = match (pressure > 0., pen_status.pen_down) {
+            (true, false) => TouchPhase::Started,
+            (false, true) => TouchPhase::Ended,
+            _ => TouchPhase::Moved,
+        };
+
+        pen_status.pen_down = pressure > 0.;
+        let button_down = match xev.evtype {
+            ffi::XI_ButtonPress => Some(true),
+            ffi::XI_ButtonRelease => Some(false),
+            _ => None,
+        };
+        button_down.map(|down| match xev.detail as u32 {
+            ffi::Button2 => pen_status.eraser_down = down,
+            ffi::Button3 => pen_status.barrel_down = down,
+            _ => {}
+        });
+
+        let device_id = mkdid(xev.deviceid);
+        let window_id = mkwid(xev.event);
+
+        callback(Event::WindowEvent {
+            window_id,
+            event: WindowEvent::Touch(Touch {
+                device_id,
+                phase,
+                location: position,
+                id: 1000,
+                force: Some(crate::event::Force::Normalized(pressure)),
+                pen_state: Some(PenState {
+                    barrel: pen_status.barrel_down,
+                    eraser: pen_status.eraser_down,
+                    inverted: false,
+                    tilt: (tilt_x, tilt_y),
+                    rotation: 0.,
+                }),
+            }),
+        });
+    }
 }
 
 impl<T: 'static> EventProcessor<T> {
     pub(super) fn init_device(&self, device: c_int) {
         let wt = get_xtarget(&self.target);
         let mut devices = self.devices.borrow_mut();
+        let pen_atoms = PenAtoms::new(&wt.xconn);
         if let Some(info) = DeviceInfo::get(&wt.xconn, device) {
             for info in info.iter() {
-                devices.insert(DeviceId(info.deviceid), Device::new(info));
+                devices.insert(DeviceId(info.deviceid), Device::new(&pen_atoms, info));
             }
         }
     }
@@ -662,7 +738,6 @@ impl<T: 'static> EventProcessor<T> {
                     ElementState::{Pressed, Released},
                     MouseButton::{Left, Middle, Other, Right},
                     MouseScrollDelta::LineDelta,
-                    Touch,
                     WindowEvent::{
                         AxisMotion, CursorEntered, CursorLeft, CursorMoved, Focused, MouseInput,
                         MouseWheel,
@@ -681,6 +756,13 @@ impl<T: 'static> EventProcessor<T> {
 
                         let modifiers = ModifiersState::from_x11(&xev.mods);
                         update_modifiers!(modifiers, None);
+
+                        handle_pen_event(
+                            &self.devices.borrow(),
+                            &mut self.pen_status,
+                            xev,
+                            &mut callback,
+                        );
 
                         let state = if xev.evtype == ffi::XI_ButtonPress {
                             Pressed
@@ -758,6 +840,13 @@ impl<T: 'static> EventProcessor<T> {
 
                         let modifiers = ModifiersState::from_x11(&xev.mods);
                         update_modifiers!(modifiers, None);
+
+                        handle_pen_event(
+                            &self.devices.borrow(),
+                            &mut self.pen_status,
+                            xev,
+                            &mut callback,
+                        );
 
                         let cursor_moved = self.with_window(xev.event, |window| {
                             let mut shared_state_lock = window.shared_state_lock();
@@ -1052,6 +1141,7 @@ impl<T: 'static> EventProcessor<T> {
                                     phase,
                                     location,
                                     force: None, // TODO
+                                    pen_state: None,
                                     id,
                                 }),
                             })


### PR DESCRIPTION
Issue: https://github.com/rust-windowing/winit/issues/99

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I ported my previous pen work (https://github.com/rust-windowing/winit/pull/1879) over to the API from Android/Windows PR (https://github.com/rust-windowing/winit/pull/2396).

Though I have a couple of concerns with that API. I'm not sure if it is best to add the pen pressure on top of the normal touch event. I think an application developer would want to treat pens and touches quite differently. For example, you probably don't want a pinch-to-zoom gesture with one finger and the pen. Though I can also see that if the pen is the sole input, you would also treat it as a touch.
It also seems we break the "contract" of the touch phase, because we need to emit move emits between stop and start when the pen is hovering over the screen.
We could also simplify Touch event by putting `pen_state` into `force`. The unsupported values can just be set to a sensible default.
Note, the Apple Pencil 2 also supports hovering and has a button, so the additional `PenState` variable could probably be filled for that as well. Though I'm not an apple developer.

It is also not clear to me what the difference between `SharedState` and putting state into the `EventProcessor` struct directly. Specifically, where should I put the `PenStatus` struct?

I'm also not sure which button to map to `barrel` and `eraser`. My pen has two side buttons, I mapped the lower to the eraser. Maybe if someone's pen has an actual eraser, they could comment to which button X11 maps that.

Lastly, I would also like to have pen support on wayland, but right now seems an inopportune time to implement that since SCTK is currently being rewritten from scratch, so I don't want to spend much effort on adding pen support to the current version, which is used by winit. It also seems like a lot of work to port winit to the new version of SCTK since its API changes significantly.
