### PR TITLE
Make media queries more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** `WindowExtWebSys::canvas()` now returns an `Option`.
 - On Web, use the correct canvas size when calculating the new size during scale factor change,
   instead of using the output bitmap size.
+- On Web, scale factor and dark mode detection are now more robust.
 
 # 0.28.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,6 @@ features = [
     'HtmlElement',
     'KeyboardEvent',
     'MediaQueryList',
-    'MediaQueryListEvent',
     'Node',
     'PointerEvent',
     'Window',

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -17,9 +17,7 @@ use smol_str::SmolStr;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{
-    Event, FocusEvent, HtmlCanvasElement, KeyboardEvent, MediaQueryListEvent, WheelEvent,
-};
+use web_sys::{Event, FocusEvent, HtmlCanvasElement, KeyboardEvent, WheelEvent};
 
 #[allow(dead_code)]
 pub struct Canvas {
@@ -343,13 +341,11 @@ impl Canvas {
     where
         F: 'static + FnMut(bool),
     {
-        let closure =
-            Closure::wrap(
-                Box::new(move |event: MediaQueryListEvent| handler(event.matches()))
-                    as Box<dyn FnMut(_)>,
-            );
-        self.on_dark_mode =
-            MediaQueryListHandle::new(&self.common.window, "(prefers-color-scheme: dark)", closure);
+        self.on_dark_mode = Some(MediaQueryListHandle::new(
+            &self.common.window,
+            "(prefers-color-scheme: dark)",
+            move |mql| handler(mql.matches()),
+        ));
     }
 
     pub fn request_fullscreen(&self) {

--- a/src/platform_impl/web/web_sys/media_query_handle.rs
+++ b/src/platform_impl/web/web_sys/media_query_handle.rs
@@ -1,54 +1,46 @@
 use wasm_bindgen::{prelude::Closure, JsCast};
-use web_sys::{MediaQueryList, MediaQueryListEvent};
+use web_sys::MediaQueryList;
 
 pub(super) struct MediaQueryListHandle {
     mql: MediaQueryList,
-    listener: Option<Closure<dyn FnMut(MediaQueryListEvent)>>,
+    closure: Closure<dyn FnMut()>,
 }
 
 impl MediaQueryListHandle {
-    pub fn new(
-        window: &web_sys::Window,
-        media_query: &str,
-        listener: Closure<dyn FnMut(MediaQueryListEvent)>,
-    ) -> Option<Self> {
+    pub fn new<F>(window: &web_sys::Window, media_query: &str, mut listener: F) -> Self
+    where
+        F: 'static + FnMut(&MediaQueryList),
+    {
         let mql = window
             .match_media(media_query)
-            .ok()
-            .flatten()
-            .and_then(|mql| {
-                mql.add_listener_with_opt_callback(Some(listener.as_ref().unchecked_ref()))
-                    .map(|_| mql)
-                    .ok()
-            });
-        mql.map(|mql| Self {
-            mql,
-            listener: Some(listener),
-        })
+            .expect("Failed to parse media query")
+            .expect("Found empty media query");
+
+        let closure = Closure::new({
+            let mql = mql.clone();
+            move || listener(&mql)
+        });
+        // TODO: Replace obsolete `addListener()` with `addEventListener()` and use
+        // `MediaQueryListEvent` instead of cloning the `MediaQueryList`.
+        // Requires Safari v14.
+        mql.add_listener_with_opt_callback(Some(closure.as_ref().unchecked_ref()))
+            .expect("Invalid listener");
+
+        Self { mql, closure }
     }
 
     pub fn mql(&self) -> &MediaQueryList {
         &self.mql
     }
-
-    /// Removes the listener and returns the original listener closure, which
-    /// can be reused.
-    pub fn remove(mut self) -> Closure<dyn FnMut(MediaQueryListEvent)> {
-        let listener = self.listener.take().unwrap_or_else(|| unreachable!());
-        remove_listener(&self.mql, &listener);
-        listener
-    }
 }
 
 impl Drop for MediaQueryListHandle {
     fn drop(&mut self) {
-        if let Some(listener) = self.listener.take() {
-            remove_listener(&self.mql, &listener);
-        }
+        remove_listener(&self.mql, &self.closure);
     }
 }
 
-fn remove_listener(mql: &MediaQueryList, listener: &Closure<dyn FnMut(MediaQueryListEvent)>) {
+fn remove_listener(mql: &MediaQueryList, listener: &Closure<dyn FnMut()>) {
     mql.remove_listener_with_opt_callback(Some(listener.as_ref().unchecked_ref()))
         .unwrap_or_else(|e| {
             web_sys::console::error_2(&"Error removing media query listener".into(), &e)


### PR DESCRIPTION
This improves on the original implementation: #1690.

- Remove the use of `MediaQueryListEvent`, which isn't supported by Safari until v14. The callback parameter differs depending on browser support. Without `MediaQueryListEvent` support `MediaQueryList` is passed ([spec](https://github.com/w3c/csswg-drafts/blob/2dc7a6b3ebeedb502b428c3c9a8e19e90148bd46/cssom-view/Overview.html#L843)). So we instead just clone the `MediaQueryList` into the closure.
- Use accurate scale factors in the media query instead of approximating with min/max, which should avoid any further issues as discussed in https://github.com/rust-windowing/winit/pull/2747#issuecomment-1554549488.
- Always initialize media queries. They should always work unless something is seriously wrong with our code.

Reverts #2599.
Replaces #2747 as discussed in https://github.com/rust-windowing/winit/pull/2747#issuecomment-1554549488.