### PR TITLE
Move `Event::RedrawRequested` to `WindowEvent::RedrawRequested`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Fix window size sometimes being invalid when resizing on macOS.
 - On Web, `ControlFlow::Poll` and `ControlFlow::WaitUntil` are now using the Prioritized Task Scheduling API. `setTimeout()` with a trick to circumvent throttling to 4ms is used as a fallback.
 - On Web, never return a `MonitorHandle`.
+- **Breaking:** Move `Event::RedrawRequested` to `WindowEvent::RedrawRequested`.
 
 # 0.29.1-beta
 

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -72,11 +72,12 @@ fn main() -> Result<(), impl std::error::Error> {
                 } => {
                     spawn_child_window(&parent_window, event_loop, &mut windows);
                 }
+                WindowEvent::RedrawRequested => {
+                    if let Some(window) = windows.get(&window_id) {
+                        fill::fill_window(window);
+                    }
+                }
                 _ => (),
-            }
-        } else if let Event::RedrawRequested(wid) = event {
-            if let Some(window) = windows.get(&wid) {
-                fill::fill_window(window);
             }
         }
     })

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -93,6 +93,9 @@ fn main() -> Result<(), impl std::error::Error> {
                     }
                     _ => (),
                 },
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
                 _ => (),
             },
             Event::AboutToWait => {
@@ -116,9 +119,6 @@ fn main() -> Result<(), impl std::error::Error> {
                 if close_requested {
                     control_flow.set_exit();
                 }
-            }
-            Event::RedrawRequested(_window_id) => {
-                fill::fill_window(&window);
             }
             _ => (),
         }

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -22,37 +22,32 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                state: ElementState::Pressed,
-                                ..
-                            },
-                        ..
-                    },
-                ..
-            } => {
-                println!("Setting cursor to \"{:?}\"", CURSORS[cursor_idx]);
-                window.set_cursor_icon(CURSORS[cursor_idx]);
-                if cursor_idx < CURSORS.len() - 1 {
-                    cursor_idx += 1;
-                } else {
-                    cursor_idx = 0;
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                } => {
+                    println!("Setting cursor to \"{:?}\"", CURSORS[cursor_idx]);
+                    window.set_cursor_icon(CURSORS[cursor_idx]);
+                    if cursor_idx < CURSORS.len() - 1 {
+                        cursor_idx += 1;
+                    } else {
+                        cursor_idx = 0;
+                    }
                 }
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
+                WindowEvent::CloseRequested => {
+                    control_flow.set_exit();
+                }
+                _ => (),
             }
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => {
-                control_flow.set_exit();
-            }
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
-            }
-            _ => (),
         }
     })
 }

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -60,6 +60,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     }
                 }
                 WindowEvent::ModifiersChanged(new) => modifiers = new.state(),
+                WindowEvent::RedrawRequested => fill::fill_window(&window),
                 _ => (),
             },
             Event::DeviceEvent { event, .. } => match event {
@@ -70,7 +71,6 @@ fn main() -> Result<(), impl std::error::Error> {
                 },
                 _ => (),
             },
-            Event::RedrawRequested(_) => fill::fill_window(&window),
             _ => (),
         }
     })

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -49,7 +49,10 @@ fn main() -> Result<(), impl std::error::Error> {
                 event: WindowEvent::CloseRequested,
                 ..
             } => control_flow.set_exit(),
-            Event::RedrawRequested(_) => {
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            } => {
                 fill::fill_window(&window);
             }
             _ => (),

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -59,15 +59,16 @@ fn main() -> Result<(), impl std::error::Error> {
                 name_windows(entered_id, switched, &window_1, &window_2);
                 println!("Switched!")
             }
+            WindowEvent::RedrawRequested => {
+                if window_id == window_1.id() {
+                    fill::fill_window(&window_1);
+                } else if window_id == window_2.id() {
+                    fill::fill_window(&window_2);
+                }
+            }
             _ => (),
         },
-        Event::RedrawRequested(wid) => {
-            if wid == window_1.id() {
-                fill::fill_window(&window_1);
-            } else if wid == window_2.id() {
-                fill::fill_window(&window_2);
-            }
-        }
+
         _ => (),
     })
 }

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -55,8 +55,8 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, elwt, control_flow| {
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent { event, .. } => match event {
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
                 WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::KeyboardInput {
                     event:
@@ -155,12 +155,11 @@ fn main() -> Result<(), impl std::error::Error> {
                     },
                     _ => (),
                 },
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
                 _ => (),
-            },
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
             }
