### PR TITLE
Use linux scancode values for KeyCodeExtScancode

### DIFF
--- a/src/platform/scancode.rs
+++ b/src/platform/scancode.rs
@@ -1,9 +1,8 @@
 #![cfg(any(windows_platform, macos_platform, x11_platform, wayland_platform))]
 
-// TODO: Maybe merge this with `modifier_supplement` if the two are indeed supported on the same
-// set of platforms
-
 use crate::keyboard::KeyCode;
+
+// TODO: Describe what this value contains for each platform
 
 /// Additional methods for the [`KeyCode`] type that allow the user to access the platform-specific
 /// scancode.
@@ -16,13 +15,16 @@ pub trait KeyCodeExtScancode {
     ///
     /// ## Platform-specific
     /// - **Windows:** A 16bit extended scancode
-    /// - **Wayland/X11**: A 32-bit X11-style keycode.
-    // TODO: Describe what this value contains for each platform
+    /// - **Wayland/X11**: A 32-bit linux scancode, which is X11/Wayland keycode subtracted by 8.
     fn to_scancode(self) -> Option<u32>;
 
     /// Constructs a `KeyCode` from a platform-specific physical key identifier.
     ///
     /// Note that this conversion may be lossy, i.e. converting the returned `KeyCode` back
     /// using `to_scancode` might not yield the original value.
+    ///
+    /// ## Platform-specific
+    /// - **Wayland/X11**: A 32-bit linux scancode. When building from X11/Wayland keycode subtract
+    ///                    `8` to get the value you wanted.
     fn from_scancode(scancode: u32) -> KeyCode;
 }

--- a/src/platform_impl/linux/common/keymap.rs
+++ b/src/platform_impl/linux/common/keymap.rs
@@ -6,7 +6,13 @@ use crate::keyboard::{Key, KeyCode, KeyLocation, NativeKey, NativeKeyCode};
 ///
 /// X11-style keycodes are offset by 8 from the keycodes the Linux kernel uses.
 pub fn raw_keycode_to_keycode(keycode: u32) -> KeyCode {
-    let rawkey = keycode - 8;
+    scancode_to_keycode(keycode.saturating_sub(8))
+}
+
+/// Map the linux scancode to Keycode.
+///
+/// Both X11 and Wayland use keys with `+ 8` offset to linux scancode.
+pub fn scancode_to_keycode(scancode: u32) -> KeyCode {
     // The keycode values are taken from linux/include/uapi/linux/input-event-codes.h, as
     // libxkbcommon's documentation seems to suggest that the keycode values we're interested in
     // are defined by the Linux kernel. If Winit programs end up being run on other Unix-likes,
@@ -15,7 +21,7 @@ pub fn raw_keycode_to_keycode(keycode: u32) -> KeyCode {
     // Some of the keycodes are likely superfluous for our purposes, and some are ones which are
     // difficult to test the correctness of, or discover the purpose of. Because of this, they've
     // either been commented out here, or not included at all.
-    match rawkey {
+    match scancode {
         0 => KeyCode::Unidentified(NativeKeyCode::Xkb(0)),
         1 => KeyCode::Escape,
         2 => KeyCode::Digit1,
@@ -259,11 +265,11 @@ pub fn raw_keycode_to_keycode(keycode: u32) -> KeyCode {
         // 246 => KeyCode::WWAN,
         // 247 => KeyCode::RFKILL,
         // 248 => KeyCode::KEY_MICMUTE,
-        _ => KeyCode::Unidentified(NativeKeyCode::Xkb(rawkey)),
+        _ => KeyCode::Unidentified(NativeKeyCode::Xkb(scancode)),
     }
 }
 
-pub fn keycode_to_raw(keycode: KeyCode) -> Option<u32> {
+pub fn keycode_to_scancode(keycode: KeyCode) -> Option<u32> {
     match keycode {
         KeyCode::Unidentified(NativeKeyCode::Unidentified) => Some(240),
         KeyCode::Unidentified(NativeKeyCode::Xkb(raw)) => Some(raw),
@@ -405,7 +411,6 @@ pub fn keycode_to_raw(keycode: KeyCode) -> Option<u32> {
         KeyCode::F24 => Some(194),
         _ => None,
     }
-    .map(|raw| raw + 8)
 }
 
 pub fn keysym_to_key(keysym: u32) -> Key {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -656,11 +656,11 @@ impl KeyEventExtModifierSupplement for KeyEvent {
 
 impl KeyCodeExtScancode for KeyCode {
     fn from_scancode(scancode: u32) -> KeyCode {
-        common::keymap::raw_keycode_to_keycode(scancode)
+        common::keymap::scancode_to_keycode(scancode)
     }
 
     fn to_scancode(self) -> Option<u32> {
-        common::keymap::keycode_to_raw(self)
+        common::keymap::keycode_to_scancode(self)
     }
 }
 


### PR DESCRIPTION
Old winit was using linux scancodes, so this should make it backward compatible with itself.