### PR TITLE
Allow recreating wasm event loop with `spawn`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Web, allow event loops to be recreated with `spawn`.
 - **Breaking:** Rename `Window::set_ime_position` to `Window::set_ime_cursor_area` adding a way to set exclusive zone.
 - On Android, changed default behavior of Android to ignore volume keys letting the operating system handle them.
 - On Android, added `EventLoopBuilderExtAndroid::handle_volume_keys` to indicate that the application will handle the volume keys manually.

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -66,6 +66,11 @@ pub trait EventLoopExtWebSys {
     ///
     /// Unlike `run`, this returns immediately, and doesn't throw an exception in order to
     /// satisfy its `!` return type.
+    ///
+    /// Once the event loop has been destroyed, it's possible to reinitialize another event loop
+    /// by calling this function again. This can be useful if you want to recreate the event loop
+    /// while the WebAssembly module is still loaded. For example, this can be used to recreate the
+    /// event loop when switching between tabs on a single page application.
     fn spawn<F>(self, event_handler: F)
     where
         F: 'static


### PR DESCRIPTION
Rebased #2720

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

It seems to work after rebasing but haven't been able to test in detail yet. It looks like some other recent winit changes broke my canvas sizing so I need to look into that.