### PR TITLE
Improve CI caching, and give each job names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,22 +100,18 @@ jobs:
       run: cargo install cargo-apk --version=^0.9.7
 
     - name: Check documentation
-      shell: bash
       run: cargo doc --no-deps $OPTIONS --document-private-items
 
     - name: Build crate
-      shell: bash
       run: cargo $CMD build $OPTIONS
 
     - name: Build tests
-      shell: bash
       if: >
         !contains(matrix.platform.target, 'redox') &&
         matrix.toolchain != '1.65.0'
       run: cargo $CMD test --no-run $OPTIONS
 
     - name: Run tests
-      shell: bash
       if: >
         !contains(matrix.platform.target, 'android') &&
         !contains(matrix.platform.target, 'ios') &&
@@ -125,19 +121,16 @@ jobs:
       run: cargo $CMD test $OPTIONS
 
     - name: Lint with clippy
-      shell: bash
       if: (matrix.toolchain == 'stable') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets $OPTIONS -- -Dwarnings
 
     - name: Build tests with serde enabled
-      shell: bash
       if: >
         !contains(matrix.platform.target, 'redox') &&
         matrix.toolchain != '1.65.0'
       run: cargo $CMD test --no-run $OPTIONS --features serde
 
     - name: Run tests with serde enabled
-      shell: bash
       if: >
         !contains(matrix.platform.target, 'android') &&
         !contains(matrix.platform.target, 'ios') &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,12 +52,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    # Used to cache cargo-web
-    - name: Cache cargo folder
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo
-        key: ${{ matrix.platform.target }}-cargo-${{ matrix.toolchain }}
 
     - uses: dtolnay/rust-toolchain@master
       with:
@@ -65,12 +59,37 @@ jobs:
         targets: ${{ matrix.platform.target }}
         components: clippy
 
+    # Generate the lockfile so that `actions/cache` can use it in the key
+    - name: Generate Cargo.lock
+      run: cargo generate-lockfile
+
+    - name: Cache cargo folder
+      uses: actions/cache@v3
+      with:
+        # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
+        # Note: We don't cache `~/.cargo/bin`, that is done separately when needed.
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-${{ matrix.toolchain }}-${{ matrix.platform.name }}-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
       run: sudo apt-get update && sudo apt-get install gcc-multilib
-    - name: Install cargo-apk
+
+    - name: Cache cargo-apk
       if: contains(matrix.platform.target, 'android')
-      run: cargo install cargo-apk
+      id: cargo-apk-cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cargo/bin/cargo-apk
+        # Change this key if we update the required cargo-apk version
+        key: cargo-apk-${{ matrix.toolchain }}-${{ matrix.platform.name }}-v0-9-7
+
+    - name: Install cargo-apk
+      if: contains(matrix.platform.target, 'android') && (steps.cargo-apk-cache.outputs.cache-hit != 'true')
+      run: cargo install cargo-apk --version=^0.9.7
 
     - name: Check documentation
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,9 +40,7 @@ jobs:
           - { name: 'macOS',              target: x86_64-apple-darwin,      os: macos-latest,    }
           - { name: 'iOS x86_64',         target: x86_64-apple-ios,         os: macos-latest,    }
           - { name: 'iOS Aarch64',        target: aarch64-apple-ios,        os: macos-latest,    }
