### PR TITLE
Fix new tab creation on macOS

### DIFF
--- a/src/platform_impl/macos/appkit/mod.rs
+++ b/src/platform_impl/macos/appkit/mod.rs
@@ -57,6 +57,7 @@ pub(crate) use self::view::{NSTrackingRectTag, NSView};
 pub(crate) use self::window::{
     NSBackingStoreType, NSWindow, NSWindowButton, NSWindowLevel, NSWindowOcclusionState,
     NSWindowOrderingMode, NSWindowSharingType, NSWindowStyleMask, NSWindowTitleVisibility,
+    NSWindowTabbingMode
 };
 
 #[link(name = "AppKit", kind = "framework")]

--- a/src/platform_impl/macos/appkit/mod.rs
+++ b/src/platform_impl/macos/appkit/mod.rs
@@ -56,8 +56,8 @@ pub(crate) use self::version::NSAppKitVersion;
 pub(crate) use self::view::{NSTrackingRectTag, NSView};
 pub(crate) use self::window::{
     NSBackingStoreType, NSWindow, NSWindowButton, NSWindowLevel, NSWindowOcclusionState,
-    NSWindowOrderingMode, NSWindowSharingType, NSWindowStyleMask, NSWindowTitleVisibility,
-    NSWindowTabbingMode
+    NSWindowOrderingMode, NSWindowSharingType, NSWindowStyleMask, NSWindowTabbingMode,
+    NSWindowTitleVisibility,
 };
 
 #[link(name = "AppKit", kind = "framework")]

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -89,6 +89,9 @@ extern_methods!(
         #[sel(setSharingType:)]
         pub fn setSharingType(&self, sharingType: NSWindowSharingType);
 
+        #[sel(setTabbingMode:)]
+        pub fn setTabbingMode(&self, tabbingMode: NSWindowTabbingMode);
+
         #[sel(setOpaque:)]
         pub fn setOpaque(&self, opaque: bool);
 
@@ -423,5 +426,18 @@ pub enum NSWindowOrderingMode {
 }
 
 unsafe impl Encode for NSWindowOrderingMode {
+    const ENCODING: Encoding = NSInteger::ENCODING;
+}
+
+#[allow(dead_code)]
+#[repr(isize)] // NSInteger
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum NSWindowTabbingMode {
+    NSWindowTabbingModeAutomatic = 0,
+    NSWindowTabbingModeDisallowed = 2,
+    NSWindowTabbingModePreferred = 1,
+}
+
+unsafe impl Encode for NSWindowTabbingMode {
     const ENCODING: Encoding = NSInteger::ENCODING;
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -48,7 +48,7 @@ use super::appkit::{
     NSApp, NSAppKitVersion, NSAppearance, NSApplicationPresentationOptions, NSBackingStoreType,
     NSColor, NSCursor, NSFilenamesPboardType, NSRequestUserAttentionType, NSResponder, NSScreen,
     NSView, NSWindow, NSWindowButton, NSWindowLevel, NSWindowSharingType, NSWindowStyleMask,
-    NSWindowTitleVisibility,
+    NSWindowTitleVisibility, NSWindowTabbingMode
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -363,6 +363,8 @@ impl WinitWindow {
             if let Some(identifier) = pl_attrs.tabbing_identifier {
                 this.setTabbingIdentifier(&NSString::from_str(&identifier));
             }
+
+            this.setTabbingMode(NSWindowTabbingMode::NSWindowTabbingModePreferred);
 
             if attrs.content_protected {
                 this.setSharingType(NSWindowSharingType::NSWindowSharingNone);

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -48,7 +48,7 @@ use super::appkit::{
     NSApp, NSAppKitVersion, NSAppearance, NSApplicationPresentationOptions, NSBackingStoreType,
     NSColor, NSCursor, NSFilenamesPboardType, NSRequestUserAttentionType, NSResponder, NSScreen,
     NSView, NSWindow, NSWindowButton, NSWindowLevel, NSWindowSharingType, NSWindowStyleMask,
-    NSWindowTitleVisibility, NSWindowTabbingMode
+    NSWindowTabbingMode, NSWindowTitleVisibility,
 };
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -362,9 +362,8 @@ impl WinitWindow {
 
             if let Some(identifier) = pl_attrs.tabbing_identifier {
                 this.setTabbingIdentifier(&NSString::from_str(&identifier));
+                this.setTabbingMode(NSWindowTabbingMode::NSWindowTabbingModePreferred);
             }
-
-            this.setTabbingMode(NSWindowTabbingMode::NSWindowTabbingModePreferred);
 
             if attrs.content_protected {
                 this.setSharingType(NSWindowSharingType::NSWindowSharingNone);


### PR DESCRIPTION
Set tabbingMode on all macOS windows so that new tabs are correctly created as tabs, rather than separate windows.

See https://github.com/rust-windowing/winit/pull/2956#issuecomment-1634647001

- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
