### PR TITLE
Add cargo-deny check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,24 @@ jobs:
   cargo-deny:
     name: cargo-deny
 
+    # TODO: remove this matrix when https://github.com/EmbarkStudios/cargo-deny/issues/324 is resolved
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - aarch64-apple-ios
+          - aarch64-linux-android
+          - i686-pc-windows-gnu
+          - i686-pc-windows-msvc
+          - i686-unknown-linux-gnu
+          - wasm32-unknown-unknown
+          - x86_64-apple-darwin
+          - x86_64-apple-ios
+          - x86_64-pc-windows-gnu
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-redox
+
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -27,7 +45,7 @@ jobs:
       with:
         command: check
         log-level: error
-        arguments: --all-features
+        arguments: --all-features --target ${{ matrix.platform }}
 
   tests:
     name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         command: check
         log-level: error
-        arguments: --all-features --target ${{ matrix.platform.target }}
+        arguments: --all-features --target ${{ matrix.platform }}
 
   tests:
     name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,18 +20,6 @@ jobs:
   cargo-deny:
     name: cargo-deny
 
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - aarch64-apple-darwin
-          - aarch64-apple-darwin
-          - aarch64-linux-android
-          - x86_64-apple-darwin
-          - x86_64-pc-windows-msvc
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -39,7 +27,7 @@ jobs:
       with:
         command: check
         log-level: error
-        arguments: --all-features --target ${{ matrix.platform }}
+        arguments: --all-features
 
   tests:
     name: Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,9 @@ jobs:
         !contains(matrix.platform.target, 'redox') &&
         matrix.rust_version != '1.64.0'
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
+
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check
+        log-level: error
+        arguments: --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,30 @@ jobs:
         components: rustfmt
     - name: Check Formatting
       run: cargo +stable fmt --all -- --check
+  
+  cargo-deny:
+    name: cargo-deny
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - aarch64-apple-darwin
+          - aarch64-apple-darwin
+          - aarch64-linux-android
+          - x86_64-apple-darwin
+          - x86_64-pc-windows-msvc
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check
+        log-level: error
+        arguments: --all-features --target ${{ matrix.platform.target }}
 
   tests:
     name: Tests
