### PR TITLE
Reexport raw-window-handle in window module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Reexport `raw-window-handle` in `window` module.
 - **Breaking:** `WINIT_UNIX_BACKEND` was removed in favor of standard `WAYLAND_DISPLAY` and `DISPLAY` variables.
 - **Breaking:** `EventLoop::new` and `EventLoopBuilder::build` now return `Result<Self, EventLoopError>`
 - On X11, set `visual_id` in returned `raw-window-handle`.

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -6,11 +6,11 @@ mod fill;
 fn main() -> Result<(), impl std::error::Error> {
     use std::collections::HashMap;
 
-    use raw_window_handle::HasRawWindowHandle;
     use winit::{
         dpi::{LogicalPosition, LogicalSize, Position},
         event::{ElementState, Event, KeyEvent, WindowEvent},
         event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+        window::raw_window_handle::HasRawWindowHandle,
         window::{Window, WindowBuilder, WindowId},
     };
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -18,6 +18,9 @@ pub use crate::icon::{BadIcon, Icon};
 #[doc(inline)]
 pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
 
+#[doc(inline)]
+pub use raw_window_handle;
+
 /// Represents a window.
 ///
 /// # Example


### PR DESCRIPTION
We use raw-window-handle extensive in the public API as well as we force the users to use it to get some essential data for interop, thus reexport it.

Fixes: #2913.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
