### PR TITLE
On Web, never return a `MonitorHandle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Fix window size sometimes being invalid when resizing on macOS.
 - On Web, `ControlFlow::Poll` and `ControlFlow::WaitUntil` are now using the Prioritized Task Scheduling API. `setTimeout()` with a trick to circumvent throttling to 4ms is used as a fallback.
+- On Web, never return a `MonitorHandle`.
 
 # 0.29.1-beta
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -355,7 +355,7 @@ impl<T> EventLoopWindowTarget<T> {
     ///
     /// ## Platform-specific
     ///
-    /// **Wayland:** Always returns `None`.
+    /// **Wayland / Web:** Always returns `None`.
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         self.p

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -108,20 +108,12 @@ impl MonitorHandle {
     /// Returns a human-readable name of the monitor.
     ///
     /// Returns `None` if the monitor doesn't exist anymore.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web:** Always returns None
     #[inline]
     pub fn name(&self) -> Option<String> {
         self.inner.name()
     }
 
     /// Returns the monitor's resolution.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web:** Always returns (0,0)
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         self.inner.size()
@@ -129,10 +121,6 @@ impl MonitorHandle {
 
     /// Returns the top-left corner position of the monitor relative to the larger full
     /// screen area.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web:** Always returns (0,0)
     #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         self.inner.position()
@@ -158,7 +146,6 @@ impl MonitorHandle {
     ///
     /// - **X11:** Can be overridden using the `WINIT_X11_SCALE_FACTOR` environment variable.
     /// - **Android:** Always returns 1.0.
-    /// - **Web:** Always returns 1.0
     #[inline]
     pub fn scale_factor(&self) -> f64 {
         self.inner.scale_factor()

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -746,7 +746,7 @@ impl<T> EventLoopWindowTarget<T> {
     }
 
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        Some(MonitorHandle)
+        None
     }
 
     pub fn raw_display_handle(&self) -> RawDisplayHandle {

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -1,3 +1,5 @@
+use std::iter::Empty;
+
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -5,30 +7,27 @@ pub struct MonitorHandle;
 
 impl MonitorHandle {
     pub fn scale_factor(&self) -> f64 {
-        1.0
+        unreachable!()
     }
 
     pub fn position(&self) -> PhysicalPosition<i32> {
-        PhysicalPosition { x: 0, y: 0 }
+        unreachable!()
     }
 
     pub fn name(&self) -> Option<String> {
-        None
+        unreachable!()
     }
 
     pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        None
+        unreachable!()
     }
 
     pub fn size(&self) -> PhysicalSize<u32> {
-        PhysicalSize {
-            width: 0,
-            height: 0,
-        }
+        unreachable!()
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
-        std::iter::empty()
+    pub fn video_modes(&self) -> Empty<VideoMode> {
+        unreachable!()
     }
 }
 
@@ -37,18 +36,18 @@ pub struct VideoMode;
 
 impl VideoMode {
     pub fn size(&self) -> PhysicalSize<u32> {
-        unimplemented!();
+        unreachable!();
     }
 
     pub fn bit_depth(&self) -> u16 {
-        unimplemented!();
+        unreachable!();
     }
 
     pub fn refresh_rate_millihertz(&self) -> u32 {
-        32000
+        unreachable!();
     }
 
     pub fn monitor(&self) -> MonitorHandle {
-        MonitorHandle
+        unreachable!();
     }
 }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -274,7 +274,7 @@ impl Inner {
     #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.borrow().is_fullscreen() {
-            Some(Fullscreen::Borderless(Some(MonitorHandle)))
+            Some(Fullscreen::Borderless(None))
         } else {
             None
         }
@@ -335,7 +335,7 @@ impl Inner {
 
     #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
-        Some(MonitorHandle)
+        None
     }
 
     #[inline]
@@ -345,7 +345,7 @@ impl Inner {
 
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        Some(MonitorHandle)
+        None
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1050,6 +1050,7 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread.
     /// - **Android / Orbital:** Will always return `None`.
     /// - **Wayland:** Can return `Borderless(None)` when there are no monitors.
+    /// - **Web:** Can only return `None` or `Borderless(None)`.
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         self.window


### PR DESCRIPTION
Just made it consistent really. E.g. `Window::available_monitors()` returned no monitors even though `Window::primary_monitor()` did return a handle. On Web we don't have access to the monitor and no information about it either.