### PR TITLE
Fix event loop not waking up due to repeat source

### DIFF
--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -124,7 +124,7 @@ impl<T: 'static> EventLoop<T> {
         event_loop.handle().insert_source(
             event_loop_awakener_source,
             move |_, _, winit_state: &mut WinitState| {
-                // No extra handling is required, we just need to wake-up.
+                // Mark that we have something to dispatch.
                 winit_state.dispatched_events = true;
             },
         )?;

--- a/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
@@ -151,6 +151,9 @@ impl Dispatch<WlKeyboard, KeyboardData, WinitState> for WinitState {
                 keyboard_state.repeat_token = keyboard_state
                     .loop_handle
                     .insert_source(timer, move |_, _, state| {
+                        // Required to handle the wakeups from the repeat sources.
+                        state.dispatched_events = true;
+
                         let data = wl_keyboard.data::<KeyboardData>().unwrap();
                         let seat_state = state.seats.get_mut(&data.seat.id()).unwrap();
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -287,6 +287,10 @@ impl Window {
 
     #[inline]
     pub fn request_redraw(&self) {
+        // NOTE: try to not wake up the loop when the event was already scheduled and not yet
+        // processed by the loop, because if at this point the value was `true` it could only
+        // mean that the loop still haven't dispatched the value to the client and will do
+        // eventually, resetting it to `false`.
         if self
             .window_requests
             .redraw_requested


### PR DESCRIPTION
Force the wake up from the repeat source as well.

Fixes: cad327755 (On Wayland, reduce amount of spurious wakeups)

- [x] Tested on all platforms changed