### PR TITLE
Bring `OptionAsAlt` back for macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ And please only add new entries to the top of this list, right below the `# Unre
     portable) interpretations of a given key-press.
   - Add `KeyCodeExtScancode`, which lets you convert between raw keycodes and
     `KeyCode`.
-  - Remove `WindowExtMacOS::option_as_alt` and `WindowExtMacOS::set_option_as_alt`.
   - `ModifiersChanged` now uses dedicated `Modifiers` struct.
 - On Orbital, fix `ModifiersChanged` not being sent.
 - **Breaking:** `CursorIcon` is now used from the `cursor-icon` crate.

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -1,0 +1,75 @@
+#![allow(clippy::single_match)]
+
+#[cfg(target_os = "macos")]
+use winit::platform::macos::{OptionAsAlt, WindowExtMacOS};
+
+#[cfg(target_os = "macos")]
+use winit::{
+    event::ElementState,
+    event::{Event, MouseButton, WindowEvent},
+    event_loop::EventLoop,
+    window::WindowBuilder,
+};
+
+#[cfg(target_os = "macos")]
+#[path = "util/fill.rs"]
+mod fill;
+
+/// Prints the keyboard events characters received when option_is_alt is true versus false.
+/// A left mouse click will toggle option_is_alt.
+#[cfg(target_os = "macos")]
+fn main() {
+    let event_loop = EventLoop::new();
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
+        .build(&event_loop)
+        .unwrap();
+
+    window.set_ime_allowed(true);
+
+    let mut option_as_alt = window.option_as_alt();
+
+    event_loop.run(move |event, _, control_flow| {
+        control_flow.set_wait();
+
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                window_id,
+            } if window_id == window.id() => control_flow.set_exit(),
+            Event::WindowEvent { event, .. } => match event {
+                WindowEvent::MouseInput {
+                    state: ElementState::Pressed,
+                    button: MouseButton::Left,
+                    ..
+                } => {
+                    option_as_alt = match option_as_alt {
+                        OptionAsAlt::None => OptionAsAlt::OnlyLeft,
+                        OptionAsAlt::OnlyLeft => OptionAsAlt::OnlyRight,
+                        OptionAsAlt::OnlyRight => OptionAsAlt::Both,
+                        OptionAsAlt::Both => OptionAsAlt::None,
+                    };
+
+                    println!("Received Mouse click, toggling option_as_alt to: {option_as_alt:?}");
+                    window.set_option_as_alt(option_as_alt);
+                }
+                WindowEvent::KeyboardInput { .. } => println!("KeyboardInput: {event:?}"),
+                _ => (),
+            },
+            Event::MainEventsCleared => {
+                window.request_redraw();
+            }
+            Event::RedrawRequested(_) => {
+                fill::fill_window(&window);
+            }
+            _ => (),
+        }
+    });
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    println!("This example is only supported on MacOS");
+}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -56,6 +56,17 @@ pub trait WindowExtMacOS {
 
     /// Put the window in a state which indicates a file save is required.
     fn set_document_edited(&self, edited: bool);
+
+    /// Set option as alt behavior as described in [`OptionAsAlt`].
+    ///
+    /// This will ignore diacritical marks and accent characters from
+    /// being processed as received characters. Instead, the input
+    /// device's raw character will be placed in event queues with the
+    /// Alt modifier set.
+    fn set_option_as_alt(&self, option_as_alt: OptionAsAlt);
+
+    /// Getter for the [`WindowExtMacOS::set_option_as_alt`].
+    fn option_as_alt(&self) -> OptionAsAlt;
 }
 
 impl WindowExtMacOS for Window {
@@ -97,6 +108,16 @@ impl WindowExtMacOS for Window {
     #[inline]
     fn set_document_edited(&self, edited: bool) {
         self.window.set_document_edited(edited)
+    }
+
+    #[inline]
+    fn set_option_as_alt(&self, option_as_alt: OptionAsAlt) {
+        self.window.set_option_as_alt(option_as_alt)
+    }
+
+    #[inline]
+    fn option_as_alt(&self) -> OptionAsAlt {
+        self.window.option_as_alt()
     }
 }
 
@@ -140,6 +161,10 @@ pub trait WindowBuilderExtMacOS {
     fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
     /// Window accepts click-through mouse events.
     fn with_accepts_first_mouse(self, accepts_first_mouse: bool) -> WindowBuilder;
+    /// Set how the <kbd>Option</kbd> keys are interpreted.
+    ///
+    /// See [`WindowExtMacOS::set_option_as_alt`] for details on what this means if set.
+    fn with_option_as_alt(self, option_as_alt: OptionAsAlt) -> WindowBuilder;
 }
 
 impl WindowBuilderExtMacOS for WindowBuilder {
@@ -197,6 +222,12 @@ impl WindowBuilderExtMacOS for WindowBuilder {
     #[inline]
     fn with_accepts_first_mouse(mut self, accepts_first_mouse: bool) -> WindowBuilder {
         self.platform_specific.accepts_first_mouse = accepts_first_mouse;
+        self
+    }
+
+    #[inline]
+    fn with_option_as_alt(mut self, option_as_alt: OptionAsAlt) -> WindowBuilder {
+        self.platform_specific.option_as_alt = option_as_alt;
         self
     }
 }
@@ -308,4 +339,24 @@ impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
     fn hide_other_applications(&self) {
         self.p.hide_other_applications()
     }
+}
+
+/// Option as alt behavior.
+///
+/// The default is `None`.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum OptionAsAlt {
+    /// The left `Option` key is treated as `Alt`.
+    OnlyLeft,
+
+    /// The right `Option` key is treated as `Alt`.
+    OnlyRight,
+
+    /// Both `Option` keys are treated as `Alt`.
+    Both,
+
+    /// No special handling is applied for `Option` key.
+    #[default]
+    None,
 }

--- a/src/platform_impl/macos/appkit/event.rs
+++ b/src/platform_impl/macos/appkit/event.rs
@@ -67,6 +67,35 @@ extern_methods!(
             }
         }
 
+        pub fn keyEventWithType(
+            type_: NSEventType,
+            location: NSPoint,
+            modifier_flags: NSEventModifierFlags,
+            timestamp: NSTimeInterval,
+            window_num: NSInteger,
+            context: Option<&NSObject>,
+            characters: &NSString,
+            characters_ignoring_modifiers: &NSString,
+            is_a_repeat: bool,
+            scancode: c_ushort,
+        ) -> Id<Self, Shared> {
+            unsafe {
+                msg_send_id![
+                    Self::class(),
+                    keyEventWithType: type_,
+                    location: location,
+                    modifierFlags: modifier_flags,
+                    timestamp: timestamp,
+                    windowNumber: window_num,
+                    context: context,
+                    characters: characters,
+                    charactersIgnoringModifiers: characters_ignoring_modifiers,
+                    isARepeat: is_a_repeat,
+                    keyCode: scancode,
+                ]
+            }
+        }
+
         #[sel(locationInWindow)]
         pub fn locationInWindow(&self) -> NSPoint;
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -21,7 +21,7 @@ use crate::{
     error::{ExternalError, NotSupportedError, OsError as RootOsError},
     event::WindowEvent,
     icon::Icon,
-    platform::macos::WindowExtMacOS,
+    platform::macos::{OptionAsAlt, WindowExtMacOS},
     platform_impl::platform::{
         app_state::AppState,
         appkit::NSWindowOrderingMode,
@@ -85,6 +85,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub disallow_hidpi: bool,
     pub has_shadow: bool,
     pub accepts_first_mouse: bool,
+    pub option_as_alt: OptionAsAlt,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -100,6 +101,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             disallow_hidpi: false,
             has_shadow: true,
             accepts_first_mouse: true,
+            option_as_alt: Default::default(),
         }
     }
 }
@@ -160,6 +162,8 @@ pub struct SharedState {
 
     /// The current resize incerments for the window content.
     pub(crate) resize_increments: NSSize,
+    /// The state of the `Option` as `Alt`.
+    pub(crate) option_as_alt: OptionAsAlt,
 }
 
 impl SharedState {
@@ -368,6 +372,8 @@ impl WinitWindow {
                 if attrs.position.is_none() {
                     this.center();
                 }
+
+                this.set_option_as_alt(pl_attrs.option_as_alt);
 
                 Id::into_shared(this)
             })
@@ -1375,6 +1381,16 @@ impl WindowExtMacOS for WinitWindow {
 
     fn set_document_edited(&self, edited: bool) {
         self.setDocumentEdited(edited)
+    }
+
+    fn set_option_as_alt(&self, option_as_alt: OptionAsAlt) {
+        let mut shared_state_lock = self.shared_state.lock().unwrap();
+        shared_state_lock.option_as_alt = option_as_alt;
+    }
+
+    fn option_as_alt(&self) -> OptionAsAlt {
+        let shared_state_lock = self.shared_state.lock().unwrap();
+        shared_state_lock.option_as_alt
     }
 }
 


### PR DESCRIPTION
The correct handling of this setting requires to change the events we're getting from the macOS on the fly and call `interpretKeyEvents`, which could affect handling of the next events, meaning that we can't provide them on `KeyEvent`.

--

This is basically old option we had with winit `0.28.0`.

cc @fredizzimo if you want to try it with neovide.
