### PR TITLE
On Web, cache commonly used values

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,4 +4,5 @@ disallowed-methods = [
     { path = "web_sys::HtmlCanvasElement::height", reason = "Winit shouldn't touch the internal canvas size" },
     { path = "web_sys::HtmlCanvasElement::set_width", reason = "Winit shouldn't touch the internal canvas size" },
     { path = "web_sys::HtmlCanvasElement::set_height", reason = "Winit shouldn't touch the internal canvas size" },
+    { path = "web_sys::Window::document", reason = "cache this to reduce calls to JS" },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,4 +5,5 @@ disallowed-methods = [
     { path = "web_sys::HtmlCanvasElement::set_width", reason = "Winit shouldn't touch the internal canvas size" },
     { path = "web_sys::HtmlCanvasElement::set_height", reason = "Winit shouldn't touch the internal canvas size" },
     { path = "web_sys::Window::document", reason = "cache this to reduce calls to JS" },
+    { path = "web_sys::Window::get_computed_style", reason = "cache this to reduce calls to JS" },
 ]

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -725,7 +725,7 @@ impl<T> EventLoopWindowTarget<T> {
         let runner = self.runner.clone();
         canvas.on_intersection(move |is_intersecting| {
             // only fire if visible while skipping the first event if it's intersecting
-            if backend::is_visible(runner.window())
+            if backend::is_visible(runner.document())
                 && !(is_intersecting && canvas_clone.borrow().is_intersecting.is_none())
             {
                 runner.send_event(Event::WindowEvent {

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -67,34 +67,28 @@ pub fn scale_factor(window: &web_sys::Window) -> f64 {
 }
 
 pub fn set_canvas_size(
-    window: &web_sys::Window,
     document: &Document,
     raw: &HtmlCanvasElement,
+    style: &CssStyleDeclaration,
     mut new_size: LogicalSize<f64>,
 ) {
     if !document.contains(Some(raw)) {
         return;
     }
 
-    let style = window
-        .get_computed_style(raw)
-        .expect("Failed to obtain computed style")
-        // this can't fail: we aren't using a pseudo-element
-        .expect("Invalid pseudo-element");
-
     if style.get_property_value("display").unwrap() == "none" {
         return;
     }
 
     if style.get_property_value("box-sizing").unwrap() == "border-box" {
-        new_size.width += style_size_property(&style, "border-left-width")
-            + style_size_property(&style, "border-right-width")
-            + style_size_property(&style, "padding-left")
-            + style_size_property(&style, "padding-right");
-        new_size.height += style_size_property(&style, "border-top-width")
-            + style_size_property(&style, "border-bottom-width")
-            + style_size_property(&style, "padding-top")
-            + style_size_property(&style, "padding-bottom");
+        new_size.width += style_size_property(style, "border-left-width")
+            + style_size_property(style, "border-right-width")
+            + style_size_property(style, "padding-left")
+            + style_size_property(style, "padding-right");
+        new_size.height += style_size_property(style, "border-top-width")
+            + style_size_property(style, "border-bottom-width")
+            + style_size_property(style, "padding-top")
+            + style_size_property(style, "padding-bottom");
     }
 
     set_canvas_style_property(raw, "width", &format!("{}px", new_size.width));

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -18,16 +18,14 @@ use crate::platform::web::WindowExtWebSys;
 use crate::window::Window;
 use wasm_bindgen::closure::Closure;
 use web_sys::{
-    CssStyleDeclaration, Element, HtmlCanvasElement, PageTransitionEvent, VisibilityState,
+    CssStyleDeclaration, Document, Element, HtmlCanvasElement, PageTransitionEvent, VisibilityState,
 };
 
 pub fn throw(msg: &str) {
     wasm_bindgen::throw_str(msg);
 }
 
-pub fn exit_fullscreen(window: &web_sys::Window) {
-    let document = window.document().expect("Failed to obtain document");
-
+pub fn exit_fullscreen(document: &Document) {
     document.exit_fullscreen();
 }
 
@@ -70,11 +68,10 @@ pub fn scale_factor(window: &web_sys::Window) -> f64 {
 
 pub fn set_canvas_size(
     window: &web_sys::Window,
+    document: &Document,
     raw: &HtmlCanvasElement,
     mut new_size: LogicalSize<f64>,
 ) {
-    let document = window.document().expect("Failed to obtain document");
-
     if !document.contains(Some(raw)) {
         return;
     }
@@ -123,9 +120,7 @@ pub fn set_canvas_style_property(raw: &HtmlCanvasElement, property: &str, value:
         .unwrap_or_else(|err| panic!("error: {err:?}\nFailed to set {property}"))
 }
 
-pub fn is_fullscreen(window: &web_sys::Window, canvas: &HtmlCanvasElement) -> bool {
-    let document = window.document().expect("Failed to obtain document");
-
+pub fn is_fullscreen(document: &Document, canvas: &HtmlCanvasElement) -> bool {
     match document.fullscreen_element() {
         Some(elem) => {
             let canvas: &Element = canvas;
@@ -143,8 +138,7 @@ pub fn is_dark_mode(window: &web_sys::Window) -> Option<bool> {
         .map(|media| media.matches())
 }
 
-pub fn is_visible(window: &web_sys::Window) -> bool {
-    let document = window.document().expect("Failed to obtain document");
+pub fn is_visible(document: &Document) -> bool {
     document.visibility_state() == VisibilityState::Visible
 }
 

--- a/src/platform_impl/web/web_sys/resize_scaling.rs
+++ b/src/platform_impl/web/web_sys/resize_scaling.rs
@@ -3,7 +3,7 @@ use once_cell::unsync::Lazy;
 use wasm_bindgen::prelude::{wasm_bindgen, Closure};
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{
-    HtmlCanvasElement, MediaQueryList, ResizeObserver, ResizeObserverBoxOptions,
+    Document, HtmlCanvasElement, MediaQueryList, ResizeObserver, ResizeObserverBoxOptions,
     ResizeObserverEntry, ResizeObserverOptions, ResizeObserverSize, Window,
 };
 
@@ -20,6 +20,7 @@ pub struct ResizeScaleHandle(Rc<RefCell<ResizeScaleInternal>>);
 impl ResizeScaleHandle {
     pub(crate) fn new<S, R>(
         window: Window,
+        document: Document,
         canvas: HtmlCanvasElement,
         scale_handler: S,
         resize_handler: R,
@@ -30,6 +31,7 @@ impl ResizeScaleHandle {
     {
         Self(ResizeScaleInternal::new(
             window,
+            document,
             canvas,
             scale_handler,
             resize_handler,
@@ -45,6 +47,7 @@ impl ResizeScaleHandle {
 /// changes of the `devicePixelRatio`.
 struct ResizeScaleInternal {
     window: Window,
+    document: Document,
     canvas: HtmlCanvasElement,
     mql: MediaQueryListHandle,
     observer: ResizeObserver,
@@ -57,6 +60,7 @@ struct ResizeScaleInternal {
 impl ResizeScaleInternal {
     fn new<S, R>(
         window: Window,
+        document: Document,
         canvas: HtmlCanvasElement,
         scale_handler: S,
         resize_handler: R,
@@ -94,6 +98,7 @@ impl ResizeScaleInternal {
 
             RefCell::new(Self {
                 window,
+                document,
                 canvas,
                 mql,
                 observer,
@@ -149,9 +154,7 @@ impl ResizeScaleInternal {
             // this can't fail: we aren't using a pseudo-element
             .expect("Invalid pseudo-element");
 
-        let document = self.window.document().expect("Failed to obtain document");
-
-        if !document.contains(Some(&self.canvas))
+        if !self.document.contains(Some(&self.canvas))
             || style.get_property_value("display").unwrap() == "none"
         {
             let size = PhysicalSize::new(0, 0);


### PR DESCRIPTION
This removes unnecessary calls to get `Document` and `CssStyleDeclaration`, not only reducing calls to JS, but also removing a lot of `expect()` calls.