### PR TITLE
Port to use raw-window-handle v0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On macOS, add tabbing APIs on `WindowExtMacOS` and `EventLoopWindowTargetExtMacOS`.
 - **Breaking:** Rename `Window::set_inner_size` to `Window::request_inner_size` and indicate if the size was applied immediately.
 - On X11, fix false positive flagging of key repeats when pressing different keys with no release between presses.
+- Port types to use `raw-window-handle` v0.6. `raw-window-handle` v0.5 is still supported.
 - Implement `PartialOrd` and `Ord` for `KeyCode` and `NativeKeyCode`.
 - On Web, implement `WindowEvent::Occluded`.
 - On Web, fix touch location to be as accurate as mouse position.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,8 @@ cursor-icon = "1.0.0"
 log = "0.4"
 mint = { version = "0.5.6", optional = true }
 once_cell = "1.12"
-raw_window_handle = { package = "raw-window-handle", version = "0.5", features = ["std"] }
+raw_window_handle = { package = "raw-window-handle", git = "https://github.com/rust-windowing/raw-window-handle.git", features = ["std"] }
+raw_window_handle_05 = { package = "raw-window-handle", version = "0.5" }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 smol_str = "0.2.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ image = { version = "0.24.0", default-features = false, features = ["png"] }
 simple_logger = { version = "2.1.0", default_features = false }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dev-dependencies]
-softbuffer = "0.3.0"
+softbuffer = { git = "https://github.com/rust-windowing/softbuffer.git", branch = "notgull/rwh-v0.6" }
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ cursor-icon = "1.0.0"
 log = "0.4"
 mint = { version = "0.5.6", optional = true }
 once_cell = "1.12"
-raw_window_handle = { package = "raw-window-handle", git = "https://github.com/rust-windowing/raw-window-handle.git", features = ["std"] }
+raw_window_handle = { package = "raw-window-handle", version = "0.6", features = ["std"] }
 raw_window_handle_05 = { package = "raw-window-handle", version = "0.5" }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 smol_str = "0.2.0"
@@ -65,7 +65,7 @@ image = { version = "0.24.0", default-features = false, features = ["png"] }
 simple_logger = { version = "2.1.0", default_features = false }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dev-dependencies]
-softbuffer = { git = "https://github.com/rust-windowing/softbuffer.git", branch = "notgull/rwh-v0.6" }
+softbuffer = "0.3.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 # Coordinate the next winit release with android-ndk-rs: https://github.com/rust-windowing/winit/issues/1995
@@ -207,3 +207,7 @@ web-sys = { version = "0.3.22", features = ['CanvasRenderingContext2d'] }
 members = [
     "run-wasm",
 ]
+
+[patch.crates-io]
+softbuffer = { git = "https://github.com/rust-windowing/softbuffer.git", branch = "notgull/rwh-v0.6" }
+raw_window_handle = { package = "raw-window-handle", git = "https://github.com/rust-windowing/raw-window-handle.git", branch = "notgull/next" }

