### PR TITLE
Use `Window.requestIdleCallback()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, fix the bfcache by not using the `beforeunload` event.
 - On Web, fix scale factor resize suggestion always overwriting the canvas size.
 - On macOS, fix crash when dropping `Window`.
+- On Web, use `Window.requestIdleCallback()` for `ControlFlow::Poll` when available.
 
 # 0.28.6
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -158,13 +158,6 @@ impl<T> fmt::Debug for EventLoopWindowTarget<T> {
 pub enum ControlFlow {
     /// When the current loop iteration finishes, immediately begin a new iteration regardless of
     /// whether or not new events are available to process.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web:** Events are queued and usually sent when `requestAnimationFrame` fires but sometimes
-    ///   the events in the queue may be sent before the next `requestAnimationFrame` callback, for
-    ///   example when the scaling of the page has changed. This should be treated as an implementation
-    ///   detail which should not be relied on.
     Poll,
 
     /// When the current loop iteration finishes, suspend the thread until another event arrives.

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -442,10 +442,9 @@ impl<T: 'static> Shared<T> {
             ControlFlow::Poll => {
                 let cloned = self.clone();
                 State::Poll {
-                    request: backend::AnimationFrameRequest::new(
-                        self.window().clone(),
-                        move || cloned.poll(),
-                    ),
+                    request: backend::IdleCallback::new(self.window().clone(), move || {
+                        cloned.poll()
+                    }),
                 }
             }
             ControlFlow::Wait => State::Wait {

--- a/src/platform_impl/web/event_loop/state.rs
+++ b/src/platform_impl/web/event_loop/state.rs
@@ -15,7 +15,7 @@ pub enum State {
         start: Instant,
     },
     Poll {
-        request: backend::AnimationFrameRequest,
+        request: backend::IdleCallback,
     },
     Exit,
 }

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -9,7 +9,7 @@ mod timeout;
 pub use self::canvas::Canvas;
 pub use self::event::ButtonsState;
 pub use self::scaling::ScaleChangeDetector;
-pub use self::timeout::{AnimationFrameRequest, Timeout};
+pub use self::timeout::{IdleCallback, Timeout};
 
 use crate::dpi::{LogicalSize, Size};
 use crate::platform::web::WindowExtWebSys;


### PR DESCRIPTION
This PR replaces the use of `Window.requestAnimationFrame` with `Window.requestIdleCallback`, which is in line with what `ControlFlow::Poll` is supposed to be:
> When the current loop iteration finishes, immediately begin a new iteration regardless of whether or not new events are available to process.

This is going to make `ControlFlow::Poll` very fast, which is much closer to how other backends work, but it is also gonna consume way more power, which may or may not be desired considering this is Web and running in the browser.

I think a lot of people are using `RedrawRequested` as a VSync source, which it is not as far as I understand. See #2412 for that.

Reverts #1519.
Related #1305.