### PR TITLE
Add an MSRV policy to the README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,13 @@ jobs:
           - { name: 'iOS x86_64',         target: x86_64-apple-ios,         os: macos-latest,    }
           - { name: 'iOS Aarch64',        target: aarch64-apple-ios,        os: macos-latest,    }
           - { name: 'web',                target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
+        exclude:
+          # Android is tested on stable-3
+          - toolchain: '1.65.0'
+            platform: { name: 'Android', target: aarch64-linux-android, os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
+        include:
+          - toolchain: '1.69.0'
+            platform: { name: 'Android', target: aarch64-linux-android, os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
 
     env:
       # Set more verbose terminal output

--- a/README.md
+++ b/README.md
@@ -91,11 +91,10 @@ capped at the latest stable version of Rust minus three. This inconsistency is
 not reflected in Cargo metadata, as it is not powerful enough to expose this 
 restriction.
 
-All crates in the [`rust-windowing`] and [`rust-mobile`] organizations have the 
+All crates in the [`rust-windowing`] organizations have the 
 same MSRV policy.
 
 [`rust-windowing`]: https://github.com/rust-windowing
-[`rust-mobile`]: https://github.com/rust-mobile
 
 ### Platform-specific usage
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,31 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 
 ## MSRV Policy
 
-The Minimum Supported Rust Version (MSRV) of this crate is **1.65**. Changes to the MSRV will be released as patch version updates to `winit`. Once `winit` v1.0 is released, they will instead be released as minor version updates.
+The Minimum Supported Rust Version (MSRV) of this crate is **1.65**. Changes to 
+the MSRV will by a minor version bump. 
 
-As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Sid](https://packages.debian.org/sid/rustc). At the time of writing, this version of Rust is *1.66*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
+As a **tentative** policy, the upper bound of the MSRV is given by the following
+formula:
 
-The exception to this is for the Android platform, where a higher Rust version must be used for certain Android features. In this case, the MSRV will be capped at the latest stable version of Rust minus three. This inconsistency is not reflected in Cargo metadata, as it is not powerful enough to expose this restriction.
+```
+min(sid, stable - 3)
+```
 
-All crates in the [`rust-windowing`](https://github.com/rust-windowing) and [`rust-mobile`](https://github.com/rust-mobile) organizations have the same MSRV policy.
+Where `sid` is the current version of `rustc` provided by [Debian Sid], and
+`stable` is the latest stable version of Rust. This bound may be broken in the
+event of a major ecosystem shift or a security vulnerability.
+
+[Debian Sid]: https://packages.debian.org/sid/rustc
+
+The exception to this is for the Android platform, where a higher Rust version 
+must be used for certain Android features. In this case, the MSRV will be 
+capped at the latest stable version of Rust minus three. This inconsistency is 
+not reflected in Cargo metadata, as it is not powerful enough to expose this 
+restriction.
+
+All crates in the [`rust-windowing`](https://github.com/rust-windowing) and 
+[`rust-mobile`](https://github.com/rust-mobile) organizations have the same 
+MSRV policy.
 
 ### Platform-specific usage
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 ## MSRV Policy
 
 The Minimum Supported Rust Version (MSRV) of this crate is **1.65**. Changes to 
-the MSRV will by a minor version bump. 
+the MSRV will be accompanied by minor version bump. 
 
 As a **tentative** policy, the upper bound of the MSRV is given by the following
 formula:
@@ -91,9 +91,11 @@ capped at the latest stable version of Rust minus three. This inconsistency is
 not reflected in Cargo metadata, as it is not powerful enough to expose this 
 restriction.
 
-All crates in the [`rust-windowing`](https://github.com/rust-windowing) and 
-[`rust-mobile`](https://github.com/rust-mobile) organizations have the same 
-MSRV policy.
+All crates in the [`rust-windowing`] and [`rust-mobile`] organizations have the 
+same MSRV policy.
+
+[`rust-windowing`]: https://github.com/rust-windowing
+[`rust-mobile`]: https://github.com/rust-mobile
 
 ### Platform-specific usage
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 * `wayland` (enabled by default): On Unix platform, compiles with the Wayland backend
 * `mint`: Enables mint (math interoperability standard types) conversions.
 
+## MSRV Policy
+
+The Minimum Supported Rust Version (MSRV) of this crate is **1.65**.
+
+As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Testing](https://packages.debian.org/testing/rustc). At the time of writing, this version of Rust is *1.66*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
+
+The exception to this is for the Android platform, where a higher Rust version must be used for certain Android features. In this case, the MSRV will be capped at the latest stable version of Rust minus three. This inconsistency is not reflected in Cargo metadata, as it is not powerful enough to expose this restriction.
+
+All crates in the [`rust-windowing`](https://github.com/rust-windowing) and [`rust-mobile`](https://github.com/rust-mobile) organizations have the same MSRV policy.
+
 ### Platform-specific usage
 
 #### Wayland

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 
 ## MSRV Policy
 
-The Minimum Supported Rust Version (MSRV) of this crate is **1.65**.
+The Minimum Supported Rust Version (MSRV) of this crate is **1.65**. Changes to the MSRV will be released as patch version updates to `winit`. Once `winit` v1.0 is released, they will instead be released as minor version updates.
 
-As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Testing](https://packages.debian.org/testing/rustc). At the time of writing, this version of Rust is *1.66*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
+As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Sid](https://packages.debian.org/sid/rustc). At the time of writing, this version of Rust is *1.66*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
 
 The exception to this is for the Android platform, where a higher Rust version must be used for certain Android features. In this case, the MSRV will be capped at the latest stable version of Rust minus three. This inconsistency is not reflected in Cargo metadata, as it is not powerful enough to expose this restriction.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 ## MSRV Policy
 
 The Minimum Supported Rust Version (MSRV) of this crate is **1.65**. Changes to 
-the MSRV will be accompanied by minor version bump. 
+the MSRV will be accompanied by a minor version bump. 
 
 As a **tentative** policy, the upper bound of the MSRV is given by the following
 formula:


### PR DESCRIPTION
As discussed in #3000, this adopts an official MSRV policy for the rust-windowing organization. It uses Debian Testing as the definition of our support. In the future once winit becomes more stable we might want to use Debian Stable instead, in order to allow Debian to use crates like Alacritty in the stable channel.

Outstanding questions:

- What are the general thoughts on the organizational policy?
- Does this give us enough leeway to add new features?
- Are there any other Linux distros that we need to support?

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
