### PR TITLE
Replace libc with rustix in some modules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
-x11 = ["x11-dl", "bytemuck", "rustix", "percent-encoding", "xkbcommon-dl/x11", "x11rb"]
+x11 = ["x11-dl", "bytemuck", "percent-encoding", "xkbcommon-dl/x11", "x11rb"]
 wayland = ["wayland-client", "wayland-backend", "wayland-protocols", "sctk", "fnv", "memmap2"]
 wayland-dlopen = ["wayland-backend/dlopen"]
 wayland-csd-adwaita = ["sctk-adwaita", "sctk-adwaita/ab_glyph"]
@@ -123,7 +123,7 @@ wayland-client = { version = "0.30.0", optional = true }
 wayland-backend = { version = "0.1.0", default_features = false, features = ["client_system"], optional = true }
 wayland-protocols = { version = "0.30.0", features = [ "staging"], optional = true }
 calloop = "0.10.5"
-rustix = { version = "0.38.4", default-features = false, features = ["std", "system", "thread", "process"], optional = true }
+rustix = { version = "0.38.4", default-features = false, features = ["std", "system", "thread", "process"] }
 x11-dl = { version = "2.18.5", optional = true }
 x11rb = { version = "0.12.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "xinput", "xkb"], optional = true }
 xkbcommon-dl = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ wayland-client = { version = "0.30.0", optional = true }
 wayland-backend = { version = "0.1.0", default_features = false, features = ["client_system"], optional = true }
 wayland-protocols = { version = "0.30.0", features = [ "staging"], optional = true }
 calloop = "0.10.5"
-rustix = { version = "0.38.4", default-features = false, features = ["std", "system", "process"], optional = true }
+rustix = { version = "0.38.4", default-features = false, features = ["std", "system", "thread", "process"], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
 x11rb = { version = "0.12.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "xinput", "xkb"], optional = true }
 xkbcommon-dl = "0.4.0"

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -935,9 +935,7 @@ fn sticky_exit_callback<T, F>(
 
 #[cfg(target_os = "linux")]
 fn is_main_thread() -> bool {
-    use libc::{c_long, getpid, syscall, SYS_gettid};
-
-    unsafe { syscall(SYS_gettid) == getpid() as c_long }
+    rustix::thread::gettid() == rustix::process::getpid()
 }
 
 #[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd"))]

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1,6 +1,11 @@
-use std::{cell::RefCell, collections::HashMap, rc::Rc, slice, sync::Arc};
-
-use libc::{c_char, c_int, c_long, c_ulong};
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    os::raw::{c_char, c_int, c_long, c_ulong},
+    rc::Rc,
+    slice,
+    sync::Arc,
+};
 
 use x11rb::protocol::xproto::{self, ConnectionExt as _};
 use x11rb::x11_utils::Serialize;

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -230,7 +230,7 @@ impl<T: 'static> EventLoop<T> {
                 xconn.display,
                 &mut xinput_major_ver,
                 &mut xinput_minor_ver,
-            ) != ffi::Success as libc::c_int
+            ) != ffi::Success as std::os::raw::c_int
             {
                 panic!(
                     "X server has XInput extension {xinput_major_ver}.{xinput_minor_ver} but does not support XInput2",

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -46,7 +46,7 @@ unsafe impl Send for XConnection {}
 unsafe impl Sync for XConnection {}
 
 pub type XErrorHandler =
-    Option<unsafe extern "C" fn(*mut ffi::Display, *mut ffi::XErrorEvent) -> libc::c_int>;
+    Option<unsafe extern "C" fn(*mut ffi::Display, *mut ffi::XErrorEvent) -> std::os::raw::c_int>;
 
 impl XConnection {
     pub fn new(error_handler: XErrorHandler) -> Result<XConnection, XNotSupported> {


### PR DESCRIPTION
We recently added `rustix` as a direct dependency of `winit`, so why not?

Unfortunately this isn't a total removal, for two reasons:

- We still need "libc" for the Xlib XIM implementation, for locales.
- BSD requires libc to check for main-threadedness.

First one we can likely resolve in the near future, not so sure about the second one without using some weird pthreads trick.

The end goal is to reduce our usage of `libc` in `winit` proper, as direct syscalls are significantly faster. Unfortunately they can't be totally removed, as we will be using `libxcb` for the foreseeable future and that uses `libc` whether we like it or not (as well as `pthreads`). Still, the less `libc` calls we make, the better.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
