### PR TITLE
Correctly detect that we don't support Emscripten

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,12 +8,12 @@ fn main() {
     cfg_aliases! {
         // Systems.
         android_platform: { target_os = "android" },
-        wasm_platform: { target_family = "wasm" },
+        wasm_platform: { all(target_family = "wasm", not(target_os = "emscripten")) },
         macos_platform: { target_os = "macos" },
         ios_platform: { target_os = "ios" },
         windows_platform: { target_os = "windows" },
         apple: { any(target_os = "ios", target_os = "macos") },
-        free_unix: { all(unix, not(apple), not(android_platform)) },
+        free_unix: { all(unix, not(apple), not(android_platform), not(target_os = "emscripten")) },
         redox: { target_os = "redox" },
 
         // Native displays.


### PR DESCRIPTION
Winit fails compilation on unsupported targets. But we didn't account for Emscripten until now, it was recognized as a Wasm and Unix platform.

This correctly account for Emscripten.

Fixes #2970.