### PR TITLE
Add Platform enumeration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Add `fn EventLoopWindowTarget::platform() -> Platform`
+
 # 0.28.1
 
 - On Wayland, fix crash when dropping a window in multi-window setup.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = "0.4"
 mint = { version = "0.5.6", optional = true }
 once_cell = "1.12"
+cfg-if = "1.0.0"
 raw_window_handle = { package = "raw-window-handle", version = "0.5" }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -15,7 +15,7 @@ use instant::{Duration, Instant};
 use once_cell::sync::OnceCell;
 use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
 
-use crate::{event::Event, monitor::MonitorHandle, platform_impl};
+use crate::{event::Event, monitor::MonitorHandle, platform::Platform, platform_impl};
 
 /// Provides a way to retrieve events from the system and from the windows that were registered to
 /// the events loop.
@@ -358,6 +358,11 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn set_device_event_filter(&self, _filter: DeviceEventFilter) {
         #[cfg(any(x11_platform, wayland_platform, windows))]
         self.p.set_device_event_filter(_filter);
+    }
+
+    /// Return detected platform
+    pub fn platform(&self) -> Platform {
+        self.p.platform()
     }
 }
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -41,3 +41,130 @@ pub mod x11;
     orbital_platform
 ))]
 pub mod run_return;
+
+/// Enumeration of platforms
+///
+/// Each option is compile-time enabled only if that platform is possible.
+/// Methods like [`Self::is_wayland`] are available on all platforms.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Platform {
+    #[cfg(android_platform)]
+    Android,
+
+    #[cfg(ios_platform)]
+    IOS,
+
+    #[cfg(macos_platform)]
+    MacOS,
+
+    #[cfg(orbital_platform)]
+    Orbital,
+
+    #[cfg(wasm_platform)]
+    Web,
+
+    #[cfg(windows_platform)]
+    Windows,
+
+    #[cfg(any(x11_platform, wayland_platform))]
+    Wayland,
+    #[cfg(any(x11_platform, wayland_platform))]
+    X11,
+}
+
+impl Platform {
+    /// True if the platform is Android
+    pub fn is_android(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(android_platform)] {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// True if the platform is IOS
+    pub fn is_ios(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(ios_platform)] {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// True if the platform is MacOS
+    pub fn is_macos(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(macos_platform)] {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// True if the platform is Orbital
+    pub fn is_orbital(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(orbital_platform)] {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// True if the platform is Web
+    pub fn is_web(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(wasm_platform)] {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// True if the platform is Windows
+    pub fn is_windows(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(windows_platform)] {
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    /// True if the platform is Wayland
+    pub fn is_wayland(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(any(x11_platform, wayland_platform))] {
+                match self {
+                    Platform::Wayland => true,
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }
+    }
+
+    /// True if the platform is X11
+    pub fn is_x11(&self) -> bool {
+        cfg_if::cfg_if! {
+            if #[cfg(any(x11_platform, wayland_platform))] {
+                match self {
+                    Platform::X11 => true,
+                    _ => false,
+                }
+            } else {
+                false
+            }
+        }
+    }
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -144,10 +144,7 @@ impl Platform {
     pub fn is_wayland(&self) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(any(x11_platform, wayland_platform))] {
-                match self {
-                    Platform::Wayland => true,
-                    _ => false,
-                }
+                matches!(self, Platform::Wayland)
             } else {
                 false
             }
@@ -158,10 +155,7 @@ impl Platform {
     pub fn is_x11(&self) -> bool {
         cfg_if::cfg_if! {
             if #[cfg(any(x11_platform, wayland_platform))] {
-                match self {
-                    Platform::X11 => true,
-                    _ => false,
-                }
+                matches!(self, Platform::X11)
             } else {
                 false
             }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -838,6 +838,10 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::Android(AndroidDisplayHandle::empty())
     }
+
+    pub fn platform(&self) -> crate::platform::Platform {
+        crate::platform::Platform::Android
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -65,6 +65,10 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::UiKit(UiKitDisplayHandle::empty())
     }
+
+    pub fn platform(&self) -> crate::platform::Platform {
+        crate::platform::Platform::IOS
+    }
 }
 
 pub struct EventLoop<T: 'static> {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -866,6 +866,14 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
         x11_or_wayland!(match self; Self(evlp) => evlp.raw_display_handle())
     }
+
+    pub fn platform(&self) -> crate::platform::Platform {
+        if self.is_wayland() {
+            crate::platform::Platform::Wayland
+        } else {
+            crate::platform::Platform::X11
+        }
+    }
 }
 
 fn sticky_exit_callback<T, F>(

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -91,6 +91,10 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::AppKit(AppKitDisplayHandle::empty())
     }
+
+    pub fn platform(&self) -> crate::platform::Platform {
+        crate::platform::Platform::MacOS
+    }
 }
 
 impl<T> EventLoopWindowTarget<T> {

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -706,4 +706,8 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::Orbital(OrbitalDisplayHandle::empty())
     }
+
+    pub fn platform(&self) -> crate::platform::Platform {
+        crate::platform::Platform::Orbital
+    }
 }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -352,4 +352,8 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::Web(WebDisplayHandle::empty())
     }
+
+    pub fn platform(&self) -> crate::platform::Platform {
+        crate::platform::Platform::Web
+    }
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -337,6 +337,10 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn set_device_event_filter(&self, filter: DeviceEventFilter) {
         raw_input::register_all_mice_and_keyboards_for_raw_input(self.thread_msg_target, filter);
     }
+
+    pub fn platform(&self) -> crate::platform::Platform {
+        crate::platform::Platform::Windows
+    }
 }
 
 /// Returns the id of the main thread.


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Add `enum Platform`, which compiles down to a single variant on most targets (two on Unixes).

Main motivation: make it easy to detect the platform without requiring things like this:
```rust
        #[cfg(any(
            target_os = "linux",
            target_os = "dragonfly",
            target_os = "freebsd",
            target_os = "netbsd",
            target_os = "openbsd"
        ))]
        {
            use winit::platform::unix::EventLoopWindowTargetExtUnix;
            if elwt.is_wayland() {
                // ...
            }
        }
```
Now it's just:
```rust
    if elwt.platform().is_wayland() {
        // ...
    }
```
with the method compile-time reducing to `false` on most platforms.

Disadvantage of this approach: there's a little more to keep in sync with the cfg-foo in `platform_impl`.

Possibly this could be tested in CI, though it'd probably just result in *another* copy of the cfg-foo.