### PR TITLE
Fix device description leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
 - On macOS, fix crash when calling `Window::set_ime_position` from another thread.
+- On macOS, fixed memory leak when getting monitor handle.
 
 # 0.28.3
 

--- a/src/platform_impl/macos/appkit/screen.rs
+++ b/src/platform_impl/macos/appkit/screen.rs
@@ -39,21 +39,25 @@ extern_methods!(
         }
 
         pub fn display_id(&self) -> u32 {
-            let device_description = self.deviceDescription();
+            let key = ns_string!("NSScreenNumber");
 
-            // Retrieve the CGDirectDisplayID associated with this screen
-            //
-            // SAFETY: The value from @"NSScreenNumber" in deviceDescription is guaranteed
-            // to be an NSNumber. See documentation for `deviceDescription` for details:
-            // <https://developer.apple.com/documentation/appkit/nsscreen/1388360-devicedescription?language=objc>
-            let obj = device_description
-                .get(ns_string!("NSScreenNumber"))
-                .expect("failed getting screen display id from device description");
-            let obj: *const Object = obj;
-            let obj: *const NSNumber = obj.cast();
-            let obj: &NSNumber = unsafe { &*obj };
+            objc2::rc::autoreleasepool(|_| {
+                let device_description = self.deviceDescription();
 
-            obj.as_u32()
+                // Retrieve the CGDirectDisplayID associated with this screen
+                //
+                // SAFETY: The value from @"NSScreenNumber" in deviceDescription is guaranteed
+                // to be an NSNumber. See documentation for `deviceDescription` for details:
+                // <https://developer.apple.com/documentation/appkit/nsscreen/1388360-devicedescription?language=objc>
+                let obj = device_description
+                    .get(key)
+                    .expect("failed getting screen display id from device description");
+                let obj: *const Object = obj;
+                let obj: *const NSNumber = obj.cast();
+                let obj: &NSNumber = unsafe { &*obj };
+
+                obj.as_u32()
+            })
         }
 
         #[sel(backingScaleFactor)]


### PR DESCRIPTION
`deviceDescription` should be called in autoreleasepool.

<img width="868" alt="图片" src="https://user-images.githubusercontent.com/11287532/229797021-330ad1bf-683c-488d-9f21-bd61c01f6a83.png">

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
