### PR TITLE
On Wayland, make the CSD frame double click reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- On Wayland, make double clicking and moving the CSD frame more reliable.
 - On macOS, add tabbing APIs on `WindowExtMacOS` and `EventLoopWindowTargetExtMacOS`.
 - **Breaking:** Rename `Window::set_inner_size` to `Window::request_inner_size` and indicate if the size was applied immediately.
 - On X11, fix false positive flagging of key repeats when pressing different keys with no release between presses.

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -68,7 +68,7 @@ impl PointerHandler for WinitState {
                     if parent_surface != surface =>
                 {
                     if let Some(icon) =
-                        window.frame_point_moved(surface, event.position.0, event.position.1)
+                        window.frame_point_moved(seat, surface, event.position.0, event.position.1)
                     {
                         if let Some(pointer) = seat_state.pointer.as_ref() {
                             let surface = pointer


### PR DESCRIPTION
It was discovered that on GNOME the click sometimes being swallowed by the mutter's wl_pointer::enter/leave sequences. This was happening due to `xdg_toplevel::move` making the pointer to leave the surface.

To make handling of that more robust, we could start the `xdg_toplevel::move` when the actual pointer motion is being performed.

Links: https://github.com/alacritty/alacritty/issues/7011
Links: https://gitlab.gnome.org/GNOME/mutter/-/issues/2669#note_1790825

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

