### PR TITLE
On Web, map bfcache load/unload to suspend/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, use the correct canvas size when calculating the new size during scale factor change,
   instead of using the output bitmap size.
 - On Web, scale factor and dark mode detection are now more robust.
-- On Web, fix the bfcache by not using the `beforeunload` event.
+- On Web, fix the bfcache by not using the `beforeunload` event and map bfcache loading/unloading to `Suspended`/`Resumed` events.
 - On Web, fix scale factor resize suggestion always overwriting the canvas size.
 - On macOS, fix crash when dropping `Window`.
 - On Web, use `Window.requestIdleCallback()` for `ControlFlow::Poll` when available.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ features = [
     'KeyboardEvent',
     'MediaQueryList',
     'Node',
+    'PageTransitionEvent',
     'PointerEvent',
     'ResizeObserver',
     'ResizeObserverBoxOptions',

--- a/src/event.rs
+++ b/src/event.rs
@@ -125,6 +125,18 @@ pub enum Event<'a, T: 'static> {
     /// [`applicationWillResignActive`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622950-applicationwillresignactive
     /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
     ///
+    /// ## Web
+    ///
+    /// On Web, the `Suspended` event is emitted in response to a [`pagehide`] event
+    /// with the property [`persisted`] being true, which means that the page is being
+    /// put in the [´bfcache`] (back/forward cache) - an in-memory cache that stores a
+    /// complete snapshot of a page (including the JavaScript heap) as the user is
+    /// navigating away.
+    ///
+    /// [`pagehide`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event
+    /// [`persisted`]: https://developer.mozilla.org/en-US/docs/Web/API/PageTransitionEvent/persisted
+    /// [`bfcache`]: https://web.dev/bfcache/
+    ///
     /// [`Resumed`]: Self::Resumed
     Suspended,
 
@@ -178,6 +190,18 @@ pub enum Event<'a, T: 'static> {
     ///
     /// [`applicationDidBecomeActive`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622956-applicationdidbecomeactive
     /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
+    ///
+    /// ## Web
+    ///
+    /// On Web, the `Resumed` event is emitted in response to a [`pageshow`] event
+    /// with the property [`persisted`] being true, which means that the page is being
+    /// restored from the [´bfcache`] (back/forward cache) - an in-memory cache that
+    /// stores a complete snapshot of a page (including the JavaScript heap) as the
+    /// user is navigating away.
+    ///
+    /// [`pageshow`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/pageshow_event
+    /// [`persisted`]: https://developer.mozilla.org/en-US/docs/Web/API/PageTransitionEvent/persisted
+    /// [`bfcache`]: https://web.dev/bfcache/
     ///
     /// [`Suspended`]: Self::Suspended
     Resumed,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I'm not certain about this being the right way, so see it as a start of discussion.

In #2261, the web backend was changed to use the `pagehide` event instead of `unload`, to allow the bfcache to be used.

See https://web.dev/bfcache/ for more information about the bfcache (back/forward cache), and https://developer.chrome.com/docs/devtools/application/back-forward-cache/ for how to test it in chrome. Summary from the first resource:

> bfcache is an in-memory cache that stores a complete snapshot of a page (including the JavaScript heap) as the user is navigating away

The problem with winit and the bfcache is that the event loop is destroyed in `pagehide` - which happens before the snapshot is put in the bfcache. So when a user navigates back to the page running a winit program it's no longer responding.

This can be seen on e.g. the web example program (`cargo run-wasm --example web`) - after restoring the page from the bfcache the event log is no longer updated.

This PR changes `pagehide` handling to only destroy the event loop if [persisted](https://developer.mozilla.org/en-US/docs/Web/API/PageTransitionEvent/persisted) is `false`. If persisted is `true`, we now emit a `Suspended` event.

It also adds a corresponding listener for `pageshow` with `persisted` being `true`, to emit a `Resumed` event in that case.