### PR TITLE
Fix conversion from u32 to c_int

### DIFF
--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -203,8 +203,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_position(&mut self, position: Option<(i32, i32)>) {
         if let Some((x, y)) = position {
             self.size_hints.flags |= ffi::PPosition;
-            self.size_hints.x = to_c_int(x);
-            self.size_hints.y = to_c_int(y);
+            self.size_hints.x = Self::to_c_int(x);
+            self.size_hints.y = Self::to_c_int(y);
         } else {
             self.size_hints.flags &= !ffi::PPosition;
         }
@@ -214,8 +214,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_size(&mut self, size: Option<(u32, u32)>) {
         if let Some((width, height)) = size {
             self.size_hints.flags |= ffi::PSize;
-            self.size_hints.width = to_c_int(width);
-            self.size_hints.height = to_c_int(height);
+            self.size_hints.width = Self::to_c_int(width);
+            self.size_hints.height = Self::to_c_int(height);
         } else {
             self.size_hints.flags &= !ffi::PSize;
         }
@@ -224,8 +224,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_max_size(&mut self, max_size: Option<(u32, u32)>) {
         if let Some((max_width, max_height)) = max_size {
             self.size_hints.flags |= ffi::PMaxSize;
-            self.size_hints.max_width = to_c_int(max_width);
-            self.size_hints.max_height = to_c_int(max_height);
+            self.size_hints.max_width = Self::to_c_int(max_width);
+            self.size_hints.max_height = Self::to_c_int(max_height);
         } else {
             self.size_hints.flags &= !ffi::PMaxSize;
         }
@@ -234,8 +234,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_min_size(&mut self, min_size: Option<(u32, u32)>) {
         if let Some((min_width, min_height)) = min_size {
             self.size_hints.flags |= ffi::PMinSize;
-            self.size_hints.min_width = to_c_int(min_width);
-            self.size_hints.min_height = to_c_int(min_height);
+            self.size_hints.min_width = Self::to_c_int(min_width);
+            self.size_hints.min_height = Self::to_c_int(min_height);
         } else {
             self.size_hints.flags &= !ffi::PMinSize;
         }
@@ -244,8 +244,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_resize_increments(&mut self, resize_increments: Option<(u32, u32)>) {
         if let Some((width_inc, height_inc)) = resize_increments {
             self.size_hints.flags |= ffi::PResizeInc;
-            self.size_hints.width_inc = to_c_int(width_inc);
-            self.size_hints.height_inc = to_c_int(height_inc);
+            self.size_hints.width_inc = Self::to_c_int(width_inc);
+            self.size_hints.height_inc = Self::to_c_int(height_inc);
         } else {
             self.size_hints.flags &= !ffi::PResizeInc;
         }
@@ -254,8 +254,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_base_size(&mut self, base_size: Option<(u32, u32)>) {
         if let Some((base_width, base_height)) = base_size {
             self.size_hints.flags |= ffi::PBaseSize;
-            self.size_hints.base_width = to_c_int(base_width);
-            self.size_hints.base_height = to_c_int(base_height);
+            self.size_hints.base_width = Self::to_c_int(base_width);
+            self.size_hints.base_height = Self::to_c_int(base_height);
         } else {
             self.size_hints.flags &= !ffi::PBaseSize;
         }

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -203,8 +203,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_position(&mut self, position: Option<(i32, i32)>) {
         if let Some((x, y)) = position {
             self.size_hints.flags |= ffi::PPosition;
-            self.size_hints.x = x as c_int;
-            self.size_hints.y = y as c_int;
+            self.size_hints.x = to_c_int(x);
+            self.size_hints.y = to_c_int(y);
         } else {
             self.size_hints.flags &= !ffi::PPosition;
         }
@@ -214,8 +214,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_size(&mut self, size: Option<(u32, u32)>) {
         if let Some((width, height)) = size {
             self.size_hints.flags |= ffi::PSize;
-            self.size_hints.width = width as c_int;
-            self.size_hints.height = height as c_int;
+            self.size_hints.width = to_c_int(width);
+            self.size_hints.height = to_c_int(height);
         } else {
             self.size_hints.flags &= !ffi::PSize;
         }
@@ -224,8 +224,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_max_size(&mut self, max_size: Option<(u32, u32)>) {
         if let Some((max_width, max_height)) = max_size {
             self.size_hints.flags |= ffi::PMaxSize;
-            self.size_hints.max_width = max_width as c_int;
-            self.size_hints.max_height = max_height as c_int;
+            self.size_hints.max_width = to_c_int(max_width);
+            self.size_hints.max_height = to_c_int(max_height);
         } else {
             self.size_hints.flags &= !ffi::PMaxSize;
         }
@@ -234,8 +234,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_min_size(&mut self, min_size: Option<(u32, u32)>) {
         if let Some((min_width, min_height)) = min_size {
             self.size_hints.flags |= ffi::PMinSize;
-            self.size_hints.min_width = min_width as c_int;
-            self.size_hints.min_height = min_height as c_int;
+            self.size_hints.min_width = to_c_int(min_width);
+            self.size_hints.min_height = to_c_int(min_height);
         } else {
             self.size_hints.flags &= !ffi::PMinSize;
         }
@@ -244,8 +244,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_resize_increments(&mut self, resize_increments: Option<(u32, u32)>) {
         if let Some((width_inc, height_inc)) = resize_increments {
             self.size_hints.flags |= ffi::PResizeInc;
-            self.size_hints.width_inc = width_inc as c_int;
-            self.size_hints.height_inc = height_inc as c_int;
+            self.size_hints.width_inc = to_c_int(width_inc);
+            self.size_hints.height_inc = to_c_int(height_inc);
         } else {
             self.size_hints.flags &= !ffi::PResizeInc;
         }
@@ -254,11 +254,15 @@ impl<'a> NormalHints<'a> {
     pub fn set_base_size(&mut self, base_size: Option<(u32, u32)>) {
         if let Some((base_width, base_height)) = base_size {
             self.size_hints.flags |= ffi::PBaseSize;
-            self.size_hints.base_width = base_width as c_int;
-            self.size_hints.base_height = base_height as c_int;
+            self.size_hints.base_width = to_c_int(base_width);
+            self.size_hints.base_height = to_c_int(base_height);
         } else {
             self.size_hints.flags &= !ffi::PBaseSize;
         }
+    }
+
+    fn to_c_int(n: u32) -> c_int {
+        n.min(c_int::MAX as u32) as c_int
     }
 }
 

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -203,8 +203,8 @@ impl<'a> NormalHints<'a> {
     pub fn set_position(&mut self, position: Option<(i32, i32)>) {
         if let Some((x, y)) = position {
             self.size_hints.flags |= ffi::PPosition;
-            self.size_hints.x = Self::to_c_int(x);
-            self.size_hints.y = Self::to_c_int(y);
+            self.size_hints.x = x as c_int;
+            self.size_hints.y = y as c_int;
         } else {
             self.size_hints.flags &= !ffi::PPosition;
         }


### PR DESCRIPTION
This PR fixes the conversion from `u32` to `c_int` which resulted in negative `c_int` values for big `u32` values.

I'm a new contributor to Winit and I honestly didn't check all the guidelines nor I understand all the code, but I think I found a bug while investigating a bug in Bevy, which uses Winit: https://github.com/bevyengine/bevy/pull/8948#discussion_r1249397391

In short, when using `set_max_inner_size` or `with_max_inner_size` with a big value (for Bevy we use a `f32` logical size but I believe it's simply converted to a `u32` down the line), the max constraint end up being equal to the min one (making the window not resizeable, to the size of the min constraint). After testing, the threshold value for this to happen seem to be around `u32::MAX / 2` (more or less, not sure why not exactly that but can be rounding errors), which seem to indicate a conversion to a signed int that would make the value negative somewhere.

After investigating in Winit's code, I found conversions from `u32` to `c_int`, and after testing in the playground it seems to be what's wrong: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=be9b6b0416fbb79ff0935ae4300036c7

I'm not sure how to test stuff with Winit alone so I didn't test my changes, but they seem minor enough to not be a problem, hopefully?