### PR TITLE
Fix macos memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - Bump MSRV from `1.60` to `1.64`.
+- Fix macOS memory leaks.
 
 # 0.28.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ ndk = "0.7.0"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 core-foundation = "0.9.3"
-objc2 = "=0.3.0-beta.3"
+objc2 = ">=0.3.0-beta.3, <0.3.0-beta.4" # Allow `0.3.0-beta.3.patch-leaks`
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.22.3"


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/2722 by patching `objc2` instead, and using version ranges to allow the patched version to be selected.

If the user has `accesskit_macos` in their dependency tree, this will not work until @mwcampbell uses `objc2 = ">=0.3.0-beta.3, <0.3.0-beta.4"` in that.

- [x] Tested on all platforms changed
  - ~Currently very limited internet, and having a few problems with `cargo update`, so I can't test this fully myself right now. I have tested that the version resolution works though!~
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
