### PR TITLE
Android: Change default implementation to ignore volume keys and let operating system handle them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Android, changed default behavior of Android to ignore volume keys letting the operating system handle them.
+- On Android, added `EventLoopBuilderExtAndroid::handle_volume_keys` to indicate that the application will handle the volume keys manually.
 - **Breaking:** Rename `DeviceEventFilter` to `DeviceEvents` reversing the behavior of variants.
 - **Breaking:** Rename `EventLoopWindowTarget::set_device_event_filter` to `listen_device_events`.
 - On X11, fix `EventLoopWindowTarget::listen_device_events` effect being reversed.

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -42,11 +42,21 @@ pub trait EventLoopBuilderExtAndroid {
     ///
     /// This must be called on Android since the `AndroidApp` is not global state.
     fn with_android_app(&mut self, app: AndroidApp) -> &mut Self;
+
+    /// Calling this will mark the volume keys to be manually handled by the application
+    ///
+    /// Default is to let the operating system handle the volume keys
+    fn handle_volume_keys(&mut self) -> &mut Self;
 }
 
 impl<T> EventLoopBuilderExtAndroid for EventLoopBuilder<T> {
     fn with_android_app(&mut self, app: AndroidApp) -> &mut Self {
         self.platform_specific.android_app = Some(app);
+        self
+    }
+
+    fn handle_volume_keys(&mut self) -> &mut Self {
+        self.platform_specific.ignore_volume_keys = false;
         self
     }
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -327,8 +327,8 @@ impl<T: 'static> EventLoop<T> {
         }
 
         // Process input events
-
         self.android_app.input_events(|event| {
+            let mut input_status = InputStatus::Handled;
             match event {
                 InputEvent::MotionEvent(motion_event) => {
                     let window_id = window::WindowId(WindowId);
@@ -394,68 +394,74 @@ impl<T: 'static> EventLoop<T> {
                         }
                     }
                 }
-                InputEvent::KeyEvent(key) => {
-                    let state = match key.action() {
-                        KeyAction::Down => event::ElementState::Pressed,
-                        KeyAction::Up => event::ElementState::Released,
-                        _ => event::ElementState::Released,
-                    };
-
-                    #[cfg(feature = "android-native-activity")]
-                    let (keycode_u32, scancode_u32) = unsafe {
-                        // We abuse the fact that `android_activity`'s `KeyEvent` is `repr(transparent)`
-                        let event = (key as *const android_activity::input::KeyEvent<'_>).cast::<ndk::event::KeyEvent>();
-                        // We use the unsafe function directly because we want to forward the
-                        // keycode value even if it doesn't have a variant defined in the ndk
-                        // crate.
-                        (
-                            AKeyEvent_getKeyCode((*event).ptr().as_ptr()) as u32,
-                            (*event).scan_code() as u32
-                        )
-                    };
-                    #[cfg(feature = "android-game-activity")]
-                    let (keycode_u32, scancode_u32) = (key.keyCode as u32, key.scanCode as u32);
-                    let keycode = keycode_u32
-                        .try_into()
-                        .unwrap_or(ndk::event::Keycode::Unknown);
-                    let physical_key = KeyCode::Unidentified(
-                        NativeKeyCode::Android(scancode_u32),
-                    );
-                    let native = NativeKey::Android(keycode_u32);
-                    let logical_key = keycode_to_logical(keycode, native);
-                    // TODO: maybe use getUnicodeChar to get the logical key
-
-                    let event = event::Event::WindowEvent {
-                        window_id: window::WindowId(WindowId),
-                        event: event::WindowEvent::KeyboardInput {
-                            device_id: event::DeviceId(DeviceId),
-                            event: event::KeyEvent {
-                                state,
-                                physical_key,
-                                logical_key,
-                                location: keycode_to_location(keycode),
-                                repeat: key.repeat_count() > 0,
-                                text: None,
-                                platform_specific: KeyEventExtra {},
-                            },
-                            is_synthetic: false,
+                InputEvent::KeyEvent(key) => {  
+                    match key.key_code() {
+                        // Flagg keys related to volume as unhandled. While winit does not have a way for applications
+                        // to configure what keys to flag as handled, this appears to be a good default until winit
+                        // can be configured.
+                        ndk::event::Keycode::VolumeUp | ndk::event::Keycode::VolumeDown | ndk::event::Keycode::VolumeMute => {
+                            input_status = InputStatus::Unhandled
                         },
-                    };
-                    sticky_exit_callback(
-                        event,
-                        self.window_target(),
-                        control_flow,
-                        callback,
-                    );
+                        _ => {
+                            let state = match key.action() {
+                                KeyAction::Down => event::ElementState::Pressed,
+                                KeyAction::Up => event::ElementState::Released,
+                                _ => event::ElementState::Released,
+                            };
+
+                            #[cfg(feature = "android-native-activity")]
+                            let (keycode_u32, scancode_u32) = unsafe {
+                                // We abuse the fact that `android_activity`'s `KeyEvent` is `repr(transparent)`
+                                let event = (key as *const android_activity::input::KeyEvent<'_>).cast::<ndk::event::KeyEvent>();
+                                // We use the unsafe function directly because we want to forward the
+                                // keycode value even if it doesn't have a variant defined in the ndk
+                                // crate.
+                                (
+                                    AKeyEvent_getKeyCode((*event).ptr().as_ptr()) as u32,
+                                    (*event).scan_code() as u32
+                                )
+                            };
+                            #[cfg(feature = "android-game-activity")]
+                            let (keycode_u32, scancode_u32) = (key.keyCode as u32, key.scanCode as u32);
+                            let keycode = keycode_u32
+                                .try_into()
+                                .unwrap_or(ndk::event::Keycode::Unknown);
+                            let physical_key = KeyCode::Unidentified(
+                                NativeKeyCode::Android(scancode_u32),
+                            );
+                            let native = NativeKey::Android(keycode_u32);
+                            let logical_key = keycode_to_logical(keycode, native);
+                            // TODO: maybe use getUnicodeChar to get the logical key
+
+                            let event = event::Event::WindowEvent {
+                                window_id: window::WindowId(WindowId),
+                                event: event::WindowEvent::KeyboardInput {
+                                    device_id: event::DeviceId(DeviceId),
+                                    event: event::KeyEvent {
+                                        state,
+                                        physical_key,
+                                        logical_key,
+                                        location: keycode_to_location(keycode),
+                                        repeat: key.repeat_count() > 0,
+                                        text: None,
+                                        platform_specific: KeyEventExtra {},
+                                    },
+                                    is_synthetic: false,
+                                },
+                            };
+                            sticky_exit_callback(
+                                event,
+                                self.window_target(),
+                                control_flow,
+                                callback,
+                            );
+                        }
+                    }
                 }
                 _ => {
                     warn!("Unknown android_activity input event {event:?}")
                 }
             }
-
-            // Assume all events are handled, while Winit doesn't currently give a way for
-            // applications to report whether they handled an input event.
-            InputStatus::Handled
         });
 
         // Empty the user event buffer

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -406,7 +406,7 @@ impl<T: 'static> EventLoop<T> {
                         }
                     }
                 }
