### PR TITLE
On Web, wake event loop on `request_redraw()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Bump MSRV from `1.60` to `1.64`.
 - Fix macOS memory leaks.
+- On Web: fix `Window::request_redraw` not waking the event loop when called from outside the loop.
 
 # 0.28.2
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -157,6 +157,7 @@ impl<T: 'static> Shared<T> {
 
     pub fn request_redraw(&self, id: WindowId) {
         self.0.redraw_pending.borrow_mut().insert(id);
+        self.send_events(iter::empty());
     }
 
     pub fn init(&self) {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Currently, when calling `Window::request_redraw()` from outside the event loop, for example from an async background task, it will not wake up the event loop.
This fixes it by simply calling the same internal function used to wake up the event loop by sending a `UserEvent`, I hope that is correct.

Fixes #2019.