### PR TITLE
feat: Cross-platform popup windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, remove unnecessary `Window::is_dark_mode()`, which was replaced with `Window::theme()`.
 - On Web, add `WindowBuilderExtWebSys::with_append()` to append the canvas element to the web page on creation.
 - On Windows, add `drag_resize_window` method support.
+- Add the `platform::popup` module, for a cross-platform strategy for creating popup windows.
 
 # 0.29.0-beta.0
 

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -191,7 +191,7 @@ Legend:
 |Fullscreen toggle                |✔️     |✔️     |✔️         |✔️             |**N/A**|✔️     |✔️        |**N/A** |
 |Exclusive fullscreen             |✔️     |✔️     |✔️         |**N/A**         |❌    |✔️     |**N/A**|**N/A** |
 |HiDPI support                    |✔️     |✔️     |✔️         |✔️             |✔️     |✔️    |✔️    |❌      |
-|Popup windows                    |❌     |❌     |❌         |❌             |❌    |❌     |**N/A**|**N/A** |
+|Popup windows                    |✔     |❌    |✔         |❌             |❌    |❌     |**N/A**|**N/A** |
 
 ### System information
 |Feature          |Windows|MacOS |Linux x11|Linux Wayland|Android|iOS      |Web      |Redox OS|

--- a/examples/window_popup.rs
+++ b/examples/window_popup.rs
@@ -1,4 +1,8 @@
 #[cfg(any(x11_platform, windows_platform))]
+#[path = "util/fill.rs"]
+mod fill;
+
+#[cfg(any(x11_platform, windows_platform))]
 fn main() {
     use winit::{
         dpi::{LogicalPosition, LogicalSize, Position},
@@ -20,11 +24,16 @@ fn main() {
 
     println!("parent window: {parent_window:?})");
 
+    let monitor_size = event_loop.primary_monitor().unwrap().size();
+    let child_posn = LogicalPosition::new(
+        (monitor_size.width as f64 - 200.0) / 2.0,
+        (monitor_size.height as f64 - 200.0) / 2.0,
+    );
     let mut child_window = Some(
         WindowBuilder::new()
             .with_title("popup window")
             .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
-            .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+            .with_position(Position::Logical(child_posn))
             .with_transient_parent(parent_window.as_ref().unwrap())
             .build(&event_loop)
             .unwrap(),
@@ -47,6 +56,12 @@ fn main() {
                     child_window.take();
                 }
                 _ => (),
+            }
+        } else if let Event::RedrawRequested(wid) = event {
+            if Some(wid) == parent_window.as_ref().map(|w| w.id()) {
+                fill::fill_window(parent_window.as_ref().unwrap());
+            } else if Some(wid) == child_window.as_ref().map(|w| w.id()) {
+                fill::fill_window(child_window.as_ref().unwrap());
             }
         }
     })

--- a/examples/window_popup.rs
+++ b/examples/window_popup.rs
@@ -1,0 +1,58 @@
+#[cfg(any(x11_platform, windows_platform))]
+fn main() {
+    use winit::{
+        dpi::{LogicalPosition, LogicalSize, Position},
+        event::{Event, WindowEvent},
+        event_loop::EventLoop,
+        platform::popup::WindowBuilderExtPopup,
+        window::WindowBuilder,
+    };
+
+    let event_loop: EventLoop<()> = EventLoop::new();
+    let mut parent_window = Some(
+        WindowBuilder::new()
+            .with_title("parent window")
+            .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+            .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))
+            .build(&event_loop)
+            .unwrap(),
+    );
+
+    println!("parent window: {parent_window:?})");
+
+    let mut child_window = Some(
+        WindowBuilder::new()
+            .with_title("popup window")
+            .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
+            .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+            .with_transient_parent(parent_window.as_ref().unwrap())
+            .build(&event_loop)
+            .unwrap(),
+    );
+
+    event_loop.run(move |event: Event<'_, ()>, _, control_flow| {
+        control_flow.set_wait();
+
+        if let Event::WindowEvent { event, window_id } = event {
+            match event {
+                WindowEvent::CloseRequested
+                    if Some(window_id) == parent_window.as_ref().map(|w| w.id()) =>
+                {
+                    parent_window.take();
+                    control_flow.set_exit();
+                }
+                WindowEvent::CloseRequested
+                    if Some(window_id) == child_window.as_ref().map(|w| w.id()) =>
+                {
+                    child_window.take();
+                }
+                _ => (),
+            }
+        }
+    })
+}
+
+#[cfg(not(any(x11_platform, windows_platform)))]
+fn main() {
+    panic!("This example is supported only on x11 and Windows.");
+}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -45,3 +45,6 @@ pub mod modifier_supplement;
 ))]
 pub mod run_return;
 pub mod scancode;
