### PR TITLE
Implement `HasRawDisplayHandle` for `EventLoop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Implement `HasRawDisplayHandle` for `EventLoop`.
+
 # 0.28.1
 
 - On Wayland, fix crash when dropping a window in multi-window setup.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -313,6 +313,13 @@ impl<T> EventLoop<T> {
     }
 }
 
+unsafe impl<T> HasRawDisplayHandle for EventLoop<T> {
+    /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
+    fn raw_display_handle(&self) -> RawDisplayHandle {
+        self.event_loop.window_target().p.raw_display_handle()
+    }
+}
+
 impl<T> Deref for EventLoop<T> {
     type Target = EventLoopWindowTarget<T>;
     fn deref(&self) -> &EventLoopWindowTarget<T> {


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


The trait is already implemented for `EventLoopWindowTarget`, which `EventLoop` derefs to, but that is not enough when using an API that takes a `T: HasRawDisplayHandle + 'static` (because the API takes ownership of the display handle, in an attempt to offer a safer API to the user than what crates typically do). Also implementing the trait for `EventLoop` itself solves this problem.

(admittedly the use cases for this are rather limited – consuming the `EventLoop` like this makes it impossible to actually handle events, and so makes windows useless too, but it *is* handy when you need a display handle without actually wanting to draw anything; in my specific use case, in order to open a connection to VA-API)