### PR TITLE
Disallow cleanup for TLS in examples

### DIFF
--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -14,6 +14,7 @@ pub(super) fn fill_window(window: &Window) {
     use softbuffer::{Context, Surface};
     use std::cell::RefCell;
     use std::collections::HashMap;
+    use std::mem::ManuallyDrop;
     use std::num::NonZeroU32;
     use winit::window::WindowId;
 
@@ -43,8 +44,12 @@ pub(super) fn fill_window(window: &Window) {
     }
 
     thread_local! {
-        /// A static, thread-local map of graphics contexts to open windows.
-        static GC: RefCell<Option<GraphicsContext>> = RefCell::new(None);
+        // NOTE: You should never do things like that, create context and drop it before
+        // you drop the event loop. We do this for brevity to not blow up examples. We use
+        // ManuallyDrop to prevent destructors from running.
+        //
+        // A static, thread-local map of graphics contexts to open windows.
+        static GC: ManuallyDrop<RefCell<Option<GraphicsContext>>> = ManuallyDrop::new(RefCell::new(None));
     }
 
     GC.with(|gc| {


### PR DESCRIPTION
Fixes issue on Wayland due to drop order, since TLS is being dropped after the event loop, while it shouldn't. In particular it fixes the crash in the window_run_return example.


