### PR TITLE
Add Occluded events based on foreground/background on iOS and MemoryWarning on iOS/Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** `with_x11_visual` now takes the visual ID instead of the bare pointer.
 - On X11, add a `with_embedded_parent_window` function to the window builder to allow embedding a window into another window.
 - On iOS, add force data to touch events when using the Apple Pencil.
-- On iOS, add events `Event::Foreground`, `Event::Background` and `Event::MemoryWarning`.
+- On iOS, send events `WindowEvent::Occluded(false)`, `WindowEvent::Occluded(true)` when application enters/leaves foreground.
+- on iOS, add event `Event::MemoryWarning`.
 - On Android, add event `Event::MemoryWarning`.
 
 # 0.29.0-beta.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** `with_x11_visual` now takes the visual ID instead of the bare pointer.
 - On X11, add a `with_embedded_parent_window` function to the window builder to allow embedding a window into another window.
 - On iOS, add force data to touch events when using the Apple Pencil.
+- On iOS, add events `Event::Foreground`, `Event::Background` and `Event::MemoryWarning`.
+- On Android, add event `Event::MemoryWarning`.
 
 # 0.29.0-beta.0
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -208,30 +208,6 @@ pub enum Event<T: 'static> {
     /// [`Suspended`]: Self::Suspended
     Resumed,
 
-    /// Emitted when the application will enter the foreground.
-    ///
-    /// ## iOS
-    ///
-    /// On iOS, the `Foreground` event is emitted in response to an [`applicationWillEnterForeground`]
-    /// callback which means the application should start preparing its data (according to the
-    /// [iOS application lifecycle]).
-    ///
-    /// [`applicationWillEnterForeground`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623076-applicationwillenterforeground
-    /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
-    Foreground,
-
-    /// Emitted when the application has entered the background.
-    ///
-    /// ## iOS
-    ///
-    /// On iOS, the `Background` event is emitted in response to an [`applicationDidEnterBackground`]
-    /// callback which means the application should free resources (according to the
-    /// [iOS application lifecycle]).
-    ///
-    /// [`applicationDidEnterBackground`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622997-applicationdidenterbackground
-    /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
-    Background,
-
     /// Emitted when the event loop is about to block and wait for new events.
     ///
     /// Most applications shouldn't need to hook into this event since there is no real relationship
@@ -284,8 +260,6 @@ impl<T> Event<T> {
             LoopExiting => Ok(LoopExiting),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
-            Foreground => Ok(Foreground),
-            Background => Ok(Background),
             MemoryWarning => Ok(MemoryWarning),
         }
     }