-            _ => {}
         }
     })
 }

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -25,67 +25,64 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent { event, .. } => {
-                match event {
-                    WindowEvent::CloseRequested => {
-                        // `CloseRequested` is sent when the close button on the window is pressed (or
-                        // through whatever other mechanisms the window manager provides for closing a
-                        // window). If you don't handle this event, the close button won't actually do
-                        // anything.
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
+                WindowEvent::CloseRequested => {
+                    // `CloseRequested` is sent when the close button on the window is pressed (or
+                    // through whatever other mechanisms the window manager provides for closing a
+                    // window). If you don't handle this event, the close button won't actually do
+                    // anything.
 
-                        // A common thing to do here is prompt the user if they have unsaved work.
-                        // Creating a proper dialog box for that is far beyond the scope of this
-                        // example, so here we'll just respond to the Y and N keys.
-                        println!("Are you ready to bid your window farewell? [Y/N]");
-                        close_requested = true;
+                    // A common thing to do here is prompt the user if they have unsaved work.
+                    // Creating a proper dialog box for that is far beyond the scope of this
+                    // example, so here we'll just respond to the Y and N keys.
+                    println!("Are you ready to bid your window farewell? [Y/N]");
+                    close_requested = true;
 
-                        // In applications where you can safely close the window without further
-                        // action from the user, this is generally where you'd handle cleanup before
-                        // closing the window. How to close the window is detailed in the handler for
-                        // the Y key.
-                    }
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: key,
-                                state: ElementState::Released,
-                                ..
-                            },
-                        ..
-                    } => {
-                        // WARNING: Consider using `key_without_modifers()` if available on your platform.
-                        // See the `key_binding` example
-                        match key.as_ref() {
-                            Key::Character("y") => {
-                                if close_requested {
-                                    // This is where you'll want to do any cleanup you need.
-                                    println!("Buh-bye!");
-
-                                    // For a single-window application like this, you'd normally just
-                                    // break out of the event loop here. If you wanted to keep running the
-                                    // event loop (i.e. if it's a multi-window application), you need to
-                                    // drop the window. That closes it, and results in `Destroyed` being
-                                    // sent.
-                                    control_flow.set_exit();
-                                }
-                            }
-                            Key::Character("n") => {
-                                if close_requested {
-                                    println!("Your window will continue to stay by your side.");
-                                    close_requested = false;
-                                }
-                            }
-                            _ => (),
-                        }
-                    }
-                    _ => (),
+                    // In applications where you can safely close the window without further
+                    // action from the user, this is generally where you'd handle cleanup before
+                    // closing the window. How to close the window is detailed in the handler for
+                    // the Y key.
                 }
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            logical_key: key,
+                            state: ElementState::Released,
+                            ..
+                        },
+                    ..
+                } => {
+                    // WARNING: Consider using `key_without_modifers()` if available on your platform.
+                    // See the `key_binding` example
+                    match key.as_ref() {
+                        Key::Character("y") => {
+                            if close_requested {
+                                // This is where you'll want to do any cleanup you need.
+                                println!("Buh-bye!");
+
+                                // For a single-window application like this, you'd normally just
+                                // break out of the event loop here. If you wanted to keep running the
+                                // event loop (i.e. if it's a multi-window application), you need to
+                                // drop the window. That closes it, and results in `Destroyed` being
+                                // sent.
+                                control_flow.set_exit();
+                            }
+                        }
+                        Key::Character("n") => {
+                            if close_requested {
+                                println!("Your window will continue to stay by your side.");
+                                close_requested = false;
+                            }
+                        }
+                        _ => (),
+                    }
+                }
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
+                _ => (),
             }
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
-            }
-            _ => (),
         }
     })
 }

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -41,69 +41,55 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
-        match event {
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => *control_flow = ControlFlow::Exit,
-            Event::WindowEvent {
-                event: WindowEvent::CursorMoved { position, .. },
-                ..
-            } => {
-                cursor_position = position;
-            }
-            Event::WindowEvent {
-                event:
-                    WindowEvent::MouseInput {
-                        state: ElementState::Released,
-                        ..
-                    },
-                ..
-            } => {
-                println!(
-                    "Setting ime position to {}, {}",
-                    cursor_position.x, cursor_position.y
-                );
-                ime_pos = cursor_position;
-                if may_show_ime {
-                    window.set_ime_cursor_area(ime_pos, PhysicalSize::new(10, 10));
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CursorMoved { position, .. } => {
+                    cursor_position = position;
                 }
-            }
-            Event::WindowEvent {
-                event: WindowEvent::Ime(event),
-                ..
-            } => {
-                println!("{event:?}");
-                may_show_ime = event != Ime::Disabled;
-                if may_show_ime {
-                    window.set_ime_cursor_area(ime_pos, PhysicalSize::new(10, 10));
+                WindowEvent::MouseInput {
+                    state: ElementState::Released,
+                    ..
+                } => {
+                    println!(
+                        "Setting ime position to {}, {}",
+                        cursor_position.x, cursor_position.y
+                    );
+                    ime_pos = cursor_position;
+                    if may_show_ime {
+                        window.set_ime_cursor_area(ime_pos, PhysicalSize::new(10, 10));
+                    }
                 }
-            }
-            Event::WindowEvent {
-                event: WindowEvent::KeyboardInput { event, .. },
-                ..
-            } => {
-                println!("key: {event:?}");
+                WindowEvent::Ime(event) => {
+                    println!("{event:?}");
+                    may_show_ime = event != Ime::Disabled;
+                    if may_show_ime {
+                        window.set_ime_cursor_area(ime_pos, PhysicalSize::new(10, 10));
+                    }
+                }
+                WindowEvent::KeyboardInput { event, .. } => {
+                    println!("key: {event:?}");
 
-                if event.state == ElementState::Pressed && event.physical_key == KeyCode::F2 {
-                    ime_allowed = !ime_allowed;
-                    window.set_ime_allowed(ime_allowed);
-                    println!("\nIME allowed: {ime_allowed}\n");
+                    if event.state == ElementState::Pressed && event.physical_key == KeyCode::F2 {
+                        ime_allowed = !ime_allowed;
+                        window.set_ime_allowed(ime_allowed);
+                        println!("\nIME allowed: {ime_allowed}\n");
+                    }
+                    if event.state == ElementState::Pressed && event.logical_key == Key::F3 {
+                        ime_purpose = match ime_purpose {
+                            ImePurpose::Normal => ImePurpose::Password,
+                            ImePurpose::Password => ImePurpose::Terminal,
+                            _ => ImePurpose::Normal,
+                        };
+                        window.set_ime_purpose(ime_purpose);
+                        println!("\nIME purpose: {ime_purpose:?}\n");
+                    }
                 }
-                if event.state == ElementState::Pressed && event.logical_key == Key::F3 {
-                    ime_purpose = match ime_purpose {
-                        ImePurpose::Normal => ImePurpose::Password,
-                        ImePurpose::Password => ImePurpose::Terminal,
-                        _ => ImePurpose::Normal,
-                    };
-                    window.set_ime_purpose(ime_purpose);
-                    println!("\nIME purpose: {ime_purpose:?}\n");
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
                 }
+                _ => (),
             }
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
-            }
-            _ => (),
         }
     })
 }

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -34,8 +34,8 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
-        match event {
-            Event::WindowEvent { event, .. } => match event {
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
                 WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
                 WindowEvent::ModifiersChanged(new) => {
                     modifiers = new.state();
@@ -54,12 +54,11 @@ fn main() -> Result<(), impl std::error::Error> {
                         }
                     }
                 }
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
                 _ => (),
-            },
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
             }
