### PR TITLE
Add missing `Hash` impls on bitflags

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1572,7 +1572,7 @@ bitflags! {
     /// Represents the current state of the keyboard modifiers
     ///
     /// Each flag represents a modifier and is set if this modifier is active.
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct ModifiersState: u32 {
         /// The "shift" key.
         const SHIFT = 0b100;
@@ -1623,7 +1623,7 @@ pub enum ModifiersKeyState {
 // to treat modifiers differently based on their position, which is required
 // on macOS due to their AltGr/Option situation.
 bitflags! {
-    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub(crate) struct ModifiersKeys: u8 {
         const LSHIFT   = 0b0000_0001;
         const RSHIFT   = 0b0000_0010;

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -253,7 +253,7 @@ impl MonitorHandleExtIOS for MonitorHandle {
 }
 
 /// Valid orientations for a particular [`Window`].
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ValidOrientations {
     /// Excludes `PortraitUpsideDown` on iphone
     #[default]
@@ -268,7 +268,7 @@ pub enum ValidOrientations {
 /// The device [idiom].
 ///
 /// [idiom]: https://developer.apple.com/documentation/uikit/uidevice/1620037-userinterfaceidiom?language=objc
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Idiom {
     Unspecified,
 
@@ -287,7 +287,7 @@ bitflags! {
     /// The [edges] of a screen.
     ///
     /// [edges]: https://developer.apple.com/documentation/uikit/uirectedge?language=objc
-    #[derive(Default, Clone, Copy)]
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct ScreenEdge: u8 {
         const NONE   = 0;
         const TOP    = 1 << 0;


### PR DESCRIPTION
Some bitflags in public API lost their `Hash` implementations.

Fixes: 31ebc5caf (Update `bitflags` to `2.0`)