### PR TITLE
Pointer API Sketch

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -378,35 +378,10 @@ pub enum WindowEvent {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     Ime(Ime),
 
-    PointerMoved {
+    Pointer {
         device_id: DeviceId,
-        source: PointerSource,
-        location: PhysicalPosition<f64>,
-        force: Option<Force>,
-    },
-
-    PointerInput {
-        device_id: DeviceId,
-        source: PointerSource,
-        state: ElementState,
-        button: Option<MouseButton>,
-        location: Option<PhysicalPosition<f64>>,
-        force: Option<Force>,
-    },
-
-    PointerEntered {
-        device_id: DeviceId,
-        source: PointerSource,
-    },
-
-    PointerLeft {
-        device_id: DeviceId,
-        source: PointerSource,
-    },
-
-    PointerCancelled {
-        device_id: DeviceId,
-        source: PointerSource,
+        pointer_id: PointerId,
+        event: PointerEvent,
     },
 
     // /// An mouse button press has been received.
@@ -417,7 +392,7 @@ pub enum WindowEvent {
     // },
     /// A mouse wheel movement or touchpad scroll occurred.
     MouseWheel {
-        device_id: DeviceId,
+        device_id: DeviceId,g
         delta: MouseScrollDelta,
         phase: TouchPhase,
     },
@@ -875,21 +850,45 @@ pub enum Ime {
     Disabled,
 }
 
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum PointerSource {
-    Cursor,
-    Touch { finger: u64 },
-}
-
-/// Describes touch-screen input state.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum TouchPhase {
     Started,
     Moved,
     Ended,
     Cancelled,
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PointerEvent {
+    Created,
+    Destroyed,
+    Entered,
+    Left,
+    UpdateForce(Force),
+    UpdateTilt(Tilt),
+    UpdateAngle(f64),
+    Moved(PhysicalPosition<f64>),
+    Button {
+        button: PointerButton,
+        state: ElementState,
+    },
+    MotionCancelled,
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PointerId {
+    Cursor,
+    Touch { finger: u64 },
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Tilt {
+    angle_x: f64,
+    angle_y: f64,
 }
 
 /// Describes the force of a touch event
@@ -985,6 +984,15 @@ pub enum MouseButton {
     Back,
     Forward,
     Other(u16),
+}
+
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PointerButton {
+    Mouse(MouseButton),
+    // Touch (probably) doesn't have any variations, different fingers
+    // are different pointers.
+    Touch,
 }
 
 /// Describes a difference in the mouse scroll wheel state.

--- a/src/event.rs
+++ b/src/event.rs
@@ -392,7 +392,7 @@ pub enum WindowEvent {
     // },
     /// A mouse wheel movement or touchpad scroll occurred.
     MouseWheel {
-        device_id: DeviceId,g
+        device_id: DeviceId,
         delta: MouseScrollDelta,
         phase: TouchPhase,
     },

--- a/src/event.rs
+++ b/src/event.rs
@@ -380,33 +380,33 @@ pub enum WindowEvent {
 
     PointerMoved {
         device_id: DeviceId,
-        position: PhysicalPosition<f64>,
-        source: PointerMoved,
+        source: PointerSource,
+        location: PhysicalPosition<f64>,
+        force: Option<Force>,
     },
 
-    PointerDown {
+    PointerInput {
         device_id: DeviceId,
-        source: PointerDown,
-    },
-
-    PointerUp {
-        device_id: DeviceId,
-        source: PointerUp,
+        source: PointerSource,
+        state: ElementState,
+        button: Option<MouseButton>,
+        location: Option<PhysicalPosition<f64>>,
+        force: Option<Force>,
     },
 
     PointerEntered {
         device_id: DeviceId,
-        source: PointerEntered,
+        source: PointerSource,
     },
 
     PointerLeft {
         device_id: DeviceId,
-        source: PointerLeft,
+        source: PointerSource,
     },
 
     PointerCancelled {
         device_id: DeviceId,
-        source: PointerCancelled,
+        source: PointerSource,
     },
 
     // /// An mouse button press has been received.
@@ -877,47 +877,9 @@ pub enum Ime {
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum PointerEntered {
+pub enum PointerSource {
     Cursor,
-}
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum PointerLeft {
-    Cursor,
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum PointerMoved {
-    Cursor,
-    Touch { finger: u64, force: Option<Force> },
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum PointerDown {
-    Cursor {
-        button: MouseButton,
-    },
-    Touch {
-        finger: u64,
-        force: Option<Force>,
-        location: PhysicalPosition<f64>,
-    },
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum PointerUp {
-    Cursor { button: MouseButton },
-    Touch { finger: u64, force: Option<Force> },
-}
-
-#[derive(Debug, PartialEq, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum PointerCancelled {
-    Touch { finger: u64, force: Option<Force> },
+    Touch { finger: u64 },
 }
 
 /// Describes touch-screen input state.

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -22,7 +22,7 @@ use sctk::shell::xdg::frame::FrameClick;
 
 use crate::dpi::{LogicalPosition, PhysicalPosition};
 use crate::event::{
-    ElementState, MouseButton, MouseScrollDelta, PointerSource, TouchPhase, WindowEvent,
+    ElementState, MouseButton, MouseScrollDelta, PointerId, TouchPhase, WindowEvent,
 };
 
 use crate::platform_impl::wayland::state::WinitState;
@@ -120,7 +120,7 @@ impl PointerHandler for WinitState {
                     self.events_sink.push_window_event(
                         WindowEvent::PointerEntered {
                             device_id,
-                            source: PointerSource::Cursor,
+                            source: PointerId::Cursor,
                         },
                         window_id,
                     );
@@ -136,7 +136,7 @@ impl PointerHandler for WinitState {
                         WindowEvent::PointerMoved {
                             device_id,
                             location: position,
-                            source: PointerSource::Cursor,
+                            source: PointerId::Cursor,
                             force: None,
                         },
                         window_id,
@@ -153,7 +153,7 @@ impl PointerHandler for WinitState {
                     self.events_sink.push_window_event(
                         WindowEvent::PointerLeft {
                             device_id,
-                            source: PointerSource::Cursor,
+                            source: PointerId::Cursor,
                         },
                         window_id,
                     );
@@ -163,7 +163,7 @@ impl PointerHandler for WinitState {
                         WindowEvent::PointerMoved {
                             device_id,
                             location: position,
-                            source: PointerSource::Cursor,
+                            source: PointerId::Cursor,
                             force: None,
                         },
                         window_id,
@@ -186,9 +186,9 @@ impl PointerHandler for WinitState {
                         ElementState::Released
                     };
                     self.events_sink.push_window_event(
-                        WindowEvent::PointerInput {
+                        WindowEvent::PointerButton {
                             device_id,
-                            source: PointerSource::Cursor,
+                            source: PointerId::Cursor,
                             state,
                             button: Some(button),
                             location: None,

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -21,7 +21,10 @@ use sctk::seat::SeatState;
 use sctk::shell::xdg::frame::FrameClick;
 
 use crate::dpi::{LogicalPosition, PhysicalPosition};
-use crate::event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent};
+use crate::event::{
+    ElementState, MouseButton, MouseScrollDelta, PointerDown, PointerEntered, PointerLeft,
+    PointerMoved, PointerUp, TouchPhase, WindowEvent,
+};
 
 use crate::platform_impl::wayland::state::WinitState;
 use crate::platform_impl::wayland::{self, DeviceId, WindowId};
@@ -115,8 +118,13 @@ impl PointerHandler for WinitState {
                 }
                 // Regular events on the main surface.
                 PointerEventKind::Enter { .. } => {
-                    self.events_sink
-                        .push_window_event(WindowEvent::CursorEntered { device_id }, window_id);
+                    self.events_sink.push_window_event(
+                        WindowEvent::PointerEntered {
+                            device_id,
+                            source: PointerEntered::Cursor,
+                        },
+                        window_id,
+                    );
 
                     if let Some(pointer) = seat_state.pointer.as_ref().map(Arc::downgrade) {
                         window.pointer_entered(pointer);
@@ -126,9 +134,10 @@ impl PointerHandler for WinitState {
                     pointer.winit_data().inner.lock().unwrap().surface = Some(window_id);
 
                     self.events_sink.push_window_event(
-                        WindowEvent::CursorMoved {
+                        WindowEvent::PointerMoved {
                             device_id,
                             position,
+                            source: PointerMoved::Cursor,
                         },
                         window_id,
                     );
@@ -141,14 +150,20 @@ impl PointerHandler for WinitState {
                     // Remove the active surface.
                     pointer.winit_data().inner.lock().unwrap().surface = None;
 
-                    self.events_sink
-                        .push_window_event(WindowEvent::CursorLeft { device_id }, window_id);
+                    self.events_sink.push_window_event(
+                        WindowEvent::PointerLeft {
+                            device_id,
+                            source: PointerLeft::Cursor,
+                        },
+                        window_id,
+                    );
                 }
                 PointerEventKind::Motion { .. } => {
                     self.events_sink.push_window_event(
-                        WindowEvent::CursorMoved {
+                        WindowEvent::PointerMoved {
                             device_id,
                             position,
+                            source: PointerMoved::Cursor,
                         },
                         window_id,
                     );
@@ -170,10 +185,15 @@ impl PointerHandler for WinitState {
                         ElementState::Released
                     };
                     self.events_sink.push_window_event(
-                        WindowEvent::MouseInput {
-                            device_id,
-                            state,
-                            button,
+                        match state {
+                            ElementState::Pressed => WindowEvent::PointerDown {
+                                device_id,
+                                source: PointerDown::Cursor { button },
+                            },
+                            ElementState::Released => WindowEvent::PointerUp {
+                                device_id,
+                                source: PointerUp::Cursor { button },
+                            },
                         },
                         window_id,
                     );

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -22,8 +22,7 @@ use sctk::shell::xdg::frame::FrameClick;
 
 use crate::dpi::{LogicalPosition, PhysicalPosition};
 use crate::event::{
-    ElementState, MouseButton, MouseScrollDelta, PointerDown, PointerEntered, PointerLeft,
-    PointerMoved, PointerUp, TouchPhase, WindowEvent,
+    ElementState, MouseButton, MouseScrollDelta, PointerSource, TouchPhase, WindowEvent,
 };
 
 use crate::platform_impl::wayland::state::WinitState;
@@ -121,7 +120,7 @@ impl PointerHandler for WinitState {
                     self.events_sink.push_window_event(
                         WindowEvent::PointerEntered {
                             device_id,
-                            source: PointerEntered::Cursor,
+                            source: PointerSource::Cursor,
                         },
                         window_id,
                     );
@@ -136,8 +135,9 @@ impl PointerHandler for WinitState {
                     self.events_sink.push_window_event(
                         WindowEvent::PointerMoved {
                             device_id,
-                            position,
-                            source: PointerMoved::Cursor,
+                            location: position,
+                            source: PointerSource::Cursor,
+                            force: None,
                         },
                         window_id,
                     );
@@ -153,7 +153,7 @@ impl PointerHandler for WinitState {
                     self.events_sink.push_window_event(
                         WindowEvent::PointerLeft {
                             device_id,
-                            source: PointerLeft::Cursor,
+                            source: PointerSource::Cursor,
                         },
                         window_id,
                     );
@@ -162,8 +162,9 @@ impl PointerHandler for WinitState {
                     self.events_sink.push_window_event(
                         WindowEvent::PointerMoved {
                             device_id,
-                            position,
-                            source: PointerMoved::Cursor,
+                            location: position,
+                            source: PointerSource::Cursor,
+                            force: None,
                         },
                         window_id,
                     );
@@ -185,15 +186,13 @@ impl PointerHandler for WinitState {
                         ElementState::Released
                     };
                     self.events_sink.push_window_event(
-                        match state {
-                            ElementState::Pressed => WindowEvent::PointerDown {
-                                device_id,
-                                source: PointerDown::Cursor { button },
-                            },
-                            ElementState::Released => WindowEvent::PointerUp {
-                                device_id,
-                                source: PointerUp::Cursor { button },
-                            },
+                        WindowEvent::PointerInput {
+                            device_id,
+                            source: PointerSource::Cursor,
+                            state,
+                            button: Some(button),
+                            location: None,
+                            force: None,
                         },
                         window_id,
                     );

--- a/src/platform_impl/linux/wayland/seat/touch/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/touch/mod.rs
@@ -8,7 +8,7 @@ use sctk::reexports::client::{Connection, Proxy, QueueHandle};
 use sctk::seat::touch::{TouchData, TouchHandler};
 
 use crate::dpi::{LogicalPosition, PhysicalPosition};
-use crate::event::{PointerCancelled, PointerDown, PointerMoved, PointerUp, WindowEvent};
+use crate::event::{ElementState, PointerSource, WindowEvent};
 
 use crate::platform_impl::wayland::state::WinitState;
 use crate::platform_impl::wayland::{self, DeviceId};
@@ -41,15 +41,15 @@ impl TouchHandler for WinitState {
             .insert(id, TouchPoint { surface, location });
 
         self.events_sink.push_window_event(
-            WindowEvent::PointerDown {
+            WindowEvent::PointerInput {
                 device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                     DeviceId,
                 )),
-                source: PointerDown::Touch {
-                    finger: id as u64,
-                    force: None,
-                    location: location.to_physical(scale_factor),
-                },
+                source: PointerSource::Touch { finger: id as u64 },
+                force: None,
+                location: Some(location.to_physical(scale_factor)),
+                state: ElementState::Pressed,
+                button: None,
             },
             window_id,
         );
@@ -79,14 +79,15 @@ impl TouchHandler for WinitState {
         };
 
         self.events_sink.push_window_event(
-            WindowEvent::PointerUp {
+            WindowEvent::PointerInput {
                 device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                     DeviceId,
                 )),
-                source: PointerUp::Touch {
-                    finger: id as u64,
-                    force: None,
-                },
+                source: PointerSource::Touch { finger: id as u64 },
+                state: ElementState::Released,
+                button: None,
+                location: None,
+                force: None,
             },
             window_id,
         );
@@ -122,11 +123,9 @@ impl TouchHandler for WinitState {
                 device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                     DeviceId,
                 )),
-                position: touch_point.location.to_physical(scale_factor),
-                source: PointerMoved::Touch {
-                    finger: id as u64,
-                    force: None,
-                },
+                source: PointerSource::Touch { finger: id as u64 },
+                location: touch_point.location.to_physical(scale_factor),
+                force: None,
             },
             window_id,
         );
@@ -149,10 +148,7 @@ impl TouchHandler for WinitState {
                     device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                         DeviceId,
                     )),
-                    source: PointerCancelled::Touch {
-                        finger: id as u64,
-                        force: None,
-                    },
+                    source: PointerSource::Touch { finger: id as u64 },
                 },
                 window_id,
             )

--- a/src/platform_impl/linux/wayland/seat/touch/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/touch/mod.rs
@@ -8,7 +8,7 @@ use sctk::reexports::client::{Connection, Proxy, QueueHandle};
 use sctk::seat::touch::{TouchData, TouchHandler};
 
 use crate::dpi::{LogicalPosition, PhysicalPosition};
-use crate::event::{ElementState, PointerSource, WindowEvent};
+use crate::event::{ElementState, PointerId, WindowEvent};
 
 use crate::platform_impl::wayland::state::WinitState;
 use crate::platform_impl::wayland::{self, DeviceId};
@@ -41,11 +41,11 @@ impl TouchHandler for WinitState {
             .insert(id, TouchPoint { surface, location });
 
         self.events_sink.push_window_event(
-            WindowEvent::PointerInput {
+            WindowEvent::PointerButton {
                 device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                     DeviceId,
                 )),
-                source: PointerSource::Touch { finger: id as u64 },
+                source: PointerId::Touch { finger: id as u64 },
                 force: None,
                 location: Some(location.to_physical(scale_factor)),
                 state: ElementState::Pressed,
@@ -79,11 +79,11 @@ impl TouchHandler for WinitState {
         };
 
         self.events_sink.push_window_event(
-            WindowEvent::PointerInput {
+            WindowEvent::PointerButton {
                 device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                     DeviceId,
                 )),
-                source: PointerSource::Touch { finger: id as u64 },
+                source: PointerId::Touch { finger: id as u64 },
                 state: ElementState::Released,
                 button: None,
                 location: None,
@@ -123,7 +123,7 @@ impl TouchHandler for WinitState {
                 device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                     DeviceId,
                 )),
-                source: PointerSource::Touch { finger: id as u64 },
+                source: PointerId::Touch { finger: id as u64 },
                 location: touch_point.location.to_physical(scale_factor),
                 force: None,
             },
@@ -148,7 +148,7 @@ impl TouchHandler for WinitState {
                     device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
                         DeviceId,
                     )),
-                    source: PointerSource::Touch { finger: id as u64 },
+                    source: PointerId::Touch { finger: id as u64 },
                 },
                 window_id,
             )


### PR DESCRIPTION
- [ ] Tested on all platforms changed (No. Only wayland tested)
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users (No)
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior (No)
- [ ] Created or updated an example program if it would help users understand this functionality (No)
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented (No)

This is a very rough sketch of what a pointer-based API could look like (based on #336). Personally I'm interested in moving winit towards an API that can support pen input, which is why I'm interested in this, and I'm willing to help implement it. But I'd like to make sure the WindowEvent API matches what the winit team wants and what would be useful and ergonomic for the user, so please let me know your thoughts!

It's worth noting that by heading in this direction we will be breaking apps which already use cursor and touch events. Would it be better to just add a "pen" event like with touch?