### PR TITLE
On macOS, add a way to query amount of tabbed windows

### DIFF
--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -81,7 +81,14 @@ fn main() {
                         }
                         Key::Character(ch) => {
                             if let Ok(index) = ch.parse::<NonZeroUsize>() {
-                                windows.get(&window_id).unwrap().select_tab_at_index(index);
+                                let index = index.get();
+                                // Select the last tab when pressing `9`.
+                                let window = windows.get(&window_id).unwrap();
+                                if index == 9 {
+                                    window.select_tab_at_index(window.num_tabs() - 1)
+                                } else {
+                                    window.select_tab_at_index(index - 1);
+                                }
                             }
                         }
                         _ => (),

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -1,4 +1,4 @@
-use std::{num::NonZeroUsize, os::raw::c_void};
+use std::os::raw::c_void;
 
 use objc2::rc::Id;
 
@@ -55,7 +55,10 @@ pub trait WindowExtMacOS {
     /// Select the tab with the given index.
     ///
     /// Will no-op when the index is out of bounds.
-    fn select_tab_at_index(&self, index: NonZeroUsize);
+    fn select_tab_at_index(&self, index: usize);
+
+    /// Get the number of tabs in the window tab group.
+    fn num_tabs(&self) -> usize;
 
     /// Get the window's edit state.
     ///
@@ -140,8 +143,13 @@ impl WindowExtMacOS for Window {
     }
 
     #[inline]
-    fn select_tab_at_index(&self, index: NonZeroUsize) {
+    fn select_tab_at_index(&self, index: usize) {
         self.window.select_tab_at_index(index);
+    }
+
+    #[inline]
+    fn num_tabs(&self) -> usize {
+        self.window.num_tabs()
     }
 
     #[inline]

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -2,7 +2,6 @@
 
 use std::collections::VecDeque;
 use std::f64;
-use std::num::NonZeroUsize;
 use std::ops;
 use std::os::raw::c_void;
 use std::ptr::NonNull;
@@ -1423,13 +1422,18 @@ impl WindowExtMacOS for WinitWindow {
     }
 
     #[inline]
-    fn select_tab_at_index(&self, index: NonZeroUsize) {
+    fn select_tab_at_index(&self, index: usize) {
         let tab_group = self.tabGroup();
         let windows = tab_group.tabbedWindows();
-        let index = index.get() - 1;
         if index < windows.len() {
             tab_group.setSelectedWindow(&windows[index]);
         }
+    }
+
+    #[inline]
+    fn num_tabs(&self) -> usize {
+        let tab_group = self.tabGroup();
+        tab_group.tabbedWindows().len()
     }
 
     fn is_document_edited(&self) -> bool {


### PR DESCRIPTION
This should provide a way to iterate all the tabs and select the last tab. The tab indicies are now zero based as any other sane index.

Follow-up-to: c5941d105f5f327544d18e010801bf4dd1f714f1 (add tabbing API)

cc @Samasaur1
