### PR TITLE
Stop using `&mut` in Objective-C delegate methods

### DIFF
--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -70,6 +70,10 @@ impl From<UIUserInterfaceIdiom> for Idiom {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UIRectEdge(NSUInteger);
 
+impl UIRectEdge {
+    pub(crate) const NONE: Self = Self(0);
+}
+
 unsafe impl Encode for UIRectEdge {
     const ENCODING: Encoding = NSUInteger::ENCODING;
 }

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -23,7 +23,6 @@ use crate::{
     platform_impl::platform::{
         app_state,
         event_loop::{EventProxy, EventWrapper},
-        ffi::UIRectEdge,
         monitor, EventLoopWindowTarget, Fullscreen, MonitorHandle,
     },
     window::{
@@ -538,17 +537,16 @@ impl Inner {
 
     pub fn set_prefers_home_indicator_hidden(&self, hidden: bool) {
         self.view_controller
-            .setPrefersHomeIndicatorAutoHidden(hidden);
+            .set_prefers_home_indicator_auto_hidden(hidden);
     }
 
     pub fn set_preferred_screen_edges_deferring_system_gestures(&self, edges: ScreenEdge) {
-        let edges: UIRectEdge = edges.into();
         self.view_controller
-            .setPreferredScreenEdgesDeferringSystemGestures(edges);
+            .set_preferred_screen_edges_deferring_system_gestures(edges.into());
     }
 
     pub fn set_prefers_status_bar_hidden(&self, hidden: bool) {
-        self.view_controller.setPrefersStatusBarHidden(hidden);
+        self.view_controller.set_prefers_status_bar_hidden(hidden);
     }
 }
 

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -1,3 +1,5 @@
+use std::ptr::NonNull;
+
 use objc2::foundation::NSObject;
 use objc2::rc::{Id, Shared};
 use objc2::runtime::Object;
@@ -21,18 +23,18 @@ declare_class!(
 
     unsafe impl ApplicationDelegate {
         #[sel(initWithActivationPolicy:defaultMenu:activateIgnoringOtherApps:)]
-        fn init(
+        unsafe fn init(
             &mut self,
             activation_policy: NSApplicationActivationPolicy,
             default_menu: bool,
             activate_ignoring_other_apps: bool,
-        ) -> Option<&mut Self> {
+        ) -> Option<NonNull<Self>> {
             let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
             this.map(|this| {
                 *this.activation_policy = activation_policy;
                 *this.default_menu = default_menu;
                 *this.activate_ignoring_other_apps = activate_ignoring_other_apps;
-                this
+                NonNull::from(this)
             })
         }
 

--- a/src/platform_impl/macos/appkit/responder.rs
+++ b/src/platform_impl/macos/appkit/responder.rs
@@ -17,8 +17,7 @@ extern_class!(
 
 extern_methods!(
     unsafe impl NSResponder {
-        // TODO: Allow "immutably" on main thread
         #[sel(interpretKeyEvents:)]
-        pub unsafe fn interpretKeyEvents(&mut self, events: &NSArray<NSEvent, Shared>);
+        pub unsafe fn interpretKeyEvents(&self, events: &NSArray<NSEvent, Shared>);
     }
 );

--- a/src/platform_impl/macos/appkit/view.rs
+++ b/src/platform_impl/macos/appkit/view.rs
@@ -66,7 +66,7 @@ extern_methods!(
         pub fn setWantsLayer(&self, wants_layer: bool);
 
         #[sel(setPostsFrameChangedNotifications:)]
-        pub fn setPostsFrameChangedNotifications(&mut self, value: bool);
+        pub fn setPostsFrameChangedNotifications(&self, value: bool);
 
         #[sel(removeTrackingRect:)]
         pub fn removeTrackingRect(&self, tag: NSTrackingRectTag);

--- a/src/platform_impl/macos/util/async.rs
+++ b/src/platform_impl/macos/util/async.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use dispatch::Queue;
 use objc2::foundation::{is_main_thread, CGFloat, NSPoint, NSSize, NSString};
-use objc2::rc::{autoreleasepool, Id};
+use objc2::rc::autoreleasepool;
 
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
@@ -209,8 +209,7 @@ pub(crate) fn set_ime_cursor_area_sync(
 ) {
     let window = MainThreadSafe(window);
     run_on_main(move || {
-        // TODO(madsmtm): Remove the need for this
-        unsafe { Id::from_shared(window.view()) }.set_ime_cursor_area(logical_spot, size);
+        window.view().set_ime_cursor_area(logical_spot, size);
     });
 }
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -1,12 +1,11 @@
 #![allow(clippy::unnecessary_cast)]
 
-use std::{
-    boxed::Box,
-    collections::{HashMap, VecDeque},
-    os::raw::*,
-    ptr, str,
-    sync::Mutex,
-};
+use std::boxed::Box;
+use std::collections::{HashMap, VecDeque};
+use std::os::raw::*;
+use std::ptr::{self, NonNull};
+use std::str;
+use std::sync::Mutex;
 
 use objc2::declare::{Ivar, IvarDrop};
 use objc2::foundation::{
@@ -158,11 +157,11 @@ declare_class!(
 
     unsafe impl WinitView {
         #[sel(initWithId:acceptsFirstMouse:)]
-        fn init_with_id(
+        unsafe fn init_with_id(
             &mut self,
             window: &WinitWindow,
             accepts_first_mouse: bool,
-        ) -> Option<&mut Self> {
+        ) -> Option<NonNull<Self>> {
             let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
             this.map(|this| {
                 let state = ViewState {
@@ -205,7 +204,7 @@ declare_class!(
                 }
 
                 this.state.input_source = this.current_input_source();
-                this
+                NonNull::from(this)
             })
         }
     }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1192,8 +1192,7 @@ impl WinitWindow {
 
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
-        // TODO(madsmtm): Remove the need for this
-        unsafe { Id::from_shared(self.view()) }.set_ime_allowed(allowed);
+        self.view().set_ime_allowed(allowed);
     }
 
     #[inline]

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -776,9 +776,7 @@ impl WinitWindow {
 
     pub fn set_cursor_icon(&self, icon: CursorIcon) {
         let view = self.view();
-        let mut cursor_state = view.state.cursor_state.lock().unwrap();
-        cursor_state.cursor = NSCursor::from_icon(icon);
-        drop(cursor_state);
+        view.set_cursor_icon(NSCursor::from_icon(icon));
         self.invalidateCursorRectsForView(&view);
     }
 
@@ -800,10 +798,8 @@ impl WinitWindow {
     #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         let view = self.view();
-        let mut cursor_state = view.state.cursor_state.lock().unwrap();
-        if visible != cursor_state.visible {
-            cursor_state.visible = visible;
-            drop(cursor_state);
+        let state_changed = view.set_cursor_visible(visible);
+        if state_changed {
             self.invalidateCursorRectsForView(&view);
         }
     }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -14,7 +14,6 @@ use super::appkit::{
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     event::{Event, WindowEvent},
-    keyboard::ModifiersState,
     platform_impl::platform::{
         app_state::AppState,
         event::{EventProxy, EventWrapper},
@@ -166,17 +165,7 @@ declare_class!(
             // NSWindowDelegate, and as a result a tracked modifiers state can quite
             // easily fall out of synchrony with reality.  This requires us to emit
             // a synthetic ModifiersChanged event when we lose focus.
-
-            // TODO(madsmtm): Remove the need for this unsafety
-            let mut view = unsafe { Id::from_shared(self.window.view()) };
-
-            // Both update the state and emit a ModifiersChanged event.
-            if !view.state.modifiers.state().is_empty() {
-                view.state.modifiers = ModifiersState::empty().into();
-                self.queue_event(WindowEvent::ModifiersChanged(
-                    ModifiersState::empty().into(),
-                ));
-            }
+            self.window.view().reset_modifiers();
 
             self.queue_event(WindowEvent::Focused(false));
         }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unnecessary_cast)]
 
-use std::ptr;
+use std::ptr::{self, NonNull};
 
 use objc2::declare::{Ivar, IvarDrop};
 use objc2::foundation::{NSArray, NSObject, NSSize, NSString};
@@ -51,12 +51,12 @@ declare_class!(
 
     unsafe impl WinitWindowDelegate {
         #[sel(initWithWindow:initialFullscreen:)]
-        fn init_with_winit(
+        unsafe fn init_with_winit(
             &mut self,
             window: &WinitWindow,
             initial_fullscreen: bool,
-        ) -> Option<&mut Self> {
-            let this: Option<&mut Self> = unsafe { msg_send![self, init] };
+        ) -> Option<NonNull<Self>> {
+            let this: Option<&mut Self> = unsafe { msg_send![super(self), init] };
             this.map(|this| {
                 let scale_factor = window.scale_factor();
 
@@ -85,7 +85,7 @@ declare_class!(
                     ]
                 };
 
-                this
+                NonNull::from(this)
             })
         }
     }


### PR DESCRIPTION
This is and has always been clear UB, and if Rust happened to optimize external function calls better using this assumption, a lot of stuff in `winit` would be broken.
Instead, we must use interior mutability.

Required to do https://github.com/rust-windowing/winit/issues/2724, since not using interior mutability is a compilation error in `objc2 v0.4`.

- [x] Tested on all platforms changed
  - [x] MacOS
  - [x] IOS (simulator, I don't have my device readily available)
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
