### PR TITLE
Run examples in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,16 @@ jobs:
         !contains(matrix.platform.target, 'redox') &&
         matrix.rust_version != '1.60.0'
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
+
+    # derived from  https://github.com/psychon/x11rb/blob/15153e514a4e3e4c116279f76ab1c3635abc05e5/.github/workflows/CI.yml#L141-L159
+    - name: Run examples
+      shell: bash
+      if: >
+        contains(matrix.platform.target, 'linux') &&
+        contains(matrix.platform.features, 'x11')
+      run: |
+          for example in examples/*.rs; do
+            example=${examples/examples\//}
+            example=${example/.rs/}
+            WINIT_EXAMPLE_TIMEOUT=1 xvfb-run -a cargo run --example "$example" || exit 1
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
         contains(matrix.platform.features, 'x11')
       run: |
           for example in examples/*.rs; do
-            example=${examples/examples\//}
+            example=${example/examples\//}
             example=${example/.rs/}
             WINIT_EXAMPLE_TIMEOUT=1 xvfb-run -a cargo run --example "$example" || exit 1
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,8 @@ jobs:
       shell: bash
       if: >
         contains(matrix.platform.target, 'linux') &&
-        contains(matrix.platform.features, 'x11')
+        contains(matrix.platform.features, 'x11') && 
+        (contains(matrix.rust_version, 'stable') || contains(matrix.rust_version, 'nightly'))
       run: |
           for example in examples/*.rs; do
             example=${example/examples\//}

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -1,4 +1,7 @@
 #[cfg(any(x11_platform, macos_platform, windows_platform))]
+include!("it_util/timeout.rs");
+
+#[cfg(any(x11_platform, macos_platform, windows_platform))]
 fn main() {
     use std::collections::HashMap;
 
@@ -39,6 +42,7 @@ fn main() {
         .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))
         .build(&event_loop)
         .unwrap();
+    util::start_timeout_thread(&event_loop, ());
 
     println!("parent window: {parent_window:?})");
 
@@ -70,6 +74,9 @@ fn main() {
                 }
                 _ => (),
             }
+        } else if let Event::UserEvent(()) = event {
+            windows.clear();
+            *control_flow = ControlFlow::Exit;
         }
     })
 }

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use std::{thread, time};
 
 use simple_logger::SimpleLogger;
@@ -33,6 +35,8 @@ fn main() {
         .with_title("Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.")
         .build(&event_loop)
         .unwrap();
+
+    util::start_timeout_thread(&event_loop, ());
 
     let mut mode = Mode::Wait;
     let mut request_redraw = false;
@@ -107,6 +111,9 @@ fn main() {
                         control_flow.set_poll();
                     }
                 };
+            }
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyboardInput, WindowEvent},
@@ -10,6 +12,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new().build(&event_loop).unwrap();
     window.set_title("A fantastic window!");
@@ -44,6 +47,9 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
+                control_flow.set_exit();
+            }
+            Event::UserEvent(()) => {
                 control_flow.set_exit();
             }
             _ => (),

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{DeviceEvent, ElementState, Event, KeyboardInput, ModifiersState, WindowEvent},
@@ -10,6 +12,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("Super Cursor Grab'n'Hide Simulator 9000")
@@ -64,6 +67,7 @@ fn main() {
                 },
                 _ => (),
             },
+            Event::UserEvent(()) => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{
@@ -12,6 +14,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window_1 = WindowBuilder::new().build(&event_loop).unwrap();
     let window_2 = WindowBuilder::new().build(&event_loop).unwrap();
@@ -59,6 +62,7 @@ fn main() {
             }
             _ => (),
         },
+        Event::UserEvent(()) => control_flow.set_exit(),
         _ => (),
     });
 }

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent};
 use winit::event_loop::EventLoop;
@@ -8,6 +10,7 @@ use winit::window::{Fullscreen, WindowBuilder};
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let mut decorations = true;
     let mut minimized = false;
@@ -107,6 +110,7 @@ fn main() {
                 },
                 _ => (),
             },
+            Event::UserEvent(()) => control_flow.set_exit(),
             _ => {}
         }
     });

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, KeyboardInput, WindowEvent},
@@ -10,6 +12,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let _window = WindowBuilder::new()
         .with_title("Your faithful window")
@@ -80,6 +83,7 @@ fn main() {
                     _ => (),
                 }
             }
+            Event::UserEvent(()) => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use log::LevelFilter;
 use simple_logger::SimpleLogger;
 use winit::{
@@ -21,6 +23,7 @@ fn main() {
     println!("Press F3 to cycle through IME purposes.");
 
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_inner_size(winit::dpi::LogicalSize::new(256f64, 128f64))
@@ -105,6 +108,9 @@ fn main() {
                     window.set_ime_purpose(ime_purpose);
                     println!("\nIME purpose: {ime_purpose:?}\n");
                 }
+            }
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/it_util/timeout.rs
+++ b/examples/it_util/timeout.rs
@@ -1,0 +1,42 @@
+// Spawns a timeout thread that will close the event loop after one second.
+
+#[cfg(not(wasm_platform))]
+mod util {
+    use std::env;
+    use std::thread;
+    use winit::event_loop::EventLoop;
+
+    pub(super) fn start_timeout_thread<T: Send + 'static>(event_loop: &EventLoop<T>, msg_to_send: T) {
+        // If the WINIT_EXAMPLE_TIMEOUT environment variable is set, get the number of seconds
+        // to wait before closing the window.
+        let secs = match env::var("WINIT_EXAMPLE_TIMEOUT")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+        {
+            Some(secs) => secs,
+            None => return,
+        };
+
+        // Spawn a thread that will close the window after `secs` seconds.
+        thread::Builder::new()
+            .name("winit example timeout".to_string())
+            .spawn({
+                let proxy = event_loop.create_proxy();
+                move || {
+                    thread::sleep(std::time::Duration::from_secs(secs));
+                    println!("Closing window due to timeout");
+                    proxy.send_event(msg_to_send).unwrap_or_else(|_| panic!("Failed to send event to event loop"));
+                }
+            })
+            .expect("failed to spawn timeout thread");
+    }
+}
+
+#[cfg(wasm_platform)]
+mod util {
+    use winit::event_loop::EventLoop;
+
+    pub(super) fn start_timeout_thread<T: Send + 'static>(_event_loop: &EventLoop<T>, _msg_to_send: T) {
+        // Not supported on web.
+    }
+}

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
@@ -10,6 +12,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("Mouse Wheel events")
@@ -56,6 +59,9 @@ In other words, the deltas indicate the direction in which to move the content (
                 },
                 _ => (),
             },
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
+            }
             _ => (),
         }
     });

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::single_match)]
 
 #[cfg(not(wasm_platform))]
+include!("it_util/timeout.rs");
+
+#[cfg(not(wasm_platform))]
 fn main() {
     use std::{collections::HashMap, sync::mpsc, thread, time::Duration};
 
@@ -17,6 +20,8 @@ fn main() {
 
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
+
     let mut window_senders = HashMap::with_capacity(WINDOW_COUNT);
     for _ in 0..WINDOW_COUNT {
         let window = WindowBuilder::new()
@@ -188,6 +193,10 @@ fn main() {
                     }
                 }
             },
+            Event::UserEvent(()) => {
+                window_senders.clear();
+                control_flow.set_exit();
+            }
             _ => {}
         }
     })

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use std::collections::HashMap;
 
 use simple_logger::SimpleLogger;
@@ -12,6 +14,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let mut windows = HashMap::new();
     for _ in 0..3 {
@@ -54,6 +57,9 @@ fn main() {
                     }
                     _ => (),
                 }
+            }
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, WindowEvent},
@@ -10,6 +12,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -34,6 +37,9 @@ fn main() {
             },
             Event::RedrawRequested(_) => {
                 println!("\nredrawing!\n");
+            }
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::single_match)]
 
 #[cfg(not(wasm_platform))]
+include!("it_util/timeout.rs");
+
+#[cfg(not(wasm_platform))]
 fn main() {
     use std::{thread, time};
 
@@ -13,6 +16,7 @@ fn main() {
 
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -36,6 +40,9 @@ fn main() {
             } => control_flow.set_exit(),
             Event::RedrawRequested(_) => {
                 println!("\nredrawing!\n");
+            }
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
@@ -11,6 +13,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let mut resizable = false;
 
@@ -44,6 +47,9 @@ fn main() {
                 }
                 _ => (),
             },
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
+            }
             _ => (),
         };
     });

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
@@ -10,6 +12,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -65,6 +68,7 @@ fn main() {
                 }
                 _ => (),
             },
+            Event::UserEvent(()) => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use instant::Instant;
 use std::time::Duration;
 
@@ -13,6 +15,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let _window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -35,7 +38,8 @@ fn main() {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => control_flow.set_exit(),
+            }
+            | Event::UserEvent(()) => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -5,9 +5,12 @@ use winit::{
     window::WindowBuilder,
 };
 
+include!("it_util/timeout.rs");
+
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let _window = WindowBuilder::new()
         .with_title("Touchpad gestures")
@@ -41,6 +44,8 @@ fn main() {
                 }
                 _ => (),
             }
+        } else if let Event::UserEvent(()) = event {
+            control_flow.set_exit();
         }
     });
 }

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
@@ -10,6 +12,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_decorations(false)
@@ -27,7 +30,8 @@ fn main() {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => control_flow.set_exit(),
+            }
+            | Event::UserEvent(()) => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/video_modes.rs
+++ b/examples/video_modes.rs
@@ -6,6 +6,7 @@ use winit::event_loop::EventLoop;
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+
     let monitor = match event_loop.primary_monitor() {
         Some(monitor) => monitor,
         None => {

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -8,6 +10,7 @@ use winit::{
 
 pub fn main() {
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -30,6 +33,9 @@ pub fn main() {
             } if window_id == window.id() => control_flow.set_exit(),
             Event::MainEventsCleared => {
                 window.request_redraw();
+            }
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
@@ -10,6 +12,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -28,6 +31,9 @@ fn main() {
             } if window_id == window.id() => control_flow.set_exit(),
             Event::MainEventsCleared => {
                 window.request_redraw();
+            }
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -2,6 +2,8 @@
 
 // This example is used by developers to test various window functions.
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
@@ -13,6 +15,7 @@ use winit::{
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -62,6 +65,9 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 window_id,
             } if window_id == window.id() => control_flow.set_exit(),
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
+            }
             _ => (),
         }
     });

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -10,9 +10,12 @@ use winit::{
     window::{Fullscreen, WindowBuilder},
 };
 
+include!("it_util/timeout.rs");
+
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -126,6 +129,7 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 window_id,
             } if window_id == window.id() => control_flow.set_exit(),
+            Event::UserEvent(()) => control_flow.set_exit(),
             _ => (),
         }
     });

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -1,5 +1,7 @@
 //! Demonstrates capability to create in-app draggable regions for client-side decoration support.
 
+include!("it_util/timeout.rs");
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{
@@ -14,6 +16,7 @@ const BORDER: f64 = 8.0;
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_inner_size(winit::dpi::LogicalSize::new(600.0, 400.0))
@@ -66,6 +69,7 @@ fn main() {
             }
             _ => (),
         },
+        Event::UserEvent(()) => control_flow.set_exit(),
         _ => (),
     });
 }

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::single_match)]
 
+include!("it_util/timeout.rs");
+
 use std::path::Path;
 
 use simple_logger::SimpleLogger;
@@ -21,6 +23,7 @@ fn main() {
     let icon = load_icon(Path::new(path));
 
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("An iconic window!")
@@ -42,6 +45,8 @@ fn main() {
                 }
                 _ => (),
             }
+        } else if let Event::UserEvent(()) = event {
+            control_flow.set_exit();
         }
     });
 }

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::single_match)]
 
 #[cfg(target_os = "macos")]
+include!("it_util/timeout.rs");
+
+#[cfg(target_os = "macos")]
 use winit::platform::macos::{OptionAsAlt, WindowExtMacOS};
 
 #[cfg(target_os = "macos")]
@@ -16,6 +19,7 @@ use winit::{
 #[cfg(target_os = "macos")]
 fn main() {
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -55,6 +59,9 @@ fn main() {
             },
             Event::MainEventsCleared => {
                 window.request_redraw();
+            }
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
             }
             _ => (),
         }

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -7,9 +7,12 @@ use winit::{
     window::WindowBuilder,
 };
 
+include!("it_util/timeout.rs");
+
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")
@@ -51,6 +54,9 @@ fn main() {
                 window.set_resize_increments(new_increments);
             }
             Event::MainEventsCleared => window.request_redraw(),
+            Event::UserEvent(()) => {
+                control_flow.set_exit();
+            }
             _ => (),
         }
     });

--- a/examples/window_run_return.rs
+++ b/examples/window_run_return.rs
@@ -1,5 +1,15 @@
 #![allow(clippy::single_match)]
 
+#[cfg(any(
+    windows_platform,
+    macos_platform,
+    x11_platform,
+    wayland_platform,
+    android_platform,
+    orbital_platform,
+))]
+include!("it_util/timeout.rs");
+
 // Limit this example to only compatible platforms.
 #[cfg(any(
     windows_platform,
@@ -20,6 +30,7 @@ fn main() {
         window::WindowBuilder,
     };
     let mut event_loop = EventLoop::new();
+    util::start_timeout_thread(&event_loop, ());
 
     SimpleLogger::new().init().unwrap();
     let _window = WindowBuilder::new()
@@ -46,6 +57,10 @@ fn main() {
                     quit = true;
                 }
                 Event::MainEventsCleared => {
+                    control_flow.set_exit();
+                }
+                Event::UserEvent(()) => {
+                    quit = true;
                     control_flow.set_exit();
                 }
                 _ => (),


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR sets up the example so that they can be ran in the CI using X11 under `xvfb`, essentially allowing us to run them as integration tests. I accomplish this by spawning a thread that sends a user event to the event loop that makes it time out.

There are ways of running the examples of other platforms, but I figured I'd start with X11.