### PR TITLE
Implement PartialOrd/Ord for dpi module types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, fix forward compatibility issues.
 - On Wayland, add `Window::drag_resize_window` method.
 - On Wayland, drop `WINIT_WAYLAND_CSD_THEME` variable.
+- Implement `PartialOrd` and `Ord` on types in the `dpi` module.
 - Bump MSRV from `1.60` to `1.64`.
 
 # 0.28.6

--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -167,7 +167,7 @@ pub fn validate_scale_factor(scale_factor: f64) -> bool {
 /// The position is stored as floats, so please be careful. Casting floats to integers truncates the
 /// fractional part, which can cause noticable issues. To help with that, an `Into<(i32, i32)>`
 /// implementation is provided which does the rounding for you.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LogicalPosition<P> {
     pub x: P,
@@ -246,7 +246,7 @@ impl<P: Pixel> From<LogicalPosition<P>> for mint::Point2<P> {
 }
 
 /// A position represented in physical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PhysicalPosition<P> {
     pub x: P,
@@ -325,7 +325,7 @@ impl<P: Pixel> From<PhysicalPosition<P>> for mint::Point2<P> {
 }
 
 /// A size represented in logical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct LogicalSize<P> {
     pub width: P,
@@ -407,7 +407,7 @@ impl<P: Pixel> From<LogicalSize<P>> for mint::Vector2<P> {
 }
 
 /// A size represented in physical pixels.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Default, Hash)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct PhysicalSize<P> {
     pub width: P,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -32,12 +32,9 @@ impl PartialOrd for VideoMode {
 
 impl Ord for VideoMode {
     fn cmp(&self, other: &VideoMode) -> std::cmp::Ordering {
-        // TODO: we can impl `Ord` for `PhysicalSize` once we switch from `f32`
-        // to `u32` there
-        let size: (u32, u32) = self.size().into();
-        let other_size: (u32, u32) = other.size().into();
         self.monitor().cmp(&other.monitor()).then(
-            size.cmp(&other_size)
+            self.size()
+                .cmp(&other.size())
                 .then(
                     self.refresh_rate_millihertz()
                         .cmp(&other.refresh_rate_millihertz())


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

The lowest hanging fruit tastes the sweetest.