### PR TITLE
Remove `lifetime` from the `Event`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 # Unreleased
 
 - On Windows, added `WindowBuilderExtWindows::with_class_name` to customize the internal class name.
+- **Breaking:** Remove lifetime parameter from `Event` and `WindowEvent`.
+- **Breaking:** `ScaleFactorChanged` now contains a writer instead of a reference to update inner size.
 - On iOS, always wake the event loop when transitioning from `ControlFlow::Poll` to `ControlFlow::Poll`.
 - **Breaking:** `ActivationTokenDone` event which could be requested with the new `startup_notify` module, see its docs for more.
 - On Wayland, make double clicking and moving the CSD frame more reliable.

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("parent window: {parent_window:?})");
 
-    event_loop.run(move |event: Event<'_, ()>, event_loop, control_flow| {
+    event_loop.run(move |event: Event<()>, event_loop, control_flow| {
         *control_flow = ControlFlow::Wait;
 
         if let Event::WindowEvent { event, window_id } = event {

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -195,9 +195,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 }
                 _ => {
                     if let Some(tx) = window_senders.get(&window_id) {
-                        if let Some(event) = event.to_static() {
-                            tx.send(event).unwrap();
-                        }
+                        tx.send(event).unwrap();
                     }
                 }
             },

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,8 @@ use crate::platform_impl;
 pub enum ExternalError {
     /// The operation is not supported by the backend.
     NotSupported(NotSupportedError),
+    /// The operation was ignored.
+    Ignored,
     /// The OS cannot perform the operation.
     Os(OsError),
 }
@@ -74,6 +76,7 @@ impl fmt::Display for ExternalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             ExternalError::NotSupported(e) => e.fmt(f),
+            ExternalError::Ignored => write!(f, "Operation was ignored"),
             ExternalError::Os(e) => e.fmt(f),
         }
     }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -314,7 +314,7 @@ impl<T> EventLoop<T> {
     #[inline]
     pub fn run<F>(self, event_handler: F) -> Result<(), RunLoopError>
     where
-        F: 'static + FnMut(Event<'_, T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.event_loop.run(event_handler)
     }

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -174,11 +174,7 @@ pub trait EventLoopExtPumpEvents {
     ///   callback.
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(
-            Event<'_, Self::UserEvent>,
-            &EventLoopWindowTarget<Self::UserEvent>,
-            &mut ControlFlow,
-        );
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
 }
 
 impl<T> EventLoopExtPumpEvents for EventLoop<T> {
@@ -186,11 +182,7 @@ impl<T> EventLoopExtPumpEvents for EventLoop<T> {
 
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(
-            Event<'_, Self::UserEvent>,
-            &EventLoopWindowTarget<Self::UserEvent>,
-            &mut ControlFlow,
-        ),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
     {
         self.event_loop.pump_events(timeout, event_handler)
     }

--- a/src/platform/run_ondemand.rs
+++ b/src/platform/run_ondemand.rs
@@ -59,11 +59,7 @@ pub trait EventLoopExtRunOnDemand {
     /// - **iOS:** It's not possible to stop and start an `NSApplication` repeatedly on iOS.
     fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), RunLoopError>
     where
-        F: FnMut(
-            Event<'_, Self::UserEvent>,
-            &EventLoopWindowTarget<Self::UserEvent>,
-            &mut ControlFlow,
-        );
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
 }
 
 impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
@@ -71,11 +67,7 @@ impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
 
     fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), RunLoopError>
     where
