### PR TITLE
Removed the pesky reference for WindowEvent::ScaleFactorChanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Made ScaleFactorChanged::new_inner_size not a reference, therefore allowing Event to no longer need a lifetime annotation.
 - On Android, changed default behavior of Android to ignore volume keys letting the operating system handle them.
 - On Android, added `EventLoopBuilderExtAndroid::handle_volume_keys` to indicate that the application will handle the volume keys manually.
 - **Breaking:** Rename `DeviceEventFilter` to `DeviceEvents` reversing the behavior of variants.

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -42,7 +42,7 @@ fn main() {
 
     println!("parent window: {parent_window:?})");
 
-    event_loop.run(move |event: Event<'_, ()>, event_loop, control_flow| {
+    event_loop.run(move |event: Event<()>, event_loop, control_flow| {
         *control_flow = ControlFlow::Wait;
 
         if let Event::WindowEvent { event, window_id } = event {

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -193,9 +193,7 @@ fn main() {
                 }
                 _ => {
                     if let Some(tx) = window_senders.get(&window_id) {
-                        if let Some(event) = event.to_static() {
-                            tx.send(event).unwrap();
-                        }
+                        tx.send(event).unwrap();
                     }
                 }
             },

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -303,7 +303,7 @@ impl<T> EventLoop<T> {
     #[inline]
     pub fn run<F>(self, event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.event_loop.run(event_handler)
     }

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -30,11 +30,7 @@ pub trait EventLoopExtRunReturn {
     ///   the display server.
     fn run_return<F>(&mut self, event_handler: F) -> i32
     where
-        F: FnMut(
-            Event<Self::UserEvent>,
-            &EventLoopWindowTarget<Self::UserEvent>,
-            &mut ControlFlow,
-        );
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
 }
 
 impl<T> EventLoopExtRunReturn for EventLoop<T> {
@@ -42,11 +38,7 @@ impl<T> EventLoopExtRunReturn for EventLoop<T> {
 
     fn run_return<F>(&mut self, event_handler: F) -> i32
     where
-        F: FnMut(
-            Event<Self::UserEvent>,
-            &EventLoopWindowTarget<Self::UserEvent>,
-            &mut ControlFlow,
-        ),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
     {
         self.event_loop.run_return(event_handler)
     }

--- a/src/platform/run_return.rs
+++ b/src/platform/run_return.rs
@@ -31,7 +31,7 @@ pub trait EventLoopExtRunReturn {
     fn run_return<F>(&mut self, event_handler: F) -> i32
     where
         F: FnMut(
-            Event<'_, Self::UserEvent>,
+            Event<Self::UserEvent>,
             &EventLoopWindowTarget<Self::UserEvent>,
             &mut ControlFlow,
         );
@@ -43,7 +43,7 @@ impl<T> EventLoopExtRunReturn for EventLoop<T> {
     fn run_return<F>(&mut self, event_handler: F) -> i32
     where
         F: FnMut(
-            Event<'_, Self::UserEvent>,
+            Event<Self::UserEvent>,
             &EventLoopWindowTarget<Self::UserEvent>,
             &mut ControlFlow,
         ),

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -30,7 +30,7 @@ pub struct FileDropHandlerData {
     pub interface: IDropTarget,
     refcount: AtomicUsize,
     window: HWND,
-    send_event: Box<dyn Fn(Event<'static, ()>)>,
+    send_event: Box<dyn Fn(Event<()>)>,
     cursor_effect: u32,
     hovered_is_valid: bool, /* If the currently hovered item is not valid there must not be any `HoveredFileCancelled` emitted */
 }
@@ -41,7 +41,7 @@ pub struct FileDropHandler {
 
 #[allow(non_snake_case)]
 impl FileDropHandler {
-    pub fn new(window: HWND, send_event: Box<dyn Fn(Event<'static, ()>)>) -> FileDropHandler {
+    pub fn new(window: HWND, send_event: Box<dyn Fn(Event<()>)>) -> FileDropHandler {
         let data = Box::new(FileDropHandlerData {
             interface: IDropTarget {
                 lpVtbl: &DROP_TARGET_VTBL as *const IDropTargetVtbl,
@@ -211,7 +211,7 @@ impl FileDropHandler {
 }
 
 impl FileDropHandlerData {
-    fn send_event(&self, event: Event<'static, ()>) {
+    fn send_event(&self, event: Event<()>) {
         (self.send_event)(event);
     }
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -142,7 +142,7 @@ pub(crate) struct WindowData<T: 'static> {
 }
 
 impl<T> WindowData<T> {
-    unsafe fn send_event(&self, event: Event<'_, T>) {
+    unsafe fn send_event(&self, event: Event<T>) {
         self.event_loop_runner.send_event(event);
     }
 
@@ -157,7 +157,7 @@ struct ThreadMsgTargetData<T: 'static> {
 }
 
 impl<T> ThreadMsgTargetData<T> {
-    unsafe fn send_event(&self, event: Event<'_, T>) {
+    unsafe fn send_event(&self, event: Event<T>) {
         self.event_loop_runner.send_event(event);
     }
 }
@@ -251,7 +251,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         let exit_code = self.run_return(event_handler);
         ::std::process::exit(exit_code);
@@ -259,7 +259,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run_return<F>(&mut self, mut event_handler: F) -> i32
     where
-        F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         let event_loop_windows_ref = &self.window_target;
 
@@ -2032,7 +2032,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
             // `allow_resize` prevents us from re-applying DPI adjustment to the restored size after
             // exiting fullscreen (the restored size is already DPI adjusted).
-            let mut new_physical_inner_size = match allow_resize {
+            let new_physical_inner_size = match allow_resize {
                 // We calculate our own size because the default suggested rect doesn't do a great job
                 // of preserving the window's logical size.
                 true => old_physical_inner_size
@@ -2045,7 +2045,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 window_id: RootWindowId(WindowId(window)),
                 event: ScaleFactorChanged {
                     scale_factor: new_scale_factor,
-                    new_inner_size: &mut new_physical_inner_size,
+                    new_inner_size: new_physical_inner_size,
                 },
             });
 

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -434,7 +434,7 @@ impl<T> BufferedEvent<T> {
                     window_id,
                     event: WindowEvent::ScaleFactorChanged {
                         scale_factor,
-                        new_inner_size: new_inner_size,
+                        new_inner_size,
                     },
                 });
 


### PR DESCRIPTION
Disclaimer: I have no idea if it was important that there was a reference for new_inner_size, I just think it is pointless.

I have not tested on linux nor mac os, but it seems to work on windows.