### PR TITLE
Web: Only Use PointerEvent for Touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - Bump MSRV from `1.60` to `1.64`.
+- Web: Canvases will now capture the contextmenu if prevent_default is enabled so they don't interfere with right click pointer events.
+- Web: Canvases will now have `user-select: none` to prevent double clicks from selecting text outside the canvas.
+- Web: Only use pointer events for touch typed events.
+- Web: Use mouse events for generic mouse button events.
 
 # 0.28.3
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -85,6 +85,8 @@ impl<T> EventLoopWindowTarget<T> {
             });
         });
 
+        canvas.on_contextmenu(prevent_default);
+
         let runner = self.runner.clone();
         canvas.on_keyboard_press(
             move |scancode, virtual_keycode, modifiers| {

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -100,7 +100,7 @@ impl Canvas {
             on_fullscreen_change: None,
             on_dark_mode: None,
             mouse_handler: mouse_handler::MouseHandler::new(),
-            pointer_handler: has_pointer_event().then(|| pointer_handler::PointerHandler::new()),
+            pointer_handler: has_pointer_event().then(pointer_handler::PointerHandler::new),
         })
     }
 

--- a/src/platform_impl/web/web_sys/canvas/mouse_handler.rs
+++ b/src/platform_impl/web/web_sys/canvas/mouse_handler.rs
@@ -40,6 +40,7 @@ impl MouseHandler {
             mouse_capture_state: Rc::new(RefCell::new(MouseCaptureState::NotCaptured)),
         }
     }
+
     pub fn on_cursor_leave<F>(&mut self, canvas_common: &super::Common, handler: F)
     where
         F: 'static + FnMut(i32),

--- a/src/platform_impl/web/web_sys/canvas/pointer_handler.rs
+++ b/src/platform_impl/web/web_sys/canvas/pointer_handler.rs
@@ -23,11 +23,8 @@ impl PointerHandler {
         }
     }
 
-    pub fn on_mouse_release<F>(
-        &mut self,
-        canvas_common: &super::Common,
-        mut handler: F,
-    ) where
+    pub fn on_mouse_release<F>(&mut self, canvas_common: &super::Common, mut handler: F)
+    where
         F: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
         let canvas = canvas_common.raw.clone();
@@ -46,11 +43,8 @@ impl PointerHandler {
         ));
     }
 
-    pub fn on_mouse_press<F>(
-        &mut self,
-        canvas_common: &super::Common,
-        mut handler: F,
-    ) where
+    pub fn on_mouse_press<F>(&mut self, canvas_common: &super::Common, mut handler: F)
+    where
         F: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
         let canvas = canvas_common.raw.clone();

--- a/src/platform_impl/web/web_sys/canvas/pointer_handler.rs
+++ b/src/platform_impl/web/web_sys/canvas/pointer_handler.rs
@@ -2,14 +2,11 @@ use super::event;
 use super::EventListenerHandle;
 use crate::dpi::PhysicalPosition;
 use crate::event::Force;
