### PR TITLE
Fix panic when destroying window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, scale factor and dark mode detection are now more robust.
 - On Web, fix the bfcache by not using the `beforeunload` event.
 - On Web, fix scale factor resize suggestion always overwriting the canvas size.
+- On macOS, fix crash when dropping `Window`.
 
 # 0.28.6
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -243,6 +243,7 @@ declare_class!(
         fn draw_rect(&mut self, rect: NSRect) {
             trace_scope!("drawRect:");
 
+            // It's a workaround for https://github.com/rust-windowing/winit/issues/2640, don't replace with `self.window_id()`.
             if let Some(window) = self._ns_window.load() {
                 AppState::handle_redraw(WindowId(window.id()));
             }

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -243,7 +243,9 @@ declare_class!(
         fn draw_rect(&mut self, rect: NSRect) {
             trace_scope!("drawRect:");
 
-            AppState::handle_redraw(self.window_id());
+            if let Some(window) = self._ns_window.load() {
+                AppState::handle_redraw(WindowId(window.id()));
+            }
 
             #[allow(clippy::let_unit_value)]
             unsafe {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

Dropping window may cause panic.

```
thread 'main' panicked at 'view to have a window', src/platform_impl/macos/view.rs:880:32
```

