### PR TITLE
Changed 'an' to 'a' in documentation

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -227,7 +227,7 @@ pub enum Event<'a, T: 'static> {
     /// Emitted when the event loop is being shut down.
     ///
     /// This is irreversible - if this event is emitted, it is guaranteed to be the last event that
-    /// gets emitted. You generally want to treat this as an "do on quit" event.
+    /// gets emitted. You generally want to treat this as a "do on quit" event.
     LoopDestroyed,
 }
 


### PR DESCRIPTION
This change is motivated by the distinct use cases of the articles 'a'
and 'an'. In this case 'a' is more suitable as 'do' begins phonetically
with a consonant.

See documentation: https://en.wiktionary.org/wiki/an#Usage_notes

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
