### PR TITLE
Use a transparent color for the transparent example

### DIFF
--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 ..
             } => control_flow.set_exit(),
             Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
+                fill::fill_window_with_color(&window, 0x33181818);
             }
             _ => (),
         }

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -9,8 +9,14 @@
 
 use winit::window::Window;
 
-#[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub(super) fn fill_window(window: &Window) {
+    // Fill a buffer with a solid color.
+    const DARK_GRAY: u32 = 0xFF181818;
+    fill_window_with_color(window, DARK_GRAY);
+}
+
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub(super) fn fill_window_with_color(window: &Window, color: u32) {
     use softbuffer::{Context, Surface};
     use std::cell::RefCell;
     use std::collections::HashMap;
@@ -59,8 +65,6 @@ pub(super) fn fill_window(window: &Window) {
             .get_or_insert_with(|| GraphicsContext::new(window))
             .surface(window);
 
-        // Fill a buffer with a solid color.
-        const DARK_GRAY: u32 = 0xFF181818;
         let size = window.inner_size();
 
         surface
@@ -73,7 +77,7 @@ pub(super) fn fill_window(window: &Window) {
         let mut buffer = surface
             .buffer_mut()
             .expect("Failed to get the softbuffer buffer");
-        buffer.fill(DARK_GRAY);
+        buffer.fill(color);
         buffer
             .present()
             .expect("Failed to present the softbuffer buffer");
@@ -81,6 +85,6 @@ pub(super) fn fill_window(window: &Window) {
 }
 
 #[cfg(any(target_os = "android", target_os = "ios"))]
-pub(super) fn fill_window(_window: &Window) {
+pub(super) fn fill_window_with_color(_window: &Window, color: u32) {
     // No-op on mobile platforms.
 }

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -85,6 +85,6 @@ pub(super) fn fill_window_with_color(window: &Window, color: u32) {
 }
 
 #[cfg(any(target_os = "android", target_os = "ios"))]
-pub(super) fn fill_window_with_color(_window: &Window, color: u32) {
+pub(super) fn fill_window_with_color(_window: &Window, _color: u32) {
     // No-op on mobile platforms.
 }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Created or updated an example program if it would help users understand this functionality


The transparency example used a solid fill color, which seems a tad odd. This fixes this by using a semi-transparent gray. However, we should wait for softbuffer to support transparency. https://github.com/rust-windowing/softbuffer/issues/17
I only have a Windows machine, so I only managed to test the example on Windows.

The example can be tested with `cargo run --example transparent`