### PR TITLE
Fix invalid size when resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Fix window size sometimes being invalid when resizing on macOS.
+
 # 0.29.1-beta
 
 - **Breaking:** Bump `ndk` version to `0.8.0-beta.0`, ndk-sys to `v0.5.0-beta.0`, `android-activity` to `0.5.0-beta.1`.

--- a/clippy.toml
+++ b/clippy.toml
@@ -9,4 +9,5 @@ disallowed-methods = [
     { path = "web_sys::Element::request_fullscreen", reason = "Doesn't account for compatibility with Safari" },
     { path = "web_sys::Document::exit_fullscreen", reason = "Doesn't account for compatibility with Safari" },
     { path = "web_sys::Document::fullscreen_element", reason = "Doesn't account for compatibility with Safari" },
+    { path = "icrate::AppKit::NSView::visibleRect", reason = "We expose a render target to the user, and visibility is not really relevant to that (and can break if you don't use the rectangle position as well). Use `frame` instead." },
 ]

--- a/src/platform_impl/macos/appkit/view.rs
+++ b/src/platform_impl/macos/appkit/view.rs
@@ -44,9 +44,6 @@ extern_methods!(
             // _mtm: MainThreadMarker,
         ) -> Option<Id<NSTextInputContext>>;
 
-        #[method(visibleRect)]
-        pub fn visibleRect(&self) -> NSRect;
-
         #[method(hasMarkedText)]
         pub fn hasMarkedText(&self) -> bool;
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -212,7 +212,7 @@ declare_class!(
                 self.removeTrackingRect(tracking_rect);
             }
 
-            let rect = self.visibleRect();
+            let rect = self.frame();
             let tracking_rect = self.add_tracking_rect(rect, false);
             self.state.tracking_rect.set(Some(tracking_rect));
         }
@@ -224,7 +224,7 @@ declare_class!(
                 self.removeTrackingRect(tracking_rect);
             }
 
-            let rect = self.visibleRect();
+            let rect = self.frame();
             let tracking_rect = self.add_tracking_rect(rect, false);
             self.state.tracking_rect.set(Some(tracking_rect));
 


### PR DESCRIPTION
We were invalidly using `visibleRect` where we should have been using `frame`; the former is used if your view is in e.g. a scroll view, and you want to save resources by only rendering the visible part of the view.

This _is_ confusing, since [`visibleRect` is put under the drawing collection in the documentation](https://developer.apple.com/documentation/appkit/nsview/drawing?language=objc), so I've banned it from our codebase using `clippy.toml` to avoid this issue in the future (though that will only take effect after #2982).

Fixes #2876

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