--- a/deny.toml
+++ b/deny.toml
@@ -40,6 +40,7 @@ skip = [
     { name = "num_enum"},       # See above ^, waiting for release
     { name = "num_enum_derive"},# See above ^, waiting for release
     { name = "miniz_oxide"},    # https://github.com/rust-lang/flate2-rs/issues/340
+    { name = "raw-window-handle" }, # https://github.com/rust-windowing/raw-window-handle/issues/125, slow transition
     { name = "redox_syscall" }, # https://gitlab.redox-os.org/redox-os/orbclient/-/issues/46
 ]
 skip-tree = []

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), impl std::error::Error> {
         event_loop: &EventLoopWindowTarget<()>,
         windows: &mut HashMap<WindowId, Window>,
     ) {
-        let parent = parent.raw_window_handle();
+        let parent = parent.raw_window_handle().unwrap();
         let mut builder = WindowBuilder::new()
             .with_title("child window")
             .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -5,6 +5,7 @@ mod fill;
 #[cfg(any(x11_platform, macos_platform, windows_platform))]
 fn main() -> Result<(), impl std::error::Error> {
     use std::collections::HashMap;
+    use std::rc::Rc;
 
     use raw_window_handle::HasRawWindowHandle;
     use winit::{
@@ -17,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     fn spawn_child_window(
         parent: &Window,
         event_loop: &EventLoopWindowTarget<()>,
-        windows: &mut HashMap<WindowId, Window>,
+        windows: &mut HashMap<WindowId, Rc<Window>>,
     ) {
         let parent = parent.raw_window_handle().unwrap();
         let mut builder = WindowBuilder::new()
@@ -27,7 +28,7 @@ fn main() -> Result<(), impl std::error::Error> {
             .with_visible(true);
         // `with_parent_window` is unsafe. Parent window must be a valid window.
         builder = unsafe { builder.with_parent_window(Some(parent)) };
-        let child_window = builder.build(event_loop).unwrap();
+        let child_window = Rc::new(builder.build(event_loop).unwrap());
 
         let id = child_window.id();
         windows.insert(id, child_window);
@@ -37,12 +38,14 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut windows = HashMap::new();
 
     let event_loop: EventLoop<()> = EventLoop::new();
-    let parent_window = WindowBuilder::new()
-        .with_title("parent window")
-        .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
-        .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))
-        .build(&event_loop)
-        .unwrap();
+    let parent_window = Rc::new(
+        WindowBuilder::new()
+            .with_title("parent window")
+            .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+            .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     println!("parent window: {parent_window:?})");
 

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::single_match)]
 
+use std::rc::Rc;
 use std::thread;
 #[cfg(not(wasm_platform))]
 use std::time;
@@ -37,10 +38,14 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Press 'Esc' to close the window.");
 
     let event_loop = EventLoop::new();
-    let window = WindowBuilder::new()
-        .with_title("Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title(
+                "Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.",
+            )
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let mut mode = Mode::Wait;
     let mut request_redraw = false;

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
@@ -14,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
     window.set_title("A fantastic window!");
 
     let mut cursor_idx = 0;

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{DeviceEvent, ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
@@ -15,10 +16,12 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("Super Cursor Grab'n'Hide Simulator 9000")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("Super Cursor Grab'n'Hide Simulator 9000")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let mut modifiers = ModifiersState::default();
 

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -3,6 +3,7 @@
 #[cfg(not(wasm_platform))]
 fn main() -> Result<(), impl std::error::Error> {
     use simple_logger::SimpleLogger;
+    use std::rc::Rc;
     use winit::{
         event::{Event, WindowEvent},
         event_loop::EventLoopBuilder,
@@ -20,10 +21,12 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoopBuilder::<CustomEvent>::with_user_event().build();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     // `EventLoopProxy` allows you to dispatch custom events to the main Winit event
     // loop from any thread.

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{ElementState, Event, KeyEvent, MouseButton, StartCause, WindowEvent},
     event_loop::EventLoop,
@@ -15,8 +16,8 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window_1 = WindowBuilder::new().build(&event_loop).unwrap();
-    let window_2 = WindowBuilder::new().build(&event_loop).unwrap();
+    let window_1 = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
+    let window_2 = Rc::new(WindowBuilder::new().build(&event_loop).unwrap());
 
     let mut switched = false;
     let mut entered_id = window_2.id();

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::dpi::PhysicalSize;
 use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
 use winit::event_loop::EventLoop;
@@ -22,10 +23,12 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut with_min_size = false;
     let mut with_max_size = false;
 
-    let window = WindowBuilder::new()
-        .with_title("Hello world!")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("Hello world!")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let mut monitor_index = 0;
     let mut monitor = event_loop

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
@@ -15,10 +16,12 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("Your faithful window")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("Your faithful window")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let mut close_requested = false;
 

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -2,6 +2,7 @@
 
 use log::LevelFilter;
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{ElementState, Event, Ime, WindowEvent},
@@ -26,10 +27,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_inner_size(winit::dpi::LogicalSize::new(256f64, 128f64))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_inner_size(winit::dpi::LogicalSize::new(256f64, 128f64))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let mut ime_purpose = ImePurpose::Normal;
     let mut ime_allowed = true;

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -18,16 +18,20 @@ fn main() {
 
 #[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 fn main() -> Result<(), impl std::error::Error> {
+    use std::rc::Rc;
+
     #[path = "util/fill.rs"]
     mod fill;
 
     simple_logger::SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_inner_size(LogicalSize::new(400.0, 200.0))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_inner_size(LogicalSize::new(400.0, 200.0))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let mut modifiers = ModifiersState::default();
 

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -14,10 +15,12 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("Mouse Wheel events")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("Mouse Wheel events")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     println!(
         r"

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -2,7 +2,12 @@
 
 #[cfg(not(wasm_platform))]
 fn main() -> Result<(), impl std::error::Error> {
-    use std::{collections::HashMap, sync::mpsc, thread, time::Duration};
+    use std::{
+        collections::HashMap,
+        sync::{mpsc, Arc},
+        thread,
+        time::Duration,
+    };
 
     use simple_logger::SimpleLogger;
     use winit::{
@@ -20,10 +25,12 @@ fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new();
     let mut window_senders = HashMap::with_capacity(WINDOW_COUNT);
     for _ in 0..WINDOW_COUNT {
-        let window = WindowBuilder::new()
-            .with_inner_size(WINDOW_SIZE)
-            .build(&event_loop)
-            .unwrap();
+        let window = Arc::new(
+            WindowBuilder::new()
+                .with_inner_size(WINDOW_SIZE)
+                .build(&event_loop)
+                .unwrap(),
+        );
 
         let mut video_modes: Vec<_> = window.current_monitor().unwrap().video_modes().collect();
         let mut video_mode_id = 0usize;

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use simple_logger::SimpleLogger;
 use winit::{
@@ -19,7 +20,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut windows = HashMap::new();
     for _ in 0..3 {
-        let window = Window::new(&event_loop).unwrap();
+        let window = Rc::new(Window::new(&event_loop).unwrap());
         println!("Opened a new window: {:?}", window.id());
         windows.insert(window.id(), window);
     }
@@ -52,7 +53,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         is_synthetic: false,
                         ..
                     } if matches!(c.as_ref(), "n" | "N") => {
-                        let window = Window::new(event_loop).unwrap();
+                        let window = Rc::new(Window::new(event_loop).unwrap());
                         println!("Opened a new window: {:?}", window.id());
                         windows.insert(window.id(), window);
                     }

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{ElementState, Event, WindowEvent},
     event_loop::EventLoop,
@@ -14,10 +15,12 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     event_loop.run(move |event, _, control_flow| {
         println!("{event:?}");

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -18,14 +19,16 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut resizable = false;
 
-    let window = WindowBuilder::new()
-        .with_title("Hit space to toggle resizability.")
-        .with_inner_size(LogicalSize::new(600.0, 300.0))
-        .with_min_inner_size(LogicalSize::new(400.0, 200.0))
-        .with_max_inner_size(LogicalSize::new(800.0, 400.0))
-        .with_resizable(resizable)
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("Hit space to toggle resizability.")
+            .with_inner_size(LogicalSize::new(600.0, 300.0))
+            .with_min_inner_size(LogicalSize::new(400.0, 200.0))
+            .with_max_inner_size(LogicalSize::new(800.0, 400.0))
+            .with_resizable(resizable)
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -15,11 +16,13 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .with_theme(Some(Theme::Dark))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .with_theme(Some(Theme::Dark))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     println!("Initial theme: {:?}", window.theme());
     println!("debugging keys:");

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::single_match)]
 
+use std::rc::Rc;
 use std::time::Duration;
+
 #[cfg(not(wasm_platform))]
 use std::time::Instant;
 #[cfg(wasm_platform)]
@@ -20,10 +22,12 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let timer_length = Duration::new(1, 0);
 

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -1,4 +1,5 @@
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -12,10 +13,12 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("Touchpad gestures")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("Touchpad gestures")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     println!("Only supported on macOS at the moment.");
 

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -14,11 +15,13 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_decorations(false)
-        .with_transparent(true)
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_decorations(false)
+            .with_transparent(true)
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     window.set_title("A fantastic window!");
 

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -116,4 +116,5 @@ mod fill {
     }
 }
 
+#[allow(dead_code, unused_imports)]
 pub(super) use fill::{discard_window, fill_window};

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -22,7 +22,6 @@ pub(super) fn fill_window(window: &(impl FullHandleTy + Clone)) {
     use softbuffer::{Context, Surface};
     use std::cell::RefCell;
     use std::collections::HashMap;
-    use std::mem::ManuallyDrop;
     use std::num::NonZeroU32;
     use std::rc::Rc;
     use winit::window::WindowId;
@@ -59,12 +58,8 @@ pub(super) fn fill_window(window: &(impl FullHandleTy + Clone)) {
     }
 
     thread_local! {
-        // NOTE: You should never do things like that, create context and drop it before
-        // you drop the event loop. We do this for brevity to not blow up examples. We use
-        // ManuallyDrop to prevent destructors from running.
-        //
         // A static, thread-local map of graphics contexts to open windows.
-        static GC: ManuallyDrop<RefCell<Option<GraphicsContext>>> = ManuallyDrop::new(RefCell::new(None));
+        static GC: RefCell<Option<GraphicsContext>> = RefCell::new(None);
     }
 
     GC.with(|gc| {

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::disallowed_methods, clippy::single_match)]
 
+use std::rc::Rc;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
@@ -10,13 +11,15 @@ use winit::{
 pub fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new();
 
-    let builder = WindowBuilder::new().with_title("A fantastic window!");
-    #[cfg(wasm_platform)]
-    let builder = {
-        use winit::platform::web::WindowBuilderExtWebSys;
-        builder.with_append(true)
-    };
-    let window = builder.build(&event_loop).unwrap();
+    let window = Rc::new({
+        let builder = WindowBuilder::new().with_title("A fantastic window!");
+        #[cfg(wasm_platform)]
+        let builder = {
+            use winit::platform::web::WindowBuilderExtWebSys;
+            builder.with_append(true)
+        };
+        builder.build(&event_loop).unwrap()
+    });
 
     #[cfg(wasm_platform)]
     let log_list = wasm::insert_canvas_and_create_log_list(&window);

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -6,6 +6,7 @@ pub fn main() {
 
 #[cfg(wasm_platform)]
 mod wasm {
+    use std::rc::Rc;
     use wasm_bindgen::prelude::*;
     use wasm_bindgen::JsCast;
     use web_sys::HtmlCanvasElement;
@@ -33,14 +34,16 @@ This example demonstrates the desired future functionality which will possibly b
         console_log::init_with_level(log::Level::Debug).expect("error initializing logger");
         let event_loop = EventLoop::new();
 
-        let window = WindowBuilder::new()
-            .with_title("A fantastic window!")
-            // When running in a non-wasm environment this would set the window size to 100x100.
-            // However in this example it just sets a default initial size of 100x100 that is immediately overwritten due to the layout + styling of the page.
-            .with_inner_size(PhysicalSize::new(100, 100))
-            .with_append(true)
-            .build(&event_loop)
-            .unwrap();
+        let window = Rc::new(
+            WindowBuilder::new()
+                .with_title("A fantastic window!")
+                // When running in a non-wasm environment this would set the window size to 100x100.
+                // However in this example it just sets a default initial size of 100x100 that is immediately overwritten due to the layout + styling of the page.
+                .with_inner_size(PhysicalSize::new(100, 100))
+                .with_append(true)
+                .build(&event_loop)
+                .unwrap(),
+        );
 
         let canvas = create_canvas(&window);
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -14,11 +15,13 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -3,6 +3,7 @@
 // This example is used by developers to test various window functions.
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -18,11 +19,13 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .with_inner_size(LogicalSize::new(300.0, 300.0))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .with_inner_size(LogicalSize::new(300.0, 300.0))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     eprintln!("Window Button keys:");
     eprintln!("  (F) Toggle close button");

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -3,6 +3,7 @@
 // This example is used by developers to test various window functions.
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     dpi::{LogicalSize, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, KeyEvent, RawKeyEvent, WindowEvent},
@@ -18,11 +19,13 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .with_inner_size(LogicalSize::new(100.0, 100.0))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .with_inner_size(LogicalSize::new(100.0, 100.0))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     eprintln!("debugging keys:");
     eprintln!("  (E) Enter exclusive fullscreen");

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -1,6 +1,7 @@
 //! Demonstrates capability to create in-app draggable regions for client-side decoration support.
 
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     event::{ElementState, Event, KeyEvent, MouseButton, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -17,12 +18,14 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_inner_size(winit::dpi::LogicalSize::new(600.0, 400.0))
-        .with_min_inner_size(winit::dpi::LogicalSize::new(400.0, 200.0))
-        .with_decorations(false)
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_inner_size(winit::dpi::LogicalSize::new(600.0, 400.0))
+            .with_min_inner_size(winit::dpi::LogicalSize::new(400.0, 200.0))
+            .with_decorations(false)
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let mut border = false;
     let mut cursor_location = None;

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::single_match)]
 
 use std::path::Path;
+use std::rc::Rc;
 
 use simple_logger::SimpleLogger;
 use winit::{
@@ -25,13 +26,15 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("An iconic window!")
-        // At present, this only does anything on Windows and X11, so if you want to save load
-        // time, you can put icon loading behind a function that returns `None` on other platforms.
-        .with_window_icon(Some(icon))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("An iconic window!")
+            // At present, this only does anything on Windows and X11, so if you want to save load
+            // time, you can put icon loading behind a function that returns `None` on other platforms.
+            .with_window_icon(Some(icon))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();

--- a/examples/window_ondemand.rs
+++ b/examples/window_ondemand.rs
@@ -3,7 +3,7 @@
 // Limit this example to only compatible platforms.
 #[cfg(any(windows_platform, macos_platform, x11_platform, wayland_platform,))]
 fn main() -> Result<(), impl std::error::Error> {
-    use std::time::Duration;
+    use std::{rc::Rc, time::Duration};
 
     use simple_logger::SimpleLogger;
 
@@ -21,7 +21,7 @@ fn main() -> Result<(), impl std::error::Error> {
     #[derive(Default)]
     struct App {
         window_id: Option<WindowId>,
-        window: Option<Window>,
+        window: Option<Rc<Window>>,
     }
 
     SimpleLogger::new().init().unwrap();
@@ -56,8 +56,9 @@ fn main() -> Result<(), impl std::error::Error> {
                         window_id,
                     } if id == window_id => {
                         println!("--------------------------------------------------------- Window {idx} Destroyed");
-                        app.window_id = None;
+                        let wid = app.window_id.take().unwrap();
                         control_flow.set_exit();
+                        fill::discard_window(&wid);
                     }
                     _ => (),
                 }
@@ -68,7 +69,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         .build(event_loop)
                         .unwrap();
                 app.window_id = Some(window.id());
-                app.window = Some(window);
+                app.window = Some(Rc::new(window));
             }
         })
     }

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::single_match)]
 
 #[cfg(target_os = "macos")]
+use std::rc::Rc;
+
+#[cfg(target_os = "macos")]
 use winit::platform::macos::{OptionAsAlt, WindowExtMacOS};
 
 #[cfg(target_os = "macos")]
@@ -21,11 +24,13 @@ mod fill;
 fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     window.set_ime_allowed(true);
 

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -10,7 +10,7 @@
 ))]
 
 fn main() -> std::process::ExitCode {
-    use std::{process::ExitCode, thread::sleep, time::Duration, rc::Rc};
+    use std::{process::ExitCode, rc::Rc, thread::sleep, time::Duration};
 
     use simple_logger::SimpleLogger;
     use winit::{

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -8,8 +8,9 @@
     wayland_platform,
     android_platform,
 ))]
+
 fn main() -> std::process::ExitCode {
-    use std::{process::ExitCode, thread::sleep, time::Duration};
+    use std::{process::ExitCode, thread::sleep, time::Duration, rc::Rc};
 
     use simple_logger::SimpleLogger;
     use winit::{
@@ -25,10 +26,12 @@ fn main() -> std::process::ExitCode {
     let mut event_loop = EventLoop::new();
 
     SimpleLogger::new().init().unwrap();
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     'main: loop {
         let timeout = Some(Duration::ZERO);

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -1,5 +1,6 @@
 use log::debug;
 use simple_logger::SimpleLogger;
+use std::rc::Rc;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyEvent, WindowEvent},
@@ -15,12 +16,14 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .with_inner_size(LogicalSize::new(128.0, 128.0))
-        .with_resize_increments(LogicalSize::new(25.0, 25.0))
-        .build(&event_loop)
-        .unwrap();
+    let window = Rc::new(
+        WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .with_inner_size(LogicalSize::new(128.0, 128.0))
+            .with_resize_increments(LogicalSize::new(25.0, 25.0))
+            .build(&event_loop)
+            .unwrap(),
+    );
 
     let mut has_increments = true;
 

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::single_match)]
 
 #[cfg(target_os = "macos")]
-use std::{collections::HashMap, num::NonZeroUsize};
+use std::{collections::HashMap, num::NonZeroUsize, rc::Rc};
 
 #[cfg(target_os = "macos")]
 use simple_logger::SimpleLogger;
@@ -24,7 +24,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new();
 
     let mut windows = HashMap::new();
-    let window = Window::new(&event_loop).unwrap();
+    let window = Rc::new(Window::new(&event_loop).unwrap());
     println!("Opened a new window: {:?}", window.id());
     windows.insert(window.id(), window);
 
@@ -63,10 +63,12 @@ fn main() -> Result<(), impl std::error::Error> {
                     } => match logical_key.as_ref() {
                         Key::Character("t") => {
                             let tabbing_id = windows.get(&window_id).unwrap().tabbing_identifier();
-                            let window = WindowBuilder::new()
-                                .with_tabbing_identifier(&tabbing_id)
-                                .build(event_loop)
-                                .unwrap();
+                            let window = Rc::new(
+                                WindowBuilder::new()
+                                    .with_tabbing_identifier(&tabbing_id)
+                                    .build(event_loop)
+                                    .unwrap(),
+                            );
                             println!("Added a new tab: {:?}", window.id());
                             windows.insert(window.id(), window);
                         }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -350,7 +350,7 @@ unsafe impl<T> raw_window_handle_05::HasRawDisplayHandle for EventLoop<T> {
 
         match result {
             Ok(handle) => cvt_rdh_06_to_05(handle),
-            Err(e) => panic!("Failed to get raw display handle: {:?}", e),
+            Err(e) => panic!("failed to get raw display handle: {:?}", e),
         }
     }
 }
@@ -435,7 +435,7 @@ unsafe impl<T> raw_window_handle_05::HasRawDisplayHandle for EventLoopWindowTarg
 
         match result {
             Ok(handle) => cvt_rdh_06_to_05(handle),
-            Err(e) => panic!("Failed to get raw display handle: {:?}", e),
+            Err(e) => panic!("failed to get raw display handle: {:?}", e),
         }
     }
 }
@@ -476,7 +476,7 @@ unsafe impl raw_window_handle_05::HasRawDisplayHandle for OwnedDisplayHandle {
 
         match result {
             Ok(handle) => cvt_rdh_06_to_05(handle),
-            Err(e) => panic!("Failed to get raw display handle: {:?}", e),
+            Err(e) => panic!("failed to get raw display handle: {:?}", e),
         }
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{error, fmt};
 
-use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
+use raw_window_handle::{HandleError, HasRawDisplayHandle, RawDisplayHandle};
 #[cfg(not(wasm_platform))]
 use std::time::{Duration, Instant};
 #[cfg(wasm_platform)]
@@ -329,8 +329,8 @@ impl<T> EventLoop<T> {
 
 unsafe impl<T> HasRawDisplayHandle for EventLoop<T> {
     /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
-    fn raw_display_handle(&self) -> RawDisplayHandle {
-        self.event_loop.window_target().p.raw_display_handle()
+    fn raw_display_handle(&self) -> Result<RawDisplayHandle, HandleError> {
+        Ok(self.event_loop.window_target().p.raw_display_handle())
     }
 }
 
@@ -385,8 +385,8 @@ impl<T> EventLoopWindowTarget<T> {
 
 unsafe impl<T> HasRawDisplayHandle for EventLoopWindowTarget<T> {
     /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
-    fn raw_display_handle(&self) -> RawDisplayHandle {
-        self.p.raw_display_handle()
+    fn raw_display_handle(&self) -> Result<RawDisplayHandle, HandleError> {
+        Ok(self.p.raw_display_handle())
     }
 }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -411,6 +411,14 @@ unsafe impl<T> HasRawDisplayHandle for EventLoopWindowTarget<T> {
     }
 }
 
+impl<T> HasDisplayHandle for EventLoopWindowTarget<T> {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        // SAFETY: The returned display handle is always valid for this lifetime.
+        self.raw_display_handle()
+            .map(|handle| unsafe { DisplayHandle::borrow_raw(handle) })
+    }
+}
+
 unsafe impl<T> raw_window_handle_05::HasRawDisplayHandle for EventLoopWindowTarget<T> {
     fn raw_display_handle(&self) -> raw_window_handle_05::RawDisplayHandle {
         let result = HasRawDisplayHandle::raw_display_handle(self);

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -12,7 +12,9 @@ use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{error, fmt};
 
-use raw_window_handle::{HandleError, HasRawDisplayHandle, RawDisplayHandle};
+use raw_window_handle::{
+    DisplayHandle, HandleError, HasDisplayHandle, HasRawDisplayHandle, RawDisplayHandle,
+};
 #[cfg(not(wasm_platform))]
 use std::time::{Duration, Instant};
 #[cfg(wasm_platform)]
@@ -331,6 +333,14 @@ unsafe impl<T> HasRawDisplayHandle for EventLoop<T> {
     /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
     fn raw_display_handle(&self) -> Result<RawDisplayHandle, HandleError> {
         Ok(self.event_loop.window_target().p.raw_display_handle())
+    }
+}
+
+impl<T> HasDisplayHandle for EventLoop<T> {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        // SAFETY: The returned display handle is always valid for this lifetime.
+        self.raw_display_handle()
+            .map(|handle| unsafe { DisplayHandle::borrow_raw(handle) })
     }
 }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -729,6 +729,19 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::Android(AndroidDisplayHandle::empty())
     }
+
+    pub fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        OwnedDisplayHandle
+    }
+}
+
+#[derive(Clone)]
+pub struct OwnedDisplayHandle;
+
+impl OwnedDisplayHandle {
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::Android(AndroidDisplayHandle::empty())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -65,10 +65,23 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::UiKit(UiKitDisplayHandle::empty())
     }
+
+    pub fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        OwnedDisplayHandle
+    }
 }
 
 pub struct EventLoop<T: 'static> {
     window_target: RootEventLoopWindowTarget<T>,
+}
+
+#[derive(Clone)]
+pub struct OwnedDisplayHandle;
+
+impl OwnedDisplayHandle {
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::UiKit(UiKitDisplayHandle::empty())
+    }
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -81,7 +81,8 @@ use std::fmt;
 
 pub(crate) use self::{
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        EventLoop, EventLoopProxy, EventLoopWindowTarget, OwnedDisplayHandle,
+        PlatformSpecificEventLoopAttributes,
     },
     monitor::{MonitorHandle, VideoMode},
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -10,7 +10,9 @@ use icrate::Foundation::{CGFloat, CGPoint, CGRect, CGSize, MainThreadMarker};
 use objc2::rc::Id;
 use objc2::runtime::Object;
 use objc2::{class, msg_send};
