### PR TITLE
On Web, use `target_family = "wasm"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ features = [
     "Win32_UI_WindowsAndMessaging",
 ]
 
-[target.'cfg(all(unix, not(any(target_os = "redox", target_arch = "wasm32", target_os = "android", target_os = "ios", target_os = "macos"))))'.dependencies]
+[target.'cfg(all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_os = "ios", target_os = "macos"))))'.dependencies]
 libc = "0.2.64"
 mio = { version = "0.8", features = ["os-ext"], optional = true }
 percent-encoding = { version = "2.0", optional = true }
@@ -121,7 +121,7 @@ redox_syscall = "0.3"
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.build-dependencies]
 wayland-scanner = "0.29.5"
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.web_sys]
+[target.'cfg(target_family = "wasm")'.dependencies.web_sys]
 package = "web-sys"
 version = "0.3.22"
 features = [
@@ -148,10 +148,10 @@ features = [
     'WheelEvent'
 ]
 
-[target.'cfg(target_arch = "wasm32")'.dependencies.wasm-bindgen]
+[target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen]
 version = "0.2.45"
 
-[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
 console_log = "0.2"
 web-sys = { version = "0.3.22", features = ['CanvasRenderingContext2d'] }
 

--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,7 @@ fn main() {
     cfg_aliases! {
         // Systems.
         android_platform: { target_os = "android" },
-        wasm_platform: { target_arch = "wasm32" },
+        wasm_platform: { target_family = "wasm" },
         macos_platform: { target_os = "macos" },
         ios_platform: { target_os = "ios" },
         windows_platform: { target_os = "windows" },


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This changes all uses of `target_arch = "wasm32"` to `target_family = "wasm"`, which also covers the `wasm64-unknown-unknown` target.

This was introduced in [Rust v1.54](https://github.com/rust-lang/rust/blob/1.68.0/RELEASES.md#compiler-14).

Not sure if I should add a changelog entry?