### PR TITLE
WIP implementation for inhibiting system shortcuts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,3 +158,6 @@ web-sys = { version = "0.3.22", features = ['CanvasRenderingContext2d'] }
 members = [
     "run-wasm",
 ]
+
+[patch.crates-io]
+smithay-client-toolkit = { git = "https://github.com/ids1024/client-toolkit", branch = "shortcuts-inhibit" }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -622,6 +622,11 @@ impl Window {
     pub fn title(&self) -> String {
         x11_or_wayland!(match self; Window(window) => window.title())
     }
+
+    #[inline]
+    pub fn set_inhibit_system_shortcuts(&self, inhibit: bool) {
+        x11_or_wayland!(match self; Window(w) => w.set_inhibit_system_shortcuts(inhibit))
+    }
 }
 
 /// Hooks for X11 errors.

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -11,12 +11,14 @@ use sctk::reexports::client::{Connection, Proxy, QueueHandle, Dispatch};
 use sctk::reexports::protocols::wp::pointer_constraints::zv1::client::zwp_confined_pointer_v1::ZwpConfinedPointerV1;
 use sctk::reexports::protocols::wp::pointer_constraints::zv1::client::zwp_locked_pointer_v1::ZwpLockedPointerV1;
 use sctk::reexports::protocols::wp::pointer_constraints::zv1::client::zwp_pointer_constraints_v1::{Lifetime, ZwpPointerConstraintsV1};
+use sctk::reexports::protocols::wp::keyboard_shortcuts_inhibit::zv1::client::zwp_keyboard_shortcuts_inhibitor_v1::ZwpKeyboardShortcutsInhibitorV1;
 use sctk::reexports::client::globals::{BindError, GlobalList};
 
 use sctk::compositor::SurfaceData;
 use sctk::globals::GlobalData;
 use sctk::seat::pointer::{PointerData, PointerDataExt};
 use sctk::seat::pointer::{PointerEvent, PointerEventKind, PointerHandler};
+use sctk::seat::shortcuts_inhibit::ShortcutsInhibitState;
 use sctk::seat::SeatState;
 use sctk::shell::xdg::frame::FrameClick;
 
@@ -313,6 +315,29 @@ impl WinitPointerData {
         }
     }
 
+    // TODO shouldn't be associated with pointer
+    pub fn inhibit_system_shortcuts(
+        &self,
+        shortcuts_inhibit_state: &ShortcutsInhibitState,
+        surface: &WlSurface,
+        queue_handle: &QueueHandle<WinitState>,
+    ) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.shortcuts_inhibitor.is_none() {
+            let inhibitor = shortcuts_inhibit_state
+                .inhibit_shortcuts(surface, self.seat(), queue_handle)
+                .ok();
+            inner.shortcuts_inhibitor = inhibitor;
+        }
+    }
+
+    pub fn uninhibit_system_shortcuts(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(inhibitor) = inner.shortcuts_inhibitor.take() {
+            inhibitor.destroy();
+        }
+    }
+
     /// Seat associated with this pointer.
     pub fn seat(&self) -> &WlSeat {
         self.sctk_data.seat()
@@ -374,6 +399,8 @@ pub struct WinitPointerDataInner {
 
     /// Current axis phase.
     phase: TouchPhase,
+
+    shortcuts_inhibitor: Option<ZwpKeyboardShortcutsInhibitorV1>,
 }
 
 impl Drop for WinitPointerDataInner {
@@ -394,6 +421,7 @@ impl Default for WinitPointerDataInner {
             surface: None,
             locked_pointer: None,
             confined_pointer: None,
+            shortcuts_inhibitor: None,
             latest_button_serial: 0,
             phase: TouchPhase::Ended,
         }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -614,6 +614,13 @@ impl Window {
     pub fn title(&self) -> String {
         self.window_state.lock().unwrap().title().to_owned()
     }
+
+    pub fn set_inhibit_system_shortcuts(&self, inhibit: bool) {
+        self.window_state
+            .lock()
+            .unwrap()
+            .set_inhibit_system_shortcuts(inhibit);
+    }
 }
 
 impl Drop for Window {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1629,4 +1629,8 @@ impl UnownedWindow {
     pub fn title(&self) -> String {
         String::new()
     }
+
+    pub fn set_inhibit_system_shortcuts(&self, inhibit: bool) {
+        // TODO
+    }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1155,6 +1155,10 @@ impl Window {
     pub fn title(&self) -> String {
         self.window.title()
     }
+
+    pub fn set_inhibit_system_shortcuts(&self, inhibit: bool) {
+        self.window.set_inhibit_system_shortcuts(inhibit);
+    }
 }
 
 /// Cursor functions.


### PR DESCRIPTION
Implementation for https://github.com/rust-windowing/winit/issues/2776, on Wayland currently only.

Wayland implementation should be done more cleanly, needs X11 and any other applicable platforms, documentation etc. And this will need the feature to be merged in sctk and released.

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
