### PR TITLE
On macOS, fix initial focused state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix rare crash on DPI change
 - Web: Added support for `Window::theme`.
 - On Wayland, fix rounding issues when doing resize.
+- On macOS, fix wrong focused state on startup.
 
 # 0.28.1
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -466,6 +466,10 @@ impl WinitWindow {
 
         let delegate = WinitWindowDelegate::new(&this, attrs.fullscreen.is_some());
 
+        // XXX Send `Focused(false)` right after creating the window delegate, so we won't
+        // obscure the real focused events on the startup.
+        delegate.queue_event(WindowEvent::Focused(false));
+
         // Set fullscreen mode after we setup everything
         this.set_fullscreen(attrs.fullscreen.map(Into::into));
 
@@ -484,8 +488,6 @@ impl WinitWindow {
         if attrs.maximized {
             this.set_maximized(attrs.maximized);
         }
-
-        delegate.queue_event(WindowEvent::Focused(false));
 
         Ok((this, delegate))
     }


### PR DESCRIPTION
The synthetic focused event was queued after the real event was send leading to focused issues on startup.

Fixes #2695.
