### PR TITLE
On X11, fix IME not working

### DIFF
--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -188,6 +188,15 @@ impl<T: 'static> EventLoop<T> {
                 panic!("X server missing XKB extension");
             }
 
+            // Enable detectable auto repeat.
+            let mut supported = 0;
+            unsafe {
+                (xconn.xlib.XkbSetDetectableAutoRepeat)(xconn.display, 1, &mut supported);
+            }
+            if supported == 0 {
+                warn!("Detectable auto repeart is not supported");
+            }
+
             ext
         };
 
@@ -283,6 +292,7 @@ impl<T: 'static> EventLoop<T> {
             first_touch: None,
             active_window: None,
             is_composing: false,
+            got_key_release: true,
         };
 
         // Register for device hotplug events

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -245,6 +245,7 @@ impl UnownedWindow {
                 | ffi::StructureNotifyMask
                 | ffi::VisibilityChangeMask
                 | ffi::KeyPressMask
+                | ffi::KeyReleaseMask
                 | ffi::KeymapStateMask
                 | ffi::ButtonPressMask
                 | ffi::ButtonReleaseMask
@@ -446,8 +447,6 @@ impl UnownedWindow {
             let mask = ffi::XI_MotionMask
                 | ffi::XI_ButtonPressMask
                 | ffi::XI_ButtonReleaseMask
-                | ffi::XI_KeyPressMask
-                | ffi::XI_KeyReleaseMask
                 | ffi::XI_EnterMask
                 | ffi::XI_LeaveMask
                 | ffi::XI_FocusInMask

--- a/src/window.rs
+++ b/src/window.rs
@@ -1074,6 +1074,7 @@ impl Window {
     ///
     /// - **macOS:** IME must be enabled to receive text-input where dead-key sequences are combined.
     /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **X11**: Enabling IME will disable dead keys reporting during compose.
     ///
     /// [`Ime`]: crate::event::WindowEvent::Ime
     /// [`KeyboardInput`]: crate::event::WindowEvent::KeyboardInput


### PR DESCRIPTION
The change to xinput2 completely disabled IME support, thus we've got a dead keys reporting, because nothing was eating the key events anymore, however that's not what we really need, given that not working IME makes it impossible for some users to type.

The proper solution is to not use Xlib at all for that and rely on xcb and its tooling around the XIM and text compose stuff, so we'll have full control over what is getting sent to the XIM/IC or not.

Fixes #2888.

- [x] Tested on all platforms changed
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior