### PR TITLE
Add direct `builder` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,10 @@ Unreleased` header.
 - **Breaking:** Add `Event::MemoryWarning`; implemented on iOS/Android.
 - **Breaking:** Bump `ndk` version to `0.8.0`, ndk-sys to `0.5.0`, `android-activity` to `0.5.0`.
 - **Breaking:** Change default `ControlFlow` from `Poll` to `Wait`.
+- Added `EventLoop::builder`, which is intended to replace the (now deprecated) `EventLoopBuilder::new`.
 - Added `Window::builder`, which is intended to replace the (now deprecated) `WindowBuilder::new`.
+- **Breaking:** Changed the signature of `EventLoop::with_user_event` to return a builder.
+- **Breaking:** Removed `EventLoopBuilder::with_user_event`, the functionality is now available in `EventLoop::with_user_event`.
 - Make iOS `MonitorHandle` and `VideoMode` usable from other threads.
 - Fix window size sometimes being invalid when resizing on macOS.
 - On Web, `ControlFlow::Poll` and `ControlFlow::WaitUntil` are now using the Prioritized Task Scheduling API. `setTimeout()` with a trick to circumvent throttling to 4ms is used as a fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,11 @@ Unreleased` header.
 - **Breaking:** Add `Event::MemoryWarning`; implemented on iOS/Android.
 - **Breaking:** Bump `ndk` version to `0.8.0`, ndk-sys to `0.5.0`, `android-activity` to `0.5.0`.
 - **Breaking:** Change default `ControlFlow` from `Poll` to `Wait`.
+- Added `Window::builder`, which is intended to replace the (now deprecated) `WindowBuilder::new`.
+- Make iOS `MonitorHandle` and `VideoMode` usable from other threads.
+- Fix window size sometimes being invalid when resizing on macOS.
+- On Web, `ControlFlow::Poll` and `ControlFlow::WaitUntil` are now using the Prioritized Task Scheduling API. `setTimeout()` with a trick to circumvent throttling to 4ms is used as a fallback.
+- On Web, never return a `MonitorHandle`.
 - **Breaking:** Move `Event::RedrawRequested` to `WindowEvent::RedrawRequested`.
 - **Breaking:** Moved `ControlFlow::Exit` to `EventLoopWindowTarget::exit()` and `EventLoopWindowTarget::exiting()` and removed `ControlFlow::ExitWithCode(_)` entirely.
 - **Breaking:** Moved `ControlFlow` to `EventLoopWindowTarget::set_control_flow()` and `EventLoopWindowTarget::control_flow()`.

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -16,9 +16,8 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         dpi::{LogicalPosition, LogicalSize, Position},
         event::{ElementState, Event, KeyEvent, WindowEvent},
+        event_loop::{EventLoop, EventLoopWindowTarget},
         raw_window_handle::HasRawWindowHandle,
-        event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
-        window::raw_window_handle::HasRawWindowHandle,
         window::{Window, WindowId},
     };
 

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -16,9 +16,10 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         dpi::{LogicalPosition, LogicalSize, Position},
         event::{ElementState, Event, KeyEvent, WindowEvent},
-        event_loop::{EventLoop, EventLoopWindowTarget},
         raw_window_handle::HasRawWindowHandle,
