### PR TITLE
On macOS, fix backspace emission on preedit clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, add `Window::drag_resize_window` method.
 - On Wayland, drop `WINIT_WAYLAND_CSD_THEME` variable.
 - Bump MSRV from `1.60` to `1.64`.
+- On macOS, fix `Backspace` being emitted when clearing preedit with it.
 
 # 0.28.5
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -50,7 +50,7 @@ impl Default for CursorState {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 enum ImeState {
     /// The IME events are disabled, so only `ReceivedCharacter` is being sent to the user.
     Disabled,
@@ -481,6 +481,7 @@ declare_class!(
                 && !ev_mods.logo();
 
             let characters = get_characters(event, ignore_alt_characters);
+            let old_ime_state = self.state.ime_state;
             self.state.forward_key_to_app = false;
 
             // The `interpretKeyEvents` function might call
@@ -518,7 +519,8 @@ declare_class!(
                     true
                 }
                 ImeState::Preedit => true,
-                _ => false,
+                // `key_down` could result in preedit clear, so compare old and current state.
+                _ => old_ime_state != self.state.ime_state,
             };
 
             if !had_ime_input || self.state.forward_key_to_app {


### PR DESCRIPTION
Fixes: d15feb5cfa (On macOS, fix empty marked text)

--

Tested on macOS. Will backport to 0.28.6.
