### PR TITLE
m(windows): Name the waiter thread

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -205,7 +205,10 @@ impl<T: 'static> EventLoop<T> {
 
         let thread_msg_target = create_event_target_window::<T>();
 
-        thread::spawn(move || wait_thread(thread_id, thread_msg_target));
+        thread::Builder::new()
+            .name("winit wait thread".to_string())
+            .spawn(move || wait_thread(thread_id, thread_msg_target))
+            .expect("Failed to spawn winit wait thread");
         let wait_thread_id = get_wait_thread_id();
 
         let runner_shared = Rc::new(EventLoopRunner::new(thread_msg_target, wait_thread_id));


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

It's easier to debug if the waiting thread has an explicit name.

Also, quick question, is there any particular reason why we use the waiter thread instead of just `WM_TIMER`? I'm guessing that `WM_TIMER` doesn't play well with `timeBeginPeriod`.