### PR TITLE
On Wayland, reduce amount of spurious wakeups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** on Wayland, dispatching user created wayland queue won't wake up the loop unless winit has event to send back.
 - Removed platform-specific extensions that should be retrieved through `raw-window-handle` trait implementations instead:
   - `platform::windows::HINSTANCE`.
   - `WindowExtWindows::hinstance`.

--- a/src/platform_impl/linux/wayland/event_loop/sink.rs
+++ b/src/platform_impl/linux/wayland/event_loop/sink.rs
@@ -20,6 +20,12 @@ impl EventSink {
         Default::default()
     }
 
+    /// Return `true` if there're pending events.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.window_events.is_empty()
+    }
+
     /// Add new device event to a queue.
     #[inline]
     pub fn push_device_event(&mut self, event: DeviceEvent, device_id: DeviceId) {

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -287,10 +287,14 @@ impl Window {
 
     #[inline]
     pub fn request_redraw(&self) {
-        self.window_requests
+        if self
+            .window_requests
             .redraw_requested
-            .store(true, Ordering::Relaxed);
-        self.event_loop_awakener.ping();
+            .compare_exchange(false, true, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            self.event_loop_awakener.ping();
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Mark it as breaking, since some clients relied on that behavior, simply because dispatching clients queue always woke up a winit, meaning that they won't be able to use user events for this sake.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
