### PR TITLE
Replace mio with calloop in the X11 backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
-x11 = ["x11-dl", "mio", "percent-encoding", "xkbcommon-dl/x11"]
+x11 = ["x11-dl", "percent-encoding", "xkbcommon-dl/x11"]
 wayland = ["wayland-client", "wayland-backend", "wayland-protocols", "sctk", "fnv", "memmap2"]
 wayland-dlopen = ["wayland-backend/dlopen"]
 wayland-csd-adwaita = ["sctk-adwaita", "sctk-adwaita/ab_glyph"]
@@ -112,7 +112,7 @@ features = [
 
 [target.'cfg(all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_os = "ios", target_os = "macos"))))'.dependencies]
 libc = "0.2.64"
-mio = { version = "0.8", features = ["os-ext"], optional = true }
+calloop = "0.10.5"
 percent-encoding = { version = "2.0", optional = true }
 fnv = { version = "1.0.3", optional = true }
 sctk = { package = "smithay-client-toolkit", version = "0.17.0", default-features = false, features = ["calloop"], optional = true }
@@ -120,7 +120,6 @@ sctk-adwaita = { version = "0.6.0", default_features = false, optional = true }
 wayland-client = { version = "0.30.0", optional = true }
 wayland-backend = { version = "0.1.0", default_features = false, features = ["client_system"], optional = true }
 wayland-protocols = { version = "0.30.0", features = [ "staging"], optional = true }
-calloop = "0.10.5"
 x11-dl = { version = "2.18.5", optional = true }
 xkbcommon-dl = "0.3.0"
 memmap2 = { version = "0.5.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,6 @@ features = [
 
 [target.'cfg(all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_os = "ios", target_os = "macos"))))'.dependencies]
 libc = "0.2.64"
-calloop = "0.10.5"
 percent-encoding = { version = "2.0", optional = true }
 fnv = { version = "1.0.3", optional = true }
 sctk = { package = "smithay-client-toolkit", version = "0.17.0", default-features = false, features = ["calloop"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ sctk-adwaita = { version = "0.6.0", default_features = false, optional = true }
 wayland-client = { version = "0.30.0", optional = true }
 wayland-backend = { version = "0.1.0", default_features = false, features = ["client_system"], optional = true }
 wayland-protocols = { version = "0.30.0", features = [ "staging"], optional = true }
+calloop = "0.10.5"
 x11-dl = { version = "2.18.5", optional = true }
 xkbcommon-dl = "0.3.0"
 memmap2 = { version = "0.5.0", optional = true }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -493,7 +493,7 @@ impl<T: 'static> EventLoop<T> {
                     // We don't go straight into executing the event loop iteration, we instead go
                     // to the start of this loop and check again if there's any pending event. We
                     // must do this because during the execution of the iteration we sometimes wake
-                    // the mio waker, and if the waker is already awaken before we call poll(),
+                    // the calloop waker, and if the waker is already awaken before we call poll(),
                     // then poll doesn't block, but it returns immediately. This caused the event
                     // loop to run continuously even if the control_flow was `Wait`
                     continue;

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -383,9 +383,20 @@ impl<T: 'static> EventLoop<T> {
                     callback,
                 );
             }
+
+            // Quickly dispatch all pending events to clear channels
+            this.event_loop
+                .dispatch(
+                    Some(Duration::ZERO),
+                    &mut get_xtarget(&this.target).state.borrow_mut(),
+                )
+                .ok();
+
             // Empty the redraw requests
             {
                 let mut windows = HashSet::new();
+
+                // Empty the channel.
 
                 while let Some(window_id) = get_xtarget(&this.target)
                     .state

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -58,7 +58,6 @@ use crate::{
 };
 
 type X11Source = Generic<RawFd>;
-//type X11Dispatcher = calloop::Dispatcher<'static, X11Source, EventLoopState>;
 
 pub struct EventLoopWindowTarget<T> {
     xconn: Arc<XConnection>,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Closes #2763 by replacing `mio` with `calloop` in the X11 backend.