### PR TITLE
Throttle `RedrawRequested`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Add `Window::pre_present_notify` to notify winit before presenting to the windowing system.
 - On Windows, added `WindowBuilderExtWindows::with_class_name` to customize the internal class name.
 - **Breaking:** Remove lifetime parameter from `Event` and `WindowEvent`.
 - **Breaking:** `ScaleFactorChanged` now contains a writer instead of a reference to update inner size.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Wayland, use frame callbacks to throttle `RedrawRequested` events so redraws will align with compositor.
 - Add `Window::pre_present_notify` to notify winit before presenting to the windowing system.
 - On Windows, added `WindowBuilderExtWindows::with_class_name` to customize the internal class name.
 - **Breaking:** Remove lifetime parameter from `Event` and `WindowEvent`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Web, use `Window.requestAnimationFrame()` to throttle `RedrawRequested` events.
 - On Wayland, use frame callbacks to throttle `RedrawRequested` events so redraws will align with compositor.
 - Add `Window::pre_present_notify` to notify winit before presenting to the windowing system.
 - On Windows, added `WindowBuilderExtWindows::with_class_name` to customize the internal class name.

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -33,6 +33,8 @@ fn main() -> Result<(), impl std::error::Error> {
                 window.request_redraw();
             }
             Event::RedrawRequested(_) => {
+                // Notify the windowing system that we'll be presenting to the window.
+                window.pre_present_notify();
                 fill::fill_window(&window);
             }
             _ => (),

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -813,6 +813,8 @@ impl Window {
         self.redraw_requester.request_redraw()
     }
 
+    pub fn pre_present_notify(&self) {}
+
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
         Err(error::NotSupportedError::new())
     }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -74,6 +74,8 @@ impl Inner {
         }
     }
 
