### PR TITLE
Add support of using custom image as cursor icon on windows

### DIFF
--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,10 +1,13 @@
 #![allow(clippy::single_match)]
 
+use std::path::Path;
+
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
-    window::{CursorIcon, WindowBuilder},
+    keyboard::{KeyCode, PhysicalKey},
+    window::{CursorIcon, Icon, WindowBuilder},
 };
 
 #[path = "util/fill.rs"]
@@ -22,6 +25,20 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, elwt| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            state: ElementState::Pressed,
+                            physical_key: PhysicalKey::Code(KeyCode::KeyC),
+                            ..
+                        },
+                    ..
+                } => {
+                    println!("Setting cursor to custom");
+                    let path: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/icon.png");
+                    let icon = load_icon(Path::new(path));
+                    window.set_cursor_custom_icon(icon.clone());
+                }
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {
@@ -86,3 +103,15 @@ const CURSORS: &[CursorIcon] = &[
     CursorIcon::ColResize,
     CursorIcon::RowResize,
 ];
+
+fn load_icon(path: &Path) -> Icon {
+    let (icon_rgba, icon_width, icon_height) = {
+        let image = image::open(path)
+            .expect("Failed to open icon path")
+            .into_rgba8();
+        let (width, height) = image.dimensions();
+        let rgba = image.into_raw();
+        (rgba, width, height)
+    };
+    Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
+}

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -113,5 +113,6 @@ fn load_icon(path: &Path) -> Icon {
         let rgba = image.into_raw();
         (rgba, width, height)
     };
-    Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
+    // Assumes that hotspot is at the left top corner.
+    Icon::from_rgba_cursor(icon_rgba, icon_width, icon_height, 0, 0).expect("Failed to open icon")
 }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::single_match)]
 
-use std::path::Path;
-
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -104,6 +102,10 @@ const CURSORS: &[CursorIcon] = &[
     CursorIcon::RowResize,
 ];
 
+#[cfg(windows_platform)]
+use std::path::Path;
+
+#[cfg(windows_platform)]
 fn load_icon(path: &Path) -> Icon {
     let (icon_rgba, icon_width, icon_height) = {
         let image = image::open(path)

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2017,7 +2017,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                             .mouse
                             .custom_cursor
                             .as_ref()
-                            .and_then(|v| Some(v.inner.as_raw_handle())),
+                            .map(|v| v.inner.as_raw_handle()),
                     )
                 } else {
                     (None, None)

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -397,9 +397,19 @@ impl Window {
     #[inline]
     pub fn set_cursor_icon(&self, cursor: CursorIcon) {
         self.window_state_lock().mouse.cursor = cursor;
+        self.window_state_lock().mouse.custom_cursor = None;
         self.thread_executor.execute_in_thread(move || unsafe {
             let cursor = LoadCursorW(0, util::to_windows_cursor(cursor));
             SetCursor(cursor);
+        });
+    }
+
+    #[inline]
+    pub fn set_cursor_custom_icon(&self, cursor: Icon) {
+        let handle = cursor.inner.as_raw_handle();
+        self.window_state_lock().mouse.custom_cursor = Some(cursor);
+        self.thread_executor.execute_in_thread(move || unsafe {
+            SetCursor(handle);
         });
     }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -68,6 +68,7 @@ pub struct SavedWindow {
 #[derive(Clone)]
 pub struct MouseProperties {
     pub cursor: CursorIcon,
+    pub custom_cursor: Option<Icon>,
     pub capture_count: u32,
     cursor_flags: CursorFlags,
     pub last_position: Option<PhysicalPosition<f64>>,
@@ -144,6 +145,7 @@ impl WindowState {
         WindowState {
             mouse: MouseProperties {
                 cursor: CursorIcon::default(),
+                custom_cursor: None,
                 capture_count: 0,
                 cursor_flags: CursorFlags::empty(),
                 last_position: None,

--- a/src/window.rs
+++ b/src/window.rs
@@ -1352,9 +1352,9 @@ impl Window {
     ///
     ///  - Only **Windows** supported for now.
     #[inline]
-    pub fn set_cursor_custom_icon(&self, cursor: Icon) {
+    pub fn set_cursor_custom_icon(&self, _cursor: Icon) {
         #[cfg(windows_platform)]
-        self.window.set_cursor_custom_icon(cursor);
+        self.window.set_cursor_custom_icon(_cursor);
     }
 
     /// Changes the position of the cursor in window coordinates.

--- a/src/window.rs
+++ b/src/window.rs
@@ -1353,6 +1353,7 @@ impl Window {
     ///  - Only **Windows** supported for now.
     #[inline]
     pub fn set_cursor_custom_icon(&self, cursor: Icon) {
+        #[cfg(windows_platform)]
         self.window.set_cursor_custom_icon(cursor);
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1346,6 +1346,16 @@ impl Window {
             .maybe_queue_on_main(move |w| w.set_cursor_icon(cursor))
     }
 
+    /// Modifies the cursor icon of the window.
+    ///
+    /// ## Platform-specific
+    ///
+    ///  - Only **Windows** supported for now.
+    #[inline]
+    pub fn set_cursor_custom_icon(&self, cursor: Icon) {
+        self.window.set_cursor_custom_icon(cursor);
+    }
+
     /// Changes the position of the cursor in window coordinates.
     ///
     /// ```no_run


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Adds a `Window::set_cursor_custom_icon` method, which we can pass an `Icon` to. And this icon is sightly different from a icon created by `Icon::from_rgba`, because it lacks of hotspot infomation (default to the center of image in fact), so I add an `Icon::from_rgba_cursor` which has extra hotspot parameters.

A custom cursor icon has higher priority than system cursor once it is set (when processing WM_SETCURSOR). And custom cursor icon will be dropped if `Window::set_cursor_icon` is called again.

This feature is only added to Windows platform for now, and `.cur` or `.ani` format is also not supported for potential cross-platform requirements.

Maybe a common `Cursor` struct should be added instead of reusing `Icon`, but on Windows an icon or cursor is not strictly differentiated and I haven't delved into the api of other platforms yet. So I just make minimal changes.
