### PR TITLE
On Web, handle coalesced events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   a transient activation.
 - On Web, fix pointer button events not being processed when a buttons is already pressed.
 - **Breaking:** Updated `bitflags` crate version to `2`, which changes the API on exposed types.
+- On Web, handle coalesced pointer events, which increases the resolution of pointer inputs.
 
 # 0.28.6
 

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -7,7 +7,7 @@ use std::convert::TryInto;
 use web_sys::{HtmlCanvasElement, KeyboardEvent, MouseEvent, PointerEvent, WheelEvent};
 
 bitflags! {
-    #[derive(Clone, Copy, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ButtonsState: u16 {
         const LEFT   = 0b001;
         const RIGHT  = 0b010;


### PR DESCRIPTION
This PR handles coalesced pointer events, which dramatically increases the resolution of pointer inputs.
Safari doesn't currently supports this, which is automatically detected.

See https://www.w3.org/TR/pointerevents3/#coalesced-events for more information.

Cc https://github.com/rust-windowing/winit/issues/1392.