### PR TITLE
On Wayland, handle `none` decorations

### DIFF
--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -105,11 +105,18 @@ impl Window {
             .map(|size| size.to_logical::<u32>(1.))
             .unwrap_or((800, 600).into());
 
-        let window = state.xdg_shell.create_window(
-            surface.clone(),
-            WindowDecorations::ServerDefault,
-            &queue_handle,
-        );
+        // We prefer server side decorations, however to not have decorations we ask for client
+        // side decorations instead.
+        let default_decorations = if attributes.decorations {
+            WindowDecorations::RequestServer
+        } else {
+            WindowDecorations::RequestClient
+        };
+
+        let window =
+            state
+                .xdg_shell
+                .create_window(surface.clone(), default_decorations, &queue_handle);
 
         let mut window_state = WindowState::new(
             event_loop_window_target.connection.clone(),
@@ -122,6 +129,9 @@ impl Window {
 
         // Set transparency hint.
         window_state.set_transparent(attributes.transparent);
+
+        // Set the decorations hint.
+        window_state.set_decorate(attributes.decorations);
 
         // Set the app_id.
         if let Some(name) = platform_attributes.name.map(|name| name.general) {


### PR DESCRIPTION
During the migration some logic wrt `none` decorations was lost along the way, however we also now try to ask for client side decorations if the user wants to disable server side decorations.

Fixes #2902.