-use crate::event::{ModifiersState, MouseButton};
 
 use web_sys::PointerEvent;
 
 #[allow(dead_code)]
 pub(super) struct PointerHandler {
-    on_cursor_leave: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
-    on_cursor_enter: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
     on_cursor_move: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
     on_pointer_press: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
     on_pointer_release: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
@@ -19,8 +16,6 @@ pub(super) struct PointerHandler {
 impl PointerHandler {
     pub fn new() -> Self {
         Self {
-            on_cursor_leave: None,
-            on_cursor_enter: None,
             on_cursor_move: None,
             on_pointer_press: None,
             on_pointer_release: None,
@@ -28,121 +23,59 @@ impl PointerHandler {
         }
     }
 
-    pub fn on_cursor_leave<F>(&mut self, canvas_common: &super::Common, mut handler: F)
-    where
-        F: 'static + FnMut(i32),
-    {
-        self.on_cursor_leave = Some(canvas_common.add_event(
-            "pointerout",
-            move |event: PointerEvent| {
-                // touch events are handled separately
-                // handling them here would produce duplicate mouse events, inconsistent with
-                // other platforms.
-                if event.pointer_type() == "touch" {
-                    return;
-                }
-
-                handler(event.pointer_id());
-            },
-        ));
-    }
-
-    pub fn on_cursor_enter<F>(&mut self, canvas_common: &super::Common, mut handler: F)
-    where
-        F: 'static + FnMut(i32),
-    {
-        self.on_cursor_enter = Some(canvas_common.add_event(
-            "pointerover",
-            move |event: PointerEvent| {
-                // touch events are handled separately
-                // handling them here would produce duplicate mouse events, inconsistent with
-                // other platforms.
-                if event.pointer_type() == "touch" {
-                    return;
-                }
-
-                handler(event.pointer_id());
-            },
-        ));
-    }
-
-    pub fn on_mouse_release<M, T>(
+    pub fn on_mouse_release<F>(
         &mut self,
         canvas_common: &super::Common,
-        mut mouse_handler: M,
-        mut touch_handler: T,
+        mut handler: F,
     ) where
-        M: 'static + FnMut(i32, MouseButton, ModifiersState),
-        T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
         let canvas = canvas_common.raw.clone();
         self.on_pointer_release = Some(canvas_common.add_user_event(
             "pointerup",
             move |event: PointerEvent| {
                 if event.pointer_type() == "touch" {
-                    touch_handler(
+                    handler(
                         event.pointer_id(),
                         event::touch_position(&event, &canvas)
                             .to_physical(super::super::scale_factor()),
                         Force::Normalized(event.pressure() as f64),
-                    );
-                } else {
-                    mouse_handler(
-                        event.pointer_id(),
-                        event::mouse_button(&event),
-                        event::mouse_modifiers(&event),
                     );
                 }
             },
         ));
     }
 
-    pub fn on_mouse_press<M, T>(
+    pub fn on_mouse_press<F>(
         &mut self,
         canvas_common: &super::Common,
-        mut mouse_handler: M,
-        mut touch_handler: T,
+        mut handler: F,
     ) where
-        M: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
-        T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
         let canvas = canvas_common.raw.clone();
         self.on_pointer_press = Some(canvas_common.add_user_event(
             "pointerdown",
             move |event: PointerEvent| {
                 if event.pointer_type() == "touch" {
-                    touch_handler(
+                    handler(
                         event.pointer_id(),
                         event::touch_position(&event, &canvas)
                             .to_physical(super::super::scale_factor()),
                         Force::Normalized(event.pressure() as f64),
                     );
-                } else {
-                    mouse_handler(
-                        event.pointer_id(),
-                        event::mouse_position(&event).to_physical(super::super::scale_factor()),
-                        event::mouse_button(&event),
-                        event::mouse_modifiers(&event),
-                    );
-
-                    // Error is swallowed here since the error would occur every time the mouse is
-                    // clicked when the cursor is grabbed, and there is probably not a situation where
-                    // this could fail, that we care if it fails.
-                    let _e = canvas.set_pointer_capture(event.pointer_id());
                 }
             },
         ));
     }
 
-    pub fn on_cursor_move<M, T>(
+    pub fn on_cursor_move<F>(
         &mut self,
         canvas_common: &super::Common,
-        mut mouse_handler: M,
-        mut touch_handler: T,
+        mut handler: F,
         prevent_default: bool,
     ) where
-        M: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>, ModifiersState),
-        T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
+        F: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
         let canvas = canvas_common.raw.clone();
         self.on_cursor_move = Some(canvas_common.add_event(
@@ -153,18 +86,11 @@ impl PointerHandler {
                         // prevent scroll on mobile web
                         event.prevent_default();
                     }
-                    touch_handler(
+                    handler(
                         event.pointer_id(),
                         event::touch_position(&event, &canvas)
                             .to_physical(super::super::scale_factor()),
                         Force::Normalized(event.pressure() as f64),
-                    );
-                } else {
-                    mouse_handler(
-                        event.pointer_id(),
-                        event::mouse_position(&event).to_physical(super::super::scale_factor()),
-                        event::mouse_delta(&event).to_physical(super::super::scale_factor()),
-                        event::mouse_modifiers(&event),
                     );
                 }
             },
@@ -192,8 +118,6 @@ impl PointerHandler {
     }
 
     pub fn remove_listeners(&mut self) {
-        self.on_cursor_leave = None;
-        self.on_cursor_enter = None;
         self.on_cursor_move = None;
         self.on_pointer_press = None;
         self.on_pointer_release = None;


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x]  Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This builds on top of #2721 by making the mouse handler be the way to handle mouse events instead of pointer. Pointer events are still conditionally used (depending on browser support) for touch events.

By doing this it should resolve issue #2475 as pointer events don't trigger events for mouse buttons pressed while another mouse button is being held. More information can be found [here](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointerdown_event) but the main concern is in the first paragraph:
> For mouse, it is fired when the device transitions from no buttons pressed to at least one button pressed.