### PR TITLE
Revert "On Web, send modifiers on key events first"

### DIFF
--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -134,7 +134,7 @@ impl<T> EventLoopWindowTarget<T> {
         let modifiers = self.modifiers.clone();
         canvas.on_keyboard_press(
             move |physical_key, logical_key, text, location, repeat, active_modifiers| {
-                let modifiers = (modifiers.get() != active_modifiers).then(|| {
+                let modifiers_changed = (modifiers.get() != active_modifiers).then(|| {
                     modifiers.set(active_modifiers);
                     Event::WindowEvent {
                         window_id: RootWindowId(id),
@@ -142,22 +142,25 @@ impl<T> EventLoopWindowTarget<T> {
                     }
                 });
 
-                runner.send_events(modifiers.into_iter().chain(iter::once(Event::WindowEvent {
-                    window_id: RootWindowId(id),
-                    event: WindowEvent::KeyboardInput {
-                        device_id: RootDeviceId(unsafe { DeviceId::dummy() }),
-                        event: KeyEvent {
-                            physical_key,
-                            logical_key,
-                            text,
-                            location,
-                            state: ElementState::Pressed,
-                            repeat,
-                            platform_specific: KeyEventExtra,
+                runner.send_events(
+                    iter::once(Event::WindowEvent {
+                        window_id: RootWindowId(id),
+                        event: WindowEvent::KeyboardInput {
+                            device_id: RootDeviceId(unsafe { DeviceId::dummy() }),
+                            event: KeyEvent {
+                                physical_key,
+                                logical_key,
+                                text,
+                                location,
+                                state: ElementState::Pressed,
+                                repeat,
+                                platform_specific: KeyEventExtra,
+                            },
+                            is_synthetic: false,
                         },
-                        is_synthetic: false,
-                    },
-                })));
+                    })
+                    .chain(modifiers_changed),
+                );
             },
             prevent_default,
         );
@@ -166,7 +169,7 @@ impl<T> EventLoopWindowTarget<T> {
         let modifiers = self.modifiers.clone();
         canvas.on_keyboard_release(
             move |physical_key, logical_key, text, location, repeat, active_modifiers| {
-                let modifiers = (modifiers.get() != active_modifiers).then(|| {
+                let modifiers_changed = (modifiers.get() != active_modifiers).then(|| {
                     modifiers.set(active_modifiers);
                     Event::WindowEvent {
                         window_id: RootWindowId(id),
@@ -174,22 +177,25 @@ impl<T> EventLoopWindowTarget<T> {
                     }
                 });
 
-                runner.send_events(modifiers.into_iter().chain(iter::once(Event::WindowEvent {
-                    window_id: RootWindowId(id),
-                    event: WindowEvent::KeyboardInput {
-                        device_id: RootDeviceId(unsafe { DeviceId::dummy() }),
-                        event: KeyEvent {
-                            physical_key,
-                            logical_key,
-                            text,
-                            location,
-                            state: ElementState::Released,
-                            repeat,
-                            platform_specific: KeyEventExtra,
+                runner.send_events(
+                    iter::once(Event::WindowEvent {
+                        window_id: RootWindowId(id),
+                        event: WindowEvent::KeyboardInput {
+                            device_id: RootDeviceId(unsafe { DeviceId::dummy() }),
+                            event: KeyEvent {
+                                physical_key,
+                                logical_key,
+                                text,
+                                location,
+                                state: ElementState::Released,
+                                repeat,
+                                platform_specific: KeyEventExtra,
+                            },
+                            is_synthetic: false,
                         },
-                        is_synthetic: false,
-                    },
-                })))
+                    })
+                    .chain(modifiers_changed),
+                )
             },
             prevent_default,
         );


### PR DESCRIPTION
Reverts rust-windowing/winit#2879.
Pressing a Shift key and receiving a Shift key modifier beforehand is strange, so it was right the first time.
This aligns with Wayland as well.