### PR TITLE
Drop `pointerrawupdate` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,6 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, fix touch input not gaining or loosing focus.
 - **Breaking:** On Web, dropped support for Safari versions below 13.
 - On Web, prevent clicks on the canvas to select text.
-- On Web, use high-frequency pointer input events when supported by the browser.
 - On Web, `EventLoopProxy` now implements `Send`.
 - On Web, `Window` now implements `Send` and `Sync`.
 - **Breaking:** `WindowExtWebSys::canvas()` now returns an `Option`.


### PR DESCRIPTION
Unfortunately it turned out in https://github.com/rust-windowing/winit/pull/2847#issuecomment-1588198559 that `pointerrawupdate` is a bit too buggy. It was only implemented in Chrome anyway:
- [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1289683): Not working when pointer is locked.
- [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1068958): Reporting wrong positions in an inline frame.

I decided to rip out support for `pointerrawupdate` completely. This is unfortunate, but working around it would increase the code complexity and maintenance burden significantly.