### PR TITLE
Bug fix: Nonresizable windows should not be able to maximize in Windows

### DIFF
--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -267,6 +267,10 @@ impl Window {
                 f.set(WindowFlags::RESIZABLE, resizable)
             });
         });
+        //Nonresizable windows can still contain a maximize button, so we'd have to additionally remove the button.
+        let mut buttons = self.enabled_buttons();
+        buttons.set(WindowButtons::MAXIMIZE, resizable);
+        self.set_enabled_buttons(buttons);
     }
 
     #[inline]
@@ -1055,7 +1059,10 @@ impl<'a, T: 'static> InitData<'a, T> {
         // attribute is correctly applied.
         win.set_visible(attributes.visible);
 
-        win.set_enabled_buttons(attributes.enabled_buttons);
+        //Nonresizable windows can still contain a maximize button, so we'd have to additionally remove the button.
+        let mut buttons = attributes.enabled_buttons;
+        buttons.set(WindowButtons::MAXIMIZE, attributes.resizable);
+        win.set_enabled_buttons(buttons);
 
         if attributes.fullscreen.is_some() {
             win.set_fullscreen(attributes.fullscreen.map(Into::into));


### PR DESCRIPTION
There was a bug with Windows: Nonresizable windows should not be able to maximize.

Nonresizable windows should not be able to maximize. I updated the functionality in Windows for both initialization, and the set_resizable method, to disable maximizing when the window is nonresizable.

I asked about it earlier here - https://github.com/rust-windowing/winit/discussions/2987

It was already documented in the Changelog here - https://github.com/rust-windowing/winit/blob/master/CHANGELOG.md#version-0162-2018-07-07

- [X] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
