### PR TITLE
Fix `Window::set_inner_size()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, drop `WINIT_WAYLAND_CSD_THEME` variable.
 - Implement `PartialOrd` and `Ord` on types in the `dpi` module.
 - **Breaking:** Bump MSRV from `1.60` to `1.64`.
-- **Breaking:** On Web, the canvas output bitmap size is no longer adjusted.
+- **Breaking:** On Web, `Window::(set_)inner_size()` will return/change the visual canvas size
+  instead of the internal canvas size.
 - On Web: fix `Window::request_redraw` not waking the event loop when called from outside the loop.
 - On Web: fix position of touch events to be relative to the canvas.
 - On Web, fix `Window:::set_fullscreen` doing nothing when called outside the event loop but during

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -73,17 +73,11 @@ pub fn scale_factor(window: &web_sys::Window) -> f64 {
 
 pub fn set_canvas_size(canvas: &Canvas, new_size: Size) {
     let scale_factor = scale_factor(canvas.window());
+    let new_size = new_size.to_physical(scale_factor);
 
-    let physical_size = new_size.to_physical(scale_factor);
-    canvas.size().set(physical_size);
-
-    let logical_size = new_size.to_logical::<f64>(scale_factor);
-    set_canvas_style_property(canvas.raw(), "width", &format!("{}px", logical_size.width));
-    set_canvas_style_property(
-        canvas.raw(),
-        "height",
-        &format!("{}px", logical_size.height),
-    );
+    canvas.size().set(new_size);
+    set_canvas_style_property(canvas.raw(), "width", &format!("{}px", new_size.width));
+    set_canvas_style_property(canvas.raw(), "height", &format!("{}px", new_size.height));
 }
 
 pub fn set_canvas_style_property(raw: &HtmlCanvasElement, property: &str, value: &str) {


### PR DESCRIPTION
So since #2778 properly decoupling internal and visual canvas size, we should make things consistent.

### Before (#2778)

Using `Window::set_inner_size()` would apply physical pixels to the internal canvas size and logical pixel to the visual canvas size. The logical pixel would be applied to the canvas size as physical pixels by setting CSS width and height as `px` values.

E.g.: `Window::set_inner_size(PhysicalSize::new(500, 500))` with a scale factor of 2. Would apply 500x500px to the the internal canvas size and 250x250px to the visual size. `Window::inner_size()` would report a size of 500x500px.

In the meanwhile the reported size by `Window::inner_size()` would be the 

### Currently (after #2778)

Same as before, but it would only apply the visual size, internal size wouldn't be touched at all.

### After (this PR)

`Window::set_inner_size()` will apply the correct size to the canvas. E.g. `Window::set_inner_size(PhysicalSize::new(500, 500))` will apply 500x500px to the visual size of the canvas, no matter the current scale factor.