### PR TITLE
Improve detection of key repeats on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On X11, fix false positive flagging of key repeats when pressing different keys with no release
+  between presses.
 - Implement `PartialOrd` and `Ord` for `KeyCode` and `NativeKeyCode`.
 
 # 0.29.0-beta.0

--- a/src/platform_impl/linux/common/xkb_state.rs
+++ b/src/platform_impl/linux/common/xkb_state.rs
@@ -354,7 +354,6 @@ impl KbdState {
         self.post_init(state, keymap);
     }
 
-    #[cfg(feature = "wayland")]
     pub fn key_repeats(&mut self, keycode: ffi::xkb_keycode_t) -> bool {
         unsafe { (XKBH.xkb_keymap_key_repeats)(self.xkb_keymap, keycode) == 1 }
     }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -289,10 +289,10 @@ impl<T: 'static> EventLoop<T> {
             xkbext,
             kb_state,
             num_touch: 0,
+            held_key_press: None,
             first_touch: None,
             active_window: None,
             is_composing: false,
-            got_key_release: true,
         };
 
         // Register for device hotplug events


### PR DESCRIPTION
Instead of a single `bool` indicating that a key press has occurred and no key has been released since then, we store the scancode of the last pressed key (if it is a key that repeats when held). This fixes a bug where pressing a new key while one is already held down will be flagged as a repeat even though it is obviously not a repeat.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


Thanks to @kchibisov for guidance :heart: 