-            _ => (),
         };
     })
 }

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -37,8 +37,8 @@ In other words, the deltas indicate the direction in which to move the content (
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent { event, .. } => match event {
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
                 WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::MouseWheel { delta, .. } => match delta {
                     winit::event::MouseScrollDelta::LineDelta(x, y) => {
@@ -57,12 +57,11 @@ In other words, the deltas indicate the direction in which to move the content (
                         window.set_outer_position(pos)
                     }
                 },
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
                 _ => (),
-            },
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
             }
-            _ => (),
         }
     })
 }

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -29,42 +29,39 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, event_loop, control_flow| {
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent { event, window_id } => {
-                match event {
-                    WindowEvent::CloseRequested => {
-                        println!("Window {window_id:?} has received the signal to close");
+        if let Event::WindowEvent { event, window_id } = event {
+            match event {
+                WindowEvent::CloseRequested => {
+                    println!("Window {window_id:?} has received the signal to close");
 
-                        // This drops the window, causing it to close.
-                        windows.remove(&window_id);
+                    // This drops the window, causing it to close.
+                    windows.remove(&window_id);
 
-                        if windows.is_empty() {
-                            control_flow.set_exit();
-                        }
+                    if windows.is_empty() {
+                        control_flow.set_exit();
                     }
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                state: ElementState::Pressed,
-                                logical_key: Key::Character(c),
-                                ..
-                            },
-                        is_synthetic: false,
-                        ..
-                    } if matches!(c.as_ref(), "n" | "N") => {
-                        let window = Window::new(event_loop).unwrap();
-                        println!("Opened a new window: {:?}", window.id());
-                        windows.insert(window.id(), window);
+                }
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            state: ElementState::Pressed,
+                            logical_key: Key::Character(c),
+                            ..
+                        },
+                    is_synthetic: false,
+                    ..
+                } if matches!(c.as_ref(), "n" | "N") => {
+                    let window = Window::new(event_loop).unwrap();
+                    println!("Opened a new window: {:?}", window.id());
+                    windows.insert(window.id(), window);
+                }
+                WindowEvent::RedrawRequested => {
+                    if let Some(window) = windows.get(&window_id) {
+                        fill::fill_window(window);
                     }
-                    _ => (),
                 }
+                _ => (),
             }
-            Event::RedrawRequested(window_id) => {
-                if let Some(window) = windows.get(&window_id) {
-                    fill::fill_window(window);
-                }
-            }
-            _ => (),
         }
     })
 }

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -24,8 +24,8 @@ fn main() -> Result<(), impl std::error::Error> {
 
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent { event, .. } => match event {
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
                 WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::MouseInput {
                     state: ElementState::Released,
@@ -33,13 +33,12 @@ fn main() -> Result<(), impl std::error::Error> {
                 } => {
                     window.request_redraw();
                 }
+                WindowEvent::RedrawRequested => {
+                    println!("\nredrawing!\n");
+                    fill::fill_window(&window);
+                }
                 _ => (),
-            },
-            Event::RedrawRequested(_) => {
-                println!("\nredrawing!\n");
-                fill::fill_window(&window);
             }
-            _ => (),
         }
     })
 }

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -43,7 +43,10 @@ fn main() -> Result<(), impl std::error::Error> {
                 event: WindowEvent::CloseRequested,
                 ..
             } => control_flow.set_exit(),
-            Event::RedrawRequested(_) => {
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            } => {
                 println!("\nredrawing!\n");
                 fill::fill_window(&window);
             }

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -30,8 +30,8 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent { event, .. } => match event {
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
                 WindowEvent::CloseRequested => control_flow.set_exit(),
                 WindowEvent::KeyboardInput {
                     event:
@@ -46,12 +46,11 @@ fn main() -> Result<(), impl std::error::Error> {
                     println!("Resizable: {resizable}");
                     window.set_resizable(resizable);
                 }
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
                 _ => (),
-            },
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
             }
