### PR TITLE
On Web, implement `DeviceEvent`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   the canvas size will be reported through `WindowEvent::Resized`.
 - On Web, respect `EventLoopWindowTarget::listen_device_events()` settings.
 - On Web, fix `DeviceEvent::MouseMotion` only being emitted for each canvas instead of the whole window.
-- On Web, add `DeviceEvent::Motion` and `DeviceEvent::MouseWheel` support.
+- On Web, add `DeviceEvent::Motion`, `DeviceEvent::MouseWheel` and `DeviceEvent::Button` support.
 
 # 0.28.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, use `Window.requestIdleCallback()` for `ControlFlow::Poll` when available.
 - **Breaking:** On Web, the canvas size is not controlled by Winit anymore and external changes to
   the canvas size will be reported through `WindowEvent::Resized`.
+- On Web, fix `DeviceEvent::MouseMotion` only being emitted for each canvas instead of the whole window.
 
 # 0.28.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   the canvas size will be reported through `WindowEvent::Resized`.
 - On Web, respect `EventLoopWindowTarget::listen_device_events()` settings.
 - On Web, fix `DeviceEvent::MouseMotion` only being emitted for each canvas instead of the whole window.
+- On Web, add `DeviceEvent::Motion` support.
 
 # 0.28.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, use `Window.requestIdleCallback()` for `ControlFlow::Poll` when available.
 - **Breaking:** On Web, the canvas size is not controlled by Winit anymore and external changes to
   the canvas size will be reported through `WindowEvent::Resized`.
+- On Web, respect `EventLoopWindowTarget::listen_device_events()` settings.
 - On Web, fix `DeviceEvent::MouseMotion` only being emitted for each canvas instead of the whole window.
 
 # 0.28.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,8 @@ And please only add new entries to the top of this list, right below the `# Unre
   the canvas size will be reported through `WindowEvent::Resized`.
 - On Web, respect `EventLoopWindowTarget::listen_device_events()` settings.
 - On Web, fix `DeviceEvent::MouseMotion` only being emitted for each canvas instead of the whole window.
-- On Web, add `DeviceEvent::Motion`, `DeviceEvent::MouseWheel` and `DeviceEvent::Button` support.
+- On Web, add `DeviceEvent::Motion`, `DeviceEvent::MouseWheel`, `DeviceEvent::Button` and
+  `DeviceEvent::Key` support.
 
 # 0.28.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   the canvas size will be reported through `WindowEvent::Resized`.
 - On Web, respect `EventLoopWindowTarget::listen_device_events()` settings.
 - On Web, fix `DeviceEvent::MouseMotion` only being emitted for each canvas instead of the whole window.
-- On Web, add `DeviceEvent::Motion` support.
+- On Web, add `DeviceEvent::Motion` and `DeviceEvent::MouseWheel` support.
 
 # 0.28.6
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -356,11 +356,11 @@ impl<T> EventLoopWindowTarget<T> {
     ///
     /// ## Platform-specific
     ///
-    /// - **Wayland / macOS / iOS / Android / Web / Orbital:** Unsupported.
+    /// - **Wayland / macOS / iOS / Android / Orbital:** Unsupported.
     ///
     /// [`DeviceEvent`]: crate::event::DeviceEvent
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {
-        #[cfg(any(x11_platform, wayland_platform, windows))]
+        #[cfg(any(x11_platform, wasm_platform, wayland_platform, windows))]
         self.p.listen_device_events(_allowed);
     }
 }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -598,16 +598,21 @@ impl<T> EventLoopWindowTarget<T> {
                         }
                     });
 
