### PR TITLE
examples/monitor_list: properly print output

### DIFF
--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use winit::monitor::MonitorHandle;
 use winit::{event_loop::EventLoop, window::WindowBuilder};
 
 fn main() {
@@ -8,6 +9,30 @@ fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    dbg!(window.available_monitors().collect::<Vec<_>>());
-    dbg!(window.primary_monitor());
+    for mon in window.available_monitors() {
+        print_info(mon);
+    }
+    if let Some(mon) = window.primary_monitor() {
+        print_info(mon);
+    }
+}
+
+fn print_info(monitor: MonitorHandle) {
+    if let Some(name) = monitor.name() {
+        println!("name: {name}");
+    } else {
+        println!("name: <none>");
+    }
+    println!("size: {:?}", monitor.size());
+    println!("position: {:?}", monitor.position());
+    println!("refresh_rate: {:?} mHz", monitor.refresh_rate_millihertz());
+    println!("scale_factor: {:?}", monitor.scale_factor());
+    for mode in monitor.video_modes() {
+        println!(
+            "mode: {:?}, depth = {} bits, refresh rate = {} mHz",
+            mode.size(),
+            mode.bit_depth(),
+            mode.refresh_rate_millihertz()
+        );
+    }
 }

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -19,7 +19,7 @@ fn main() {
             continue;
         }
 
-        println!("");
+        println!();
         print_info("Output", mon);
     }
 }
@@ -36,7 +36,7 @@ fn print_info(intro: &str, monitor: MonitorHandle) {
     if let Some(m_hz) = monitor.refresh_rate_millihertz() {
         println!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000);
     } else {
-        println!("");
+        println!();
     }
 
     let PhysicalPosition { x, y } = monitor.position();


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

The old version of `examples/monitor_list.rs` simply used the debug repr of `MonitorHandle`, which on Wayland looks like this:
```
[examples/monitor_list.rs:11] window.available_monitors().collect::<Vec<_>>() = [
    MonitorHandle {
        inner: Wayland(
            MonitorHandle {
                proxy: wl_output@13,
            },
        ),
    },
]
[examples/monitor_list.rs:12] window.primary_monitor() = None
```

Updated version prints useful, more platform consistent info:
```
name: eDP-1-unknown (InfoVision)
size: PhysicalSize { width: 1920, height: 1200 }
position: PhysicalPosition { x: 0, y: 0 }
refresh_rate: Some(59999) mHz
scale_factor: 1.0
mode: PhysicalSize { width: 1920, height: 1200 }, depth = 32 bits, refresh rate = 59999 mHz
```