-use raw_window_handle::{RawDisplayHandle, RawWindowHandle, UiKitDisplayHandle, UiKitWindowHandle};
+use raw_window_handle::{
+    HandleError, RawDisplayHandle, RawWindowHandle, UiKitDisplayHandle, UiKitWindowHandle,
+};
 
 use super::uikit::{UIApplication, UIScreen, UIScreenOverscanCompensation};
 use super::view::{WinitUIWindow, WinitView, WinitViewController};
@@ -337,12 +339,12 @@ impl Inner {
         self.window.id()
     }
 
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
+    pub fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
         let mut window_handle = UiKitWindowHandle::empty();
         window_handle.ui_window = Id::as_ptr(&self.window) as _;
         window_handle.ui_view = Id::as_ptr(&self.view) as _;
         window_handle.ui_view_controller = Id::as_ptr(&self.view_controller) as _;
-        RawWindowHandle::UiKit(window_handle)
+        Ok(RawWindowHandle::UiKit(window_handle))
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -17,7 +17,7 @@ use std::{
 
 #[cfg(x11_platform)]
 use once_cell::sync::Lazy;
-use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
+use raw_window_handle::{HandleError, RawDisplayHandle, RawWindowHandle};
 use smol_str::SmolStr;
 use std::time::Duration;
 
@@ -616,8 +616,8 @@ impl Window {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
-        x11_or_wayland!(match self; Window(window) => window.raw_window_handle())
+    pub fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
+        Ok(x11_or_wayland!(match self; Window(window) => window.raw_window_handle()))
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -607,6 +607,10 @@ impl<T> EventLoopWindowTarget<T> {
         display_handle.display = self.connection.display().id().as_ptr() as *mut _;
         RawDisplayHandle::Wayland(display_handle)
     }
+
+    pub fn display(&self) -> &Connection {
+        &self.connection
+    }
 }
 
 // The default routine does floor, but we need round on Wayland.

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -93,6 +93,11 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::AppKit(AppKitDisplayHandle::empty())
     }
