### PR TITLE
iOS: Use NSOperatingSystemVersion from icrate

### DIFF
--- a/src/platform_impl/ios/ffi.rs
+++ b/src/platform_impl/ios/ffi.rs
@@ -7,25 +7,6 @@ use objc2::encode::{Encode, Encoding};
 
 use crate::platform::ios::{Idiom, ScreenEdge};
 
-#[repr(C)]
-#[derive(Clone, Debug)]
-pub struct NSOperatingSystemVersion {
-    pub major: NSInteger,
-    pub minor: NSInteger,
-    pub patch: NSInteger,
-}
-
-unsafe impl Encode for NSOperatingSystemVersion {
-    const ENCODING: Encoding = Encoding::Struct(
-        "NSOperatingSystemVersion",
-        &[
-            NSInteger::ENCODING,
-            NSInteger::ENCODING,
-            NSInteger::ENCODING,
-        ],
-    );
-}
-
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct UIUserInterfaceIdiom(NSInteger);


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Without this code I'm getting the following error when running in the iOS simulator with winit master (commit bd2f1e8312aab84a21ad1e3d2c0dbcb01379ef28):

> thread 'main' panicked at 'invalid message send to -[NSProcessInfo operatingSystemVersion]: expected return to have type code '{?=qqq}', but found '{NSOperatingSystemVersion=qqq}'', ~/.cargo/git/checkouts/winit-c2fdb27092aba5a7/bd2f1e8/src/platform_impl/ios/app_state.rs:978:13

To reproduce the above issue, checkout https://github.com/fornwall/wgpu-game-of-life and run `make run-ios-simulator`.

Ping @madsmtm.