-                runner.send_events(modifiers_changed.into_iter().chain(iter::once(
-                    Event::WindowEvent {
+                let device_event = runner.device_events().then_some(Event::DeviceEvent {
+                    device_id: RootDeviceId(DeviceId(pointer_id)),
+                    event: DeviceEvent::MouseWheel { delta },
+                });
+
+                runner.send_events(modifiers_changed.into_iter().chain(device_event).chain(
+                    iter::once(Event::WindowEvent {
                         window_id: RootWindowId(id),
                         event: WindowEvent::MouseWheel {
                             device_id: RootDeviceId(DeviceId(pointer_id)),
                             delta,
                             phase: TouchPhase::Moved,
                         },
-                    },
-                )));
+                    }),
+                ));
             },
             prevent_default,
         );

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -380,38 +380,41 @@ impl<T> EventLoopWindowTarget<T> {
                             }
                         });
 
-                    let button_event = if buttons.contains(button.into()) {
-                        Event::WindowEvent {
-                            window_id: RootWindowId(id),
-                            event: WindowEvent::MouseInput {
-                                device_id: RootDeviceId(DeviceId(pointer_id)),
-                                state: ElementState::Pressed,
-                                button,
-                            },
-                        }
+                    let device_id = RootDeviceId(DeviceId(pointer_id));
+
+                    let state = if buttons.contains(button.into()) {
+                        ElementState::Pressed
                     } else {
-                        Event::WindowEvent {
-                            window_id: RootWindowId(id),
-                            event: WindowEvent::MouseInput {
-                                device_id: RootDeviceId(DeviceId(pointer_id)),
-                                state: ElementState::Released,
-                                button,
-                            },
-                        }
+                        ElementState::Released
                     };
+
+                    let device_event = runner.device_events().then(|| Event::DeviceEvent {
+                        device_id,
+                        event: DeviceEvent::Button {
+                            button: button.to_id(),
+                            state,
+                        },
+                    });
 
                     // A chorded button event may come in without any prior CursorMoved events,
                     // therefore we should send a CursorMoved event to make sure that the
                     // user code has the correct cursor position.
-                    runner.send_events(modifiers.into_iter().chain([
+                    runner.send_events(modifiers.into_iter().chain(device_event).chain([
                         Event::WindowEvent {
                             window_id: RootWindowId(id),
                             event: WindowEvent::CursorMoved {
-                                device_id: RootDeviceId(DeviceId(pointer_id)),
+                                device_id,
                                 position,
                             },
                         },
-                        button_event,
+                        Event::WindowEvent {
+                            window_id: RootWindowId(id),
+                            event: WindowEvent::MouseInput {
+                                device_id,
+                                state,
+                                button,
+                            },
+                        },
                     ]));
                 }
             },
@@ -446,21 +449,30 @@ impl<T> EventLoopWindowTarget<T> {
                         }
                     });
 
+                    let device_id: RootDeviceId = RootDeviceId(DeviceId(pointer_id));
+                    let device_event = runner.device_events().then(|| Event::DeviceEvent {
+                        device_id,
+                        event: DeviceEvent::Button {
+                            button: button.to_id(),
+                            state: ElementState::Pressed,
+                        },
+                    });
+
                     // A mouse down event may come in without any prior CursorMoved events,
                     // therefore we should send a CursorMoved event to make sure that the
                     // user code has the correct cursor position.