-        window::{Window, WindowBuilder, WindowId},
+        event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+        window::raw_window_handle::HasRawWindowHandle,
+        window::{Window, WindowId},
     };
 
     fn spawn_child_window(
@@ -27,7 +28,7 @@ fn main() -> Result<(), impl std::error::Error> {
         windows: &mut HashMap<WindowId, Window>,
     ) {
         let parent = parent.raw_window_handle().unwrap();
-        let mut builder = WindowBuilder::new()
+        let mut builder = Window::builder()
             .with_title("child window")
             .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
             .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
@@ -44,7 +45,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut windows = HashMap::new();
 
     let event_loop: EventLoop<()> = EventLoop::new().unwrap();
-    let parent_window = WindowBuilder::new()
+    let parent_window = Window::builder()
         .with_title("parent window")
         .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
         .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -11,7 +11,6 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
-    keyboard::Key,
     window::Window,
 };
 

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -11,7 +11,8 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
-    window::WindowBuilder,
+    keyboard::Key,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -37,7 +38,7 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Press 'Esc' to close the window.");
 
     let event_loop = EventLoop::new().unwrap();
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.")
         .build(&event_loop)
         .unwrap();

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
-    window::{CursorIcon, WindowBuilder},
+    window::{CursorIcon, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = Window::builder().build(&event_loop).unwrap();
     window.set_title("A fantastic window!");
 
     let mut cursor_idx = 0;

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{DeviceEvent, ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::{Key, ModifiersState, NamedKey},
-    window::{CursorGrabMode, WindowBuilder},
+    window::{CursorGrabMode, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Super Cursor Grab'n'Hide Simulator 9000")
         .build(&event_loop)
         .unwrap();

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -6,7 +6,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{EventLoop, EventLoopWindowTarget},
     keyboard::Key,
-    window::{CursorIcon, CustomCursor, WindowBuilder},
+    window::{CursorIcon, CustomCursor, Window},
 };
 #[cfg(web_platform)]
 use {
@@ -42,7 +42,7 @@ fn main() -> Result<(), impl std::error::Error> {
     console_log::init_with_level(log::Level::Debug).unwrap();
 
     let event_loop = EventLoop::new().unwrap();
-    let builder = WindowBuilder::new().with_title("A fantastic window!");
+    let builder = Window::builder().with_title("A fantastic window!");
     #[cfg(web_platform)]
     let builder = {
         use winit::platform::web::WindowBuilderExtWebSys;

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         event::{Event, WindowEvent},
         event_loop::EventLoopBuilder,
-        window::WindowBuilder,
+        window::Window,
     };
 
     #[path = "util/fill.rs"]
@@ -22,7 +22,7 @@ fn main() -> Result<(), impl std::error::Error> {
         .build()
         .unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::EventLoopBuilder,
+        event_loop::EventLoop,
         window::Window,
     };
 
@@ -18,9 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     }
 
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoopBuilder::<CustomEvent>::with_user_event()
-        .build()
-        .unwrap();
+    let event_loop = EventLoop::<CustomEvent>::with_user_event().build().unwrap();
 
     let window = Window::builder()
         .with_title("A fantastic window!")

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, MouseButton, StartCause, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::{Window, WindowBuilder, WindowId},
+    window::{Window, WindowId},
 };
 
 #[path = "util/fill.rs"]
@@ -15,8 +15,8 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window_1 = WindowBuilder::new().build(&event_loop).unwrap();
-    let window_2 = WindowBuilder::new().build(&event_loop).unwrap();
+    let window_1 = Window::builder().build(&event_loop).unwrap();
+    let window_2 = Window::builder().build(&event_loop).unwrap();
 
     let mut switched = false;
     let mut entered_id = window_2.id();

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -10,7 +10,7 @@ use web_time as time;
 use winit::{
     event::{Event, StartCause, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -20,7 +20,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
         .build(&event_loop)

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -5,7 +5,7 @@ use winit::dpi::LogicalSize;
 use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
 use winit::event_loop::EventLoop;
 use winit::keyboard::{Key, NamedKey};
-use winit::window::{Fullscreen, WindowBuilder};
+use winit::window::{Fullscreen, Window};
 
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowExtMacOS;
@@ -22,7 +22,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut with_min_size = false;
     let mut with_max_size = false;
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Hello world!")
         .build(&event_loop)
         .unwrap();

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Your faithful window")
         .build(&event_loop)
         .unwrap();

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -5,9 +5,10 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{ElementState, Event, Ime, WindowEvent},
-    event_loop::EventLoop,
     keyboard::NamedKey,
-    window::{ImePurpose, WindowBuilder},
+    event_loop::{ControlFlow, EventLoop},
+    keyboard::{Key, KeyCode},
+    window::{ImePurpose, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -26,7 +27,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_inner_size(winit::dpi::LogicalSize::new(256f64, 128f64))
         .build(&event_loop)
         .unwrap();

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -5,9 +5,8 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{ElementState, Event, Ime, WindowEvent},
+    event_loop::EventLoop,
     keyboard::NamedKey,
-    event_loop::{ControlFlow, EventLoop},
-    keyboard::{Key, KeyCode},
     window::{ImePurpose, Window},
 };
 

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -8,7 +8,7 @@ use winit::{
     keyboard::{Key, ModifiersState},
     // WARNING: This is not available on all platforms (for example on the web).
     platform::modifier_supplement::KeyEventExtModifierSupplement,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
@@ -24,7 +24,7 @@ fn main() -> Result<(), impl std::error::Error> {
     simple_logger::SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_inner_size(LogicalSize::new(400.0, 200.0))
         .build(&event_loop)
         .unwrap();

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -3,12 +3,12 @@
 use simple_logger::SimpleLogger;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::monitor::MonitorHandle;
-use winit::{event_loop::EventLoop, window::WindowBuilder};
+use winit::{event_loop::EventLoop, window::Window};
 
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = Window::builder().build(&event_loop).unwrap();
 
     if let Some(mon) = window.primary_monitor() {
         print_info("Primary output", mon);

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Mouse Wheel events")
         .build(&event_loop)
         .unwrap();

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), impl std::error::Error> {
         event::{ElementState, Event, KeyEvent, WindowEvent},
         event_loop::EventLoop,
         keyboard::{Key, ModifiersState, NamedKey},
-        window::{CursorGrabMode, CursorIcon, Fullscreen, WindowBuilder, WindowLevel},
+        window::{CursorGrabMode, CursorIcon, Fullscreen, Window, WindowLevel},
     };
 
     const WINDOW_COUNT: usize = 3;
@@ -20,7 +20,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new().unwrap();
     let mut window_senders = HashMap::with_capacity(WINDOW_COUNT);
     for _ in 0..WINDOW_COUNT {
-        let window = WindowBuilder::new()
+        let window = Window::builder()
             .with_inner_size(WINDOW_SIZE)
             .build(&event_loop)
             .unwrap();

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         event::{Event, WindowEvent},
         event_loop::EventLoop,
-        window::WindowBuilder,
+        window::Window,
     };
 
     #[path = "util/fill.rs"]
@@ -18,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new().unwrap();
 
     let window = {
-        let window = WindowBuilder::new()
+        let window = Window::builder()
             .with_title("A fantastic window!")
             .build(&event_loop)
             .unwrap();

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -6,7 +6,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::{KeyCode, PhysicalKey},
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -18,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut resizable = false;
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Hit space to toggle resizability.")
         .with_inner_size(LogicalSize::new(600.0, 300.0))
         .with_min_inner_size(LogicalSize::new(400.0, 200.0))

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -14,7 +14,7 @@ mod example {
     use winit::platform::startup_notify::{
         EventLoopExtStartupNotify, WindowBuilderExtStartupNotify, WindowExtStartupNotify,
     };
-    use winit::window::{Window, WindowBuilder, WindowId};
+    use winit::window::{Window, WindowId};
 
     pub(super) fn main() -> Result<(), impl std::error::Error> {
         // Create the event loop and get the activation token.
@@ -84,8 +84,7 @@ mod example {
             if current_token.is_some() || create_first_window {
                 // Create the initial window.
                 let window = {
-                    let mut builder =
-                        WindowBuilder::new().with_title(format!("Window {}", counter));
+                    let mut builder = Window::builder().with_title(format!("Window {}", counter));
 
                     if let Some(token) = current_token.take() {
                         println!("Creating a window with token {token:?}");

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::{Theme, WindowBuilder},
+    window::{Theme, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_theme(Some(Theme::Dark))
         .build(&event_loop)

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -10,7 +10,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -20,7 +20,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();

--- a/examples/touch_gestures.rs
+++ b/examples/touch_gestures.rs
@@ -1,8 +1,8 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::EventLoop,
-    window::WindowBuilder,
+    event_loop::{ControlFlow, EventLoop},
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -12,7 +12,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Touchpad gestures")
         .build(&event_loop)
         .unwrap();

--- a/examples/touch_gestures.rs
+++ b/examples/touch_gestures.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::Window,
 };
 

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_decorations(false)
         .with_transparent(true)
         .build(&event_loop)

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -3,15 +3,15 @@
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
-    keyboard::Key,
-    window::{Fullscreen, WindowBuilder},
+    keyboard::KeyCode,
+    window::{Fullscreen, Window},
 };
 
 pub fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new().unwrap();
 
-    let builder = WindowBuilder::new().with_title("A fantastic window!");
-    #[cfg(web_platform)]
+    let builder = Window::builder().with_title("A fantastic window!");
+    #[cfg(wasm_platform)]
     let builder = {
         use winit::platform::web::WindowBuilderExtWebSys;
         builder.with_append(true)

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -3,7 +3,7 @@
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
-    keyboard::KeyCode,
+    keyboard::Key,
     window::{Fullscreen, Window},
 };
 

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -14,7 +14,7 @@ mod wasm {
         event::{Event, WindowEvent},
         event_loop::EventLoop,
         platform::web::WindowBuilderExtWebSys,
-        window::{Window, WindowBuilder},
+        window::Window,
     };
 
     const EXPLANATION: &str = "
@@ -33,7 +33,7 @@ This example demonstrates the desired future functionality which will possibly b
         console_log::init_with_level(log::Level::Debug).expect("error initializing logger");
         let event_loop = EventLoop::new().unwrap();
 
-        let window = WindowBuilder::new()
+        let window = Window::builder()
             .with_title("A fantastic window!")
             // When running in a non-wasm environment this would set the window size to 100x100.
             // However in this example it just sets a default initial size of 100x100 that is immediately overwritten due to the layout + styling of the page.

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
         .build(&event_loop)

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -8,7 +8,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{DeviceEvents, EventLoop},
     keyboard::Key,
-    window::{WindowBuilder, WindowButtons},
+    window::{Window, WindowButtons},
 };
 
 #[path = "util/fill.rs"]
@@ -18,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(LogicalSize::new(300.0, 300.0))
         .build(&event_loop)

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -8,7 +8,7 @@ use winit::{
     event::{DeviceEvent, ElementState, Event, KeyEvent, RawKeyEvent, WindowEvent},
     event_loop::{DeviceEvents, EventLoop},
     keyboard::{Key, KeyCode, PhysicalKey},
-    window::{Fullscreen, WindowBuilder},
+    window::{Fullscreen, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -18,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(LogicalSize::new(100.0, 100.0))
         .build(&event_loop)

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, MouseButton, StartCause, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::{CursorIcon, ResizeDirection, WindowBuilder},
+    window::{CursorIcon, ResizeDirection, Window},
 };
 
 const BORDER: f64 = 8.0;
@@ -17,7 +17,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_inner_size(winit::dpi::LogicalSize::new(600.0, 400.0))
         .with_min_inner_size(winit::dpi::LogicalSize::new(400.0, 200.0))
         .with_decorations(false)

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -6,7 +6,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::{Icon, WindowBuilder},
+    window::{Icon, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -25,7 +25,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("An iconic window!")
         // At present, this only does anything on Windows and X11, so if you want to save load
         // time, you can put icon loading behind a function that returns `None` on other platforms.

--- a/examples/window_on_demand.rs
+++ b/examples/window_on_demand.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), impl std::error::Error> {
         event::{Event, WindowEvent},
         event_loop::EventLoop,
         platform::run_on_demand::EventLoopExtRunOnDemand,
-        window::{Window, WindowBuilder, WindowId},
+        window::{Window, WindowId},
     };
 
     #[path = "util/fill.rs"]
@@ -65,7 +65,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     _ => (),
                 }
             } else if let Event::Resumed = event {
-                let window = WindowBuilder::new()
+                let window = Window::builder()
                         .with_title("Fantastic window number one!")
                         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
                         .build(elwt)

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -8,7 +8,7 @@ use winit::{
     event::ElementState,
     event::{Event, MouseButton, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[cfg(target_os = "macos")]
@@ -21,7 +21,7 @@ mod fill;
 fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
         .build(&event_loop)

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -16,7 +16,7 @@ fn main() -> std::process::ExitCode {
         event::{Event, WindowEvent},
         event_loop::EventLoop,
         platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
-        window::WindowBuilder,
+        window::Window,
     };
 
     #[path = "util/fill.rs"]
@@ -25,7 +25,7 @@ fn main() -> std::process::ExitCode {
     let mut event_loop = EventLoop::new().unwrap();
 
     SimpleLogger::new().init().unwrap();
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, WindowEvent},
     event_loop::EventLoop,
     keyboard::NamedKey,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(LogicalSize::new(128.0, 128.0))
         .with_resize_increments(LogicalSize::new(25.0, 25.0))

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -11,7 +11,7 @@ use winit::{
     event_loop::EventLoop,
     keyboard::{Key, NamedKey},
     platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS},
-    window::{Window, WindowBuilder},
+    window::Window,
 };
 
 #[cfg(target_os = "macos")]
@@ -60,7 +60,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 } => match logical_key.as_ref() {
                     Key::Character("t") => {
                         let tabbing_id = windows.get(&window_id).unwrap().tabbing_identifier();
-                        let window = WindowBuilder::new()
+                        let window = Window::builder()
                             .with_tabbing_identifier(&tabbing_id)
                             .build(elwt)
                             .unwrap();

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -12,7 +12,7 @@ mod imple {
         event::{Event, WindowEvent},
         event_loop::EventLoop,
         platform::x11::WindowBuilderExtX11,
-        window::WindowBuilder,
+        window::Window,
     };
 
     pub(super) fn entry() -> Result<(), Box<dyn std::error::Error>> {
@@ -25,7 +25,7 @@ mod imple {
         SimpleLogger::new().init().unwrap();
         let event_loop = EventLoop::new()?;
 
-        let window = WindowBuilder::new()
+        let window = Window::builder()
             .with_title("An embedded window!")
             .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
             .with_embed_parent_window(parent_window_id)

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -57,33 +57,26 @@ pub struct EventLoopWindowTarget {
 ///
 /// This is used to make specifying options that affect the whole application
 /// easier. But note that constructing multiple event loops is not supported.
+///
+/// This can be created using [`EventLoop::new`] or [`EventLoop::with_user_event`].
 #[derive(Default)]
 pub struct EventLoopBuilder<T: 'static> {
     pub(crate) platform_specific: platform_impl::PlatformSpecificEventLoopAttributes,
     _p: PhantomData<T>,
 }
 
+static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
+
 impl EventLoopBuilder<()> {
     /// Start building a new event loop.
     #[inline]
+    #[deprecated = "use `EventLoop::builder` instead"]
     pub fn new() -> Self {
-        Self::with_user_event()
+        EventLoop::builder()
     }
 }
 
-static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
-
 impl<T> EventLoopBuilder<T> {
-    /// Start building a new event loop, with the given type as the user event
-    /// type.
-    #[inline]
-    pub fn with_user_event() -> Self {
-        Self {
-            platform_specific: Default::default(),
-            _p: PhantomData,
-        }
-    }
-
     /// Builds a new event loop.
     ///
     /// ***For cross-platform compatibility, the [`EventLoop`] must be created on the main thread,
@@ -193,19 +186,33 @@ impl ControlFlow {
 }
 
 impl EventLoop<()> {
-    /// Alias for [`EventLoopBuilder::new().build()`].
+    /// Create the event loop.
     ///
-    /// [`EventLoopBuilder::new().build()`]: EventLoopBuilder::build
+    /// This is an alias of `EventLoop::builder().build()`.
     #[inline]
     pub fn new() -> Result<EventLoop<()>, EventLoopError> {
-        EventLoopBuilder::new().build()
+        Self::builder().build()
+    }
+
+    /// Start building a new event loop.
+    ///
+    /// This returns an [`EventLoopBuilder`], to allow configuring the event loop before creation.
+    ///
+    /// To get the actual event loop, call [`build`][EventLoopBuilder::build] on that.
+    #[inline]
+    pub fn builder() -> EventLoopBuilder<()> {
+        Self::with_user_event()
     }
 }
 
 impl<T> EventLoop<T> {
-    #[deprecated = "Use `EventLoopBuilder::<T>::with_user_event().build()` instead."]
-    pub fn with_user_event() -> Result<EventLoop<T>, EventLoopError> {
-        EventLoopBuilder::<T>::with_user_event().build()
+    /// Start building a new event loop, with the given type as the user event
+    /// type.
+    pub fn with_user_event() -> EventLoopBuilder<T> {
+        EventLoopBuilder {
+            platform_specific: Default::default(),
+            _p: PhantomData,
+        }
     }
 
     /// Runs the event loop in the calling thread and calls the given `event_handler` closure

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! Once this is done, there are two ways to create a [`Window`]:
 //!
 //!  - Calling [`Window::new(&event_loop)`][window_new].
-//!  - Calling [`let builder = WindowBuilder::new()`][window_builder_new] then [`builder.build(&event_loop)`][window_builder_build].
+//!  - Calling [`let builder = Window::builder()`][window_builder_new] then [`builder.build(&event_loop)`][window_builder_build].
 //!
 //! The first method is the simplest and will give you default values for everything. The second
 //! method allows you to customize the way your [`Window`] will look and behave by modifying the
@@ -63,11 +63,11 @@
 //! use winit::{
 //!     event::{Event, WindowEvent},
 //!     event_loop::{ControlFlow, EventLoop},
-//!     window::WindowBuilder,
+//!     window::Window,
 //! };
 //!
 //! let event_loop = EventLoop::new().unwrap();
-//! let window = WindowBuilder::new().build(&event_loop).unwrap();
+//! let window = Window::builder().build(&event_loop).unwrap();
 //!
 //! // ControlFlow::Poll continuously runs the event loop, even if the OS hasn't
 //! // dispatched any events. This is ideal for games and similar applications.
@@ -137,7 +137,7 @@
 //! [`WindowId`]: window::WindowId
 //! [`WindowBuilder`]: window::WindowBuilder
 //! [window_new]: window::Window::new
-//! [window_builder_new]: window::WindowBuilder::new
+//! [window_builder_new]: window::Window::builder
 //! [window_builder_build]: window::WindowBuilder::build
 //! [`Window::id()`]: window::Window::id
 //! [`WindowEvent`]: event::WindowEvent

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -51,12 +51,12 @@ pub trait EventLoopExtPumpEvents {
     /// #         event::{Event, WindowEvent},
     /// #         event_loop::EventLoop,
     /// #         platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
-    /// #         window::WindowBuilder,
+    /// #         window::Window,
     /// #     };
     ///     let mut event_loop = EventLoop::new().unwrap();
     /// #
     /// #   SimpleLogger::new().init().unwrap();
-    ///     let window = WindowBuilder::new()
+    ///     let window = Window::builder()
     ///         .with_title("A fantastic window!")
     ///         .build(&event_loop)
     ///         .unwrap();

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -159,13 +159,13 @@ pub trait WindowBuilderExtX11 {
     ///
     /// ```
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
-    /// # use winit::window::WindowBuilder;
+    /// # use winit::window::Window;
     /// # use winit::platform::x11::WindowBuilderExtX11;
     /// // Specify the size in logical dimensions like this:
-    /// WindowBuilder::new().with_base_size(LogicalSize::new(400.0, 200.0));
+    /// Window::builder().with_base_size(LogicalSize::new(400.0, 200.0));
     ///
     /// // Or specify the size in physical dimensions like this:
-    /// WindowBuilder::new().with_base_size(PhysicalSize::new(400, 200));
+    /// Window::builder().with_base_size(PhysicalSize::new(400, 200));
     /// ```
     fn with_base_size<S: Into<Size>>(self, base_size: S) -> Self;
 
@@ -174,12 +174,12 @@ pub trait WindowBuilderExtX11 {
     /// # Example
     ///
     /// ```no_run
-    /// use winit::window::WindowBuilder;
+    /// use winit::window::Window;
     /// use winit::platform::x11::{XWindow, WindowBuilderExtX11};
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let event_loop = winit::event_loop::EventLoop::new().unwrap();
     /// let parent_window_id = std::env::args().nth(1).unwrap().parse::<XWindow>()?;
-    /// let window = WindowBuilder::new()
+    /// let window = Window::builder()
     ///     .with_embed_parent_window(parent_window_id)
     ///     .build(&event_loop)?;
     /// # Ok(()) }

--- a/src/window.rs
+++ b/src/window.rs
@@ -123,7 +123,9 @@ impl From<u64> for WindowId {
     }
 }
 
-/// Object that allows building windows.
+/// Configure windows before creation.
+///
+/// You can access this from [`Window::builder`].
 #[derive(Clone, Default)]
 #[must_use]
 pub struct WindowBuilder {
@@ -139,7 +141,7 @@ impl fmt::Debug for WindowBuilder {
     }
 }
 
-/// Attributes to use when creating a window.
+/// Attributes used when creating a window.
 #[derive(Debug, Clone)]
 pub struct WindowAttributes {
     pub inner_size: Option<Size>,
@@ -226,6 +228,7 @@ impl WindowAttributes {
 impl WindowBuilder {
     /// Initializes a new builder with default values.
     #[inline]
+    #[deprecated = "use `Window::builder` instead"]
     pub fn new() -> Self {
         Default::default()
     }
@@ -551,7 +554,7 @@ impl WindowBuilder {
 impl Window {
     /// Creates a new Window for platforms where this is appropriate.
     ///
-    /// This function is equivalent to [`WindowBuilder::new().build(event_loop)`].
+    /// This function is equivalent to [`Window::builder().build(event_loop)`].
     ///
     /// Error should be very rare and only occur in case of permission denied, incompatible system,
     ///  out of memory, etc.
@@ -561,11 +564,16 @@ impl Window {
     /// - **Web:** The window is created but not inserted into the web page automatically. Please
     ///   see the web platform module for more information.
     ///
-    /// [`WindowBuilder::new().build(event_loop)`]: WindowBuilder::build
+    /// [`Window::builder().build(event_loop)`]: WindowBuilder::build
     #[inline]
-    pub fn new(event_loop: &EventLoopWindowTarget) -> Result<Window, OsError> {
-        let builder = WindowBuilder::new();
-        builder.build(event_loop)
+    pub fn new<T: 'static>(event_loop: &EventLoopWindowTarget<T>) -> Result<Window, OsError> {
+        Window::builder().build(event_loop)
+    }
+
+    /// Create a new [`WindowBuilder`] which allows modifying the window's attributes before creation.
+    #[inline]
+    pub fn builder() -> WindowBuilder {
+        WindowBuilder::default()
     }
 
     /// Returns an identifier unique to the window.

--- a/src/window.rs
+++ b/src/window.rs
@@ -566,7 +566,7 @@ impl Window {
     ///
     /// [`Window::builder().build(event_loop)`]: WindowBuilder::build
     #[inline]
-    pub fn new<T: 'static>(event_loop: &EventLoopWindowTarget<T>) -> Result<Window, OsError> {
+    pub fn new(event_loop: &EventLoopWindowTarget) -> Result<Window, OsError> {
         Window::builder().build(event_loop)
     }
 


### PR DESCRIPTION
Add methods `EventLoop::builder` and `Window::builder`, which allows creating the related builders without having to import them. See the examples for how things look cleaner.

Unsure about whether we should deprecate the old methods or not?

- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
