### PR TITLE
web: Fix Enter key being handled as character E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Web, fix Enter key being handled as the character E if `with_prevent_default` is false.
+
 # 0.28.1
 
 - On Wayland, fix crash when dropping a window in multi-window setup.

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -239,6 +239,11 @@ impl Canvas {
                     event.prevent_default();
                 }
 
+                if event.key().len() > 1 {
+                    // ignore keypress for "Enter" key etc.
+                    return;
+                }
+
                 handler(event::codepoint(&event));
             },
         ));

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -239,7 +239,7 @@ impl Canvas {
                     event.prevent_default();
                 }
 
-                if event.key().len() > 1 {
+                if event.key().chars().nth(1).is_some() {
                     // ignore keypress for "Enter" key etc.
                     return;
                 }


### PR DESCRIPTION
When with_prevent_default is set to false, browsers will send keypress events for the enter key, with event.key set to Enter.

Ignore it by checking the length of the key string.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- ~~[] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- ~~[ ] Created or updated an example program if it would help users understand this functionality~~
- ~~[ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~