-                InputEvent::KeyEvent(key) => {  
+                InputEvent::KeyEvent(key) => {
                     match key.key_code() {
                         // Flagg keys related to volume as unhandled. While winit does not have a way for applications
                         // to configure what keys to flag as handled, this appears to be a good default until winit

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -408,6 +408,9 @@ impl<T: 'static> EventLoop<T> {
                 }
                 InputEvent::KeyEvent(key) => {  
                     match key.key_code() {
+                        // Flagg keys related to volume as unhandled. While winit does not have a way for applications
+                        // to configure what keys to flag as handled, this appears to be a good default until winit
+                        // can be configured.
                         ndk::event::Keycode::VolumeUp |
                         ndk::event::Keycode::VolumeDown |
                         ndk::event::Keycode::VolumeMute => {
@@ -475,6 +478,7 @@ impl<T: 'static> EventLoop<T> {
                     warn!("Unknown android_activity input event {event:?}")
                 }
             }
+            input_status
         });
 
         // Empty the user event buffer


### PR DESCRIPTION
## The Issue
Current Android implementation will always mark the volume keys as handled by the application (window) overriding the default operating system behavior. This is a bit unexpected I would argue the opposite would be expected as default, to opt in to override default operating system behavior. 

## The Change
1. By default volume keys `Volume Up/Down & Mute` will all be marked as unhandled by the application. Letting the operating system handle them.
2. Added a new function `EventLoopBuilderExtAndroid::handle_volume_keys` for applications that want to manually handle the volume keys.

## Remarks
This could be considered a breaking change from a users point of view, even though I would argue this is the "correct" default. So I'm not sure how or if that should be reflected in the `CHANGELOG.md`.

This PR is heavily inspired by the PR #1919 

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


## How to make the app handle volume keys
```rust
#[cfg(target_os = "android")]
use winit::platform::android::activity::AndroidApp;

#[cfg(target_os = "android")]
#[no_mangle]
fn android_main(app: AndroidApp) {
    use winit::platform::android::EventLoopBuilderExtAndroid;

    android_logger::init_once(android_logger::Config::default().with_min_level(log::Level::Trace));

    let event_loop = EventLoopBuilder::with_user_event()
        .with_android_app(app)
        .handle_volume_keys()   // New function
        .build();
    _main(event_loop);
}
```