### PR TITLE
Fix rerun-if-changed emmiting from build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -28,7 +28,9 @@ mod wayland {
 
 fn main() {
     // The script doesn't depend on our code
-    println!("cargo:rerun-if-changed=build.rs:wayland_protocols");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=wayland_protocols");
+
     // Setup cfg aliases
     cfg_aliases! {
         // Systems.


### PR DESCRIPTION
The docs state that it accepts `PATH`, but not like the env variable. So to make it work each `PATH` should be emmited from each `println!`.

Fixes #2657.