### PR TITLE
Use correct canvas size for scale factor change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, `EventLoopProxy` now implements `Send`.
 - On Web, `Window` now implements `Send` and `Sync`.
 - **Breaking:** `WindowExtWebSys::canvas()` now returns an `Option`.
+- On Web, use the correct canvas size when calculating the new size during scale factor change,
+  instead of using the output bitmap size.
 
 # 0.28.6
 

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -59,7 +59,10 @@ mod wasm {
         let body = document.body().unwrap();
 
         // Set a background color for the canvas to make it easier to tell where the canvas is for debugging purposes.
-        canvas.style().set_css_text("background-color: crimson;");
+        canvas
+            .style()
+            .set_property("background-color", "crimson")
+            .unwrap();
         body.append_child(&canvas).unwrap();
 
         let log_header = document.create_element("h2").unwrap();

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -76,12 +76,19 @@ pub fn scale_factor(window: &web_sys::Window) -> f64 {
     window.device_pixel_ratio()
 }
 
-pub fn set_canvas_size(window: &web_sys::Window, raw: &HtmlCanvasElement, size: Size) {
-    let scale_factor = scale_factor(window);
-    let logical_size = size.to_logical::<f64>(scale_factor);
+pub fn set_canvas_size(canvas: &Canvas, new_size: Size) {
+    let scale_factor = scale_factor(canvas.window());
 
-    set_canvas_style_property(raw, "width", &format!("{}px", logical_size.width));
-    set_canvas_style_property(raw, "height", &format!("{}px", logical_size.height));
+    let physical_size = new_size.to_physical(scale_factor);
+    canvas.size().set(physical_size);
+
+    let logical_size = new_size.to_logical::<f64>(scale_factor);
+    set_canvas_style_property(canvas.raw(), "width", &format!("{}px", logical_size.width));
+    set_canvas_style_property(
+        canvas.raw(),
+        "height",
+        &format!("{}px", logical_size.height),
+    );
 }
 
 pub fn set_canvas_style_property(raw: &HtmlCanvasElement, property: &str, value: &str) {


### PR DESCRIPTION
Until now the internal canvas size was used to determine it's current size, even when calculating the new size on a scale factor change, which was kind of problematic already as discussed in #2778.

This PR change that to track the canvas size we set in Winit, so we can use it for recalculations and to report to the user what we set it to when calling `Window::inner_size()`.

I briefly explore if it would be possible to query it instead of having to track it, unfortunately there is no reliable way through JS to track the CSS width and height we set ourselves. The closest is `getComputedStyle()`, which has it's own set of problems, among them the fact that it will always return zero until the canvas is actually inserted into the window.

Related #2778.
Fixes #2524.