-          # We're using Windows rather than Ubuntu to run the wasm tests because caching cargo-web
-          # doesn't currently work on Linux.
-          - { name: 'web',                target: wasm32-unknown-unknown,   os: windows-latest,  }
+          - { name: 'web',                target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
 
     env:
       RUST_BACKTRACE: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
           - { name: 'Windows 32bit GNU',  target: i686-pc-windows-gnu,      os: windows-latest, host: -i686-pc-windows-gnu }
           - { name: 'Linux 32bit',        target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
           - { name: 'Linux 64bit',        target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
-          - { name: 'X11',                target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: x11 }
-          - { name: 'Wayland',            target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "wayland,wayland-dlopen" }
-          - { name: 'Android',            target: aarch64-linux-android,    os: ubuntu-latest, options: -p winit, cmd: 'apk --', features: "android-native-activity" }
+          - { name: 'X11',                target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: '--no-default-features --features=x11' }
+          - { name: 'Wayland',            target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: '--no-default-features --features=wayland,wayland-dlopen' }
+          - { name: 'Android',            target: aarch64-linux-android,    os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
           - { name: 'Redox OS',           target: x86_64-unknown-redox,     os: ubuntu-latest,   }
           - { name: 'macOS',              target: x86_64-apple-darwin,      os: macos-latest,    }
           - { name: 'iOS x86_64',         target: x86_64-apple-ios,         os: macos-latest,    }
@@ -43,12 +43,16 @@ jobs:
           - { name: 'web',                target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
 
     env:
+      # Set more verbose terminal output
+      CARGO_TERM_VERBOSE: true
       RUST_BACKTRACE: 1
-      RUSTFLAGS: "-C debuginfo=0 --deny warnings"
-      OPTIONS: ${{ matrix.platform.options }}
-      FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
+
+      # Faster compilation and error on warnings
+      RUSTFLAGS: '--codegen=debuginfo=0 --deny=warnings'
+      RUSTDOCFLAGS: '--deny=warnings'
+
+      OPTIONS: --target=${{ matrix.platform.target }} ${{ matrix.platform.options }}
       CMD: ${{ matrix.platform.cmd }}
-      RUSTDOCFLAGS: -Dwarnings
 
     steps:
     - uses: actions/checkout@v3
@@ -93,18 +97,18 @@ jobs:
 
     - name: Check documentation
       shell: bash
-      run: cargo doc --no-deps --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES --document-private-items
+      run: cargo doc --no-deps $OPTIONS --document-private-items
 
     - name: Build crate
       shell: bash
-      run: cargo $CMD build --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
+      run: cargo $CMD build $OPTIONS
 
     - name: Build tests
       shell: bash
       if: >
         !contains(matrix.platform.target, 'redox') &&
         matrix.toolchain != '1.65.0'
-      run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
+      run: cargo $CMD test --no-run $OPTIONS
 
     - name: Run tests
       shell: bash
@@ -114,19 +118,20 @@ jobs:
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
         matrix.toolchain != '1.65.0'
-      run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
+      run: cargo $CMD test $OPTIONS
 
     - name: Lint with clippy
       shell: bash
       if: (matrix.toolchain == 'stable') && !contains(matrix.platform.options, '--no-default-features')
-      run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
+      run: cargo clippy --all-targets $OPTIONS -- -Dwarnings
 
     - name: Build tests with serde enabled
       shell: bash
       if: >
         !contains(matrix.platform.target, 'redox') &&
         matrix.toolchain != '1.65.0'
-      run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
+      run: cargo $CMD test --no-run $OPTIONS --features serde
+
     - name: Run tests with serde enabled
       shell: bash
       if: >
@@ -135,7 +140,7 @@ jobs:
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
         matrix.toolchain != '1.65.0'
-      run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
+      run: cargo $CMD test $OPTIONS --features serde
 
   cargo-deny:
     name: Run cargo-deny on ${{ matrix.platform.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,20 +63,24 @@ jobs:
         targets: ${{ matrix.platform.target }}
         components: clippy
 
-    # Generate the lockfile so that `actions/cache` can use it in the key
-    - name: Generate Cargo.lock
-      run: cargo generate-lockfile
-
-    - name: Cache cargo folder
-      uses: actions/cache@v3
+    - name: Restore cache of cargo folder
+      # We use `restore` and later `save`, so that we can create the key after
+      # the cache has been downloaded.
+      #
+      # This could be avoided if we added Cargo.lock to the repository.
+      uses: actions/cache/restore@v3
       with:
         # https://doc.rust-lang.org/cargo/guide/cargo-home.html#caching-the-cargo-home-in-ci
-        # Note: We don't cache `~/.cargo/bin`, that is done separately when needed.
         path: |
           ~/.cargo/registry/index/
           ~/.cargo/registry/cache/
           ~/.cargo/git/db/
-        key: cargo-${{ matrix.toolchain }}-${{ matrix.platform.name }}-${{ hashFiles('**/Cargo.lock') }}
+        key: cargo-${{ matrix.toolchain }}-${{ matrix.platform.name }}-never-intended-to-be-found
+        restore-keys: cargo-${{ matrix.toolchain }}-${{ matrix.platform.name }}
+
+    - name: Generate lockfile
+      # Also updates the crates.io index
+      run: cargo generate-lockfile
 
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')
@@ -141,6 +145,16 @@ jobs:
         !contains(matrix.platform.target, 'redox') &&
         matrix.toolchain != '1.65.0'
       run: cargo $CMD test $OPTIONS --features serde
+
+    # See restore step above
+    - name: Save cache of cargo folder
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-${{ matrix.toolchain }}-${{ matrix.platform.name }}-${{ hashFiles('Cargo.lock') }}
 
   cargo-deny:
     name: Run cargo-deny on ${{ matrix.platform.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,36 +17,6 @@ jobs:
     - name: Check Formatting
       run: cargo fmt -- --check
 
-  cargo-deny:
-    name: cargo-deny
-
-    # TODO: remove this matrix when https://github.com/EmbarkStudios/cargo-deny/issues/324 is resolved
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - aarch64-apple-ios
-          - aarch64-linux-android
-          - i686-pc-windows-gnu
-          - i686-pc-windows-msvc
-          - i686-unknown-linux-gnu
-          - wasm32-unknown-unknown
-          - x86_64-apple-darwin
-          - x86_64-apple-ios
-          - x86_64-pc-windows-gnu
-          - x86_64-pc-windows-msvc
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-redox
-
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: EmbarkStudios/cargo-deny-action@v1
-      with:
-        command: check
-        log-level: error
-        arguments: --all-features --target ${{ matrix.platform }}
-
   tests:
     name: Tests
     strategy:
@@ -148,3 +118,28 @@ jobs:
         !contains(matrix.platform.target, 'redox') &&
         matrix.toolchain != '1.65.0'
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
+
+  cargo-deny:
+    name: Run cargo-deny on ${{ matrix.platform.name }}
+    runs-on: ubuntu-latest
+
+    # TODO: remove this matrix when https://github.com/EmbarkStudios/cargo-deny/issues/324 is resolved
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - { name: 'Android', target: aarch64-linux-android }
+          - { name: 'iOS', target: aarch64-apple-ios }
+          - { name: 'Linux', target: x86_64-unknown-linux-gnu }
+          - { name: 'macOS', target: x86_64-apple-darwin }
+          - { name: 'Redox OS', target: x86_64-unknown-redox }
+          - { name: 'web', target: wasm32-unknown-unknown }
+          - { name: 'Windows', target: x86_64-pc-windows-gnu }
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: EmbarkStudios/cargo-deny-action@v1
+      with:
+        command: check
+        log-level: error
+        arguments: --all-features --target ${{ matrix.platform.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,29 +18,31 @@ jobs:
       run: cargo fmt -- --check
 
   tests:
-    name: Tests
+    name: Test ${{ matrix.toolchain }} ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.os }}
+
     strategy:
       fail-fast: false
       matrix:
-        toolchain: ['1.65.0', stable, nightly]
+        toolchain: [stable, nightly, '1.65.0']
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
-          - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
-          - { target: i686-pc-windows-msvc,     os: windows-latest,  }
-          - { target: x86_64-pc-windows-gnu,    os: windows-latest, host: -x86_64-pc-windows-gnu }
-          - { target: i686-pc-windows-gnu,      os: windows-latest, host: -i686-pc-windows-gnu }
-          - { target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: x11 }
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "wayland,wayland-dlopen" }
-          - { target: aarch64-linux-android,    os: ubuntu-latest, options: -p winit, cmd: 'apk --', features: "android-native-activity" }
-          - { target: x86_64-unknown-redox,     os: ubuntu-latest,   }
-          - { target: x86_64-apple-darwin,      os: macos-latest,    }
-          - { target: x86_64-apple-ios,         os: macos-latest,    }
-          - { target: aarch64-apple-ios,        os: macos-latest,    }
+          - { name: 'Windows 64bit MSVC', target: x86_64-pc-windows-msvc,   os: windows-latest,  }
+          - { name: 'Windows 32bit MSVC', target: i686-pc-windows-msvc,     os: windows-latest,  }
+          - { name: 'Windows 64bit GNU',  target: x86_64-pc-windows-gnu,    os: windows-latest, host: -x86_64-pc-windows-gnu }
+          - { name: 'Windows 32bit GNU',  target: i686-pc-windows-gnu,      os: windows-latest, host: -i686-pc-windows-gnu }
+          - { name: 'Linux 32bit',        target: i686-unknown-linux-gnu,   os: ubuntu-latest,   }
+          - { name: 'Linux 64bit',        target: x86_64-unknown-linux-gnu, os: ubuntu-latest,   }
+          - { name: 'X11',                target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: x11 }
+          - { name: 'Wayland',            target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: --no-default-features, features: "wayland,wayland-dlopen" }
+          - { name: 'Android',            target: aarch64-linux-android,    os: ubuntu-latest, options: -p winit, cmd: 'apk --', features: "android-native-activity" }
+          - { name: 'Redox OS',           target: x86_64-unknown-redox,     os: ubuntu-latest,   }
+          - { name: 'macOS',              target: x86_64-apple-darwin,      os: macos-latest,    }
+          - { name: 'iOS x86_64',         target: x86_64-apple-ios,         os: macos-latest,    }
+          - { name: 'iOS Aarch64',        target: aarch64-apple-ios,        os: macos-latest,    }
           # We're using Windows rather than Ubuntu to run the wasm tests because caching cargo-web
           # doesn't currently work on Linux.
-          - { target: wasm32-unknown-unknown,   os: windows-latest,  }
+          - { name: 'web',                target: wasm32-unknown-unknown,   os: windows-latest,  }
 
     env:
       RUST_BACKTRACE: 1
@@ -50,7 +52,6 @@ jobs:
       CMD: ${{ matrix.platform.cmd }}
       RUSTDOCFLAGS: -Dwarnings
 
-    runs-on: ${{ matrix.platform.os }}
     steps:
     - uses: actions/checkout@v3
     # Used to cache cargo-web

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,17 +6,17 @@ on:
     branches: [master]
 
 jobs:
-  Check_Formatting:
+  fmt:
+    name: Check formatting
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: hecrj/setup-rust-action@v1
+    - uses: dtolnay/rust-toolchain@stable
       with:
-        rust-version: stable
         components: rustfmt
     - name: Check Formatting
-      run: cargo +stable fmt --all -- --check
-  
+      run: cargo fmt -- --check
+
   cargo-deny:
     name: cargo-deny
 
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ['1.65.0', stable, nightly]
+        toolchain: ['1.65.0', stable, nightly]
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
           - { target: x86_64-pc-windows-msvc,   os: windows-latest,  }
@@ -74,7 +74,6 @@ jobs:
 
     env:
       RUST_BACKTRACE: 1
-      CARGO_INCREMENTAL: 0
       RUSTFLAGS: "-C debuginfo=0 --deny warnings"
       OPTIONS: ${{ matrix.platform.options }}
       FEATURES: ${{ format(',{0}', matrix.platform.features ) }}
@@ -89,11 +88,11 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo
-        key: ${{ matrix.platform.target }}-cargo-${{ matrix.rust_version }}
+        key: ${{ matrix.platform.target }}-cargo-${{ matrix.toolchain }}
 
-    - uses: hecrj/setup-rust-action@v1
+    - uses: dtolnay/rust-toolchain@master
       with:
-        rust-version: ${{ matrix.rust_version }}${{ matrix.platform.host }}
+        toolchain: ${{ matrix.toolchain }}${{ matrix.platform.host }}
         targets: ${{ matrix.platform.target }}
         components: clippy
 
@@ -116,7 +115,7 @@ jobs:
       shell: bash
       if: >
         !contains(matrix.platform.target, 'redox') &&
-        matrix.rust_version != '1.65.0'
+        matrix.toolchain != '1.65.0'
       run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
     - name: Run tests
@@ -126,19 +125,19 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
-        matrix.rust_version != '1.65.0'
+        matrix.toolchain != '1.65.0'
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES
 
     - name: Lint with clippy
       shell: bash
-      if: (matrix.rust_version == 'stable') && !contains(matrix.platform.options, '--no-default-features')
+      if: (matrix.toolchain == 'stable') && !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets --target ${{ matrix.platform.target }} $OPTIONS --features $FEATURES -- -Dwarnings
 
     - name: Build tests with serde enabled
       shell: bash
       if: >
         !contains(matrix.platform.target, 'redox') &&
-        matrix.rust_version != '1.65.0'
+        matrix.toolchain != '1.65.0'
       run: cargo $CMD test --no-run --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES
     - name: Run tests with serde enabled
       shell: bash
@@ -147,5 +146,5 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
-        matrix.rust_version != '1.65.0'
+        matrix.toolchain != '1.65.0'
       run: cargo $CMD test --verbose --target ${{ matrix.platform.target }} $OPTIONS --features serde,$FEATURES


### PR DESCRIPTION
Two things to discuss:
1. The move from `hecrj/setup-rust-action` to `dtolnay/rust-toolchain` (done because of slightly better performance, and it seems like this is what everyone is moving to) removes support for the problem matchers, see https://github.com/dtolnay/rust-toolchain/issues/50. We can [re-add this explicitly](https://github.com/r7kamura/rust-problem-matchers) if desired, so: Is it desired? Do people actually like this feature? I myself don't ever use it, as I find it is really cluttered anyhow (since it's run on so many platforms, and GitHub doesn't do any deduplication).
2. Would it be time to start committing the `Cargo.lock`? Because if we do, we can use [Swatinem/rust-cache](https://github.com/Swatinem/rust-cache) or do something similarly easier instead. This should also prevent unrelated updates breaking CI in the future.