@@ -580,8 +554,19 @@ pub enum WindowEvent {
     ///
     /// Platform-specific behavior:
     ///
+    /// ## iOS
+    ///
+    /// On iOS, the `Occluded(false)` event is emitted in response to an [`applicationWillEnterForeground`]
+    /// callback which means the application should start preparing its data. The `Occluded(true)` event is
+    /// emitted in response to an [`applicationDidEnterBackground`] callback which means the application
+    /// should free resources (according to the [iOS application lifecycle]).
+    ///
+    /// [`applicationWillEnterForeground`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623076-applicationwillenterforeground
+    /// [`applicationDidEnterBackground`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622997-applicationdidenterbackground
+    /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
+    ///
     /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
-    /// - **iOS / Android / Wayland / Windows / Orbital:** Unsupported.
+    /// - **Android / Wayland / Windows / Orbital:** Unsupported.
     ///
     /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
     /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding

--- a/src/event.rs
+++ b/src/event.rs
@@ -208,6 +208,12 @@ pub enum Event<T: 'static> {
     /// [`Suspended`]: Self::Suspended
     Resumed,
 
+    /// Emitted when the application will enter the foreground.
+    Foreground,
+
+    /// Emitted when the application has entered the background.
+    Background,
+
     /// Emitted when the event loop is about to block and wait for new events.
     ///
     /// Most applications shouldn't need to hook into this event since there is no real relationship
@@ -240,6 +246,8 @@ impl<T> Event<T> {
             LoopExiting => Ok(LoopExiting),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
+            Foreground => Ok(Foreground),
+            Background => Ok(Background),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -252,6 +252,14 @@ pub enum Event<T: 'static> {
 
     /// Emitted when the application has received a memory warning.
     ///
+    /// ## Android
+    ///
+    /// On Android, the `MemoryWarning` event is sent when [`onLowMemory`] was called. The application
+    /// must [release memory] or risk being killed.
+    ///
+    /// [`onLowMemory`]: https://developer.android.com/reference/android/app/Application.html#onLowMemory()
+    /// [release memory]: https://developer.android.com/topic/performance/memory#release
+    ///
     /// ## iOS
     ///
     /// On iOS, the `MemoryWarning` event is emitted in response to an [`applicationDidReceiveMemoryWarning`]

--- a/src/event.rs
+++ b/src/event.rs
@@ -249,6 +249,18 @@ pub enum Event<T: 'static> {
     /// This is irreversible - if this event is emitted, it is guaranteed to be the last event that
     /// gets emitted. You generally want to treat this as a "do on quit" event.
     LoopExiting,
+
+    /// Emitted when the application has received a memory warning.
+    ///
+    /// ## iOS
+    ///
+    /// On iOS, the `MemoryWarning` event is emitted in response to an [`applicationDidReceiveMemoryWarning`]
+    /// callback. The application must free as much memory as possible or risk being terminated, see
+    /// [how to respond to memory warnings].
+    ///
+    /// [`applicationDidReceiveMemoryWarning`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623063-applicationdidreceivememorywarni
+    /// [how to respond to memory warnings]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle/responding_to_memory_warnings
+    MemoryWarning,
 }
 
 impl<T> Event<T> {
@@ -266,6 +278,7 @@ impl<T> Event<T> {
             Resumed => Ok(Resumed),
             Foreground => Ok(Foreground),
             Background => Ok(Background),
+            MemoryWarning => Ok(MemoryWarning),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -209,9 +209,27 @@ pub enum Event<T: 'static> {
     Resumed,
 
     /// Emitted when the application will enter the foreground.
+    ///
+    /// ## iOS
+    ///
+    /// On iOS, the `Foreground` event is emitted in response to an [`applicationWillEnterForeground`]
+    /// callback which means the application should start preparing its data (according to the
+    /// [iOS application lifecycle]).
+    ///
+    /// [`applicationWillEnterForeground`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623076-applicationwillenterforeground
+    /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
     Foreground,
 
     /// Emitted when the application has entered the background.
+    ///
+    /// ## iOS
+    ///
+    /// On iOS, the `Background` event is emitted in response to an [`applicationDidEnterBackground`]
+    /// callback which means the application should free resources (according to the
+    /// [iOS application lifecycle]).
+    ///
+    /// [`applicationDidEnterBackground`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622997-applicationdidenterbackground
+    /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
     Background,
 
     /// Emitted when the event loop is about to block and wait for new events.

--- a/src/event.rs
+++ b/src/event.rs
@@ -228,7 +228,9 @@ pub enum Event<T: 'static> {
 
     /// Emitted when the application has received a memory warning.
     ///
-    /// ## Android
+    /// ## Platform-specific
+    ///
+    /// ### Android
     ///
     /// On Android, the `MemoryWarning` event is sent when [`onLowMemory`] was called. The application
     /// must [release memory] or risk being killed.
@@ -236,7 +238,7 @@ pub enum Event<T: 'static> {
     /// [`onLowMemory`]: https://developer.android.com/reference/android/app/Application.html#onLowMemory()
     /// [release memory]: https://developer.android.com/topic/performance/memory#release
     ///
-    /// ## iOS
+    /// ### iOS
     ///
     /// On iOS, the `MemoryWarning` event is emitted in response to an [`applicationDidReceiveMemoryWarning`]
     /// callback. The application must free as much memory as possible or risk being terminated, see
@@ -244,6 +246,10 @@ pub enum Event<T: 'static> {
     ///
     /// [`applicationDidReceiveMemoryWarning`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623063-applicationdidreceivememorywarni
     /// [how to respond to memory warnings]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle/responding_to_memory_warnings
+    ///
+    /// ### Others
+    ///
+    /// - **macOS / Wayland / Windows / Orbital:** Unsupported.
     MemoryWarning,
 }
 
@@ -552,9 +558,9 @@ pub enum WindowEvent {
     /// This is different to window visibility as it depends on whether the window is closed,
     /// minimised, set invisible, or fully occluded by another window.
     ///
-    /// Platform-specific behavior:
+    /// ## Platform-specific
     ///
-    /// ## iOS
+    /// ### iOS
     ///
     /// On iOS, the `Occluded(false)` event is emitted in response to an [`applicationWillEnterForeground`]
     /// callback which means the application should start preparing its data. The `Occluded(true)` event is
@@ -564,6 +570,8 @@ pub enum WindowEvent {
     /// [`applicationWillEnterForeground`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623076-applicationwillenterforeground
     /// [`applicationDidEnterBackground`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622997-applicationdidenterbackground
     /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
+    ///
+    /// ### Others
     ///
     /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
     /// - **Android / Wayland / Windows / Orbital:** Unsupported.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -275,7 +275,7 @@ impl<T: 'static> EventLoop<T> {
                     sticky_exit_callback(
                         event::Event::MemoryWarning,
                         self.window_target(),
-                        control_flow,
+                        &mut control_flow,
                         callback,
                     );
                 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -272,12 +272,7 @@ impl<T: 'static> EventLoop<T> {
                     }
                 }
                 MainEvent::LowMemory => {
-                    sticky_exit_callback(
-                        event::Event::MemoryWarning,
-                        self.window_target(),
-                        &mut control_flow,
-                        callback,
-                    );
+                    callback(event::Event::MemoryWarning, self.window_target());
                 }
                 MainEvent::Start => {
                     // XXX: how to forward this state to applications?

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -276,6 +276,12 @@ impl<T: 'static> EventLoop<T> {
                     // It seems like ideally winit should support lifecycle and
                     // low-memory events, especially for mobile platforms.
                     warn!("TODO: handle Android LowMemory notification");
+                    sticky_exit_callback(
+                        event::Event::MemoryWarning,
+                        self.window_target(),
+                        control_flow,
+                        callback,
+                    );
                 }
                 MainEvent::Start => {
                     // XXX: how to forward this state to applications?

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -272,10 +272,6 @@ impl<T: 'static> EventLoop<T> {
                     }
                 }
                 MainEvent::LowMemory => {
-                    // XXX: how to forward this state to applications?
-                    // It seems like ideally winit should support lifecycle and
-                    // low-memory events, especially for mobile platforms.
-                    warn!("TODO: handle Android LowMemory notification");
                     sticky_exit_callback(
                         event::Event::MemoryWarning,
                         self.window_target(),

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -556,7 +556,7 @@ declare_class!(
             app_state::terminated(mtm);
         }
 
-        #[sel(applicationDidReceiveMemoryWarning:)]
+        #[method(applicationDidReceiveMemoryWarning:)]
         fn did_receive_memory_warning(&self, _application: &UIApplication) {
             unsafe {
                 app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::MemoryWarning))

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -367,14 +367,6 @@ impl WinitViewController {
         }
     }
 
-    extern "C" fn will_enter_foreground(_: &Object, _: Sel, _: id) {
-        unsafe { app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Foreground)) }
-    }
-
-    extern "C" fn did_enter_background(_: &Object, _: Sel, _: id) {
-        unsafe { app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Background)) }
-    }
-
     pub(crate) fn set_supported_interface_orientations(
         &self,
         mtm: MainThreadMarker,
@@ -533,10 +525,14 @@ declare_class!(
         }
 
         #[method(applicationWillEnterForeground:)]
-        fn will_enter_foreground(&self, _application: &UIApplication) {}
+        fn will_enter_foreground(&self, _application: &UIApplication) {
+            unsafe { app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Foreground)) }
+        }
 
         #[method(applicationDidEnterBackground:)]