@@ -119,9 +143,3 @@ jobs:
         !contains(matrix.platform.target, 'redox') &&
         matrix.rust_version != '1.64.0'
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
-
-    - uses: EmbarkStudios/cargo-deny-action@v1
-      with:
-        command: check
-        log-level: error
-        arguments: --all-features

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,35 @@
+# https://embarkstudios.github.io/cargo-deny/
+# cargo install cargo-deny
+# cargo deny --all-features --log-level error check
+
+targets = [
+    { triple = "aarch64-apple-darwin" },
+    { triple = "aarch64-apple-darwin" },
+    { triple = "aarch64-linux-android" },
+    { triple = "wasm32-unknown-unknown" },
+    { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-pc-windows-msvc" },
+    { triple = "x86_64-unknown-linux-gnu" },
+    { triple = "x86_64-unknown-linux-musl" },
+]
+
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "deny"
+ignore = []
+
+
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"        # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
+deny = []
+skip = []
+skip-tree = []
+
+
+[licenses]
+unlicensed = "allow"
+allow-osi-fsf-free = "either"
+copyleft = "allow"

--- a/deny.toml
+++ b/deny.toml
@@ -1,8 +1,8 @@
 # https://embarkstudios.github.io/cargo-deny/
 # cargo install cargo-deny
-# cargo update && cargo deny --all-features --log-level error check
-
-# If we don't specify this, all targets are checked
+# cargo update && cargo deny --all-features --log-level error --target aarch64-apple-ios check
+# Note: running just `cargo deny check` without a `--target` will result in
+# false positives due to https://github.com/EmbarkStudios/cargo-deny/issues/324
 targets = [
     { triple = "aarch64-apple-ios" },
     { triple = "aarch64-linux-android" },

--- a/deny.toml
+++ b/deny.toml
@@ -2,14 +2,20 @@
 # cargo install cargo-deny
 # cargo update && cargo deny --all-features --log-level error check
 
+# If we don't specify this, all targets are checked
 targets = [
-    { triple = "aarch64-apple-darwin" },
-    { triple = "aarch64-apple-darwin" },
+    { triple = "aarch64-apple-ios" },
     { triple = "aarch64-linux-android" },
+    { triple = "i686-pc-windows-gnu" },
+    { triple = "i686-pc-windows-msvc" },
+    { triple = "i686-unknown-linux-gnu" },
+    { triple = "wasm32-unknown-unknown" },
     { triple = "x86_64-apple-darwin" },
+    { triple = "x86_64-apple-ios" },
+    { triple = "x86_64-pc-windows-gnu" },
     { triple = "x86_64-pc-windows-msvc" },
     { triple = "x86_64-unknown-linux-gnu" },
-    { triple = "x86_64-unknown-linux-musl" },
+    { triple = "x86_64-unknown-redox" },
 ]
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,6 @@ targets = [
     { triple = "aarch64-apple-darwin" },
     { triple = "aarch64-apple-darwin" },
     { triple = "aarch64-linux-android" },
-    { triple = "wasm32-unknown-unknown" },
     { triple = "x86_64-apple-darwin" },
     { triple = "x86_64-pc-windows-msvc" },
     { triple = "x86_64-unknown-linux-gnu" },

--- a/deny.toml
+++ b/deny.toml
@@ -31,7 +31,8 @@ multiple-versions = "deny"
 wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
 deny = []
 skip = [
-    { name = "nix" }, # differing version - as of 2023-03-02 whis can be solved with `cargo update && cargo update -p calloop --precise 0.10.2`
+    { name = "nix" },           # differing version - as of 2023-03-02 whis can be solved with `cargo update && cargo update -p calloop --precise 0.10.2`
+    { name = "redox_syscall" }, # https://gitlab.redox-os.org/redox-os/orbclient/-/issues/46
 ]
 skip-tree = []
 

--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,25 @@ skip-tree = []
 
 
 [licenses]
-unlicensed = "allow"
-allow-osi-fsf-free = "either"
-copyleft = "allow"
+private = { ignore = true }
+unlicensed = "deny"
+allow-osi-fsf-free = "neither"
+confidence-threshold = 0.92 # We want really high confidence when inferring licenses from text
+copyleft = "deny"
+allow = [
+    "Apache-2.0 WITH LLVM-exception", # https://spdx.org/licenses/LLVM-exception.html
+    "Apache-2.0",                     # https://tldrlegal.com/license/apache-license-2.0-(apache-2.0)
+    "BSD-2-Clause",                   # https://tldrlegal.com/license/bsd-2-clause-license-(freebsd)
+    "BSD-3-Clause",                   # https://tldrlegal.com/license/bsd-3-clause-license-(revised)
+    "BSL-1.0",                        # https://tldrlegal.com/license/boost-software-license-1.0-explained
+    "CC0-1.0",                        # https://creativecommons.org/publicdomain/zero/1.0/
+    "ISC",                            # https://tldrlegal.com/license/-isc-license
+    "LicenseRef-UFL-1.0",             # https://tldrlegal.com/license/ubuntu-font-license,-1.0 - no official SPDX, see https://github.com/emilk/egui/issues/2321
+    "MIT-0",                          # https://choosealicense.com/licenses/mit-0/
+    "MIT",                            # https://tldrlegal.com/license/mit-license
+    "MPL-2.0",                        # https://www.mozilla.org/en-US/MPL/2.0/FAQ/ - see Q11. Used by webpki-roots on Linux.
+    "OFL-1.1",                        # https://spdx.org/licenses/OFL-1.1.html
+    "OpenSSL",                        # https://www.openssl.org/source/license.html - used on Linux
+    "Unicode-DFS-2016",               # https://spdx.org/licenses/Unicode-DFS-2016.html
+    "Zlib",                           # https://tldrlegal.com/license/zlib-libpng-license-(zlib)
+]

--- a/deny.toml
+++ b/deny.toml
@@ -22,9 +22,11 @@ ignore = []
 
 [bans]
 multiple-versions = "deny"
-wildcards = "allow"        # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
+wildcards = "allow" # at least until https://github.com/EmbarkStudios/cargo-deny/issues/241 is fixed
 deny = []
-skip = []
+skip = [
+    { name = "nix" }, # differing version - as of 2023-03-02 whis can be solved with `cargo update && cargo update -p calloop --precise 0.10.2`
+]
 skip-tree = []
 
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,6 +1,6 @@
 # https://embarkstudios.github.io/cargo-deny/
 # cargo install cargo-deny
-# cargo deny --all-features --log-level error check
+# cargo update && cargo deny --all-features --log-level error check
 
 targets = [
     { triple = "aarch64-apple-darwin" },


### PR DESCRIPTION
[cargo-deny](https://github.com/EmbarkStudios/cargo-deny) is an amazing tool that protects from:

* duplicated crates (code bloat)
* copy-left licenses in the dependency tree
* RUSTSEC advisories

Try it:
```sh
cargo install cargo-deny
cargo update
cargo deny --all-features --log-level error check
```


(**EDIT**: removed wrong stuff about rustsec and duplicated deps due to me using an outdated `Cargo.lock`)

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
