### PR TITLE
On Web, fix async `Window::set_fullscreen`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, the canvas output bitmap size is no longer adjusted.
 - On Web: fix `Window::request_redraw` not waking the event loop when called from outside the loop.
 - On Web: fix position of touch events to be relative to the canvas.
+- On Web, fix `Window:::set_fullscreen` doing nothing when called outside the event loop but during
+  a transient activation.
 
 # 0.28.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,8 +156,10 @@ features = [
     'WheelEvent'
 ]
 
-[target.'cfg(target_family = "wasm")'.dependencies.wasm-bindgen]
-version = "0.2.45"
+[target.'cfg(target_family = "wasm")'.dependencies]
+js-sys = "0.3"
+wasm-bindgen = "0.2.45"
+wasm-bindgen-futures = "0.4"
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 console_log = "0.2"

--- a/src/window.rs
+++ b/src/window.rs
@@ -941,6 +941,10 @@ impl Window {
     /// - **Wayland:** Does not support exclusive fullscreen mode and will no-op a request.
     /// - **Windows:** Screen saver is disabled in fullscreen mode.
     /// - **Android / Orbital:** Unsupported.
+    /// - **Web:** Does nothing without a [transient activation], but queues the request
+    ///   for the next activation.
+    ///
+    /// [transient activation]: https://developer.mozilla.org/en-US/docs/Glossary/Transient_activation
     #[inline]
     pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         self.window.set_fullscreen(fullscreen.map(|f| f.into()))


### PR DESCRIPTION
Currently the behavior of `Window::set_fullscreen()` on Web queues the request to the current or next keyboard or mouse event. This doesn't work if `Window::set_fullscreen()` is called asynchronously outside the event loop.

This was probably done to satisfy the [transient activation](https://developer.mozilla.org/en-US/docs/Glossary/Transient_activation) [requirement](https://developer.mozilla.org/en-US/docs/Web/API/Element/requestFullscreen#security) for `requestFullscreen()`. But transient activation doesn't run out during the event loop, it's time based, usually one second.

This PR adjusts `Window::set_fullscreen()` to immediately call `requestFullscreen()`, only on failure a request is queued. This required some custom imports because the API was changed in the spec to return a `Promise` and `web-sys` doesn't reflect that change. Additionally Safari doesn't reflect that change before 16.4 (which came out today (2023-03-28)) too. So both APIs are now supported.

Additionally I noticed that the behavior of `Window::set_fullscreen()` on Web was undocumented, so I added some.