### PR TITLE
Fix touch force for Apple Pencil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Added `AboutToWait` event which is emitted when the event loop is about to block and wait for new events ([#2900](https://github.com/rust-windowing/winit/issues/2900))
 - **Breaking:** `with_x11_visual` now takes the visual ID instead of the bare pointer.
 - On X11, add a `with_embedded_parent_window` function to the window builder to allow embedding a window into another window.
+- On iOS, add force data to touch events when using the Apple Pencil.
 
 # 0.29.0-beta.0
 

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -201,7 +201,9 @@ impl WinitView {
                 let trait_collection = unsafe { self.traitCollection() };
                 let touch_capability = trait_collection.forceTouchCapability();
                 // Both the OS _and_ the device need to be checked for force touch support.
-                if touch_capability == UIForceTouchCapability::Available {
+                if touch_capability == UIForceTouchCapability::Available
+                    || touch_type == UITouchType::Pencil
+                {
                     let force = touch.force();
                     let max_possible_force = touch.maximumPossibleForce();
                     let altitude_angle: Option<f64> = if touch_type == UITouchType::Pencil {


### PR DESCRIPTION
This sets the touch force property when the touch event was made with an apple pencil.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
