### PR TITLE
On Web, implement `Send` and `Sync` for `Window` and `EventLoopProxy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Fix macOS memory leaks.
 - On Web: fix `Window::request_redraw` not waking the event loop when called from outside the loop.
-- On Web, `EventLoopProxy` now implements `Send`.
+- On Web, `EventLoopProxy` now implements `Send` and `Sync`.
+- On Web, `Window` now implements `Send` and `Sync`.
 
 # 0.28.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 # 0.28.3
 
 - Fix macOS memory leaks.
+- On Web: fix `Window::request_redraw` not waking the event loop when called from outside the loop.
 
 # 0.28.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Fix macOS memory leaks.
 - On Web: fix `Window::request_redraw` not waking the event loop when called from outside the loop.
+- On Web, `EventLoopProxy` now implements `Send`.
 
 # 0.28.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,8 @@ features = [
 ]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
+atomic-waker = "1.1.0"
+js-sys = "0.3.22"
 wasm-bindgen = "0.2.45"
 wasm-bindgen-futures = "0.4.31"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,8 +148,9 @@ features = [
     'WheelEvent'
 ]
 
-[target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen]
-version = "0.2.45"
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasm-bindgen = "0.2.45"
+wasm-bindgen-futures = "0.4.31"
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 console_log = "0.2"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "web_sys::window", reason = "is not available in every context" },
+]

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::single_match)]
+#![allow(clippy::disallowed_methods, clippy::single_match)]
 
 use winit::{
     event::{Event, WindowEvent},
@@ -52,7 +52,7 @@ mod wasm {
     pub fn insert_canvas_and_create_log_list(window: &Window) -> web_sys::Element {
         use winit::platform::web::WindowExtWebSys;
 
-        let canvas = window.canvas();
+        let canvas = window.canvas().unwrap();
 
         let window = web_sys::window().unwrap();
         let document = window.document().unwrap();

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::disallowed_methods)]
+
 pub fn main() {
     println!("This example must be run with cargo run-wasm --example web_aspect_ratio")
 }
@@ -66,7 +68,7 @@ This example demonstrates the desired future functionality which will possibly b
         let body = document.body().unwrap();
 
         // Set a background color for the canvas to make it easier to tell the where the canvas is for debugging purposes.
-        let canvas = window.canvas();
+        let canvas = window.canvas().unwrap();
         canvas
             .style()
             .set_css_text("display: block; background-color: crimson; margin: auto; width: 50%; aspect-ratio: 4 / 1;");

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -12,7 +12,8 @@ use crate::window::WindowBuilder;
 use web_sys::HtmlCanvasElement;
 
 pub trait WindowExtWebSys {
-    fn canvas(&self) -> HtmlCanvasElement;
+    /// Only returns the canvas if called from inside the window.
+    fn canvas(&self) -> Option<HtmlCanvasElement>;
 
     /// Whether the browser reports the preferred color scheme to be "dark".
     fn is_dark_mode(&self) -> bool;

--- a/src/platform_impl/web/async.rs
+++ b/src/platform_impl/web/async.rs
@@ -1,0 +1,267 @@
+use atomic_waker::AtomicWaker;
+use once_cell::unsync::Lazy;
+use std::cell::{Ref, RefCell, RefMut};
+use std::future;
+use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
+use std::rc::{Rc, Weak};
+use std::sync::mpsc::{self, Receiver, RecvError, SendError, Sender, TryRecvError};
+use std::sync::{Arc, Condvar, Mutex};
+use std::task::Poll;
+use wasm_bindgen::prelude::wasm_bindgen;
+use wasm_bindgen::{JsCast, JsValue};
+
+// Unsafe wrapper type that allows us to use `T` when it's not `Send` from other threads.
+// `value` must *only* be accessed on the main thread.
+pub struct MainThreadSafe<T: 'static, E: 'static> {
+    value: ManuallyDrop<Weak<RefCell<T>>>,
+    handler: fn(&RefCell<T>, E),
+    sender: AsyncSender<E>,
+}
+
+impl<T, E> MainThreadSafe<T, E> {
+    thread_local! {
+        static MAIN_THREAD: Lazy<bool> = Lazy::new(|| {
+            #[wasm_bindgen]
+            extern "C" {
+                #[derive(Clone)]
+                pub(crate) type Global;
+
+                #[wasm_bindgen(method, getter, js_name = Window)]
+                fn window(this: &Global) -> JsValue;
+            }
+
+            let global: Global = js_sys::global().unchecked_into();
+            !global.window().is_undefined()
+        });
+    }
+
+    #[track_caller]
+    pub fn new(value: T, handler: fn(&RefCell<T>, E)) -> Option<Self> {
+        Self::MAIN_THREAD.with(|safe| {
+            if !*safe.deref() {
+                panic!("only callable from inside the `Window`")
+            }
+        });
+
+        let value = Rc::new(RefCell::new(value));
+        let weak = Rc::downgrade(&value);
+
+        let (sender, receiver) = channel::<E>();
+
+        wasm_bindgen_futures::spawn_local({
+            async move {
+                while let Ok(event) = receiver.next().await {
+                    handler(&value, event)
+                }
+
+                // An error was returned because the channel was closed, which
+                // happens when the window get dropped, so we can stop now.
+                match Rc::try_unwrap(value) {
+                    Ok(value) => drop(value),
+                    Err(_) => panic!("couldn't enforce that value is dropped on the main thread"),
+                }
+            }
+        });
+
+        Some(Self {
+            value: ManuallyDrop::new(weak),
+            handler,
+            sender,
+        })
+    }
+
+    pub fn send(&self, event: E) {
+        Self::MAIN_THREAD.with(|is_main_thread| {
+            if *is_main_thread.deref() {
+                (self.handler)(&self.value.upgrade().unwrap(), event)
+            } else {
+                self.sender.send(event).unwrap()
+            }
+        })
+    }
+
+    fn is_main_thread(&self) -> bool {
+        Self::MAIN_THREAD.with(|is_main_thread| *is_main_thread.deref())
+    }
+
+    pub fn with<R>(&self, f: impl FnOnce(Ref<'_, T>) -> R) -> Option<R> {
+        Self::MAIN_THREAD.with(|is_main_thread| {
+            if *is_main_thread.deref() {
+                Some(f(self.value.upgrade().unwrap().borrow()))
+            } else {
+                None
+            }
+        })
+    }
+
+    fn with_mut<R>(&self, f: impl FnOnce(RefMut<'_, T>) -> R) -> Option<R> {
+        Self::MAIN_THREAD.with(|is_main_thread| {
+            if *is_main_thread.deref() {
+                Some(f(self.value.upgrade().unwrap().borrow_mut()))
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl<T, E> Clone for MainThreadSafe<T, E> {
+    fn clone(&self) -> Self {
+        Self {
+            value: self.value.clone(),
+            handler: self.handler,
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+unsafe impl<T, E> Send for MainThreadSafe<T, E> {}
+unsafe impl<T, E> Sync for MainThreadSafe<T, E> {}
+
+pub struct Dispatcher<T: 'static>(MainThreadSafe<T, Closure<T>>);
+
+pub enum Closure<T> {
+    Ref(Box<dyn FnOnce(&T) + Send>),
+    RefMut(Box<dyn FnOnce(&mut T) + Send>),
+}
+
+impl<T> Dispatcher<T> {
+    #[track_caller]
+    pub fn new(value: T) -> Option<Self> {
+        MainThreadSafe::new(value, |value, closure| {
+            match closure {
+                Closure::Ref(f) => f(value.borrow().deref()),
+                Closure::RefMut(f) => f(value.borrow_mut().deref_mut()),
+            }
+
+            // An error was returned because the channel was closed, which
+            // happens when the window get dropped, so we can stop now.
+        })
+        .map(Self)
+    }
+
+    pub fn dispatch(&self, f: impl 'static + FnOnce(&T) + Send) {
+        if self.is_main_thread() {
+            self.0.with(|value| f(value.deref())).unwrap()
+        } else {
+            self.0.send(Closure::Ref(Box::new(f)))
+        }
+    }
+
+    pub fn dispatch_mut(&self, f: impl 'static + FnOnce(&mut T) + Send) {
+        if self.is_main_thread() {
+            self.0.with_mut(|mut value| f(value.deref_mut())).unwrap()
+        } else {
+            self.0.send(Closure::RefMut(Box::new(f)))
+        }
+    }
+
+    pub fn queue<R: 'static + Send>(&self, f: impl 'static + FnOnce(&T) -> R + Send) -> R {
+        if self.is_main_thread() {
+            self.0.with(|value| f(value.deref())).unwrap()
+        } else {
+            let pair = Arc::new((Mutex::new(None), Condvar::new()));
+            let closure = Closure::Ref(Box::new({
+                let pair = pair.clone();
+                move |value| {
+                    *pair.0.lock().unwrap() = Some(f(value));
+                    pair.1.notify_one();
+                }
+            }));
+
+            self.0.send(closure);
+
+            let mut started = pair.0.lock().unwrap();
+
+            while started.is_none() {
+                started = pair.1.wait(started).unwrap();
+            }
+
+            started.take().unwrap()
+        }
+    }
+}
+
+impl<T> Deref for Dispatcher<T> {
+    type Target = MainThreadSafe<T, Closure<T>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+fn channel<T>() -> (AsyncSender<T>, AsyncReceiver<T>) {
+    let (sender, receiver) = mpsc::channel();
+    let sender = Mutex::new(Some(sender));
+    let waker = Arc::new(AtomicWaker::new());
+
+    let sender = AsyncSender {
+        sender,
+        waker: Arc::clone(&waker),
+    };
+    let receiver = AsyncReceiver { receiver, waker };
+
+    (sender, receiver)
+}
+
+struct AsyncSender<T> {
+    sender: Mutex<Option<Sender<T>>>,
+    waker: Arc<AtomicWaker>,
+}
+
+impl<T> AsyncSender<T> {
+    pub fn send(&self, event: T) -> Result<(), SendError<T>> {
+        self.sender.lock().unwrap().as_ref().unwrap().send(event)?;
+        self.waker.wake();
+
+        Ok(())
+    }
+}
+
+impl<T> Clone for AsyncSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: Mutex::new(self.sender.lock().unwrap().clone()),
+            waker: self.waker.clone(),
+        }
+    }
+}
+
+impl<T> Drop for AsyncSender<T> {
+    fn drop(&mut self) {
+        self.sender.lock().unwrap().take().unwrap();
+
+        // If it's the last + the one held by the receiver make sure to wake it
+        // up and tell it to drop the value. It will only drop the value if the
+        // receiver reports that the last sender was dropped, this is why we
+        // drop the sender before this check.
+        if Arc::strong_count(&self.waker) == 2 {
+            self.waker.wake()
+        }
+    }
+}
+
+struct AsyncReceiver<T> {
+    receiver: Receiver<T>,
+    waker: Arc<AtomicWaker>,
+}
+
+impl<T> AsyncReceiver<T> {
+    pub async fn next(&self) -> Result<T, RecvError> {
+        future::poll_fn(|cx| match self.receiver.try_recv() {
+            Ok(event) => Poll::Ready(Ok(event)),
+            Err(TryRecvError::Empty) => {
+                self.waker.register(cx.waker());
+
+                match self.receiver.try_recv() {
+                    Ok(event) => Poll::Ready(Ok(event)),
+                    Err(TryRecvError::Empty) => Poll::Pending,
+                    Err(TryRecvError::Disconnected) => Poll::Ready(Err(RecvError)),
+                }
+            }
+            Err(TryRecvError::Disconnected) => Poll::Ready(Err(RecvError)),
+        })
+        .await
+    }
+}

--- a/src/platform_impl/web/event_loop/proxy.rs
+++ b/src/platform_impl/web/event_loop/proxy.rs
@@ -1,26 +1,96 @@
-use super::runner;
-use crate::event::Event;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::mpsc::{self, Receiver, RecvError, SendError, Sender, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll, Waker};
+
 use crate::event_loop::EventLoopClosed;
 
 pub struct EventLoopProxy<T: 'static> {
-    runner: runner::Shared<T>,
+    sender: AsyncSender<T>,
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn new(runner: runner::Shared<T>) -> Self {
-        Self { runner }
+    pub fn new(sender: AsyncSender<T>) -> Self {
+        Self { sender }
     }
 
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
-        self.runner.send_event(Event::UserEvent(event));
-        Ok(())
+        match self.sender.send(event) {
+            Ok(()) => Ok(()),
+            Err(SendError(val)) => Err(EventLoopClosed(val)),
+        }
     }
 }
 
 impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
         Self {
-            runner: self.runner.clone(),
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+pub fn channel<T: 'static>() -> (AsyncSender<T>, AsyncReceiver<T>) {
+    let (sender, receiver) = mpsc::channel();
+    let waker = Arc::new(Mutex::new(None));
+
+    let sender = AsyncSender {
+        sender,
+        waker: Arc::clone(&waker),
+    };
+    let receiver = AsyncReceiver { receiver, waker };
+
+    (sender, receiver)
+}
+
+pub struct AsyncSender<T: 'static> {
+    sender: Sender<T>,
+    waker: Arc<Mutex<Option<Waker>>>,
+}
+
+impl<T: 'static> AsyncSender<T> {
+    pub fn send(&self, event: T) -> Result<(), SendError<T>> {
+        self.sender.send(event)?;
+
+        if let Some(waker) = self.waker.lock().unwrap().take() {
+            waker.wake();
+        }
+
+        Ok(())
+    }
+}
+
+impl<T: 'static> Clone for AsyncSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            sender: self.sender.clone(),
+            waker: self.waker.clone(),
+        }
+    }
+}
+
+pub struct AsyncReceiver<T: 'static> {
+    receiver: Receiver<T>,
+    waker: Arc<Mutex<Option<Waker>>>,
+}
+
+impl<T: 'static> Future for AsyncReceiver<T> {
+    type Output = Result<T, RecvError>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.receiver.try_recv() {
+            Ok(event) => Poll::Ready(Ok(event)),
+            Err(TryRecvError::Empty) => {
+                *self.waker.lock().unwrap() = Some(cx.waker().clone());
+
+                match self.receiver.try_recv() {
+                    Ok(event) => Poll::Ready(Ok(event)),
+                    Err(TryRecvError::Empty) => Poll::Pending,
+                    Err(TryRecvError::Disconnected) => Poll::Ready(Err(RecvError)),
+                }
+            }
+            Err(TryRecvError::Disconnected) => Poll::Ready(Err(RecvError)),
         }
     }
 }

--- a/src/platform_impl/web/event_loop/proxy.rs
+++ b/src/platform_impl/web/event_loop/proxy.rs
@@ -1,96 +1,32 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::mpsc::{self, Receiver, RecvError, SendError, Sender, TryRecvError};
-use std::sync::{Arc, Mutex};
-use std::task::{Context, Poll, Waker};
-
+use super::runner;
+use crate::event::Event;
 use crate::event_loop::EventLoopClosed;
+use crate::platform_impl::platform::r#async::MainThreadSafe;
 
 pub struct EventLoopProxy<T: 'static> {
-    sender: AsyncSender<T>,
+    runner: MainThreadSafe<runner::Shared<T>, T>,
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn new(sender: AsyncSender<T>) -> Self {
-        Self { sender }
+    pub fn new(runner: runner::Shared<T>) -> Self {
+        Self {
+            runner: MainThreadSafe::new(runner, |runner, event| {
+                runner.borrow().send_event(Event::UserEvent(event))
+            })
+            .unwrap(),
+        }
     }
 
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
-        match self.sender.send(event) {
-            Ok(()) => Ok(()),
-            Err(SendError(val)) => Err(EventLoopClosed(val)),
-        }
+        self.runner.send(event);
+        Ok(())
     }
 }
 
 impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
         Self {
-            sender: self.sender.clone(),
-        }
-    }
-}
-
-pub fn channel<T: 'static>() -> (AsyncSender<T>, AsyncReceiver<T>) {
-    let (sender, receiver) = mpsc::channel();
-    let waker = Arc::new(Mutex::new(None));
-
-    let sender = AsyncSender {
-        sender,
-        waker: Arc::clone(&waker),
-    };
-    let receiver = AsyncReceiver { receiver, waker };
-
-    (sender, receiver)
-}
-
-pub struct AsyncSender<T: 'static> {
-    sender: Sender<T>,
-    waker: Arc<Mutex<Option<Waker>>>,
-}
-
-impl<T: 'static> AsyncSender<T> {
-    pub fn send(&self, event: T) -> Result<(), SendError<T>> {
-        self.sender.send(event)?;
-
-        if let Some(waker) = self.waker.lock().unwrap().take() {
-            waker.wake();
-        }
-
-        Ok(())
-    }
-}
-
-impl<T: 'static> Clone for AsyncSender<T> {
-    fn clone(&self) -> Self {
-        Self {
-            sender: self.sender.clone(),
-            waker: self.waker.clone(),
-        }
-    }
-}
-
-pub struct AsyncReceiver<T: 'static> {
-    receiver: Receiver<T>,
-    waker: Arc<Mutex<Option<Waker>>>,
-}
-
-impl<T: 'static> Future for AsyncReceiver<T> {
-    type Output = Result<T, RecvError>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        match self.receiver.try_recv() {
-            Ok(event) => Poll::Ready(Ok(event)),
-            Err(TryRecvError::Empty) => {
-                *self.waker.lock().unwrap() = Some(cx.waker().clone());
-
-                match self.receiver.try_recv() {
-                    Ok(event) => Poll::Ready(Ok(event)),
-                    Err(TryRecvError::Empty) => Poll::Pending,
-                    Err(TryRecvError::Disconnected) => Poll::Ready(Err(RecvError)),
-                }
-            }
-            Err(TryRecvError::Disconnected) => Poll::Ready(Err(RecvError)),
+            runner: self.runner.clone(),
         }
     }
 }

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -157,6 +157,7 @@ impl<T: 'static> Shared<T> {
 
     pub fn request_redraw(&self, id: WindowId) {
         self.0.redraw_pending.borrow_mut().insert(id);
+        self.send_events(iter::empty());
     }
 
     pub fn init(&self) {

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -36,7 +36,7 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     pub fn proxy(&self) -> EventLoopProxy<T> {
-        EventLoopProxy::new(self.runner.clone())
+        self.runner.create_proxy()
     }
 
     pub fn run(&self, event_handler: Box<runner::EventHandler<T>>) {

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -17,6 +17,7 @@
 // incoming events (from the registered handlers) and ensuring they are passed to the user in a
 // compliant way.
 
+mod r#async;
 mod device;
 mod error;
 mod event_loop;

--- a/src/platform_impl/web/web_sys/canvas/mouse_handler.rs
+++ b/src/platform_impl/web/web_sys/canvas/mouse_handler.rs
@@ -129,6 +129,7 @@ impl MouseHandler {
         F: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
     {
         let mouse_capture_state = self.mouse_capture_state.clone();
+        let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
         self.on_mouse_press = Some(canvas_common.add_window_mouse_event(
             "mousedown",
@@ -153,7 +154,7 @@ impl MouseHandler {
                 event.stop_propagation();
                 handler(
                     0,
-                    event::mouse_position(&event).to_physical(super::super::scale_factor()),
+                    event::mouse_position(&event).to_physical(super::super::scale_factor(&window)),
                     event::mouse_button(&event),
                     event::mouse_modifiers(&event),
                 );
@@ -166,6 +167,7 @@ impl MouseHandler {
         F: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>, ModifiersState),
     {
         let mouse_capture_state = self.mouse_capture_state.clone();
+        let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
         self.on_mouse_move = Some(canvas_common.add_window_mouse_event(
             "mousemove",
@@ -196,8 +198,8 @@ impl MouseHandler {
                         let mouse_delta = event::mouse_delta(&event);
                         handler(
                             0,
-                            mouse_pos.to_physical(super::super::scale_factor()),
-                            mouse_delta.to_physical(super::super::scale_factor()),
+                            mouse_pos.to_physical(super::super::scale_factor(&window)),
+                            mouse_delta.to_physical(super::super::scale_factor(&window)),
                             event::mouse_modifiers(&event),
                         );
                     }

--- a/src/platform_impl/web/web_sys/canvas/pointer_handler.rs
+++ b/src/platform_impl/web/web_sys/canvas/pointer_handler.rs
@@ -75,6 +75,7 @@ impl PointerHandler {
         M: 'static + FnMut(i32, MouseButton, ModifiersState),
         T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
+        let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
         self.on_pointer_release = Some(canvas_common.add_user_event(
             "pointerup",
@@ -83,7 +84,7 @@ impl PointerHandler {
                     touch_handler(
                         event.pointer_id(),
                         event::touch_position(&event, &canvas)
-                            .to_physical(super::super::scale_factor()),
+                            .to_physical(super::super::scale_factor(&window)),
                         Force::Normalized(event.pressure() as f64),
                     );
                 } else {
@@ -106,6 +107,7 @@ impl PointerHandler {
         M: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton, ModifiersState),
         T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
+        let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
         self.on_pointer_press = Some(canvas_common.add_user_event(
             "pointerdown",
@@ -114,13 +116,14 @@ impl PointerHandler {
                     touch_handler(
                         event.pointer_id(),
                         event::touch_position(&event, &canvas)
-                            .to_physical(super::super::scale_factor()),
+                            .to_physical(super::super::scale_factor(&window)),
                         Force::Normalized(event.pressure() as f64),
                     );
                 } else {
                     mouse_handler(
                         event.pointer_id(),
-                        event::mouse_position(&event).to_physical(super::super::scale_factor()),
+                        event::mouse_position(&event)
+                            .to_physical(super::super::scale_factor(&window)),
                         event::mouse_button(&event),
                         event::mouse_modifiers(&event),
                     );
@@ -144,6 +147,7 @@ impl PointerHandler {
         M: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>, ModifiersState),
         T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
+        let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
         self.on_cursor_move = Some(canvas_common.add_event(
             "pointermove",
@@ -156,14 +160,15 @@ impl PointerHandler {
                     touch_handler(
                         event.pointer_id(),
                         event::touch_position(&event, &canvas)
-                            .to_physical(super::super::scale_factor()),
+                            .to_physical(super::super::scale_factor(&window)),
                         Force::Normalized(event.pressure() as f64),
                     );
                 } else {
                     mouse_handler(
                         event.pointer_id(),
-                        event::mouse_position(&event).to_physical(super::super::scale_factor()),
-                        event::mouse_delta(&event).to_physical(super::super::scale_factor()),
+                        event::mouse_position(&event)
+                            .to_physical(super::super::scale_factor(&window)),
+                        event::mouse_delta(&event).to_physical(super::super::scale_factor(&window)),
                         event::mouse_modifiers(&event),
                     );
                 }
@@ -175,6 +180,7 @@ impl PointerHandler {
     where
         F: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
+        let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
         self.on_touch_cancel = Some(canvas_common.add_event(
             "pointercancel",
@@ -183,7 +189,7 @@ impl PointerHandler {
                     handler(
                         event.pointer_id(),
                         event::touch_position(&event, &canvas)
-                            .to_physical(super::super::scale_factor()),
+                            .to_physical(super::super::scale_factor(&window)),
                         Force::Normalized(event.pressure() as f64),
                     );
                 }

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -47,14 +47,17 @@ pub fn mouse_position_by_client(
     }
 }
 
-pub fn mouse_scroll_delta(event: &WheelEvent) -> Option<MouseScrollDelta> {
+pub fn mouse_scroll_delta(
+    window: &web_sys::Window,
+    event: &WheelEvent,
+) -> Option<MouseScrollDelta> {
     let x = -event.delta_x();
     let y = -event.delta_y();
 
     match event.delta_mode() {
         WheelEvent::DOM_DELTA_LINE => Some(MouseScrollDelta::LineDelta(x as f32, y as f32)),
         WheelEvent::DOM_DELTA_PIXEL => {
-            let delta = LogicalPosition::new(x, y).to_physical(super::scale_factor());
+            let delta = LogicalPosition::new(x, y).to_physical(super::scale_factor(window));
             Some(MouseScrollDelta::PixelDelta(delta))
         }
         _ => None,

--- a/src/platform_impl/web/web_sys/media_query_handle.rs
+++ b/src/platform_impl/web/web_sys/media_query_handle.rs
@@ -8,10 +8,10 @@ pub(super) struct MediaQueryListHandle {
 
 impl MediaQueryListHandle {
     pub fn new(
+        window: &web_sys::Window,
         media_query: &str,
         listener: Closure<dyn FnMut(MediaQueryListEvent)>,
     ) -> Option<Self> {
-        let window = web_sys::window().expect("Failed to obtain window");
         let mql = window
             .match_media(media_query)
             .ok()

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -13,14 +13,13 @@ use crate::dpi::{LogicalSize, Size};
 use crate::platform::web::WindowExtWebSys;
 use crate::window::Window;
 use wasm_bindgen::closure::Closure;
-use web_sys::{window, BeforeUnloadEvent, Element, HtmlCanvasElement};
+use web_sys::{BeforeUnloadEvent, Element, HtmlCanvasElement};
 
 pub fn throw(msg: &str) {
     wasm_bindgen::throw_str(msg);
 }
 
-pub fn exit_fullscreen() {
-    let window = web_sys::window().expect("Failed to obtain window");
+pub fn exit_fullscreen(window: &web_sys::Window) {
     let document = window.document().expect("Failed to obtain document");
 
     document.exit_fullscreen();
@@ -30,38 +29,33 @@ pub struct UnloadEventHandle {
     _listener: event_handle::EventListenerHandle<dyn FnMut(BeforeUnloadEvent)>,
 }
 
-pub fn on_unload(mut handler: impl FnMut() + 'static) -> UnloadEventHandle {
-    let window = web_sys::window().expect("Failed to obtain window");
-
+pub fn on_unload(
+    window: &web_sys::Window,
+    mut handler: impl FnMut() + 'static,
+) -> UnloadEventHandle {
     let closure = Closure::wrap(
         Box::new(move |_: BeforeUnloadEvent| handler()) as Box<dyn FnMut(BeforeUnloadEvent)>
     );
 
-    let listener = event_handle::EventListenerHandle::new(&window, "beforeunload", closure);
+    let listener = event_handle::EventListenerHandle::new(window, "beforeunload", closure);
     UnloadEventHandle {
         _listener: listener,
     }
 }
 
 impl WindowExtWebSys for Window {
-    fn canvas(&self) -> HtmlCanvasElement {
-        self.window.canvas().raw().clone()
+    fn canvas(&self) -> Option<HtmlCanvasElement> {
+        self.window.canvas()
     }
 
     fn is_dark_mode(&self) -> bool {
-        let window = web_sys::window().expect("Failed to obtain window");
-
-        window
-            .match_media("(prefers-color-scheme: dark)")
-            .ok()
-            .flatten()
-            .map(|media| media.matches())
-            .unwrap_or(false)
+        self.window
+            .inner
+            .queue(|inner| is_dark_mode(&inner.window).unwrap_or(false))
     }
 }
 
-pub fn window_size() -> LogicalSize<f64> {
-    let window = web_sys::window().expect("Failed to obtain window");
+pub fn window_size(window: &web_sys::Window) -> LogicalSize<f64> {
     let width = window
         .inner_width()
         .expect("Failed to get width")
@@ -76,13 +70,12 @@ pub fn window_size() -> LogicalSize<f64> {
     LogicalSize { width, height }
 }
 
-pub fn scale_factor() -> f64 {
-    let window = web_sys::window().expect("Failed to obtain window");
+pub fn scale_factor(window: &web_sys::Window) -> f64 {
     window.device_pixel_ratio()
 }
 
-pub fn set_canvas_size(raw: &HtmlCanvasElement, size: Size) {
-    let scale_factor = scale_factor();
+pub fn set_canvas_size(window: &web_sys::Window, raw: &HtmlCanvasElement, size: Size) {
+    let scale_factor = scale_factor(window);
 
     let physical_size = size.to_physical::<u32>(scale_factor);
     let logical_size = size.to_logical::<f64>(scale_factor);
@@ -101,8 +94,7 @@ pub fn set_canvas_style_property(raw: &HtmlCanvasElement, property: &str, value:
         .unwrap_or_else(|err| panic!("error: {err:?}\nFailed to set {property}"))
 }
 
-pub fn is_fullscreen(canvas: &HtmlCanvasElement) -> bool {
-    let window = window().expect("Failed to obtain window");
+pub fn is_fullscreen(window: &web_sys::Window, canvas: &HtmlCanvasElement) -> bool {
     let document = window.document().expect("Failed to obtain document");
 
     match document.fullscreen_element() {
@@ -112,6 +104,14 @@ pub fn is_fullscreen(canvas: &HtmlCanvasElement) -> bool {
         }
         None => false,
     }
+}
+
+pub fn is_dark_mode(window: &web_sys::Window) -> Option<bool> {
+    window
+        .match_media("(prefers-color-scheme: dark)")
+        .ok()
+        .flatten()
+        .map(|media| media.matches())
 }
 
 pub type RawCanvasType = HtmlCanvasElement;

--- a/src/platform_impl/web/web_sys/scaling.rs
+++ b/src/platform_impl/web/web_sys/scaling.rs
@@ -8,29 +8,31 @@ use web_sys::MediaQueryListEvent;
 pub struct ScaleChangeDetector(Rc<RefCell<ScaleChangeDetectorInternal>>);
 
 impl ScaleChangeDetector {
-    pub(crate) fn new<F>(handler: F) -> Self
+    pub(crate) fn new<F>(window: web_sys::Window, handler: F) -> Self
     where
         F: 'static + FnMut(ScaleChangeArgs),
     {
-        Self(ScaleChangeDetectorInternal::new(handler))
+        Self(ScaleChangeDetectorInternal::new(window, handler))
     }
 }
 
 /// This is a helper type to help manage the `MediaQueryList` used for detecting
 /// changes of the `devicePixelRatio`.
 struct ScaleChangeDetectorInternal {
+    window: web_sys::Window,
     callback: Box<dyn FnMut(ScaleChangeArgs)>,
     mql: Option<MediaQueryListHandle>,
     last_scale: f64,
 }
 
 impl ScaleChangeDetectorInternal {
-    fn new<F>(handler: F) -> Rc<RefCell<Self>>
+    fn new<F>(window: web_sys::Window, handler: F) -> Rc<RefCell<Self>>
     where
         F: 'static + FnMut(ScaleChangeArgs),
     {
-        let current_scale = super::scale_factor();
+        let current_scale = super::scale_factor(&window);
         let new_self = Rc::new(RefCell::new(Self {
+            window: window.clone(),
             callback: Box::new(handler),
             mql: None,
             last_scale: current_scale,
@@ -43,7 +45,7 @@ impl ScaleChangeDetectorInternal {
             }
         }) as Box<dyn FnMut(_)>);
 
-        let mql = Self::create_mql(closure);
+        let mql = Self::create_mql(&window, closure);
         {
             let mut borrowed_self = new_self.borrow_mut();
             borrowed_self.mql = mql;
@@ -52,9 +54,10 @@ impl ScaleChangeDetectorInternal {
     }
 
     fn create_mql(
+        window: &web_sys::Window,
         closure: Closure<dyn FnMut(MediaQueryListEvent)>,
     ) -> Option<MediaQueryListHandle> {
-        let current_scale = super::scale_factor();
+        let current_scale = super::scale_factor(window);
         // This media query initially matches the current `devicePixelRatio`.
         // We add 0.0001 to the lower and upper bounds such that it won't fail
         // due to floating point precision limitations.
@@ -63,7 +66,7 @@ impl ScaleChangeDetectorInternal {
              (-webkit-min-device-pixel-ratio: {min_scale:.4}) and (-webkit-max-device-pixel-ratio: {max_scale:.4})",
             min_scale = current_scale - 0.0001, max_scale= current_scale + 0.0001,
         );
-        let mql = MediaQueryListHandle::new(&media_query, closure);
+        let mql = MediaQueryListHandle::new(window, &media_query, closure);
         if let Some(mql) = &mql {
             assert!(mql.mql().matches());
         }
@@ -76,12 +79,12 @@ impl ScaleChangeDetectorInternal {
             .take()
             .expect("DevicePixelRatioChangeDetector::mql should not be None");
         let closure = mql.remove();
-        let new_scale = super::scale_factor();
+        let new_scale = super::scale_factor(&self.window);
         (self.callback)(ScaleChangeArgs {
             old_scale: self.last_scale,
             new_scale,
         });
-        let new_mql = Self::create_mql(closure);
+        let new_mql = Self::create_mql(&self.window, closure);
         self.mql = new_mql;
         self.last_scale = new_scale;
     }

--- a/tests/send_objects.rs
+++ b/tests/send_objects.rs
@@ -1,7 +1,6 @@
 #[allow(dead_code)]
 fn needs_send<T: Send>() {}
 
-#[cfg(not(wasm_platform))]
 #[test]
 fn event_loop_proxy_send() {
     #[allow(dead_code)]

--- a/tests/send_objects.rs
+++ b/tests/send_objects.rs
@@ -10,7 +10,6 @@ fn event_loop_proxy_send() {
     }
 }
 
-#[cfg(not(wasm_platform))]
 #[test]
 fn window_send() {
     // ensures that `winit::Window` implements `Send`

--- a/tests/sync_object.rs
+++ b/tests/sync_object.rs
@@ -1,7 +1,6 @@
 #[allow(dead_code)]
 fn needs_sync<T: Sync>() {}
 
-#[cfg(not(wasm_platform))]
 #[test]
 fn window_sync() {
     // ensures that `winit::Window` implements `Sync`


### PR DESCRIPTION
This is an experiment to let `Window` implement `Send` and `Sync` on Wasm and reuse the same code to implement `Sync` for `EventLoopProxy`.
I took some inspiration from [`MainThreadSafe` on macOS](https://github.com/rust-windowing/winit/blob/77f8e511e965354a4b827cfb1ca197e9e51e6ded/src/platform_impl/macos/util/async.rs).

It's implemented in a way that if you call this from the `Window` it will do nothing special and just call the appropriate method on the `Window`, as before. Therefor, except a single `Rc<Cell<bool>>` to `Arc<AtomicBool>` change, there is no overhead if Wasm is only used single-threaded.

If used in a multi-threaded environment from a worker, it will use a `mpsc::Sender` to do it's work on the main thread. Currently this is implemented by just sending a boxed function to execute, but it could be rewritten to just send a message and a message handler would then do the right thing.

When it's necessary to return a value a `Condvar` and a `Mutex` is used to await the completion, which would block, but as it's not in the window that should be fine.

Most of the small changes here and there are to disallow calls to `web_sys::window()`, as these are the main culprits that will fail if not called from a window. This was necessary because it was quite hard to figure out what needs to be changed, so I added a Clippy `disallowed-methods`, which should hopefully make maintenance of this feature easy. Let me know what you think of this.

Builds on top of #2732 and #2737.

Fixes #2294.