-        F: FnMut(
-            Event<'_, Self::UserEvent>,
-            &EventLoopWindowTarget<Self::UserEvent>,
-            &mut ControlFlow,
-        ),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
     {
         self.event_loop.run_ondemand(event_handler)
     }

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -116,11 +116,7 @@ pub trait EventLoopExtWebSys {
     fn spawn<F>(self, event_handler: F)
     where
         F: 'static
-            + FnMut(
-                Event<'_, Self::UserEvent>,
-                &EventLoopWindowTarget<Self::UserEvent>,
-                &mut ControlFlow,
-            );
+            + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
 }
 
 impl<T> EventLoopExtWebSys for EventLoop<T> {
@@ -129,11 +125,7 @@ impl<T> EventLoopExtWebSys for EventLoop<T> {
     fn spawn<F>(self, event_handler: F)
     where
         F: 'static
-            + FnMut(
-                Event<'_, Self::UserEvent>,
-                &EventLoopWindowTarget<Self::UserEvent>,
-                &mut ControlFlow,
-            ),
+            + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
     {
         self.event_loop.spawn(event_handler)
     }

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -33,7 +33,7 @@ use crate::{
 
 #[derive(Debug)]
 pub(crate) enum EventWrapper {
-    StaticEvent(Event<'static, Never>),
+    StaticEvent(Event<Never>),
     EventProxy(EventProxy),
 }
 
@@ -106,7 +106,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(self, event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         unsafe {
             let application = UIApplication::shared(MainThreadMarker::new().unwrap());
@@ -315,7 +315,7 @@ fn setup_control_flow_observers() {
 pub enum Never {}
 
 pub trait EventHandler: Debug {
-    fn handle_nonuser_event(&mut self, event: Event<'_, Never>, control_flow: &mut ControlFlow);
+    fn handle_nonuser_event(&mut self, event: Event<Never>, control_flow: &mut ControlFlow);
     fn handle_user_events(&mut self, control_flow: &mut ControlFlow);
 }
 
@@ -334,10 +334,10 @@ impl<F, T: 'static> Debug for EventLoopHandler<F, T> {
 
 impl<F, T> EventHandler for EventLoopHandler<F, T>
 where
-    F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
+    F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     T: 'static,
 {
-    fn handle_nonuser_event(&mut self, event: Event<'_, Never>, control_flow: &mut ControlFlow) {
+    fn handle_nonuser_event(&mut self, event: Event<Never>, control_flow: &mut ControlFlow) {
         (self.f)(
             event.map_nonuser_event().unwrap(),
             &self.event_loop,

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -89,7 +89,7 @@ pub(crate) use self::{
 
 use self::uikit::UIScreen;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
-pub(self) use crate::platform_impl::Fullscreen;
+pub(crate) use crate::platform_impl::Fullscreen;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
-pub(self) use crate::platform_impl::Fullscreen;
+pub(crate) use crate::platform_impl::Fullscreen;
 
 pub mod common;
 #[cfg(wayland_platform)]
@@ -832,21 +832,21 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, callback: F) -> Result<(), RunLoopError>
     where
-        F: FnMut(crate::event::Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(crate::event::Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         self.run_ondemand(callback)
     }
 
     pub fn run_ondemand<F>(&mut self, callback: F) -> Result<(), RunLoopError>
     where
-        F: FnMut(crate::event::Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(crate::event::Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_ondemand(callback))
     }
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(crate::event::Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(crate::event::Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.pump_events(timeout, callback))
     }
@@ -928,12 +928,12 @@ impl<T> EventLoopWindowTarget<T> {
 }
 
 fn sticky_exit_callback<T, F>(
-    evt: Event<'_, T>,
+    evt: Event<T>,
     target: &RootELW<T>,
     control_flow: &mut ControlFlow,
     callback: &mut F,
 ) where
-    F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+    F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
 {
     // make ControlFlow::ExitWithCode sticky by providing a dummy
     // control flow reference if it is already ExitWithCode.

--- a/src/platform_impl/linux/wayland/event_loop/sink.rs
+++ b/src/platform_impl/linux/wayland/event_loop/sink.rs
@@ -12,7 +12,7 @@ use super::{DeviceId, WindowId};
 /// to the winit's user.
 #[derive(Default)]
 pub struct EventSink {
-    pub window_events: Vec<Event<'static, ()>>,
+    pub window_events: Vec<Event<()>>,
 }
 
 impl EventSink {
@@ -31,7 +31,7 @@ impl EventSink {
 
     /// Add new window event to a queue.
     #[inline]
-    pub fn push_window_event(&mut self, event: WindowEvent<'static>, window_id: WindowId) {
+    pub fn push_window_event(&mut self, event: WindowEvent, window_id: WindowId) {
         self.window_events.push(Event::WindowEvent {
             event,
             window_id: RootWindowId(window_id),
@@ -44,7 +44,7 @@ impl EventSink {
     }
 
     #[inline]
-    pub fn drain(&mut self) -> Drain<'_, Event<'static, ()>> {
+    pub fn drain(&mut self) -> Drain<'_, Event<()>> {
         self.window_events.drain(..)
     }
 }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -434,7 +434,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run_ondemand<F>(&mut self, mut event_handler: F) -> Result<(), RunLoopError>
     where
-        F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         if self.loop_running {
             return Err(RunLoopError::AlreadyRunning);
@@ -468,7 +468,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut callback: F) -> PumpStatus
     where
-        F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         if !self.loop_running {
             self.loop_running = true;
@@ -512,7 +512,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn poll_events_with_timeout<F>(&mut self, mut timeout: Option<Duration>, mut callback: F)
     where
-        F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         let start = Instant::now();
 
@@ -595,7 +595,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn single_iteration<F>(&mut self, callback: &mut F, cause: StartCause)
     where
-        F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         let mut control_flow = self.control_flow;
 
@@ -694,7 +694,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn drain_events<F>(&mut self, callback: &mut F, control_flow: &mut ControlFlow)
     where
-        F: FnMut(Event<'_, T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         let target = &self.target;
         let mut xev = MaybeUninit::uninit();

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -24,7 +24,7 @@ use crate::{
 
 #[derive(Debug)]
 pub(crate) enum EventWrapper {
-    StaticEvent(Event<'static, Never>),
+    StaticEvent(Event<Never>),
     EventProxy(EventProxy),
 }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -195,7 +195,7 @@ impl<T> EventLoop<T> {
 
     pub fn run<F>(mut self, callback: F) -> Result<(), RunLoopError>
     where
-        F: 'static + FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         self.run_ondemand(callback)
     }
@@ -206,7 +206,7 @@ impl<T> EventLoop<T> {
     // redundant wake ups.
     pub fn run_ondemand<F>(&mut self, callback: F) -> Result<(), RunLoopError>
     where
-        F: FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         if AppState::is_running() {
             return Err(RunLoopError::AlreadyRunning);
@@ -223,8 +223,8 @@ impl<T> EventLoop<T> {
 
         let callback = unsafe {
             mem::transmute::<
-                Rc<RefCell<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>,
-                Rc<RefCell<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>>,
             >(Rc::new(RefCell::new(callback)))
         };
 
@@ -293,7 +293,7 @@ impl<T> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         // # Safety
         // We are erasing the lifetime of the application callback here so that we
@@ -306,8 +306,8 @@ impl<T> EventLoop<T> {
 
         let callback = unsafe {
             mem::transmute::<
-                Rc<RefCell<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>,
-                Rc<RefCell<dyn FnMut(Event<'_, T>, &RootWindowTarget<T>, &mut ControlFlow)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow)>>,
             >(Rc::new(RefCell::new(callback)))
         };
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -821,7 +821,7 @@ impl WinitView {
         WindowId(self.window().id())
     }
 
-    fn queue_event(&self, event: WindowEvent<'static>) {
+    fn queue_event(&self, event: WindowEvent) {
         let event = Event::WindowEvent {
             window_id: self.window_id(),
             event,

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -442,7 +442,7 @@ impl WinitWindowDelegate {
         }
     }
 
-    pub(crate) fn queue_event(&self, event: WindowEvent<'static>) {
+    pub(crate) fn queue_event(&self, event: WindowEvent) {
         let event = Event::WindowEvent {
             window_id: WindowId(self.window.id()),
             event,

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -308,7 +308,7 @@ impl<T: 'static> EventLoop<T> {
         event_state: &mut EventState,
         mut event_handler: F,
     ) where
-        F: FnMut(event::Event<'_, T>),
+        F: FnMut(event::Event<T>),
     {
         match event_option {
             EventOption::Key(KeyEvent {
@@ -446,11 +446,11 @@ impl<T: 'static> EventLoop<T> {
     pub fn run<F>(mut self, mut event_handler_inner: F) -> Result<(), RunLoopError>
     where
         F: 'static
-            + FnMut(event::Event<'_, T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
+            + FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         // Wrapper for event handler function that prevents ExitWithCode from being unset.
         let mut event_handler =
-            move |event: event::Event<'_, T>,
+            move |event: event::Event<T>,
                   window_target: &event_loop::EventLoopWindowTarget<T>,
                   control_flow: &mut ControlFlow| {
                 if let ControlFlow::ExitWithCode(code) = control_flow {

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -31,7 +31,7 @@ impl<T> EventLoop<T> {
 
     pub fn run<F>(self, event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.spawn_inner(event_handler, false);
 
@@ -46,14 +46,14 @@ impl<T> EventLoop<T> {
 
     pub fn spawn<F>(self, event_handler: F)
     where
-        F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.spawn_inner(event_handler, true);
     }
 
     fn spawn_inner<F>(self, mut event_handler: F, event_loop_recreation: bool)
     where
-        F: 'static + FnMut(Event<'_, T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
+        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         let target = RootEventLoopWindowTarget {
             p: self.elw.p.clone(),

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -24,7 +24,7 @@ use web_time::{Duration, Instant};
 
 pub struct Shared<T: 'static>(Rc<Execution<T>>);
 
-pub(super) type EventHandler<T> = dyn FnMut(Event<'_, T>, &mut ControlFlow);
+pub(super) type EventHandler<T> = dyn FnMut(Event<T>, &mut ControlFlow);
 
 impl<T> Clone for Shared<T> {
     fn clone(&self) -> Self {
@@ -748,7 +748,7 @@ impl<T: 'static> Shared<T> {
 }
 
 pub(crate) enum EventWrapper<T: 'static> {
-    Event(Event<'static, T>),
+    Event(Event<T>),
     ScaleChange {
         canvas: Weak<RefCell<backend::Canvas>>,
         size: PhysicalSize<u32>,
@@ -756,8 +756,8 @@ pub(crate) enum EventWrapper<T: 'static> {
     },
 }
 
-impl<T> From<Event<'static, T>> for EventWrapper<T> {
-    fn from(value: Event<'static, T>) -> Self {
+impl<T> From<Event<T>> for EventWrapper<T> {
+    fn from(value: Event<T>) -> Self {
         Self::Event(value)
     }
 }

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -38,4 +38,4 @@ pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId
 
 pub(crate) use self::keyboard::KeyEventExtra;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
-pub(self) use crate::platform_impl::Fullscreen;
+pub(crate) use crate::platform_impl::Fullscreen;

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -30,7 +30,7 @@ pub struct FileDropHandlerData {
     pub interface: IDropTarget,
     refcount: AtomicUsize,
     window: HWND,
-    send_event: Box<dyn Fn(Event<'static, ()>)>,
+    send_event: Box<dyn Fn(Event<()>)>,
     cursor_effect: u32,
     hovered_is_valid: bool, /* If the currently hovered item is not valid there must not be any `HoveredFileCancelled` emitted */
 }
@@ -41,7 +41,7 @@ pub struct FileDropHandler {
 
 #[allow(non_snake_case)]
 impl FileDropHandler {
-    pub fn new(window: HWND, send_event: Box<dyn Fn(Event<'static, ()>)>) -> FileDropHandler {
+    pub fn new(window: HWND, send_event: Box<dyn Fn(Event<()>)>) -> FileDropHandler {
         let data = Box::new(FileDropHandlerData {
             interface: IDropTarget {
                 lpVtbl: &DROP_TARGET_VTBL as *const IDropTargetVtbl,
@@ -211,7 +211,7 @@ impl FileDropHandler {
 }
 
 impl FileDropHandlerData {
-    fn send_event(&self, event: Event<'static, ()>) {
+    fn send_event(&self, event: Event<()>) {
         (self.send_event)(event);
     }
 }


### PR DESCRIPTION
Lifetimes don't work nicely when dealing with multithreaded environments in the current design of the existing winit's event handling model, so remove it in favor of `Weak` fences passed to client, so they could try to update the size.

Fixes #1387.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


--

The changes are uncontroversial and basically removed one concept with another. If backend maintainers think that they can do better now due to event being without a lifetime they should do that in the follow up PR.