### PR TITLE
Fix window drop on Wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Wayland, fix crash when dropping a window in multi-window setup.
+
 # 0.28.0
 
 - On macOS, fixed `Ime::Commit` persisting for all input after interacting with `Ime`.

--- a/src/platform_impl/linux/wayland/seat/keyboard/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/keyboard/handlers.rs
@@ -24,7 +24,10 @@ pub(super) fn handle_keyboard(
         KeyboardEvent::Enter { surface, .. } => {
             let window_id = wayland::make_wid(&surface);
 
-            let window_handle = winit_state.window_map.get_mut(&window_id).unwrap();
+            let window_handle = match winit_state.window_map.get_mut(&window_id) {
+                Some(window_handle) => window_handle,
+                None => return,
+            };
             window_handle.has_focus.store(true, Ordering::Relaxed);
 
             // Window gained focus.
@@ -39,7 +42,14 @@ pub(super) fn handle_keyboard(
             inner.target_window_id = Some(window_id);
         }
         KeyboardEvent::Leave { surface, .. } => {
+            // Reset the id.
+            inner.target_window_id = None;
+
             let window_id = wayland::make_wid(&surface);
+            let window_handle = match winit_state.window_map.get_mut(&window_id) {
+                Some(window_handle) => window_handle,
+                None => return,
+            };
 
             // Notify that no modifiers are being pressed.
             if !inner.modifiers_state.borrow().is_empty() {
@@ -49,14 +59,10 @@ pub(super) fn handle_keyboard(
                 );
             }
 
-            let window_handle = winit_state.window_map.get_mut(&window_id).unwrap();
             window_handle.has_focus.store(false, Ordering::Relaxed);
 
             // Window lost focus.
             event_sink.push_window_event(WindowEvent::Focused(false), window_id);
-
-            // Reset the id.
-            inner.target_window_id = None;
         }
         KeyboardEvent::Key {
             rawkey,

--- a/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/handlers.rs
@@ -45,9 +45,6 @@ pub(super) fn handle_pointer(
             pointer_data.latest_enter_serial.replace(serial);
 
             let window_id = wayland::make_wid(&surface);
-            if !winit_state.window_map.contains_key(&window_id) {
-                return;
-            }
             let window_handle = match winit_state.window_map.get_mut(&window_id) {
                 Some(window_handle) => window_handle,
                 None => return,


### PR DESCRIPTION
In some scenarios of window dropping the callback for keyboard may run after the window was dropped.