-            _ => (),
         };
     })
 }

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -36,56 +36,49 @@ mod example {
             match event {
                 Event::Resumed => create_first_window = true,
 
-                Event::WindowEvent {
-                    window_id,
-                    event:
-                        WindowEvent::KeyboardInput {
-                            event:
-                                KeyEvent {
-                                    logical_key,
-                                    state: ElementState::Pressed,
-                                    ..
-                                },
-                            ..
-                        },
-                } => {
-                    if logical_key == Key::Character("n".into()) {
-                        if let Some(window) = windows.get(&window_id) {
-                            // Request a new activation token on this window.
-                            // Once we get it we will use it to create a window.
-                            window
-                                .request_activation_token()
-                                .expect("Failed to request activation token.");
+                Event::WindowEvent { window_id, event } => match event {
+                    WindowEvent::KeyboardInput {
+                        event:
+                            KeyEvent {
+                                logical_key,
+                                state: ElementState::Pressed,
+                                ..
+                            },
+                        ..
+                    } => {
+                        if logical_key == Key::Character("n".into()) {
+                            if let Some(window) = windows.get(&window_id) {
+                                // Request a new activation token on this window.
+                                // Once we get it we will use it to create a window.
+                                window
+                                    .request_activation_token()
+                                    .expect("Failed to request activation token.");
+                            }
                         }
                     }
-                }
 
-                Event::WindowEvent {
-                    window_id,
-                    event: WindowEvent::CloseRequested,
-                } => {
-                    // Remove the window from the map.
-                    windows.remove(&window_id);
-                    if windows.is_empty() {
-                        flow.set_exit();
-                        return;
+                    WindowEvent::CloseRequested => {
+                        // Remove the window from the map.
+                        windows.remove(&window_id);
+                        if windows.is_empty() {
+                            flow.set_exit();
+                            return;
+                        }
                     }
-                }
 
-                Event::WindowEvent {
-                    event: WindowEvent::ActivationTokenDone { token, .. },
-                    ..
-                } => {
-                    current_token = Some(token);
-                }
-
-                Event::RedrawRequested(id) => {
-                    if let Some(window) = windows.get(&id) {
-                        super::fill::fill_window(window);
+                    WindowEvent::ActivationTokenDone { token, .. } => {
+                        current_token = Some(token);
                     }
-                }
 
-                _ => {}
+                    WindowEvent::RedrawRequested => {
+                        if let Some(window) = windows.get(&window_id) {
+                            super::fill::fill_window(window);
+                        }
+                    }
+
+                    _ => {}
+                },
+                _ => (),
             }
 
             // See if we've passed the deadline.

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -30,50 +30,41 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, _, control_flow| {
         *control_flow = ControlFlow::Wait;
 
-        match event {
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => *control_flow = ControlFlow::Exit,
-            Event::WindowEvent {
-                event: WindowEvent::ThemeChanged(theme),
-                window_id,
-                ..
-            } if window_id == window.id() => {
-                println!("Theme is changed: {theme:?}")
-            }
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: key,
-                                state: ElementState::Pressed,
-                                ..
-                            },
-                        ..
-                    },
-                ..
-            } => match key.as_ref() {
-                Key::Character("A" | "a") => {
-                    println!("Theme was: {:?}", window.theme());
-                    window.set_theme(None);
+        if let Event::WindowEvent { window_id, event } = event {
+            match event {
+                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::ThemeChanged(theme) if window_id == window.id() => {
+                    println!("Theme is changed: {theme:?}")
                 }
-                Key::Character("L" | "l") => {
-                    println!("Theme was: {:?}", window.theme());
-                    window.set_theme(Some(Theme::Light));
-                }
-                Key::Character("D" | "d") => {
-                    println!("Theme was: {:?}", window.theme());
-                    window.set_theme(Some(Theme::Dark));
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            logical_key: key,
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                } => match key.as_ref() {
+                    Key::Character("A" | "a") => {
+                        println!("Theme was: {:?}", window.theme());
+                        window.set_theme(None);
+                    }
+                    Key::Character("L" | "l") => {
+                        println!("Theme was: {:?}", window.theme());
+                        window.set_theme(Some(Theme::Light));
+                    }
+                    Key::Character("D" | "d") => {
+                        println!("Theme was: {:?}", window.theme());
+                        window.set_theme(Some(Theme::Dark));
+                    }
+                    _ => (),
+                },
+                WindowEvent::RedrawRequested => {
+                    println!("\nredrawing!\n");
+                    fill::fill_window(&window);
                 }
                 _ => (),
-            },
-            Event::RedrawRequested(_) => {
-                println!("\nredrawing!\n");
-                fill::fill_window(&window);
             }
-            _ => (),
         }
     })
 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -42,7 +42,10 @@ fn main() -> Result<(), impl std::error::Error> {
                 event: WindowEvent::CloseRequested,
                 ..
             } => control_flow.set_exit(),
-            Event::RedrawRequested(_) => {
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            } => {
                 fill::fill_window(&window);
             }
             _ => (),

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -42,10 +42,11 @@ fn main() -> Result<(), impl std::error::Error> {
                         println!("Rotated clockwise {delta}");
                     }
                 }
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
                 _ => (),
             }
-        } else if let Event::RedrawRequested(_) = event {
-            fill::fill_window(&window);
         }
     })
 }

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -26,15 +26,14 @@ fn main() -> Result<(), impl std::error::Error> {
         control_flow.set_wait();
         println!("{event:?}");
 
-        match event {
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => control_flow.set_exit(),
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
+                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
+                _ => (),
             }
-            _ => (),
         }
     })
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -25,18 +25,19 @@ fn main() -> Result<(), impl std::error::Error> {
         println!("{event:?}");
 
         match event {
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                window_id,
-            } if window_id == window.id() => control_flow.set_exit(),
+            Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
+                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::RedrawRequested => {
+                    // Notify the windowing system that we'll be presenting to the window.
+                    window.pre_present_notify();
+                    fill::fill_window(&window);
+                }
+                _ => (),
+            },
             Event::AboutToWait => {
                 window.request_redraw();
             }
-            Event::RedrawRequested(_) => {
-                // Notify the windowing system that we'll be presenting to the window.
-                window.pre_present_notify();
-                fill::fill_window(&window);
-            }
+
             _ => (),
         }
     })

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -34,42 +34,37 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, _, control_flow| {
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: key,
-                                state: ElementState::Pressed,
-                                ..
-                            },
-                        ..
-                    },
-                ..
-            } => match key.as_ref() {
-                Key::Character("F" | "f") => {
-                    let buttons = window.enabled_buttons();
-                    window.set_enabled_buttons(buttons ^ WindowButtons::CLOSE);
-                }
-                Key::Character("G" | "g") => {
-                    let buttons = window.enabled_buttons();
-                    window.set_enabled_buttons(buttons ^ WindowButtons::MAXIMIZE);
-                }
-                Key::Character("H" | "h") => {
-                    let buttons = window.enabled_buttons();
-                    window.set_enabled_buttons(buttons ^ WindowButtons::MINIMIZE);
+        if let Event::WindowEvent { window_id, event } = event {
+            match event {
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            logical_key: key,
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                } => match key.as_ref() {
+                    Key::Character("F" | "f") => {
+                        let buttons = window.enabled_buttons();
+                        window.set_enabled_buttons(buttons ^ WindowButtons::CLOSE);
+                    }
+                    Key::Character("G" | "g") => {
+                        let buttons = window.enabled_buttons();
+                        window.set_enabled_buttons(buttons ^ WindowButtons::MAXIMIZE);
+                    }
+                    Key::Character("H" | "h") => {
+                        let buttons = window.enabled_buttons();
+                        window.set_enabled_buttons(buttons ^ WindowButtons::MINIMIZE);
+                    }
+                    _ => (),
+                },
+                WindowEvent::CloseRequested if window_id == window.id() => control_flow.set_exit(),
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
                 }
                 _ => (),
-            },
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                window_id,
-            } if window_id == window.id() => control_flow.set_exit(),
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
             }
