### PR TITLE
Fix for linux aarch64 where c_char is not i8

### DIFF
--- a/src/platform_impl/linux/common/xkb_state.rs
+++ b/src/platform_impl/linux/common/xkb_state.rs
@@ -154,7 +154,7 @@ impl KbdState {
     /// `xkb_state_key_get_utf8`.
     fn make_string_with<F>(&mut self, mut f: F) -> Option<SmolStr>
     where
-        F: FnMut(*mut i8, usize) -> i32,
+        F: FnMut(*mut c_char, usize) -> i32,
     {
         let size = f(ptr::null_mut(), 0);
         if size == 0 {


### PR DESCRIPTION
- [x] Tested on all platforms changed (I only tested that `cargo c --target aarch64-unknown-linux-gnu` produces no errors)
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
