### PR TITLE
Rename `LoopDestroyed` to `LoopExiting`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking** Removed `EventLoopExtRunReturn` / `run_return` in favor of `EventLoopExtPumpEvents` / `pump_events` and `EventLoopExtRunOnDemand` / `run_ondemand` ([#2767](https://github.com/rust-windowing/winit/pull/2767))
 - `RedrawRequested` is no longer guaranteed to be emitted after `MainEventsCleared`, it is now platform-specific when the event is emitted after being requested via `redraw_request()`.
   - On Windows, `RedrawRequested` is now driven by `WM_PAINT` messages which are requested via `redraw_request()`
+- **Breaking** `LoopDestroyed` renamed to `LoopExiting` ([#2900](https://github.com/rust-windowing/winit/issues/2900))
 
 # 0.29.0-beta.0
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -26,7 +26,7 @@
 //!     start_cause = wait_if_necessary(control_flow);
 //! }
 //!
-//! event_handler(LoopDestroyed, ..., &mut control_flow);
+//! event_handler(LoopExiting, ..., &mut control_flow);
 //! ```
 //!
 //! This leaves out timing details like [`ControlFlow::WaitUntil`] but hopefully
@@ -258,7 +258,7 @@ pub enum Event<'a, T: 'static> {
     ///
     /// This is irreversible - if this event is emitted, it is guaranteed to be the last event that
     /// gets emitted. You generally want to treat this as a "do on quit" event.
-    LoopDestroyed,
+    LoopExiting,
 }
 
 impl<T: Clone> Clone for Event<'static, T> {
@@ -278,7 +278,7 @@ impl<T: Clone> Clone for Event<'static, T> {
             MainEventsCleared => MainEventsCleared,
             RedrawRequested(wid) => RedrawRequested(*wid),
             RedrawEventsCleared => RedrawEventsCleared,
-            LoopDestroyed => LoopDestroyed,
+            LoopExiting => LoopExiting,
             Suspended => Suspended,
             Resumed => Resumed,
         }
@@ -297,7 +297,7 @@ impl<'a, T> Event<'a, T> {
             MainEventsCleared => Ok(MainEventsCleared),
             RedrawRequested(wid) => Ok(RedrawRequested(wid)),
             RedrawEventsCleared => Ok(RedrawEventsCleared),
-            LoopDestroyed => Ok(LoopDestroyed),
+            LoopExiting => Ok(LoopExiting),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
         }
@@ -317,7 +317,7 @@ impl<'a, T> Event<'a, T> {
             MainEventsCleared => Some(MainEventsCleared),
             RedrawRequested(wid) => Some(RedrawRequested(wid)),
             RedrawEventsCleared => Some(RedrawEventsCleared),
-            LoopDestroyed => Some(LoopDestroyed),
+            LoopExiting => Some(LoopExiting),
             Suspended => Some(Suspended),
             Resumed => Some(Resumed),
         }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -181,7 +181,7 @@ pub enum ControlFlow {
     /// [`Poll`]: Self::Poll
     WaitUntil(Instant),
 
-    /// Send a [`LoopDestroyed`] event and stop the event loop. This variant is *sticky* - once set,
+    /// Send a [`LoopExiting`] event and stop the event loop. This variant is *sticky* - once set,
     /// `control_flow` cannot be changed from `ExitWithCode`, and any future attempts to do so will
     /// result in the `control_flow` parameter being reset to `ExitWithCode`.
     ///
@@ -195,7 +195,7 @@ pub enum ControlFlow {
     ///   which can cause surprises with negative exit values (`-42` would end up as `214`). See
     ///   [`std::process::exit`].
     ///
-    /// [`LoopDestroyed`]: Event::LoopDestroyed
+    /// [`LoopExiting`]: Event::LoopExiting
     /// [`Exit`]: ControlFlow::Exit
     ExitWithCode(i32),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 //! dispatch events for every [`Window`] that was created with that particular [`EventLoop`], and
 //! will run until the `control_flow` argument given to the closure is set to
 //! [`ControlFlow`]`::`[`ExitWithCode`] (which [`ControlFlow`]`::`[`Exit`] aliases to), at which
-//! point [`Event`]`::`[`LoopDestroyed`] is emitted and the entire program terminates.
+//! point [`Event`]`::`[`LoopExiting`] is emitted and the entire program terminates.
 //!
 //! Winit no longer uses a `EventLoop::poll_events() -> impl Iterator<Event>`-based event loop
 //! model, since that can't be implemented properly on some platforms (e.g web, iOS) and works poorly on
@@ -126,7 +126,7 @@
 //! [`WindowEvent`]: event::WindowEvent
 //! [`DeviceEvent`]: event::DeviceEvent
 //! [`UserEvent`]: event::Event::UserEvent
-//! [`LoopDestroyed`]: event::Event::LoopDestroyed
+//! [`LoopExiting`]: event::Event::LoopExiting
 //! [`platform`]: platform
 //! [`raw_window_handle`]: ./window/struct.Window.html#method.raw_window_handle
 //! [`raw_display_handle`]: ./window/struct.Window.html#method.raw_display_handle

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -585,7 +585,7 @@ impl<T: 'static> EventLoop<T> {
 
             let mut dummy = self.control_flow;
             sticky_exit_callback(
-                event::Event::LoopDestroyed,
+                event::Event::LoopExiting,
                 self.window_target(),
                 &mut dummy,
                 &mut callback,

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -444,10 +444,7 @@ impl AppState {
     fn terminated_transition(&mut self) -> Box<dyn EventHandler> {
         match self.replace_state(AppStateImpl::Terminated) {
             AppStateImpl::ProcessingEvents { event_handler, .. } => event_handler,
-            s => bug!(
-                "`LoopDestroyed` happened while not processing events {:?}",
-                s
-            ),
+            s => bug!("`LoopExiting` happened while not processing events {:?}", s),
         }
     }
 }
@@ -785,7 +782,7 @@ pub unsafe fn terminated() {
     let mut control_flow = this.control_flow;
     drop(this);
 
-    event_handler.handle_nonuser_event(Event::LoopDestroyed, &mut control_flow)
+    event_handler.handle_nonuser_event(Event::LoopExiting, &mut control_flow)
 }
 
 fn handle_event_proxy(

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -48,12 +48,12 @@
 //!
 //!  - applicationDidBecomeActive is Resumed
 //!  - applicationWillResignActive is Suspended
-//!  - applicationWillTerminate is LoopDestroyed
+//!  - applicationWillTerminate is LoopExiting
 //!
-//! Keep in mind that after LoopDestroyed event is received every attempt to draw with
+//! Keep in mind that after LoopExiting event is received every attempt to draw with
 //! opengl will result in segfault.
 //!
-//! Also note that app may not receive the LoopDestroyed event if suspended; it might be SIGKILL'ed.
+//! Also note that app may not receive the LoopExiting event if suspended; it might be SIGKILL'ed.
 
 #![cfg(ios_platform)]
 #![allow(clippy::let_unit_value)]

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -202,7 +202,7 @@ impl<T: 'static> EventLoop<T> {
 
             let mut dummy = self.control_flow;
             sticky_exit_callback(
-                Event::LoopDestroyed,
+                Event::LoopExiting,
                 self.window_target(),
                 &mut dummy,
                 &mut callback,

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -492,7 +492,7 @@ impl<T: 'static> EventLoop<T> {
 
             let mut dummy = self.control_flow;
             sticky_exit_callback(
-                Event::LoopDestroyed,
+                Event::LoopExiting,
                 self.window_target(),
                 &mut dummy,
                 &mut callback,

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -436,7 +436,7 @@ impl AppState {
 
     pub fn exit() -> i32 {
         HANDLER.set_in_callback(true);
-        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::LoopDestroyed));
+        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::LoopExiting));
         HANDLER.set_in_callback(false);
         HANDLER.exit();
         Self::clear_callback();

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -64,7 +64,7 @@ extern "C" fn control_flow_begin_handler(
 }
 
 // end is queued with the lowest priority to ensure it is processed after other observers
-// without that, LoopDestroyed would  get sent after MainEventsCleared
+// without that, LoopExiting would  get sent after MainEventsCleared
 extern "C" fn control_flow_end_handler(
     _: CFRunLoopObserverRef,
     activity: CFRunLoopActivity,

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -684,7 +684,7 @@ impl<T: 'static> EventLoop<T> {
         };
 
         event_handler(
-            event::Event::LoopDestroyed,
+            event::Event::LoopExiting,
             &self.window_target,
             &mut control_flow,
         );

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -585,7 +585,7 @@ impl<T: 'static> Shared<T> {
         let mut control = self.current_control_flow();
         // We don't call `handle_loop_destroyed` here because we don't need to
         // perform cleanup when the web browser is going to destroy the page.
-        self.handle_event(Event::LoopDestroyed, &mut control);
+        self.handle_event(Event::LoopExiting, &mut control);
     }
 
     // handle_event takes in events and either queues them or applies a callback
@@ -665,7 +665,7 @@ impl<T: 'static> Shared<T> {
     }
 
     fn handle_loop_destroyed(&self, control: &mut ControlFlow) {
-        self.handle_event(Event::LoopDestroyed, control);
+        self.handle_event(Event::LoopExiting, control);
         let all_canvases = std::mem::take(&mut *self.0.all_canvases.borrow_mut());
         *self.0.page_transition_event_handle.borrow_mut() = None;
         *self.0.on_mouse_move.borrow_mut() = None;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -341,7 +341,7 @@ impl<T: 'static> EventLoop<T> {
         };
 
         // We wait until we've checked for an exit status before clearing the
-        // application callback, in case we need to dispatch a LoopDestroyed event
+        // application callback, in case we need to dispatch a LoopExiting event
         //
         // # Safety
         // This pairs up with our call to `runner.set_event_handler` and ensures

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -251,7 +251,7 @@ impl<T> EventLoopRunner<T> {
     }
 
     /// Dispatch control flow events (`NewEvents`, `MainEventsCleared`, `RedrawEventsCleared`, and
-    /// `LoopDestroyed`) as necessary to bring the internal `RunnerState` to the new runner state.
+    /// `LoopExiting`) as necessary to bring the internal `RunnerState` to the new runner state.
     ///
     /// The state transitions are defined as follows:
     ///
@@ -298,7 +298,7 @@ impl<T> EventLoopRunner<T> {
                 self.call_new_events(true);
                 self.call_event_handler(Event::MainEventsCleared);
                 self.call_redraw_events_cleared();
-                self.call_event_handler(Event::LoopDestroyed);
+                self.call_event_handler(Event::LoopExiting);
             }
             (_, Uninitialized) => panic!("cannot move state to Uninitialized"),
 
@@ -307,7 +307,7 @@ impl<T> EventLoopRunner<T> {
                 self.call_new_events(false);
             }
             (Idle, Destroyed) => {
-                self.call_event_handler(Event::LoopDestroyed);
+                self.call_event_handler(Event::LoopExiting);
             }
 
             (HandlingMainEvents, Idle) => {
@@ -317,7 +317,7 @@ impl<T> EventLoopRunner<T> {
             (HandlingMainEvents, Destroyed) => {
                 self.call_event_handler(Event::MainEventsCleared);
                 self.call_redraw_events_cleared();
-                self.call_event_handler(Event::LoopDestroyed);
+                self.call_event_handler(Event::LoopExiting);
             }
 
             (Destroyed, _) => panic!("cannot move state from Destroyed"),


### PR DESCRIPTION
Considering the possibility of re-running an event loop via `run_ondemand` then it's more correct to say that the loop is about to exit without assuming it's going to be destroyed.

This is one of the follow ups for #2900, assuming that #2767 hopefully lands soon.

_Note: the base for this PR isn't currently set to master, since it's stacked on the changes for #2767_