-            _ => (),
         }
     })
 }

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -68,75 +68,71 @@ fn main() -> Result<(), impl std::error::Error> {
                 }
                 _ => (),
             },
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: Key::Character(key_str),
-                                state: ElementState::Pressed,
-                                ..
-                            },
-                        ..
-                    },
-                ..
-            } => match key_str.as_ref() {
-                // WARNING: Consider using `key_without_modifers()` if available on your platform.
-                // See the `key_binding` example
-                "e" => {
-                    fn area(size: PhysicalSize<u32>) -> u32 {
-                        size.width * size.height
-                    }
+            Event::WindowEvent { window_id, event } => match event {
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            logical_key: Key::Character(key_str),
+                            state: ElementState::Pressed,
+                            ..
+                        },
+                    ..
+                } => match key_str.as_ref() {
+                    // WARNING: Consider using `key_without_modifers()` if available on your platform.
+                    // See the `key_binding` example
+                    "e" => {
+                        fn area(size: PhysicalSize<u32>) -> u32 {
+                            size.width * size.height
+                        }
 
-                    let monitor = window.current_monitor().unwrap();
-                    if let Some(mode) = monitor
-                        .video_modes()
-                        .max_by(|a, b| area(a.size()).cmp(&area(b.size())))
-                    {
-                        window.set_fullscreen(Some(Fullscreen::Exclusive(mode)));
-                    } else {
-                        eprintln!("no video modes available");
+                        let monitor = window.current_monitor().unwrap();
+                        if let Some(mode) = monitor
+                            .video_modes()
+                            .max_by(|a, b| area(a.size()).cmp(&area(b.size())))
+                        {
+                            window.set_fullscreen(Some(Fullscreen::Exclusive(mode)));
+                        } else {
+                            eprintln!("no video modes available");
+                        }
                     }
-                }
-                "f" => {
-                    if window.fullscreen().is_some() {
-                        window.set_fullscreen(None);
-                    } else {
-                        let monitor = window.current_monitor();
-                        window.set_fullscreen(Some(Fullscreen::Borderless(monitor)));
+                    "f" => {
+                        if window.fullscreen().is_some() {
+                            window.set_fullscreen(None);
+                        } else {
+                            let monitor = window.current_monitor();
+                            window.set_fullscreen(Some(Fullscreen::Borderless(monitor)));
+                        }
                     }
-                }
-                "p" => {
-                    if window.fullscreen().is_some() {
-                        window.set_fullscreen(None);
-                    } else {
-                        window.set_fullscreen(Some(Fullscreen::Borderless(None)));
+                    "p" => {
+                        if window.fullscreen().is_some() {
+                            window.set_fullscreen(None);
+                        } else {
+                            window.set_fullscreen(Some(Fullscreen::Borderless(None)));
+                        }
                     }
-                }
-                "m" => {
-                    minimized = !minimized;
-                    window.set_minimized(minimized);
-                }
-                "q" => {
-                    control_flow.set_exit();
-                }
-                "v" => {
-                    visible = !visible;
-                    window.set_visible(visible);
-                }
-                "x" => {
-                    let is_maximized = window.is_maximized();
-                    window.set_maximized(!is_maximized);
+                    "m" => {
+                        minimized = !minimized;
+                        window.set_minimized(minimized);
+                    }
+                    "q" => {
+                        control_flow.set_exit();
+                    }
+                    "v" => {
+                        visible = !visible;
+                        window.set_visible(visible);
+                    }
+                    "x" => {
+                        let is_maximized = window.is_maximized();
+                        window.set_maximized(!is_maximized);
+                    }
+                    _ => (),
+                },
+                WindowEvent::CloseRequested if window_id == window.id() => control_flow.set_exit(),
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
                 }
                 _ => (),
             },
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                window_id,
-            } if window_id == window.id() => control_flow.set_exit(),
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
-            }
             _ => (),
         }
     })

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -68,11 +68,12 @@ fn main() -> Result<(), impl std::error::Error> {
                 border = !border;
                 window.set_decorations(border);
             }
+            WindowEvent::RedrawRequested => {
+                fill::fill_window(&window);
+            }
             _ => (),
         },
-        Event::RedrawRequested(_) => {
-            fill::fill_window(&window);
-        }
+
         _ => (),
     })
 }

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use simple_logger::SimpleLogger;
 use winit::{
-    event::Event,
+    event::{Event, WindowEvent},
     event_loop::EventLoop,
     window::{Icon, WindowBuilder},
 };
@@ -37,16 +37,14 @@ fn main() -> Result<(), impl std::error::Error> {
         control_flow.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
-            use winit::event::WindowEvent::*;
             match event {
-                CloseRequested => control_flow.set_exit(),
-                DroppedFile(path) => {
+                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::DroppedFile(path) => {
                     window.set_window_icon(Some(load_icon(&path)));
                 }
+                WindowEvent::RedrawRequested => fill::fill_window(&window),
                 _ => (),
             }
-        } else if let Event::RedrawRequested(_) = event {
-            fill::fill_window(&window);
         }
     })
 }

--- a/examples/window_ondemand.rs
+++ b/examples/window_ondemand.rs
@@ -44,7 +44,10 @@ fn main() -> Result<(), impl std::error::Error> {
                         app.window = None;
                     }
                     Event::AboutToWait => window.request_redraw(),
