### PR TITLE
On macOS, set resize increments only for live resize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - Implement `HasRawDisplayHandle` for `EventLoop`.
+- On macOS, set resize increments only for live resizes.
 
 # 0.28.1
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -3,7 +3,7 @@
 use std::ptr;
 
 use objc2::declare::{Ivar, IvarDrop};
-use objc2::foundation::{NSArray, NSObject, NSString};
+use objc2::foundation::{NSArray, NSObject, NSSize, NSString};
 use objc2::rc::{autoreleasepool, Id, Shared};
 use objc2::runtime::Object;
 use objc2::{class, declare_class, msg_send, msg_send_id, sel, ClassType};
@@ -115,6 +115,23 @@ declare_class!(
             trace_scope!("windowDidResize:");
             // NOTE: WindowEvent::Resized is reported in frameDidChange.
             self.emit_move_event();
+        }
+
+        #[sel(windowWillStartLiveResize:)]
+        fn window_will_start_live_resize(&mut self, _: Option<&Object>) {
+            trace_scope!("windowWillStartLiveResize:");
+
+            let increments = self
+                .window
+                .lock_shared_state("window_will_enter_fullscreen")
+                .resize_increments;
+            self.window.set_resize_increments_inner(increments);
+        }
+
+        #[sel(windowDidEndLiveResize:)]
+        fn window_did_end_live_resize(&mut self, _: Option<&Object>) {
+            trace_scope!("windowDidEndLiveResize:");
+            self.window.set_resize_increments_inner(NSSize::new(1., 1.));
         }
 
         // This won't be triggered if the move was part of a resize.


### PR DESCRIPTION
Fixes #2684.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
