### PR TITLE
macOS: send the unfocus event before making the window key

### DIFF
--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -468,6 +468,10 @@ impl WinitWindow {
         // Set fullscreen mode after we setup everything
         this.set_fullscreen(attrs.fullscreen.map(Into::into));
 
+        // Sending the unfocused event by default
+        // A focus event will be sent if the window is made key by the next step
+        delegate.queue_event(WindowEvent::Focused(false));
+
         // Setting the window as key has to happen *after* we set the fullscreen
         // state, since otherwise we'll briefly see the window at normal size
         // before it transitions.
@@ -483,8 +487,6 @@ impl WinitWindow {
         if attrs.maximized {
             this.set_maximized(attrs.maximized);
         }
-
-        delegate.queue_event(WindowEvent::Focused(false));
 
         Ok((this, delegate))
     }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

On macOS, when creating a window after the application creation, it starts as unfocused, receiving a `WindowEvent::Focus(false)` immediately after a `WindowEvent::Focus(true)`.

This is because the event queued to set the default focus (false) was sent after the call to `makeKeyAndOrderFront`. This works fine if both windows are created at the same time at application creation, but not if the second window is created later as a result of something happening in the first window.

This PR moves the default event just before making the window key which fixes the issue for me.