### PR TITLE
Fix pointer deltas on Firefox and send coalesced events together

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ redox_syscall = "0.3"
 
 [target.'cfg(target_family = "wasm")'.dependencies.web_sys]
 package = "web-sys"
-version = "0.3.22"
+version = "0.3"
 features = [
     'console',
     'CssStyleDeclaration',
@@ -151,8 +151,8 @@ features = [
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 atomic-waker = "1"
-js-sys = "0.3"
-wasm-bindgen = "0.2.45"
+js-sys = "0.3.64"
+wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-time = "0.2"
 

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -224,22 +224,18 @@ impl Canvas {
         ));
     }
 
-    pub fn on_cursor_leave<MOD, M>(&mut self, modifier_handler: MOD, mouse_handler: M)
+    pub fn on_cursor_leave<F>(&mut self, handler: F)
     where
-        MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32),
+        F: 'static + FnMut(ModifiersState, Option<i32>),
     {
-        self.pointer_handler
-            .on_cursor_leave(&self.common, modifier_handler, mouse_handler)
+        self.pointer_handler.on_cursor_leave(&self.common, handler)
     }
 
-    pub fn on_cursor_enter<MOD, M>(&mut self, modifier_handler: MOD, mouse_handler: M)
+    pub fn on_cursor_enter<F>(&mut self, handler: F)
     where
-        MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32),
+        F: 'static + FnMut(ModifiersState, Option<i32>),
     {
-        self.pointer_handler
-            .on_cursor_enter(&self.common, modifier_handler, mouse_handler)
+        self.pointer_handler.on_cursor_enter(&self.common, handler)
     }
 
     pub fn on_mouse_release<MOD, M, T>(
@@ -249,8 +245,8 @@ impl Canvas {
         touch_handler: T,
     ) where
         MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton),
-        T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
+        M: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, MouseButton),
+        T: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, Force),
     {
         self.pointer_handler.on_mouse_release(
             &self.common,
@@ -268,8 +264,8 @@ impl Canvas {
         prevent_default: bool,
     ) where
         MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton),
-        T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
+        M: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, MouseButton),
+        T: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, Force),
     {
         self.pointer_handler.on_mouse_press(
             &self.common,
@@ -290,9 +286,14 @@ impl Canvas {
     ) where
         MOD: 'static + FnMut(ModifiersState),
         M: 'static
-            + FnMut(i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, PhysicalPosition<f64>)>),
-        T: 'static + FnMut(i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, Force)>),
-        B: 'static + FnMut(i32, PhysicalPosition<f64>, ButtonsState, MouseButton),
+            + FnMut(
+                ModifiersState,
+                i32,
+                &mut dyn Iterator<Item = (PhysicalPosition<f64>, PhysicalPosition<f64>)>,
+            ),
+        T: 'static
+            + FnMut(ModifiersState, i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, Force)>),
+        B: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, ButtonsState, MouseButton),
     {
         self.pointer_handler.on_cursor_move(
             &self.common,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -289,8 +289,9 @@ impl Canvas {
         prevent_default: bool,
     ) where
         MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32, PhysicalPosition<f64>, PhysicalPosition<f64>),
-        T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
+        M: 'static
+            + FnMut(i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, PhysicalPosition<f64>)>),
+        T: 'static + FnMut(i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, Force)>),
         B: 'static + FnMut(i32, PhysicalPosition<f64>, ButtonsState, MouseButton),
     {
         self.pointer_handler.on_cursor_move(

--- a/src/platform_impl/web/web_sys/pointer.rs
+++ b/src/platform_impl/web/web_sys/pointer.rs
@@ -30,54 +30,40 @@ impl PointerHandler {
         }
     }
 
-    pub fn on_cursor_leave<MOD, M>(
-        &mut self,
-        canvas_common: &Common,
-        mut modifier_handler: MOD,
-        mut mouse_handler: M,
-    ) where
-        MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32),
+    pub fn on_cursor_leave<F>(&mut self, canvas_common: &Common, mut handler: F)
+    where
+        F: 'static + FnMut(ModifiersState, Option<i32>),
     {
         self.on_cursor_leave = Some(canvas_common.add_event(
             "pointerout",
             move |event: PointerEvent| {
-                modifier_handler(event::mouse_modifiers(&event));
+                let modifiers = event::mouse_modifiers(&event);
 
                 // touch events are handled separately
                 // handling them here would produce duplicate mouse events, inconsistent with
                 // other platforms.
-                if event.pointer_type() != "mouse" {
-                    return;
-                }
+                let pointer_id = (event.pointer_type() == "mouse").then(|| event.pointer_id());
 
-                mouse_handler(event.pointer_id());
+                handler(modifiers, pointer_id);
             },
         ));
     }
 
