### PR TITLE
Don't change the internal canvas size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Bump MSRV from `1.60` to `1.64`.
 - On macOS, fixed potential panic when getting refresh rate.
 - On macOS, fix crash when calling `Window::set_ime_position` from another thread.
+- On Web, the canvas output bitmap size is no longer adjusted.
 
 # 0.28.3
 

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -83,12 +83,7 @@ pub fn scale_factor() -> f64 {
 
 pub fn set_canvas_size(raw: &HtmlCanvasElement, size: Size) {
     let scale_factor = scale_factor();
-
-    let physical_size = size.to_physical::<u32>(scale_factor);
     let logical_size = size.to_logical::<f64>(scale_factor);
-
-    raw.set_width(physical_size.width);
-    raw.set_height(physical_size.height);
 
     set_canvas_style_property(raw, "width", &format!("{}px", logical_size.width));
     set_canvas_style_property(raw, "height", &format!("{}px", logical_size.height));


### PR DESCRIPTION
See https://github.com/rust-windowing/winit/issues/2733, https://github.com/gfx-rs/wgpu/issues/3620 and https://github.com/gfx-rs/wgpu/pull/3690 for more information.

This is a follow-up to https://github.com/gfx-rs/wgpu/pull/3690. Now renderer are responsible for changing the internal canvas size. Winit will still continue to adjust the **visual** size of the canvas.

Both `wgpu` and `softbuffer` handle this correctly. Happy to check and make PR's to other crates that come to mind.

Fixes #2733.