+
+    #[inline]
+    pub fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        OwnedDisplayHandle
+    }
 }
 
 impl<T> EventLoopWindowTarget<T> {
@@ -110,6 +115,15 @@ impl<T> EventLoopWindowTarget<T> {
 
     pub(crate) fn allows_automatic_window_tabbing(&self) -> bool {
         NSWindow::allowsAutomaticWindowTabbing()
+    }
+}
+
+#[derive(Clone)]
+pub struct OwnedDisplayHandle;
+
+impl OwnedDisplayHandle {
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::AppKit(AppKitDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -24,7 +24,8 @@ use self::window_delegate::WinitWindowDelegate;
 pub(crate) use self::{
     event::KeyEventExtra,
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        EventLoop, EventLoopProxy, EventLoopWindowTarget, OwnedDisplayHandle,
+        PlatformSpecificEventLoopAttributes,
     },
     monitor::{MonitorHandle, VideoMode},
     window::{PlatformSpecificWindowBuilderAttributes, WindowId},

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -8,7 +8,7 @@ use std::ptr::NonNull;
 use std::sync::{Mutex, MutexGuard};
 
 use raw_window_handle::{
-    AppKitDisplayHandle, AppKitWindowHandle, RawDisplayHandle, RawWindowHandle,
+    AppKitDisplayHandle, AppKitWindowHandle, HandleError, RawDisplayHandle, RawWindowHandle,
 };
 
 use crate::{
@@ -1245,11 +1245,11 @@ impl WinitWindow {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
+    pub fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
         let mut window_handle = AppKitWindowHandle::empty();
         window_handle.ns_window = self.ns_window();
         window_handle.ns_view = self.ns_view();
-        RawWindowHandle::AppKit(window_handle)
+        Ok(RawWindowHandle::AppKit(window_handle))
     }
 
     #[inline]

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -754,4 +754,17 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
         RawDisplayHandle::Orbital(OrbitalDisplayHandle::empty())
     }
+
+    pub fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        OwnedDisplayHandle
+    }
+}
+
+#[derive(Clone)]
+pub struct OwnedDisplayHandle;
+
+impl OwnedDisplayHandle {
+    pub fn raw_display_handle(&self) -> RawDisplayHandle {
+        RawDisplayHandle::Orbital(OrbitalDisplayHandle::empty())
+    }
 }

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -4,7 +4,7 @@ use std::str;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 
-pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
+pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget, OwnedDisplayHandle};
 mod event_loop;
 
 pub use self::window::Window;

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use raw_window_handle::{
-    OrbitalDisplayHandle, OrbitalWindowHandle, RawDisplayHandle, RawWindowHandle,
+    HandleError, OrbitalDisplayHandle, OrbitalWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 
 use crate::{
@@ -384,10 +384,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
+    pub fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
         let mut handle = OrbitalWindowHandle::empty();
         handle.window = self.window_socket.fd as *mut _;
-        RawWindowHandle::Orbital(handle)
+        Ok(RawWindowHandle::Orbital(handle))
     }
 
     #[inline]

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -4,7 +4,7 @@ mod state;
 mod window_target;
 
 pub use self::proxy::EventLoopProxy;
-pub use self::window_target::EventLoopWindowTarget;
+pub use self::window_target::{EventLoopWindowTarget, OwnedDisplayHandle};
 
 use super::{backend, device, window};
 use crate::event::Event;

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -753,4 +753,17 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn listen_device_events(&self, allowed: DeviceEvents) {
         self.runner.listen_device_events(allowed)
     }
+
+    pub fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        OwnedDisplayHandle
+    }
+}
+
+#[derive(Clone)]
+pub struct OwnedDisplayHandle;
+
+impl OwnedDisplayHandle {
+    pub(crate) fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
+        raw_window_handle::WebDisplayHandle::empty().into()
+    }
 }

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -31,7 +31,8 @@ mod backend;
 pub use self::device::DeviceId;
 pub use self::error::OsError;
 pub(crate) use self::event_loop::{
-    EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+    EventLoop, EventLoopProxy, EventLoopWindowTarget, OwnedDisplayHandle,
+    PlatformSpecificEventLoopAttributes,
 };
 pub use self::monitor::{MonitorHandle, VideoMode};
 pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId};

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -6,7 +6,9 @@ use crate::window::{
     WindowAttributes, WindowButtons, WindowId as RootWI, WindowLevel,
 };
 
