### PR TITLE
Web: Updates the canvas to disable the contextmenu event and double click text selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ rls/
 *.js
 #*#
 .DS_Store
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** `CursorIcon` is now used from the `cursor-icon` crate.
 - **Breaking:** `CursorIcon::Hand` is now named `CursorIcon::Pointer`.
 - **Breaking:** `CursorIcon::Arrow` was removed.
+- **Breaking:** Web: Canvases will now capture the contextmenu if prevent_default is enabled so they don't interfere with right click pointer events.
+- **Breaking:** Web: Canvases will now have `user-select: none` to prevent double clicks from selecting text outside the canvas.
 - On Wayland, fix maximized startup not taking full size on GNOME.
 - On Wayland, fix initial window size not restored for maximized/fullscreened on startup window.
 - On Wayland, `Window::outer_size` now accounts for **client side** decorations.

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -85,6 +85,8 @@ impl<T> EventLoopWindowTarget<T> {
             });
         });
 
+        canvas.on_contextmenu(prevent_default);
+
         let runner = self.runner.clone();
         canvas.on_keyboard_press(
             move |scancode, virtual_keycode, modifiers| {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Fixes #2608.

Text selection: Try double clicking the canvas  on this [bevy example](https://bevyengine.org/examples/ui/text/). You'll see the example code below get selected