### PR TITLE
Refactor errors to be more specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- **Breaking:** Reworked errors. Errors now live in the module in which they are used, and are named according to their use.
 - Added `EventLoop::builder`, which is intended to replace the (now deprecated) `EventLoopBuilder::new`.
 - Added `Window::builder`, which is intended to replace the (now deprecated) `WindowBuilder::new`.
 - **Breaking:** Changed the signature of `EventLoop::with_user_event` to return a builder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Added `Window::builder`, which is intended to replace the (now deprecated) `WindowBuilder::new`.
 - Make iOS `MonitorHandle` and `VideoMode` usable from other threads.
 - Fix window size sometimes being invalid when resizing on macOS.
 - On Web, `ControlFlow::Poll` and `ControlFlow::WaitUntil` are now using the Prioritized Task Scheduling API. `setTimeout()` with a trick to circumvent throttling to 4ms is used as a fallback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 # Unreleased
 
+- Added `EventLoop::builder`, which is intended to replace the (now deprecated) `EventLoopBuilder::new`.
 - Added `Window::builder`, which is intended to replace the (now deprecated) `WindowBuilder::new`.
+- **Breaking:** Changed the signature of `EventLoop::with_user_event` to return a builder.
+- **Breaking:** Removed `EventLoopBuilder::with_user_event`, the functionality is now available in `EventLoop::with_user_event`.
 - Make iOS `MonitorHandle` and `VideoMode` usable from other threads.
 - Fix window size sometimes being invalid when resizing on macOS.
 - On Web, `ControlFlow::Poll` and `ControlFlow::WaitUntil` are now using the Prioritized Task Scheduling API. `setTimeout()` with a trick to circumvent throttling to 4ms is used as a fallback.

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -11,7 +11,7 @@ fn main() -> Result<(), impl std::error::Error> {
         event::{ElementState, Event, KeyEvent, WindowEvent},
         event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
         window::raw_window_handle::HasRawWindowHandle,
-        window::{Window, WindowBuilder, WindowId},
+        window::{Window, WindowId},
     };
 
     fn spawn_child_window(
@@ -20,7 +20,7 @@ fn main() -> Result<(), impl std::error::Error> {
         windows: &mut HashMap<WindowId, Window>,
     ) {
         let parent = parent.raw_window_handle();
-        let mut builder = WindowBuilder::new()
+        let mut builder = Window::builder()
             .with_title("child window")
             .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
             .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
@@ -37,7 +37,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut windows = HashMap::new();
 
     let event_loop: EventLoop<()> = EventLoop::new().unwrap();
-    let parent_window = WindowBuilder::new()
+    let parent_window = Window::builder()
         .with_title("parent window")
         .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
         .with_inner_size(LogicalSize::new(640.0f32, 480.0f32))

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -11,7 +11,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -37,7 +37,7 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Press 'Esc' to close the window.");
 
     let event_loop = EventLoop::new().unwrap();
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.")
         .build(&event_loop)
         .unwrap();

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
-    window::{CursorIcon, WindowBuilder},
+    window::{CursorIcon, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = Window::builder().build(&event_loop).unwrap();
     window.set_title("A fantastic window!");
 
     let mut cursor_idx = 0;

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{DeviceEvent, ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::{Key, ModifiersState},
-    window::{CursorGrabMode, WindowBuilder},
+    window::{CursorGrabMode, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Super Cursor Grab'n'Hide Simulator 9000")
         .build(&event_loop)
         .unwrap();

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -6,7 +6,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         event::{Event, WindowEvent},
         event_loop::EventLoopBuilder,
-        window::WindowBuilder,
+        window::Window,
     };
 
     #[path = "util/fill.rs"]
@@ -22,7 +22,7 @@ fn main() -> Result<(), impl std::error::Error> {
         .build()
         .unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::EventLoopBuilder,
+        event_loop::EventLoop,
         window::Window,
     };
 
@@ -18,9 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     }
 
     SimpleLogger::new().init().unwrap();
-    let event_loop = EventLoopBuilder::<CustomEvent>::with_user_event()
-        .build()
-        .unwrap();
+    let event_loop = EventLoop::<CustomEvent>::with_user_event().build().unwrap();
 
     let window = Window::builder()
         .with_title("A fantastic window!")

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, MouseButton, StartCause, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::{Window, WindowBuilder, WindowId},
+    window::{Window, WindowId},
 };
 
 #[path = "util/fill.rs"]
@@ -15,8 +15,8 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window_1 = WindowBuilder::new().build(&event_loop).unwrap();
-    let window_2 = WindowBuilder::new().build(&event_loop).unwrap();
+    let window_1 = Window::builder().build(&event_loop).unwrap();
+    let window_2 = Window::builder().build(&event_loop).unwrap();
 
     let mut switched = false;
     let mut entered_id = window_2.id();

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -5,7 +5,7 @@ use winit::dpi::PhysicalSize;
 use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
 use winit::event_loop::EventLoop;
 use winit::keyboard::Key;
-use winit::window::{Fullscreen, WindowBuilder};
+use winit::window::{Fullscreen, Window};
 
 #[cfg(target_os = "macos")]
 use winit::platform::macos::WindowExtMacOS;
@@ -22,7 +22,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut with_min_size = false;
     let mut with_max_size = false;
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Hello world!")
         .build(&event_loop)
         .unwrap();

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Your faithful window")
         .build(&event_loop)
         .unwrap();

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -7,7 +7,7 @@ use winit::{
     event::{ElementState, Event, Ime, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, KeyCode},
-    window::{ImePurpose, WindowBuilder},
+    window::{ImePurpose, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -26,7 +26,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_inner_size(winit::dpi::LogicalSize::new(256f64, 128f64))
         .build(&event_loop)
         .unwrap();

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -8,7 +8,7 @@ use winit::{
     keyboard::{Key, ModifiersState},
     // WARNING: This is not available on all platforms (for example on the web).
     platform::modifier_supplement::KeyEventExtModifierSupplement,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[cfg(not(any(target_os = "macos", target_os = "windows", target_os = "linux")))]
@@ -24,7 +24,7 @@ fn main() -> Result<(), impl std::error::Error> {
     simple_logger::SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_inner_size(LogicalSize::new(400.0, 200.0))
         .build(&event_loop)
         .unwrap();

--- a/examples/monitor_list.rs
+++ b/examples/monitor_list.rs
@@ -3,12 +3,12 @@
 use simple_logger::SimpleLogger;
 use winit::dpi::{PhysicalPosition, PhysicalSize};
 use winit::monitor::MonitorHandle;
-use winit::{event_loop::EventLoop, window::WindowBuilder};
+use winit::{event_loop::EventLoop, window::Window};
 
 fn main() {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = Window::builder().build(&event_loop).unwrap();
 
     if let Some(mon) = window.primary_monitor() {
         print_info("Primary output", mon);

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Mouse Wheel events")
         .build(&event_loop)
         .unwrap();

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), impl std::error::Error> {
         event::{ElementState, Event, KeyEvent, WindowEvent},
         event_loop::EventLoop,
         keyboard::{Key, ModifiersState},
-        window::{CursorGrabMode, CursorIcon, Fullscreen, WindowBuilder, WindowLevel},
+        window::{CursorGrabMode, CursorIcon, Fullscreen, Window, WindowLevel},
     };
 
     const WINDOW_COUNT: usize = 3;
@@ -20,7 +20,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new().unwrap();
     let mut window_senders = HashMap::with_capacity(WINDOW_COUNT);
     for _ in 0..WINDOW_COUNT {
-        let window = WindowBuilder::new()
+        let window = Window::builder()
             .with_inner_size(WINDOW_SIZE)
             .build(&event_loop)
             .unwrap();

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         event::{Event, WindowEvent},
         event_loop::EventLoop,
-        window::WindowBuilder,
+        window::Window,
     };
 
     #[path = "util/fill.rs"]
@@ -18,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new().unwrap();
 
     let window = {
-        let window = WindowBuilder::new()
+        let window = Window::builder()
             .with_title("A fantastic window!")
             .build(&event_loop)
             .unwrap();

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -6,7 +6,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::KeyCode,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -18,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut resizable = false;
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Hit space to toggle resizability.")
         .with_inner_size(LogicalSize::new(600.0, 300.0))
         .with_min_inner_size(LogicalSize::new(400.0, 200.0))

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -15,7 +15,7 @@ mod example {
     use winit::platform::startup_notify::{
         EventLoopExtStartupNotify, WindowBuilderExtStartupNotify, WindowExtStartupNotify,
     };
-    use winit::window::{Window, WindowBuilder, WindowId};
+    use winit::window::{Window, WindowId};
 
     pub(super) fn main() -> Result<(), impl std::error::Error> {
         // Create the event loop and get the activation token.
@@ -85,8 +85,7 @@ mod example {
             if current_token.is_some() || create_first_window {
                 // Create the initial window.
                 let window = {
-                    let mut builder =
-                        WindowBuilder::new().with_title(format!("Window {}", counter));
+                    let mut builder = Window::builder().with_title(format!("Window {}", counter));
 
                     if let Some(token) = current_token.take() {
                         println!("Creating a window with token {token:?}");

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::Key,
-    window::{Theme, WindowBuilder},
+    window::{Theme, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_theme(Some(Theme::Dark))
         .build(&event_loop)

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -10,7 +10,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, StartCause, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -20,7 +20,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -2,7 +2,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -12,7 +12,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("Touchpad gestures")
         .build(&event_loop)
         .unwrap();

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_decorations(false)
         .with_transparent(true)
         .build(&event_loop)

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -4,13 +4,13 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::KeyCode,
-    window::{Fullscreen, WindowBuilder},
+    window::{Fullscreen, Window},
 };
 
 pub fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new().unwrap();
 
-    let builder = WindowBuilder::new().with_title("A fantastic window!");
+    let builder = Window::builder().with_title("A fantastic window!");
     #[cfg(wasm_platform)]
     let builder = {
         use winit::platform::web::WindowBuilderExtWebSys;

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -14,7 +14,7 @@ mod wasm {
         event::{Event, WindowEvent},
         event_loop::{ControlFlow, EventLoop},
         platform::web::WindowBuilderExtWebSys,
-        window::{Window, WindowBuilder},
+        window::Window,
     };
 
     const EXPLANATION: &str = "
@@ -33,7 +33,7 @@ This example demonstrates the desired future functionality which will possibly b
         console_log::init_with_level(log::Level::Debug).expect("error initializing logger");
         let event_loop = EventLoop::new().unwrap();
 
-        let window = WindowBuilder::new()
+        let window = Window::builder()
             .with_title("A fantastic window!")
             // When running in a non-wasm environment this would set the window size to 100x100.
             // However in this example it just sets a default initial size of 100x100 that is immediately overwritten due to the layout + styling of the page.

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -14,7 +14,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
         .build(&event_loop)

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -8,7 +8,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{DeviceEvents, EventLoop},
     keyboard::Key,
-    window::{WindowBuilder, WindowButtons},
+    window::{Window, WindowButtons},
 };
 
 #[path = "util/fill.rs"]
@@ -18,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(LogicalSize::new(300.0, 300.0))
         .build(&event_loop)

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -8,7 +8,7 @@ use winit::{
     event::{DeviceEvent, ElementState, Event, KeyEvent, RawKeyEvent, WindowEvent},
     event_loop::{DeviceEvents, EventLoop},
     keyboard::{Key, KeyCode},
-    window::{Fullscreen, WindowBuilder},
+    window::{Fullscreen, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -18,7 +18,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(LogicalSize::new(100.0, 100.0))
         .build(&event_loop)

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, MouseButton, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::Key,
-    window::{CursorIcon, ResizeDirection, WindowBuilder},
+    window::{CursorIcon, ResizeDirection, Window},
 };
 
 const BORDER: f64 = 8.0;
@@ -17,7 +17,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_inner_size(winit::dpi::LogicalSize::new(600.0, 400.0))
         .with_min_inner_size(winit::dpi::LogicalSize::new(400.0, 200.0))
         .with_decorations(false)

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -6,7 +6,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
-    window::{Icon, WindowBuilder},
+    window::{Icon, Window},
 };
 
 #[path = "util/fill.rs"]
@@ -25,7 +25,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("An iconic window!")
         // At present, this only does anything on Windows and X11, so if you want to save load
         // time, you can put icon loading behind a function that returns `None` on other platforms.

--- a/examples/window_ondemand.rs
+++ b/examples/window_ondemand.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), impl std::error::Error> {
         event::{Event, WindowEvent},
         event_loop::EventLoop,
         platform::run_ondemand::EventLoopExtRunOnDemand,
-        window::{Window, WindowBuilder, WindowId},
+        window::{Window, WindowId},
     };
 
     #[path = "util/fill.rs"]
@@ -65,7 +65,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     _ => (),
                 }
             } else if let Event::Resumed = event {
-                let window = WindowBuilder::new()
+                let window = Window::builder()
                         .with_title("Fantastic window number one!")
                         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
                         .build(event_loop)

--- a/examples/window_ondemand.rs
+++ b/examples/window_ondemand.rs
@@ -8,9 +8,8 @@ fn main() -> Result<(), impl std::error::Error> {
     use simple_logger::SimpleLogger;
 
     use winit::{
-        error::EventLoopError,
         event::{Event, WindowEvent},
-        event_loop::EventLoop,
+        event_loop::{EventLoop, EventLoopRunError},
         platform::run_ondemand::EventLoopExtRunOnDemand,
         window::{Window, WindowId},
     };
@@ -27,7 +26,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let mut event_loop = EventLoop::new().unwrap();
 
-    fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), EventLoopError> {
+    fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), EventLoopRunError> {
         let mut app = App::default();
 
         event_loop.run_ondemand(move |event, event_loop, control_flow| {

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -8,7 +8,7 @@ use winit::{
     event::ElementState,
     event::{Event, MouseButton, WindowEvent},
     event_loop::EventLoop,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[cfg(target_os = "macos")]
@@ -21,7 +21,7 @@ mod fill;
 fn main() -> Result<(), impl std::error::Error> {
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
         .build(&event_loop)

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -16,7 +16,7 @@ fn main() -> std::process::ExitCode {
         event::{Event, WindowEvent},
         event_loop::{ControlFlow, EventLoop},
         platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
-        window::WindowBuilder,
+        window::Window,
     };
 
     #[path = "util/fill.rs"]
@@ -25,7 +25,7 @@ fn main() -> std::process::ExitCode {
     let mut event_loop = EventLoop::new().unwrap();
 
     SimpleLogger::new().init().unwrap();
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .build(&event_loop)
         .unwrap();

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -5,7 +5,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::WindowBuilder,
+    window::Window,
 };
 
 #[path = "util/fill.rs"]
@@ -15,7 +15,7 @@ fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
+    let window = Window::builder()
         .with_title("A fantastic window!")
         .with_inner_size(LogicalSize::new(128.0, 128.0))
         .with_resize_increments(LogicalSize::new(25.0, 25.0))

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -11,7 +11,7 @@ use winit::{
     event_loop::EventLoop,
     keyboard::Key,
     platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS},
-    window::{Window, WindowBuilder},
+    window::Window,
 };
 
 #[cfg(target_os = "macos")]
@@ -62,7 +62,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 } => match logical_key.as_ref() {
                     Key::Character("t") => {
                         let tabbing_id = windows.get(&window_id).unwrap().tabbing_identifier();
-                        let window = WindowBuilder::new()
+                        let window = Window::builder()
                             .with_tabbing_identifier(&tabbing_id)
                             .build(event_loop)
                             .unwrap();

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -12,7 +12,7 @@ mod imple {
         event::{Event, WindowEvent},
         event_loop::EventLoop,
         platform::x11::WindowBuilderExtX11,
-        window::WindowBuilder,
+        window::Window,
     };
 
     pub(super) fn entry() -> Result<(), Box<dyn std::error::Error>> {
@@ -25,7 +25,7 @@ mod imple {
         SimpleLogger::new().init().unwrap();
         let event_loop = EventLoop::new()?;
 
-        let window = WindowBuilder::new()
+        let window = Window::builder()
             .with_title("An embedded window!")
             .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
             .with_embed_parent_window(parent_window_id)

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,27 +26,6 @@ pub struct OsError {
     error: platform_impl::OsError,
 }
 
-/// A general error that may occur while running the Winit event loop
-#[derive(Debug)]
-pub enum EventLoopError {
-    /// The operation is not supported by the backend.
-    NotSupported(NotSupportedError),
-    /// The OS cannot perform the operation.
-    Os(OsError),
-    /// The event loop can't be re-run while it's already running
-    AlreadyRunning,
-    /// The event loop can't be re-created.
-    RecreationAttempt,
-    /// Application has exit with an error status.
-    ExitFailure(i32),
-}
-
-impl From<OsError> for EventLoopError {
-    fn from(value: OsError) -> Self {
-        Self::Os(value)
-    }
-}
-
 impl NotSupportedError {
     #[inline]
     #[allow(dead_code)]
@@ -99,22 +78,9 @@ impl fmt::Display for NotSupportedError {
     }
 }
 
-impl fmt::Display for EventLoopError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            EventLoopError::AlreadyRunning => write!(f, "EventLoop is already running"),
-            EventLoopError::RecreationAttempt => write!(f, "EventLoop can't be recreated"),
-            EventLoopError::NotSupported(e) => e.fmt(f),
-            EventLoopError::Os(e) => e.fmt(f),
-            EventLoopError::ExitFailure(status) => write!(f, "Exit Failure: {status}"),
-        }
-    }
-}
-
 impl error::Error for OsError {}
 impl error::Error for ExternalError {}
 impl error::Error for NotSupportedError {}
-impl error::Error for EventLoopError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,8 +8,6 @@ use crate::platform_impl;
 pub enum ExternalError {
     /// The operation is not supported by the backend.
     NotSupported(NotSupportedError),
-    /// The operation was ignored.
-    Ignored,
     /// The OS cannot perform the operation.
     Os(OsError),
 }
@@ -84,7 +82,6 @@ impl fmt::Display for ExternalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             ExternalError::NotSupported(e) => e.fmt(f),
-            ExternalError::Ignored => write!(f, "Operation was ignored"),
             ExternalError::Os(e) => e.fmt(f),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,36 +2,12 @@ use std::{error, fmt};
 
 use crate::platform_impl;
 
-// TODO: Rename
-/// An error that may be generated when requesting Winit state
-#[derive(Debug)]
-pub enum ExternalError {
-    /// The operation is not supported by the backend.
-    NotSupported(NotSupportedError),
-    /// The OS cannot perform the operation.
-    Os(OsError),
-}
-
-/// The error type for when the requested operation is not supported by the backend.
-#[derive(Clone)]
-pub struct NotSupportedError {
-    _marker: (),
-}
-
 /// The error type for when the OS cannot perform the requested operation.
 #[derive(Debug)]
 pub struct OsError {
     line: u32,
     file: &'static str,
     error: platform_impl::OsError,
-}
-
-impl NotSupportedError {
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn new() -> NotSupportedError {
-        NotSupportedError { _marker: () }
-    }
 }
 
 impl OsError {
@@ -57,49 +33,4 @@ impl fmt::Display for OsError {
     }
 }
 
-impl fmt::Display for ExternalError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            ExternalError::NotSupported(e) => e.fmt(f),
-            ExternalError::Os(e) => e.fmt(f),
-        }
-    }
-}
-
-impl fmt::Debug for NotSupportedError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_struct("NotSupportedError").finish()
-    }
-}
-
-impl fmt::Display for NotSupportedError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.pad("the requested operation is not supported by Winit")
-    }
-}
-
 impl error::Error for OsError {}
-impl error::Error for ExternalError {}
-impl error::Error for NotSupportedError {}
-
-#[cfg(test)]
-mod tests {
-    #![allow(clippy::redundant_clone)]
-
-    use super::*;
-
-    // Eat attributes for testing
-    #[test]
-    fn ensure_fmt_does_not_panic() {
-        let _ = format!(
-            "{:?}, {}",
-            NotSupportedError::new(),
-            NotSupportedError::new().clone()
-        );
-        let _ = format!(
-            "{:?}, {}",
-            ExternalError::NotSupported(NotSupportedError::new()),
-            ExternalError::NotSupported(NotSupportedError::new())
-        );
-    }
-}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1072,7 +1072,6 @@ pub enum MouseScrollDelta {
 ///
 /// See [`InnerSizeWriter::request_inner_size`] for details.
 #[derive(Debug)] // Explicitly not other traits, in case we want to extend it in the future
-#[non_exhaustive]
 pub struct RequestIgnored {
     _priv: (),
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -1104,9 +1104,8 @@ impl InnerSizeWriter {
     ///
     /// # Errors
     ///
-    /// This method returns an error when the request to change the inner size
-    /// of the window was ignored - likely because you tried to change the
-    /// inner size outside the event loop callback.
+    /// This method returns an error when the request was ignored because it
+    /// was done asynchronously, outside the event loop callback.
     pub fn request_inner_size(
         &mut self,
         new_inner_size: PhysicalSize<u32>,

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -56,33 +56,26 @@ pub struct EventLoopWindowTarget<T: 'static> {
 ///
 /// This is used to make specifying options that affect the whole application
 /// easier. But note that constructing multiple event loops is not supported.
+///
+/// This can be created using [`EventLoop::new`] or [`EventLoop::with_user_event`].
 #[derive(Default)]
 pub struct EventLoopBuilder<T: 'static> {
     pub(crate) platform_specific: platform_impl::PlatformSpecificEventLoopAttributes,
     _p: PhantomData<T>,
 }
 
+static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
+
 impl EventLoopBuilder<()> {
     /// Start building a new event loop.
     #[inline]
+    #[deprecated = "use `EventLoop::builder` instead"]
     pub fn new() -> Self {
-        Self::with_user_event()
+        EventLoop::builder()
     }
 }
 
-static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
-
 impl<T> EventLoopBuilder<T> {
-    /// Start building a new event loop, with the given type as the user event
-    /// type.
-    #[inline]
-    pub fn with_user_event() -> Self {
-        Self {
-            platform_specific: Default::default(),
-            _p: PhantomData,
-        }
-    }
-
     /// Builds a new event loop.
     ///
     /// ***For cross-platform compatibility, the [`EventLoop`] must be created on the main thread,
@@ -265,19 +258,33 @@ impl Default for ControlFlow {
 }
 
 impl EventLoop<()> {
-    /// Alias for [`EventLoopBuilder::new().build()`].
+    /// Create the event loop.
     ///
-    /// [`EventLoopBuilder::new().build()`]: EventLoopBuilder::build
+    /// This is an alias of `EventLoop::builder().build()`.
     #[inline]
     pub fn new() -> Result<EventLoop<()>, EventLoopError> {
-        EventLoopBuilder::new().build()
+        Self::builder().build()
+    }
+
+    /// Start building a new event loop.
+    ///
+    /// This returns an [`EventLoopBuilder`], to allow configuring the event loop before creation.
+    ///
+    /// To get the actual event loop, call [`build`][EventLoopBuilder::build] on that.
+    #[inline]
+    pub fn builder() -> EventLoopBuilder<()> {
+        Self::with_user_event()
     }
 }
 
 impl<T> EventLoop<T> {
-    #[deprecated = "Use `EventLoopBuilder::<T>::with_user_event().build()` instead."]
-    pub fn with_user_event() -> Result<EventLoop<T>, EventLoopError> {
-        EventLoopBuilder::<T>::with_user_event().build()
+    /// Start building a new event loop, with the given type as the user event
+    /// type.
+    pub fn with_user_event() -> EventLoopBuilder<T> {
+        EventLoopBuilder {
+            platform_specific: Default::default(),
+            _p: PhantomData,
+        }
     }
 
     /// Runs the event loop in the calling thread and calls the given `event_handler` closure

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -441,7 +441,7 @@ impl fmt::Display for EventLoopCreationError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Self::RecreationAttempt => write!(f, "tried to recreate EventLoop"),
-            Self::Os(e) => write!(f, "{e}"),
+            Self::Os(e) => write!(f, "error while creating EventLoop: {e}"),
         }
     }
 }
@@ -471,7 +471,7 @@ impl fmt::Display for EventLoopRunError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             Self::AlreadyRunning => write!(f, "EventLoop is already running"),
-            Self::Os(e) => write!(f, "{e}"),
+            Self::Os(e) => write!(f, "error while running EventLoop: {e}"),
             Self::ExitFailure(status) => write!(f, "exit failure: {status}"),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 //! Once this is done there are two ways to create a [`Window`]:
 //!
 //!  - Calling [`Window::new(&event_loop)`][window_new].
-//!  - Calling [`let builder = WindowBuilder::new()`][window_builder_new] then [`builder.build(&event_loop)`][window_builder_build].
+//!  - Calling [`let builder = Window::builder()`][window_builder_new] then [`builder.build(&event_loop)`][window_builder_build].
 //!
 //! The first method is the simplest, and will give you default values for everything. The second
 //! method allows you to customize the way your [`Window`] will look and behave by modifying the
@@ -45,11 +45,11 @@
 //! use winit::{
 //!     event::{Event, WindowEvent},
 //!     event_loop::EventLoop,
-//!     window::WindowBuilder,
+//!     window::Window,
 //! };
 //!
 //! let event_loop = EventLoop::new().unwrap();
-//! let window = WindowBuilder::new().build(&event_loop).unwrap();
+//! let window = Window::builder().build(&event_loop).unwrap();
 //!
 //! event_loop.run(move |event, _, control_flow| {
 //!     // ControlFlow::Poll continuously runs the event loop, even if the OS hasn't
@@ -122,7 +122,7 @@
 //! [`WindowId`]: window::WindowId
 //! [`WindowBuilder`]: window::WindowBuilder
 //! [window_new]: window::Window::new
-//! [window_builder_new]: window::WindowBuilder::new
+//! [window_builder_new]: window::Window::builder
 //! [window_builder_build]: window::WindowBuilder::build
 //! [window_id_fn]: window::Window::id
 //! [`Event`]: event::Event

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -51,12 +51,12 @@ pub trait EventLoopExtPumpEvents {
     /// #         event::{Event, WindowEvent},
     /// #         event_loop::EventLoop,
     /// #         platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
-    /// #         window::WindowBuilder,
+    /// #         window::Window,
     /// #     };
     ///     let mut event_loop = EventLoop::new().unwrap();
     /// #
     /// #   SimpleLogger::new().init().unwrap();
-    ///     let window = WindowBuilder::new()
+    ///     let window = Window::builder()
     ///         .with_title("A fantastic window!")
     ///         .build(&event_loop)
     ///         .unwrap();

--- a/src/platform/run_ondemand.rs
+++ b/src/platform/run_ondemand.rs
@@ -1,7 +1,6 @@
 use crate::{
-    error::EventLoopError,
     event::Event,
-    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+    event_loop::{ControlFlow, EventLoop, EventLoopRunError, EventLoopWindowTarget},
 };
 
 #[cfg(doc)]
@@ -57,7 +56,7 @@ pub trait EventLoopExtRunOnDemand {
     ///   polled to ask for new events. Events are delivered via callbacks based
     ///   on an event loop that is internal to the browser itself.
     /// - **iOS:** It's not possible to stop and start an `NSApplication` repeatedly on iOS.
-    fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
+    fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), EventLoopRunError>
     where
         F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
 }
@@ -65,7 +64,7 @@ pub trait EventLoopExtRunOnDemand {
 impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
     type UserEvent = T;
 
-    fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
+    fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), EventLoopRunError>
     where
         F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
     {

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -112,13 +112,13 @@ pub trait WindowBuilderExtX11 {
     ///
     /// ```
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
-    /// # use winit::window::WindowBuilder;
+    /// # use winit::window::Window;
     /// # use winit::platform::x11::WindowBuilderExtX11;
     /// // Specify the size in logical dimensions like this:
-    /// WindowBuilder::new().with_base_size(LogicalSize::new(400.0, 200.0));
+    /// Window::builder().with_base_size(LogicalSize::new(400.0, 200.0));
     ///
     /// // Or specify the size in physical dimensions like this:
-    /// WindowBuilder::new().with_base_size(PhysicalSize::new(400, 200));
+    /// Window::builder().with_base_size(PhysicalSize::new(400, 200));
     /// ```
     fn with_base_size<S: Into<Size>>(self, base_size: S) -> Self;
 
@@ -127,12 +127,12 @@ pub trait WindowBuilderExtX11 {
     /// # Example
     ///
     /// ```no_run
-    /// use winit::window::WindowBuilder;
+    /// use winit::window::Window;
     /// use winit::platform::x11::{XWindow, WindowBuilderExtX11};
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let event_loop = winit::event_loop::EventLoop::new().unwrap();
     /// let parent_window_id = std::env::args().nth(1).unwrap().parse::<XWindow>()?;
-    /// let window = WindowBuilder::new()
+    /// let window = Window::builder()
     ///     .with_embed_parent_window(parent_window_id)
     ///     .build(&event_loop)?;
     /// # Ok(()) }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -22,7 +22,7 @@ use raw_window_handle::{
 use crate::platform_impl::Fullscreen;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
-    error,
+    error::OsError as RootOsError,
     event::{self, InnerSizeWriter, StartCause},
     event_loop::{
         self, ControlFlow, EventLoopCreationError, EventLoopRunError,
@@ -30,7 +30,8 @@ use crate::{
     },
     platform::pump_events::PumpStatus,
     window::{
-        self, CursorGrabMode, ImePurpose, ResizeDirection, Theme, WindowButtons, WindowLevel,
+        self, CursorGrabMode, ImePurpose, NotSupportedError, ResizeDirection, Theme, WindowButtons,
+        WindowError, WindowLevel,
     },
 };
 
@@ -794,7 +795,7 @@ impl Window {
         el: &EventLoopWindowTarget<T>,
         _window_attrs: window::WindowAttributes,
         _: PlatformSpecificWindowBuilderAttributes,
-    ) -> Result<Self, error::OsError> {
+    ) -> Result<Self, RootOsError> {
         // FIXME this ignores requested window attributes
 
         Ok(Self {
@@ -839,12 +840,12 @@ impl Window {
 
     pub fn pre_present_notify(&self) {}
 
-    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
-        Err(error::NotSupportedError::new())
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+        Err(NotSupportedError::new())
     }
 
-    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
-        Err(error::NotSupportedError::new())
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+        Err(NotSupportedError::new())
     }
 
     pub fn set_outer_position(&self, _position: Position) {
@@ -937,39 +938,26 @@ impl Window {
 
     pub fn set_cursor_icon(&self, _: window::CursorIcon) {}
 
-    pub fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn set_cursor_position(&self, _: Position) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn set_cursor_grab(&self, _: CursorGrabMode) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn set_cursor_grab(&self, _: CursorGrabMode) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     pub fn set_cursor_visible(&self, _: bool) {}
 
-    pub fn drag_window(&self) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn drag_window(&self) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn drag_resize_window(
-        &self,
-        _direction: ResizeDirection,
-    ) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     pub fn raw_window_handle(&self) -> RawWindowHandle {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -19,10 +19,10 @@ use objc2::ClassType;
 use raw_window_handle::{RawDisplayHandle, UiKitDisplayHandle};
 
 use crate::{
-    error::EventLoopError,
     event::Event,
     event_loop::{
-        ControlFlow, EventLoopClosed, EventLoopWindowTarget as RootEventLoopWindowTarget,
+        ControlFlow, EventLoopClosed, EventLoopCreationError,
+        EventLoopWindowTarget as RootEventLoopWindowTarget,
     },
     platform::ios::Idiom,
 };
@@ -63,7 +63,7 @@ pub(crate) struct PlatformSpecificEventLoopAttributes {}
 impl<T: 'static> EventLoop<T> {
     pub(crate) fn new(
         _: &PlatformSpecificEventLoopAttributes,
-    ) -> Result<EventLoop<T>, EventLoopError> {
+    ) -> Result<EventLoop<T>, EventLoopCreationError> {
         let mtm = MainThreadMarker::new()
             .expect("On iOS, `EventLoop` must be created on the main thread");
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -13,7 +13,7 @@ use super::uikit::{UIApplication, UIScreen, UIScreenOverscanCompensation};
 use super::view::{WinitUIWindow, WinitView, WinitViewController};
 use crate::{
     dpi::{self, LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size},
-    error::{ExternalError, NotSupportedError, OsError as RootOsError},
+    error::OsError as RootOsError,
     event::{Event, WindowEvent},
     icon::Icon,
     platform::ios::{ScreenEdge, ValidOrientations},
@@ -21,8 +21,9 @@ use crate::{
         app_state, monitor, EventLoopWindowTarget, Fullscreen, MonitorHandle,
     },
     window::{
-        CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
-        WindowAttributes, WindowButtons, WindowId as RootWindowId, WindowLevel,
+        CursorGrabMode, CursorIcon, ImePurpose, NotSupportedError, ResizeDirection, Theme,
+        UserAttentionType, WindowAttributes, WindowButtons, WindowError, WindowId as RootWindowId,
+        WindowLevel,
     },
 };
 
@@ -174,28 +175,28 @@ impl Inner {
         debug!("`Window::set_cursor_icon` ignored on iOS")
     }
 
-    pub fn set_cursor_position(&self, _position: Position) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn set_cursor_position(&self, _position: Position) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn set_cursor_grab(&self, _: CursorGrabMode) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn set_cursor_grab(&self, _: CursorGrabMode) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     pub fn set_cursor_visible(&self, _visible: bool) {
         debug!("`Window::set_cursor_visible` is ignored on iOS")
     }
 
-    pub fn drag_window(&self) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn drag_window(&self) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
-    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     pub fn set_minimized(&self, _minimized: bool) {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -767,8 +767,8 @@ impl<T: 'static> EventLoop<T> {
             return Ok(EventLoop::new_x11_any_thread().unwrap());
         }
 
-        Err(EventLoopCreationError::Os(os_error!(OsError::Misc(
-            "neither WAYLAND_DISPLAY nor DISPLAY is set."
+        Err(EventLoopCreationError::Os(RootOsError::new(OsError::Misc(
+            "neither WAYLAND_DISPLAY nor DISPLAY is set.",
         ))))
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -14,11 +14,12 @@ use once_cell::sync::Lazy;
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use smol_str::SmolStr;
 
+use crate::platform::startup_notify::ActivationTokenNotFound;
 #[cfg(x11_platform)]
 use crate::platform::x11::XlibErrorHook;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
-    error::{ExternalError, NotSupportedError, OsError as RootOsError},
+    error::OsError as RootOsError,
     event::{Event, KeyEvent},
     event_loop::{
         AsyncRequestSerial, ControlFlow, DeviceEvents, EventLoopClosed, EventLoopCreationError,
@@ -31,8 +32,9 @@ use crate::{
         scancode::KeyCodeExtScancode,
     },
     window::{
-        ActivationToken, CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme,
-        UserAttentionType, WindowAttributes, WindowButtons, WindowLevel,
+        ActivationToken, CursorGrabMode, CursorIcon, ImePurpose, NotSupportedError,
+        ResizeDirection, Theme, UserAttentionType, WindowAttributes, WindowButtons, WindowError,
+        WindowLevel,
     },
 };
 #[cfg(x11_platform)]
@@ -375,7 +377,9 @@ impl Window {
     }
 
     #[inline]
-    pub(crate) fn request_activation_token(&self) -> Result<AsyncRequestSerial, NotSupportedError> {
+    pub(crate) fn request_activation_token(
+        &self,
+    ) -> Result<AsyncRequestSerial, ActivationTokenNotFound> {
         x11_or_wayland!(match self; Window(w) => w.request_activation_token())
     }
 
@@ -425,7 +429,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
+    pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), WindowError> {
         x11_or_wayland!(match self; Window(window) => window.set_cursor_grab(mode))
     }
 
@@ -435,17 +439,17 @@ impl Window {
     }
 
     #[inline]
-    pub fn drag_window(&self) -> Result<(), ExternalError> {
+    pub fn drag_window(&self) -> Result<(), WindowError> {
         x11_or_wayland!(match self; Window(window) => window.drag_window())
     }
 
     #[inline]
-    pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+    pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), WindowError> {
         x11_or_wayland!(match self; Window(window) => window.drag_resize_window(direction))
     }
 
     #[inline]
-    pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
+    pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), WindowError> {
         x11_or_wayland!(match self; Window(w) => w.set_cursor_hittest(hittest))
     }
 
@@ -455,7 +459,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
+    pub fn set_cursor_position(&self, position: Position) -> Result<(), WindowError> {
         x11_or_wayland!(match self; Window(w) => w.set_cursor_position(position))
     }
 

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -79,7 +79,7 @@ impl<T: 'static> EventLoop<T> {
     pub fn new() -> Result<EventLoop<T>, EventLoopCreationError> {
         macro_rules! map_err {
             ($e:expr, $err:expr) => {
-                $e.map_err(|error| EventLoopCreationError::Os(os_error!($err(error).into())))
+                $e.map_err(|error| EventLoopCreationError::Os(RootOsError::new($err(error).into())))
             };
         }
 
@@ -97,7 +97,7 @@ impl<T: 'static> EventLoop<T> {
         )?;
 
         let mut winit_state = WinitState::new(&globals, &queue_handle, event_loop.handle())
-            .map_err(|error| os_error!(error))
+            .map_err(RootOsError::new)
             .map_err(EventLoopCreationError::Os)?;
 
         // NOTE: do a roundtrip after binding the globals to prevent potential
@@ -657,8 +657,8 @@ impl<T: 'static> EventLoop<T> {
         let mut wayland_source = self.wayland_dispatcher.as_source_mut();
         let event_queue = wayland_source.queue();
         event_queue.roundtrip(state).map_err(|error| {
-            os_error!(OsError::WaylandError(Arc::new(WaylandError::Dispatch(
-                error
+            RootOsError::new(OsError::WaylandError(Arc::new(WaylandError::Dispatch(
+                error,
             ))))
         })
     }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -207,16 +207,16 @@ impl Window {
 
         // Do a roundtrip.
         event_queue.roundtrip(&mut state).map_err(|error| {
-            os_error!(OsError::WaylandError(Arc::new(WaylandError::Dispatch(
-                error
+            RootOsError::new(OsError::WaylandError(Arc::new(WaylandError::Dispatch(
+                error,
             ))))
         })?;
 
         // XXX Wait for the initial configure to arrive.
         while !window_state.lock().unwrap().is_configured() {
             event_queue.blocking_dispatch(&mut state).map_err(|error| {
-                os_error!(OsError::WaylandError(Arc::new(WaylandError::Dispatch(
-                    error
+                RootOsError::new(OsError::WaylandError(Arc::new(WaylandError::Dispatch(
+                    error,
                 ))))
             })?;
         }
@@ -575,7 +575,9 @@ impl Window {
             Ok(())
         } else {
             let region = Region::new(&*self.compositor).map_err(|_| {
-                WindowError::Os(os_error!(OsError::Misc("failed to set input region.")))
+                WindowError::Os(RootOsError::new(OsError::Misc(
+                    "failed to set input region.",
+                )))
             })?;
             region.add(0, 0, 0, 0);
             surface.set_input_region(Some(region.wl_region()));

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -25,6 +25,7 @@ use sctk::shm::Shm;
 use sctk::subcompositor::SubcompositorState;
 
 use crate::dpi::{LogicalPosition, LogicalSize};
+use crate::error::OsError as RootOsError;
 use crate::platform_impl::WindowId;
 use crate::window::{
     CursorGrabMode, CursorIcon, ImePurpose, NotSupportedError, ResizeDirection, Theme, WindowError,
@@ -712,10 +713,10 @@ impl WindowState {
 
         // Positon can be set only for locked cursor.
         if self.cursor_grab_mode.current_grab_mode != CursorGrabMode::Locked {
-            return Err(WindowError::Os(os_error!(
+            return Err(WindowError::Os(RootOsError::new(
                 crate::platform_impl::OsError::Misc(
-                    "cursor position can be set only for locked cursor."
-                )
+                    "cursor position can be set only for locked cursor.",
+                ),
             )));
         }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -427,7 +427,9 @@ impl<T: 'static> EventLoop<T> {
         // X Server.
         let wt = get_xtarget(&self.target);
         wt.x_connection().sync_with_server().map_err(|x_err| {
-            EventLoopRunError::Os(os_error!(OsError::XError(Arc::new(X11Error::Xlib(x_err)))))
+            EventLoopRunError::Os(RootOsError::new(OsError::XError(Arc::new(X11Error::Xlib(
+                x_err,
+            )))))
         })?;
 
         exit

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -451,7 +451,7 @@ impl WinitWindow {
 
             Some(this)
         })
-        .ok_or_else(|| os_error!(OsError::CreationError("Couldn't create `NSWindow`")))?;
+        .ok_or_else(|| RootOsError::new(OsError::CreationError("Couldn't create `NSWindow`")))?;
 
         match attrs.parent_window {
             Some(RawWindowHandle::AppKit(handle)) => {
@@ -464,14 +464,14 @@ impl WinitWindow {
                             match unsafe { Id::retain(handle.ns_view.cast()) } {
                                 Some(view) => view,
                                 None => {
-                                    return Err(os_error!(OsError::CreationError(
-                                        "raw window handle should be non-empty"
+                                    return Err(RootOsError::new(OsError::CreationError(
+                                        "raw window handle should be non-empty",
                                     )))
                                 }
                             };
                         parent_view.window().ok_or_else(|| {
-                            os_error!(OsError::CreationError(
-                                "parent view should be installed in a window"
+                            RootOsError::new(OsError::CreationError(
+                                "parent view should be installed in a window",
                             ))
                         })?
                     }
@@ -845,7 +845,7 @@ impl WinitWindow {
 
         // TODO: Do this for real https://stackoverflow.com/a/40922095/5435443
         CGDisplay::associate_mouse_and_mouse_cursor_position(associate_mouse_cursor)
-            .map_err(|status| WindowError::Os(os_error!(OsError::CGError(status))))
+            .map_err(|status| WindowError::Os(RootOsError::new(OsError::CGError(status))))
     }
 
     #[inline]
@@ -873,9 +873,9 @@ impl WinitWindow {
             y: logical_cursor_position.y + window_position.y,
         };
         CGDisplay::warp_mouse_cursor_position(point)
-            .map_err(|e| WindowError::Os(os_error!(OsError::CGError(e))))?;
+            .map_err(|e| WindowError::Os(RootOsError::new(OsError::CGError(e))))?;
         CGDisplay::associate_mouse_and_mouse_cursor_position(true)
-            .map_err(|e| WindowError::Os(os_error!(OsError::CGError(e))))?;
+            .map_err(|e| WindowError::Os(RootOsError::new(OsError::CGError(e))))?;
 
         Ok(())
     }

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -12,6 +12,7 @@ use orbclient::{
 use raw_window_handle::{OrbitalDisplayHandle, RawDisplayHandle};
 
 use crate::{
+    error::OsError as RootOsError,
     event::{self, Ime, Modifiers, StartCause},
     event_loop::{self, ControlFlow, EventLoopCreationError, EventLoopRunError},
     keyboard::{
@@ -277,13 +278,13 @@ impl<T: 'static> EventLoop<T> {
         let event_socket = Arc::new(
             RedoxSocket::event()
                 .map_err(OsError::new)
-                .map_err(|error| EventLoopCreationError::Os(os_error!(error)))?,
+                .map_err(|error| EventLoopCreationError::Os(RootOsError::new(error)))?,
         );
 
         let wake_socket = Arc::new(
             TimeSocket::open()
                 .map_err(OsError::new)
-                .map_err(|error| EventLoopCreationError::Os(os_error!(error)))?,
+                .map_err(|error| EventLoopCreationError::Os(RootOsError::new(error)))?,
         );
 
         event_socket
@@ -293,7 +294,7 @@ impl<T: 'static> EventLoop<T> {
                 data: wake_socket.0.fd,
             })
             .map_err(OsError::new)
-            .map_err(|error| EventLoopCreationError::Os(os_error!(error)))?;
+            .map_err(|error| EventLoopCreationError::Os(RootOsError::new(error)))?;
 
         Ok(Self {
             windows: Vec::new(),

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -9,10 +9,10 @@ use raw_window_handle::{
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
-    error,
+    error::OsError,
     platform_impl::Fullscreen,
-    window,
     window::ImePurpose,
+    window::{self, NotSupportedError, WindowError},
 };
 
 use super::{
@@ -41,7 +41,7 @@ impl Window {
         el: &EventLoopWindowTarget<T>,
         attrs: window::WindowAttributes,
         _: PlatformSpecificWindowBuilderAttributes,
-    ) -> Result<Self, error::OsError> {
+    ) -> Result<Self, OsError> {
         let scale = MonitorHandle.scale_factor();
 
         let (x, y) = if let Some(pos) = attrs.position {
@@ -183,7 +183,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
+    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self
             .window_socket
@@ -194,7 +194,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
+    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         //TODO: adjust for window decorations
         self.inner_position()
     }
@@ -354,44 +354,34 @@ impl Window {
     pub fn set_cursor_icon(&self, _: window::CursorIcon) {}
 
     #[inline]
-    pub fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn set_cursor_position(&self, _: Position) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]
-    pub fn set_cursor_grab(&self, _: window::CursorGrabMode) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn set_cursor_grab(&self, _: window::CursorGrabMode) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]
     pub fn set_cursor_visible(&self, _: bool) {}
 
     #[inline]
-    pub fn drag_window(&self) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn drag_window(&self) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]
     pub fn drag_resize_window(
         &self,
         _direction: window::ResizeDirection,
-    ) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    ) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]
-    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(
-            error::NotSupportedError::new(),
-        ))
+    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -1,8 +1,9 @@
 use std::marker::PhantomData;
 
-use crate::error::EventLoopError;
 use crate::event::Event;
-use crate::event_loop::{ControlFlow, EventLoopWindowTarget as RootEventLoopWindowTarget};
+use crate::event_loop::{
+    ControlFlow, EventLoopCreationError, EventLoopWindowTarget as RootEventLoopWindowTarget,
+};
 
 use super::{backend, device, window};
 
@@ -22,7 +23,9 @@ pub struct EventLoop<T: 'static> {
 pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
 impl<T> EventLoop<T> {
-    pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> Result<Self, EventLoopError> {
+    pub(crate) fn new(
+        _: &PlatformSpecificEventLoopAttributes,
+    ) -> Result<Self, EventLoopCreationError> {
         Ok(EventLoop {
             elw: RootEventLoopWindowTarget {
                 p: EventLoopWindowTarget::new(),

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -10,7 +10,7 @@ use web_sys::{
 };
 
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
-use crate::error::OsError as RootOE;
+use crate::error::OsError as RootOsError;
 use crate::event::{Force, InnerSizeWriter, MouseButton, MouseScrollDelta};
 use crate::keyboard::{Key, KeyCode, KeyLocation, ModifiersState};
 use crate::platform_impl::{OsError, PlatformSpecificWindowBuilderAttributes};
@@ -63,12 +63,14 @@ impl Canvas {
         document: Document,
         attr: &WindowAttributes,
         platform_attr: PlatformSpecificWindowBuilderAttributes,
-    ) -> Result<Self, RootOE> {
+    ) -> Result<Self, RootOsError> {
         let canvas = match platform_attr.canvas {
             Some(canvas) => canvas,
             None => document
                 .create_element("canvas")
-                .map_err(|_| os_error!(OsError("Failed to create canvas element".to_owned())))?
+                .map_err(|_| {
+                    RootOsError::new(OsError("Failed to create canvas element".to_owned()))
+                })?
                 .unchecked_into(),
         };
 
@@ -88,7 +90,7 @@ impl Canvas {
         if platform_attr.focusable {
             canvas
                 .set_attribute("tabindex", "0")
-                .map_err(|_| os_error!(OsError("Failed to set a tabindex".to_owned())))?;
+                .map_err(|_| RootOsError::new(OsError("Failed to set a tabindex".to_owned())))?;
         }
 
         #[allow(clippy::disallowed_methods)]
@@ -156,7 +158,7 @@ impl Canvas {
         })
     }
 
-    pub fn set_cursor_lock(&self, lock: bool) -> Result<(), RootOE> {
+    pub fn set_cursor_lock(&self, lock: bool) -> Result<(), RootOsError> {
         if lock {
             self.raw().request_pointer_lock();
         } else {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -1,9 +1,10 @@
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
-use crate::error::{ExternalError, NotSupportedError, OsError as RootOE};
+use crate::error::OsError as RootOE;
 use crate::icon::Icon;
 use crate::window::{
-    CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
-    WindowAttributes, WindowButtons, WindowId as RootWI, WindowLevel,
+    CursorGrabMode, CursorIcon, ImePurpose, NotSupportedError, ResizeDirection, Theme,
+    UserAttentionType, WindowAttributes, WindowButtons, WindowError, WindowId as RootWI,
+    WindowLevel,
 };
 
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
@@ -199,24 +200,24 @@ impl Inner {
     }
 
     #[inline]
-    pub fn set_cursor_position(&self, _position: Position) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn set_cursor_position(&self, _position: Position) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]
-    pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
+    pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), WindowError> {
         let lock = match mode {
             CursorGrabMode::None => false,
             CursorGrabMode::Locked => true,
             CursorGrabMode::Confined => {
-                return Err(ExternalError::NotSupported(NotSupportedError::new()))
+                return Err(WindowError::NotSupported(NotSupportedError::new()))
             }
         };
 
         self.canvas
             .borrow()
             .set_cursor_lock(lock)
-            .map_err(ExternalError::Os)
+            .map_err(WindowError::Os)
     }
 
     #[inline]
@@ -233,18 +234,18 @@ impl Inner {
     }
 
     #[inline]
-    pub fn drag_window(&self) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn drag_window(&self) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]
-    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]
-    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), WindowError> {
+        Err(WindowError::NotSupported(NotSupportedError::new()))
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -375,7 +375,7 @@ impl Window {
                 .unwrap()
                 .mouse
                 .set_cursor_flags(window.0, |f| f.set(CursorFlags::GRABBED, confine))
-                .map_err(|e| WindowError::Os(os_error!(e)));
+                .map_err(|e| WindowError::Os(RootOsError::new(e)));
             let _ = tx.send(result);
         });
         rx.recv().unwrap()
@@ -413,10 +413,14 @@ impl Window {
         let mut point = POINT { x, y };
         unsafe {
             if ClientToScreen(self.hwnd(), &mut point) == false.into() {
-                return Err(WindowError::Os(os_error!(io::Error::last_os_error())));
+                return Err(WindowError::Os(
+                    RootOsError::new(io::Error::last_os_error()),
+                ));
             }
             if SetCursorPos(point.x, point.y) == false.into() {
-                return Err(WindowError::Os(os_error!(io::Error::last_os_error())));
+                return Err(WindowError::Os(
+                    RootOsError::new(io::Error::last_os_error()),
+                ));
             }
         }
         Ok(())
@@ -1191,7 +1195,7 @@ where
     }
 
     if handle == 0 {
-        return Err(os_error!(io::Error::last_os_error()));
+        return Err(RootOsError::new(io::Error::last_os_error()));
     }
 
     // If the handle is non-null, then window creation must have succeeded, which means

--- a/src/window.rs
+++ b/src/window.rs
@@ -1524,8 +1524,8 @@ pub enum WindowError {
 impl fmt::Display for WindowError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            Self::NotSupported(e) => write!(f, "{e}"),
-            Self::Os(e) => write!(f, "{e}"),
+            Self::NotSupported(e) => write!(f, "window operation failed: {e}"),
+            Self::Os(e) => write!(f, "window operation failed: {e}"),
         }
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -119,7 +119,9 @@ impl From<u64> for WindowId {
     }
 }
 
-/// Object that allows building windows.
+/// Configure windows before creation.
+///
+/// You can access this from [`Window::builder`].
 #[derive(Clone, Default)]
 #[must_use]
 pub struct WindowBuilder {
@@ -138,7 +140,7 @@ impl fmt::Debug for WindowBuilder {
     }
 }
 
-/// Attributes to use when creating a window.
+/// Attributes used when creating a window.
 #[derive(Debug, Clone)]
 pub struct WindowAttributes {
     pub inner_size: Option<Size>,
@@ -192,6 +194,7 @@ impl Default for WindowAttributes {
 impl WindowBuilder {
     /// Initializes a new builder with default values.
     #[inline]
+    #[deprecated = "use `Window::builder` instead"]
     pub fn new() -> Self {
         Default::default()
     }
@@ -443,7 +446,7 @@ impl WindowBuilder {
     ///
     /// [`WindowEvent::Focused`]: crate::event::WindowEvent::Focused.
     #[inline]
-    pub fn with_active(mut self, active: bool) -> WindowBuilder {
+    pub fn with_active(mut self, active: bool) -> Self {
         self.window.active = active;
         self
     }
@@ -493,7 +496,7 @@ impl WindowBuilder {
 impl Window {
     /// Creates a new Window for platforms where this is appropriate.
     ///
-    /// This function is equivalent to [`WindowBuilder::new().build(event_loop)`].
+    /// This function is equivalent to [`Window::builder().build(event_loop)`].
     ///
     /// Error should be very rare and only occur in case of permission denied, incompatible system,
     ///  out of memory, etc.
@@ -503,11 +506,16 @@ impl Window {
     /// - **Web:** The window is created but not inserted into the web page automatically. Please
     ///   see the web platform module for more information.
     ///
-    /// [`WindowBuilder::new().build(event_loop)`]: WindowBuilder::build
+    /// [`Window::builder().build(event_loop)`]: WindowBuilder::build
     #[inline]
     pub fn new<T: 'static>(event_loop: &EventLoopWindowTarget<T>) -> Result<Window, OsError> {
-        let builder = WindowBuilder::new();
-        builder.build(event_loop)
+        Window::builder().build(event_loop)
+    }
+
+    /// Create a new [`WindowBuilder`] which allows modifying the window's attributes before creation.
+    #[inline]
+    pub fn builder() -> WindowBuilder {
+        WindowBuilder::default()
     }
 
     /// Returns an identifier unique to the window.


### PR DESCRIPTION
Move errors out of the generic `error` module, and into the module where they're used.

This should help the user with actually handling the errors (instead of just propagating them), and with seeing what kind of errors a method can return (more work is still needed in this area, but this is a first step towards that).

The public changes are:
- `error::ExternalError::Ignored` -> `event::RequestIgnored`.
- `error::EventLoopError` is split into:
  - `event_loop::EventLoopCreationError` (with less variants).
  - `event_loop::EventLoopRunError` (with less variants).
- `platform::startup_notify::EventLoopExtStartupNotify::request_activation_token` now errors with `platform::startup_notify::ActivationTokenNotFound` instead of `error::NotSupportedError`.
- `error::ExternalError` -> `window::WindowError`.
- `error::NotSupportedError` -> `window::NotSupportedError`.

A few documents that guide decision making here:
- [Error Handling in Rust](https://nrc.github.io/error-docs/intro.html)
- [Designing error types in Rust](https://mmapped.blog/posts/12-rust-error-handling)
- [`std::error`](https://doc.rust-lang.org/nightly/std/error/index.html)

Checklist:
- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
  - Unsure how much information is relevant here.
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Builds upon #3066, DO NOT MERGE YET!