-                    Event::RedrawRequested(_) => {
+                    Event::WindowEvent {
+                        event: WindowEvent::RedrawRequested,
+                        ..
+                    }  => {
                         fill::fill_window(window);
                     }
                     _ => (),

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -56,14 +56,15 @@ fn main() -> Result<(), impl std::error::Error> {
                     window.set_option_as_alt(option_as_alt);
                 }
                 WindowEvent::KeyboardInput { .. } => println!("KeyboardInput: {event:?}"),
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
                 _ => (),
             },
             Event::AboutToWait => {
                 window.request_redraw();
             }
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
-            }
+
             _ => (),
         }
     })

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -48,7 +48,10 @@ fn main() -> std::process::ExitCode {
                 Event::AboutToWait => {
                     window.request_redraw();
                 }
-                Event::RedrawRequested(_) => {
+                Event::WindowEvent {
+                    event: WindowEvent::RedrawRequested,
+                    ..
+                } => {
                     fill::fill_window(&window);
                 }
                 _ => (),

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -28,36 +28,33 @@ fn main() -> Result<(), impl std::error::Error> {
         control_flow.set_wait();
 
         match event {
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                window_id,
-            } if window_id == window.id() => control_flow.set_exit(),
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: Key::Space,
-                                state: ElementState::Released,
-                                ..
-                            },
-                        ..
-                    },
-                window_id,
-            } if window_id == window.id() => {
-                has_increments = !has_increments;
+            Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
+                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            logical_key: Key::Space,
+                            state: ElementState::Released,
+                            ..
+                        },
+                    ..
+                } => {
+                    has_increments = !has_increments;
 
-                let new_increments = match window.resize_increments() {
-                    Some(_) => None,
-                    None => Some(LogicalSize::new(25.0, 25.0)),
-                };
-                debug!("Had increments: {}", new_increments.is_none());
-                window.set_resize_increments(new_increments);
-            }
+                    let new_increments = match window.resize_increments() {
+                        Some(_) => None,
+                        None => Some(LogicalSize::new(25.0, 25.0)),
+                    };
+                    debug!("Had increments: {}", new_increments.is_none());
+                    window.set_resize_increments(new_increments);
+                }
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
+                _ => (),
+            },
             Event::AboutToWait => window.request_redraw(),
