### PR TITLE
Fix potential panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - Bump MSRV from `1.60` to `1.64`.
+- On macOS, fixed potential panic when getting refresh rate.
 
 # 0.28.3
 

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -230,6 +230,10 @@ impl MonitorHandle {
                 return None;
             }
 
+            if time.time_value < 1 {
+                return None;
+            }
+
             Some((time.time_scale as i64 / time.time_value * 1000) as u32)
         }
     }

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -230,11 +230,9 @@ impl MonitorHandle {
                 return None;
             }
 
-            if time.time_value < 1 {
-                return None;
-            }
-
-            Some((time.time_scale as i64 / time.time_value * 1000) as u32)
+            (time.time_scale as i64)
+                .checked_div(time.time_value)
+                .map(|v| (v * 1000) as u32)
         }
     }
 


### PR DESCRIPTION
```
uncaught panic: "attempt to divide by zero" at /Users/X20230112120246_ssea_lrtse_cpfx/.cargo/git/checkouts/winit-c2fdb27092aba5a7/3fd7384/src/platform_impl/macos/monitor.rs:233:19
```

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented