### PR TITLE
Implement X11 extensions using x11rb instead of Xlib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ wayland-protocols = { version = "0.30.0", features = [ "staging"], optional = tr
 calloop = "0.10.5"
 rustix = { version = "0.38.4", default-features = false, features = ["std", "system", "thread", "process"] }
 x11-dl = { version = "2.18.5", optional = true }
-x11rb = { version = "0.12.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "xinput", "xkb"], optional = true }
+x11rb = { version = "0.12.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "randr", "xinput", "xkb"], optional = true }
 xkbcommon-dl = "0.4.0"
 memmap2 = { version = "0.5.0", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ wayland-protocols = { version = "0.30.0", features = [ "staging"], optional = tr
 calloop = "0.10.5"
 rustix = { version = "0.38.4", default-features = false, features = ["std", "system", "thread", "process"] }
 x11-dl = { version = "2.18.5", optional = true }
-x11rb = { version = "0.12.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "randr", "xinput", "xkb"], optional = true }
+x11rb = { version = "0.12.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "randr", "resource_manager", "xinput", "xkb"], optional = true }
 xkbcommon-dl = "0.4.0"
 memmap2 = { version = "0.5.0", optional = true }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -850,8 +850,8 @@ impl<T> EventLoopWindowTarget<T> {
             EventLoopWindowTarget::X(ref evlp) => evlp
                 .x_connection()
                 .available_monitors()
-                .expect("Failed to list monitors")
                 .into_iter()
+                .flatten()
                 .map(MonitorHandle::X)
                 .collect(),
         }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -864,11 +864,7 @@ impl<T> EventLoopWindowTarget<T> {
             EventLoopWindowTarget::Wayland(ref evlp) => evlp.primary_monitor(),
             #[cfg(x11_platform)]
             EventLoopWindowTarget::X(ref evlp) => {
-                let primary_monitor = MonitorHandle::X(
-                    evlp.x_connection()
-                        .primary_monitor()
-                        .expect("Failed to get primary monitor"),
-                );
+                let primary_monitor = MonitorHandle::X(evlp.x_connection().primary_monitor().ok()?);
                 Some(primary_monitor)
             }
         }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -850,6 +850,7 @@ impl<T> EventLoopWindowTarget<T> {
             EventLoopWindowTarget::X(ref evlp) => evlp
                 .x_connection()
                 .available_monitors()
+                .expect("Failed to list monitors")
                 .into_iter()
                 .map(MonitorHandle::X)
                 .collect(),
@@ -863,7 +864,11 @@ impl<T> EventLoopWindowTarget<T> {
             EventLoopWindowTarget::Wayland(ref evlp) => evlp.primary_monitor(),
             #[cfg(x11_platform)]
             EventLoopWindowTarget::X(ref evlp) => {
-                let primary_monitor = MonitorHandle::X(evlp.x_connection().primary_monitor());
+                let primary_monitor = MonitorHandle::X(
+                    evlp.x_connection()
+                        .primary_monitor()
+                        .expect("Failed to get primary monitor"),
+                );
                 Some(primary_monitor)
             }
         }

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -61,12 +61,9 @@ impl<T: 'static> EventProcessor<T> {
     pub(super) fn init_device(&self, device: xinput::DeviceId) {
         let wt = get_xtarget(&self.target);
         let mut devices = self.devices.borrow_mut();
-        if let Some(info) = DeviceInfo::get(&wt.xconn, device) {
-            for info in info.info.iter() {
-                devices.insert(
-                    DeviceId(info.deviceid),
-                    Device::new(info).expect("Failed to get device info"),
-                );
+        if let Some(info) = DeviceInfo::get(&wt.xconn, device as _) {
+            for info in info.iter() {
+                devices.insert(DeviceId(info.deviceid as _), Device::new(info));
             }
         }
     }
@@ -892,17 +889,19 @@ impl<T: 'static> EventProcessor<T> {
                         let window_id = mkwid(window);
                         let device_id = mkdid(xev.deviceid as xinput::DeviceId);
 
-                        if let Some(all_info) = DeviceInfo::get(&wt.xconn, super::ALL_DEVICES) {
+                        if let Some(all_info) =
+                            DeviceInfo::get(&wt.xconn, super::ALL_DEVICES.into())
+                        {
                             let mut devices = self.devices.borrow_mut();
-                            for device_info in all_info.info.iter() {
-                                if device_info.deviceid == xev.sourceid as xinput::DeviceId
+                            for device_info in all_info.iter() {
+                                if device_info.deviceid == xev.sourceid
                                 // This is needed for resetting to work correctly on i3, and
                                 // presumably some other WMs. On those, `XI_Enter` doesn't include
                                 // the physical device ID, so both `sourceid` and `deviceid` are
                                 // the virtual device.
-                                || device_info.attachment == xev.sourceid as xinput::DeviceId
+                                || device_info.attachment == xev.sourceid
                                 {
-                                    let device_id = DeviceId(device_info.deviceid);
+                                    let device_id = DeviceId(device_info.deviceid as _);
                                     if let Some(device) = devices.get_mut(&device_id) {
                                         device.reset_scroll_position(device_info);
                                     }
@@ -996,7 +995,7 @@ impl<T: 'static> EventProcessor<T> {
                             callback(Event::WindowEvent {
                                 window_id,
                                 event: CursorMoved {
-                                    device_id: mkdid(pointer_id),
+                                    device_id: mkdid(pointer_id as _),
                                     position,
                                 },
                             });

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -892,7 +892,7 @@ impl<T: 'static> EventProcessor<T> {
                         let window_id = mkwid(window);
                         let device_id = mkdid(xev.deviceid as xinput::DeviceId);
 
-                        if let Some(all_info) = DeviceInfo::get(&wt.xconn, 0) {
+                        if let Some(all_info) = DeviceInfo::get(&wt.xconn, super::ALL_DEVICES) {
                             let mut devices = self.devices.borrow_mut();
                             for device_info in all_info.info.iter() {
                                 if device_info.deviceid == xev.sourceid as xinput::DeviceId

--- a/src/platform_impl/linux/x11/ffi.rs
+++ b/src/platform_impl/linux/x11/ffi.rs
@@ -1,7 +1,6 @@
 use x11_dl::xmd::CARD32;
 pub use x11_dl::{
     error::OpenError, keysym::*, xcursor::*, xinput::*, xinput2::*, xlib::*, xlib_xcb::*,
-    xrandr::*, xrender::*,
 };
 
 // Isn't defined by x11_dl

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -393,7 +393,7 @@ impl<T: 'static> EventLoop<T> {
             )
             .unwrap();
 
-        event_processor.init_device(0);
+        event_processor.init_device(ALL_DEVICES);
 
         EventLoop {
             loop_running: false,

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -79,6 +79,10 @@ use crate::{
     window::WindowAttributes,
 };
 
+// Xinput constants not defined in x11rb
+const ALL_DEVICES: u16 = 0;
+const ALL_MASTER_DEVICES: u16 = 1;
+
 type X11Source = Generic<RawFd>;
 
 struct WakeSender<T> {
@@ -239,7 +243,7 @@ impl<T: 'static> EventLoop<T> {
         let xi2ext = xconn
             .xcb_connection()
             .extension_information(xinput::X11_EXTENSION_NAME)
-            .expect("Failed to query XInput2 extension")
+            .expect("Failed to query XInput extension")
             .expect("X server missing XInput extension");
         let xkbext = xconn
             .xcb_connection()
@@ -1101,7 +1105,3 @@ impl Device {
         }
     }
 }
-
-// Xinput constants not defined in x11rb
-const ALL_DEVICES: u16 = 0;
-const ALL_MASTER_DEVICES: u16 = 1;

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -49,7 +49,7 @@ use raw_window_handle::{RawDisplayHandle, XlibDisplayHandle};
 
 use x11rb::protocol::{
     xinput,
-    xproto::{self, ConnectionExt},
+    xproto::{self, ConnectionExt as _},
 };
 use x11rb::x11_utils::X11Error as LogicalError;
 use x11rb::{
@@ -229,7 +229,7 @@ impl<T: 'static> EventLoop<T> {
         });
 
         let randr_event_offset = xconn
-            .select_xrandr_input(root as ffi::Window)
+            .select_xrandr_input(root)
             .expect("Failed to query XRandR extension");
 
         let xi2ext = unsafe {
@@ -894,6 +894,9 @@ pub enum X11Error {
     /// Got an invalid activation token.
     InvalidActivationToken(Vec<u8>),
 
+    /// An extension that we rely on is not available.
+    MissingExtension(&'static str),
+
     /// Could not find a matching X11 visual for this visualid
     NoSuchVisual(xproto::Visualid),
 }
@@ -912,6 +915,7 @@ impl fmt::Display for X11Error {
                 "Invalid activation token: {}",
                 std::str::from_utf8(s).unwrap_or("<invalid utf8>")
             ),
+            X11Error::MissingExtension(s) => write!(f, "Missing X11 extension: {}", s),
             X11Error::NoSuchVisual(visualid) => {
                 write!(
                     f,

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -10,30 +10,6 @@ pub const VIRTUAL_CORE_KEYBOARD: u16 = 3;
 // re-allocate (and make another round-trip) in the *vast* majority of cases.
 // To test if `lookup_utf8` works correctly, set this to 1.
 const TEXT_BUFFER_SIZE: usize = 1024;
-// NOTE: Some of these fields are not used, but may be of use in the future.
-pub struct PointerState<'a> {
-    xconn: &'a XConnection,
-    pub root: xproto::Window,
-    pub child: xproto::Window,
-    pub root_x: c_double,
-    pub root_y: c_double,
-    pub win_x: c_double,
-    pub win_y: c_double,
-    buttons: ffi::XIButtonState,
-    pub group: ffi::XIGroupState,
-    pub relative_to_window: bool,
-}
-
-impl<'a> Drop for PointerState<'a> {
-    fn drop(&mut self) {
-        if !self.buttons.mask.is_null() {
-            unsafe {
-                // This is why you need to read the docs carefully...
-                (self.xconn.xlib.XFree)(self.buttons.mask as _);
-            }
-        }
-    }
-}
 
 impl XConnection {
     pub fn select_xinput_events(

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -10,7 +10,6 @@ pub const VIRTUAL_CORE_KEYBOARD: u16 = 3;
 // re-allocate (and make another round-trip) in the *vast* majority of cases.
 // To test if `lookup_utf8` works correctly, set this to 1.
 const TEXT_BUFFER_SIZE: usize = 1024;
-
 // NOTE: Some of these fields are not used, but may be of use in the future.
 pub struct PointerState<'a> {
     xconn: &'a XConnection,

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -162,9 +162,9 @@ impl XConnection {
                 crtc.rotation,
                 &crtc.outputs,
             )?
-            .reply()?;
-
-        Ok(())
+            .reply()
+            .map(|_| ())
+            .map_err(Into::into)
     }
 
     pub fn get_crtc_mode(&self, crtc_id: randr::Crtc) -> Result<randr::Mode, X11Error> {

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -36,21 +36,10 @@ pub fn calc_dpi_factor(
 
 impl XConnection {
     // Retrieve DPI from Xft.dpi property
-    pub unsafe fn get_xft_dpi(&self) -> Option<f64> {
-        (self.xlib.XrmInitialize)();
-        let resource_manager_str = (self.xlib.XResourceManagerString)(self.display);
-        if resource_manager_str.is_null() {
-            return None;
-        }
-        if let Ok(res) = ::std::ffi::CStr::from_ptr(resource_manager_str).to_str() {
-            let name: &str = "Xft.dpi:\t";
-            for pair in res.split('\n') {
-                if let Some(stripped) = pair.strip_prefix(name) {
-                    return f64::from_str(stripped).ok();
-                }
-            }
-        }
-        None
+    pub fn get_xft_dpi(&self) -> Option<f64> {
+        self.database()
+            .get_string("Xfi.dpi", "")
+            .and_then(|s| f64::from_str(s).ok())
     }
     pub fn get_output_info(
         &self,
@@ -138,7 +127,7 @@ impl XConnection {
                 dpi_override
             }
             EnvVarDPI::NotSet => {
-                if let Some(dpi) = unsafe { self.get_xft_dpi() } {
+                if let Some(dpi) = self.get_xft_dpi() {
                     dpi / 96.
                 } else {
                     calc_dpi_factor(

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -1,11 +1,10 @@
-use std::{env, slice, str::FromStr};
+use std::{env, str, str::FromStr};
 
-use super::{
-    ffi::{CurrentTime, RRCrtc, RRMode, Success, XRRCrtcInfo, XRRScreenResources},
-    *,
-};
+use super::*;
 use crate::platform_impl::platform::x11::monitor;
 use crate::{dpi::validate_scale_factor, platform_impl::platform::x11::VideoMode};
+
+use x11rb::protocol::randr::{self, ConnectionExt as _};
 
 /// Represents values of `WINIT_HIDPI_FACTOR`.
 pub enum EnvVarDPI {
@@ -53,26 +52,27 @@ impl XConnection {
         }
         None
     }
-    pub unsafe fn get_output_info(
+    pub fn get_output_info(
         &self,
-        resources: *mut XRRScreenResources,
-        crtc: *mut XRRCrtcInfo,
+        resources: &monitor::ScreenResources,
+        crtc: &randr::GetCrtcInfoReply,
     ) -> Option<(String, f64, Vec<VideoMode>)> {
-        let output_info =
-            (self.xrandr.XRRGetOutputInfo)(self.display, resources, *(*crtc).outputs.offset(0));
-        if output_info.is_null() {
-            // When calling `XRRGetOutputInfo` on a virtual monitor (versus a physical display)
-            // it's possible for it to return null.
-            // https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=816596
-            let _ = self.check_errors(); // discard `BadRROutput` error
-            return None;
-        }
+        let output_info = match self
+            .xcb_connection()
+            .randr_get_output_info(crtc.outputs[0], x11rb::CURRENT_TIME)
+            .map_err(X11Error::from)
+            .and_then(|r| r.reply().map_err(X11Error::from))
+        {
+            Ok(output_info) => output_info,
+            Err(err) => {
+                warn!("Failed to get output info: {:?}", err);
+                return None;
+            }
+        };
 
         let bit_depth = self.default_root().root_depth;
-
-        let output_modes =
-            slice::from_raw_parts((*output_info).modes, (*output_info).nmode as usize);
-        let resource_modes = slice::from_raw_parts((*resources).modes, (*resources).nmode as usize);
+        let output_modes = &output_info.modes;
+        let resource_modes = resources.modes();
 
         let modes = resource_modes
             .iter()
@@ -81,7 +81,7 @@ impl XConnection {
             .filter(|x| output_modes.iter().any(|id| x.id == *id))
             .map(|mode| {
                 VideoMode {
-                    size: (mode.width, mode.height),
+                    size: (mode.width.into(), mode.height.into()),
                     refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode)
                         .unwrap_or(0),
                     bit_depth: bit_depth as u16,
@@ -93,11 +93,13 @@ impl XConnection {
             })
             .collect();
 
-        let name_slice = slice::from_raw_parts(
-            (*output_info).name as *mut u8,
-            (*output_info).nameLen as usize,
-        );
-        let name = String::from_utf8_lossy(name_slice).into();
+        let name = match str::from_utf8(&output_info.name) {
+            Ok(name) => name.to_owned(),
+            Err(err) => {
+                warn!("Failed to get output name: {:?}", err);
+                return None;
+            }
+        };
         // Override DPI if `WINIT_X11_SCALE_FACTOR` variable is set
         let deprecated_dpi_override = env::var("WINIT_HIDPI_FACTOR").ok();
         if deprecated_dpi_override.is_some() {
@@ -124,8 +126,8 @@ impl XConnection {
 
         let scale_factor = match dpi_env {
             EnvVarDPI::Randr => calc_dpi_factor(
-                ((*crtc).width, (*crtc).height),
-                ((*output_info).mm_width as _, (*output_info).mm_height as _),
+                (crtc.width.into(), crtc.height.into()),
+                (output_info.mm_width as _, output_info.mm_height as _),
             ),
             EnvVarDPI::Scale(dpi_override) => {
                 if !validate_scale_factor(dpi_override) {
@@ -136,78 +138,51 @@ impl XConnection {
                 dpi_override
             }
             EnvVarDPI::NotSet => {
-                if let Some(dpi) = self.get_xft_dpi() {
+                if let Some(dpi) = unsafe { self.get_xft_dpi() } {
                     dpi / 96.
                 } else {
                     calc_dpi_factor(
-                        ((*crtc).width, (*crtc).height),
-                        ((*output_info).mm_width as _, (*output_info).mm_height as _),
+                        (crtc.width.into(), crtc.height.into()),
+                        (output_info.mm_width as _, output_info.mm_height as _),
                     )
                 }
             }
         };
 
-        (self.xrandr.XRRFreeOutputInfo)(output_info);
         Some((name, scale_factor, modes))
     }
 
-    #[must_use]
-    pub fn set_crtc_config(&self, crtc_id: RRCrtc, mode_id: RRMode) -> Option<()> {
-        unsafe {
-            let mut major = 0;
-            let mut minor = 0;
-            (self.xrandr.XRRQueryVersion)(self.display, &mut major, &mut minor);
+    pub fn set_crtc_config(
+        &self,
+        crtc_id: randr::Crtc,
+        mode_id: randr::Mode,
+    ) -> Result<(), X11Error> {
+        let crtc = self
+            .xcb_connection()
+            .randr_get_crtc_info(crtc_id, x11rb::CURRENT_TIME)?
+            .reply()?;
 
-            let root = self.default_root().root;
-            let resources = if (major == 1 && minor >= 3) || major > 1 {
-                (self.xrandr.XRRGetScreenResourcesCurrent)(self.display, root as ffi::Window)
-            } else {
-                (self.xrandr.XRRGetScreenResources)(self.display, root as ffi::Window)
-            };
-
-            let crtc = (self.xrandr.XRRGetCrtcInfo)(self.display, resources, crtc_id);
-            let status = (self.xrandr.XRRSetCrtcConfig)(
-                self.display,
-                resources,
+        self.xcb_connection()
+            .randr_set_crtc_config(
                 crtc_id,
-                CurrentTime,
-                (*crtc).x,
-                (*crtc).y,
+                crtc.timestamp,
+                x11rb::CURRENT_TIME,
+                crtc.x,
+                crtc.y,
                 mode_id,
-                (*crtc).rotation,
-                (*crtc).outputs.offset(0),
-                1,
-            );
+                crtc.rotation,
+                &crtc.outputs,
+            )?
+            .reply()?;
 
-            (self.xrandr.XRRFreeCrtcInfo)(crtc);
-            (self.xrandr.XRRFreeScreenResources)(resources);
-
-            if status == Success as i32 {
-                Some(())
-            } else {
-                None
-            }
-        }
+        Ok(())
     }
 
-    pub fn get_crtc_mode(&self, crtc_id: RRCrtc) -> RRMode {
-        unsafe {
-            let mut major = 0;
-            let mut minor = 0;
-            (self.xrandr.XRRQueryVersion)(self.display, &mut major, &mut minor);
-
-            let root = self.default_root().root;
-            let resources = if (major == 1 && minor >= 3) || major > 1 {
-                (self.xrandr.XRRGetScreenResourcesCurrent)(self.display, root as ffi::Window)
-            } else {
-                (self.xrandr.XRRGetScreenResources)(self.display, root as ffi::Window)
-            };
-
-            let crtc = (self.xrandr.XRRGetCrtcInfo)(self.display, resources, crtc_id);
-            let mode = (*crtc).mode;
-            (self.xrandr.XRRFreeCrtcInfo)(crtc);
-            (self.xrandr.XRRFreeScreenResources)(resources);
-            mode
-        }
+    pub fn get_crtc_mode(&self, crtc_id: randr::Crtc) -> Result<randr::Mode, X11Error> {
+        Ok(self
+            .xcb_connection()
+            .randr_get_crtc_info(crtc_id, x11rb::CURRENT_TIME)?
+            .reply()?
+            .mode)
     }
 }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -523,7 +523,7 @@ impl UnownedWindow {
                 | xinput::XIEventMask::TOUCH_BEGIN
                 | xinput::XIEventMask::TOUCH_UPDATE
                 | xinput::XIEventMask::TOUCH_END;
-            leap!(xconn.select_xinput_events(window.xwindow, ffi::XIAllMasterDevices as u16, mask))
+            leap!(xconn.select_xinput_events(window.xwindow, super::ALL_MASTER_DEVICES, mask))
                 .ignore_error();
 
             {

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -17,7 +17,6 @@ use x11rb::{connection::Connection, protocol::xproto, xcb_ffi::XCBConnection};
 pub(crate) struct XConnection {
     pub xlib: ffi::Xlib,
     pub xcursor: ffi::Xcursor,
-    pub xinput2: ffi::XInput2,
     pub display: *mut ffi::Display,
     /// The manager for the XCB connection.
     ///
@@ -54,7 +53,6 @@ impl XConnection {
         // opening the libraries
         let xlib = ffi::Xlib::open()?;
         let xcursor = ffi::Xcursor::open()?;
-        let xinput2 = ffi::XInput2::open()?;
         let xlib_xcb = ffi::Xlib_xcb::open()?;
 
         unsafe { (xlib.XInitThreads)() };
@@ -95,7 +93,6 @@ impl XConnection {
         Ok(XConnection {
             xlib,
             xcursor,
-            xinput2,
             display,
             xcb: Some(xcb),
             atoms: Box::new(atoms),

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -18,8 +18,8 @@ pub(crate) struct XConnection {
     pub xlib: ffi::Xlib,
     pub xcursor: ffi::Xcursor,
 
-    /// I'd like to remove this, but apparently Xlib and Xinput2 are tied together
-    /// for some reason.
+    // TODO(notgull): I'd like to remove this, but apparently Xlib and Xinput2 are tied together
+    // for some reason.
     pub xinput2: ffi::XInput2,
 
     pub display: *mut ffi::Display,

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -17,6 +17,11 @@ use x11rb::{connection::Connection, protocol::xproto, resource_manager, xcb_ffi:
 pub(crate) struct XConnection {
     pub xlib: ffi::Xlib,
     pub xcursor: ffi::Xcursor,
+
+    /// I'd like to remove this, but apparently Xlib and Xinput2 are tied together
+    /// for some reason.
+    pub xinput2: ffi::XInput2,
+
     pub display: *mut ffi::Display,
 
     /// The manager for the XCB connection.
@@ -58,6 +63,7 @@ impl XConnection {
         let xlib = ffi::Xlib::open()?;
         let xcursor = ffi::Xcursor::open()?;
         let xlib_xcb = ffi::Xlib_xcb::open()?;
+        let xinput2 = ffi::XInput2::open()?;
 
         unsafe { (xlib.XInitThreads)() };
         unsafe { (xlib.XSetErrorHandler)(error_handler) };
@@ -101,6 +107,7 @@ impl XConnection {
         Ok(XConnection {
             xlib,
             xcursor,
+            xinput2,
             display,
             xcb: Some(xcb),
             atoms: Box::new(atoms),


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Ports the code for the XInput and XRandr to use `x11rb` instead of Xlib.

Draft because there's still more to do, and also I seem to have broken raw event inputs.