### PR TITLE
Don't allow event loops to run in parallel

### DIFF
--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -35,6 +35,7 @@ type OnEventHandle<T> = RefCell<Option<EventListenerHandle<dyn FnMut(T)>>>;
 
 pub struct Execution<T: 'static> {
     runner: RefCell<RunnerEnum<T>>,
+    event_loop_recreation: Cell<bool>,
     events: RefCell<VecDeque<EventWrapper<T>>>,
     id: RefCell<u32>,
     window: web_sys::Window,
@@ -139,6 +140,7 @@ impl<T: 'static> Shared<T> {
     pub fn new() -> Self {
         Shared(Rc::new(Execution {
             runner: RefCell::new(RunnerEnum::Pending),
+            event_loop_recreation: Cell::new(false),
             events: RefCell::new(VecDeque::new()),
             #[allow(clippy::disallowed_methods)]
             window: web_sys::window().expect("only callable from inside the `Window`"),
@@ -633,6 +635,9 @@ impl<T: 'static> Shared<T> {
         // * For each undropped `Window`:
         //     * The `register_redraw_request` closure.
         //     * The `destroy_fn` closure.
+        if self.0.event_loop_recreation.get() {
+            crate::event_loop::EventLoopBuilder::<T>::allow_event_loop_recreation();
+        }
     }
 
     // Check if the event loop is currently closed
@@ -674,6 +679,10 @@ impl<T: 'static> Shared<T> {
             }),
             DeviceEvents::Never => false,
         }
+    }
+
+    pub fn event_loop_recreation(&self, allow: bool) {
+        self.0.event_loop_recreation.set(allow)
     }
 }
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -69,7 +69,8 @@ impl<T> EventLoopWindowTarget<T> {
         EventLoopProxy::new(self.runner.clone())
     }
 
-    pub fn run(&self, event_handler: Box<runner::EventHandler<T>>) {
+    pub fn run(&self, event_handler: Box<runner::EventHandler<T>>, event_loop_recreation: bool) {
+        self.runner.event_loop_recreation(event_loop_recreation);
         self.runner.set_listener(event_handler);
     }
 


### PR DESCRIPTION
Currently multiple event loops can be run at the same time when using `spawn()`, which was not the intention of #2897 and isn't documented as such.

Follow up on #2897.
Cc @grovesNL.