-        fn did_enter_background(&self, _application: &UIApplication) {}
+        fn did_enter_background(&self, _application: &UIApplication) {
+            unsafe { app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Background)) }
+        }
 
         #[method(applicationWillTerminate:)]
         fn will_terminate(&self, application: &UIApplication) {

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -555,5 +555,12 @@ declare_class!(
             app_state::handle_nonuser_events(mtm, events);
             app_state::terminated(mtm);
         }
+
+        #[sel(applicationDidReceiveMemoryWarning:)]
+        fn did_receive_memory_warning(&self, _application: &UIApplication) {
+            unsafe {
+                app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::MemoryWarning))
+            }
+        }
     }
 );

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -367,6 +367,14 @@ impl WinitViewController {
         }
     }
 
+    extern "C" fn will_enter_foreground(_: &Object, _: Sel, _: id) {
+        unsafe { app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Foreground)) }
+    }
+
+    extern "C" fn did_enter_background(_: &Object, _: Sel, _: id) {
+        unsafe { app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::Background)) }
+    }
+
     pub(crate) fn set_supported_interface_orientations(
         &self,
         mtm: MainThreadMarker,


### PR DESCRIPTION
Adopted from #2144, and updated.

From https://github.com/rust-windowing/winit/pull/2144#issuecomment-1129990322 I'm not confident on adding events `Foreground` and `Background` to Android, they seem to be equivalent to `Suspend` / `Resume` where iOS split that in two steps.


- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
