### PR TITLE
Export smol_str; impl Ord for Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On macOS, add tabbing APIs on `WindowExtMacOS` and `EventLoopWindowTargetExtMacOS`.
 - **Breaking:** Rename `Window::set_inner_size` to `Window::request_inner_size` and indicate if the size was applied immediately.
 - On X11, fix false positive flagging of key repeats when pressing different keys with no release between presses.
-- Implement `PartialOrd` and `Ord` for `KeyCode` and `NativeKeyCode`.
+- Implement `PartialOrd` and `Ord` for `Key`, `KeyCode`, `NativeKey` and `NativeKeyCode`.
 - On Web, implement `WindowEvent::Occluded`.
 - On Web, fix touch location to be as accurate as mouse position.
 - On Web, account for CSS `padding`, `border`, and `margin` when getting or setting the canvas position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Rename `Window::set_inner_size` to `Window::request_inner_size` and indicate if the size was applied immediately.
 - On X11, fix false positive flagging of key repeats when pressing different keys with no release between presses.
 - Implement `PartialOrd` and `Ord` for `Key`, `KeyCode`, `NativeKey` and `NativeKeyCode`.
+- Add `ElementState::is_pressed`.
 - On Web, implement `WindowEvent::Occluded`.
 - On Web, fix touch location to be as accurate as mouse position.
 - On Web, account for CSS `padding`, `border`, and `margin` when getting or setting the canvas position.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On macOS, add tabbing APIs on `WindowExtMacOS` and `EventLoopWindowTargetExtMacOS`.
 - **Breaking:** Rename `Window::set_inner_size` to `Window::request_inner_size` and indicate if the size was applied immediately.
 - On X11, fix false positive flagging of key repeats when pressing different keys with no release between presses.
-- Implement `PartialOrd` and `Ord` for `Key`, `KeyCode`, `NativeKey` and `NativeKeyCode`.
+- Implement `PartialOrd` and `Ord` for `Key`, `KeyCode`, `NativeKey`, and `NativeKeyCode`.
 - Add `ElementState::is_pressed`.
 - On Web, implement `WindowEvent::Occluded`.
 - On Web, fix touch location to be as accurate as mouse position.

--- a/src/event.rs
+++ b/src/event.rs
@@ -1020,7 +1020,7 @@ pub enum ElementState {
 }
 
 impl ElementState {
-    /// True if `self == Pressed`
+    /// True if `self == Pressed`.
     pub fn is_pressed(self) -> bool {
         self == ElementState::Pressed
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1019,6 +1019,13 @@ pub enum ElementState {
     Released,
 }
 
+impl ElementState {
+    /// True if `self == Pressed`
+    pub fn is_pressed(self) -> bool {
+        self == ElementState::Pressed
+    }
+}
+
 /// Describes a button of a mouse controller.
 ///
 /// ## Platform-specific

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -69,7 +69,7 @@
 //
 // --------- END OF W3C SHORT NOTICE ---------------------------------------------------------------
 
-use smol_str::SmolStr;
+pub use smol_str::SmolStr;
 
 /// Contains the platform-native physical key identifier
 ///
@@ -135,7 +135,7 @@ impl std::fmt::Debug for NativeKeyCode {
 /// This enum is primarily used to store raw keysym when Winit doesn't map a given native logical
 /// key identifier to a meaningful [`Key`] variant. This lets you use [`Key`], and let the user
 /// define keybinds which work in the presence of identifiers we haven't mapped for you yet.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum NativeKey {
     Unidentified,
@@ -662,7 +662,7 @@ pub enum KeyCode {
 ///
 /// [`KeyboardEvent.key`]: https://w3c.github.io/uievents-key/
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Key<Str = SmolStr> {
     /// A key string that corresponds to the character typed by the user, taking into account the


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Publically export smol_str. Closes #2996 

Implement `Ord` for `Key`, `NativeKey`. Motivation: I have a mapping from `Key` to X that I serialise to a file. This is normally stored in a `HashMap`, but sorted before serialisation to ensure the file does not constantly mutate needlessly (and make direct edits to the file more user friendly).

I *could* add a note to `Key` mentioning that ordering is arbitrary and not guaranteed to remain stable across releases, but this seems like fluff.