### PR TITLE
Remove `EventLoopExtIOS::idiom` and `ios::Idiom`

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -154,7 +154,6 @@ If your PR makes notable changes to Winit's features, please update this section
 * Home indicator visibility
 * Status bar visibility and style
 * Deferring system gestures
-* Getting the device idiom
 * Getting the preferred video mode
 
 ### Web

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -59,3 +59,7 @@ changelog entry.
 - Remove `EventLoopExtRunOnDemand::run_on_demand`.
 - Remove `EventLoopExtPumpEvents::pump_events`.
 - Remove `Event`.
+- On iOS, remove `platform::ios::EventLoopExtIOS` and related `platform::ios::Idiom` type.
+
+  This feature was incomplete, and the equivalent functionality can be trivially achieved outside
+  of `winit` using `objc2-ui-kit` and calling `UIDevice::currentDevice().userInterfaceIdiom()`.

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -66,21 +66,8 @@
 
 use std::os::raw::c_void;
 
-use crate::event_loop::EventLoop;
 use crate::monitor::{MonitorHandle, VideoModeHandle};
 use crate::window::{Window, WindowAttributes};
-
-/// Additional methods on [`EventLoop`] that are specific to iOS.
-pub trait EventLoopExtIOS {
-    /// Returns the [`Idiom`] (phone/tablet/tv/etc) for the current device.
-    fn idiom(&self) -> Idiom;
-}
-
-impl EventLoopExtIOS for EventLoop {
-    fn idiom(&self) -> Idiom {
-        self.event_loop.idiom()
-    }
-}
 
 /// Additional methods on [`Window`] that are specific to iOS.
 pub trait WindowExtIOS {
@@ -377,24 +364,6 @@ pub enum ValidOrientations {
 
     /// Excludes `PortraitUpsideDown` on iphone
     Portrait,
-}
-
-/// The device [idiom].
-///
-/// [idiom]: https://developer.apple.com/documentation/uikit/uidevice/1620037-userinterfaceidiom?language=objc
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum Idiom {
-    Unspecified,
-
-    /// iPhone and iPod touch.
-    Phone,
-
-    /// iPad.
-    Pad,
-
-    /// tvOS and Apple TV.
-    TV,
-    CarPlay,
 }
 
 bitflags::bitflags! {

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -15,14 +15,13 @@ use core_foundation::runloop::{
 use objc2::rc::Retained;
 use objc2::{msg_send_id, ClassType};
 use objc2_foundation::{MainThreadMarker, NSString};
-use objc2_ui_kit::{UIApplication, UIApplicationMain, UIDevice, UIScreen, UIUserInterfaceIdiom};
+use objc2_ui_kit::{UIApplication, UIApplicationMain, UIScreen};
 
 use super::app_state::EventLoopHandler;
 use crate::application::ApplicationHandler;
 use crate::error::EventLoopError;
 use crate::event::Event;
 use crate::event_loop::{ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents};
-use crate::platform::ios::Idiom;
 use crate::window::{CustomCursor, CustomCursorSource};
 
 use super::app_delegate::AppDelegate;
@@ -219,20 +218,6 @@ impl EventLoop {
 
     pub fn window_target(&self) -> &RootActiveEventLoop {
         &self.window_target
-    }
-}
-
-// EventLoopExtIOS
-impl EventLoop {
-    pub fn idiom(&self) -> Idiom {
-        match UIDevice::currentDevice(self.mtm).userInterfaceIdiom() {
-            UIUserInterfaceIdiom::Unspecified => Idiom::Unspecified,
-            UIUserInterfaceIdiom::Phone => Idiom::Phone,
-            UIUserInterfaceIdiom::Pad => Idiom::Pad,
-            UIUserInterfaceIdiom::TV => Idiom::TV,
-            UIUserInterfaceIdiom::CarPlay => Idiom::CarPlay,
-            _ => Idiom::Unspecified,
-        }
     }
 }
 


### PR DESCRIPTION
Introduced in #871 with unclear motivation.

@mtak- could you provide context for why Winit has this? Is it just for convenience?

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