+    pub fn pre_present_notify(&self) {}
+
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         unsafe {
             let safe_area = self.safe_area_screen_space();

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -555,17 +555,17 @@ impl Window {
         }
     }
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
-        match self {
-            #[cfg(x11_platform)]
-            Window::X(ref w) => w.request_user_attention(request_type),
-            #[cfg(wayland_platform)]
-            Window::Wayland(ref w) => w.request_user_attention(request_type),
-        }
+        x11_or_wayland!(match self; Window(w) => w.request_user_attention(request_type))
     }
 
     #[inline]
     pub fn request_redraw(&self) {
         x11_or_wayland!(match self; Window(w) => w.request_redraw())
+    }
+
+    #[inline]
+    pub fn pre_present_notify(&self) {
+        x11_or_wayland!(match self; Window(w) => w.pre_present_notify())
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -321,7 +321,15 @@ impl CompositorHandler for WinitState {
         self.scale_factor_changed(surface, scale_factor as f64, true)
     }
 
-    fn frame(&mut self, _: &Connection, _: &QueueHandle<Self>, _: &WlSurface, _: u32) {}
+    fn frame(&mut self, _: &Connection, _: &QueueHandle<Self>, surface: &WlSurface, _: u32) {
+        let window_id = super::make_wid(surface);
+        let window = match self.windows.get_mut().get(&window_id) {
+            Some(window) => window,
+            None => return,
+        };
+
+        window.lock().unwrap().frame_callback_received();
+    }
 }
 
 impl ProvidesRegistryState for WinitState {

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -38,7 +38,7 @@ use super::state::WinitState;
 use super::types::xdg_activation::XdgActivationTokenData;
 use super::{EventLoopWindowTarget, WindowId};
 
-mod state;
+pub(crate) mod state;
 
 pub use state::WindowState;
 
@@ -295,7 +295,7 @@ impl Window {
 
     #[inline]
     pub fn pre_present_notify(&self) {
-        // TODO
+        self.window_state.lock().unwrap().request_frame_callback();
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -294,6 +294,11 @@ impl Window {
     }
 
     #[inline]
+    pub fn pre_present_notify(&self) {
+        // TODO
+    }
+
+    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         let window_state = self.window_state.lock().unwrap();
         let scale_factor = window_state.scale_factor();

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1732,6 +1732,11 @@ impl UnownedWindow {
     }
 
     #[inline]
+    pub fn pre_present_notify(&self) {
+        // TODO timer
+    }
+
+    #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
         let mut window_handle = XlibWindowHandle::empty();
         window_handle.window = self.xlib_window();

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -569,6 +569,9 @@ impl WinitWindow {
         AppState::queue_redraw(RootWindowId(self.id()));
     }
 
+    #[inline]
+    pub fn pre_present_notify(&self) {}
+
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let frame_rect = self.frame();
         let position = LogicalPosition::new(

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -167,6 +167,9 @@ impl Window {
     }
 
     #[inline]
+    pub fn pre_present_notify(&self) {}
+
+    #[inline]
     pub fn reset_dead_keys(&self) {
         // TODO?
     }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -735,7 +735,10 @@ impl<T> EventLoopWindowTarget<T> {
             }
 
             canvas_clone.borrow_mut().is_intersecting = Some(is_intersecting);
-        })
+        });
+
+        let runner = self.runner.clone();
+        canvas.on_animation_frame(move || runner.request_redraw(RootWindowId(id)));
     }
 
     pub fn available_monitors(&self) -> VecDequeIter<MonitorHandle> {

--- a/src/platform_impl/web/web_sys/animation_frame.rs
+++ b/src/platform_impl/web/web_sys/animation_frame.rs
@@ -1,0 +1,62 @@
+use std::cell::Cell;
+use std::rc::Rc;
+use wasm_bindgen::closure::Closure;
+use wasm_bindgen::JsCast;
+
+pub struct AnimationFrameHandler {
+    window: web_sys::Window,
+    closure: Closure<dyn FnMut()>,
+    handle: Rc<Cell<Option<i32>>>,
+}
+
+impl AnimationFrameHandler {
+    pub fn new(window: web_sys::Window) -> Self {
+        let handle = Rc::new(Cell::new(None));
+        let closure = Closure::new({
+            let handle = handle.clone();
+            move || handle.set(None)
+        });
+
+        Self {
+            window,
+            closure,
+            handle,
+        }
+    }
+
+    pub fn on_animation_frame<F>(&mut self, mut f: F)
+    where
+        F: 'static + FnMut(),
+    {
+        let handle = self.handle.clone();
+        self.closure = Closure::new(move || {
+            handle.set(None);
+            f();
+        })
+    }
+
+    pub fn request(&self) {
+        if let Some(handle) = self.handle.take() {
+            self.window
+                .cancel_animation_frame(handle)
+                .expect("Failed to cancel animation frame");
+        }
+
+        let handle = self
+            .window
+            .request_animation_frame(self.closure.as_ref().unchecked_ref())
+            .expect("Failed to request animation frame");
+
+        self.handle.set(Some(handle));
+    }
+}
+
+impl Drop for AnimationFrameHandler {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            self.window
+                .cancel_animation_frame(handle)
+                .expect("Failed to cancel animation frame");
+        }
+    }
+}

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -1,3 +1,4 @@
+mod animation_frame;
 mod canvas;
 pub mod event;
 mod event_handle;

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -114,6 +114,8 @@ impl Window {
             .dispatch(|inner| (inner.register_redraw_request)());
     }
 
