### PR TITLE
Process pointer button events when a buttons is already pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web: fix position of touch events to be relative to the canvas.
 - On Web, fix `Window:::set_fullscreen` doing nothing when called outside the event loop but during
   a transient activation.
+- On Web, fix pointer button events not being processed when a buttons is already pressed.
 
 # 0.28.6
 

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -1,6 +1,6 @@
-use super::event;
 use super::event_handle::EventListenerHandle;
 use super::media_query_handle::MediaQueryListHandle;
+use super::{event, ButtonsState};
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
 use crate::event::{Force, MouseButton, MouseScrollDelta};
@@ -273,7 +273,15 @@ impl Canvas {
         touch_handler: T,
         prevent_default: bool,
     ) where
-        M: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>, ModifiersState),
+        M: 'static
+            + FnMut(
+                i32,
+                PhysicalPosition<f64>,
+                PhysicalPosition<f64>,
+                ModifiersState,
+                ButtonsState,
+                Option<MouseButton>,
+            ),
         T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
         match &mut self.mouse_state {

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -6,6 +6,7 @@ mod scaling;
 mod timeout;
 
 pub use self::canvas::Canvas;
+pub use self::event::ButtonsState;
 pub use self::scaling::ScaleChangeDetector;
 pub use self::timeout::{AnimationFrameRequest, Timeout};
 


### PR DESCRIPTION
When a pointer button is already pressed, new button presses/releases won't go through `pointerdown`/`pointerup`, but through `pointermove`, which is weird, but this PR now handles this correctly.

Along the way I inlined some unnecessary variables and passed button identifiers into `MouseButton::Other` directly instead of subtracting 3 (I have no clue why this was originally made).

Fixes #2455.
Cc #2475.
Replaces #2731.