### PR TITLE
Pass force on touch events on android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** `with_x11_visual` now takes the visual ID instead of the bare pointer.
 - On X11, add a `with_embedded_parent_window` function to the window builder to allow embedding a window into another window.
 - On iOS, add force data to touch events when using the Apple Pencil.
+- On Android, add force data to touch events.
 
 # 0.29.0-beta.0
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -939,7 +939,10 @@ pub struct Touch {
     ///
     /// ## Platform-specific
     ///
-    /// - Only available on **iOS** 9.0+, **Windows** 8+, and **Web**.
+    /// - Only available on **iOS** 9.0+, **Windows** 8+, **Web**, and **Android**.
+    /// - **Android**: This will never be [None]. If the device doesn't support pressure
+    /// sensitivity, force will either be 0.0 or 1.0. Also see the
+    /// [android documentation](https://developer.android.com/reference/android/view/MotionEvent#AXIS_PRESSURE).
     pub force: Option<Force>,
     /// Unique identifier of a finger.
     pub id: u64,

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -23,7 +23,7 @@ use raw_window_handle::{
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error,
-    event::{self, InnerSizeWriter, StartCause},
+    event::{self, Force, InnerSizeWriter, StartCause},
     event_loop::{self, ControlFlow, DeviceEvents, EventLoopWindowTarget as RootELW},
     platform::pump_events::PumpStatus,
     window::{
@@ -426,9 +426,7 @@ impl<T: 'static> EventLoop<T> {
                                 phase,
                                 location,
                                 id: pointer.pointer_id() as u64,
-                                force: Some(crate::event::Force::Normalized(
-                                    pointer.pressure() as f64
-                                )),
+                                force: Some(Force::Normalized(pointer.pressure() as f64)),
                             }),
                         };
                         callback(event, self.window_target());

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -426,7 +426,9 @@ impl<T: 'static> EventLoop<T> {
                                 phase,
                                 location,
                                 id: pointer.pointer_id() as u64,
-                                force: None,
+                                force: Some(crate::event::Force::Normalized(
+                                    pointer.pressure() as f64
+                                )),
                             }),
                         };
                         callback(event, self.window_target());


### PR DESCRIPTION
Adds pressure data to touch events on android

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
