### PR TITLE
Consider `RedrawEventsCleared` to be a redraw event

### DIFF
--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -59,7 +59,7 @@ enum UserCallbackTransitionResult<'a> {
 
 impl Event<'static, Never> {
     fn is_redraw(&self) -> bool {
-        matches!(self, Event::RedrawRequested(_))
+        matches!(self, Event::RedrawRequested(_) | Event::RedrawEventsCleared)
     }
 }
 


### PR DESCRIPTION
The `is_redraw()` method is used to determine when non-redraw events are received while processing redraws, and to log a warning when that happens. I noticed in a project of mine this resulted in endless spamming of warnings in the console, at least when running in the iOS simulator. Even so, I could not find any actual issues related to this.

By considering the `RedrawEventsCleared` event to also be a redraw event, the warnings stopped, while other behavior is left unmodified.

- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented