### PR TITLE
Fix window decoration check method for Gnome environment (using libadwaita)

### DIFF
--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -52,6 +52,8 @@ fn main() {
             } => {
                 if let Some(dir) = cursor_location {
                     let _res = window.drag_resize_window(dir);
+                } else if !window.is_decorated() {
+                    let _res = window.drag_window();
                 }
             }
             WindowEvent::KeyboardInput {

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -384,7 +384,7 @@ impl WindowState {
             .map(|configure| configure.decoration_mode == DecorationMode::Client)
             .unwrap_or(false);
         if let Some(frame) = csd.then_some(self.frame.as_ref()).flatten() {
-            frame.is_hidden()
+            !frame.is_hidden()
         } else {
             // Server side decorations.
             true


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR makes a little change in the code in order to fix the method which check if the window have decorations by inverting the return value of the function.

This issue was detected when using the [window_resize_increments](https://github.com/rust-windowing/winit/blob/master/examples/window_resize_increments.rs) example on my Arch Linux Gnome desktop.

Additionally, this PR adds a feature on this example allowing to move the window using the system behaviors when borders are disabled