### PR TITLE
Allow the user to force X11 under Wayland

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, remove any fullscreen requests from the queue when an external fullscreen activation was detected.
 - On Wayland, fix `TouchPhase::Canceled` being sent for moved events.
 - Mark `startup_notify` unsafe functions as safe.
+- Fix a bug where Wayland would be chosen on Linux even if the user specified `with_x11`. (#3058)
 
 # 0.29.1-beta
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -724,11 +724,13 @@ impl<T: 'static> EventLoop<T> {
             // User is forcing a backend.
             (Some(backend), _, _) => backend,
             // Wayland is present.
+            #[cfg(wayland_platform)]
             (None, true, _) => Backend::Wayland,
             // X11 is present.
-            (None, false, true) => Backend::X,
+            #[cfg(x11_platform)]
+            (None, _, true) => Backend::X,
             // No backend is present.
-            (None, false, false) => {
+            _ => {
                 return Err(EventLoopError::Os(os_error!(OsError::Misc(
                     "neither WAYLAND_DISPLAY nor DISPLAY is set."
                 ))));
@@ -737,7 +739,9 @@ impl<T: 'static> EventLoop<T> {
 
         // Create the display based on the backend.
         match backend {
+            #[cfg(wayland_platform)]
             Backend::Wayland => EventLoop::new_wayland_any_thread().map_err(Into::into),
+            #[cfg(x11_platform)]
             Backend::X => Ok(EventLoop::new_x11_any_thread().unwrap()),
         }
     }


### PR DESCRIPTION
Closes #3057 by making it so the forced backend is considered over all else.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
