### PR TITLE
Revert "Fix `Window::set_inner_size()`"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,8 +54,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, drop `WINIT_WAYLAND_CSD_THEME` variable.
 - Implement `PartialOrd` and `Ord` on types in the `dpi` module.
 - **Breaking:** Bump MSRV from `1.60` to `1.64`.
-- **Breaking:** On Web, `Window::(set_)inner_size()` will return/change the visual canvas size
-  instead of the internal canvas size.
+- **Breaking:** On Web, the canvas output bitmap size is no longer adjusted.
 - On Web: fix `Window::request_redraw` not waking the event loop when called from outside the loop.
 - On Web: fix position of touch events to be relative to the canvas.
 - On Web, fix `Window:::set_fullscreen` doing nothing when called outside the event loop but during

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -73,11 +73,17 @@ pub fn scale_factor(window: &web_sys::Window) -> f64 {
 
 pub fn set_canvas_size(canvas: &Canvas, new_size: Size) {
     let scale_factor = scale_factor(canvas.window());
-    let new_size = new_size.to_physical(scale_factor);
 
-    canvas.size().set(new_size);
-    set_canvas_style_property(canvas.raw(), "width", &format!("{}px", new_size.width));
-    set_canvas_style_property(canvas.raw(), "height", &format!("{}px", new_size.height));
+    let physical_size = new_size.to_physical(scale_factor);
+    canvas.size().set(physical_size);
+
+    let logical_size = new_size.to_logical::<f64>(scale_factor);
+    set_canvas_style_property(canvas.raw(), "width", &format!("{}px", logical_size.width));
+    set_canvas_style_property(
+        canvas.raw(),
+        "height",
+        &format!("{}px", logical_size.height),
+    );
 }
 
 pub fn set_canvas_style_property(raw: &HtmlCanvasElement, property: &str, value: &str) {


### PR DESCRIPTION
Thanks @Liamolucko.

I spent some time going through my assumptions again, but the part that I didn't understand until now was that pixels in CSS represent logical pixels, not physical ones, which explains a lot of the stuff I was trying to figure out in #2859 as well.

I went through the rest of the code again to make sure I didn't break anything else with that wrong assumption, but everything looks fine so far.