-                    runner.send_events(modifiers.into_iter().chain([
+                    runner.send_events(modifiers.into_iter().chain(device_event).chain([
                         Event::WindowEvent {
                             window_id: RootWindowId(id),
                             event: WindowEvent::CursorMoved {
-                                device_id: RootDeviceId(DeviceId(pointer_id)),
+                                device_id,
                                 position,
                             },
                         },
                         Event::WindowEvent {
                             window_id: RootWindowId(id),
                             event: WindowEvent::MouseInput {
-                                device_id: RootDeviceId(DeviceId(pointer_id)),
+                                device_id,
                                 state: ElementState::Pressed,
                                 button,
                             },
@@ -530,21 +542,30 @@ impl<T> EventLoopWindowTarget<T> {
                             }
                         });
 
+                    let device_id: RootDeviceId = RootDeviceId(DeviceId(pointer_id));
+                    let device_event = runner.device_events().then(|| Event::DeviceEvent {
+                        device_id,
+                        event: DeviceEvent::Button {
+                            button: button.to_id(),
+                            state: ElementState::Pressed,
+                        },
+                    });
+
                     // A mouse up event may come in without any prior CursorMoved events,
                     // therefore we should send a CursorMoved event to make sure that the
                     // user code has the correct cursor position.
-                    runner.send_events(modifiers.into_iter().chain([
+                    runner.send_events(modifiers.into_iter().chain(device_event).chain([
                         Event::WindowEvent {
                             window_id: RootWindowId(id),
                             event: WindowEvent::CursorMoved {
-                                device_id: RootDeviceId(DeviceId(pointer_id)),
+                                device_id,
                                 position,
                             },
                         },
                         Event::WindowEvent {
                             window_id: RootWindowId(id),
                             event: WindowEvent::MouseInput {
-                                device_id: RootDeviceId(DeviceId(pointer_id)),
+                                device_id,
                                 state: ElementState::Released,
                                 button,
                             },

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -17,8 +17,8 @@ use super::{
     window::WindowId,
 };
 use crate::event::{
-    DeviceEvent, DeviceId as RootDeviceId, ElementState, Event, KeyEvent, Touch, TouchPhase,
-    WindowEvent,
+    DeviceEvent, DeviceId as RootDeviceId, ElementState, Event, KeyEvent, RawKeyEvent, Touch,
+    TouchPhase, WindowEvent,
 };
 use crate::event_loop::DeviceEvents;
 use crate::keyboard::ModifiersState;
@@ -137,24 +137,36 @@ impl<T> EventLoopWindowTarget<T> {
                     }
                 });
 
+                let device_id = RootDeviceId(unsafe { DeviceId::dummy() });
+
+                let device_event = runner.device_events().then_some(Event::DeviceEvent {
+                    device_id,
+                    event: DeviceEvent::Key(RawKeyEvent {
+                        physical_key,
+                        state: ElementState::Pressed,
+                    }),
+                });
+
                 runner.send_events(
-                    iter::once(Event::WindowEvent {
-                        window_id: RootWindowId(id),
-                        event: WindowEvent::KeyboardInput {
-                            device_id: RootDeviceId(unsafe { DeviceId::dummy() }),
-                            event: KeyEvent {
-                                physical_key,
-                                logical_key,
-                                text,
-                                location,
-                                state: ElementState::Pressed,
-                                repeat,
-                                platform_specific: KeyEventExtra,
+                    device_event
+                        .into_iter()
+                        .chain(iter::once(Event::WindowEvent {
+                            window_id: RootWindowId(id),
+                            event: WindowEvent::KeyboardInput {
+                                device_id,
+                                event: KeyEvent {
+                                    physical_key,
+                                    logical_key,
+                                    text,
+                                    location,
+                                    state: ElementState::Pressed,
+                                    repeat,
+                                    platform_specific: KeyEventExtra,
+                                },
+                                is_synthetic: false,
                             },
-                            is_synthetic: false,
-                        },
-                    })
-                    .chain(modifiers_changed),
+                        }))
+                        .chain(modifiers_changed),
                 );
             },
             prevent_default,
@@ -172,24 +184,36 @@ impl<T> EventLoopWindowTarget<T> {
                     }
                 });
 
+                let device_id = RootDeviceId(unsafe { DeviceId::dummy() });
+
+                let device_event = runner.device_events().then_some(Event::DeviceEvent {
+                    device_id,
+                    event: DeviceEvent::Key(RawKeyEvent {
+                        physical_key,
+                        state: ElementState::Pressed,
+                    }),
+                });
+
                 runner.send_events(
-                    iter::once(Event::WindowEvent {
-                        window_id: RootWindowId(id),
-                        event: WindowEvent::KeyboardInput {
-                            device_id: RootDeviceId(unsafe { DeviceId::dummy() }),
-                            event: KeyEvent {
-                                physical_key,
-                                logical_key,
-                                text,
-                                location,
-                                state: ElementState::Released,
-                                repeat,
-                                platform_specific: KeyEventExtra,
+                    device_event
+                        .into_iter()
+                        .chain(iter::once(Event::WindowEvent {
+                            window_id: RootWindowId(id),
+                            event: WindowEvent::KeyboardInput {
+                                device_id,
+                                event: KeyEvent {
+                                    physical_key,
+                                    logical_key,
+                                    text,
+                                    location,
+                                    state: ElementState::Released,
+                                    repeat,
+                                    platform_specific: KeyEventExtra,
+                                },
+                                is_synthetic: false,
                             },
-                            is_synthetic: false,
-                        },
-                    })
-                    .chain(modifiers_changed),
+                        }))
+                        .chain(modifiers_changed),
                 )
             },
             prevent_default,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -12,6 +12,8 @@ use crate::window::{WindowAttributes, WindowId as RootWindowId};
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use js_sys::Promise;
 use smol_str::SmolStr;
@@ -24,6 +26,7 @@ use web_sys::{Event, FocusEvent, HtmlCanvasElement, KeyboardEvent, WheelEvent};
 pub struct Canvas {
     common: Common,
     id: WindowId,
+    pub has_focus: Arc<AtomicBool>,
     on_touch_start: Option<EventListenerHandle<dyn FnMut(Event)>>,
     on_touch_end: Option<EventListenerHandle<dyn FnMut(Event)>>,
     on_focus: Option<EventListenerHandle<dyn FnMut(FocusEvent)>>,
@@ -91,6 +94,7 @@ impl Canvas {
                 wants_fullscreen: Rc::new(RefCell::new(false)),
             },
             id,
+            has_focus: Arc::new(AtomicBool::new(false)),
             on_touch_start: None,
             on_touch_end: None,
             on_blur: None,

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -57,6 +57,17 @@ pub fn mouse_button(event: &MouseEvent) -> Option<MouseButton> {
     }
 }
 
+impl MouseButton {
+    pub fn to_id(self) -> u32 {
+        match self {
+            MouseButton::Left => 0,
+            MouseButton::Right => 1,
+            MouseButton::Middle => 2,
+            MouseButton::Other(value) => value.into(),
+        }
+    }
+}
+
 pub fn mouse_position(event: &MouseEvent) -> LogicalPosition<f64> {
     LogicalPosition {
         x: event.offset_x() as f64,

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -1,5 +1,5 @@
 mod canvas;
-mod event;
+pub mod event;
 mod event_handle;
 mod media_query_handle;
 mod pointer;
@@ -8,6 +8,7 @@ mod timeout;
 
 pub use self::canvas::Canvas;
 pub use self::event::ButtonsState;
+pub use self::event_handle::EventListenerHandle;
 pub use self::resize_scaling::ResizeScaleHandle;
 pub use self::timeout::{IdleCallback, Timeout};
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -51,12 +51,12 @@ impl Window {
 
         let register_redraw_request = Box::new(move || runner.request_redraw(RootWI(id)));
 
-        let has_focus = Arc::new(AtomicBool::new(false));
-        target.register(&canvas, id, prevent_default, has_focus.clone());
+        target.register(&canvas, id, prevent_default);
 
         let runner = target.runner.clone();
         let destroy_fn = Box::new(move || runner.notify_destroy_window(RootWI(id)));
 
+        let has_focus = canvas.borrow().has_focus.clone();
         let window = Window {
             id,
             has_focus,


### PR DESCRIPTION
### Tracking

- [x] `MouseMotion`
- [x] `Motion`
- [x] `MouseWheel`
- [x] `Button`
- [x] `Key`
- [ ] `Text` (not implemented on any backend)

### Changes

This PR intends to implements all `DeviceEvent`s. Additionally `DeviceEvent`s are only emitted according to the setting in `EventLoopWindowTarget::listen_device_events()`.

---

Fixes #2036.