### PR TITLE
On Web, fix scale factor resize suggestion always overwriting the canvas size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   instead of using the output bitmap size.
 - On Web, scale factor and dark mode detection are now more robust.
 - On Web, fix the bfcache by not using the `beforeunload` event.
+- On Web, fix scale factor resize suggestion always overwriting the canvas size.
 
 # 0.28.6
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -349,14 +349,16 @@ impl<T: 'static> Shared<T> {
             );
 
             // Then we resize the canvas to the new size and send a `Resized` event:
-            backend::set_canvas_size(&canvas, crate::dpi::Size::Physical(new_size));
-            self.handle_single_event_sync(
-                Event::WindowEvent {
-                    window_id: id,
-                    event: crate::event::WindowEvent::Resized(new_size),
-                },
-                &mut control,
-            );
+            if current_size != new_size {
+                backend::set_canvas_size(&canvas, crate::dpi::Size::Physical(new_size));
+                self.handle_single_event_sync(
+                    Event::WindowEvent {
+                        window_id: id,
+                        event: crate::event::WindowEvent::Resized(new_size),
+                    },
+                    &mut control,
+                );
+            }
         }
 
         // Process the destroy-pending windows again.


### PR DESCRIPTION
This makes it so users can ignore the resize suggestion provided by `ScaleFactorChanged` by setting it to the old value. Which is important when using CSS to set a specific size, like `width: 100%, height: 100%` on the canvas, which would be overwritten by Winit.

Related #1491.
Related #1661.