+
+#[cfg(any(windows_platform, x11_platform))]
+pub mod popup;

--- a/src/platform/popup.rs
+++ b/src/platform/popup.rs
@@ -1,0 +1,30 @@
+//! Extension traits for creating popup windows.
+
+use crate::window::WindowBuilder;
+use __private::Sealed;
+use raw_window_handle::HasRawWindowHandle;
+
+/// Additional methods on [`WindowBuilder`] to create popup windows.
+pub trait WindowBuilderExtPopup: Sealed {
+    /// Sets this window to be a popup window for the provided parent window.
+    ///
+    /// This method is only available on Windows and X11. This has no effect on Wayland.
+    fn with_transient_parent(self, parent: impl HasRawWindowHandle) -> WindowBuilder;
+}
+
+impl WindowBuilderExtPopup for WindowBuilder {
+    fn with_transient_parent(mut self, parent: impl HasRawWindowHandle) -> WindowBuilder {
+        let hwnd = parent.raw_window_handle();
+        self.platform_specific.owner = Some(hwnd);
+        self
+    }
+}
+
+mod __private {
+    use crate::window::WindowBuilder;
+
+    #[doc(hidden)]
+    pub trait Sealed {}
+
+    impl Sealed for WindowBuilder {}
+}

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -192,6 +192,7 @@ pub trait WindowBuilderExtWindows {
     /// - An owned window is hidden when its owner is minimized.
     ///
     /// For more information, see <https://docs.microsoft.com/en-us/windows/win32/winmsg/window-features#owned-windows>
+    #[deprecated = "Use `WindowBuilderExtPopup::with_transient_parent()` instead"]
     fn with_owner_window(self, parent: HWND) -> WindowBuilder;
 
     /// Sets a menu on the window to be created.
@@ -233,7 +234,11 @@ pub trait WindowBuilderExtWindows {
 impl WindowBuilderExtWindows for WindowBuilder {
     #[inline]
     fn with_owner_window(mut self, parent: HWND) -> WindowBuilder {
-        self.platform_specific.owner = Some(parent);
+        use raw_window_handle::{RawWindowHandle, Win32WindowHandle};
+
+        let mut hwnd = Win32WindowHandle::empty();
+        hwnd.hwnd = parent as _;
+        self.platform_specific.owner = Some(RawWindowHandle::Win32(hwnd));
         self
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -101,6 +101,8 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub override_redirect: bool,
     #[cfg(x11_platform)]
     pub x11_window_types: Vec<XWindowType>,
+    #[cfg(x11_platform)]
+    pub owner: Option<RawWindowHandle>,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -118,6 +120,8 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             override_redirect: false,
             #[cfg(x11_platform)]
             x11_window_types: vec![XWindowType::Normal],
+            #[cfg(x11_platform)]
+            owner: None,
         }
     }
 }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -22,9 +22,11 @@ use crate::event::DeviceId as RootDeviceId;
 use crate::icon::Icon;
 use crate::keyboard::Key;
 
+use raw_window_handle::RawWindowHandle;
+
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
-    pub owner: Option<HWND>,
+    pub owner: Option<RawWindowHandle>,
     pub menu: Option<HMENU>,
     pub taskbar_icon: Option<Icon>,
     pub no_redirection_bitmap: bool,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1140,10 +1140,11 @@ where
         }
         Some(raw) => unreachable!("Invalid raw window handle {raw:?} on Windows"),
         None => match pl_attribs.owner {
-            Some(parent) => {
+            Some(RawWindowHandle::Win32(parent)) => {
                 window_flags.set(WindowFlags::POPUP, true);
-                Some(parent)
+                Some(parent.hwnd as _)
             }
+            Some(raw) => unreachable!("Invalid raw window handle {raw:?} on Windows"),
             None => {
                 window_flags.set(WindowFlags::ON_TASKBAR, true);
                 None


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR adds a cross-platform way of creating popup windows; basically, what `with_owner_window` does for Windows, but cross platform. This should allow us to create popup windows on all platforms that support them.

I've only implemented Windows and X11 for now, since those are the platforms I'm most familiar with. We should also be able to add some of the other platforms.

~~Blocked on #2614~~