### PR TITLE
On Web, fix touch location accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ And please only add new entries to the top of this list, right below the `# Unre
   between presses.
 - Implement `PartialOrd` and `Ord` for `KeyCode` and `NativeKeyCode`.
 - On Web, implement `WindowEvent::Occluded`.
+- On Web, fix touch location to be as accurate as mouse position.
 
 # 0.29.0-beta.0
 

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -7,7 +7,7 @@ use smol_str::SmolStr;
 use std::convert::TryInto;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
-use web_sys::{HtmlCanvasElement, KeyboardEvent, MouseEvent, PointerEvent, WheelEvent};
+use web_sys::{KeyboardEvent, MouseEvent, PointerEvent, WheelEvent};
 
 bitflags! {
     // https://www.w3.org/TR/pointerevents3/#the-buttons-property
@@ -132,17 +132,6 @@ impl MouseDelta {
     }
 }
 
-pub fn mouse_position_by_client(
-    event: &MouseEvent,
-    canvas: &HtmlCanvasElement,
-) -> LogicalPosition<f64> {
-    let bounding_client_rect = canvas.get_bounding_client_rect();
-    LogicalPosition {
-        x: event.client_x() as f64 - bounding_client_rect.x(),
-        y: event.client_y() as f64 - bounding_client_rect.y(),
-    }
-}
-
 pub fn mouse_scroll_delta(
     window: &web_sys::Window,
     event: &WheelEvent,
@@ -231,10 +220,6 @@ pub fn mouse_modifiers(event: &MouseEvent) -> ModifiersState {
     }
 
     state
-}
-
-pub fn touch_position(event: &PointerEvent, canvas: &HtmlCanvasElement) -> LogicalPosition<f64> {
-    mouse_position_by_client(event, canvas)
 }
 
 pub fn pointer_move_event(event: PointerEvent) -> impl Iterator<Item = PointerEvent> {

--- a/src/platform_impl/web/web_sys/pointer.rs
+++ b/src/platform_impl/web/web_sys/pointer.rs
@@ -80,7 +80,6 @@ impl PointerHandler {
         T: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, Force),
     {
         let window = canvas_common.window.clone();
-        let canvas = canvas_common.raw.clone();
         self.on_pointer_release = Some(canvas_common.add_user_event(
             "pointerup",
             move |event: PointerEvent| {
@@ -90,8 +89,7 @@ impl PointerHandler {
                     "touch" => touch_handler(
                         modifiers,
                         event.pointer_id(),
-                        event::touch_position(&event, &canvas)
-                            .to_physical(super::scale_factor(&window)),
+                        event::mouse_position(&event).to_physical(super::scale_factor(&window)),
                         Force::Normalized(event.pressure() as f64),
                     ),
                     "mouse" => mouse_handler(
@@ -137,8 +135,7 @@ impl PointerHandler {
                         touch_handler(
                             modifiers,
                             event.pointer_id(),
-                            event::touch_position(&event, &canvas)
-                                .to_physical(super::scale_factor(&window)),
+                            event::mouse_position(&event).to_physical(super::scale_factor(&window)),
                             Force::Normalized(event.pressure() as f64),
                         );
                     }
@@ -247,7 +244,7 @@ impl PointerHandler {
                         id,
                         &mut event::pointer_move_event(event).map(|event| {
                             (
-                                event::touch_position(&event, &canvas).to_physical(scale),
+                                event::mouse_position(&event).to_physical(scale),
                                 Force::Normalized(event.pressure() as f64),
                             )
                         }),
@@ -263,15 +260,13 @@ impl PointerHandler {
         F: 'static + FnMut(i32, PhysicalPosition<f64>, Force),
     {
         let window = canvas_common.window.clone();
-        let canvas = canvas_common.raw.clone();
         self.on_touch_cancel = Some(canvas_common.add_event(
             "pointercancel",
             move |event: PointerEvent| {
                 if event.pointer_type() == "touch" {
                     handler(
                         event.pointer_id(),
-                        event::touch_position(&event, &canvas)
-                            .to_physical(super::scale_factor(&window)),
+                        event::mouse_position(&event).to_physical(super::scale_factor(&window)),
                         Force::Normalized(event.pressure() as f64),
                     );
                 }


### PR DESCRIPTION
We should use [`MouseEvent.offsetX`](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/offsetX) when possible to avoid any inaccurate calculations.