+    pub fn pre_present_notify(&self) {}
+
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         self.inner.queue(|inner| {
             Ok(inner

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -143,6 +143,9 @@ impl Window {
     }
 
     #[inline]
+    pub fn pre_present_notify(&self) {}
+
+    #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         util::WindowArea::Outer.get_rect(self.hwnd())
             .map(|rect| Ok(PhysicalPosition::new(rect.left, rect.top)))

--- a/src/window.rs
+++ b/src/window.rs
@@ -548,6 +548,43 @@ impl Window {
         self.window.request_redraw()
     }
 
+    /// Notify the windowing system that you're before presenting to the window.
+    ///
+    /// You should call this event after you've done drawing operations, but before you submit
+    /// the buffer to the display or commit your drawings. Doing so will help winit to properly
+    /// schedule and do assumptions about its internal state. For example, it could properly
+    /// throttle [`Event::RedrawRequested`].
+    ///
+    /// ## Example
+    ///
+    /// This example illustrates how it looks with OpenGL, but it applies to other graphics
+    /// APIs and software rendering.
+    ///
+    /// ```no_run
+    /// # use winit::event_loop::EventLoop;
+    /// # use winit::window::Window;
+    /// # let mut event_loop = EventLoop::new();
+    /// # let window = Window::new(&event_loop).unwrap();
+    /// # fn swap_buffers() {}
+    /// // Do the actual drawing with OpenGL.
+    ///
+    /// // Notify winit that we're about to submit buffer to the windowing system.
+    /// window.pre_present_notify();
+    ///
+    /// // Sumbit buffer to the windowing system.
+    /// swap_buffers();
+    /// ```
+    ///
+    /// ## Platform-specific
+    ///
+    /// **Wayland:** - schedules a frame callback to throttle [`Event::RedrawRequested`].
+    ///
+    /// [`Event::RedrawRequested`]: crate::event::Event::RedrawRequested
+    #[inline]
+    pub fn pre_present_notify(&self) {
+        self.window.pre_present_notify();
+    }
+
     /// Reset the dead key state of the keyboard.
     ///
     /// This is useful when a dead key is bound to trigger an action. Then

--- a/src/window.rs
+++ b/src/window.rs
@@ -524,11 +524,12 @@ impl Window {
         self.window.scale_factor()
     }
 
-    /// Requests a future [`Event::RedrawRequested`] event to be emitted in a way that is
-    /// synchronized and / or throttled by the windowing system.
+    /// Queues a [`Event::RedrawRequested`] event to be emitted that aligns with the windowing
+    /// system drawing loop.
     ///
     /// This is the **strongly encouraged** method of redrawing windows, as it can integrate with
-    /// OS-requested redraws (e.g. when a window gets resized).
+    /// OS-requested redraws (e.g. when a window gets resized). To improve the event delivery
+    /// consider using [`Window::pre_present_notify`] as described in docs.
     ///
     /// Applications should always aim to redraw whenever they receive a `RedrawRequested` event.
     ///
@@ -536,11 +537,16 @@ impl Window {
     /// with respect to other events, since the requirements can vary significantly between
     /// windowing systems.
     ///
+    /// However as the event aligns with the windowing system drawing loop, it may not arrive in
+    /// same or even next event loop iteration.
+    ///
     /// ## Platform-specific
     ///
     /// - **Windows** This API uses `RedrawWindow` to request a `WM_PAINT` message and `RedrawRequested`
     ///   is emitted in sync with any `WM_PAINT` messages
     /// - **iOS:** Can only be called on the main thread.
+    /// - **Wayland:** The events are aligned with the frame callbacks when [`Window::pre_present_notify`]
+    ///                is used.
     ///
     /// [`Event::RedrawRequested`]: crate::event::Event::RedrawRequested
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -547,6 +547,7 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread.
     /// - **Wayland:** The events are aligned with the frame callbacks when [`Window::pre_present_notify`]
     ///                is used.
+    /// - **Web:** [`Event::RedrawRequested`] will be aligned with the `requestAnimationFrame`.
     ///
     /// [`Event::RedrawRequested`]: crate::event::Event::RedrawRequested
     #[inline]


### PR DESCRIPTION
Fixes #2412.

- [ ] macOS (broken drawRect, DisplayLink?)
- [ ] Windows (WM_PAINT?)
- [x] Wayland (frame callbacks)
- [x] web (requestAnimationFrame)
- [ ] fallback (X11, redox) (timer based with global timer seed)

The docs are also not updated and it would be nice to have software example showing FPS it's rendering it right now.

--

Wayland done and it works.