### PR TITLE
Make iOS fully thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Make iOS `MonitorHandle` and `VideoMode` usable from other threads.
 - Fix window size sometimes being invalid when resizing on macOS.
 - On Web, `ControlFlow::Poll` and `ControlFlow::WaitUntil` are now using the Prioritized Task Scheduling API. `setTimeout()` with a trick to circumvent throttling to 4ms is used as a fallback.
 - On Web, never return a `MonitorHandle`.

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -1,5 +1,6 @@
 use std::os::raw::c_void;
 
+use icrate::Foundation::MainThreadMarker;
 use objc2::rc::Id;
 
 use crate::{
@@ -210,7 +211,9 @@ pub trait MonitorHandleExtIOS {
 impl MonitorHandleExtIOS for MonitorHandle {
     #[inline]
     fn ui_screen(&self) -> *mut c_void {
-        Id::as_ptr(self.inner.ui_screen()) as *mut c_void
+        // SAFETY: The marker is only used to get the pointer of the screen
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        Id::as_ptr(self.inner.ui_screen(mtm)) as *mut c_void
     }
 
     #[inline]

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -32,18 +32,17 @@ use super::{app_state, monitor, view, MonitorHandle};
 
 #[derive(Debug)]
 pub struct EventLoopWindowTarget<T: 'static> {
+    pub(super) mtm: MainThreadMarker,
     p: PhantomData<T>,
 }
 
 impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        monitor::uiscreens(MainThreadMarker::new().unwrap())
+        monitor::uiscreens(self.mtm)
     }
 
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        Some(MonitorHandle::new(UIScreen::main(
-            MainThreadMarker::new().unwrap(),
-        )))
+        Some(MonitorHandle::new(UIScreen::main(self.mtm)))
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {
@@ -52,6 +51,7 @@ impl<T: 'static> EventLoopWindowTarget<T> {
 }
 
 pub struct EventLoop<T: 'static> {
+    mtm: MainThreadMarker,
     sender: Sender<T>,
     receiver: Receiver<T>,
     window_target: RootEventLoopWindowTarget<T>,
@@ -64,7 +64,8 @@ impl<T: 'static> EventLoop<T> {
     pub(crate) fn new(
         _: &PlatformSpecificEventLoopAttributes,
     ) -> Result<EventLoop<T>, EventLoopError> {
-        assert_main_thread!("`EventLoop` can only be created on the main thread on iOS");
+        let mtm = MainThreadMarker::new()
+            .expect("On iOS, `EventLoop` must be created on the main thread");
 
         static mut SINGLETON_INIT: bool = false;
         unsafe {
@@ -82,10 +83,14 @@ impl<T: 'static> EventLoop<T> {
         setup_control_flow_observers();
 
         Ok(EventLoop {
+            mtm,
             sender,
             receiver,
             window_target: RootEventLoopWindowTarget {
-                p: EventLoopWindowTarget { p: PhantomData },
+                p: EventLoopWindowTarget {
+                    mtm,
+                    p: PhantomData,
+                },
                 _marker: PhantomData,
             },
         })
@@ -96,7 +101,7 @@ impl<T: 'static> EventLoop<T> {
         F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>, &mut ControlFlow),
     {
         unsafe {
-            let application = UIApplication::shared(MainThreadMarker::new().unwrap());
+            let application = UIApplication::shared(self.mtm);
             assert!(
                 application.is_none(),
                 "\
@@ -115,7 +120,7 @@ impl<T: 'static> EventLoop<T> {
                 event_loop: self.window_target,
             };
 
-            app_state::will_launch(Box::new(handler));
+            app_state::will_launch(self.mtm, Box::new(handler));
 
             // Ensure application delegate is initialized
             view::WinitApplicationDelegate::class();
@@ -142,9 +147,7 @@ impl<T: 'static> EventLoop<T> {
 // EventLoopExtIOS
 impl<T: 'static> EventLoop<T> {
     pub fn idiom(&self) -> Idiom {
-        UIDevice::current(MainThreadMarker::new().unwrap())
-            .userInterfaceIdiom()
-            .into()
+        UIDevice::current(self.mtm).userInterfaceIdiom().into()
     }
 }
 
@@ -222,12 +225,11 @@ fn setup_control_flow_observers() {
             activity: CFRunLoopActivity,
             _: *mut c_void,
         ) {
-            unsafe {
-                #[allow(non_upper_case_globals)]
-                match activity {
-                    kCFRunLoopAfterWaiting => app_state::handle_wakeup_transition(),
-                    _ => unreachable!(),
-                }
+            let mtm = MainThreadMarker::new().unwrap();
+            #[allow(non_upper_case_globals)]
+            match activity {
+                kCFRunLoopAfterWaiting => app_state::handle_wakeup_transition(mtm),
+                _ => unreachable!(),
             }
         }
 
@@ -247,13 +249,12 @@ fn setup_control_flow_observers() {
             activity: CFRunLoopActivity,
             _: *mut c_void,
         ) {
-            unsafe {
-                #[allow(non_upper_case_globals)]
-                match activity {
-                    kCFRunLoopBeforeWaiting => app_state::handle_main_events_cleared(),
-                    kCFRunLoopExit => unimplemented!(), // not expected to ever happen
-                    _ => unreachable!(),
-                }
+            let mtm = MainThreadMarker::new().unwrap();
+            #[allow(non_upper_case_globals)]
+            match activity {
+                kCFRunLoopBeforeWaiting => app_state::handle_main_events_cleared(mtm),
+                kCFRunLoopExit => unimplemented!(), // not expected to ever happen
+                _ => unreachable!(),
             }
         }
 
@@ -263,13 +264,12 @@ fn setup_control_flow_observers() {
             activity: CFRunLoopActivity,
             _: *mut c_void,
         ) {
-            unsafe {
-                #[allow(non_upper_case_globals)]
-                match activity {
-                    kCFRunLoopBeforeWaiting => app_state::handle_events_cleared(),
-                    kCFRunLoopExit => unimplemented!(), // not expected to ever happen
-                    _ => unreachable!(),
-                }
+            let mtm = MainThreadMarker::new().unwrap();
+            #[allow(non_upper_case_globals)]
+            match activity {
+                kCFRunLoopBeforeWaiting => app_state::handle_events_cleared(mtm),
+                kCFRunLoopExit => unimplemented!(), // not expected to ever happen
+                _ => unreachable!(),
             }
         }
 

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -15,12 +15,10 @@ use core_foundation::runloop::{
     CFRunLoopSourceInvalidate, CFRunLoopSourceRef, CFRunLoopSourceSignal, CFRunLoopWakeUp,
 };
 use icrate::Foundation::{MainThreadMarker, NSString};
-use objc2::rc::Id;
 use objc2::ClassType;
 use raw_window_handle::{RawDisplayHandle, UiKitDisplayHandle};
 
 use crate::{
-    dpi::LogicalSize,
     error::EventLoopError,
     event::Event,
     event_loop::{
@@ -30,23 +28,7 @@ use crate::{
 };
 
 use super::uikit::{UIApplication, UIApplicationMain, UIDevice, UIScreen};
-use super::view::WinitUIWindow;
 use super::{app_state, monitor, view, MonitorHandle};
-
-#[derive(Debug)]
-pub(crate) enum EventWrapper {
-    StaticEvent(Event<Never>),
-    EventProxy(EventProxy),
-}
-
-#[derive(Debug, PartialEq)]
-pub(crate) enum EventProxy {
-    DpiChangedProxy {
-        window: Id<WinitUIWindow>,
-        suggested_size: LogicalSize<f64>,
-        scale_factor: f64,
-    },
-}
 
 pub struct EventLoopWindowTarget<T: 'static> {
     receiver: Receiver<T>,

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -58,17 +58,6 @@
 #![cfg(ios_platform)]
 #![allow(clippy::let_unit_value)]
 
-// TODO: (mtak-) UIKit requires main thread for virtually all function/method calls. This could be
-// worked around in the future by using GCD (grand central dispatch) and/or caching of values like
-// window size/position.
-macro_rules! assert_main_thread {
-    ($($t:tt)*) => {
-        if !::icrate::Foundation::is_main_thread() {
-            panic!($($t)*);
-        }
-    };
-}
-
 mod app_state;
 mod event_loop;
 mod ffi;

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -2,11 +2,11 @@
 
 use std::{
     collections::{BTreeSet, VecDeque},
-    fmt,
-    ops::{Deref, DerefMut},
+    fmt, hash, ptr,
 };
 
-use icrate::Foundation::{MainThreadMarker, NSInteger};
+use icrate::Foundation::{MainThreadBound, MainThreadMarker, NSInteger};
+use objc2::mutability::IsRetainable;
 use objc2::rc::Id;
 
 use super::uikit::{UIScreen, UIScreenMode};
@@ -16,32 +16,59 @@ use crate::{
     platform_impl::platform::app_state,
 };
 
-// TODO(madsmtm): Remove or refactor this
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub(crate) struct ScreenModeSendSync(pub(crate) Id<UIScreenMode>);
+// Workaround for `MainThreadBound` implementing almost no traits
+#[derive(Debug)]
+struct MainThreadBoundDelegateImpls<T>(MainThreadBound<Id<T>>);
 
-unsafe impl Send for ScreenModeSendSync {}
-unsafe impl Sync for ScreenModeSendSync {}
+impl<T: IsRetainable> Clone for MainThreadBoundDelegateImpls<T> {
+    fn clone(&self) -> Self {
+        Self(
+            self.0
+                .get_on_main(|inner, mtm| MainThreadBound::new(Id::clone(inner), mtm)),
+        )
+    }
+}
+
+impl<T: IsRetainable> hash::Hash for MainThreadBoundDelegateImpls<T> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        // SAFETY: Marker only used to get the pointer
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        Id::as_ptr(self.0.get(mtm)).hash(state);
+    }
+}
+
+impl<T: IsRetainable> PartialEq for MainThreadBoundDelegateImpls<T> {
+    fn eq(&self, other: &Self) -> bool {
+        // SAFETY: Marker only used to get the pointer
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        Id::as_ptr(self.0.get(mtm)) == Id::as_ptr(other.0.get(mtm))
+    }
+}
+
+impl<T: IsRetainable> Eq for MainThreadBoundDelegateImpls<T> {}
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct VideoMode {
     pub(crate) size: (u32, u32),
     pub(crate) bit_depth: u16,
     pub(crate) refresh_rate_millihertz: u32,
-    pub(crate) screen_mode: ScreenModeSendSync,
+    screen_mode: MainThreadBoundDelegateImpls<UIScreenMode>,
     pub(crate) monitor: MonitorHandle,
 }
 
 impl VideoMode {
-    fn new(uiscreen: Id<UIScreen>, screen_mode: Id<UIScreenMode>) -> VideoMode {
-        assert_main_thread!("`VideoMode` can only be created on the main thread on iOS");
+    fn new(
+        uiscreen: Id<UIScreen>,
+        screen_mode: Id<UIScreenMode>,
+        mtm: MainThreadMarker,
+    ) -> VideoMode {
         let refresh_rate_millihertz = refresh_rate_millihertz(&uiscreen);
         let size = screen_mode.size();
         VideoMode {
             size: (size.width as u32, size.height as u32),
             bit_depth: 32,
             refresh_rate_millihertz,
-            screen_mode: ScreenModeSendSync(screen_mode),
+            screen_mode: MainThreadBoundDelegateImpls(MainThreadBound::new(screen_mode, mtm)),
             monitor: MonitorHandle::new(uiscreen),
         }
     }
@@ -61,17 +88,39 @@ impl VideoMode {
     pub fn monitor(&self) -> MonitorHandle {
         self.monitor.clone()
     }
+
+    pub(super) fn screen_mode(&self, mtm: MainThreadMarker) -> &Id<UIScreenMode> {
+        self.screen_mode.0.get(mtm)
+    }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct Inner {
-    uiscreen: Id<UIScreen>,
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MonitorHandle {
-    inner: Inner,
+    ui_screen: MainThreadBound<Id<UIScreen>>,
 }
+
+impl Clone for MonitorHandle {
+    fn clone(&self) -> Self {
+        Self {
+            ui_screen: self
+                .ui_screen
+                .get_on_main(|inner, mtm| MainThreadBound::new(inner.clone(), mtm)),
+        }
+    }
+}
+
+impl hash::Hash for MonitorHandle {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        (self as *const Self).hash(state);
+    }
+}
+
+impl PartialEq for MonitorHandle {
+    fn eq(&self, other: &Self) -> bool {
+        ptr::eq(self, other)
+    }
+}
+
+impl Eq for MonitorHandle {}
 
 impl PartialOrd for MonitorHandle {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -83,31 +132,6 @@ impl Ord for MonitorHandle {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         // TODO: Make a better ordering
         (self as *const Self).cmp(&(other as *const Self))
-    }
-}
-
-impl Deref for MonitorHandle {
-    type Target = Inner;
-
-    fn deref(&self) -> &Inner {
-        assert_main_thread!("`MonitorHandle` methods can only be run on the main thread on iOS");
-        &self.inner
-    }
-}
-
-impl DerefMut for MonitorHandle {
-    fn deref_mut(&mut self) -> &mut Inner {
-        assert_main_thread!("`MonitorHandle` methods can only be run on the main thread on iOS");
-        &mut self.inner
-    }
-}
-
-unsafe impl Send for MonitorHandle {}
-unsafe impl Sync for MonitorHandle {}
-
-impl Drop for MonitorHandle {
-    fn drop(&mut self) {
-        assert_main_thread!("`MonitorHandle` can only be dropped on the main thread on iOS");
     }
 }
 
@@ -135,59 +159,80 @@ impl fmt::Debug for MonitorHandle {
 }
 
 impl MonitorHandle {
-    pub(crate) fn new(uiscreen: Id<UIScreen>) -> Self {
-        assert_main_thread!("`MonitorHandle` can only be created on the main thread on iOS");
+    pub(crate) fn new(ui_screen: Id<UIScreen>) -> Self {
+        // Holding `Id<UIScreen>` implies we're on the main thread.
+        let mtm = MainThreadMarker::new().unwrap();
         Self {
-            inner: Inner { uiscreen },
+            ui_screen: MainThreadBound::new(ui_screen, mtm),
         }
     }
-}
 
-impl Inner {
     pub fn name(&self) -> Option<String> {
-        let main = UIScreen::main(MainThreadMarker::new().unwrap());
-        if self.uiscreen == main {
-            Some("Primary".to_string())
-        } else if self.uiscreen == main.mirroredScreen() {
-            Some("Mirrored".to_string())
-        } else {
-            UIScreen::screens(MainThreadMarker::new().unwrap())
-                .iter()
-                .position(|rhs| rhs == &*self.uiscreen)
-                .map(|idx| idx.to_string())
-        }
+        self.ui_screen.get_on_main(|ui_screen, mtm| {
+            let main = UIScreen::main(mtm);
+            if *ui_screen == main {
+                Some("Primary".to_string())
+            } else if *ui_screen == main.mirroredScreen() {
+                Some("Mirrored".to_string())
+            } else {
+                UIScreen::screens(mtm)
+                    .iter()
+                    .position(|rhs| rhs == &**ui_screen)
+                    .map(|idx| idx.to_string())
+            }
+        })
     }
 
     pub fn size(&self) -> PhysicalSize<u32> {
-        let bounds = self.uiscreen.nativeBounds();
+        let bounds = self
+            .ui_screen
+            .get_on_main(|ui_screen, _| ui_screen.nativeBounds());
         PhysicalSize::new(bounds.size.width as u32, bounds.size.height as u32)
     }
 
     pub fn position(&self) -> PhysicalPosition<i32> {
-        let bounds = self.uiscreen.nativeBounds();
+        let bounds = self
+            .ui_screen
+            .get_on_main(|ui_screen, _| ui_screen.nativeBounds());
         (bounds.origin.x as f64, bounds.origin.y as f64).into()
     }
 
     pub fn scale_factor(&self) -> f64 {
-        self.uiscreen.nativeScale() as f64
+        self.ui_screen
+            .get_on_main(|ui_screen, _| ui_screen.nativeScale()) as f64
     }
 
     pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        Some(refresh_rate_millihertz(&self.uiscreen))
+        Some(
+            self.ui_screen
+                .get_on_main(|ui_screen, _| refresh_rate_millihertz(ui_screen)),
+        )
     }
 
     pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
-        // Use Ord impl of RootVideoMode
-        let modes: BTreeSet<_> = self
-            .uiscreen
-            .availableModes()
-            .into_iter()
-            .map(|mode| RootVideoMode {
-                video_mode: VideoMode::new(self.uiscreen.clone(), mode),
-            })
-            .collect();
+        self.ui_screen.get_on_main(|ui_screen, mtm| {
+            // Use Ord impl of RootVideoMode
 
-        modes.into_iter().map(|mode| mode.video_mode)
+            let modes: BTreeSet<_> = ui_screen
+                .availableModes()
+                .into_iter()
+                .map(|mode| RootVideoMode {
+                    video_mode: VideoMode::new(ui_screen.clone(), mode, mtm),
+                })
+                .collect();
+
+            modes.into_iter().map(|mode| mode.video_mode)
+        })
+    }
+
+    pub(crate) fn ui_screen(&self, mtm: MainThreadMarker) -> &Id<UIScreen> {
+        self.ui_screen.get(mtm)
+    }
+
+    pub fn preferred_video_mode(&self) -> VideoMode {
+        self.ui_screen.get_on_main(|ui_screen, mtm| {
+            VideoMode::new(ui_screen.clone(), ui_screen.preferredMode().unwrap(), mtm)
+        })
     }
 }
 
@@ -213,20 +258,6 @@ fn refresh_rate_millihertz(uiscreen: &UIScreen) -> u32 {
     };
 
     refresh_rate_millihertz as u32 * 1000
-}
-
-// MonitorHandleExtIOS
-impl Inner {
-    pub(crate) fn ui_screen(&self) -> &Id<UIScreen> {
-        &self.uiscreen
-    }
-
-    pub fn preferred_video_mode(&self) -> VideoMode {
-        VideoMode::new(
-            self.uiscreen.clone(),
-            self.uiscreen.preferredMode().unwrap(),
-        )
-    }
 }
 
 pub fn uiscreens(mtm: MainThreadMarker) -> VecDeque<MonitorHandle> {

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -463,7 +463,7 @@ declare_class!(
 
 impl WinitUIWindow {
     pub(crate) fn new(
-        _mtm: MainThreadMarker,
+        mtm: MainThreadMarker,
         window_attributes: &WindowAttributes,
         _platform_attributes: &PlatformSpecificWindowBuilderAttributes,
         frame: CGRect,
@@ -476,12 +476,12 @@ impl WinitUIWindow {
         match window_attributes.fullscreen.clone().map(Into::into) {
             Some(Fullscreen::Exclusive(ref video_mode)) => {
                 let monitor = video_mode.monitor();
-                let screen = monitor.ui_screen();
-                screen.setCurrentMode(Some(&video_mode.screen_mode.0));
+                let screen = monitor.ui_screen(mtm);
+                screen.setCurrentMode(Some(video_mode.screen_mode(mtm)));
                 this.setScreen(screen);
             }
             Some(Fullscreen::Borderless(Some(ref monitor))) => {
-                let screen = monitor.ui_screen();
+                let screen = monitor.ui_screen(mtm);
                 this.setScreen(screen);
             }
             _ => (),

--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -4,7 +4,7 @@ use icrate::Foundation::NSObject;
 use objc2::{declare_class, msg_send, mutability, ClassType};
 
 use super::appkit::{NSApplication, NSEvent, NSEventModifierFlags, NSEventType, NSResponder};
-use super::{app_state::AppState, event::EventWrapper, DEVICE_ID};
+use super::{app_state::AppState, DEVICE_ID};
 use crate::event::{DeviceEvent, ElementState, Event};
 
 declare_class!(
@@ -96,5 +96,5 @@ fn queue_device_event(event: DeviceEvent) {
         device_id: DEVICE_ID,
         event,
     };
-    AppState::queue_event(EventWrapper::StaticEvent(event));
+    AppState::queue_event(event);
 }

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -13,22 +13,17 @@ use std::{
 
 use core_foundation::runloop::{CFRunLoopGetMain, CFRunLoopWakeUp};
 use icrate::Foundation::{is_main_thread, NSSize};
-use objc2::rc::autoreleasepool;
+use objc2::rc::{autoreleasepool, Id};
 use once_cell::sync::Lazy;
 
 use super::appkit::{NSApp, NSApplication, NSApplicationActivationPolicy, NSEvent};
+use super::{
+    event_loop::PanicInfo, menu, observer::EventLoopWaker, util::Never, window::WinitWindow,
+};
 use crate::{
-    dpi::LogicalSize,
+    dpi::PhysicalSize,
     event::{Event, InnerSizeWriter, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoopWindowTarget as RootWindowTarget},
-    platform_impl::platform::{
-        event::{EventProxy, EventWrapper},
-        event_loop::PanicInfo,
-        menu,
-        observer::EventLoopWaker,
-        util::Never,
-        window::WinitWindow,
-    },
     window::WindowId,
 };
 
@@ -114,6 +109,16 @@ impl<T> EventHandler for EventLoopHandler<T> {
             }
         });
     }
+}
+
+#[derive(Debug)]
+enum EventWrapper {
+    StaticEvent(Event<Never>),
+    ScaleFactorChanged {
+        window: Id<WinitWindow>,
+        suggested_size: PhysicalSize<u32>,
+        scale_factor: f64,
+    },
 }
 
 #[derive(Default)]
@@ -313,14 +318,9 @@ impl Handler {
         self.callback.lock().unwrap().is_some()
     }
 
-    fn handle_nonuser_event(&self, wrapper: EventWrapper) {
+    fn handle_nonuser_event(&self, event: Event<Never>) {
         if let Some(ref mut callback) = *self.callback.lock().unwrap() {
-            match wrapper {
-                EventWrapper::StaticEvent(event) => {
-                    callback.handle_nonuser_event(event, &mut self.control_flow.lock().unwrap())
-                }
-                EventWrapper::EventProxy(proxy) => self.handle_proxy(proxy, callback),
-            }
+            callback.handle_nonuser_event(event, &mut self.control_flow.lock().unwrap())
         }
     }
 
@@ -332,41 +332,27 @@ impl Handler {
 
     fn handle_scale_factor_changed_event(
         &self,
-        callback: &mut Box<dyn EventHandler + 'static>,
         window: &WinitWindow,
-        suggested_size: LogicalSize<f64>,
+        suggested_size: PhysicalSize<u32>,
         scale_factor: f64,
     ) {
-        let new_inner_size = Arc::new(Mutex::new(suggested_size.to_physical(scale_factor)));
-        let event = Event::WindowEvent {
-            window_id: WindowId(window.id()),
-            event: WindowEvent::ScaleFactorChanged {
-                scale_factor,
-                inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
-            },
-        };
+        if let Some(ref mut callback) = *self.callback.lock().unwrap() {
+            let new_inner_size = Arc::new(Mutex::new(suggested_size));
+            let event = Event::WindowEvent {
+                window_id: WindowId(window.id()),
+                event: WindowEvent::ScaleFactorChanged {
+                    scale_factor,
+                    inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
+                },
+            };
 
-        callback.handle_nonuser_event(event, &mut self.control_flow.lock().unwrap());
+            callback.handle_nonuser_event(event, &mut self.control_flow.lock().unwrap());
 
-        let physical_size = *new_inner_size.lock().unwrap();
-        drop(new_inner_size);
-        let logical_size = physical_size.to_logical(scale_factor);
-        let size = NSSize::new(logical_size.width, logical_size.height);
-        window.setContentSize(size);
-    }
-
-    fn handle_proxy(&self, proxy: EventProxy, callback: &mut Box<dyn EventHandler + 'static>) {
-        match proxy {
-            EventProxy::DpiChangedProxy {
-                window,
-                suggested_size,
-                scale_factor,
-            } => self.handle_scale_factor_changed_event(
-                callback,
-                &window,
-                suggested_size,
-                scale_factor,
-            ),
+            let physical_size = *new_inner_size.lock().unwrap();
+            drop(new_inner_size);
+            let logical_size = physical_size.to_logical(scale_factor);
+            let size = NSSize::new(logical_size.width, logical_size.height);
+            window.setContentSize(size);
         }
     }
 }
@@ -435,7 +421,7 @@ impl AppState {
 
     pub fn exit() -> i32 {
         HANDLER.set_in_callback(true);
-        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::LoopExiting));
+        HANDLER.handle_nonuser_event(Event::LoopExiting);
         HANDLER.set_in_callback(false);
         HANDLER.exit();
         Self::clear_callback();
@@ -448,12 +434,10 @@ impl AppState {
 
     pub fn dispatch_init_events() {
         HANDLER.set_in_callback(true);
-        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::NewEvents(
-            StartCause::Init,
-        )));
+        HANDLER.handle_nonuser_event(Event::NewEvents(StartCause::Init));
         // NB: For consistency all platforms must emit a 'resumed' event even though macOS
         // applications don't themselves have a formal suspend/resume lifecycle.
-        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::Resumed));
+        HANDLER.handle_nonuser_event(Event::Resumed);
         HANDLER.set_in_callback(false);
     }
 
@@ -544,7 +528,7 @@ impl AppState {
             ControlFlow::ExitWithCode(_) => StartCause::Poll, //panic!("unexpected `ControlFlow::Exit`"),
         };
         HANDLER.set_in_callback(true);
-        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::NewEvents(cause)));
+        HANDLER.handle_nonuser_event(Event::NewEvents(cause));
         HANDLER.set_in_callback(false);
     }
 
@@ -564,10 +548,10 @@ impl AppState {
         // Redraw request might come out of order from the OS.
         // -> Don't go back into the callback when our callstack originates from there
         if !HANDLER.in_callback.swap(true, Ordering::AcqRel) {
-            HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+            HANDLER.handle_nonuser_event(Event::WindowEvent {
                 window_id,
                 event: WindowEvent::RedrawRequested,
-            }));
+            });
             HANDLER.set_in_callback(false);
 
             // `pump_events` will request to stop immediately _after_ dispatching RedrawRequested events
@@ -578,11 +562,25 @@ impl AppState {
         }
     }
 
-    pub fn queue_event(wrapper: EventWrapper) {
+    pub fn queue_event(event: Event<Never>) {
         if !is_main_thread() {
-            panic!("Event queued from different thread: {wrapper:#?}");
+            panic!("Event queued from different thread: {event:#?}");
         }
-        HANDLER.events().push_back(wrapper);
+        HANDLER.events().push_back(EventWrapper::StaticEvent(event));
+    }
+
+    pub fn queue_static_scale_factor_changed_event(
+        window: Id<WinitWindow>,
+        suggested_size: PhysicalSize<u32>,
+        scale_factor: f64,
+    ) {
+        HANDLER
+            .events()
+            .push_back(EventWrapper::ScaleFactorChanged {
+                window,
+                suggested_size,
+                scale_factor,
+            });
     }
 
     pub fn stop() {
@@ -614,17 +612,32 @@ impl AppState {
         HANDLER.set_in_callback(true);
         HANDLER.handle_user_events();
         for event in HANDLER.take_events() {
-            HANDLER.handle_nonuser_event(event);
+            match event {
+                EventWrapper::StaticEvent(event) => {
+                    HANDLER.handle_nonuser_event(event);
+                }
+                EventWrapper::ScaleFactorChanged {
+                    window,
+                    suggested_size,
+                    scale_factor,
+                } => {
+                    HANDLER.handle_scale_factor_changed_event(
+                        &window,
+                        suggested_size,
+                        scale_factor,
+                    );
+                }
+            }
         }
 
         for window_id in HANDLER.should_redraw() {
-            HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+            HANDLER.handle_nonuser_event(Event::WindowEvent {
                 window_id,
                 event: WindowEvent::RedrawRequested,
-            }));
+            });
         }
 
-        HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::AboutToWait));
+        HANDLER.handle_nonuser_event(Event::AboutToWait);
         HANDLER.set_in_callback(false);
 
         if HANDLER.should_exit() {

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -5,36 +5,17 @@ use core_foundation::{
     data::{CFDataGetBytePtr, CFDataRef},
 };
 use icrate::Foundation::MainThreadMarker;
-use objc2::rc::Id;
 use smol_str::SmolStr;
 
 use super::appkit::{NSEvent, NSEventModifierFlags};
-use super::util::Never;
-use super::window::WinitWindow;
 use crate::{
-    dpi::LogicalSize,
-    event::{ElementState, Event, KeyEvent, Modifiers},
+    event::{ElementState, KeyEvent, Modifiers},
     keyboard::{
         Key, KeyCode, KeyLocation, ModifiersKeys, ModifiersState, NativeKey, NativeKeyCode,
     },
     platform::{modifier_supplement::KeyEventExtModifierSupplement, scancode::KeyCodeExtScancode},
     platform_impl::platform::ffi,
 };
-
-#[derive(Debug)]
-pub(crate) enum EventWrapper {
-    StaticEvent(Event<Never>),
-    EventProxy(EventProxy),
-}
-
-#[derive(Debug)]
-pub(crate) enum EventProxy {
-    DpiChangedProxy {
-        window: Id<WinitWindow>,
-        suggested_size: LogicalSize<f64>,
-        scale_factor: f64,
-    },
-}
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeyEventExtra {

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -31,7 +31,7 @@ use crate::{
     platform::scancode::KeyCodeExtScancode,
     platform_impl::platform::{
         app_state::AppState,
-        event::{create_key_event, event_mods, EventWrapper},
+        event::{create_key_event, event_mods},
         util,
         window::WinitWindow,
         DEVICE_ID,
@@ -826,7 +826,7 @@ impl WinitView {
             window_id: self.window_id(),
             event,
         };
-        AppState::queue_event(EventWrapper::StaticEvent(event));
+        AppState::queue_event(event);
     }
 
     fn queue_device_event(&self, event: DeviceEvent) {
@@ -834,7 +834,7 @@ impl WinitView {
             device_id: DEVICE_ID,
             event,
         };
-        AppState::queue_event(EventWrapper::StaticEvent(event));
+        AppState::queue_event(event);
     }
 
     fn scale_factor(&self) -> f64 {

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -11,16 +11,15 @@ use objc2::{class, declare_class, msg_send, msg_send_id, mutability, sel, ClassT
 use super::appkit::{
     NSApplicationPresentationOptions, NSFilenamesPboardType, NSPasteboard, NSWindowOcclusionState,
 };
+use super::{
+    app_state::AppState,
+    util,
+    window::{get_ns_theme, WinitWindow},
+    Fullscreen,
+};
 use crate::{
     dpi::{LogicalPosition, LogicalSize},
     event::{Event, WindowEvent},
-    platform_impl::platform::{
-        app_state::AppState,
-        event::{EventProxy, EventWrapper},
-        util,
-        window::{get_ns_theme, WinitWindow},
-        Fullscreen,
-    },
     window::WindowId,
 };
 
@@ -447,7 +446,7 @@ impl WinitWindowDelegate {
             window_id: WindowId(self.window.id()),
             event,
         };
-        AppState::queue_event(EventWrapper::StaticEvent(event));
+        AppState::queue_event(event);
     }
 
     fn queue_static_scale_factor_changed_event(&self) {
@@ -457,12 +456,12 @@ impl WinitWindowDelegate {
         };
 
         self.state.previous_scale_factor.set(scale_factor);
-        let wrapper = EventWrapper::EventProxy(EventProxy::DpiChangedProxy {
-            window: self.window.clone(),
-            suggested_size: self.view_size(),
+        let suggested_size = self.view_size();
+        AppState::queue_static_scale_factor_changed_event(
+            self.window.clone(),
+            suggested_size.to_physical(scale_factor),
             scale_factor,
-        });
-        AppState::queue_event(wrapper);
+        );
     }
 
     fn emit_move_event(&self) {


### PR DESCRIPTION
Part of #2464.

Now, `MonitorHandle` and `VideoMode` are usable from any thread.

Also did a few other cleanups, in preparation for making `EventLoopWindowTarget` independent of the user event type, to fix the macOS and iOS part of https://github.com/rust-windowing/winit/issues/3053.

- [x] Tested on all platforms changed
  - [x] macOS
  - [x] iOS
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