-use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
+use raw_window_handle::{
+    HandleError, RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle,
+};
 use web_sys::{Document, HtmlCanvasElement};
 
 use super::r#async::Dispatcher;
@@ -399,10 +401,10 @@ impl Window {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
+    pub fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
         let mut window_handle = WebWindowHandle::empty();
         window_handle.id = self.id.0;
-        RawWindowHandle::Web(window_handle)
+        Ok(RawWindowHandle::Web(window_handle))
     }
 
     #[inline]

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -197,6 +197,9 @@ pub struct EventLoopWindowTarget<T: 'static> {
     pub(crate) runner_shared: EventLoopRunnerShared<T>,
 }
 
+#[derive(Clone)]
+pub struct OwnedDisplayHandle;
+
 impl<T: 'static> EventLoop<T> {
     pub(crate) fn new(attributes: &mut PlatformSpecificEventLoopAttributes) -> Self {
         let thread_id = unsafe { GetCurrentThreadId() };
@@ -541,6 +544,16 @@ impl<T> EventLoopWindowTarget<T> {
 
     pub fn listen_device_events(&self, allowed: DeviceEvents) {
         raw_input::register_all_mice_and_keyboards_for_raw_input(self.thread_msg_target, allowed);
+    }
+
+    pub fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        OwnedDisplayHandle
+    }
+}
+
+impl OwnedDisplayHandle {
+    pub fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
+        raw_window_handle::WindowsDisplayHandle::empty().into()
     }
 }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -8,7 +8,8 @@ use windows_sys::Win32::{
 
 pub(crate) use self::{
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        EventLoop, EventLoopProxy, EventLoopWindowTarget, OwnedDisplayHandle,
+        PlatformSpecificEventLoopAttributes,
     },
     icon::WinIcon,
     monitor::{MonitorHandle, VideoMode},

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1,7 +1,7 @@
 #![cfg(windows_platform)]
 
 use raw_window_handle::{
-    RawDisplayHandle, RawWindowHandle, Win32WindowHandle, WindowsDisplayHandle,
+    HandleError, RawDisplayHandle, RawWindowHandle, Win32WindowHandle, WindowsDisplayHandle,
 };
 use std::{
     cell::Cell,
@@ -325,11 +325,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
+    pub fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
         let mut window_handle = Win32WindowHandle::empty();
         window_handle.hwnd = self.window.0 as *mut _;
         window_handle.hinstance = self.hinstance() as *mut _;
-        RawWindowHandle::Win32(window_handle)
+        Ok(RawWindowHandle::Win32(window_handle))
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1391,7 +1391,7 @@ unsafe impl HasRawWindowHandle for Window {
     /// [`Event::Resumed`]: crate::event::Event::Resumed
     /// [`Event::Suspended`]: crate::event::Event::Suspended
     fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
-        Ok(self.window.raw_window_handle())
+        self.window.raw_window_handle()
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -2,7 +2,8 @@
 use std::fmt;
 
 use raw_window_handle::{
-    HandleError, HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+    DisplayHandle, HandleError, HasDisplayHandle, HasRawDisplayHandle, HasRawWindowHandle,
+    HasWindowHandle, RawDisplayHandle, RawWindowHandle, WindowHandle,
 };
 
 use crate::{
@@ -1395,6 +1396,13 @@ unsafe impl HasRawWindowHandle for Window {
     }
 }
 
+impl HasWindowHandle for Window {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        self.raw_window_handle()
+            .map(|window| unsafe { WindowHandle::borrow_raw(window) })
+    }
+}
+
 unsafe impl raw_window_handle_05::HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> raw_window_handle_05::RawWindowHandle {
         let result = HasRawWindowHandle::raw_window_handle(self);
@@ -1413,6 +1421,13 @@ unsafe impl HasRawDisplayHandle for Window {
     /// [`EventLoop`]: crate::event_loop::EventLoop
     fn raw_display_handle(&self) -> Result<RawDisplayHandle, HandleError> {
         Ok(self.window.raw_display_handle())
+    }
+}
+
+impl HasDisplayHandle for Window {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        self.raw_display_handle()
+            .map(|display| unsafe { DisplayHandle::borrow_raw(display) })
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1709,6 +1709,6 @@ fn cvt_rwh_06_to_05(handle: RawWindowHandle) -> raw_window_handle_05::RawWindowH
             v5::RawWindowHandle::Xlib(handle)
         }
 
-        handle => panic!("Unsupported raw window handle type: {:?}", handle),
+        handle => panic!("unsupported raw window handle type: {:?}", handle),
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -2,7 +2,7 @@
 use std::fmt;
 
 use raw_window_handle::{
-    HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+    HandleError, HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
 };
 
 use crate::{
@@ -1373,6 +1373,7 @@ impl Window {
             .map(|inner| MonitorHandle { inner })
     }
 }
+
 unsafe impl HasRawWindowHandle for Window {
     /// Returns a [`raw_window_handle::RawWindowHandle`] for the Window
     ///
@@ -1389,8 +1390,8 @@ unsafe impl HasRawWindowHandle for Window {
     ///
     /// [`Event::Resumed`]: crate::event::Event::Resumed
     /// [`Event::Suspended`]: crate::event::Event::Suspended
-    fn raw_window_handle(&self) -> RawWindowHandle {
-        self.window.raw_window_handle()
+    fn raw_window_handle(&self) -> Result<RawWindowHandle, HandleError> {
+        Ok(self.window.raw_window_handle())
     }
 }
 
@@ -1399,8 +1400,8 @@ unsafe impl HasRawDisplayHandle for Window {
     /// created a window.
     ///
     /// [`EventLoop`]: crate::event_loop::EventLoop
-    fn raw_display_handle(&self) -> RawDisplayHandle {
-        self.window.raw_display_handle()
+    fn raw_display_handle(&self) -> Result<RawDisplayHandle, HandleError> {
+        Ok(self.window.raw_display_handle())
     }
 }
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

cc rust-windowing/raw-window-handle#125

Testing out the new release before it becomes official.

Tests will fail until I also port `softbuffer` to the new version.