-            Event::RedrawRequested(_) => {
-                fill::fill_window(&window);
-            }
+
             _ => (),
         }
     })

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -33,75 +33,72 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run(move |event, event_loop, control_flow| {
         control_flow.set_wait();
 
-        match event {
-            Event::WindowEvent { event, window_id } => {
-                match event {
-                    WindowEvent::CloseRequested => {
-                        println!("Window {window_id:?} has received the signal to close");
+        if let Event::WindowEvent { event, window_id } = event {
+            match event {
+                WindowEvent::CloseRequested => {
+                    println!("Window {window_id:?} has received the signal to close");
 
-                        // This drops the window, causing it to close.
-                        windows.remove(&window_id);
+                    // This drops the window, causing it to close.
+                    windows.remove(&window_id);
 
-                        if windows.is_empty() {
-                            control_flow.set_exit();
-                        }
+                    if windows.is_empty() {
+                        control_flow.set_exit();
                     }
-                    WindowEvent::Resized(_) => {
-                        if let Some(window) = windows.get(&window_id) {
-                            window.request_redraw();
-                        }
+                }
+                WindowEvent::Resized(_) => {
+                    if let Some(window) = windows.get(&window_id) {
+                        window.request_redraw();
                     }
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                state: ElementState::Pressed,
-                                logical_key,
-                                ..
-                            },
-                        is_synthetic: false,
-                        ..
-                    } => match logical_key.as_ref() {
-                        Key::Character("t") => {
-                            let tabbing_id = windows.get(&window_id).unwrap().tabbing_identifier();
-                            let window = WindowBuilder::new()
-                                .with_tabbing_identifier(&tabbing_id)
-                                .build(event_loop)
-                                .unwrap();
-                            println!("Added a new tab: {:?}", window.id());
-                            windows.insert(window.id(), window);
-                        }
-                        Key::Character("w") => {
-                            let _ = windows.remove(&window_id);
-                        }
-                        Key::ArrowRight => {
-                            windows.get(&window_id).unwrap().select_next_tab();
-                        }
-                        Key::ArrowLeft => {
-                            windows.get(&window_id).unwrap().select_previous_tab();
-                        }
-                        Key::Character(ch) => {
-                            if let Ok(index) = ch.parse::<NonZeroUsize>() {
-                                let index = index.get();
-                                // Select the last tab when pressing `9`.
-                                let window = windows.get(&window_id).unwrap();
-                                if index == 9 {
-                                    window.select_tab_at_index(window.num_tabs() - 1)
-                                } else {
-                                    window.select_tab_at_index(index - 1);
-                                }
+                }
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            state: ElementState::Pressed,
+                            logical_key,
+                            ..
+                        },
+                    is_synthetic: false,
+                    ..
+                } => match logical_key.as_ref() {
+                    Key::Character("t") => {
+                        let tabbing_id = windows.get(&window_id).unwrap().tabbing_identifier();
+                        let window = WindowBuilder::new()
+                            .with_tabbing_identifier(&tabbing_id)
+                            .build(event_loop)
+                            .unwrap();
+                        println!("Added a new tab: {:?}", window.id());
+                        windows.insert(window.id(), window);
+                    }
+                    Key::Character("w") => {
+                        let _ = windows.remove(&window_id);
+                    }
+                    Key::ArrowRight => {
+                        windows.get(&window_id).unwrap().select_next_tab();
+                    }
+                    Key::ArrowLeft => {
+                        windows.get(&window_id).unwrap().select_previous_tab();
+                    }
+                    Key::Character(ch) => {
+                        if let Ok(index) = ch.parse::<NonZeroUsize>() {
+                            let index = index.get();
+                            // Select the last tab when pressing `9`.
+                            let window = windows.get(&window_id).unwrap();
+                            if index == 9 {
+                                window.select_tab_at_index(window.num_tabs() - 1)
+                            } else {
+                                window.select_tab_at_index(index - 1);
                             }
                         }
-                        _ => (),
-                    },
+                    }
                     _ => (),
+                },
+                WindowEvent::RedrawRequested => {
+                    if let Some(window) = windows.get(&window_id) {
+                        fill::fill_window(window);
+                    }
                 }
+                _ => (),
             }
-            Event::RedrawRequested(window_id) => {
-                if let Some(window) = windows.get(&window_id) {
-                    fill::fill_window(window);
-                }
-            }
-            _ => (),
         }
     })
 }

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -43,7 +43,10 @@ mod imple {
                 Event::AboutToWait => {
                     window.request_redraw();
                 }
-                Event::RedrawRequested(_) => {
+                Event::WindowEvent {
+                    event: WindowEvent::RedrawRequested,
+                    ..
+                } => {
                     // Notify the windowing system that we'll be presenting to the window.
                     window.pre_present_notify();
                     fill::fill_window(&window);

--- a/src/event.rs
+++ b/src/event.rs
@@ -218,19 +218,8 @@ pub enum Event<T: 'static> {
     /// ups and also lots of corresponding `AboutToWait` events.
     ///
     /// This is not an ideal event to drive application rendering from and instead applications
-    /// should render in response to [`Event::RedrawRequested`] events.
+    /// should render in response to [`WindowEvent::RedrawRequested`] events.
     AboutToWait,
-
-    /// Emitted when a window should be redrawn.
-    ///
-    /// This gets triggered in two scenarios:
-    /// - The OS has performed an operation that's invalidated the window's contents (such as
-    ///   resizing the window).
-    /// - The application has explicitly requested a redraw via [`Window::request_redraw`].
-    ///
-    /// Winit will aggregate duplicate redraw requests into a single event, to
-    /// help avoid duplicating rendering work.
-    RedrawRequested(WindowId),
 
     /// Emitted when the event loop is being shut down.
     ///
@@ -249,7 +238,6 @@ impl<T> Event<T> {
             DeviceEvent { device_id, event } => Ok(DeviceEvent { device_id, event }),
             NewEvents(cause) => Ok(NewEvents(cause)),
             AboutToWait => Ok(AboutToWait),
-            RedrawRequested(wid) => Ok(RedrawRequested(wid)),
             LoopExiting => Ok(LoopExiting),
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
@@ -553,6 +541,17 @@ pub enum WindowEvent {
     /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     Occluded(bool),
+
+    /// Emitted when a window should be redrawn.
+    ///
+    /// This gets triggered in two scenarios:
+    /// - The OS has performed an operation that's invalidated the window's contents (such as
+    ///   resizing the window).
+    /// - The application has explicitly requested a redraw via [`Window::request_redraw`].
+    ///
+    /// Winit will aggregate duplicate redraw requests into a single event, to
+    /// help avoid duplicating rendering work.
+    RedrawRequested,
 }
 
 /// Identifier of an input device.
@@ -1122,7 +1121,6 @@ mod tests {
                 let wid = unsafe { WindowId::dummy() };
                 x(UserEvent(()));
                 x(NewEvents(event::StartCause::Init));
-                x(RedrawRequested(wid));
                 x(AboutToWait);
                 x(LoopExiting);
                 x(Suspended);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,10 @@
 //!             // can just render here instead.
 //!             window.request_redraw();
 //!         },
-//!         Event::RedrawRequested(_) => {
+//!         Event::WindowEvent {
+//!             event: WindowEvent::RedrawRequested,
+//!             ..
+//!         } => {
 //!             // Redraw the application.
 //!             //
 //!             // It's preferable for applications that do not render continuously to render in

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -407,7 +407,10 @@ impl<T: 'static> EventLoop<T> {
             pending_redraw |= self.redraw_flag.get_and_reset();
             if pending_redraw {
                 pending_redraw = false;
-                let event = event::Event::RedrawRequested(window::WindowId(WindowId));
+                let event = event::Event::WindowEvent {
+                    window_id: window::WindowId(WindowId),
+                    event: event::WindowEvent::RedrawRequested,
+                };
                 sticky_exit_callback(event, self.window_target(), &mut control_flow, callback);
             }
         }

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -57,7 +57,13 @@ enum UserCallbackTransitionResult<'a> {
 
 impl Event<Never> {
     fn is_redraw(&self) -> bool {
-        matches!(self, Event::RedrawRequested(_))
+        matches!(
+            self,
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            }
+        )
     }
 }
 
@@ -755,7 +761,12 @@ pub unsafe fn handle_main_events_cleared() {
     let redraw_events: Vec<EventWrapper> = this
         .main_events_cleared_transition()
         .into_iter()
-        .map(|window| EventWrapper::StaticEvent(Event::RedrawRequested(RootWindowId(window.id()))))
+        .map(|window| {
+            EventWrapper::StaticEvent(Event::WindowEvent {
+                window_id: RootWindowId(window.id()),
+                event: WindowEvent::RedrawRequested,
+            })
+        })
         .collect();
     drop(this);
 

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -43,9 +43,10 @@ declare_class!(
         fn draw_rect(&self, rect: CGRect) {
             let window = self.window().unwrap();
             unsafe {
-                app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawRequested(
-                    RootWindowId(window.id()),
-                )));
+                app_state::handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+                    window_id: RootWindowId(window.id()),
+                    event: WindowEvent::RedrawRequested,
+                }));
             }
             let _: () = unsafe { msg_send![super(self), drawRect: rect] };
         }

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -580,7 +580,10 @@ impl<T: 'static> EventLoop<T> {
 
             if request_redraw {
                 sticky_exit_callback(
-                    Event::RedrawRequested(crate::window::WindowId(window_id)),
+                    Event::WindowEvent {
+                        window_id: crate::window::WindowId(window_id),
+                        event: WindowEvent::RedrawRequested,
+                    },
                     &self.window_target,
                     &mut control_flow,
                     &mut callback,

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -576,7 +576,10 @@ impl<T: 'static> EventProcessor<T> {
                     let window = xev.window as xproto::Window;
                     let window_id = mkwid(window);
 
-                    callback(Event::RedrawRequested(window_id));
+                    callback(Event::WindowEvent {
+                        window_id,
+                        event: WindowEvent::RedrawRequested,
+                    });
                 }
             }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -65,7 +65,7 @@ use self::{
 use super::{common::xkb_state::KbdState, OsError};
 use crate::{
     error::{EventLoopError, OsError as RootOsError},
-    event::{Event, StartCause},
+    event::{Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
     platform::pump_events::PumpStatus,
     platform_impl::{
@@ -671,7 +671,10 @@ impl<T: 'static> EventLoop<T> {
             for window_id in windows {
                 let window_id = crate::window::WindowId(window_id);
                 sticky_exit_callback(
-                    Event::RedrawRequested(window_id),
+                    Event::WindowEvent {
+                        window_id,
+                        event: WindowEvent::RedrawRequested,
+                    },
                     &self.target,
                     &mut control_flow,
                     callback,
@@ -708,7 +711,11 @@ impl<T: 'static> EventLoop<T> {
                     target,
                     control_flow,
                     &mut |event, window_target, control_flow| {
-                        if let Event::RedrawRequested(crate::window::WindowId(wid)) = event {
+                        if let Event::WindowEvent {
+                            window_id: crate::window::WindowId(wid),
+                            event: WindowEvent::RedrawRequested,
+                        } = event
+                        {
                             wt.redraw_sender.send(wid).unwrap();
                         } else {
                             callback(event, window_target, control_flow);

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -564,8 +564,10 @@ impl AppState {
         // Redraw request might come out of order from the OS.
         // -> Don't go back into the callback when our callstack originates from there
         if !HANDLER.in_callback.swap(true, Ordering::AcqRel) {
-            HANDLER
-                .handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawRequested(window_id)));
+            HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+                window_id,
+                event: WindowEvent::RedrawRequested,
+            }));
             HANDLER.set_in_callback(false);
 
             // `pump_events` will request to stop immediately _after_ dispatching RedrawRequested events
@@ -616,8 +618,10 @@ impl AppState {
         }
 
         for window_id in HANDLER.should_redraw() {
-            HANDLER
-                .handle_nonuser_event(EventWrapper::StaticEvent(Event::RedrawRequested(window_id)));
+            HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::WindowEvent {
+                window_id,
+                event: WindowEvent::RedrawRequested,
+            }));
         }
 
         HANDLER.handle_nonuser_event(EventWrapper::StaticEvent(Event::AboutToWait));

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -608,7 +608,10 @@ impl<T: 'static> EventLoop<T> {
                 redraws.pop_front()
             } {
                 event_handler(
-                    event::Event::RedrawRequested(RootWindowId(window_id)),
+                    event::Event::WindowEvent {
+                        window_id: RootWindowId(window_id),
+                        event: event::WindowEvent::RedrawRequested,
+                    },
                     &self.window_target,
                     &mut control_flow,
                 );

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -567,7 +567,13 @@ impl<T: 'static> Shared<T> {
         // Collect all of the redraw events to avoid double-locking the RefCell
         let redraw_events: Vec<WindowId> = self.0.redraw_pending.borrow_mut().drain().collect();
         for window_id in redraw_events {
-            self.handle_event(Event::RedrawRequested(window_id), &mut control);
+            self.handle_event(
+                Event::WindowEvent {
+                    window_id,
+                    event: WindowEvent::RedrawRequested,
+                },
+                &mut control,
+            );
         }
 
         self.handle_event(Event::AboutToWait, &mut control);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1152,7 +1152,10 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 // redraw the window outside the normal flow of the event loop.
                 RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
             } else {
-                userdata.send_event(Event::RedrawRequested(RootWindowId(WindowId(window))));
+                userdata.send_event(Event::WindowEvent {
+                    window_id: RootWindowId(WindowId(window)),
+                    event: WindowEvent::RedrawRequested,
+                });
             }
             result = ProcResult::DefWindowProc(wparam);
         }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -198,7 +198,11 @@ impl<T> EventLoopRunner<T> {
     }
 
     pub(crate) fn send_event(&self, event: Event<T>) {
-        if let Event::RedrawRequested(_) = event {
+        if let Event::WindowEvent {
+            event: WindowEvent::RedrawRequested,
+            ..
+        } = event
+        {
             self.call_event_handler(event);
             // As a rule, to ensure that `pump_events` can't block an external event loop
             // for too long, we always guarantee that `pump_events` will return control to

--- a/src/window.rs
+++ b/src/window.rs
@@ -539,7 +539,7 @@ impl Window {
         self.window.maybe_wait_on_main(|w| w.scale_factor())
     }
 
-    /// Queues a [`Event::RedrawRequested`] event to be emitted that aligns with the windowing
+    /// Queues a [`WindowEvent::RedrawRequested`] event to be emitted that aligns with the windowing
     /// system drawing loop.
     ///
     /// This is the **strongly encouraged** method of redrawing windows, as it can integrate with
@@ -562,9 +562,9 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread.
     /// - **Wayland:** The events are aligned with the frame callbacks when [`Window::pre_present_notify`]
     ///                is used.
-    /// - **Web:** [`Event::RedrawRequested`] will be aligned with the `requestAnimationFrame`.
+    /// - **Web:** [`WindowEvent::RedrawRequested`] will be aligned with the `requestAnimationFrame`.
     ///
-    /// [`Event::RedrawRequested`]: crate::event::Event::RedrawRequested
+    /// [`WindowEvent::RedrawRequested`]: crate::event::WindowEvent::RedrawRequested
     #[inline]
     pub fn request_redraw(&self) {
         self.window.maybe_queue_on_main(|w| w.request_redraw())
@@ -575,7 +575,7 @@ impl Window {
     /// You should call this event after you've done drawing operations, but before you submit
     /// the buffer to the display or commit your drawings. Doing so will help winit to properly
     /// schedule and do assumptions about its internal state. For example, it could properly
-    /// throttle [`Event::RedrawRequested`].
+    /// throttle [`WindowEvent::RedrawRequested`].
     ///
     /// ## Example
     ///
@@ -599,9 +599,9 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// **Wayland:** - schedules a frame callback to throttle [`Event::RedrawRequested`].
+    /// **Wayland:** - schedules a frame callback to throttle [`WindowEvent::RedrawRequested`].
     ///
-    /// [`Event::RedrawRequested`]: crate::event::Event::RedrawRequested
+    /// [`WindowEvent::RedrawRequested`]: crate::event::WindowEvent::RedrawRequested
     #[inline]
     pub fn pre_present_notify(&self) {
         self.window.maybe_queue_on_main(|w| w.pre_present_notify());


### PR DESCRIPTION
I merged `WindowEvent` patterns in the examples and turned them into an `if let` when appropriate.

Fixes #3047.