### PR TITLE
[macOS] resize simple fullscreen windows on windowDidChangeScreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix rounding issues when doing resize.
 - On macOS, fix wrong focused state on startup.
 - On Windows, fix crash on setting taskbar when using Visual Studio debugger.
+- On macOS, resize simple fullscreen windows on windowDidChangeScreen events.
 
 # 0.28.1
 

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -5,6 +5,9 @@ use winit::event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEve
 use winit::event_loop::EventLoop;
 use winit::window::{Fullscreen, WindowBuilder};
 
+#[cfg(target_os = "macos")]
+use winit::platform::macos::WindowExtMacOS;
+
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
@@ -32,6 +35,8 @@ fn main() {
     println!("- Esc\tExit");
     println!("- F\tToggle exclusive fullscreen mode");
     println!("- B\tToggle borderless mode");
+    #[cfg(target_os = "macos")]
+    println!("- C\tToggle simple fullscreen mode");
     println!("- S\tNext screen");
     println!("- M\tNext mode for this screen");
     println!("- D\tToggle window decorations");
@@ -66,6 +71,10 @@ fn main() {
                         let fullscreen = Some(Fullscreen::Borderless(Some(monitor.clone())));
                         println!("Setting mode: {fullscreen:?}");
                         window.set_fullscreen(fullscreen);
+                    }
+                    #[cfg(target_os = "macos")]
+                    VirtualKeyCode::C => {
+                        window.set_simple_fullscreen(!window.simple_fullscreen());
                     }
                     VirtualKeyCode::S => {
                         monitor_index += 1;

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -409,6 +409,20 @@ declare_class!(
                 self.queue_event(WindowEvent::ThemeChanged(theme));
             }
         }
+
+        #[sel(windowDidChangeScreen:)]
+        fn window_did_change_screen(&self, _: Option<&Object>) {
+            trace_scope!("windowDidChangeScreen:");
+            let is_simple_fullscreen = self
+                .window
+                .lock_shared_state("window_did_change_screen")
+                .is_simple_fullscreen;
+            if is_simple_fullscreen {
+                if let Some(screen) = self.window.screen() {
+                    self.window.setFrame_display(screen.frame(), true);
+                }
+            }
+        }
     }
 );
 


### PR DESCRIPTION
I'm an Alacritty user and ran into #1118 (via alacritty/alacritty#2741). It's tagged with "good first issue" and someone helpfully left some details on the AppKit side of things so I thought I'd take a crack at it. I'm kind of a Rust newb (and even bigger AppKit/ObjC newb) so happy for any feedback if this should be tackled in a different way.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
