### PR TITLE
Propagate error from `EventLoop` creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** `EventLoop::new` and `EventLoopBuilder::build` now return `Result<Self, EventLoopError>`
 - **Breaking:** on Wayland, dispatching user created wayland queue won't wake up the loop unless winit has event to send back.
 - Removed platform-specific extensions that should be retrieved through `raw-window-handle` trait implementations instead:
   - `platform::windows::HINSTANCE`.
@@ -50,7 +51,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, remove unnecessary `Window::is_dark_mode()`, which was replaced with `Window::theme()`.
 - On Web, add `WindowBuilderExtWebSys::with_append()` to append the canvas element to the web page on creation.
 - On Windows, add `drag_resize_window` method support.
-- **Breaking** `run() ->!` has been replaced by `run() -> Result<(), RunLoopError>` for returning errors without calling `std::process::exit()` ([#2767](https://github.com/rust-windowing/winit/pull/2767))
+- **Breaking** `run() ->!` has been replaced by `run() -> Result<(), EventLoopError>` for returning errors without calling `std::process::exit()` ([#2767](https://github.com/rust-windowing/winit/pull/2767))
 - **Breaking** Removed `EventLoopExtRunReturn` / `run_return` in favor of `EventLoopExtPumpEvents` / `pump_events` and `EventLoopExtRunOnDemand` / `run_ondemand` ([#2767](https://github.com/rust-windowing/winit/pull/2767))
 - `RedrawRequested` is no longer guaranteed to be emitted after `MainEventsCleared`, it is now platform-specific when the event is emitted after being requested via `redraw_request()`.
   - On Windows, `RedrawRequested` is now driven by `WM_PAINT` messages which are requested via `redraw_request()`

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut windows = HashMap::new();
 
-    let event_loop: EventLoop<()> = EventLoop::new();
+    let event_loop: EventLoop<()> = EventLoop::new().unwrap();
     let parent_window = WindowBuilder::new()
         .with_title("parent window")
         .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Press 'R' to toggle request_redraw() calls.");
     println!("Press 'Esc' to close the window.");
 
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
     let window = WindowBuilder::new()
         .with_title("Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.")
         .build(&event_loop)

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -12,7 +12,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new().build(&event_loop).unwrap();
     window.set_title("A fantastic window!");

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -13,7 +13,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("Super Cursor Grab'n'Hide Simulator 9000")

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -18,7 +18,9 @@ fn main() -> Result<(), impl std::error::Error> {
     }
 
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoopBuilder::<CustomEvent>::with_user_event().build();
+    let event_loop = EventLoopBuilder::<CustomEvent>::with_user_event()
+        .build()
+        .unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -13,7 +13,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window_1 = WindowBuilder::new().build(&event_loop).unwrap();
     let window_2 = WindowBuilder::new().build(&event_loop).unwrap();

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -15,7 +15,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let mut decorations = true;
     let mut minimized = false;

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -13,7 +13,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("Your faithful window")

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Press F2 to toggle IME. See the documentation of `set_ime_allowed` for more info");
     println!("Press F3 to cycle through IME purposes.");
 
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_inner_size(winit::dpi::LogicalSize::new(256f64, 128f64))

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), impl std::error::Error> {
     mod fill;
 
     simple_logger::SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_inner_size(LogicalSize::new(400.0, 200.0))

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -7,7 +7,7 @@ use winit::{event_loop::EventLoop, window::WindowBuilder};
 
 fn main() {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
     if let Some(mon) = window.primary_monitor() {

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -12,7 +12,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("Mouse Wheel events")

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -17,7 +17,7 @@ fn main() -> Result<(), impl std::error::Error> {
     const WINDOW_SIZE: PhysicalSize<u32> = PhysicalSize::new(600, 400);
 
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
     let mut window_senders = HashMap::with_capacity(WINDOW_COUNT);
     for _ in 0..WINDOW_COUNT {
         let window = WindowBuilder::new()

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -15,7 +15,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let mut windows = HashMap::new();
     for _ in 0..3 {

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -12,7 +12,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     mod fill;
 
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = {
         let window = WindowBuilder::new()

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -14,7 +14,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let mut resizable = false;
 

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -19,7 +19,7 @@ mod example {
 
     pub(super) fn main() -> Result<(), impl std::error::Error> {
         // Create the event loop and get the activation token.
-        let event_loop = EventLoop::new();
+        let event_loop = EventLoop::new().unwrap();
         let mut current_token = match event_loop.read_token_from_env() {
             Some(token) => Some(token),
             None => {

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -13,7 +13,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -18,7 +18,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -10,7 +10,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("Touchpad gestures")

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -12,7 +12,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_decorations(false)

--- a/examples/video_modes.rs
+++ b/examples/video_modes.rs
@@ -5,7 +5,7 @@ use winit::event_loop::EventLoop;
 
 fn main() {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
     let monitor = match event_loop.primary_monitor() {
         Some(monitor) => monitor,
         None => {

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -8,7 +8,7 @@ use winit::{
 };
 
 pub fn main() -> Result<(), impl std::error::Error> {
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let builder = WindowBuilder::new().with_title("A fantastic window!");
     #[cfg(wasm_platform)]

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -31,7 +31,7 @@ This example demonstrates the desired future functionality which will possibly b
     #[wasm_bindgen(start)]
     pub fn run() {
         console_log::init_with_level(log::Level::Debug).expect("error initializing logger");
-        let event_loop = EventLoop::new();
+        let event_loop = EventLoop::new().unwrap();
 
         let window = WindowBuilder::new()
             .with_title("A fantastic window!")

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -12,7 +12,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -16,7 +16,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -16,7 +16,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -15,7 +15,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_inner_size(winit::dpi::LogicalSize::new(600.0, 400.0))

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let icon = load_icon(Path::new(path));
 
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("An iconic window!")

--- a/examples/window_ondemand.rs
+++ b/examples/window_ondemand.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use simple_logger::SimpleLogger;
 
     use winit::{
-        error::RunLoopError,
+        error::EventLoopError,
         event::{Event, WindowEvent},
         event_loop::EventLoop,
         platform::run_ondemand::EventLoopExtRunOnDemand,
@@ -25,9 +25,9 @@ fn main() -> Result<(), impl std::error::Error> {
     }
 
     SimpleLogger::new().init().unwrap();
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::new().unwrap();
 
-    fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), RunLoopError> {
+    fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), EventLoopError> {
         let mut app = App::default();
 
         event_loop.run_ondemand(move |event, event_loop, control_flow| {

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -19,7 +19,7 @@ mod fill;
 /// A left mouse click will toggle option_is_alt.
 #[cfg(target_os = "macos")]
 fn main() -> Result<(), impl std::error::Error> {
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -22,7 +22,7 @@ fn main() -> std::process::ExitCode {
     #[path = "util/fill.rs"]
     mod fill;
 
-    let mut event_loop = EventLoop::new();
+    let mut event_loop = EventLoop::new().unwrap();
 
     SimpleLogger::new().init().unwrap();
     let window = WindowBuilder::new()

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -13,7 +13,7 @@ mod fill;
 
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let window = WindowBuilder::new()
         .with_title("A fantastic window!")

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -21,7 +21,7 @@ mod fill;
 #[cfg(target_os = "macos")]
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
 
     let mut windows = HashMap::new();
     let window = Window::new(&event_loop).unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ pub struct OsError {
 
 /// A general error that may occur while running the Winit event loop
 #[derive(Debug)]
-pub enum RunLoopError {
+pub enum EventLoopError {
     /// The operation is not supported by the backend.
     NotSupported(NotSupportedError),
     /// The OS cannot perform the operation.
@@ -39,6 +39,12 @@ pub enum RunLoopError {
     AlreadyRunning,
     /// Application has exit with an error status.
     ExitFailure(i32),
+}
+
+impl From<OsError> for EventLoopError {
+    fn from(value: OsError) -> Self {
+        Self::Os(value)
+    }
 }
 
 impl NotSupportedError {
@@ -94,13 +100,13 @@ impl fmt::Display for NotSupportedError {
     }
 }
 
-impl fmt::Display for RunLoopError {
+impl fmt::Display for EventLoopError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            RunLoopError::AlreadyRunning => write!(f, "EventLoop is already running"),
-            RunLoopError::NotSupported(e) => e.fmt(f),
-            RunLoopError::Os(e) => e.fmt(f),
-            RunLoopError::ExitFailure(status) => write!(f, "Exit Failure: {status}"),
+            EventLoopError::AlreadyRunning => write!(f, "EventLoop is already running"),
+            EventLoopError::NotSupported(e) => e.fmt(f),
+            EventLoopError::Os(e) => e.fmt(f),
+            EventLoopError::ExitFailure(status) => write!(f, "Exit Failure: {status}"),
         }
     }
 }
@@ -108,7 +114,7 @@ impl fmt::Display for RunLoopError {
 impl error::Error for OsError {}
 impl error::Error for ExternalError {}
 impl error::Error for NotSupportedError {}
-impl error::Error for RunLoopError {}
+impl error::Error for EventLoopError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 #[cfg(wasm_platform)]
 use web_time::{Duration, Instant};
 
-use crate::error::RunLoopError;
+use crate::error::EventLoopError;
 use crate::{event::Event, monitor::MonitorHandle, platform_impl};
 
 /// Provides a way to retrieve events from the system and from the windows that were registered to
@@ -88,21 +88,18 @@ impl<T> EventLoopBuilder<T> {
     /// ***For cross-platform compatibility, the [`EventLoop`] must be created on the main thread,
     /// and only once per application.***
     ///
-    /// Attempting to create the event loop on a different thread, or multiple event loops in
-    /// the same application, will panic. This restriction isn't
-    /// strictly necessary on all platforms, but is imposed to eliminate any nasty surprises when
-    /// porting to platforms that require it. `EventLoopBuilderExt::any_thread` functions are exposed
-    /// in the relevant [`platform`] module if the target platform supports creating an event loop on
-    /// any thread.
+    /// Attempting to create the event loop on a different thread, or multiple
+    /// event loops in the same application, will panic. This restriction
+    /// isn't strictly necessary on all platforms, but is imposed to eliminate
+    /// any nasty surprises when porting to platforms that require it.
+    /// `EventLoopBuilderExt::any_thread` functions are exposed in the relevant
+    /// [`platform`] module if the target platform supports creating an event
+    /// loop on any thread.
     ///
     /// Calling this function will result in display backend initialisation.
     ///
     /// ## Platform-specific
     ///
-    /// - **Linux:** Backend type can be controlled using an environment variable
-    ///   `WINIT_UNIX_BACKEND`. Legal values are `x11` and `wayland`.
-    ///   If it is not set, winit will try to connect to a Wayland connection, and if that fails,
-    ///   will fall back on X11. If this variable is set with any other value, winit will panic.
     /// - **Android:** Must be configured with an `AndroidApp` from `android_main()` by calling
     ///     [`.with_android_app(app)`] before calling `.build()`.
     ///
@@ -116,17 +113,17 @@ impl<T> EventLoopBuilder<T> {
         doc = "[`.with_android_app(app)`]: #only-available-on-android"
     )]
     #[inline]
-    pub fn build(&mut self) -> EventLoop<T> {
+    pub fn build(&mut self) -> Result<EventLoop<T>, EventLoopError> {
         if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
-            panic!("Creating EventLoop multiple times is not supported.");
+            return Err(EventLoopError::AlreadyRunning);
         }
 
         // Certain platforms accept a mutable reference in their API.
         #[allow(clippy::unnecessary_mut_passed)]
-        EventLoop {
-            event_loop: platform_impl::EventLoop::new(&mut self.platform_specific),
+        Ok(EventLoop {
+            event_loop: platform_impl::EventLoop::new(&mut self.platform_specific)?,
             _marker: PhantomData,
-        }
+        })
     }
 
     #[cfg(wasm_platform)]
@@ -269,20 +266,14 @@ impl EventLoop<()> {
     ///
     /// [`EventLoopBuilder::new().build()`]: EventLoopBuilder::build
     #[inline]
-    pub fn new() -> EventLoop<()> {
+    pub fn new() -> Result<EventLoop<()>, EventLoopError> {
         EventLoopBuilder::new().build()
-    }
-}
-
-impl Default for EventLoop<()> {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
 impl<T> EventLoop<T> {
     #[deprecated = "Use `EventLoopBuilder::<T>::with_user_event().build()` instead."]
-    pub fn with_user_event() -> EventLoop<T> {
+    pub fn with_user_event() -> Result<EventLoop<T>, EventLoopError> {
         EventLoopBuilder::<T>::with_user_event().build()
     }
 
@@ -315,7 +306,7 @@ impl<T> EventLoop<T> {
     /// [`ControlFlow`]: crate::event_loop::ControlFlow
     #[inline]
     #[cfg(not(all(wasm_platform, target_feature = "exception-handling")))]
-    pub fn run<F>(self, event_handler: F) -> Result<(), RunLoopError>
+    pub fn run<F>(self, event_handler: F) -> Result<(), EventLoopError>
     where
         F: FnMut(Event<T>, &EventLoopWindowTarget<T>, &mut ControlFlow),
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! ```no_run
 //! use winit::event_loop::EventLoop;
-//! let event_loop = EventLoop::new();
+//! let event_loop = EventLoop::new().unwrap();
 //! ```
 //!
 //! Once this is done there are two ways to create a [`Window`]:
@@ -48,7 +48,7 @@
 //!     window::WindowBuilder,
 //! };
 //!
-//! let event_loop = EventLoop::new();
+//! let event_loop = EventLoop::new().unwrap();
 //! let window = WindowBuilder::new().build(&event_loop).unwrap();
 //!
 //! event_loop.run(move |event, _, control_flow| {

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -53,7 +53,7 @@ pub trait EventLoopExtPumpEvents {
     /// #         platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
     /// #         window::WindowBuilder,
     /// #     };
-    ///     let mut event_loop = EventLoop::new();
+    ///     let mut event_loop = EventLoop::new().unwrap();
     /// #
     /// #   SimpleLogger::new().init().unwrap();
     ///     let window = WindowBuilder::new()

--- a/src/platform/run_ondemand.rs
+++ b/src/platform/run_ondemand.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::RunLoopError,
+    error::EventLoopError,
     event::Event,
     event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
 };
@@ -57,7 +57,7 @@ pub trait EventLoopExtRunOnDemand {
     ///   polled to ask for new events. Events are delivered via callbacks based
     ///   on an event loop that is internal to the browser itself.
     /// - **iOS:** It's not possible to stop and start an `NSApplication` repeatedly on iOS.
-    fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), RunLoopError>
+    fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
         F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
 }
@@ -65,7 +65,7 @@ pub trait EventLoopExtRunOnDemand {
 impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
     type UserEvent = T;
 
-    fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), RunLoopError>
+    fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
         F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
     {

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -30,7 +30,7 @@ use crate::{
         self, CursorGrabMode, ImePurpose, ResizeDirection, Theme, WindowButtons, WindowLevel,
     },
 };
-use crate::{error::RunLoopError, platform_impl::Fullscreen};
+use crate::{error::EventLoopError, platform_impl::Fullscreen};
 
 mod keycodes;
 
@@ -186,13 +186,15 @@ fn sticky_exit_callback<T, F>(
 }
 
 impl<T: 'static> EventLoop<T> {
-    pub(crate) fn new(attributes: &PlatformSpecificEventLoopAttributes) -> Self {
+    pub(crate) fn new(
+        attributes: &PlatformSpecificEventLoopAttributes,
+    ) -> Result<Self, EventLoopError> {
         let (user_events_sender, user_events_receiver) = mpsc::channel();
 
         let android_app = attributes.android_app.as_ref().expect("An `AndroidApp` as passed to android_main() is required to create an `EventLoop` on Android");
         let redraw_flag = SharedFlag::new();
 
-        Self {
+        Ok(Self {
             android_app: android_app.clone(),
             window_target: event_loop::EventLoopWindowTarget {
                 p: EventLoopWindowTarget {
@@ -214,7 +216,7 @@ impl<T: 'static> EventLoop<T> {
             control_flow: Default::default(),
             cause: StartCause::Init,
             ignore_volume_keys: attributes.ignore_volume_keys,
-        }
+        })
     }
 
     fn single_iteration<F>(&mut self, main_event: Option<MainEvent<'_>>, callback: &mut F)
@@ -524,19 +526,19 @@ impl<T: 'static> EventLoop<T> {
         self.pending_redraw = pending_redraw;
     }
 
-    pub fn run<F>(mut self, event_handler: F) -> Result<(), RunLoopError>
+    pub fn run<F>(mut self, event_handler: F) -> Result<(), EventLoopError>
     where
         F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         self.run_ondemand(event_handler)
     }
 
-    pub fn run_ondemand<F>(&mut self, mut event_handler: F) -> Result<(), RunLoopError>
+    pub fn run_ondemand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
         F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>, &mut ControlFlow),
     {
         if self.loop_running {
-            return Err(RunLoopError::AlreadyRunning);
+            return Err(EventLoopError::AlreadyRunning);
         }
 
         loop {
@@ -545,7 +547,7 @@ impl<T: 'static> EventLoop<T> {
                     break Ok(());
                 }
                 PumpStatus::Exit(code) => {
-                    break Err(RunLoopError::ExitFailure(code));
+                    break Err(EventLoopError::ExitFailure(code));
                 }
                 _ => {
                     continue;

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -19,17 +19,19 @@ use objc2::rc::Id;
 use objc2::ClassType;
 use raw_window_handle::{RawDisplayHandle, UiKitDisplayHandle};
 
-use super::uikit::{UIApplication, UIApplicationMain, UIDevice, UIScreen};
-use super::view::WinitUIWindow;
-use super::{app_state, monitor, view, MonitorHandle};
 use crate::{
     dpi::LogicalSize,
+    error::EventLoopError,
     event::Event,
     event_loop::{
         ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootEventLoopWindowTarget,
     },
     platform::ios::Idiom,
 };
+
+use super::uikit::{UIApplication, UIApplicationMain, UIDevice, UIScreen};
+use super::view::WinitUIWindow;
+use super::{app_state, monitor, view, MonitorHandle};
 
 #[derive(Debug)]
 pub(crate) enum EventWrapper {
@@ -75,7 +77,9 @@ pub struct EventLoop<T: 'static> {
 pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
 impl<T: 'static> EventLoop<T> {
-    pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> EventLoop<T> {
+    pub(crate) fn new(
+        _: &PlatformSpecificEventLoopAttributes,
+    ) -> Result<EventLoop<T>, EventLoopError> {
         assert_main_thread!("`EventLoop` can only be created on the main thread on iOS");
 
         static mut SINGLETON_INIT: bool = false;
@@ -93,7 +97,7 @@ impl<T: 'static> EventLoop<T> {
         // this line sets up the main run loop before `UIApplicationMain`
         setup_control_flow_observers();
 
-        EventLoop {
+        Ok(EventLoop {
             window_target: RootEventLoopWindowTarget {
                 p: EventLoopWindowTarget {
                     receiver,
@@ -101,7 +105,7 @@ impl<T: 'static> EventLoop<T> {
                 },
                 _marker: PhantomData,
             },
-        }
+        })
     }
 
     pub fn run<F>(self, event_handler: F) -> !

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -1,7 +1,6 @@
 //! The event-loop routines.
 
 use std::cell::RefCell;
-use std::error::Error;
 use std::io::Result as IOResult;
 use std::marker::PhantomData;
 use std::mem;
@@ -13,11 +12,12 @@ use std::time::{Duration, Instant};
 use raw_window_handle::{RawDisplayHandle, WaylandDisplayHandle};
 
 use sctk::reexports::calloop;
+use sctk::reexports::calloop::Error as CalloopError;
 use sctk::reexports::client::globals;
 use sctk::reexports::client::{Connection, Proxy, QueueHandle, WaylandSource};
 
 use crate::dpi::{LogicalSize, PhysicalSize};
-use crate::error::{OsError as RootOsError, RunLoopError};
+use crate::error::{EventLoopError, OsError as RootOsError};
 use crate::event::{Event, InnerSizeWriter, StartCause, WindowEvent};
 use crate::event_loop::{ControlFlow, EventLoopWindowTarget as RootEventLoopWindowTarget};
 use crate::platform::pump_events::PumpStatus;
@@ -33,7 +33,7 @@ use sink::EventSink;
 
 use super::state::{WindowCompositorUpdate, WinitState};
 use super::window::state::FrameCallbackState;
-use super::{DeviceId, WindowId};
+use super::{DeviceId, WaylandError, WindowId};
 
 type WaylandDispatcher = calloop::Dispatcher<'static, WaylandSource<WinitState>, WinitState>;
 
@@ -73,22 +73,38 @@ pub struct EventLoop<T: 'static> {
 }
 
 impl<T: 'static> EventLoop<T> {
-    pub fn new() -> Result<EventLoop<T>, Box<dyn Error>> {
-        let connection = Connection::connect_to_env()?;
+    pub fn new() -> Result<EventLoop<T>, EventLoopError> {
+        macro_rules! map_err {
+            ($e:expr, $err:expr) => {
+                $e.map_err(|error| os_error!($err(error).into()))
+            };
+        }
 
-        let (globals, mut event_queue) = globals::registry_queue_init(&connection)?;
+        let connection = map_err!(Connection::connect_to_env(), WaylandError::Connection)?;
+
+        let (globals, mut event_queue) = map_err!(
+            globals::registry_queue_init(&connection),
+            WaylandError::Global
+        )?;
         let queue_handle = event_queue.handle();
 
-        let event_loop = calloop::EventLoop::<WinitState>::try_new()?;
+        let event_loop = map_err!(
+            calloop::EventLoop::<WinitState>::try_new(),
+            WaylandError::Calloop
+        )?;
 
-        let mut winit_state = WinitState::new(&globals, &queue_handle, event_loop.handle())?;
+        let mut winit_state = WinitState::new(&globals, &queue_handle, event_loop.handle())
+            .map_err(|error| os_error!(error))?;
 
         // NOTE: do a roundtrip after binding the globals to prevent potential
         // races with the server.
-        event_queue.roundtrip(&mut winit_state)?;
+        map_err!(
+            event_queue.roundtrip(&mut winit_state),
+            WaylandError::Dispatch
+        )?;
 
         // Register Wayland source.
-        let wayland_source = WaylandSource::new(event_queue)?;
+        let wayland_source = map_err!(WaylandSource::new(event_queue), WaylandError::Wire)?;
         let wayland_dispatcher =
             calloop::Dispatcher::new(wayland_source, |_, queue, winit_state: &mut WinitState| {
                 let result = queue.dispatch_pending(winit_state);
@@ -101,32 +117,52 @@ impl<T: 'static> EventLoop<T> {
                 result
             });
 
-        event_loop
-            .handle()
-            .register_dispatcher(wayland_dispatcher.clone())?;
+        map_err!(
+            event_loop
+                .handle()
+                .register_dispatcher(wayland_dispatcher.clone()),
+            WaylandError::Calloop
+        )?;
 
         // Setup the user proxy.
         let pending_user_events = Rc::new(RefCell::new(Vec::new()));
         let pending_user_events_clone = pending_user_events.clone();
         let (user_events_sender, user_events_channel) = calloop::channel::channel();
-        event_loop.handle().insert_source(
-            user_events_channel,
-            move |event, _, winit_state: &mut WinitState| {
-                if let calloop::channel::Event::Msg(msg) = event {
-                    winit_state.dispatched_events = true;
-                    pending_user_events_clone.borrow_mut().push(msg);
-                }
-            },
+        map_err!(
+            event_loop
+                .handle()
+                .insert_source(
+                    user_events_channel,
+                    move |event, _, winit_state: &mut WinitState| {
+                        if let calloop::channel::Event::Msg(msg) = event {
+                            winit_state.dispatched_events = true;
+                            pending_user_events_clone.borrow_mut().push(msg);
+                        }
+                    },
+                )
+                .map_err(|error| error.error),
+            WaylandError::Calloop
         )?;
 
         // An event's loop awakener to wake up for window events from winit's windows.
-        let (event_loop_awakener, event_loop_awakener_source) = calloop::ping::make_ping()?;
-        event_loop.handle().insert_source(
-            event_loop_awakener_source,
-            move |_, _, winit_state: &mut WinitState| {
-                // No extra handling is required, we just need to wake-up.
-                winit_state.dispatched_events = true;
-            },
+        let (event_loop_awakener, event_loop_awakener_source) = map_err!(
+            calloop::ping::make_ping()
+                .map_err(|error| CalloopError::OtherError(Box::new(error).into())),
+            WaylandError::Calloop
+        )?;
+
+        map_err!(
+            event_loop
+                .handle()
+                .insert_source(
+                    event_loop_awakener_source,
+                    move |_, _, winit_state: &mut WinitState| {
+                        // No extra handling is required, we just need to wake-up.
+                        winit_state.dispatched_events = true;
+                    },
+                )
+                .map_err(|error| error.error),
+            WaylandError::Calloop
         )?;
 
         let window_target = EventLoopWindowTarget {
@@ -158,12 +194,12 @@ impl<T: 'static> EventLoop<T> {
         Ok(event_loop)
     }
 
-    pub fn run_ondemand<F>(&mut self, mut event_handler: F) -> Result<(), RunLoopError>
+    pub fn run_ondemand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
         F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         if self.loop_running {
-            return Err(RunLoopError::AlreadyRunning);
+            return Err(EventLoopError::AlreadyRunning);
         }
 
         let exit = loop {
@@ -172,7 +208,7 @@ impl<T: 'static> EventLoop<T> {
                     break Ok(());
                 }
                 PumpStatus::Exit(code) => {
-                    break Err(RunLoopError::ExitFailure(code));
+                    break Err(EventLoopError::ExitFailure(code));
                 }
                 _ => {
                     continue;
@@ -184,7 +220,7 @@ impl<T: 'static> EventLoop<T> {
         // `run_ondemand` calls but if they have only just dropped their
         // windows we need to make sure those last requests are sent to the
         // compositor.
-        let _ = self.roundtrip().map_err(RunLoopError::Os);
+        let _ = self.roundtrip().map_err(EventLoopError::Os);
 
         exit
     }
@@ -617,10 +653,10 @@ impl<T: 'static> EventLoop<T> {
 
         let mut wayland_source = self.wayland_dispatcher.as_source_mut();
         let event_queue = wayland_source.queue();
-        event_queue.roundtrip(state).map_err(|_| {
-            os_error!(OsError::WaylandMisc(
-                "failed to do a final roundtrip before exiting the loop."
-            ))
+        event_queue.roundtrip(state).map_err(|error| {
+            os_error!(OsError::WaylandError(Arc::new(WaylandError::Dispatch(
+                error
+            ))))
         })
     }
 }

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -2,10 +2,14 @@
 
 //! Winit's Wayland backend.
 
-use sctk::reexports::client::protocol::wl_surface::WlSurface;
-use sctk::reexports::client::Proxy;
+use std::fmt::Display;
+use std::sync::Arc;
 
-pub use crate::platform_impl::platform::WindowId;
+use sctk::reexports::client::globals::{BindError, GlobalError};
+use sctk::reexports::client::protocol::wl_surface::WlSurface;
+use sctk::reexports::client::{self, ConnectError, DispatchError, Proxy};
+
+pub use crate::platform_impl::platform::{OsError, WindowId};
 pub use event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
 pub use output::{MonitorHandle, VideoMode};
 pub use window::Window;
@@ -16,6 +20,46 @@ mod seat;
 mod state;
 mod types;
 mod window;
+
+#[derive(Debug)]
+pub enum WaylandError {
+    /// Error connecting to the socket.
+    Connection(ConnectError),
+
+    /// Error binding the global.
+    Global(GlobalError),
+
+    // Bind error.
+    Bind(BindError),
+
+    /// Error during the dispatching the event queue.
+    Dispatch(DispatchError),
+
+    /// Calloop error.
+    Calloop(calloop::Error),
+
+    /// Wayland
+    Wire(client::backend::WaylandError),
+}
+
+impl Display for WaylandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WaylandError::Connection(error) => error.fmt(f),
+            WaylandError::Global(error) => error.fmt(f),
+            WaylandError::Bind(error) => error.fmt(f),
+            WaylandError::Dispatch(error) => error.fmt(f),
+            WaylandError::Calloop(error) => error.fmt(f),
+            WaylandError::Wire(error) => error.fmt(f),
+        }
+    }
+}
+
+impl From<WaylandError> for OsError {
+    fn from(value: WaylandError) -> Self {
+        Self::WaylandError(Arc::new(value))
+    }
+}
 
 /// Dummy device id, since Wayland doesn't have device events.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -1,5 +1,4 @@
 use std::cell::RefCell;
-use std::error::Error;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 
@@ -24,6 +23,7 @@ use sctk::shm::{Shm, ShmHandler};
 use sctk::subcompositor::SubcompositorState;
 
 use crate::dpi::LogicalSize;
+use crate::platform_impl::OsError;
 
 use super::event_loop::sink::EventSink;
 use super::output::MonitorHandle;
@@ -35,7 +35,7 @@ use super::types::wp_fractional_scaling::FractionalScalingManager;
 use super::types::wp_viewporter::ViewporterState;
 use super::types::xdg_activation::XdgActivationState;
 use super::window::{WindowRequests, WindowState};
-use super::WindowId;
+use super::{WaylandError, WindowId};
 
 /// Winit's Wayland state.
 pub struct WinitState {
@@ -116,14 +116,16 @@ impl WinitState {
         globals: &GlobalList,
         queue_handle: &QueueHandle<Self>,
         loop_handle: LoopHandle<'static, WinitState>,
-    ) -> Result<Self, Box<dyn Error>> {
+    ) -> Result<Self, OsError> {
         let registry_state = RegistryState::new(globals);
-        let compositor_state = CompositorState::bind(globals, queue_handle)?;
+        let compositor_state =
+            CompositorState::bind(globals, queue_handle).map_err(WaylandError::Bind)?;
         let subcompositor_state = SubcompositorState::bind(
             compositor_state.wl_compositor().clone(),
             globals,
             queue_handle,
-        )?;
+        )
+        .map_err(WaylandError::Bind)?;
 
         let output_state = OutputState::new(globals, queue_handle);
         let monitors = output_state.outputs().map(MonitorHandle::new).collect();
@@ -148,9 +150,9 @@ impl WinitState {
             subcompositor_state: Arc::new(subcompositor_state),
             output_state,
             seat_state,
-            shm: Shm::bind(globals, queue_handle)?,
+            shm: Shm::bind(globals, queue_handle).map_err(WaylandError::Bind)?,
 
-            xdg_shell: XdgShell::bind(globals, queue_handle)?,
+            xdg_shell: XdgShell::bind(globals, queue_handle).map_err(WaylandError::Bind)?,
             xdg_activation: XdgActivationState::bind(globals, queue_handle).ok(),
 
             windows: Default::default(),

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -712,7 +712,7 @@ impl WindowState {
         // Positon can be set only for locked cursor.
         if self.cursor_grab_mode.current_grab_mode != CursorGrabMode::Locked {
             return Err(ExternalError::Os(os_error!(
-                crate::platform_impl::OsError::WaylandMisc(
+                crate::platform_impl::OsError::Misc(
                     "cursor position can be set only for locked cursor."
                 )
             )));

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -64,7 +64,7 @@ use self::{
 };
 use super::{common::xkb_state::KbdState, OsError};
 use crate::{
-    error::{OsError as RootOsError, RunLoopError},
+    error::{EventLoopError, OsError as RootOsError},
     event::{Event, StartCause},
     event_loop::{ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
     platform::pump_events::PumpStatus,
@@ -432,12 +432,12 @@ impl<T: 'static> EventLoop<T> {
         &self.target
     }
 
-    pub fn run_ondemand<F>(&mut self, mut event_handler: F) -> Result<(), RunLoopError>
+    pub fn run_ondemand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
         F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
     {
         if self.loop_running {
-            return Err(RunLoopError::AlreadyRunning);
+            return Err(EventLoopError::AlreadyRunning);
         }
 
         let exit = loop {
@@ -446,7 +446,7 @@ impl<T: 'static> EventLoop<T> {
                     break Ok(());
                 }
                 PumpStatus::Exit(code) => {
-                    break Err(RunLoopError::ExitFailure(code));
+                    break Err(EventLoopError::ExitFailure(code));
                 }
                 _ => {
                     continue;
@@ -460,7 +460,7 @@ impl<T: 'static> EventLoop<T> {
         // X Server.
         let wt = get_xtarget(&self.target);
         wt.x_connection().sync_with_server().map_err(|x_err| {
-            RunLoopError::Os(os_error!(OsError::XError(Arc::new(X11Error::Xlib(x_err)))))
+            EventLoopError::Os(os_error!(OsError::XError(Arc::new(X11Error::Xlib(x_err)))))
         })?;
 
         exit

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -485,7 +485,7 @@ impl UnownedWindow {
                     &mut supported_ptr,
                 );
                 if supported_ptr == ffi::False {
-                    return Err(os_error!(OsError::XMisc(
+                    return Err(os_error!(OsError::Misc(
                         "`XkbSetDetectableAutoRepeat` failed"
                     )));
                 }
@@ -1488,7 +1488,7 @@ impl UnownedWindow {
                     }
                     _ => unreachable!(),
                 }
-                .map_err(|err| ExternalError::Os(os_error!(OsError::XMisc(err))))
+                .map_err(|err| ExternalError::Os(os_error!(OsError::Misc(err))))
             }
             CursorGrabMode::Locked => {
                 return Err(ExternalError::NotSupported(NotSupportedError::new()));

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -1,6 +1,8 @@
 #![cfg(target_os = "redox")]
 
+use std::fmt::{self, Display, Formatter};
 use std::str;
+use std::sync::Arc;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 
@@ -176,13 +178,18 @@ impl<'a> fmt::Display for WindowProperties<'a> {
     }
 }
 
-#[derive(Default, Clone, Debug)]
-pub struct OsError;
+#[derive(Clone, Debug)]
+pub struct OsError(Arc<syscall::Error>);
 
-use std::fmt::{self, Display, Formatter};
+impl OsError {
+    fn new(error: syscall::Error) -> Self {
+        Self(Arc::new(error))
+    }
+}
+
 impl Display for OsError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        write!(fmt, "Redox OS Error")
+        self.0.fmt(fmt)
     }
 }
 

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -1,16 +1,18 @@
+use std::marker::PhantomData;
+
+use crate::error::EventLoopError;
+use crate::event::Event;
+use crate::event_loop::{ControlFlow, EventLoopWindowTarget as RootEventLoopWindowTarget};
+
+use super::{backend, device, window};
+
 mod proxy;
 pub(crate) mod runner;
 mod state;
 mod window_target;
 
-pub use self::proxy::EventLoopProxy;
-pub use self::window_target::EventLoopWindowTarget;
-
-use super::{backend, device, window};
-use crate::event::Event;
-use crate::event_loop::{ControlFlow, EventLoopWindowTarget as RootEventLoopWindowTarget};
-
-use std::marker::PhantomData;
+pub use proxy::EventLoopProxy;
+pub use window_target::EventLoopWindowTarget;
 
 pub struct EventLoop<T: 'static> {
     elw: RootEventLoopWindowTarget<T>,
@@ -20,13 +22,13 @@ pub struct EventLoop<T: 'static> {
 pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
 impl<T> EventLoop<T> {
-    pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> Self {
-        EventLoop {
+    pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> Result<Self, EventLoopError> {
+        Ok(EventLoop {
             elw: RootEventLoopWindowTarget {
                 p: EventLoopWindowTarget::new(),
                 _marker: PhantomData,
             },
-        }
+        })
     }
 
     pub fn run<F>(self, mut event_handler: F) -> !

--- a/src/window.rs
+++ b/src/window.rs
@@ -29,7 +29,7 @@ pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
 ///     window::Window,
 /// };
 ///
-/// let mut event_loop = EventLoop::new();
+/// let mut event_loop = EventLoop::new().unwrap();
 /// let window = Window::new(&event_loop).unwrap();
 ///
 /// event_loop.run(move |event, _, control_flow| {
@@ -570,7 +570,7 @@ impl Window {
     /// ```no_run
     /// # use winit::event_loop::EventLoop;
     /// # use winit::window::Window;
-    /// # let mut event_loop = EventLoop::new();
+    /// # let mut event_loop = EventLoop::new().unwrap();
     /// # let window = Window::new(&event_loop).unwrap();
     /// # fn swap_buffers() {}
     /// // Do the actual drawing with OpenGL.
@@ -660,7 +660,7 @@ impl Window {
     /// # use winit::dpi::{LogicalPosition, PhysicalPosition};
     /// # use winit::event_loop::EventLoop;
     /// # use winit::window::Window;
-    /// # let mut event_loop = EventLoop::new();
+    /// # let mut event_loop = EventLoop::new().unwrap();
     /// # let window = Window::new(&event_loop).unwrap();
     /// // Specify the position in logical dimensions like this:
     /// window.set_outer_position(LogicalPosition::new(400.0, 200.0));
@@ -720,7 +720,7 @@ impl Window {
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
     /// # use winit::event_loop::EventLoop;
     /// # use winit::window::Window;
-    /// # let mut event_loop = EventLoop::new();
+    /// # let mut event_loop = EventLoop::new().unwrap();
     /// # let window = Window::new(&event_loop).unwrap();
     /// // Specify the size in logical dimensions like this:
     /// let _ = window.request_inner_size(LogicalSize::new(400.0, 200.0));
@@ -763,7 +763,7 @@ impl Window {
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
     /// # use winit::event_loop::EventLoop;
     /// # use winit::window::Window;
-    /// # let mut event_loop = EventLoop::new();
+    /// # let mut event_loop = EventLoop::new().unwrap();
     /// # let window = Window::new(&event_loop).unwrap();
     /// // Specify the size in logical dimensions like this:
     /// window.set_min_inner_size(Some(LogicalSize::new(400.0, 200.0)));
@@ -786,7 +786,7 @@ impl Window {
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
     /// # use winit::event_loop::EventLoop;
     /// # use winit::window::Window;
-    /// # let mut event_loop = EventLoop::new();
+    /// # let mut event_loop = EventLoop::new().unwrap();
     /// # let window = Window::new(&event_loop).unwrap();
     /// // Specify the size in logical dimensions like this:
     /// window.set_max_inner_size(Some(LogicalSize::new(400.0, 200.0)));
@@ -1098,7 +1098,7 @@ impl Window {
     /// # use winit::dpi::{LogicalPosition, PhysicalPosition, LogicalSize, PhysicalSize};
     /// # use winit::event_loop::EventLoop;
     /// # use winit::window::Window;
-    /// # let mut event_loop = EventLoop::new();
+    /// # let mut event_loop = EventLoop::new().unwrap();
     /// # let window = Window::new(&event_loop).unwrap();
     /// // Specify the position in logical dimensions like this:
     /// window.set_ime_cursor_area(LogicalPosition::new(400.0, 200.0), LogicalSize::new(100, 100));
@@ -1266,7 +1266,7 @@ impl Window {
     /// # use winit::dpi::{LogicalPosition, PhysicalPosition};
     /// # use winit::event_loop::EventLoop;
     /// # use winit::window::Window;
-    /// # let mut event_loop = EventLoop::new();
+    /// # let mut event_loop = EventLoop::new().unwrap();
     /// # let window = Window::new(&event_loop).unwrap();
     /// // Specify the position in logical dimensions like this:
     /// window.set_cursor_position(LogicalPosition::new(400.0, 200.0));
@@ -1292,7 +1292,7 @@ impl Window {
     /// ```no_run
     /// # use winit::event_loop::EventLoop;
     /// # use winit::window::{CursorGrabMode, Window};
-    /// # let mut event_loop = EventLoop::new();
+    /// # let mut event_loop = EventLoop::new().unwrap();
     /// # let window = Window::new(&event_loop).unwrap();
     /// window.set_cursor_grab(CursorGrabMode::Confined)
     ///             .or_else(|_e| window.set_cursor_grab(CursorGrabMode::Locked))


### PR DESCRIPTION
Inner panics could make it hard to trouble shoot the issues and for some users ints not desirable.

The inner panics were left only when they are used to `assert!` during development.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

