### PR TITLE
Add support for setting the IME purpose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, support fractional scaling via the wp-fractional-scale protocol.
 - On web, fix removal of mouse event listeners from the global object upon window distruction.
 - Add WindowAttributes getter to WindowBuilder to allow introspection of default values.
+- Added `Window::set_ime_purpose` for setting the IME purpose, currently implemented on Wayland only.
 
 # 0.27.5
 

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -6,7 +6,7 @@ use winit::{
     dpi::PhysicalPosition,
     event::{ElementState, Event, Ime, VirtualKeyCode, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::WindowBuilder,
+    window::{ImePurpose, WindowBuilder},
 };
 
 fn main() {
@@ -18,6 +18,7 @@ fn main() {
     println!("IME position will system default");
     println!("Click to set IME position to cursor's");
     println!("Press F2 to toggle IME. See the documentation of `set_ime_allowed` for more info");
+    println!("Press F3 to cycle through IME purposes.");
 
     let event_loop = EventLoop::new();
 
@@ -26,6 +27,7 @@ fn main() {
         .build(&event_loop)
         .unwrap();
 
+    let mut ime_purpose = ImePurpose::Normal;
     let mut ime_allowed = true;
     window.set_ime_allowed(ime_allowed);
 
@@ -90,7 +92,18 @@ fn main() {
                 {
                     ime_allowed = !ime_allowed;
                     window.set_ime_allowed(ime_allowed);
-                    println!("\nIME: {ime_allowed}\n");
+                    println!("\nIME allowed: {ime_allowed}\n");
+                }
+                if input.state == ElementState::Pressed
+                    && input.virtual_keycode == Some(VirtualKeyCode::F3)
+                {
+                    ime_purpose = match ime_purpose {
+                        ImePurpose::Normal => ImePurpose::Password,
+                        ImePurpose::Password => ImePurpose::Terminal,
+                        _ => ImePurpose::Normal,
+                    };
+                    window.set_ime_purpose(ime_purpose);
+                    println!("\nIME purpose: {ime_purpose:?}\n");
                 }
             }
             _ => (),

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -25,7 +25,9 @@ use crate::{
     error,
     event::{self, StartCause, VirtualKeyCode},
     event_loop::{self, ControlFlow, EventLoopWindowTarget as RootELW},
-    window::{self, CursorGrabMode, ResizeDirection, Theme, WindowButtons, WindowLevel},
+    window::{
+        self, CursorGrabMode, ImePurpose, ResizeDirection, Theme, WindowButtons, WindowLevel,
+    },
 };
 
 static HAS_FOCUS: Lazy<RwLock<bool>> = Lazy::new(|| RwLock::new(true));
@@ -1005,6 +1007,8 @@ impl Window {
     pub fn set_ime_position(&self, _position: Position) {}
 
     pub fn set_ime_allowed(&self, _allowed: bool) {}
+
+    pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     pub fn focus_window(&self) {}
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -27,8 +27,8 @@ use crate::{
         monitor, EventLoopWindowTarget, Fullscreen, MonitorHandle,
     },
     window::{
-        CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
-        WindowButtons, WindowId as RootWindowId, WindowLevel,
+        CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
+        WindowAttributes, WindowButtons, WindowId as RootWindowId, WindowLevel,
     },
 };
 
@@ -300,6 +300,10 @@ impl Inner {
     }
 
     pub fn set_ime_allowed(&self, _allowed: bool) {
+        warn!("`Window::set_ime_allowed` is ignored on iOS")
+    }
+
+    pub fn set_ime_purpose(&self, _purpose: ImePurpose) {
         warn!("`Window::set_ime_allowed` is ignored on iOS")
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -34,8 +34,8 @@ use crate::{
     },
     icon::Icon,
     window::{
-        CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
-        WindowButtons, WindowLevel,
+        CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
+        WindowAttributes, WindowButtons, WindowLevel,
     },
 };
 
@@ -517,6 +517,11 @@ impl Window {
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_ime_allowed(allowed))
+    }
+
+    #[inline]
+    pub fn set_ime_purpose(&self, purpose: ImePurpose) {
+        x11_or_wayland!(match self; Window(w) => w.set_ime_purpose(purpose))
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/seat/text_input/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/text_input/handlers.rs
@@ -9,7 +9,7 @@ use crate::event::{Ime, WindowEvent};
 use crate::platform_impl::wayland;
 use crate::platform_impl::wayland::event_loop::WinitState;
 
-use super::{Preedit, TextInputHandler, TextInputInner};
+use super::{Preedit, TextInputHandler, TextInputInner, ZwpTextInputV3Ext};
 
 #[inline]
 pub(super) fn handle_text_input(
@@ -32,6 +32,7 @@ pub(super) fn handle_text_input(
             // Enable text input on that surface.
             if window_handle.ime_allowed.get() {
                 text_input.enable();
+                text_input.set_content_type_by_purpose(window_handle.ime_purpose.get());
                 text_input.commit();
                 event_sink.push_window_event(WindowEvent::Ime(Ime::Enabled), window_id);
             }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -21,8 +21,8 @@ use crate::platform_impl::{
     OsError, PlatformSpecificWindowBuilderAttributes as PlatformAttributes,
 };
 use crate::window::{
-    CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
-    WindowButtons,
+    CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
+    WindowAttributes, WindowButtons,
 };
 
 use super::env::WindowingFeatures;
@@ -621,6 +621,11 @@ impl Window {
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         self.send_request(WindowRequest::AllowIme(allowed));
+    }
+
+    #[inline]
+    pub fn set_ime_purpose(&self, purpose: ImePurpose) {
+        self.send_request(WindowRequest::ImePurpose(purpose));
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -21,7 +21,7 @@ use crate::{
         PlatformSpecificWindowBuilderAttributes, VideoMode as PlatformVideoMode,
     },
     window::{
-        CursorGrabMode, CursorIcon, Icon, ResizeDirection, Theme, UserAttentionType,
+        CursorGrabMode, CursorIcon, Icon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
         WindowAttributes, WindowButtons, WindowLevel,
     },
 };
@@ -1531,6 +1531,9 @@ impl UnownedWindow {
             .unwrap()
             .send(ImeRequest::Allow(self.xwindow, allowed));
     }
+
+    #[inline]
+    pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     #[inline]
     pub fn focus_window(&self) {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -33,8 +33,8 @@ use crate::{
         Fullscreen, OsError,
     },
     window::{
-        CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
-        WindowButtons, WindowId as RootWindowId, WindowLevel,
+        CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
+        WindowAttributes, WindowButtons, WindowId as RootWindowId, WindowLevel,
     },
 };
 use core_graphics::display::{CGDisplay, CGPoint};
@@ -1153,6 +1153,9 @@ impl WinitWindow {
         // TODO(madsmtm): Remove the need for this
         unsafe { Id::from_shared(self.view()) }.set_ime_allowed(allowed);
     }
+
+    #[inline]
+    pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     #[inline]
     pub fn focus_window(&self) {

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -12,6 +12,7 @@ use crate::{
     error,
     platform_impl::Fullscreen,
     window,
+    window::ImePurpose,
 };
 
 use super::{
@@ -322,6 +323,9 @@ impl Window {
 
     #[inline]
     pub fn set_ime_allowed(&self, _allowed: bool) {}
+
+    #[inline]
+    pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     #[inline]
     pub fn focus_window(&self) {}

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -3,8 +3,8 @@ use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
 use crate::event;
 use crate::icon::Icon;
 use crate::window::{
-    CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
-    WindowButtons, WindowId as RootWI, WindowLevel,
+    CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
+    WindowAttributes, WindowButtons, WindowId as RootWI, WindowLevel,
 };
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
@@ -348,6 +348,11 @@ impl Window {
 
     #[inline]
     pub fn set_ime_allowed(&self, _allowed: bool) {
+        // Currently not implemented
+    }
+
+    #[inline]
+    pub fn set_ime_purpose(&self, _purpose: ImePurpose) {
         // Currently not implemented
     }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -71,8 +71,8 @@ use crate::{
         Fullscreen, PlatformSpecificWindowBuilderAttributes, WindowId,
     },
     window::{
-        CursorGrabMode, CursorIcon, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
-        WindowButtons, WindowLevel,
+        CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
+        WindowAttributes, WindowButtons, WindowLevel,
     },
 };
 
@@ -732,6 +732,9 @@ impl Window {
             ImeContext::set_ime_allowed(self.hwnd(), allowed);
         }
     }
+
+    #[inline]
+    pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1054,6 +1054,16 @@ impl Window {
         self.window.set_ime_allowed(allowed);
     }
 
+    /// Sets the IME purpose for the window using [`ImePurpose`].
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / Windows / X11 / macOS / Orbital:** Unsupported.
+    #[inline]
+    pub fn set_ime_purpose(&self, purpose: ImePurpose) {
+        self.window.set_ime_purpose(purpose);
+    }
+
     /// Brings the window to the front and sets input focus. Has no effect if the window is
     /// already in focus, minimized, or not visible.
     ///
@@ -1541,6 +1551,33 @@ pub enum WindowLevel {
 }
 
 impl Default for WindowLevel {
+    fn default() -> Self {
+        Self::Normal
+    }
+}
+
+/// Generic IME purposes for use in [`Window::set_ime_purpose`].
+///
+/// The purpose may improve UX by optimizing the IME for the specific use case,
+/// if winit can express the purpose to the platform and the platform reacts accordingly.
+///
+/// ## Platform-specific
+///
+/// - **iOS / Android / Web / Windows / X11 / macOS / Orbital:** Unsupported.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
+pub enum ImePurpose {
+    /// No special hints for the IME (default).
+    Normal,
+    /// The IME is used for password input.
+    Password,
+    /// The IME is used to input into a terminal.
+    ///
+    /// For example, that could alter OSK on Wayland to show extra buttons.
+    Terminal,
+}
+
+impl Default for ImePurpose {
     fn default() -> Self {
         Self::Normal
     }


### PR DESCRIPTION
[Wayland](https://docs.rs/wayland-protocols/latest/wayland_protocols/wp/text_input/zv3/client/zwp_text_input_v3/enum.ContentPurpose.html) and [macOS](https://developer.apple.com/documentation/appkit/nstextcontenttype) support IME purposes. I have implemented it for Wayland only, because I don't have access to macOS. XIM and Windows IMM do not seem to support it. (Although #2614 removes XIM and the successor may support IME purposes.)

This PR adds the purpose `Password` (directly supported by both Wayland and macOS) and `Terminal` (needed for https://github.com/alacritty/alacritty/issues/6644). I don't know if it makes sense to support more purposes (for example, all that Wayland supports). The `ImePurpose` enum is non exhaustive, so new purposes can be added without breaking change.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality (added to the `ime` example, although the `ime` example does not work at all on Wayland because no window shows up)
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented (IME is not contained in the feature matrix)