### PR TITLE
On macOS, move automatic tabbing setting to ELWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
-- On macOS, add tabbing APIs on `WindowExtMacOS`.
+- On macOS, add tabbing APIs on `WindowExtMacOS` and `EventLoopWindowTargetExtMacOS`.
 - **Breaking:** Rename `Window::set_inner_size` to `Window::request_inner_size` and indicate if the size was applied immediately.
 - On X11, fix false positive flagging of key repeats when pressing different keys with no release between presses.
 - Implement `PartialOrd` and `Ord` for `KeyCode` and `NativeKeyCode`.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -38,14 +38,6 @@ pub trait WindowExtMacOS {
     /// Sets whether or not the window has shadow.
     fn set_has_shadow(&self, has_shadow: bool);
 
-    /// Sets whether the system can automatically organize windows into tabs.
-    ///
-    /// <https://developer.apple.com/documentation/appkit/nswindow/1646657-allowsautomaticwindowtabbing>
-    fn set_allows_automatic_window_tabbing(&self, enabled: bool);
-
-    /// Returns whether the system can automatically organize windows into tabs.
-    fn allows_automatic_window_tabbing(&self) -> bool;
-
     /// Group windows together by using the same tabbing identifier.
     ///
     /// <https://developer.apple.com/documentation/appkit/nswindow/1644704-tabbingidentifier>
@@ -125,16 +117,6 @@ impl WindowExtMacOS for Window {
     #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
         self.window.set_has_shadow(has_shadow)
-    }
-
-    #[inline]
-    fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
-        self.window.set_allows_automatic_window_tabbing(enabled)
-    }
-
-    #[inline]
-    fn allows_automatic_window_tabbing(&self) -> bool {
-        self.window.allows_automatic_window_tabbing()
     }
 
     #[inline]
@@ -223,10 +205,6 @@ pub trait WindowBuilderExtMacOS {
     fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
     /// Window accepts click-through mouse events.
     fn with_accepts_first_mouse(self, accepts_first_mouse: bool) -> WindowBuilder;
-    /// Whether the window could do automatic window tabbing.
-    ///
-    /// The default is `true`.
-    fn with_automatic_window_tabbing(self, automatic_tabbing: bool) -> WindowBuilder;
     /// Defines the window tabbing identifier.
     ///
     /// <https://developer.apple.com/documentation/appkit/nswindow/1644704-tabbingidentifier>
@@ -292,12 +270,6 @@ impl WindowBuilderExtMacOS for WindowBuilder {
     #[inline]
     fn with_accepts_first_mouse(mut self, accepts_first_mouse: bool) -> WindowBuilder {
         self.platform_specific.accepts_first_mouse = accepts_first_mouse;
-        self
-    }
-
-    #[inline]
-    fn with_automatic_window_tabbing(mut self, automatic_tabbing: bool) -> WindowBuilder {
-        self.platform_specific.allows_automatic_window_tabbing = automatic_tabbing;
         self
     }
 
@@ -413,6 +385,12 @@ pub trait EventLoopWindowTargetExtMacOS {
     fn hide_application(&self);
     /// Hide the other applications. In most applications this is typically triggered with Command+Option-H.
     fn hide_other_applications(&self);
+    /// Set whether the system can automatically organize windows into tabs.
+    ///
+    /// <https://developer.apple.com/documentation/appkit/nswindow/1646657-allowsautomaticwindowtabbing>
+    fn set_allows_automatic_window_tabbing(&self, enabled: bool);
+    /// Returns whether the system can automatically organize windows into tabs.
+    fn allows_automatic_window_tabbing(&self) -> bool;
 }
 
 impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
@@ -422,6 +400,14 @@ impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
 
     fn hide_other_applications(&self) {
         self.p.hide_other_applications()
+    }
+
+    fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
+        self.p.set_allows_automatic_window_tabbing(enabled);
+    }
+
+    fn allows_automatic_window_tabbing(&self) -> bool {
+        self.p.allows_automatic_window_tabbing()
     }
 }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -21,7 +21,7 @@ use objc2::rc::{autoreleasepool, Id, Shared};
 use objc2::{msg_send_id, ClassType};
 use raw_window_handle::{AppKitDisplayHandle, RawDisplayHandle};
 
-use super::appkit::{NSApp, NSApplicationActivationPolicy, NSEvent};
+use super::appkit::{NSApp, NSApplicationActivationPolicy, NSEvent, NSWindow};
 use crate::{
     event::Event,
     event_loop::{ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootWindowTarget},
@@ -100,6 +100,14 @@ impl<T> EventLoopWindowTarget<T> {
 
     pub(crate) fn hide_other_applications(&self) {
         NSApp().hideOtherApplications(None)
+    }
+
+    pub(crate) fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
+        NSWindow::setAllowsAutomaticWindowTabbing(enabled)
+    }
+
+    pub(crate) fn allows_automatic_window_tabbing(&self) -> bool {
+        NSWindow::allowsAutomaticWindowTabbing()
     }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -83,7 +83,6 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub disallow_hidpi: bool,
     pub has_shadow: bool,
     pub accepts_first_mouse: bool,
-    pub allows_automatic_window_tabbing: bool,
     pub tabbing_identifier: Option<String>,
     pub option_as_alt: OptionAsAlt,
 }
@@ -101,7 +100,6 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             disallow_hidpi: false,
             has_shadow: true,
             accepts_first_mouse: true,
-            allows_automatic_window_tabbing: true,
             tabbing_identifier: None,
             option_as_alt: Default::default(),
         }
@@ -365,8 +363,6 @@ impl WinitWindow {
             if let Some(identifier) = pl_attrs.tabbing_identifier {
                 this.setTabbingIdentifier(&NSString::from_str(&identifier));
             }
-
-            NSWindow::setAllowsAutomaticWindowTabbing(pl_attrs.allows_automatic_window_tabbing);
 
             if attrs.content_protected {
                 this.setSharingType(NSWindowSharingType::NSWindowSharingNone);
@@ -1403,16 +1399,6 @@ impl WindowExtMacOS for WinitWindow {
     #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
         self.setHasShadow(has_shadow)
-    }
-
-    #[inline]
-    fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
-        NSWindow::setAllowsAutomaticWindowTabbing(enabled);
-    }
-
-    #[inline]
-    fn allows_automatic_window_tabbing(&self) -> bool {
-        NSWindow::allowsAutomaticWindowTabbing()
     }
 
     #[inline]


### PR DESCRIPTION
Those are global for the application, so it's better to keep them on EventLoopWindowTarget.
