### PR TITLE
Bump version on master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+# 0.28.0
+
 - On macOS, fixed `Ime::Commit` persisting for all input after interacting with `Ime`.
 - On macOS, added `WindowExtMacOS::option_as_alt` and `WindowExtMacOS::set_option_as_alt`.
 - On Windows, fix window size for maximized, undecorated windows.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.27.5"
+version = "0.28.0"
 authors = ["The winit contributors", "Pierre Krieger <pierre.krieger1708@gmail.com>"]
 description = "Cross-platform window creation library."
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```toml
 [dependencies]
-winit = "0.27.5"
+winit = "0.28.0"
 ```
 
 ## [Documentation](https://docs.rs/winit)


### PR DESCRIPTION
This commit does not represent a release and only
synchronizes CHANGELOG from the latest release.