### PR TITLE
On Wayland, fix Window::set_cursor_visible(true)

### DIFF
--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -690,12 +690,16 @@ impl WindowState {
     pub fn set_cursor_visible(&mut self, cursor_visible: bool) {
         self.cursor_visible = cursor_visible;
 
-        for pointer in self.pointers.iter().filter_map(|pointer| pointer.upgrade()) {
-            let latest_enter_serial = pointer.pointer().winit_data().latest_enter_serial();
+        if self.cursor_visible {
+            self.set_cursor(self.cursor_icon);
+        } else {
+            for pointer in self.pointers.iter().filter_map(|pointer| pointer.upgrade()) {
+                let latest_enter_serial = pointer.pointer().winit_data().latest_enter_serial();
 
-            pointer
-                .pointer()
-                .set_cursor(latest_enter_serial, None, 0, 0);
+                pointer
+                    .pointer()
+                    .set_cursor(latest_enter_serial, None, 0, 0);
+            }
         }
     }
 


### PR DESCRIPTION
Making the cursor back visible was simply forgotten and it was always hiding instead.

Fixes: 24960988902 (Update wayland-rs to 0.30.0)
Fixes: #2820.
