### PR TITLE
Run `Window::set_ime_position` on main thread on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
+- On macOS, fix crash when calling `Window::set_ime_position` from another thread.
 
 # 0.28.3
 

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -2,8 +2,9 @@ use std::ops::Deref;
 
 use dispatch::Queue;
 use objc2::foundation::{is_main_thread, CGFloat, NSPoint, NSSize, NSString};
-use objc2::rc::autoreleasepool;
+use objc2::rc::{autoreleasepool, Id};
 
+use crate::dpi::LogicalPosition;
 use crate::{
     dpi::LogicalSize,
     platform_impl::platform::{
@@ -199,5 +200,13 @@ pub(crate) fn close_sync(window: &NSWindow) {
         autoreleasepool(move |_| {
             window.close();
         });
+    });
+}
+
+pub(crate) fn set_ime_position_sync(window: &WinitWindow, logical_spot: LogicalPosition<f64>) {
+    let window = MainThreadSafe(window);
+    run_on_main(move || {
+        // TODO(madsmtm): Remove the need for this
+        unsafe { Id::from_shared(window.view()) }.set_ime_position(logical_spot);
     });
 }

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -4,9 +4,8 @@ use dispatch::Queue;
 use objc2::foundation::{is_main_thread, CGFloat, NSPoint, NSSize, NSString};
 use objc2::rc::{autoreleasepool, Id};
 
-use crate::dpi::LogicalPosition;
 use crate::{
-    dpi::LogicalSize,
+    dpi::{LogicalPosition, LogicalSize},
     platform_impl::platform::{
         appkit::{NSScreen, NSWindow, NSWindowLevel, NSWindowStyleMask},
         ffi,

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1165,8 +1165,7 @@ impl WinitWindow {
     pub fn set_ime_position(&self, spot: Position) {
         let scale_factor = self.scale_factor();
         let logical_spot = spot.to_logical(scale_factor);
-        // TODO(madsmtm): Remove the need for this
-        unsafe { Id::from_shared(self.view()) }.set_ime_position(logical_spot);
+        util::set_ime_position_sync(self, logical_spot);
     }
 
     #[inline]


### PR DESCRIPTION
Fixes #2756.

This fixes a crash when calling `Window::set_ime_position` from a thread that is not the main thread.

I'm not familiar with the codebase, so feel free to give feedback if I should change anything!

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
