### PR TITLE
Update the `bitflags` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, fix `Window:::set_fullscreen` doing nothing when called outside the event loop but during
   a transient activation.
 - On Web, fix pointer button events not being processed when a buttons is already pressed.
-- Updated `bitflags` crate version to `2`.
+- **Breaking:** Updated `bitflags` crate version to `2`, which changes the API on exposed types.
 
 # 0.28.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, fix `Window:::set_fullscreen` doing nothing when called outside the event loop but during
   a transient activation.
 - On Web, fix pointer button events not being processed when a buttons is already pressed.
+- Updated `bitflags` crate version to `2`.
 
 # 0.28.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = ["dep:serde", "cursor-icon/serde", "smol_str/serde"]
 cfg_aliases = "0.1.1"
 
 [dependencies]
-bitflags = "1"
+bitflags = "2"
 cursor-icon = "1.0.0"
 instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = "0.4"

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1572,7 +1572,7 @@ bitflags! {
     /// Represents the current state of the keyboard modifiers
     ///
     /// Each flag represents a modifier and is set if this modifier is active.
-    #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ModifiersState: u32 {
         /// The "shift" key.
         const SHIFT = 0b100;
@@ -1623,7 +1623,7 @@ pub enum ModifiersKeyState {
 // to treat modifiers differently based on their position, which is required
 // on macOS due to their AltGr/Option situation.
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
     pub(crate) struct ModifiersKeys: u8 {
         const LSHIFT   = 0b0000_0001;
         const RSHIFT   = 0b0000_0010;

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1572,7 +1572,7 @@ bitflags! {
     /// Represents the current state of the keyboard modifiers
     ///
     /// Each flag represents a modifier and is set if this modifier is active.
-    #[derive(Default)]
+    #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
     pub struct ModifiersState: u32 {
         /// The "shift" key.
         const SHIFT = 0b100;
@@ -1623,7 +1623,7 @@ pub enum ModifiersKeyState {
 // to treat modifiers differently based on their position, which is required
 // on macOS due to their AltGr/Option situation.
 bitflags! {
-    #[derive(Default)]
+    #[derive(Clone, Copy, Default, Debug, Eq, PartialEq)]
     pub(crate) struct ModifiersKeys: u8 {
         const LSHIFT   = 0b0000_0001;
         const RSHIFT   = 0b0000_0010;

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -287,7 +287,7 @@ bitflags! {
     /// The [edges] of a screen.
     ///
     /// [edges]: https://developer.apple.com/documentation/uikit/uirectedge?language=objc
-    #[derive(Clone, Copy, Default)]
+    #[derive(Default, Clone, Copy)]
     pub struct ScreenEdge: u8 {
         const NONE   = 0;
         const TOP    = 1 << 0;

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -287,14 +287,14 @@ bitflags! {
     /// The [edges] of a screen.
     ///
     /// [edges]: https://developer.apple.com/documentation/uikit/uirectedge?language=objc
-    #[derive(Default)]
+    #[derive(Clone, Copy, Default)]
     pub struct ScreenEdge: u8 {
         const NONE   = 0;
         const TOP    = 1 << 0;
         const LEFT   = 1 << 1;
         const BOTTOM = 1 << 2;
         const RIGHT  = 1 << 3;
-        const ALL = ScreenEdge::TOP.bits | ScreenEdge::LEFT.bits
-            | ScreenEdge::BOTTOM.bits | ScreenEdge::RIGHT.bits;
+        const ALL = ScreenEdge::TOP.bits() | ScreenEdge::LEFT.bits()
+            | ScreenEdge::BOTTOM.bits() | ScreenEdge::RIGHT.bits();
     }
 }

--- a/src/platform_impl/ios/uikit/view_controller.rs
+++ b/src/platform_impl/ios/uikit/view_controller.rs
@@ -39,7 +39,7 @@ extern_methods!(
 );
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Default)]
     pub struct UIInterfaceOrientationMask: NSUInteger {
         const Portrait = 1 << 1;
         const PortraitUpsideDown = 1 << 2;

--- a/src/platform_impl/ios/uikit/view_controller.rs
+++ b/src/platform_impl/ios/uikit/view_controller.rs
@@ -39,6 +39,7 @@ extern_methods!(
 );
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct UIInterfaceOrientationMask: NSUInteger {
         const Portrait = 1 << 1;
         const PortraitUpsideDown = 1 << 2;

--- a/src/platform_impl/ios/uikit/view_controller.rs
+++ b/src/platform_impl/ios/uikit/view_controller.rs
@@ -39,7 +39,7 @@ extern_methods!(
 );
 
 bitflags! {
-    #[derive(Clone, Copy, Default)]
+    #[derive(Clone, Copy)]
     pub struct UIInterfaceOrientationMask: NSUInteger {
         const Portrait = 1 << 1;
         const PortraitUpsideDown = 1 << 2;

--- a/src/platform_impl/macos/appkit/application.rs
+++ b/src/platform_impl/macos/appkit/application.rs
@@ -109,7 +109,7 @@ unsafe impl Encode for NSApplicationActivationPolicy {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, Default)]
+    #[derive(Clone, Copy, Debug)]
     pub struct NSApplicationPresentationOptions: NSUInteger {
         const NSApplicationPresentationDefault = 0;
         const NSApplicationPresentationAutoHideDock = 1 << 0;

--- a/src/platform_impl/macos/appkit/application.rs
+++ b/src/platform_impl/macos/appkit/application.rs
@@ -109,7 +109,7 @@ unsafe impl Encode for NSApplicationActivationPolicy {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Debug)]
+    #[derive(Debug, Clone, Copy)]
     pub struct NSApplicationPresentationOptions: NSUInteger {
         const NSApplicationPresentationDefault = 0;
         const NSApplicationPresentationAutoHideDock = 1 << 0;

--- a/src/platform_impl/macos/appkit/application.rs
+++ b/src/platform_impl/macos/appkit/application.rs
@@ -109,6 +109,7 @@ unsafe impl Encode for NSApplicationActivationPolicy {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct NSApplicationPresentationOptions: NSUInteger {
         const NSApplicationPresentationDefault = 0;
         const NSApplicationPresentationAutoHideDock = 1 << 0;

--- a/src/platform_impl/macos/appkit/application.rs
+++ b/src/platform_impl/macos/appkit/application.rs
@@ -109,7 +109,7 @@ unsafe impl Encode for NSApplicationActivationPolicy {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Debug, Default)]
     pub struct NSApplicationPresentationOptions: NSUInteger {
         const NSApplicationPresentationDefault = 0;
         const NSApplicationPresentationAutoHideDock = 1 << 0;

--- a/src/platform_impl/macos/appkit/event.rs
+++ b/src/platform_impl/macos/appkit/event.rs
@@ -194,7 +194,7 @@ const NX_DEVICERALTKEYMASK: u32 = 0x00000040;
 const NX_DEVICERCTLKEYMASK: u32 = 0x00002000;
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct NSEventModifierFlags: NSUInteger {
         const NSAlphaShiftKeyMask                     = 1 << 16;
         const NSShiftKeyMask                          = 1 << 17;
@@ -213,7 +213,7 @@ unsafe impl Encode for NSEventModifierFlags {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct NSEventPhase: NSUInteger {
        const NSEventPhaseNone        = 0;
        const NSEventPhaseBegan       = 0x1 << 0;

--- a/src/platform_impl/macos/appkit/event.rs
+++ b/src/platform_impl/macos/appkit/event.rs
@@ -194,7 +194,7 @@ const NX_DEVICERALTKEYMASK: u32 = 0x00000040;
 const NX_DEVICERCTLKEYMASK: u32 = 0x00002000;
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct NSEventModifierFlags: NSUInteger {
         const NSAlphaShiftKeyMask                     = 1 << 16;
         const NSShiftKeyMask                          = 1 << 17;
@@ -213,7 +213,7 @@ unsafe impl Encode for NSEventModifierFlags {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct NSEventPhase: NSUInteger {
        const NSEventPhaseNone        = 0;
        const NSEventPhaseBegan       = 0x1 << 0;

--- a/src/platform_impl/macos/appkit/event.rs
+++ b/src/platform_impl/macos/appkit/event.rs
@@ -194,6 +194,7 @@ const NX_DEVICERALTKEYMASK: u32 = 0x00000040;
 const NX_DEVICERCTLKEYMASK: u32 = 0x00002000;
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct NSEventModifierFlags: NSUInteger {
         const NSAlphaShiftKeyMask                     = 1 << 16;
         const NSShiftKeyMask                          = 1 << 17;
@@ -212,6 +213,7 @@ unsafe impl Encode for NSEventModifierFlags {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct NSEventPhase: NSUInteger {
        const NSEventPhaseNone        = 0;
        const NSEventPhaseBegan       = 0x1 << 0;

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -336,7 +336,7 @@ unsafe impl Encode for NSWindowLevel {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Default)]
     pub struct NSWindowOcclusionState: NSUInteger {
         const NSWindowOcclusionStateVisible = 1 << 1;
     }
@@ -347,7 +347,7 @@ unsafe impl Encode for NSWindowOcclusionState {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Default, Debug)]
     pub struct NSWindowStyleMask: NSUInteger {
         const NSBorderlessWindowMask      = 0;
         const NSTitledWindowMask          = 1 << 0;

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -336,7 +336,7 @@ unsafe impl Encode for NSWindowLevel {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default)]
+    #[derive(Clone, Copy)]
     pub struct NSWindowOcclusionState: NSUInteger {
         const NSWindowOcclusionStateVisible = 1 << 1;
     }
@@ -347,7 +347,7 @@ unsafe impl Encode for NSWindowOcclusionState {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug)]
+    #[derive(Clone, Copy, Debug)]
     pub struct NSWindowStyleMask: NSUInteger {
         const NSBorderlessWindowMask      = 0;
         const NSTitledWindowMask          = 1 << 0;

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -336,6 +336,7 @@ unsafe impl Encode for NSWindowLevel {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct NSWindowOcclusionState: NSUInteger {
         const NSWindowOcclusionStateVisible = 1 << 1;
     }
@@ -346,6 +347,7 @@ unsafe impl Encode for NSWindowOcclusionState {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct NSWindowStyleMask: NSUInteger {
         const NSBorderlessWindowMask      = 0;
         const NSTitledWindowMask          = 1 << 0;

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -347,7 +347,7 @@ unsafe impl Encode for NSWindowOcclusionState {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Debug)]
+    #[derive(Debug, Clone, Copy)]
     pub struct NSWindowStyleMask: NSUInteger {
         const NSBorderlessWindowMask      = 0;
         const NSTitledWindowMask          = 1 << 0;

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -71,7 +71,7 @@ enum ImeState {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, PartialEq)]
+    #[derive(Debug, Clone, Copy, PartialEq)]
     struct ModLocationMask: u8 {
         const LEFT = 1;
         const RIGHT = 2;

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -71,6 +71,7 @@ enum ImeState {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq)]
     struct ModLocationMask: u8 {
         const LEFT = 1;
         const RIGHT = 2;

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -120,7 +120,7 @@ fn element_state(pressed: bool) -> event::ElementState {
 }
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     struct KeyboardModifierState: u8 {
         const LSHIFT = 1 << 0;
         const RSHIFT = 1 << 1;
@@ -134,7 +134,7 @@ bitflags! {
 }
 
 bitflags! {
-    #[derive(Default)]
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     struct MouseButtonState: u8 {
         const LEFT = 1 << 0;
         const MIDDLE = 1 << 1;

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -120,7 +120,7 @@ fn element_state(pressed: bool) -> event::ElementState {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     struct KeyboardModifierState: u8 {
         const LSHIFT = 1 << 0;
         const RSHIFT = 1 << 1;
@@ -134,7 +134,7 @@ bitflags! {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     struct MouseButtonState: u8 {
         const LEFT = 1 << 0;
         const MIDDLE = 1 << 1;

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -7,6 +7,7 @@ use std::convert::TryInto;
 use web_sys::{HtmlCanvasElement, KeyboardEvent, MouseEvent, PointerEvent, WheelEvent};
 
 bitflags! {
+    #[derive(Clone, Copy, Eq, PartialEq)]
     pub struct ButtonsState: u16 {
         const LEFT   = 0b001;
         const RIGHT  = 0b010;
@@ -31,13 +32,13 @@ impl From<MouseButton> for ButtonsState {
             MouseButton::Left => ButtonsState::LEFT,
             MouseButton::Right => ButtonsState::RIGHT,
             MouseButton::Middle => ButtonsState::MIDDLE,
-            MouseButton::Other(value) => unsafe { ButtonsState::from_bits_unchecked(value) },
+            MouseButton::Other(value) => ButtonsState::from_bits_retain(value),
         }
     }
 }
 
 pub fn mouse_buttons(event: &MouseEvent) -> ButtonsState {
-    unsafe { ButtonsState::from_bits_unchecked(event.buttons()) }
+    ButtonsState::from_bits_retain(event.buttons())
 }
 
 pub fn mouse_button(event: &MouseEvent) -> Option<MouseButton> {

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 use web_sys::{HtmlCanvasElement, KeyboardEvent, MouseEvent, PointerEvent, WheelEvent};
 
 bitflags! {
-    #[derive(Clone, Copy, Eq, PartialEq)]
+    #[derive(Clone, Copy, PartialEq, Eq)]
     pub struct ButtonsState: u16 {
         const LEFT   = 0b001;
         const RIGHT  = 0b010;

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -105,7 +105,7 @@ static NUMPAD_KEYCODES: Lazy<HashSet<KeyCode>> = Lazy::new(|| {
 });
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Eq, Hash, PartialEq)]
     pub struct WindowsModifiers : u8 {
         const SHIFT = 1 << 0;
         const CONTROL = 1 << 1;

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -105,6 +105,7 @@ static NUMPAD_KEYCODES: Lazy<HashSet<KeyCode>> = Lazy::new(|| {
 });
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct WindowsModifiers : u8 {
         const SHIFT = 1 << 0;
         const CONTROL = 1 << 1;

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -105,7 +105,7 @@ static NUMPAD_KEYCODES: Lazy<HashSet<KeyCode>> = Lazy::new(|| {
 });
 
 bitflags! {
-    #[derive(Clone, Copy, Default)]
+    #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
     pub struct WindowsModifiers : u8 {
         const SHIFT = 1 << 0;
         const CONTROL = 1 << 1;
@@ -363,11 +363,11 @@ impl LayoutCache {
         }
 
         // Iterate through every combination of modifiers
-        let mods_end = WindowsModifiers::FLAGS_END.bits;
+        let mods_end = WindowsModifiers::FLAGS_END.bits();
         for mod_state in 0..mods_end {
             let mut keys_for_this_mod = HashMap::with_capacity(256);
 
-            let mod_state = unsafe { WindowsModifiers::from_bits_unchecked(mod_state) };
+            let mod_state = WindowsModifiers::from_bits_retain(mod_state);
             mod_state.apply_to_kbd_state(&mut key_state);
 
             // Virtual key values are in the domain [0, 255].
@@ -443,7 +443,7 @@ impl LayoutCache {
         // Second pass: replace right alt keys with AltGr if the layout has alt graph
         if layout.has_alt_graph {
             for mod_state in 0..mods_end {
-                let mod_state = unsafe { WindowsModifiers::from_bits_unchecked(mod_state) };
+                let mod_state = WindowsModifiers::from_bits_retain(mod_state);
                 if let Some(keys) = layout.keys.get_mut(&mod_state) {
                     if let Some(key) = keys.get_mut(&KeyCode::AltRight) {
                         *key = Key::AltGraph;

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -105,7 +105,7 @@ static NUMPAD_KEYCODES: Lazy<HashSet<KeyCode>> = Lazy::new(|| {
 });
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Default)]
     pub struct WindowsModifiers : u8 {
         const SHIFT = 1 << 0;
         const CONTROL = 1 << 1;

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -105,7 +105,7 @@ static NUMPAD_KEYCODES: Lazy<HashSet<KeyCode>> = Lazy::new(|| {
 });
 
 bitflags! {
-    #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, PartialEq, Eq, Hash)]
     pub struct WindowsModifiers : u8 {
         const SHIFT = 1 << 0;
         const CONTROL = 1 << 1;

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -71,7 +71,7 @@ pub struct MouseProperties {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct CursorFlags: u8 {
         const GRABBED   = 1 << 0;
         const HIDDEN    = 1 << 1;
@@ -79,7 +79,7 @@ bitflags! {
     }
 }
 bitflags! {
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct WindowFlags: u32 {
         const RESIZABLE         = 1 << 0;
         const MINIMIZABLE       = 1 << 1;

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -71,7 +71,7 @@ pub struct MouseProperties {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct CursorFlags: u8 {
         const GRABBED   = 1 << 0;
         const HIDDEN    = 1 << 1;
@@ -79,7 +79,7 @@ bitflags! {
     }
 }
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct WindowFlags: u32 {
         const RESIZABLE         = 1 << 0;
         const MINIMIZABLE       = 1 << 1;

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -120,7 +120,7 @@ bitflags! {
 
         const MARKER_ACTIVATE = 1 << 21;
 
-        const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits;
+        const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits();
     }
 }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -71,6 +71,7 @@ pub struct MouseProperties {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct CursorFlags: u8 {
         const GRABBED   = 1 << 0;
         const HIDDEN    = 1 << 1;
@@ -78,6 +79,7 @@ bitflags! {
     }
 }
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct WindowFlags: u32 {
         const RESIZABLE         = 1 << 0;
         const MINIMIZABLE       = 1 << 1;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1480,7 +1480,7 @@ pub enum UserAttentionType {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
+    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
     pub struct WindowButtons: u32 {
         const CLOSE  = 1 << 0;
         const MINIMIZE  = 1 << 1;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1480,7 +1480,7 @@ pub enum UserAttentionType {
 }
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct WindowButtons: u32 {
         const CLOSE  = 1 << 0;
         const MINIMIZE  = 1 << 1;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1480,6 +1480,7 @@ pub enum UserAttentionType {
 }
 
 bitflags! {
+    #[derive(Clone, Copy, Default, Debug, Eq, Hash, PartialEq)]
     pub struct WindowButtons: u32 {
         const CLOSE  = 1 << 0;
         const MINIMIZE  = 1 << 1;


### PR DESCRIPTION
- [❎] Tested on all platforms changed
- [✅] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [❎] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [❎] Created or updated an example program if it would help users understand this functionality
- [❎] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I used the largest set of `#[derive()]` traits on each `bitflags!` instance, so there should be no/minimal compile errors.
I have tested on windows, iOS, mac, and wasm. I have not yet been able to test on Linux or Android, but I used the widest range of derives on those platforms, so they should hopefully not break.
