### PR TITLE
Implement `Sync` for `EventLoopProxy` (except on Web)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
 - On macOS, fix crash when calling `Window::set_ime_position` from another thread.
-- On Android, Linux, MacOS and Windows, implement `Sync` for `EventLoopProxy`.
+- On Android, iOS, Linux, MacOS and Windows, implement `Sync` for `EventLoopProxy`.
 
 # 0.28.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
 - On macOS, fix crash when calling `Window::set_ime_position` from another thread.
-- On Linux, implement `Sync` for `EventLoopProxy`.
+- On Linux and Windows, implement `Sync` for `EventLoopProxy`.
 
 # 0.28.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
 - On macOS, fix crash when calling `Window::set_ime_position` from another thread.
-- On Linux, MacOS and Windows, implement `Sync` for `EventLoopProxy`.
+- On Android, Linux, MacOS and Windows, implement `Sync` for `EventLoopProxy`.
 
 # 0.28.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
 - On macOS, fix crash when calling `Window::set_ime_position` from another thread.
-- On Linux and Windows, implement `Sync` for `EventLoopProxy`.
+- On Linux, MacOS and Windows, implement `Sync` for `EventLoopProxy`.
 
 # 0.28.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
 - On macOS, fix crash when calling `Window::set_ime_position` from another thread.
+- On Linux, implement `Sync` for `EventLoopProxy`.
 
 # 0.28.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
 - On macOS, fix crash when calling `Window::set_ime_position` from another thread.
-- On Android, iOS, Linux, MacOS and Windows, implement `Sync` for `EventLoopProxy`.
+- On all platforms except Web, implement `Sync` for `EventLoopProxy`.
 
 # 0.28.3
 

--- a/src/platform_impl/linux/wayland/event_loop/proxy.rs
+++ b/src/platform_impl/linux/wayland/event_loop/proxy.rs
@@ -1,6 +1,7 @@
 //! An event loop proxy.
 
 use std::sync::mpsc::SendError;
+use std::sync::Mutex;
 
 use sctk::reexports::calloop::channel::Sender;
 
@@ -8,24 +9,28 @@ use crate::event_loop::EventLoopClosed;
 
 /// A handle that can be sent across the threads and used to wake up the `EventLoop`.
 pub struct EventLoopProxy<T: 'static> {
-    user_events_sender: Sender<T>,
+    user_events_sender: Mutex<Sender<T>>,
 }
 
 impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
         EventLoopProxy {
-            user_events_sender: self.user_events_sender.clone(),
+            user_events_sender: Mutex::new(self.user_events_sender.lock().unwrap().clone()),
         }
     }
 }
 
 impl<T: 'static> EventLoopProxy<T> {
     pub fn new(user_events_sender: Sender<T>) -> Self {
-        Self { user_events_sender }
+        Self {
+            user_events_sender: Mutex::new(user_events_sender),
+        }
     }
 
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
         self.user_events_sender
+            .lock()
+            .unwrap()
             .send(event)
             .map_err(|SendError(error)| EventLoopClosed(error))
     }

--- a/tests/sync_object.rs
+++ b/tests/sync_object.rs
@@ -3,6 +3,16 @@ fn needs_sync<T: Sync>() {}
 
 #[cfg(not(wasm_platform))]
 #[test]
+fn event_loop_proxy_send() {
+    #[allow(dead_code)]
+    fn is_send<T: 'static + Send>() {
+        // ensures that `winit::EventLoopProxy` implements `Sync`
+        needs_sync::<winit::event_loop::EventLoopProxy<T>>();
+    }
+}
+
+#[cfg(not(wasm_platform))]
+#[test]
 fn window_sync() {
     // ensures that `winit::Window` implements `Sync`
     needs_sync::<winit::window::Window>();


### PR DESCRIPTION
This implements `Sync` for `EventLoopProxy` for all platforms except Web, which is done in a separate PR (#2740). I tested this only on Linux and Windows, but I think it's pretty safe to say this should just work.