### PR TITLE
Remove unused `EventListenerOptions`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,7 +137,6 @@ features = [
     'DomRect',
     'Element',
     'Event',
-    "EventListenerOptions",
     'EventTarget',
     'FocusEvent',
     'HtmlCanvasElement',

--- a/src/platform_impl/web/web_sys/event_handle.rs
+++ b/src/platform_impl/web/web_sys/event_handle.rs
@@ -1,11 +1,10 @@
 use wasm_bindgen::{prelude::Closure, JsCast};
-use web_sys::{EventListenerOptions, EventTarget};
+use web_sys::EventTarget;
 
 pub struct EventListenerHandle<T: ?Sized> {
     target: EventTarget,
     event_type: &'static str,
     listener: Closure<T>,
-    options: EventListenerOptions,
 }
 
 impl<T: ?Sized> EventListenerHandle<T> {
@@ -21,7 +20,6 @@ impl<T: ?Sized> EventListenerHandle<T> {
             target,
             event_type,
             listener,
-            options: EventListenerOptions::new(),
         }
     }
 }
@@ -29,10 +27,9 @@ impl<T: ?Sized> EventListenerHandle<T> {
 impl<T: ?Sized> Drop for EventListenerHandle<T> {
     fn drop(&mut self) {
         self.target
-            .remove_event_listener_with_callback_and_event_listener_options(
+            .remove_event_listener_with_callback(
                 self.event_type,
                 self.listener.as_ref().unchecked_ref(),
-                &self.options,
             )
             .unwrap_or_else(|e| {
                 web_sys::console::error_2(


### PR DESCRIPTION
I'm a bit lazy to dig up why this was used in the past, but it's definitely not used anymore.