### PR TITLE
x11: reload dpi on PropertyChangeEvent

### DIFF
--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1102,6 +1102,17 @@ impl<T: 'static> EventProcessor<T> {
                     _ => {}
                 }
             }
+
+            ffi::PropertyNotify => {
+                let xev: &ffi::XPropertyEvent = xev.as_ref();
+
+                // XA_RESOURCE_MANAGER received from the root window indicates that xresources
+                // have been changed. Check and update Xft.dpi if the dpi value was changed.
+                if xev.atom == ffi::XA_RESOURCE_MANAGER {
+                    self.process_dpi_change(&mut callback)
+                }
+            }
+
             _ => {
                 if event_type == self.xkbext.first_event_id {
                     let xev = unsafe { &*(xev as *const _ as *const ffi::XkbAnyEvent) };
@@ -1153,62 +1164,7 @@ impl<T: 'static> EventProcessor<T> {
                     }
                 }
                 if event_type == self.randr_event_offset {
-                    // In the future, it would be quite easy to emit monitor hotplug events.
-                    let prev_list = monitor::invalidate_cached_monitor_list();
-                    if let Some(prev_list) = prev_list {
-                        let new_list = wt.xconn.available_monitors();
-                        for new_monitor in new_list {
-                            // Previous list may be empty, in case of disconnecting and
-                            // reconnecting the only one monitor. We still need to emit events in
-                            // this case.
-                            let maybe_prev_scale_factor = prev_list
-                                .iter()
-                                .find(|prev_monitor| prev_monitor.name == new_monitor.name)
-                                .map(|prev_monitor| prev_monitor.scale_factor);
-                            if Some(new_monitor.scale_factor) != maybe_prev_scale_factor {
-                                for (window_id, window) in wt.windows.borrow().iter() {
-                                    if let Some(window) = window.upgrade() {
-                                        // Check if the window is on this monitor
-                                        let monitor = window.current_monitor();
-                                        if monitor.name == new_monitor.name {
-                                            let (width, height) = window.inner_size_physical();
-                                            let (new_width, new_height) = window.adjust_for_dpi(
-                                                // If we couldn't determine the previous scale
-                                                // factor (e.g., because all monitors were closed
-                                                // before), just pick whatever the current monitor
-                                                // has set as a baseline.
-                                                maybe_prev_scale_factor
-                                                    .unwrap_or(monitor.scale_factor),
-                                                new_monitor.scale_factor,
-                                                width,
-                                                height,
-                                                &window.shared_state_lock(),
-                                            );
-
-                                            let window_id = crate::window::WindowId(*window_id);
-                                            let old_inner_size = PhysicalSize::new(width, height);
-                                            let mut new_inner_size =
-                                                PhysicalSize::new(new_width, new_height);
-
-                                            callback(Event::WindowEvent {
-                                                window_id,
-                                                event: WindowEvent::ScaleFactorChanged {
-                                                    scale_factor: new_monitor.scale_factor,
-                                                    new_inner_size: &mut new_inner_size,
-                                                },
-                                            });
-
-                                            if new_inner_size != old_inner_size {
-                                                let (new_width, new_height) = new_inner_size.into();
-                                                window
-                                                    .set_inner_size_physical(new_width, new_height);
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    self.process_dpi_change(&mut callback)
                 }
             }
         }
@@ -1299,6 +1255,72 @@ impl<T: 'static> EventProcessor<T> {
                     is_synthetic: true,
                 },
             });
+        }
+    }
+
+    fn process_dpi_change<F>(
+        &self,
+        callback: &mut F,
+    ) where
+        F: FnMut(Event<'_, T>)
+    {
+        let wt = get_xtarget(&self.target);
+
+        // In the future, it would be quite easy to emit monitor hotplug events.
+        let prev_list = monitor::invalidate_cached_monitor_list();
+        if let Some(prev_list) = prev_list {
+            let new_list = wt.xconn.available_monitors();
+            for new_monitor in new_list {
+                // Previous list may be empty, in case of disconnecting and
+                // reconnecting the only one monitor. We still need to emit events in
+                // this case.
+                let maybe_prev_scale_factor = prev_list
+                    .iter()
+                    .find(|prev_monitor| prev_monitor.name == new_monitor.name)
+                    .map(|prev_monitor| prev_monitor.scale_factor);
+                if Some(new_monitor.scale_factor) != maybe_prev_scale_factor {
+                    for (window_id, window) in wt.windows.borrow().iter() {
+                        if let Some(window) = window.upgrade() {
+                            // Check if the window is on this monitor
+                            let monitor = window.current_monitor();
+                            if monitor.name == new_monitor.name {
+                                let (width, height) = window.inner_size_physical();
+                                let (new_width, new_height) = window.adjust_for_dpi(
+                                    // If we couldn't determine the previous scale
+                                    // factor (e.g., because all monitors were closed
+                                    // before), just pick whatever the current monitor
+                                    // has set as a baseline.
+                                    maybe_prev_scale_factor
+                                        .unwrap_or(monitor.scale_factor),
+                                    new_monitor.scale_factor,
+                                    width,
+                                    height,
+                                    &window.shared_state_lock(),
+                                );
+
+                                let window_id = crate::window::WindowId(*window_id);
+                                let old_inner_size = PhysicalSize::new(width, height);
+                                let mut new_inner_size =
+                                    PhysicalSize::new(new_width, new_height);
+
+                                callback(Event::WindowEvent {
+                                    window_id,
+                                    event: WindowEvent::ScaleFactorChanged {
+                                        scale_factor: new_monitor.scale_factor,
+                                        new_inner_size: &mut new_inner_size,
+                                    },
+                                });
+
+                                if new_inner_size != old_inner_size {
+                                    let (new_width, new_height) = new_inner_size.into();
+                                    window
+                                        .set_inner_size_physical(new_width, new_height);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -279,6 +279,14 @@ impl UnownedWindow {
             )
         };
 
+        unsafe {
+            (xconn.xlib.XSelectInput)(
+                xconn.display,
+                root,
+                ffi::PropertyChangeMask,
+            );
+        }
+
         #[allow(clippy::mutex_atomic)]
         let mut window = UnownedWindow {
             xconn: Arc::clone(xconn),


### PR DESCRIPTION
This change allows X11 windows to receive ScaleFactorChanged events when using Xft.dpi via the root window PropertyChange event.

Subscribe to PropertyChange events on the root window, and reload all available monitors when an XA_RESOURCE_MANAGER change is received. This is a very heavy handed approach to this problem, but it was the least intrustive way I could find to make it work with my limited skill. Load XResources directly via XGetTextProperty on every get_xft_dpi call as XResourceManagerString returns stale cached data and does not reload for the lifetime of the window (?)

Fixes: https://github.com/rust-windowing/winit/issues/1228

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

---

Full disclosure- I have no idea what I'm doing. This has worked for me for the past few years with no issues, but the code is probably bad. I've never written Rust in my life, but I figured this was a starting point