### PR TITLE
Clarify Window::set_decorations/is_decorated behaviour

### DIFF
--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -281,12 +281,9 @@ impl Inner {
         }
     }
 
-    pub fn set_decorations(&self, _decorations: bool) {
-        warn!("`Window::set_decorations` is ignored on iOS")
-    }
+    pub fn set_decorations(&self, _decorations: bool) {}
 
     pub fn is_decorated(&self) -> bool {
-        warn!("`Window::is_decorated` is ignored on iOS");
         true
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -941,9 +941,13 @@ impl Window {
 
     /// Turn window decorations on or off.
     ///
+    /// Enable/disable window decorations provided by the server or Winit.
+    /// By default this is enabled. Note that fullscreen windows and windows on
+    /// mobile and web platforms naturally do not have decorations.
+    ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web:** Unsupported.
+    /// - **iOS / Android / Web:** No effect.
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         self.window.set_decorations(decorations)
@@ -951,10 +955,12 @@ impl Window {
 
     /// Gets the window's current decorations state.
     ///
+    /// Returns `true` when windows are decorated (server-side or by Winit).
+    /// Also returns `true` when no decorations are required (mobile, web).
+    ///
     /// ## Platform-specific
     ///
-    /// - **X11:** Not implemented.
-    /// - **iOS / Android / Web:** Unsupported.
+    /// - **iOS / Android / Web:** Always returns `true`.
     #[inline]
     pub fn is_decorated(&self) -> bool {
         self.window.is_decorated()


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Adjust documentation to make it clear that `Window::set_decorations` has no effect on mobile/web platforms, and `is_decorated` always returns true on these platforms. After this doc change, it should be clear that the client should draw decorations when `window.fullscreen().is_none() && !window.is_decorated()`.

It seems there is still no explicit API to determine whether a window *should* have decorations (i.e. is on a windowing platform, not a mobile or web platform). It seems odd that `Window::fullscreen` returns `None` on Android. This is a separate issue.

To make behaviour more consistent across platforms, the `log::warn` messages were removed from iOS. (Possibly the same should be done on other methods; I didn't investigate.)