### PR TITLE
Remove 'static requirement on `run`

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -314,7 +314,7 @@ impl<T> EventLoop<T> {
     #[inline]
     pub fn run<F>(self, event_handler: F) -> Result<(), RunLoopError>
     where
-        F: 'static + FnMut(Event<T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.event_loop.run(event_handler)
     }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -310,8 +310,11 @@ impl<T> EventLoop<T> {
     ///   asynchronously (via the browser's own, internal, event loop) and doesn't block the
     ///   current thread of execution like it does on other platforms.
     ///
+    ///   This function won't be available with `target_feature = "exception-handling"`.
+    ///
     /// [`ControlFlow`]: crate::event_loop::ControlFlow
     #[inline]
+    #[cfg(not(all(wasm_platform, target_feature = "exception-handling")))]
     pub fn run<F>(self, event_handler: F) -> Result<(), RunLoopError>
     where
         F: FnMut(Event<T>, &EventLoopWindowTarget<T>, &mut ControlFlow),

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -526,8 +526,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, event_handler: F) -> Result<(), RunLoopError>
     where
-        F: 'static
-            + FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.run_ondemand(event_handler)
     }

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -106,7 +106,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(self, event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         unsafe {
             let application = UIApplication::shared(MainThreadMarker::new().unwrap());

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -116,10 +116,18 @@ impl<T: 'static> EventLoop<T> {
                 `EventLoop` cannot be `run` after a call to `UIApplicationMain` on iOS\n\
                  Note: `EventLoop::run` calls `UIApplicationMain` on iOS",
             );
-            app_state::will_launch(Box::new(EventLoopHandler {
+
+            let event_handler = std::mem::transmute::<
+                Box<dyn FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow)>,
+                Box<EventHandlerCallback<T>>,
+            >(Box::new(event_handler));
+
+            let handler = EventLoopHandler {
                 f: event_handler,
                 event_loop: self.window_target,
-            }));
+            };
+
+            app_state::will_launch(Box::new(handler));
 
             // Ensure application delegate is initialized
             view::WinitApplicationDelegate::class();
@@ -314,17 +322,20 @@ fn setup_control_flow_observers() {
 #[derive(Debug)]
 pub enum Never {}
 
+type EventHandlerCallback<T> =
+    dyn FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow) + 'static;
+
 pub trait EventHandler: Debug {
     fn handle_nonuser_event(&mut self, event: Event<Never>, control_flow: &mut ControlFlow);
     fn handle_user_events(&mut self, control_flow: &mut ControlFlow);
 }
 
-struct EventLoopHandler<F, T: 'static> {
-    f: F,
+struct EventLoopHandler<T: 'static> {
+    f: Box<EventHandlerCallback<T>>,
     event_loop: RootEventLoopWindowTarget<T>,
 }
 
-impl<F, T: 'static> Debug for EventLoopHandler<F, T> {
+impl<T: 'static> Debug for EventLoopHandler<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EventLoopHandler")
             .field("event_loop", &self.event_loop)
@@ -332,11 +343,7 @@ impl<F, T: 'static> Debug for EventLoopHandler<F, T> {
     }
 }
 
-impl<F, T> EventHandler for EventLoopHandler<F, T>
-where
-    F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
-    T: 'static,
-{
+impl<T: 'static> EventHandler for EventLoopHandler<T> {
     fn handle_nonuser_event(&mut self, event: Event<Never>, control_flow: &mut ControlFlow) {
         (self.f)(
             event.map_nonuser_event().unwrap(),

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -195,7 +195,7 @@ impl<T> EventLoop<T> {
 
     pub fn run<F>(mut self, callback: F) -> Result<(), RunLoopError>
     where
-        F: 'static + FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootWindowTarget<T>, &mut ControlFlow),
     {
         self.run_ondemand(callback)
     }

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -445,8 +445,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, mut event_handler_inner: F) -> Result<(), RunLoopError>
     where
-        F: 'static
-            + FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         // Wrapper for event handler function that prevents ExitWithCode from being unset.
         let mut event_handler =

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -31,7 +31,7 @@ impl<T> EventLoop<T> {
 
     pub fn run<F>(self, event_handler: F) -> !
     where
-        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.spawn_inner(event_handler, false);
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -248,7 +248,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, event_handler: F) -> Result<(), RunLoopError>
     where
-        F: 'static + FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         self.run_ondemand(event_handler)
     }


### PR DESCRIPTION
There's no need to force the static on the users, given that internally some backends were not using static in the first place.

- [x] Tested on all platforms changed
- [-] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
