### PR TITLE
Skip `syn` in `cargo-deny`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,10 @@ deny = []
 skip = [
     { name = "nix" },           # differing version - as of 2023-03-02 whis can be solved with `cargo update && cargo update -p calloop --precise 0.10.2`
     { name = "redox_syscall" }, # https://gitlab.redox-os.org/redox-os/orbclient/-/issues/46
+    # https://github.com/rustwasm/wasm-bindgen/pull/3361
+    # https://github.com/sfackler/foreign-types/pull/22
+    # https://github.com/illicitonion/num_enum/issues/111
+    { name = "syn" },
 ]
 skip-tree = []
 


### PR DESCRIPTION
Current CI is broken because of only some dependencies updating to `syn` v2, this skips it during `cargo-deny`.

This doesn't completely fix the CI because of https://github.com/madsmtm/objc2/issues/432.