### PR TITLE
On macOS, fix `key_Up` being ignored without IME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, add `Window::drag_resize_window` method.
 - On Wayland, drop `WINIT_WAYLAND_CSD_THEME` variable.
 - Bump MSRV from `1.60` to `1.64`.
+- On macOS, fix `key_up` beind ignored when `Ime` is disabled.
 
 # 0.28.4
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -549,7 +549,7 @@ declare_class!(
             self.update_potentially_stale_modifiers(event);
 
             // We want to send keyboard input when we are currently in the ground state.
-            if self.state.ime_state == ImeState::Ground {
+            if matches!(self.state.ime_state, ImeState::Ground | ImeState::Disabled) {
                 #[allow(deprecated)]
                 self.queue_event(WindowEvent::KeyboardInput {
                     device_id: DEVICE_ID,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


--

That was unfortunate, but no-one noticed because everyone was testing with IME enabled.