-    pub fn on_cursor_enter<MOD, M>(
-        &mut self,
-        canvas_common: &Common,
-        mut modifier_handler: MOD,
-        mut mouse_handler: M,
-    ) where
-        MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32),
+    pub fn on_cursor_enter<F>(&mut self, canvas_common: &Common, mut handler: F)
+    where
+        F: 'static + FnMut(ModifiersState, Option<i32>),
     {
         self.on_cursor_enter = Some(canvas_common.add_event(
             "pointerover",
             move |event: PointerEvent| {
-                modifier_handler(event::mouse_modifiers(&event));
+                let modifiers = event::mouse_modifiers(&event);
 
                 // touch events are handled separately
                 // handling them here would produce duplicate mouse events, inconsistent with
                 // other platforms.
-                if event.pointer_type() != "mouse" {
-                    return;
-                }
+                let pointer_id = (event.pointer_type() == "mouse").then(|| event.pointer_id());
 
-                mouse_handler(event.pointer_id());
+                handler(modifiers, pointer_id);
             },
         ));
     }
@@ -90,29 +76,31 @@ impl PointerHandler {
         mut touch_handler: T,
     ) where
         MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton),
-        T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
+        M: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, MouseButton),
+        T: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, Force),
     {
         let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
         self.on_pointer_release = Some(canvas_common.add_user_event(
             "pointerup",
             move |event: PointerEvent| {
-                modifier_handler(event::mouse_modifiers(&event));
+                let modifiers = event::mouse_modifiers(&event);
 
                 match event.pointer_type().as_str() {
                     "touch" => touch_handler(
+                        modifiers,
                         event.pointer_id(),
                         event::touch_position(&event, &canvas)
                             .to_physical(super::scale_factor(&window)),
                         Force::Normalized(event.pressure() as f64),
                     ),
                     "mouse" => mouse_handler(
+                        modifiers,
                         event.pointer_id(),
                         event::mouse_position(&event).to_physical(super::scale_factor(&window)),
                         event::mouse_button(&event).expect("no mouse button released"),
                     ),
-                    _ => (),
+                    _ => modifier_handler(modifiers),
                 }
             },
         ));
@@ -127,8 +115,8 @@ impl PointerHandler {
         prevent_default: bool,
     ) where
         MOD: 'static + FnMut(ModifiersState),
-        M: 'static + FnMut(i32, PhysicalPosition<f64>, MouseButton),
-        T: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
+        M: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, MouseButton),
+        T: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, Force),
     {
         let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
@@ -142,11 +130,12 @@ impl PointerHandler {
                     let _ = canvas.focus();
                 }
 
-                modifier_handler(event::mouse_modifiers(&event));
+                let modifiers = event::mouse_modifiers(&event);
 
                 match event.pointer_type().as_str() {
                     "touch" => {
                         touch_handler(
+                            modifiers,
                             event.pointer_id(),
                             event::touch_position(&event, &canvas)
                                 .to_physical(super::scale_factor(&window)),
@@ -155,6 +144,7 @@ impl PointerHandler {
                     }
                     "mouse" => {
                         mouse_handler(
+                            modifiers,
                             event.pointer_id(),
                             event::mouse_position(&event).to_physical(super::scale_factor(&window)),
                             event::mouse_button(&event).expect("no mouse button pressed"),
@@ -165,7 +155,7 @@ impl PointerHandler {
                         // this could fail, that we care if it fails.
                         let _e = canvas.set_pointer_capture(event.pointer_id());
                     }
-                    _ => (),
+                    _ => modifier_handler(modifiers),
                 }
             },
         ));
@@ -182,22 +172,28 @@ impl PointerHandler {
     ) where
         MOD: 'static + FnMut(ModifiersState),
         M: 'static
-            + FnMut(i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, PhysicalPosition<f64>)>),
-        T: 'static + FnMut(i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, Force)>),
-        B: 'static + FnMut(i32, PhysicalPosition<f64>, ButtonsState, MouseButton),
+            + FnMut(
+                ModifiersState,
+                i32,
+                &mut dyn Iterator<Item = (PhysicalPosition<f64>, PhysicalPosition<f64>)>,
+            ),
+        T: 'static
+            + FnMut(ModifiersState, i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, Force)>),
+        B: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, ButtonsState, MouseButton),
     {
         let window = canvas_common.window.clone();
         let canvas = canvas_common.raw.clone();
         self.on_cursor_move = Some(canvas_common.add_event(
             "pointermove",
             move |event: PointerEvent| {
-                modifier_handler(event::mouse_modifiers(&event));
+                let modifiers = event::mouse_modifiers(&event);
 
                 let pointer_type = event.pointer_type();
 
-                match pointer_type.as_str() {
-                    "touch" | "mouse" => (),
-                    _ => return,
+                if let "touch" | "mouse" = pointer_type.as_str() {
+                } else {
+                    modifier_handler(modifiers);
+                    return;
                 }
 
                 let id = event.pointer_id();
@@ -217,6 +213,7 @@ impl PointerHandler {
                     }
 
                     button_handler(
+                        modifiers,
                         id,
                         event::mouse_position(&event).to_physical(super::scale_factor(&window)),
                         event::mouse_buttons(&event),
@@ -233,6 +230,7 @@ impl PointerHandler {
                         let mut delta = event::MouseDelta::init(&window, &event);
 
                         mouse_handler(
+                            modifiers,
                             id,
                             &mut event::pointer_move_event(event).map(|event| {
                                 let position = event::mouse_position(&event).to_physical(scale);
@@ -245,6 +243,7 @@ impl PointerHandler {
                         )
                     }
                     "touch" => touch_handler(
+                        modifiers,
                         id,
                         &mut event::pointer_move_event(event).map(|event| {
                             (


### PR DESCRIPTION
Firefox has broken movement values in coalesced events ([Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1753724)), which I fixed in this PR by calculating our own deltas when detecting Firefox.

In this case I use the lack of `pointerrawupdate` support and coalesced event support to detect Firefox and differentiate it from Safari. If Safari implements coalesced events this detection would break and we would have a (very small) increased overhead on Safari because the manual delta calculations we make would be unnecessary. When that happens we would have to do proper browser detection, which we should generally avoid, see [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent) for more information. Browser support in general is tracked in #2875.

Another change in this PR was how coalesced events are dispatched. Currently Winit restarts the event loop on every coalesced event separately. This is unnecessary because all coalesced events are available in the same callback. This required https://github.com/rustwasm/wasm-bindgen/issues/3477, which is why `js-sys` was bumped here.

I also made sure all `ModifiersChanged` events are sent together with any pointer events as well. This unfortunately caused a lot of code duplication, cleaning this up would require some re-architecturing, so hopefully I will get to that one day.

Follow-up to #2847.
Contains split-off-changes from #2871.
Cc @cybersoulK.