### PR TITLE
Remove functionality already exposed through `raw-window-handle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Removed platform-specific extensions that should be retrieved through `raw-window-handle` trait implementations instead:
+  - `platform::windows::HINSTANCE`.
+  - `WindowExtWindows::hinstance`.
+  - `WindowExtWindows::hwnd`.
+  - `WindowExtIOS::ui_window`.
+  - `WindowExtIOS::ui_view_controller`.
+  - `WindowExtIOS::ui_view`.
+  - `WindowExtMacOS::ns_window`.
+  - `WindowExtMacOS::ns_view`.
+  - `EventLoopWindowTargetExtWayland::wayland_display`.
+  - `WindowExtWayland::wayland_surface`.
+  - `WindowExtWayland::wayland_display`.
+  - `WindowExtX11::xlib_window`.
+  - `WindowExtX11::xlib_display`.
+  - `WindowExtX11::xlib_screen_id`.
+  - `WindowExtX11::xcb_connection`.
 - On Web, use `Window.requestAnimationFrame()` to throttle `RedrawRequested` events.
 - On Wayland, use frame callbacks to throttle `RedrawRequested` events so redraws will align with compositor.
 - Add `Window::pre_present_notify` to notify winit before presenting to the windowing system.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -146,9 +146,6 @@ If your PR makes notable changes to Winit's features, please update this section
 
 ### iOS
 * `winit` has a minimum OS requirement of iOS 8
-* Get the `UIWindow` object pointer
-* Get the `UIViewController` object pointer
-* Get the `UIView` object pointer
 * Get the `UIScreen` object pointer
 * Setting the `UIView` hidpi factor
 * Valid orientations

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -22,27 +22,6 @@ impl<T: 'static> EventLoopExtIOS for EventLoop<T> {
 
 /// Additional methods on [`Window`] that are specific to iOS.
 pub trait WindowExtIOS {
-    /// Returns a pointer to the [`UIWindow`] that is used by this window.
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    ///
-    /// [`UIWindow`]: https://developer.apple.com/documentation/uikit/uiwindow?language=objc
-    fn ui_window(&self) -> *mut c_void;
-
-    /// Returns a pointer to the [`UIViewController`] that is used by this window.
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    ///
-    /// [`UIViewController`]: https://developer.apple.com/documentation/uikit/uiviewcontroller?language=objc
-    fn ui_view_controller(&self) -> *mut c_void;
-
-    /// Returns a pointer to the [`UIView`] that is used by this window.
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    ///
-    /// [`UIView`]: https://developer.apple.com/documentation/uikit/uiview?language=objc
-    fn ui_view(&self) -> *mut c_void;
-
     /// Sets the [`contentScaleFactor`] of the underlying [`UIWindow`] to `scale_factor`.
     ///
     /// The default value is device dependent, and it's recommended GLES or Metal applications set
@@ -97,21 +76,6 @@ pub trait WindowExtIOS {
 }
 
 impl WindowExtIOS for Window {
-    #[inline]
-    fn ui_window(&self) -> *mut c_void {
-        self.window.ui_window()
-    }
-
-    #[inline]
-    fn ui_view_controller(&self) -> *mut c_void {
-        self.window.ui_view_controller()
-    }
-
-    #[inline]
-    fn ui_view(&self) -> *mut c_void {
-        self.window.ui_view()
-    }
-
     #[inline]
     fn set_scale_factor(&self, scale_factor: f64) {
         self.window.set_scale_factor(scale_factor)

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -10,16 +10,6 @@ use crate::{
 
 /// Additional methods on [`Window`] that are specific to MacOS.
 pub trait WindowExtMacOS {
-    /// Returns a pointer to the cocoa `NSWindow` that is used by this window.
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    fn ns_window(&self) -> *mut c_void;
-
-    /// Returns a pointer to the cocoa `NSView` that is used by this window.
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    fn ns_view(&self) -> *mut c_void;
-
     /// Returns whether or not the window is in simple fullscreen mode.
     fn simple_fullscreen(&self) -> bool;
 
@@ -92,16 +82,6 @@ pub trait WindowExtMacOS {
 }
 
 impl WindowExtMacOS for Window {
-    #[inline]
-    fn ns_window(&self) -> *mut c_void {
-        self.window.ns_window()
-    }
-
-    #[inline]
-    fn ns_view(&self) -> *mut c_void {
-        self.window.ns_view()
-    }
-
     #[inline]
     fn simple_fullscreen(&self) -> bool {
         self.window.simple_fullscreen()

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -1,17 +1,10 @@
-use std::os::raw;
-
-use sctk::reexports::client::Proxy;
-
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };
 
-use crate::platform_impl::{
-    ApplicationName, Backend, EventLoopWindowTarget as LinuxEventLoopWindowTarget,
-    Window as LinuxWindow,
-};
+use crate::platform_impl::{ApplicationName, Backend};
 
 pub use crate::window::Theme;
 
@@ -19,33 +12,12 @@ pub use crate::window::Theme;
 pub trait EventLoopWindowTargetExtWayland {
     /// True if the [`EventLoopWindowTarget`] uses Wayland.
     fn is_wayland(&self) -> bool;
-
-    /// Returns a pointer to the `wl_display` object of wayland that is used by this
-    /// [`EventLoopWindowTarget`].
-    ///
-    /// Returns `None` if the [`EventLoop`] doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the winit [`EventLoop`] is destroyed.
-    ///
-    /// [`EventLoop`]: crate::event_loop::EventLoop
-    fn wayland_display(&self) -> Option<*mut raw::c_void>;
 }
 
 impl<T> EventLoopWindowTargetExtWayland for EventLoopWindowTarget<T> {
     #[inline]
     fn is_wayland(&self) -> bool {
         self.p.is_wayland()
-    }
-
-    #[inline]
-    fn wayland_display(&self) -> Option<*mut raw::c_void> {
-        match self.p {
-            LinuxEventLoopWindowTarget::Wayland(ref p) => {
-                Some(p.connection.display().id().as_ptr() as *mut _)
-            }
-            #[cfg(x11_platform)]
-            _ => None,
-        }
     }
 }
 
@@ -76,41 +48,9 @@ impl<T> EventLoopBuilderExtWayland for EventLoopBuilder<T> {
 }
 
 /// Additional methods on [`Window`] that are specific to Wayland.
-pub trait WindowExtWayland {
-    /// Returns a pointer to the `wl_surface` object of wayland that is used by this window.
-    ///
-    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    fn wayland_surface(&self) -> Option<*mut raw::c_void>;
+pub trait WindowExtWayland {}
 
-    /// Returns a pointer to the `wl_display` object of wayland that is used by this window.
-    ///
-    /// Returns `None` if the window doesn't use wayland (if it uses xlib for example).
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    fn wayland_display(&self) -> Option<*mut raw::c_void>;
-}
-
-impl WindowExtWayland for Window {
-    #[inline]
-    fn wayland_surface(&self) -> Option<*mut raw::c_void> {
-        match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.surface().id().as_ptr() as *mut _),
-            #[cfg(x11_platform)]
-            _ => None,
-        }
-    }
-
-    #[inline]
-    fn wayland_display(&self) -> Option<*mut raw::c_void> {
-        match self.window {
-            LinuxWindow::Wayland(ref w) => Some(w.display().id().as_ptr() as *mut _),
-            #[cfg(x11_platform)]
-            _ => None,
-        }
-    }
-}
+impl WindowExtWayland for Window {}
 
 /// Additional methods on [`WindowBuilder`] that are specific to Wayland.
 pub trait WindowBuilderExtWayland {

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -17,8 +17,6 @@ pub type HWND = isize;
 pub type HMENU = isize;
 /// Monitor Handle type used by Win32 API
 pub type HMONITOR = isize;
-/// Instance Handle type used by Win32 API
-pub type HINSTANCE = isize;
 
 /// Additional methods on `EventLoop` that are specific to Windows.
 pub trait EventLoopBuilderExtWindows {
@@ -113,13 +111,6 @@ impl<T> EventLoopBuilderExtWindows for EventLoopBuilder<T> {
 
 /// Additional methods on `Window` that are specific to Windows.
 pub trait WindowExtWindows {
-    /// Returns the HINSTANCE of the window
-    fn hinstance(&self) -> HINSTANCE;
-    /// Returns the native handle that is used by this window.
-    ///
-    /// The pointer will become invalid when the native window was destroyed.
-    fn hwnd(&self) -> HWND;
-
     /// Enables or disables mouse and keyboard input to the specified window.
     ///
     /// A window must be enabled before it can be activated.
@@ -148,16 +139,6 @@ pub trait WindowExtWindows {
 }
 
 impl WindowExtWindows for Window {
-    #[inline]
-    fn hinstance(&self) -> HINSTANCE {
-        self.window.hinstance()
-    }
-
-    #[inline]
-    fn hwnd(&self) -> HWND {
-        self.window.hwnd()
-    }
-
     #[inline]
     fn set_enable(&self, enabled: bool) {
         self.window.set_enable(enabled)

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -1,4 +1,3 @@
-use std::os::raw;
 use std::ptr;
 
 use crate::{
@@ -8,9 +7,7 @@ use crate::{
 };
 
 use crate::dpi::Size;
-use crate::platform_impl::{
-    x11::ffi::XVisualInfo, ApplicationName, Backend, Window as LinuxWindow, XLIB_ERROR_HOOKS,
-};
+use crate::platform_impl::{x11::ffi::XVisualInfo, ApplicationName, Backend, XLIB_ERROR_HOOKS};
 
 pub use crate::platform_impl::{x11::util::WindowType as XWindowType, XNotSupported};
 
@@ -81,66 +78,9 @@ impl<T> EventLoopBuilderExtX11 for EventLoopBuilder<T> {
 }
 
 /// Additional methods on [`Window`] that are specific to X11.
-pub trait WindowExtX11 {
-    /// Returns the ID of the [`Window`] xlib object that is used by this window.
-    ///
-    /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
-    fn xlib_window(&self) -> Option<raw::c_ulong>;
+pub trait WindowExtX11 {}
 
-    /// Returns a pointer to the `Display` object of xlib that is used by this window.
-    ///
-    /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    fn xlib_display(&self) -> Option<*mut raw::c_void>;
-
-    fn xlib_screen_id(&self) -> Option<raw::c_int>;
-
-    /// This function returns the underlying `xcb_connection_t` of an xlib `Display`.
-    ///
-    /// Returns `None` if the window doesn't use xlib (if it uses wayland for example).
-    ///
-    /// The pointer will become invalid when the [`Window`] is destroyed.
-    fn xcb_connection(&self) -> Option<*mut raw::c_void>;
-}
-
-impl WindowExtX11 for Window {
-    #[inline]
-    fn xlib_window(&self) -> Option<raw::c_ulong> {
-        match self.window {
-            LinuxWindow::X(ref w) => Some(w.xlib_window()),
-            #[cfg(wayland_platform)]
-            _ => None,
-        }
-    }
-
-    #[inline]
-    fn xlib_display(&self) -> Option<*mut raw::c_void> {
-        match self.window {
-            LinuxWindow::X(ref w) => Some(w.xlib_display()),
-            #[cfg(wayland_platform)]
-            _ => None,
-        }
-    }
-
-    #[inline]
-    fn xlib_screen_id(&self) -> Option<raw::c_int> {
-        match self.window {
-            LinuxWindow::X(ref w) => Some(w.xlib_screen_id()),
-            #[cfg(wayland_platform)]
-            _ => None,
-        }
-    }
-
-    #[inline]
-    fn xcb_connection(&self) -> Option<*mut raw::c_void> {
-        match self.window {
-            LinuxWindow::X(ref w) => Some(w.xcb_connection()),
-            #[cfg(wayland_platform)]
-            _ => None,
-        }
-    }
-}
+impl WindowExtX11 for Window {}
 
 /// Additional methods on [`WindowBuilder`] that are specific to X11.
 pub trait WindowBuilderExtX11 {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -2,7 +2,6 @@
 
 use std::{
     collections::VecDeque,
-    ffi::c_void,
     ops::{Deref, DerefMut},
 };
 
@@ -511,16 +510,6 @@ impl Window {
 
 // WindowExtIOS
 impl Inner {
-    pub fn ui_window(&self) -> *mut c_void {
-        Id::as_ptr(&self.window) as *mut c_void
-    }
-    pub fn ui_view_controller(&self) -> *mut c_void {
-        Id::as_ptr(&self.view_controller) as *mut c_void
-    }
-    pub fn ui_view(&self) -> *mut c_void {
-        Id::as_ptr(&self.view) as *mut c_void
-    }
-
     pub fn set_scale_factor(&self, scale_factor: f64) {
         assert!(
             dpi::validate_scale_factor(scale_factor),

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -607,11 +607,6 @@ impl Window {
     }
 
     #[inline]
-    pub fn display(&self) -> &WlDisplay {
-        &self.display
-    }
-
-    #[inline]
     pub fn surface(&self) -> &WlSurface {
         self.window.wl_surface()
     }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1396,18 +1396,8 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub fn xlib_screen_id(&self) -> c_int {
-        self.screen_id
-    }
-
-    #[inline]
     pub fn xlib_window(&self) -> c_ulong {
         self.xwindow as ffi::Window
-    }
-
-    #[inline]
-    pub fn xcb_connection(&self) -> *mut c_void {
-        self.xconn.xcb_connection().get_raw_xcb_connection()
     }
 
     #[inline]

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1250,8 +1250,8 @@ impl WinitWindow {
     #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
         let mut window_handle = AppKitWindowHandle::empty();
-        window_handle.ns_window = self.ns_window();
-        window_handle.ns_view = self.ns_view();
+        window_handle.ns_window = self as *const Self as *mut _;
+        window_handle.ns_view = Id::as_ptr(&self.contentView()) as *mut _;
         RawWindowHandle::AppKit(window_handle)
     }
 
@@ -1303,16 +1303,6 @@ impl WinitWindow {
 }
 
 impl WindowExtMacOS for WinitWindow {
-    #[inline]
-    fn ns_window(&self) -> *mut c_void {
-        self as *const Self as *mut _
-    }
-
-    #[inline]
-    fn ns_view(&self) -> *mut c_void {
-        Id::as_ptr(&self.contentView()) as *mut _
-    }
-
     #[inline]
     fn simple_fullscreen(&self) -> bool {
         self.lock_shared_state("simple_fullscreen")

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -14,8 +14,7 @@ use std::{
 
 use windows_sys::Win32::{
     Foundation::{
-        HMODULE, HWND, LPARAM, OLE_E_WRONGCOMPOBJ, POINT, POINTS, RECT, RPC_E_CHANGED_MODE, S_OK,
-        WPARAM,
+        HWND, LPARAM, OLE_E_WRONGCOMPOBJ, POINT, POINTS, RECT, RPC_E_CHANGED_MODE, S_OK, WPARAM,
     },
     Graphics::{
         Dwm::{DwmEnableBlurBehindWindow, DWM_BB_BLURREGION, DWM_BB_ENABLE, DWM_BLURBEHIND},
@@ -323,15 +322,11 @@ impl Window {
     }
 
     #[inline]
-    pub fn hinstance(&self) -> HMODULE {
-        unsafe { super::get_window_long(self.hwnd(), GWLP_HINSTANCE) }
-    }
-
-    #[inline]
     pub fn raw_window_handle(&self) -> RawWindowHandle {
         let mut window_handle = Win32WindowHandle::empty();
         window_handle.hwnd = self.window.0 as *mut _;
-        window_handle.hinstance = self.hinstance() as *mut _;
+        let hinstance = unsafe { super::get_window_long(self.hwnd(), GWLP_HINSTANCE) };
+        window_handle.hinstance = hinstance as *mut _;
         RawWindowHandle::Win32(window_handle)
     }
 


### PR DESCRIPTION
It seems odd to me that we have extension methods for accessing certain raw pointers/handles, when the information is already accessible through the `raw_window_handle::RawWindowHandle` implementation (although it's maybe slightly more cumbersome, and may lead to a lot of unwrapping).

So I propose that we remove these, and direct users towards `raw-window-handle` instead.

- [x] Tested on all platforms changed
  - This hardly needs any testing
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
