### PR TITLE
On Web, implement and fix missing methods on `Window(Builder)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, account for CSS `padding`, `border`, and `margin` when getting or setting the canvas position.
 - On Web, add Fullscreen API compatibility for Safari.
 - On Web, implement `Window::set_(min|max)_inner_size()`.
-- On Web, fix `Window::set_outer_position()` using HTML attributes instead of CSS properties.
+- On Web, fix some `Window` methods using incorrect HTML attributes instead of CSS properties.
 - On Web, fix some `WindowBuilder` methods doing nothing.
 
 # 0.29.0-beta.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, implement `Window::set_(min|max)_inner_size()`.
 - On Web, fix some `Window` methods using incorrect HTML attributes instead of CSS properties.
 - On Web, fix some `WindowBuilder` methods doing nothing.
+- On Web, implement `Window::focus_window()`.
 
 # 0.29.0-beta.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, account for CSS `padding`, `border`, and `margin` when getting or setting the canvas position.
 - On Web, add Fullscreen API compatibility for Safari.
 - On Web, implement `Window::set_(min|max)_inner_size()`.
+- On Web, fix `Window::set_outer_position()` using HTML attributes instead of CSS properties.
+- On Web, fix some `WindowBuilder` methods doing nothing.
 
 # 0.29.0-beta.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, fix touch location to be as accurate as mouse position.
 - On Web, account for CSS `padding`, `border`, and `margin` when getting or setting the canvas position.
 - On Web, add Fullscreen API compatibility for Safari.
+- On Web, implement `Window::set_(min|max)_inner_size()`.
 
 # 0.29.0-beta.0
 

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -103,6 +103,11 @@ impl Canvas {
             super::set_canvas_max_size(&document, &canvas, &style, Some(size));
         }
 
+        if let Some(position) = attr.position {
+            let position = position.to_logical(super::scale_factor(&window));
+            super::set_canvas_position(&document, &canvas, &style, position);
+        }
+
         Ok(Canvas {
             common: Common {
                 window,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -93,6 +93,16 @@ impl Canvas {
             super::set_canvas_size(&document, &canvas, &style, size);
         }
 
+        if let Some(size) = attr.min_inner_size {
+            let size = size.to_logical(super::scale_factor(&window));
+            super::set_canvas_min_size(&document, &canvas, &style, Some(size));
+        }
+
+        if let Some(size) = attr.max_inner_size {
+            let size = size.to_logical(super::scale_factor(&window));
+            super::set_canvas_max_size(&document, &canvas, &style, Some(size));
+        }
+
         Ok(Canvas {
             common: Common {
                 window,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -122,6 +122,10 @@ impl Canvas {
             common.request_fullscreen();
         }
 
+        if attr.active {
+            let _ = common.raw.focus();
+        }
+
         Ok(Canvas {
             common,
             id,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -88,36 +88,42 @@ impl Canvas {
             // this can't fail: we aren't using a pseudo-element
             .expect("Invalid pseudo-element");
 
+        let common = Common {
+            window,
+            document,
+            raw: canvas,
+            style,
+            old_size: Rc::default(),
+            current_size: Rc::default(),
+            wants_fullscreen: Rc::new(RefCell::new(false)),
+        };
+
         if let Some(size) = attr.inner_size {
-            let size = size.to_logical(super::scale_factor(&window));
-            super::set_canvas_size(&document, &canvas, &style, size);
+            let size = size.to_logical(super::scale_factor(&common.window));
+            super::set_canvas_size(&common.document, &common.raw, &common.style, size);
         }
 
         if let Some(size) = attr.min_inner_size {
-            let size = size.to_logical(super::scale_factor(&window));
-            super::set_canvas_min_size(&document, &canvas, &style, Some(size));
+            let size = size.to_logical(super::scale_factor(&common.window));
+            super::set_canvas_min_size(&common.document, &common.raw, &common.style, Some(size));
         }
 
         if let Some(size) = attr.max_inner_size {
-            let size = size.to_logical(super::scale_factor(&window));
-            super::set_canvas_max_size(&document, &canvas, &style, Some(size));
+            let size = size.to_logical(super::scale_factor(&common.window));
+            super::set_canvas_max_size(&common.document, &common.raw, &common.style, Some(size));
         }
 
         if let Some(position) = attr.position {
-            let position = position.to_logical(super::scale_factor(&window));
-            super::set_canvas_position(&document, &canvas, &style, position);
+            let position = position.to_logical(super::scale_factor(&common.window));
+            super::set_canvas_position(&common.document, &common.raw, &common.style, position);
+        }
+
+        if attr.fullscreen.is_some() {
+            common.request_fullscreen();
         }
 
         Ok(Canvas {
-            common: Common {
-                window,
-                document,
-                raw: canvas,
-                style,
-                old_size: Rc::default(),
-                current_size: Rc::default(),
-                wants_fullscreen: Rc::new(RefCell::new(false)),
-            },
+            common,
             id,
             has_focus: Arc::new(AtomicBool::new(false)),
             is_intersecting: None,

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -14,7 +14,7 @@ pub use self::event_handle::EventListenerHandle;
 pub use self::resize_scaling::ResizeScaleHandle;
 pub use self::timeout::{IdleCallback, Timeout};
 
-use crate::dpi::LogicalSize;
+use crate::dpi::{LogicalPosition, LogicalSize};
 use crate::platform::web::WindowExtWebSys;
 use crate::window::Window;
 use wasm_bindgen::closure::Closure;
@@ -146,6 +146,26 @@ pub fn set_canvas_max_size(
             .remove_property("max-height")
             .expect("Property is read only");
     }
+}
+
+pub fn set_canvas_position(
+    document: &Document,
+    raw: &HtmlCanvasElement,
+    style: &CssStyleDeclaration,
+    mut position: LogicalPosition<f64>,
+) {
+    if document.contains(Some(raw)) && style.get_property_value("display").unwrap() != "none" {
+        position.x -= style_size_property(style, "margin-left")
+            + style_size_property(style, "border-left-width")
+            + style_size_property(style, "padding-left");
+        position.y -= style_size_property(style, "margin-top")
+            + style_size_property(style, "border-top-width")
+            + style_size_property(style, "padding-top");
+    }
+
+    set_canvas_style_property(raw, "position", "fixed");
+    set_canvas_style_property(raw, "left", &format!("{}px", position.x));
+    set_canvas_style_property(raw, "top", &format!("{}px", position.y));
 }
 
 /// This function will panic if the element is not inserted in the DOM

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -368,7 +368,9 @@ impl Window {
 
     #[inline]
     pub fn focus_window(&self) {
-        // Currently a no-op as it does not seem there is good support for this on web
+        self.inner.dispatch(|inner| {
+            let _ = inner.canvas.borrow().raw().focus();
+        })
     }
 
     #[inline]

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -178,13 +178,33 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_min_inner_size(&self, _dimensions: Option<Size>) {
-        // Intentionally a no-op: users can't resize canvas elements
+    pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
+        self.inner.dispatch(move |inner| {
+            let dimensions =
+                dimensions.map(|dimensions| dimensions.to_logical(inner.scale_factor()));
+            let canvas = inner.canvas.borrow();
+            backend::set_canvas_min_size(
+                canvas.document(),
+                canvas.raw(),
+                canvas.style(),
+                dimensions,
+            )
+        })
     }
 
     #[inline]
-    pub fn set_max_inner_size(&self, _dimensions: Option<Size>) {
-        // Intentionally a no-op: users can't resize canvas elements
+    pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
+        self.inner.dispatch(move |inner| {
+            let dimensions =
+                dimensions.map(|dimensions| dimensions.to_logical(inner.scale_factor()));
+            let canvas = inner.canvas.borrow();
+            backend::set_canvas_max_size(
+                canvas.document(),
+                canvas.raw(),
+                canvas.style(),
+                dimensions,
+            )
+        })
     }
 
     #[inline]

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -262,12 +262,13 @@ impl Window {
     pub fn set_cursor_visible(&self, visible: bool) {
         self.inner.dispatch(move |inner| {
             if !visible {
-                inner.canvas.borrow().set_attribute("cursor", "none");
+                backend::set_canvas_style_property(inner.canvas.borrow().raw(), "cursor", "none");
             } else {
-                inner
-                    .canvas
-                    .borrow()
-                    .set_attribute("cursor", &inner.previous_pointer.borrow());
+                backend::set_canvas_style_property(
+                    inner.canvas.borrow().raw(),
+                    "cursor",
+                    &inner.previous_pointer.borrow(),
+                );
             }
         });
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1120,7 +1120,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Wayland / Orbital:** Unsupported.
+    /// - **iOS / Android / Wayland / Orbital:** Unsupported.
     #[inline]
     pub fn focus_window(&self) {
         self.window.focus_window()

--- a/src/window.rs
+++ b/src/window.rs
@@ -730,7 +730,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS / Android / Orbital:** Unsupported.
     #[inline]
     pub fn set_min_inner_size<S: Into<Size>>(&self, min_size: Option<S>) {
         self.window.set_min_inner_size(min_size.map(|s| s.into()))
@@ -753,7 +753,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS / Android / Orbital:** Unsupported.
     #[inline]
     pub fn set_max_inner_size<S: Into<Size>>(&self, max_size: Option<S>) {
         self.window.set_max_inner_size(max_size.map(|s| s.into()))


### PR DESCRIPTION
This implements a bunch of missing methods in `Window` and `WindowBuilder`:
- `Window::set_(min|max)_inner_size()` and `WindowBuilder::with_(min|max)_inner_size()`
- `WindowBuilder::with_position()`
- `WindowBuilder::with_fullscreen()`
- `Window::focus_window()` and `WindowBuilder::with_active()`

Additionally this fixes setting the cursor and the canvas position to use CSS properties instead of (partly) incorrect HTML attributes.