### PR TITLE
Replace `instant` with `web-time`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, fix pointer button events not being processed when a buttons is already pressed.
 - **Breaking:** Updated `bitflags` crate version to `2`, which changes the API on exposed types.
 - On Web, handle coalesced pointer events, which increases the resolution of pointer inputs.
+- **Breaking:** On Web, `instant` is now replaced by `web_time`.
 
 # 0.28.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,6 @@ cfg_aliases = "0.1.1"
 [dependencies]
 bitflags = "2"
 cursor-icon = "1.0.0"
-instant = { version = "0.1", features = ["wasm-bindgen"] }
 log = "0.4"
 mint = { version = "0.5.6", optional = true }
 once_cell = "1.12"
@@ -159,6 +158,7 @@ features = [
 js-sys = "0.3"
 wasm-bindgen = "0.2.45"
 wasm-bindgen-futures = "0.4"
+web-time = "0.2"
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 console_log = "1"

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::single_match)]
 
-use std::{thread, time};
+use std::thread;
+#[cfg(not(wasm_platform))]
+use std::time;
+#[cfg(wasm_platform)]
+use web_time as time;
 
 use simple_logger::SimpleLogger;
 use winit::{
@@ -102,7 +106,7 @@ fn main() {
                     Mode::Wait => control_flow.set_wait(),
                     Mode::WaitUntil => {
                         if !wait_cancelled {
-                            control_flow.set_wait_until(instant::Instant::now() + WAIT_TIME);
+                            control_flow.set_wait_until(time::Instant::now() + WAIT_TIME);
                         }
                     }
                     Mode::Poll => {

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,7 +1,10 @@
 #![allow(clippy::single_match)]
 
-use instant::Instant;
 use std::time::Duration;
+#[cfg(not(wasm_platform))]
+use std::time::Instant;
+#[cfg(wasm_platform)]
+use web_time::Instant;
 
 use simple_logger::SimpleLogger;
 use winit::{

--- a/src/event.rs
+++ b/src/event.rs
@@ -34,9 +34,12 @@
 //!
 //! [`EventLoop::run(...)`]: crate::event_loop::EventLoop::run
 //! [`ControlFlow::WaitUntil`]: crate::event_loop::ControlFlow::WaitUntil
-use instant::Instant;
 use smol_str::SmolStr;
 use std::path::PathBuf;
+#[cfg(not(wasm_platform))]
+use std::time::Instant;
+#[cfg(wasm_platform)]
+use web_time::Instant;
 
 #[cfg(doc)]
 use crate::window::Window;

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -11,9 +11,12 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 use std::{error, fmt};
 
-use instant::{Duration, Instant};
 use once_cell::sync::OnceCell;
 use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
+#[cfg(not(wasm_platform))]
+use std::time::{Duration, Instant};
+#[cfg(wasm_platform)]
+use web_time::{Duration, Instant};
 
 use crate::{event::Event, monitor::MonitorHandle, platform_impl};
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -3,7 +3,6 @@ use crate::event::{Event, StartCause};
 use crate::event_loop::ControlFlow;
 use crate::window::WindowId;
 
-use instant::{Duration, Instant};
 use std::{
     cell::RefCell,
     clone::Clone,
@@ -12,6 +11,7 @@ use std::{
     ops::Deref,
     rc::{Rc, Weak},
 };
+use web_time::{Duration, Instant};
 
 pub struct Shared<T: 'static>(Rc<Execution<T>>);
 

--- a/src/platform_impl/web/event_loop/state.rs
+++ b/src/platform_impl/web/event_loop/state.rs
@@ -1,7 +1,7 @@
 use super::backend;
 use crate::event_loop::ControlFlow;
 
-use instant::Instant;
+use web_time::Instant;
 
 #[derive(Debug)]
 pub enum State {


### PR DESCRIPTION
This replaces [`instant`](https://crates.io/crates/instant) with [`web-time`](https://crates.io/crates/web-time).
Currently `instant` is unmaintained an has a bunch of issues:
- https://github.com/sebcrozet/instant/issues/21
- Panics in [`Instant::duration_since()`](https://github.com/sebcrozet/instant/blob/78e336db632f1f2f7350e2b2385c23d263178251/src/wasm.rs#L24-L27), [unlike std, which currently saturates](https://doc.rust-lang.org/std/time/struct.Instant.html#method.duration_since).
- https://github.com/sebcrozet/instant/issues/49
- No support for [`target_feature = "atomics"`](https://github.com/daxpedda/web-time/blob/b64662bf7aac4f856d681d0053ee1d47294820d4/src/web/instant.rs#L25-L26).

I also gated the dependency behind the Wasm target.

Replaces #2738.