### PR TITLE
On web, allow recreating event loop when using `spawn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On web, allow event loops to be recreated with `spawn`.
 - Bump MSRV from `1.60` to `1.64`.
 - Fix macOS memory leaks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
-- On web, allow event loops to be recreated with `spawn`.
+- On Web, allow `EventLoop` to be recreated after using `spawn`.
 - Bump MSRV from `1.60` to `1.64`.
 - Fix macOS memory leaks.
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -114,7 +114,10 @@ impl<T> EventLoopBuilder<T> {
     )]
     #[inline]
     pub fn build(&mut self) -> EventLoop<T> {
-        let mut event_loop_created = EVENT_LOOP_CREATED.get_or_init(|| Mutex::new(false)).lock().unwrap();
+        let mut event_loop_created = EVENT_LOOP_CREATED
+            .get_or_init(|| Mutex::new(false))
+            .lock()
+            .unwrap();
         if *event_loop_created {
             panic!("Creating EventLoop multiple times is not supported.");
         } else {

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -62,6 +62,11 @@ pub trait EventLoopExtWebSys {
     ///
     /// Unlike `run`, this returns immediately, and doesn't throw an exception in order to
     /// satisfy its `!` return type.
+    ///
+    /// Once the event loop has been destroyed, it's possible to reinitialize another event loop
+    /// by calling this function again. This can be useful if you want to recreate the event loop
+    /// while the WebAssembly module is still loaded. For example, this can be used to recreate the
+    /// event loop when switching between tabs on a single page application.
     fn spawn<F>(self, event_handler: F)
     where
         F: 'static

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -8,7 +8,9 @@ pub use self::window_target::EventLoopWindowTarget;
 
 use super::{backend, device, window};
 use crate::event::Event;
-use crate::event_loop::{ControlFlow, EventLoopBuilder, EventLoopWindowTarget as RootEventLoopWindowTarget};
+use crate::event_loop::{
+    ControlFlow, EventLoopBuilder, EventLoopWindowTarget as RootEventLoopWindowTarget,
+};
 
 use std::marker::PhantomData;
 

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -8,7 +8,7 @@ pub use self::window_target::EventLoopWindowTarget;
 
 use super::{backend, device, window};
 use crate::event::Event;
-use crate::event_loop::{ControlFlow, EventLoopWindowTarget as RootEventLoopWindowTarget};
+use crate::event_loop::{ControlFlow, EventLoopBuilder, EventLoopWindowTarget as RootEventLoopWindowTarget};
 
 use std::marker::PhantomData;
 
@@ -33,7 +33,7 @@ impl<T> EventLoop<T> {
     where
         F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
-        self.spawn(event_handler);
+        self.spawn_inner(event_handler);
 
         // Throw an exception to break out of Rust execution and use unreachable to tell the
         // compiler this function won't return, giving it a return type of '!'
@@ -44,7 +44,15 @@ impl<T> EventLoop<T> {
         unreachable!();
     }
 
-    pub fn spawn<F>(self, mut event_handler: F)
+    pub fn spawn<F>(self, event_handler: F)
+    where
+        F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
+    {
+        EventLoopBuilder::<T>::allow_event_loop_recreation();
+        self.spawn_inner(event_handler);
+    }
+
+    fn spawn_inner<F>(self, mut event_handler: F)
     where
         F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

As described in https://github.com/rust-windowing/winit/pull/2344#issuecomment-1176763837, it's useful to be able to recreate event loops on the web when using `spawn`, since the wasm module remains loaded. e.g., switching between tabs on a single page app and recreating a canvas doesn't currently work without some kind of workaround like this.

This won't change the behavior of `run`, so that will still panic when attempting to create multiple event loops.

I know there are probably still closures leaked when using this approach but don't expect this to be an issue in practice. We can also deal with any leaked closures later. At least anecdotally I've been using this approach for a while now and haven't run into any problems.