### PR TITLE
Fixes rust-windowing/winit#2597 for good

### DIFF
--- a/src/platform_impl/web/web_sys/scaling.rs
+++ b/src/platform_impl/web/web_sys/scaling.rs
@@ -64,9 +64,7 @@ impl ScaleChangeDetectorInternal {
             min_scale = current_scale - 0.0001, max_scale= current_scale + 0.0001,
         );
         let mql = MediaQueryListHandle::new(&media_query, closure);
-        if let Some(mql) = &mql {
-            assert!(mql.mql().matches());
-        }
+
         mql
     }
 


### PR DESCRIPTION
Remove assert that is being randomly hit by a very small number of users

This is a follow up to PR https://github.com/rust-windowing/winit/issues/2597. As explained in it (pls check it for context) there were a couple of asserts in this file that were unnecessary, and were causing some users to crash; while removing the assert works perfectly fine, so they don't seem to be preventing from anything serious.

In that PR, I was wary and changed the smallest amount of code possible (just removed 1 assert, out of 2). But now I've found some other users (still very few, maybe 0.001%) hitting the remaining assert. Now that time has verified that removing the first one didn't hurt and was the right call, I think that removing the remaining one is the way to go, for the same reasons explained in the previous PR, to prevent these crashes from happening anymore.