### PR TITLE
On macOS, fix `Ime::Commit` persisting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On macOS, fixed `Ime::Commit` persisting for all input after interacting with `Ime`.
 - On macOS, added `WindowExtMacOS::option_as_alt` and `WindowExtMacOS::set_option_as_alt`.
 - On Windows, fix window size for maximized, undecorated windows.
 - On Windows and macOS, add `WindowBuilder::with_active`.

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -429,9 +429,6 @@ declare_class!(
                 self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                 self.state.ime_state = ImeState::Commited;
-
-                // Remove any marked text, so normal input can continue.
-                *self.marked_text = NSMutableAttributedString::new();
             }
         }
 
@@ -500,6 +497,8 @@ declare_class!(
 
                 // If the text was commited we must treat the next keyboard event as IME related.
                 if self.state.ime_state == ImeState::Commited {
+                    // Remove any marked text, so normal input can continue.
+                    *self.marked_text = NSMutableAttributedString::new();
                     self.state.ime_state = ImeState::Enabled;
                     text_commited = true;
                 }

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -424,10 +424,14 @@ declare_class!(
 
             let is_control = string.chars().next().map_or(false, |c| c.is_control());
 
-            if self.is_ime_enabled() && !is_control {
+            // Commit only if we have marked text.
+            if self.hasMarkedText() && self.is_ime_enabled() && !is_control {
                 self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                 self.state.ime_state = ImeState::Commited;
+
+                // Remove any marked text, so normal input can continue.
+                *self.marked_text = NSMutableAttributedString::new();
             }
         }
 


### PR DESCRIPTION
This commit clears the currently marked text on `Ime::Commit`, so normal `ReceivedCharacter` input can continue.

--

@madsmtm I was thinking of using `unmarkText` but I don't really want extra `Preedit` after the `Commit`. Do I need that extra stuff with context that is present in `unmarkText`?
