### PR TITLE
Resume propagation of events

### DIFF
--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -378,16 +378,10 @@ impl Common {
         E: 'static + AsRef<web_sys::Event> + wasm_bindgen::convert::FromWasmAbi,
         F: 'static + FnMut(E),
     {
-        let closure = Closure::wrap(Box::new(move |event: E| {
-            {
-                let event_ref = event.as_ref();
-                event_ref.stop_propagation();
-                event_ref.cancel_bubble();
-            }
-
+        let closure = Closure::new(move |event: E| {
+            event.as_ref().stop_propagation();
             handler(event);
-        }) as Box<dyn FnMut(E)>);
-
+        });
         EventListenerHandle::new(&self.raw, event_name, closure)
     }
 


### PR DESCRIPTION
I'm not entirely sure why `stopPropagation()` is being used, maybe because `preventDefault()` wasn't used back then. In any case, I don't think we want to prevent parents to receive events if they want to.

The call to `cancelBubble` doesn't do anything, it's a getter.

EDIT: See https://github.com/rust-windowing/winit/pull/2873#issuecomment-1586362882, I decided to keep `stopPropagation()` for now.