### PR TITLE
Add android ime support

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -886,19 +886,21 @@ pub enum Ime {
     /// Notifies when text should be inserted into the editor widget.
     ///
     /// Right before this event winit will send empty [`Self::Preedit`] event.
-    Commit(String),
-
-    /// Notifies when the complete text should be replaced.
-    /// This event should be used in combination with
-    /// [`Window::set_ime_surrounding_text`] to set the initial text of the
-    /// currently selected input field.
-    ///
-    /// ## Platform-specific
-    /// This will only be fired on **Android**.
-    Replace {
-        text: String,
-        selection: (usize, usize),
+    Commit {
+        content: String,
+        /// If selection is Some, the selection / cursor position should be updated after
+        /// placing the `content`.
+        selection: Option<(usize, usize)>,
+        /// If compose_region is Some, the compose region should be updated after replacing the
+        /// text.
         compose_region: Option<(usize, usize)>,
+    },
+
+    /// Notifies when the text around the cursor should be deleted.
+    /// If `before_length` and `after_length` are [usize::MAX], the entire text should be deleted.
+    DeleteSurroundingText {
+        before_length: usize,
+        after_length: usize,
     },
 
     /// Notifies when the IME was disabled.

--- a/src/event.rs
+++ b/src/event.rs
@@ -378,8 +378,6 @@ pub enum WindowEvent {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     Ime(Ime),
 
-    TextInputState(TextInputState),
-
     /// The cursor has moved on the window.
     ///
     /// ## Platform-specific
@@ -890,6 +888,19 @@ pub enum Ime {
     /// Right before this event winit will send empty [`Self::Preedit`] event.
     Commit(String),
 
+    /// Notifies when the complete text should be replaced.
+    /// This event should be used in combination with
+    /// [`Window::set_ime_surrounding_text`] to set the initial text of the
+    /// currently selected input field.
+    ///
+    /// ## Platform-specific
+    /// This will only be fired on **Android**.
+    Replace {
+        text: String,
+        selection: (usize, usize),
+        compose_region: Option<(usize, usize)>,
+    },
+
     /// Notifies when the IME was disabled.
     ///
     /// After receiving this event you won't get any more [`Preedit`](Self::Preedit) or
@@ -1096,28 +1107,4 @@ impl PartialEq for InnerSizeWriter {
     fn eq(&self, other: &Self) -> bool {
         self.new_inner_size.as_ptr() == other.new_inner_size.as_ptr()
     }
-}
-
-/// This struct holds a span within a region of text from `start` (inclusive) to
-/// `end` (exclusive).
-///
-/// An empty span or cursor position is specified with `start == end`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct TextSpan {
-    /// The start of the span (inclusive)
-    pub start: usize,
-
-    /// The end of the span (exclusive)
-    pub end: usize,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct TextInputState {
-    pub text: String,
-    /// A selection defined on the text.
-    pub selection: TextSpan,
-    /// A composing region defined on the text.
-    pub compose_region: Option<TextSpan>,
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -378,6 +378,8 @@ pub enum WindowEvent {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     Ime(Ime),
 
+    TextInputState(TextInputState),
+
     /// The cursor has moved on the window.
     ///
     /// ## Platform-specific
@@ -1094,4 +1096,28 @@ impl PartialEq for InnerSizeWriter {
     fn eq(&self, other: &Self) -> bool {
         self.new_inner_size.as_ptr() == other.new_inner_size.as_ptr()
     }
+}
+
+/// This struct holds a span within a region of text from `start` (inclusive) to
+/// `end` (exclusive).
+///
+/// An empty span or cursor position is specified with `start == end`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TextSpan {
+    /// The start of the span (inclusive)
+    pub start: usize,
+
+    /// The end of the span (exclusive)
+    pub end: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct TextInputState {
+    pub text: String,
+    /// A selection defined on the text.
+    pub selection: TextSpan,
+    /// A composing region defined on the text.
+    pub compose_region: Option<TextSpan>,
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -469,6 +469,32 @@ impl<T: 'static> EventLoop<T> {
                         }
                     }
                 }
+                InputEvent::TextEvent(ime_state) => {
+                    let event = event::Event::WindowEvent {
+                        window_id: window::WindowId(WindowId),
+                        event: event::WindowEvent::TextInputState(
+                            TextInputState {
+                                text: ime_state.text.to_owned(),
+                                selection: TextSpan {
+                                    start: ime_state.selection.start,
+                                    end: ime_state.selection.end,
+                                },
+                                compose_region: ime_state
+                                    .compose_region
+                                    .map(|region| TextSpan {
+                                        start: region.start,
+                                        end: region.end,
+                                    }),
+                            }
+                        )
+                    };
+                    sticky_exit_callback(
+                        event,
+                        self.window_target(),
+                        control_flow,
+                        callback
+                    );
+                }
                 _ => {
                     warn!("Unknown android_activity input event {event:?}")
                 }
@@ -905,6 +931,28 @@ impl Window {
 
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
+    pub fn begin_ime_input(&self) {
+        self.app.show_soft_input(true);
+    }
+
+    pub fn end_ime_input(&self) {
+        self.app.hide_soft_input(true);
+    }
+
+    pub fn set_text_input_state(&self, state: TextInputState) {
+        self.app.set_text_input_state(android_activity::input::TextInputState {
+            text: state.text,
+            selection: android_activity::input::TextSpan {
+                start: state.selection.start,
+                end: state.selection.end,
+            },
+            compose_region: state.compose_region.map(|region| android_activity::input::TextSpan {
+                start: region.start,
+                end: region.end,
+            }),
+        });
+    }
+
     pub fn focus_window(&self) {}
 
     pub fn request_user_attention(&self, _request_type: Option<window::UserAttentionType>) {}
@@ -987,6 +1035,8 @@ impl Window {
 pub struct OsError;
 
 use std::fmt::{self, Display, Formatter};
+use crate::event::{TextInputState, TextSpan};
+
 impl Display for OsError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         write!(fmt, "Android OS Error")

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -30,7 +30,6 @@ use crate::{
         WindowAttributes, WindowButtons, WindowId as RootWindowId, WindowLevel,
     },
 };
-use crate::event::TextInputState;
 
 pub struct Inner {
     pub(crate) window: Id<WinitUIWindow>,
@@ -307,11 +306,9 @@ impl Inner {
         warn!("`Window::set_ime_allowed` is ignored on iOS")
     }
 
-    pub fn begin_ime_input(&self) {}
-
-    pub fn end_ime_input(&self) {}
-
-    pub fn set_text_input_state(&self, state: TextInputState) {}
+    pub fn set_ime_surrounding_text(&self, _text: String, _selection: (usize, usize)) {
+        warn!("`Window::set_ime_surrounding_text` is ignored on iOS")
+    }
 
     pub fn focus_window(&self) {
         warn!("`Window::set_focus` is ignored on iOS")

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -30,6 +30,7 @@ use crate::{
         WindowAttributes, WindowButtons, WindowId as RootWindowId, WindowLevel,
     },
 };
+use crate::event::TextInputState;
 
 pub struct Inner {
     pub(crate) window: Id<WinitUIWindow>,
@@ -305,6 +306,12 @@ impl Inner {
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {
         warn!("`Window::set_ime_allowed` is ignored on iOS")
     }
+
+    pub fn begin_ime_input(&self) {}
+
+    pub fn end_ime_input(&self) {}
+
+    pub fn set_text_input_state(&self, state: TextInputState) {}
 
     pub fn focus_window(&self) {
         warn!("`Window::set_focus` is ignored on iOS")

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -46,6 +46,7 @@ use crate::{
         UserAttentionType, WindowAttributes, WindowButtons, WindowLevel,
     },
 };
+use crate::event::TextInputState;
 
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
@@ -544,6 +545,15 @@ impl Window {
     pub fn set_ime_purpose(&self, purpose: ImePurpose) {
         x11_or_wayland!(match self; Window(w) => w.set_ime_purpose(purpose))
     }
+
+    #[inline]
+    pub fn set_text_input_state(&self, state: TextInputState) {}
+
+    #[inline]
+    pub fn begin_ime_input(&self) {}
+
+    #[inline]
+    pub fn end_ime_input(&self) {}
 
     #[inline]
     pub fn focus_window(&self) {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -46,7 +46,6 @@ use crate::{
         UserAttentionType, WindowAttributes, WindowButtons, WindowLevel,
     },
 };
-use crate::event::TextInputState;
 
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
@@ -547,13 +546,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_text_input_state(&self, state: TextInputState) {}
-
-    #[inline]
-    pub fn begin_ime_input(&self) {}
-
-    #[inline]
-    pub fn end_ime_input(&self) {}
+    pub fn set_ime_surrounding_text(&self, _text: String, _selection: (usize, usize)) {}
 
     #[inline]
     pub fn focus_window(&self) {

--- a/src/platform_impl/linux/wayland/seat/text_input/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/text_input/mod.rs
@@ -143,9 +143,14 @@ impl Dispatch<ZwpTextInputV3, TextInputData, WinitState> for TextInputState {
 
                 // Send `Commit`.
                 if let Some(text) = text_input_data.pending_commit.take() {
-                    state
-                        .events_sink
-                        .push_window_event(WindowEvent::Ime(Ime::Commit(text)), window_id);
+                    state.events_sink.push_window_event(
+                        WindowEvent::Ime(Ime::Commit {
+                            content: text,
+                            selection: None,
+                            compose_region: None,
+                        }),
+                        window_id,
+                    );
                 }
 
                 // Send preedit.

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -31,7 +31,6 @@ use crate::window::{
     CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     WindowAttributes, WindowButtons,
 };
-use crate::event::TextInputState;
 
 use super::event_loop::sink::EventSink;
 use super::output::MonitorHandle;

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -31,6 +31,7 @@ use crate::window::{
     CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     WindowAttributes, WindowButtons,
 };
+use crate::event::TextInputState;
 
 use super::event_loop::sink::EventSink;
 use super::output::MonitorHandle;

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -653,7 +653,11 @@ impl<T: 'static> EventProcessor<T> {
 
                         let event = Event::WindowEvent {
                             window_id,
-                            event: WindowEvent::Ime(Ime::Commit(written)),
+                            event: WindowEvent::Ime(Ime::Commit {
+                                content: written,
+                                selection: None,
+                                compose_region: None,
+                            }),
                         };
 
                         self.is_composing = false;

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -436,7 +436,11 @@ declare_class!(
             // Commit only if we have marked text.
             if self.hasMarkedText() && self.is_ime_enabled() && !is_control {
                 self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
-                self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
+                self.queue_event(WindowEvent::Ime(Ime::Commit {
+                    content: string,
+                    selection: None,
+                    compose_region: None,
+                }));
                 self.state.ime_state.set(ImeState::Commited);
             }
         }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -42,6 +42,7 @@ use icrate::Foundation::{
 use objc2::declare::{Ivar, IvarDrop};
 use objc2::rc::{autoreleasepool, Id};
 use objc2::{declare_class, msg_send, msg_send_id, mutability, sel, ClassType};
+use crate::event::TextInputState;
 
 use super::appkit::{
     NSApp, NSAppKitVersion, NSAppearance, NSApplicationPresentationOptions, NSBackingStoreType,
@@ -1198,6 +1199,15 @@ impl WinitWindow {
 
     #[inline]
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
+
+    #[inline]
+    pub fn begin_ime_input(&self) {}
+
+    #[inline]
+    pub fn end_ime_input(&self) {}
+
+    #[inline]
+    pub fn set_text_input_state(&self, state: TextInputState) {}
 
     #[inline]
     pub fn focus_window(&self) {

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -42,7 +42,6 @@ use icrate::Foundation::{
 use objc2::declare::{Ivar, IvarDrop};
 use objc2::rc::{autoreleasepool, Id};
 use objc2::{declare_class, msg_send, msg_send_id, mutability, sel, ClassType};
-use crate::event::TextInputState;
 
 use super::appkit::{
     NSApp, NSAppKitVersion, NSAppearance, NSApplicationPresentationOptions, NSBackingStoreType,
@@ -1201,13 +1200,7 @@ impl WinitWindow {
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     #[inline]
-    pub fn begin_ime_input(&self) {}
-
-    #[inline]
-    pub fn end_ime_input(&self) {}
-
-    #[inline]
-    pub fn set_text_input_state(&self, state: TextInputState) {}
+    pub fn set_ime_surrounding_text(&self, _text: String, _selection: (usize, usize)) {}
 
     #[inline]
     pub fn focus_window(&self) {

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -354,7 +354,11 @@ impl<T: 'static> EventLoop<T> {
                 });
                 event_handler(event::Event::WindowEvent {
                     window_id: RootWindowId(window_id),
-                    event: event::WindowEvent::Ime(Ime::Commit(character.into())),
+                    event: event::WindowEvent::Ime(Ime::Commit {
+                        content: character.into(),
+                        selection: None,
+                        compose_region: None,
+                    }),
                 });
             }
             EventOption::Mouse(MouseEvent { x, y }) => {

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -14,6 +14,7 @@ use crate::{
     window,
     window::ImePurpose,
 };
+use crate::event::TextInputState;
 
 use super::{
     EventLoopWindowTarget, MonitorHandle, PlatformSpecificWindowBuilderAttributes, RedoxSocket,
@@ -332,6 +333,15 @@ impl Window {
 
     #[inline]
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
+
+    #[inline]
+    pub fn begin_ime_input(&self) {}
+
+    #[inline]
+    pub fn end_ime_input(&self) {}
+
+    #[inline]
+    pub fn set_text_input_state(&self, state: TextInputState) {}
 
     #[inline]
     pub fn focus_window(&self) {}

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -14,7 +14,6 @@ use crate::{
     window,
     window::ImePurpose,
 };
-use crate::event::TextInputState;
 
 use super::{
     EventLoopWindowTarget, MonitorHandle, PlatformSpecificWindowBuilderAttributes, RedoxSocket,
@@ -335,13 +334,7 @@ impl Window {
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     #[inline]
-    pub fn begin_ime_input(&self) {}
-
-    #[inline]
-    pub fn end_ime_input(&self) {}
-
-    #[inline]
-    pub fn set_text_input_state(&self, state: TextInputState) {}
+    pub fn set_ime_surrounding_text(&self, _text: String, _selection: (usize, usize)) {}
 
     #[inline]
     pub fn focus_window(&self) {}

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -5,7 +5,6 @@ use crate::window::{
     CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     WindowAttributes, WindowButtons, WindowId as RootWI, WindowLevel,
 };
-use crate::event::TextInputState;
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
 use web_sys::{Document, HtmlCanvasElement};
@@ -368,17 +367,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn begin_ime_input(&self) {
-        // Currently not implemented
-    }
-
-    #[inline]
-    pub fn end_ime_input(&self) {
-        // Currently not implemented
-    }
-
-    #[inline]
-    pub fn set_text_input_state(&self, state: TextInputState) {}
+    pub fn set_ime_surrounding_text(&self, _text: String, _selection: (usize, usize)) {}
 
     #[inline]
     pub fn focus_window(&self) {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -5,6 +5,7 @@ use crate::window::{
     CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     WindowAttributes, WindowButtons, WindowId as RootWI, WindowLevel,
 };
+use crate::event::TextInputState;
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
 use web_sys::{Document, HtmlCanvasElement};
@@ -365,6 +366,19 @@ impl Window {
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {
         // Currently not implemented
     }
+
+    #[inline]
+    pub fn begin_ime_input(&self) {
+        // Currently not implemented
+    }
+
+    #[inline]
+    pub fn end_ime_input(&self) {
+        // Currently not implemented
+    }
+
+    #[inline]
+    pub fn set_text_input_state(&self, state: TextInputState) {}
 
     #[inline]
     pub fn focus_window(&self) {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1323,7 +1323,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                         });
                         userdata.send_event(Event::WindowEvent {
                             window_id: RootWindowId(WindowId(window)),
-                            event: WindowEvent::Ime(Ime::Commit(text)),
+                            event: WindowEvent::Ime(Ime::Commit {
+                                content: text,
+                                selection: None,
+                                compose_region: None,
+                            }),
                         });
                     }
                 }
@@ -1363,7 +1367,11 @@ unsafe fn public_window_callback_inner<T: 'static>(
                         });
                         userdata.send_event(Event::WindowEvent {
                             window_id: RootWindowId(WindowId(window)),
-                            event: WindowEvent::Ime(Ime::Commit(text)),
+                            event: WindowEvent::Ime(Ime::Commit {
+                                content: text,
+                                selection: None,
+                                compose_region: None,
+                            }),
                         });
                     }
                 }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -79,7 +79,6 @@ use crate::{
         WindowAttributes, WindowButtons, WindowLevel,
     },
 };
-use crate::event::TextInputState;
 
 /// The Win32 implementation of the main `Window` object.
 pub(crate) struct Window {
@@ -763,13 +762,7 @@ impl Window {
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     #[inline]
-    pub fn begin_ime_input(&self) {}
-
-    #[inline]
-    pub fn end_ime_input(&self) {}
-
-    #[inline]
-    pub fn set_text_input_state(&self, state: TextInputState) {}
+    pub fn set_ime_surrounding_text(&self, _text: String, _selection: (usize, usize)) {}
 
     #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -79,6 +79,7 @@ use crate::{
         WindowAttributes, WindowButtons, WindowLevel,
     },
 };
+use crate::event::TextInputState;
 
 /// The Win32 implementation of the main `Window` object.
 pub(crate) struct Window {
@@ -760,6 +761,15 @@ impl Window {
 
     #[inline]
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
+
+    #[inline]
+    pub fn begin_ime_input(&self) {}
+
+    #[inline]
+    pub fn end_ime_input(&self) {}
+
+    #[inline]
+    pub fn set_text_input_state(&self, state: TextInputState) {}
 
     #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,7 +12,6 @@ use crate::{
     monitor::{MonitorHandle, VideoMode},
     platform_impl,
 };
-use crate::event::TextInputState;
 
 pub use crate::icon::{BadIcon, Icon};
 
@@ -1112,21 +1111,14 @@ impl Window {
         self.window.set_ime_purpose(purpose);
     }
 
-    /// Opens the IME input (soft keyboard) if the platform supports it.
-    /// Currently only supported on Android.
-    #[inline]
-    pub fn begin_ime_input(&self) {
-        self.window.begin_ime_input();
-    }
-
-    /// Hides the IME input (soft keyboard).
-    #[inline]
-    pub fn end_ime_input(&self) {
-        self.window.end_ime_input();
-    }
-
-    pub fn set_text_input_state(&self, state: TextInputState) {
-        self.window.set_text_input_state(state);
+    /// Sets the surrounding text for IME.
+    ///
+    /// ## Platform-specific
+    /// - **Android**: should be set when a textfield is focused, so the keyboard has context
+    /// for autocomplete. If this is not set, the text will be cleared when the user starts typing.
+    /// - **iOS / Web / Windows / X11 / macOS / Orbital:** Unsupported.
+    pub fn set_ime_surrounding_text(&self, text: String, selection: (usize, usize)) {
+        self.window.set_ime_surrounding_text(text, selection);
     }
 
     /// Brings the window to the front and sets input focus. Has no effect if the window is

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,6 +12,7 @@ use crate::{
     monitor::{MonitorHandle, VideoMode},
     platform_impl,
 };
+use crate::event::TextInputState;
 
 pub use crate::icon::{BadIcon, Icon};
 
@@ -1109,6 +1110,23 @@ impl Window {
     #[inline]
     pub fn set_ime_purpose(&self, purpose: ImePurpose) {
         self.window.set_ime_purpose(purpose);
+    }
+
+    /// Opens the IME input (soft keyboard) if the platform supports it.
+    /// Currently only supported on Android.
+    #[inline]
+    pub fn begin_ime_input(&self) {
+        self.window.begin_ime_input();
+    }
+
+    /// Hides the IME input (soft keyboard).
+    #[inline]
+    pub fn end_ime_input(&self) {
+        self.window.end_ime_input();
+    }
+
+    pub fn set_text_input_state(&self, state: TextInputState) {
+        self.window.set_text_input_state(state);
     }
 
     /// Brings the window to the front and sets input focus. Has no effect if the window is


### PR DESCRIPTION
This adds Support for opening the Soft Keyboard on android and passing through `TextInputState` events to the application. 
TextInputState contains the currently edited text as string, the current selection / cursor range and a optional compose region. 
This enables applications to support text input on android including autocomplete and autocorrect. 
While the TextInputState would currently be exclusive to android, I think it should be possible to implement the same api on iOS so there is a unified api for soft keyboards.

I implemented this as a new event because I think the current Ime event wouldn't work well for mobile text input, but it might also be possible to make it work with some tweaks. There would at least need to be some way to set the current text field content, so android has some context on what to predict for autocomplete.

I implemented this api for egui here: https://github.com/lucasmerlin/egui/commit/d47677a3d49a016a176b12a15a1f6beceff94530

<details><summary>See it in action</summary>
<p>

https://user-images.githubusercontent.com/8009393/251972889-5ac5299f-16d2-429e-899c-6d1e8d31987d.mp4

</p>
</details> 

A disadvantage of this api is, that it'd probably be difficult if not impossible to reliably edit rich text with this. The alternative would be to implement some kind of shared abstraction over [InputConnection](https://developer.android.com/reference/android/view/inputmethod/InputConnection) and [UITextInput](https://developer.apple.com/documentation/uikit/uitextinput) but these apis are a lot more complicated and for android it'd be difficult to implement it with the game-activity approach.

I'm bad at naming things, so there is probably a better name for the event than `TextInputState`.

Some other things missing to allow a great keyboard experience on mobile devices:
- [ ] Inset events / some way to query the current insets, so one can make sure the text field is not covered by the keyboard
- [ ] Support setting keyboard flags, for e.g. number / password / email input, enabling / disabling autocorrect, toggling capitalization for sentences

Part of https://github.com/rust-windowing/winit/issues/1823.

---

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
