### PR TITLE
Renamed `DeviceEventFilter` to `DeviceEvents`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Please keep one empty line before and after all headers. (This is required for `
 And please only add new entries to the top of this list, right below the `# Unreleased` header.
 
 # Unreleased
+- **Breaking** Renamed `EventLoopWindowTarget::set_device_event_filter` to `EventLoopWindowTarget::listen_device_events` and `DeviceEventFilter` to `DeviceEvents` and appropriately reversed its variants.
+- On X11, fix `EventLoopWindowTarget::listen_device_events` effect being reversed.
 
 - **Breaking:** Remove all deprecated `modifiers` fields.
 - **Breaking:** Overhaul keyboard input handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ Please keep one empty line before and after all headers. (This is required for `
 
 And please only add new entries to the top of this list, right below the `# Unreleased` header.
 
-# Unreleased
-- **Breaking** Renamed `EventLoopWindowTarget::set_device_event_filter` to `EventLoopWindowTarget::listen_device_events` and `DeviceEventFilter` to `DeviceEvents` and appropriately reversed its variants.
-- On X11, fix `EventLoopWindowTarget::listen_device_events` effect being reversed.
 
+# Unreleased
+- **Breaking** Rename `DeviceEventFilter` to `DeviceEvents` reversing the behavior of variants.
+- **Breaking** Rename `EventLoopWindowTarget::set_device_event_filter` to `listen_device_events`.
+- On X11, fix `EventLoopWindowTarget::listen_device_events` effect being reversed.
 - **Breaking:** Remove all deprecated `modifiers` fields.
 - **Breaking:** Overhaul keyboard input handling.
   - Replace `KeyboardInput` with `KeyEvent` and `RawKeyEvent`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ Please keep one empty line before and after all headers. (This is required for `
 
 And please only add new entries to the top of this list, right below the `# Unreleased` header.
 
-
 # Unreleased
+
 - **Breaking** Rename `DeviceEventFilter` to `DeviceEvents` reversing the behavior of variants.
 - **Breaking** Rename `EventLoopWindowTarget::set_device_event_filter` to `listen_device_events`.
 - On X11, fix `EventLoopWindowTarget::listen_device_events` effect being reversed.

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -6,7 +6,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{DeviceEventFilter, EventLoop},
+    event_loop::{DeviceEvents, EventLoop},
     keyboard::Key,
     window::{WindowBuilder, WindowButtons},
 };
@@ -26,7 +26,7 @@ fn main() {
     eprintln!("  (G) Toggle maximize button");
     eprintln!("  (H) Toggle minimize button");
 
-    event_loop.set_device_event_filter(DeviceEventFilter::Never);
+    event_loop.listen_device_events(DeviceEvents::Always);
 
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -6,7 +6,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::{LogicalSize, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, KeyEvent, RawKeyEvent, WindowEvent},
-    event_loop::{DeviceEventFilter, EventLoop},
+    event_loop::{DeviceEvents, EventLoop},
     keyboard::{Key, KeyCode},
     window::{Fullscreen, WindowBuilder},
 };
@@ -33,7 +33,7 @@ fn main() {
     let mut minimized = false;
     let mut visible = true;
 
-    event_loop.set_device_event_filter(DeviceEventFilter::Never);
+    event_loop.listen_device_events(DeviceEvents::Always);
 
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -352,20 +352,20 @@ impl<T> EventLoopWindowTarget<T> {
             .map(|inner| MonitorHandle { inner })
     }
 
-    /// Change [`DeviceEvent`] filter mode.
+    /// Change if or when [`DeviceEvent`]s are captured.
     ///
     /// Since the [`DeviceEvent`] capture can lead to high CPU usage for unfocused windows, winit
     /// will ignore them by default for unfocused windows on Linux/BSD. This method allows changing
-    /// this filter at runtime to explicitly capture them again.
+    /// this at runtime to explicitly capture them again.
     ///
     /// ## Platform-specific
     ///
     /// - **Wayland / macOS / iOS / Android / Web / Orbital:** Unsupported.
     ///
     /// [`DeviceEvent`]: crate::event::DeviceEvent
-    pub fn listen_device_events(&self, _filter: DeviceEvents) {
+    pub fn listen_device_events(&self, _allowed: DeviceEvents) {
         #[cfg(any(x11_platform, wayland_platform, windows))]
-        self.p.listen_device_events(_filter);
+        self.p.listen_device_events(_allowed);
     }
 }
 
@@ -423,14 +423,14 @@ impl<T> fmt::Display for EventLoopClosed<T> {
 
 impl<T: fmt::Debug> error::Error for EventLoopClosed<T> {}
 
-/// Controlling when device events are propagated.
+/// Controlling when device events are captured.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum DeviceEvents {
     /// Report device events regardless of window focus.
     Always,
-    /// Only propogate device events while the window is focused.
+    /// Only capture device events while the window is focused.
     WhenFocused,
-    /// Never propogate device events.
+    /// Never capture device events.
     Never,
 }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -423,19 +423,14 @@ impl<T> fmt::Display for EventLoopClosed<T> {
 
 impl<T: fmt::Debug> error::Error for EventLoopClosed<T> {}
 
-/// Controlling when device events are captured.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+/// Control when device events are captured.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
 pub enum DeviceEvents {
     /// Report device events regardless of window focus.
     Always,
     /// Only capture device events while the window is focused.
+    #[default]
     WhenFocused,
     /// Never capture device events.
     Never,
-}
-
-impl Default for DeviceEvents {
-    fn default() -> Self {
-        Self::WhenFocused
-    }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -363,9 +363,9 @@ impl<T> EventLoopWindowTarget<T> {
     /// - **Wayland / macOS / iOS / Android / Web / Orbital:** Unsupported.
     ///
     /// [`DeviceEvent`]: crate::event::DeviceEvent
-    pub fn set_device_event_filter(&self, _filter: DeviceEventFilter) {
+    pub fn listen_device_events(&self, _filter: DeviceEvents) {
         #[cfg(any(x11_platform, wayland_platform, windows))]
-        self.p.set_device_event_filter(_filter);
+        self.p.listen_device_events(_filter);
     }
 }
 
@@ -423,19 +423,19 @@ impl<T> fmt::Display for EventLoopClosed<T> {
 
 impl<T: fmt::Debug> error::Error for EventLoopClosed<T> {}
 
-/// Filter controlling the propagation of device events.
+/// Controlling when device events are propagated.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-pub enum DeviceEventFilter {
-    /// Always filter out device events.
+pub enum DeviceEvents {
+    /// Report device events regardless of window focus.
     Always,
-    /// Filter out device events while the window is not focused.
-    Unfocused,
-    /// Report all device events regardless of window focus.
+    /// Only propogate device events while the window is focused.
+    WhenFocused,
+    /// Never propogate device events.
     Never,
 }
 
-impl Default for DeviceEventFilter {
+impl Default for DeviceEvents {
     fn default() -> Self {
-        Self::Unfocused
+        Self::WhenFocused
     }
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -29,7 +29,7 @@ use crate::platform::x11::XlibErrorHook;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
-    event::Event,
+    event::{Event, KeyEvent},
     event_loop::{ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
     icon::Icon,
     keyboard::{Key, KeyCode},

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -29,10 +29,8 @@ use crate::platform::x11::XlibErrorHook;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
-    event::{Event, KeyEvent},
-    event_loop::{
-        ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
-    },
+    event::Event,
+    event_loop::{ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
     icon::Icon,
     keyboard::{Key, KeyCode},
     platform::{modifier_supplement::KeyEventExtModifierSupplement, scancode::KeyCodeExtScancode},
@@ -894,12 +892,12 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn set_device_event_filter(&self, _filter: DeviceEventFilter) {
+    pub fn listen_device_events(&self, _filter: DeviceEvents) {
         match *self {
             #[cfg(wayland_platform)]
             EventLoopWindowTarget::Wayland(_) => (),
             #[cfg(x11_platform)]
-            EventLoopWindowTarget::X(ref evlp) => evlp.set_device_event_filter(_filter),
+            EventLoopWindowTarget::X(ref evlp) => evlp.listen_device_events(_filter),
         }
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -892,12 +892,12 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     #[inline]
-    pub fn listen_device_events(&self, _filter: DeviceEvents) {
+    pub fn listen_device_events(&self, _allowed: DeviceEvents) {
         match *self {
             #[cfg(wayland_platform)]
             EventLoopWindowTarget::Wayland(_) => (),
             #[cfg(x11_platform)]
-            EventLoopWindowTarget::X(ref evlp) => evlp.listen_device_events(_filter),
+            EventLoopWindowTarget::X(ref evlp) => evlp.set_listen_device_events(_allowed),
         }
     }
 

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -813,7 +813,7 @@ impl<T: 'static> EventProcessor<T> {
                         if self.active_window != Some(xev.event) {
                             self.active_window = Some(xev.event);
 
-                            wt.update_device_event_filter(true);
+                            wt.update_listen_device_events(true);
 
                             let window_id = mkwid(xev.event);
                             let position = PhysicalPosition::new(xev.event_x, xev.event_y);
@@ -877,7 +877,7 @@ impl<T: 'static> EventProcessor<T> {
                         if self.active_window.take() == Some(xev.event) {
                             let window_id = mkwid(xev.event);
 
-                            wt.update_device_event_filter(false);
+                            wt.update_listen_device_events(false);
 
                             // Issue key release events for all pressed keys
                             Self::handle_pressed_keys(

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -575,13 +575,13 @@ impl<T> EventLoopWindowTarget<T> {
         self.device_events.set(allowed);
     }
 
-    /// Update the device event filter based on window focus.
+    /// Update the device event based on window focus.
     pub fn update_listen_device_events(&self, focus: bool) {
-        let filter_events = self.device_events.get() == DeviceEvents::Never
-            || (self.device_events.get() == DeviceEvents::WhenFocused && !focus);
+        let device_events = self.device_events.get() == DeviceEvents::Always
+            || (focus && self.device_events.get() == DeviceEvents::WhenFocused);
 
         let mut mask = 0;
-        if !filter_events {
+        if device_events {
             mask = ffi::XI_RawMotionMask
                 | ffi::XI_RawButtonPressMask
                 | ffi::XI_RawButtonReleaseMask

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -46,9 +46,7 @@ use super::common::xkb_state::KbdState;
 use crate::{
     error::OsError as RootOsError,
     event::{Event, StartCause},
-    event_loop::{
-        ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
-    },
+    event_loop::{ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
     platform_impl::{
         platform::{sticky_exit_callback, WindowId},
         PlatformSpecificWindowBuilderAttributes,
@@ -107,7 +105,7 @@ pub struct EventLoopWindowTarget<T> {
     ime: RefCell<Ime>,
     windows: RefCell<HashMap<WindowId, Weak<UnownedWindow>>>,
     redraw_sender: WakeSender<WindowId>,
-    device_event_filter: Cell<DeviceEventFilter>,
+    device_event_filter: Cell<DeviceEvents>,
     _marker: ::std::marker::PhantomData<T>,
 }
 
@@ -573,14 +571,14 @@ impl<T> EventLoopWindowTarget<T> {
         &self.xconn
     }
 
-    pub fn set_device_event_filter(&self, filter: DeviceEventFilter) {
+    pub fn listen_device_events(&self, filter: DeviceEvents) {
         self.device_event_filter.set(filter);
     }
 
     /// Update the device event filter based on window focus.
     pub fn update_device_event_filter(&self, focus: bool) {
-        let filter_events = self.device_event_filter.get() == DeviceEventFilter::Never
-            || (self.device_event_filter.get() == DeviceEventFilter::Unfocused && !focus);
+        let filter_events = self.device_event_filter.get() == DeviceEvents::Never
+            || (self.device_event_filter.get() == DeviceEvents::WhenFocused && !focus);
 
         let mut mask = 0;
         if !filter_events {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -342,8 +342,8 @@ impl<T> EventLoopWindowTarget<T> {
         RawDisplayHandle::Windows(WindowsDisplayHandle::empty())
     }
 
-    pub fn listen_device_events(&self, filter: DeviceEvents) {
-        raw_input::register_all_mice_and_keyboards_for_raw_input(self.thread_msg_target, filter);
+    pub fn listen_device_events(&self, allowed: DeviceEvents) {
+        raw_input::register_all_mice_and_keyboards_for_raw_input(self.thread_msg_target, allowed);
     }
 }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -76,9 +76,7 @@ use windows_sys::Win32::{
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{DeviceEvent, Event, Force, Ime, RawKeyEvent, Touch, TouchPhase, WindowEvent},
-    event_loop::{
-        ControlFlow, DeviceEventFilter, EventLoopClosed, EventLoopWindowTarget as RootELW,
-    },
+    event_loop::{ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
     keyboard::{KeyCode, ModifiersState},
     platform::scancode::KeyCodeExtScancode,
     platform_impl::platform::{
@@ -344,7 +342,7 @@ impl<T> EventLoopWindowTarget<T> {
         RawDisplayHandle::Windows(WindowsDisplayHandle::empty())
     }
 
-    pub fn set_device_event_filter(&self, filter: DeviceEventFilter) {
+    pub fn listen_device_events(&self, filter: DeviceEvents) {
         raw_input::register_all_mice_and_keyboards_for_raw_input(self.thread_msg_target, filter);
     }
 }

--- a/src/platform_impl/windows/raw_input.rs
+++ b/src/platform_impl/windows/raw_input.rs
@@ -23,7 +23,7 @@ use windows_sys::Win32::{
     },
 };
 
-use crate::{event::ElementState, event_loop::DeviceEventFilter, platform_impl::platform::util};
+use crate::{event::ElementState, event_loop::DeviceEvents, platform_impl::platform::util};
 
 #[allow(dead_code)]
 pub fn get_raw_input_device_list() -> Option<Vec<RAWINPUTDEVICELIST>> {
@@ -140,18 +140,18 @@ pub fn register_raw_input_devices(devices: &[RAWINPUTDEVICE]) -> bool {
 
 pub fn register_all_mice_and_keyboards_for_raw_input(
     mut window_handle: HWND,
-    filter: DeviceEventFilter,
+    filter: DeviceEvents,
 ) -> bool {
     // RIDEV_DEVNOTIFY: receive hotplug events
     // RIDEV_INPUTSINK: receive events even if we're not in the foreground
     // RIDEV_REMOVE: don't receive device events (requires NULL hwndTarget)
     let flags = match filter {
-        DeviceEventFilter::Always => {
+        DeviceEvents::Never => {
             window_handle = 0;
             RIDEV_REMOVE
         }
-        DeviceEventFilter::Unfocused => RIDEV_DEVNOTIFY,
-        DeviceEventFilter::Never => RIDEV_DEVNOTIFY | RIDEV_INPUTSINK,
+        DeviceEvents::WhenFocused => RIDEV_DEVNOTIFY,
+        DeviceEvents::Always => RIDEV_DEVNOTIFY | RIDEV_INPUTSINK,
     };
 
     let devices: [RAWINPUTDEVICE; 2] = [


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Renamed `EventLoopWindowTarget::set_device_event_filter` to `EventLoopWindowTarget::listen_device_events` and `DeviceEventFilter` to `DeviceEvents` and appropriately reversed its variants according to https://github.com/rust-windowing/winit/issues/2591#issuecomment-1353254710.

Could only test it on Linux.

Fixes #2591.