### PR TITLE
Windows: Add `#[deny(unsafe_op_in_unsafe_fn)]`

### DIFF
--- a/src/platform_impl/windows/dpi.rs
+++ b/src/platform_impl/windows/dpi.rs
@@ -78,36 +78,36 @@ pub fn dpi_to_scale_factor(dpi: u32) -> f64 {
 }
 
 pub unsafe fn hwnd_dpi(hwnd: HWND) -> u32 {
-    let hdc = GetDC(hwnd);
+    let hdc = unsafe { GetDC(hwnd) };
     if hdc == 0 {
         panic!("[winit] `GetDC` returned null!");
     }
     if let Some(GetDpiForWindow) = *GET_DPI_FOR_WINDOW {
         // We are on Windows 10 Anniversary Update (1607) or later.
-        match GetDpiForWindow(hwnd) {
+        match unsafe { GetDpiForWindow(hwnd) } {
             0 => BASE_DPI, // 0 is returned if hwnd is invalid
             dpi => dpi,
         }
     } else if let Some(GetDpiForMonitor) = *GET_DPI_FOR_MONITOR {
         // We are on Windows 8.1 or later.
-        let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+        let monitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
         if monitor == 0 {
             return BASE_DPI;
         }
 
         let mut dpi_x = 0;
         let mut dpi_y = 0;
-        if GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) == S_OK {
+        if unsafe { GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y) } == S_OK {
             dpi_x
         } else {
             BASE_DPI
         }
     } else {
         // We are on Vista or later.
-        if IsProcessDPIAware() != false.into() {
+        if unsafe { IsProcessDPIAware() } != false.into() {
             // If the process is DPI aware, then scaling must be handled by the application using
             // this DPI value.
-            GetDeviceCaps(hdc, LOGPIXELSX) as u32
+            unsafe { GetDeviceCaps(hdc, LOGPIXELSX) as u32 }
         } else {
             // If the process is DPI unaware, then scaling is performed by the OS; we thus return
             // 96 (scale factor 1.0) to prevent the window from being re-scaled by both the

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -145,7 +145,7 @@ pub(crate) struct WindowData<T: 'static> {
 }
 
 impl<T> WindowData<T> {
-    unsafe fn send_event(&self, event: Event<T>) {
+    fn send_event(&self, event: Event<T>) {
         self.event_loop_runner.send_event(event);
     }
 
@@ -160,7 +160,7 @@ struct ThreadMsgTargetData<T: 'static> {
 }
 
 impl<T> ThreadMsgTargetData<T> {
-    unsafe fn send_event(&self, event: Event<T>) {
+    fn send_event(&self, event: Event<T>) {
         self.event_loop_runner.send_event(event);
     }
 }
@@ -596,7 +596,7 @@ fn main_thread_id() -> u32 {
     #[link_section = ".CRT$XCU"]
     static INIT_MAIN_THREAD_ID: unsafe fn() = {
         unsafe fn initer() {
-            MAIN_THREAD_ID = GetCurrentThreadId();
+            unsafe { MAIN_THREAD_ID = GetCurrentThreadId() };
         }
         initer
     };
@@ -884,7 +884,7 @@ fn insert_event_target_window_data<T>(
 /// the window.
 unsafe fn capture_mouse(window: HWND, window_state: &mut WindowState) {
     window_state.mouse.capture_count += 1;
-    SetCapture(window);
+    unsafe { SetCapture(window) };
 }
 
 /// Release mouse input, stopping windows on this thread from receiving mouse input when the cursor
@@ -894,7 +894,7 @@ unsafe fn release_mouse(mut window_state: MutexGuard<'_, WindowState>) {
     if window_state.mouse.capture_count == 0 {
         // ReleaseCapture() causes a WM_CAPTURECHANGED where we lock the window_state.
         drop(window_state);
-        ReleaseCapture();
+        unsafe { ReleaseCapture() };
     }
 }
 
@@ -922,12 +922,10 @@ fn update_modifiers<T>(window: HWND, userdata: &WindowData<T>) {
         // Drop lock
         drop(window_state);
 
-        unsafe {
-            userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
-                event: ModifiersChanged(modifiers.into()),
-            });
-        }
+        userdata.send_event(Event::WindowEvent {
+            window_id: RootWindowId(WindowId(window)),
+            event: ModifiersChanged(modifiers.into()),
+        });
     }
 }
 
@@ -970,18 +968,18 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
-    let userdata = super::get_window_long(window, GWL_USERDATA);
+    let userdata = unsafe { super::get_window_long(window, GWL_USERDATA) };
 
     let userdata_ptr = match (userdata, msg) {
         (0, WM_NCCREATE) => {
-            let createstruct = &mut *(lparam as *mut CREATESTRUCTW);
-            let initdata = &mut *(createstruct.lpCreateParams as *mut InitData<'_, T>);
+            let createstruct = unsafe { &mut *(lparam as *mut CREATESTRUCTW) };
+            let initdata = unsafe { &mut *(createstruct.lpCreateParams as *mut InitData<'_, T>) };
 
-            let result = match initdata.on_nccreate(window) {
-                Some(userdata) => {
+            let result = match unsafe { initdata.on_nccreate(window) } {
+                Some(userdata) => unsafe {
                     super::set_window_long(window, GWL_USERDATA, userdata as _);
                     DefWindowProcW(window, msg, wparam, lparam)
-                }
+                },
                 None => -1, // failed to create the window
             };
 
@@ -990,24 +988,24 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
         // Getting here should quite frankly be impossible,
         // but we'll make window creation fail here just in case.
         (0, WM_CREATE) => return -1,
-        (_, WM_CREATE) => {
+        (_, WM_CREATE) => unsafe {
             let createstruct = &mut *(lparam as *mut CREATESTRUCTW);
             let initdata = createstruct.lpCreateParams;
             let initdata = &mut *(initdata as *mut InitData<'_, T>);
 
             initdata.on_create();
             return DefWindowProcW(window, msg, wparam, lparam);
-        }
-        (0, _) => return DefWindowProcW(window, msg, wparam, lparam),
+        },
+        (0, _) => return unsafe { DefWindowProcW(window, msg, wparam, lparam) },
         _ => userdata as *mut WindowData<T>,
     };
 
     let (result, userdata_removed, recurse_depth) = {
-        let userdata = &*(userdata_ptr);
+        let userdata = unsafe { &*(userdata_ptr) };
 
         userdata.recurse_depth.set(userdata.recurse_depth.get() + 1);
 
-        let result = public_window_callback_inner(window, msg, wparam, lparam, userdata);
+        let result = unsafe { public_window_callback_inner(window, msg, wparam, lparam, userdata) };
 
         let userdata_removed = userdata.userdata_removed.get();
         let recurse_depth = userdata.recurse_depth.get() - 1;
@@ -1017,7 +1015,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
     };
 
     if userdata_removed && recurse_depth == 0 {
-        drop(Box::from_raw(userdata_ptr));
+        drop(unsafe { Box::from_raw(userdata_ptr) });
     }
 
     result
@@ -1078,7 +1076,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 return;
             }
 
-            let params = &mut *(lparam as *mut NCCALCSIZE_PARAMS);
+            let params = unsafe { &mut *(lparam as *mut NCCALCSIZE_PARAMS) };
 
             if util::is_maximized(window) {
                 // Limit the window size when maximized to the current monitor.
@@ -1087,7 +1085,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 // Use `MonitorFromRect` instead of `MonitorFromWindow` to select
                 // the correct monitor here.
                 // See https://github.com/MicrosoftEdge/WebView2Feedback/issues/2549
-                let monitor = MonitorFromRect(&params.rgrc[0], MONITOR_DEFAULTTONULL);
+                let monitor = unsafe { MonitorFromRect(&params.rgrc[0], MONITOR_DEFAULTTONULL) };
                 if let Ok(monitor_info) = monitor::get_monitor_info(monitor) {
                     params.rgrc[0] = monitor_info.monitorInfo.rcWork;
                 }
@@ -1121,7 +1119,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let mut state = userdata.window_state_lock();
             if state.dragging {
                 state.dragging = false;
-                PostMessageW(window, WM_LBUTTONUP, 0, lparam);
+                unsafe { PostMessageW(window, WM_LBUTTONUP, 0, lparam) };
             }
 
             state.set_window_flags_in_place(|f| f.remove(WindowFlags::MARKER_IN_SIZE_MOVE));
@@ -1130,7 +1128,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
         WM_NCLBUTTONDOWN => {
             if wparam == HTCAPTION as _ {
-                PostMessageW(window, WM_MOUSEMOVE, 0, lparam);
+                unsafe { PostMessageW(window, WM_MOUSEMOVE, 0, lparam) };
             }
             result = ProcResult::DefWindowProc(wparam);
         }
@@ -1146,7 +1144,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
         WM_DESTROY => {
             use crate::event::WindowEvent::Destroyed;
-            RevokeDragDrop(window);
+            unsafe { RevokeDragDrop(window) };
             userdata.send_event(Event::WindowEvent {
                 window_id: RootWindowId(WindowId(window)),
                 event: Destroyed,
@@ -1155,7 +1153,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         WM_NCDESTROY => {
-            super::set_window_long(window, GWL_USERDATA, 0);
+            unsafe { super::set_window_long(window, GWL_USERDATA, 0) };
             userdata.userdata_removed.set(true);
             result = ProcResult::Value(0);
         }
@@ -1164,7 +1162,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             if userdata.event_loop_runner.should_buffer() {
                 // this branch can happen in response to `UpdateWindow`, if win32 decides to
                 // redraw the window outside the normal flow of the event loop.
-                RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
+                unsafe { RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT) };
             } else {
                 userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
@@ -1177,7 +1175,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         WM_WINDOWPOSCHANGING => {
             let mut window_state = userdata.window_state_lock();
             if let Some(ref mut fullscreen) = window_state.fullscreen {
-                let window_pos = &mut *(lparam as *mut WINDOWPOS);
+                let window_pos = unsafe { &mut *(lparam as *mut WINDOWPOS) };
                 let new_rect = RECT {
                     left: window_pos.x,
                     top: window_pos.y,
@@ -1215,7 +1213,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 };
 
                 if let Some(new_rect) = new_rect {
-                    let new_monitor = MonitorFromRect(&new_rect, MONITOR_DEFAULTTONULL);
+                    let new_monitor = unsafe { MonitorFromRect(&new_rect, MONITOR_DEFAULTTONULL) };
                     match fullscreen {
                         Fullscreen::Borderless(ref mut fullscreen_monitor) => {
                             if new_monitor != 0
@@ -1257,8 +1255,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
             use crate::event::WindowEvent::Moved;
 
             let windowpos = lparam as *const WINDOWPOS;
-            if (*windowpos).flags & SWP_NOMOVE != SWP_NOMOVE {
-                let physical_position = PhysicalPosition::new((*windowpos).x, (*windowpos).y);
+            if unsafe { (*windowpos).flags & SWP_NOMOVE != SWP_NOMOVE } {
+                let physical_position =
+                    unsafe { PhysicalPosition::new((*windowpos).x, (*windowpos).y) };
                 userdata.send_event(Event::WindowEvent {
                     window_id: RootWindowId(WindowId(window)),
                     event: Moved(physical_position),
@@ -1321,7 +1320,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             // Windows Hangul IME sends WM_IME_COMPOSITION after WM_IME_ENDCOMPOSITION, so
             // check whether composing.
             if ime_allowed_and_composing {
-                let ime_context = ImeContext::current(window);
+                let ime_context = unsafe { ImeContext::current(window) };
 
                 if lparam == 0 {
                     userdata.send_event(Event::WindowEvent {
@@ -1333,7 +1332,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 // Google Japanese Input and ATOK have both flags, so
                 // first, receive composing result if exist.
                 if (lparam as u32 & GCS_RESULTSTR) != 0 {
-                    if let Some(text) = ime_context.get_composed_text() {
+                    if let Some(text) = unsafe { ime_context.get_composed_text() } {
                         userdata.window_state_lock().ime_state = ImeState::Enabled;
 
                         userdata.send_event(Event::WindowEvent {
@@ -1349,7 +1348,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
                 // Next, receive preedit range for next composing if exist.
                 if (lparam as u32 & GCS_COMPSTR) != 0 {
-                    if let Some((text, first, last)) = ime_context.get_composing_text_and_cursor() {
+                    if let Some((text, first, last)) =
+                        unsafe { ime_context.get_composing_text_and_cursor() }
+                    {
                         userdata.window_state_lock().ime_state = ImeState::Preedit;
                         let cursor_range = first.map(|f| (f, last.unwrap_or(f)));
 
@@ -1374,8 +1375,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 if userdata.window_state_lock().ime_state == ImeState::Preedit {
                     // Windows Hangul IME sends WM_IME_COMPOSITION after WM_IME_ENDCOMPOSITION, so
                     // trying receiving composing result and commit if exists.
-                    let ime_context = ImeContext::current(window);
-                    if let Some(text) = ime_context.get_composed_text() {
+                    let ime_context = unsafe { ImeContext::current(window) };
+                    if let Some(text) = unsafe { ime_context.get_composed_text() } {
                         userdata.send_event(Event::WindowEvent {
                             window_id: RootWindowId(WindowId(window)),
                             event: WindowEvent::Ime(Ime::Preedit(String::new(), None)),
@@ -1448,12 +1449,14 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 });
 
                 // Calling TrackMouseEvent in order to receive mouse leave events.
-                TrackMouseEvent(&mut TRACKMOUSEEVENT {
-                    cbSize: mem::size_of::<TRACKMOUSEEVENT>() as u32,
-                    dwFlags: TME_LEAVE,
-                    hwndTrack: window,
-                    dwHoverTime: HOVER_DEFAULT,
-                });
+                unsafe {
+                    TrackMouseEvent(&mut TRACKMOUSEEVENT {
+                        cbSize: mem::size_of::<TRACKMOUSEEVENT>() as u32,
+                        dwFlags: TME_LEAVE,
+                        hwndTrack: window,
+                        dwHoverTime: HOVER_DEFAULT,
+                    })
+                };
             }
 
             let x = super::get_x_lparam(lparam as u32) as f64;
@@ -1551,7 +1554,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         }
 
         WM_KEYUP | WM_SYSKEYUP => {
-            if msg == WM_SYSKEYUP && GetMenu(window) != 0 {
+            if msg == WM_SYSKEYUP && unsafe { GetMenu(window) != 0 } {
                 // let Windows handle event if the window has a native menu, a modal event loop
                 // is started here on Alt key up.
                 result = ProcResult::DefWindowProc(wparam);
@@ -1561,7 +1564,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         WM_LBUTTONDOWN => {
             use crate::event::{ElementState::Pressed, MouseButton::Left, WindowEvent::MouseInput};
 
-            capture_mouse(window, &mut userdata.window_state_lock());
+            unsafe { capture_mouse(window, &mut userdata.window_state_lock()) };
 
             update_modifiers(window, userdata);
 
@@ -1581,7 +1584,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Released, MouseButton::Left, WindowEvent::MouseInput,
             };
 
-            release_mouse(userdata.window_state_lock());
+            unsafe { release_mouse(userdata.window_state_lock()) };
 
             update_modifiers(window, userdata);
 
@@ -1601,7 +1604,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Pressed, MouseButton::Right, WindowEvent::MouseInput,
             };
 
-            capture_mouse(window, &mut userdata.window_state_lock());
+            unsafe { capture_mouse(window, &mut userdata.window_state_lock()) };
 
             update_modifiers(window, userdata);
 
@@ -1621,7 +1624,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Released, MouseButton::Right, WindowEvent::MouseInput,
             };
 
-            release_mouse(userdata.window_state_lock());
+            unsafe { release_mouse(userdata.window_state_lock()) };
 
             update_modifiers(window, userdata);
 
@@ -1641,7 +1644,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Pressed, MouseButton::Middle, WindowEvent::MouseInput,
             };
 
-            capture_mouse(window, &mut userdata.window_state_lock());
+            unsafe { capture_mouse(window, &mut userdata.window_state_lock()) };
 
             update_modifiers(window, userdata);
 
@@ -1661,7 +1664,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 ElementState::Released, MouseButton::Middle, WindowEvent::MouseInput,
             };
 
-            release_mouse(userdata.window_state_lock());
+            unsafe { release_mouse(userdata.window_state_lock()) };
 
             update_modifiers(window, userdata);
 
@@ -1683,7 +1686,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
             let xbutton = super::get_xbutton_wparam(wparam as u32);
 
-            capture_mouse(window, &mut userdata.window_state_lock());
+            unsafe { capture_mouse(window, &mut userdata.window_state_lock()) };
 
             update_modifiers(window, userdata);
 
@@ -1709,7 +1712,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
             let xbutton = super::get_xbutton_wparam(wparam as u32);
 
-            release_mouse(userdata.window_state_lock());
+            unsafe { release_mouse(userdata.window_state_lock()) };
 
             update_modifiers(window, userdata);
 
@@ -1743,21 +1746,22 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let pcount = super::loword(wparam as u32) as usize;
             let mut inputs = Vec::with_capacity(pcount);
             let htouch = lparam;
-            if GetTouchInputInfo(
-                htouch,
-                pcount as u32,
-                inputs.as_mut_ptr(),
-                mem::size_of::<TOUCHINPUT>() as i32,
-            ) > 0
-            {
-                inputs.set_len(pcount);
+            if unsafe {
+                GetTouchInputInfo(
+                    htouch,
+                    pcount as u32,
+                    inputs.as_mut_ptr(),
+                    mem::size_of::<TOUCHINPUT>() as i32,
+                ) > 0
+            } {
+                unsafe { inputs.set_len(pcount) };
                 for input in &inputs {
                     let mut location = POINT {
                         x: input.x / 100,
                         y: input.y / 100,
                     };
 
-                    if ScreenToClient(window, &mut location) == false.into() {
+                    if unsafe { ScreenToClient(window, &mut location) } == false.into() {
                         continue;
                     }
 
@@ -1784,7 +1788,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     });
                 }
             }
-            CloseTouchInputHandle(htouch);
+            unsafe { CloseTouchInputHandle(htouch) };
             result = ProcResult::Value(0);
         }
 
@@ -1801,12 +1805,14 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 let pointer_id = super::loword(wparam as u32) as u32;
                 let mut entries_count = 0u32;
                 let mut pointers_count = 0u32;
-                if GetPointerFrameInfoHistory(
-                    pointer_id,
-                    &mut entries_count,
-                    &mut pointers_count,
-                    ptr::null_mut(),
-                ) == false.into()
+                if unsafe {
+                    GetPointerFrameInfoHistory(
+                        pointer_id,
+                        &mut entries_count,
+                        &mut pointers_count,
+                        ptr::null_mut(),
+                    )
+                } == false.into()
                 {
                     result = ProcResult::Value(0);
                     return;
@@ -1814,17 +1820,19 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
                 let pointer_info_count = (entries_count * pointers_count) as usize;
                 let mut pointer_infos = Vec::with_capacity(pointer_info_count);
-                if GetPointerFrameInfoHistory(
-                    pointer_id,
-                    &mut entries_count,
-                    &mut pointers_count,
-                    pointer_infos.as_mut_ptr(),
-                ) == false.into()
+                if unsafe {
+                    GetPointerFrameInfoHistory(
+                        pointer_id,
+                        &mut entries_count,
+                        &mut pointers_count,
+                        pointer_infos.as_mut_ptr(),
+                    )
+                } == false.into()
                 {
                     result = ProcResult::Value(0);
                     return;
                 }
-                pointer_infos.set_len(pointer_info_count);
+                unsafe { pointer_infos.set_len(pointer_info_count) };
 
                 // https://docs.microsoft.com/en-us/windows/desktop/api/winuser/nf-winuser-getpointerframeinfohistory
                 // The information retrieved appears in reverse chronological order, with the most recent entry in the first
@@ -1833,17 +1841,19 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     let mut device_rect = mem::MaybeUninit::uninit();
                     let mut display_rect = mem::MaybeUninit::uninit();
 
-                    if GetPointerDeviceRects(
-                        pointer_info.sourceDevice,
-                        device_rect.as_mut_ptr(),
-                        display_rect.as_mut_ptr(),
-                    ) == false.into()
+                    if unsafe {
+                        GetPointerDeviceRects(
+                            pointer_info.sourceDevice,
+                            device_rect.as_mut_ptr(),
+                            display_rect.as_mut_ptr(),
+                        )
+                    } == false.into()
                     {
                         continue;
                     }
 
-                    let device_rect = device_rect.assume_init();
-                    let display_rect = display_rect.assume_init();
+                    let device_rect = unsafe { device_rect.assume_init() };
+                    let display_rect = unsafe { display_rect.assume_init() };
 
                     // For the most precise himetric to pixel conversion we calculate the ratio between the resolution
                     // of the display device (pixel) and the touch device (himetric).
@@ -1865,7 +1875,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                         y: y.floor() as i32,
                     };
 
-                    if ScreenToClient(window, &mut location) == false.into() {
+                    if unsafe { ScreenToClient(window, &mut location) } == false.into() {
                         continue;
                     }
 
@@ -1873,28 +1883,29 @@ unsafe fn public_window_callback_inner<T: 'static>(
                         PT_TOUCH => {
                             let mut touch_info = mem::MaybeUninit::uninit();
                             GET_POINTER_TOUCH_INFO.and_then(|GetPointerTouchInfo| {
-                                match GetPointerTouchInfo(
-                                    pointer_info.pointerId,
-                                    touch_info.as_mut_ptr(),
-                                ) {
+                                match unsafe {
+                                    GetPointerTouchInfo(
+                                        pointer_info.pointerId,
+                                        touch_info.as_mut_ptr(),
+                                    )
+                                } {
                                     0 => None,
-                                    _ => normalize_pointer_pressure(
-                                        touch_info.assume_init().pressure,
-                                    ),
+                                    _ => normalize_pointer_pressure(unsafe {
+                                        touch_info.assume_init().pressure
+                                    }),
                                 }
                             })
                         }
                         PT_PEN => {
                             let mut pen_info = mem::MaybeUninit::uninit();
                             GET_POINTER_PEN_INFO.and_then(|GetPointerPenInfo| {
-                                match GetPointerPenInfo(
-                                    pointer_info.pointerId,
-                                    pen_info.as_mut_ptr(),
-                                ) {
+                                match unsafe {
+                                    GetPointerPenInfo(pointer_info.pointerId, pen_info.as_mut_ptr())
+                                } {
                                     0 => None,
-                                    _ => {
-                                        normalize_pointer_pressure(pen_info.assume_init().pressure)
-                                    }
+                                    _ => normalize_pointer_pressure(unsafe {
+                                        pen_info.assume_init().pressure
+                                    }),
                                 }
                             })
                         }
@@ -1925,7 +1936,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     });
                 }
 
-                SkipPointerFrameMessages(pointer_id);
+                unsafe { SkipPointerFrameMessages(pointer_id) };
             }
             result = ProcResult::Value(0);
         }
@@ -1935,9 +1946,9 @@ unsafe fn public_window_callback_inner<T: 'static>(
             let active_focus_changed = userdata.window_state_lock().set_active(is_active);
             if active_focus_changed {
                 if is_active {
-                    gain_active_focus(window, userdata);
+                    unsafe { gain_active_focus(window, userdata) };
                 } else {
-                    lose_active_focus(window, userdata);
+                    unsafe { lose_active_focus(window, userdata) };
                 }
             }
             result = ProcResult::DefWindowProc(wparam);
@@ -1946,7 +1957,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         WM_SETFOCUS => {
             let active_focus_changed = userdata.window_state_lock().set_focused(true);
             if active_focus_changed {
-                gain_active_focus(window, userdata);
+                unsafe { gain_active_focus(window, userdata) };
             }
             result = ProcResult::Value(0);
         }
@@ -1954,7 +1965,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         WM_KILLFOCUS => {
             let active_focus_changed = userdata.window_state_lock().set_focused(false);
             if active_focus_changed {
-                lose_active_focus(window, userdata);
+                unsafe { lose_active_focus(window, userdata) };
             }
             result = ProcResult::Value(0);
         }
@@ -1975,8 +1986,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
             match set_cursor_to {
                 Some(cursor) => {
-                    let cursor = LoadCursorW(0, util::to_windows_cursor(cursor));
-                    SetCursor(cursor);
+                    let cursor = unsafe { LoadCursorW(0, util::to_windows_cursor(cursor)) };
+                    unsafe { SetCursor(cursor) };
                     result = ProcResult::Value(0);
                 }
                 None => result = ProcResult::DefWindowProc(wparam),
@@ -1994,18 +2005,22 @@ unsafe fn public_window_callback_inner<T: 'static>(
                     let min_size = min_size.to_physical(window_state.scale_factor);
                     let (width, height): (u32, u32) =
                         window_flags.adjust_size(window, min_size).into();
-                    (*mmi).ptMinTrackSize = POINT {
-                        x: width as i32,
-                        y: height as i32,
+                    unsafe {
+                        (*mmi).ptMinTrackSize = POINT {
+                            x: width as i32,
+                            y: height as i32,
+                        }
                     };
                 }
                 if let Some(max_size) = window_state.max_size {
                     let max_size = max_size.to_physical(window_state.scale_factor);
                     let (width, height): (u32, u32) =
                         window_flags.adjust_size(window, max_size).into();
-                    (*mmi).ptMaxTrackSize = POINT {
-                        x: width as i32,
-                        y: height as i32,
+                    unsafe {
+                        (*mmi).ptMaxTrackSize = POINT {
+                            x: width as i32,
+                            y: height as i32,
+                        }
                     };
                 }
             }
@@ -2043,7 +2058,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
             };
 
             // New size as suggested by Windows.
-            let suggested_rect = *(lparam as *const RECT);
+            let suggested_rect = unsafe { *(lparam as *const RECT) };
 
             // The window rect provided is the window's outer size, not it's inner size. However,
             // win32 doesn't provide an `UnadjustWindowRectEx` function to get the client rect from
@@ -2132,8 +2147,8 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 if dragging_window {
                     let bias = {
                         let cursor_pos = {
-                            let mut pos = mem::zeroed();
-                            GetCursorPos(&mut pos);
+                            let mut pos = unsafe { mem::zeroed() };
+                            unsafe { GetCursorPos(&mut pos) };
                             pos
                         };
                         let suggested_cursor_horizontal_ratio = (cursor_pos.x - suggested_rect.left)
@@ -2152,18 +2167,18 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
                 // Check to see if the new window rect is on the monitor with the new DPI factor.
                 // If it isn't, offset the window so that it is.
-                let new_dpi_monitor = MonitorFromWindow(window, MONITOR_DEFAULTTONULL);
+                let new_dpi_monitor = unsafe { MonitorFromWindow(window, MONITOR_DEFAULTTONULL) };
                 let conservative_rect_monitor =
-                    MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL);
+                    unsafe { MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL) };
                 new_outer_rect = if conservative_rect_monitor == new_dpi_monitor {
                     conservative_rect
                 } else {
                     let get_monitor_rect = |monitor| {
                         let mut monitor_info = MONITORINFO {
                             cbSize: mem::size_of::<MONITORINFO>() as _,
-                            ..mem::zeroed()
+                            ..unsafe { mem::zeroed() }
                         };
-                        GetMonitorInfoW(monitor, &mut monitor_info);
+                        unsafe { GetMonitorInfoW(monitor, &mut monitor_info) };
                         monitor_info.rcMonitor
                     };
                     let wrong_monitor = conservative_rect_monitor;
@@ -2200,7 +2215,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                         conservative_rect.top += delta_nudge_to_dpi_monitor.1;
                         conservative_rect.bottom += delta_nudge_to_dpi_monitor.1;
 
-                        if MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL)
+                        if unsafe { MonitorFromRect(&conservative_rect, MONITOR_DEFAULTTONULL) }
                             == new_dpi_monitor
                         {
                             break;
@@ -2211,15 +2226,17 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 };
             }
 
-            SetWindowPos(
-                window,
-                0,
-                new_outer_rect.left,
-                new_outer_rect.top,
-                new_outer_rect.right - new_outer_rect.left,
-                new_outer_rect.bottom - new_outer_rect.top,
-                SWP_NOZORDER | SWP_NOACTIVATE,
-            );
+            unsafe {
+                SetWindowPos(
+                    window,
+                    0,
+                    new_outer_rect.left,
+                    new_outer_rect.top,
+                    new_outer_rect.right - new_outer_rect.left,
+                    new_outer_rect.bottom - new_outer_rect.top,
+                    SWP_NOZORDER | SWP_NOACTIVATE,
+                )
+            };
 
             result = ProcResult::Value(0);
         }
@@ -2247,7 +2264,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
 
         _ => {
             if msg == DESTROY_MSG_ID.get() {
-                DestroyWindow(window);
+                unsafe { DestroyWindow(window) };
                 result = ProcResult::Value(0);
             } else if msg == SET_RETAIN_STATE_ON_SIZE_MSG_ID.get() {
                 let mut window_state = userdata.window_state_lock();
@@ -2257,7 +2274,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                 result = ProcResult::Value(0);
             } else if msg == TASKBAR_CREATED.get() {
                 let window_state = userdata.window_state_lock();
-                set_skip_taskbar(window, window_state.skip_taskbar);
+                unsafe { set_skip_taskbar(window, window_state.skip_taskbar) };
                 result = ProcResult::DefWindowProc(wparam);
             } else {
                 result = ProcResult::DefWindowProc(wparam);
@@ -2271,7 +2288,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
         .unwrap_or_else(|| result = ProcResult::Value(-1));
 
     match result {
-        ProcResult::DefWindowProc(wparam) => DefWindowProcW(window, msg, wparam, lparam),
+        ProcResult::DefWindowProc(wparam) => unsafe { DefWindowProcW(window, msg, wparam, lparam) },
         ProcResult::Value(val) => val,
     }
 }
@@ -2282,16 +2299,17 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
-    let userdata_ptr = super::get_window_long(window, GWL_USERDATA) as *mut ThreadMsgTargetData<T>;
+    let userdata_ptr =
+        unsafe { super::get_window_long(window, GWL_USERDATA) } as *mut ThreadMsgTargetData<T>;
     if userdata_ptr.is_null() {
         // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE` and
         // `WM_CREATE`.
-        return DefWindowProcW(window, msg, wparam, lparam);
+        return unsafe { DefWindowProcW(window, msg, wparam, lparam) };
     }
-    let userdata = Box::from_raw(userdata_ptr);
+    let userdata = unsafe { Box::from_raw(userdata_ptr) };
 
     if msg != WM_PAINT {
-        RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT);
+        unsafe { RedrawWindow(window, ptr::null(), 0, RDW_INTERNALPAINT) };
     }
 
     let mut userdata_removed = false;
@@ -2301,15 +2319,15 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     // the git blame and history would be preserved.
     let callback = || match msg {
         WM_NCDESTROY => {
-            super::set_window_long(window, GWL_USERDATA, 0);
+            unsafe { super::set_window_long(window, GWL_USERDATA, 0) };
             userdata_removed = true;
             0
         }
-        WM_PAINT => {
+        WM_PAINT => unsafe {
             ValidateRect(window, ptr::null());
             // Default WM_PAINT behaviour. This makes sure modals and popups are shown immediatly when opening them.
             DefWindowProcW(window, msg, wparam, lparam)
-        }
+        },
 
         WM_INPUT_DEVICE_CHANGE => {
             let event = match wparam as u32 {
@@ -2328,10 +2346,10 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
 
         WM_INPUT => {
             if let Some(data) = raw_input::get_raw_input_data(lparam as _) {
-                handle_raw_input(&userdata, data);
+                unsafe { handle_raw_input(&userdata, data) };
             }
 
-            DefWindowProcW(window, msg, wparam, lparam)
+            unsafe { DefWindowProcW(window, msg, wparam, lparam) }
         }
 
         _ if msg == USER_EVENT_MSG_ID.get() => {
@@ -2341,11 +2359,11 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
             0
         }
         _ if msg == EXEC_MSG_ID.get() => {
-            let mut function: ThreadExecFn = Box::from_raw(wparam as *mut _);
+            let mut function: ThreadExecFn = unsafe { Box::from_raw(wparam as *mut _) };
             function();
             0
         }
-        _ => DefWindowProcW(window, msg, wparam, lparam),
+        _ => unsafe { DefWindowProcW(window, msg, wparam, lparam) },
     };
 
     let result = userdata
@@ -2370,7 +2388,7 @@ unsafe fn handle_raw_input<T: 'static>(userdata: &ThreadMsgTargetData<T>, data: 
     let device_id = wrap_device_id(data.header.hDevice as _);
 
     if data.header.dwType == RIM_TYPEMOUSE {
-        let mouse = data.data.mouse;
+        let mouse = unsafe { data.data.mouse };
 
         if util::has_flag(mouse.usFlags as u32, MOUSE_MOVE_RELATIVE) {
             let x = mouse.lLastX as f64;
@@ -2398,10 +2416,10 @@ unsafe fn handle_raw_input<T: 'static>(userdata: &ThreadMsgTargetData<T>, data: 
             }
         }
 
-        let button_flags = mouse.Anonymous.Anonymous.usButtonFlags;
+        let button_flags = unsafe { mouse.Anonymous.Anonymous.usButtonFlags };
 
         if util::has_flag(button_flags as u32, RI_MOUSE_WHEEL) {
-            let button_data = mouse.Anonymous.Anonymous.usButtonData;
+            let button_data = unsafe { mouse.Anonymous.Anonymous.usButtonData };
             // We must cast to i16 first, becaues `usButtonData` must be interpreted as signed.
             let delta = button_data as i16 as f32 / WHEEL_DELTA as f32;
             userdata.send_event(Event::DeviceEvent {
@@ -2427,7 +2445,7 @@ unsafe fn handle_raw_input<T: 'static>(userdata: &ThreadMsgTargetData<T>, data: 
             }
         }
     } else if data.header.dwType == RIM_TYPEKEYBOARD {
-        let keyboard = data.data.keyboard;
+        let keyboard = unsafe { data.data.keyboard };
 
         let pressed = keyboard.Message == WM_KEYDOWN || keyboard.Message == WM_SYSKEYDOWN;
         let released = keyboard.Message == WM_KEYUP || keyboard.Message == WM_SYSKEYUP;
@@ -2449,7 +2467,7 @@ unsafe fn handle_raw_input<T: 'static>(userdata: &ThreadMsgTargetData<T>, data: 
         let scancode = if keyboard.MakeCode == 0 {
             // In some cases (often with media keys) the device reports a scancode of 0 but a
             // valid virtual key. In these cases we obtain the scancode from the virtual key.
-            MapVirtualKeyW(keyboard.VKey as u32, MAPVK_VK_TO_VSC_EX) as u16
+            unsafe { MapVirtualKeyW(keyboard.VKey as u32, MAPVK_VK_TO_VSC_EX) as u16 }
         } else {
             keyboard.MakeCode | extension
         };

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1,4 +1,5 @@
 #![cfg(windows_platform)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use smol_str::SmolStr;
 use windows_sys::Win32::{
@@ -154,21 +155,24 @@ const fn hiword(x: u32) -> u16 {
 #[inline(always)]
 unsafe fn get_window_long(hwnd: HWND, nindex: WINDOW_LONG_PTR_INDEX) -> isize {
     #[cfg(target_pointer_width = "64")]
-    return windows_sys::Win32::UI::WindowsAndMessaging::GetWindowLongPtrW(hwnd, nindex);
+    return unsafe { windows_sys::Win32::UI::WindowsAndMessaging::GetWindowLongPtrW(hwnd, nindex) };
     #[cfg(target_pointer_width = "32")]
-    return windows_sys::Win32::UI::WindowsAndMessaging::GetWindowLongW(hwnd, nindex) as isize;
+    return unsafe {
+        windows_sys::Win32::UI::WindowsAndMessaging::GetWindowLongW(hwnd, nindex) as isize
+    };
 }
 
 #[inline(always)]
 unsafe fn set_window_long(hwnd: HWND, nindex: WINDOW_LONG_PTR_INDEX, dwnewlong: isize) -> isize {
     #[cfg(target_pointer_width = "64")]
-    return windows_sys::Win32::UI::WindowsAndMessaging::SetWindowLongPtrW(hwnd, nindex, dwnewlong);
+    return unsafe {
+        windows_sys::Win32::UI::WindowsAndMessaging::SetWindowLongPtrW(hwnd, nindex, dwnewlong)
+    };
     #[cfg(target_pointer_width = "32")]
-    return windows_sys::Win32::UI::WindowsAndMessaging::SetWindowLongW(
-        hwnd,
-        nindex,
-        dwnewlong as i32,
-    ) as isize;
+    return unsafe {
+        windows_sys::Win32::UI::WindowsAndMessaging::SetWindowLongW(hwnd, nindex, dwnewlong as i32)
+            as isize
+    };
 }
 
 #[macro_use]

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -101,7 +101,7 @@ unsafe extern "system" fn monitor_enum_proc(
     data: LPARAM,
 ) -> BOOL {
     let monitors = data as *mut VecDeque<MonitorHandle>;
-    (*monitors).push_back(MonitorHandle::new(hmonitor));
+    unsafe { (*monitors).push_back(MonitorHandle::new(hmonitor)) };
     true.into() // continue enumeration
 }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -424,24 +424,26 @@ impl Window {
 
     unsafe fn handle_os_dragging(&self, wparam: WPARAM) {
         let points = {
-            let mut pos = mem::zeroed();
-            GetCursorPos(&mut pos);
+            let mut pos = unsafe { mem::zeroed() };
+            unsafe { GetCursorPos(&mut pos) };
             pos
         };
         let points = POINTS {
             x: points.x as i16,
             y: points.y as i16,
         };
-        ReleaseCapture();
+        unsafe { ReleaseCapture() };
 
         self.window_state_lock().dragging = true;
 
-        PostMessageW(
-            self.hwnd(),
-            WM_NCLBUTTONDOWN,
-            wparam,
-            &points as *const _ as LPARAM,
-        );
+        unsafe {
+            PostMessageW(
+                self.hwnd(),
+                WM_NCLBUTTONDOWN,
+                wparam,
+                &points as *const _ as LPARAM,
+            )
+        };
     }
 
     #[inline]
@@ -925,13 +927,13 @@ impl<'a, T: 'static> InitData<'a, T> {
     unsafe fn create_window(&self, window: HWND) -> Window {
         // Register for touch events if applicable
         {
-            let digitizer = GetSystemMetrics(SM_DIGITIZER) as u32;
+            let digitizer = unsafe { GetSystemMetrics(SM_DIGITIZER) as u32 };
             if digitizer & NID_READY != 0 {
-                RegisterTouchWindow(window, TWF_WANTPALM);
+                unsafe { RegisterTouchWindow(window, TWF_WANTPALM) };
             }
         }
 
-        let dpi = hwnd_dpi(window);
+        let dpi = unsafe { hwnd_dpi(window) };
         let scale_factor = dpi_to_scale_factor(dpi);
 
         // If the system theme is dark, we need to set the window theme now
@@ -955,7 +957,7 @@ impl<'a, T: 'static> InitData<'a, T> {
 
         enable_non_client_dpi_scaling(window);
 
-        ImeContext::set_ime_allowed(window, false);
+        unsafe { ImeContext::set_ime_allowed(window, false) };
 
         Window {
             window: WindowWrapper(window),
@@ -966,7 +968,7 @@ impl<'a, T: 'static> InitData<'a, T> {
 
     unsafe fn create_window_data(&self, win: &Window) -> event_loop::WindowData<T> {
         let file_drop_handler = if self.pl_attribs.drag_and_drop {
-            let ole_init_result = OleInitialize(ptr::null_mut());
+            let ole_init_result = unsafe { OleInitialize(ptr::null_mut()) };
             // It is ok if the initialize result is `S_FALSE` because it might happen that
             // multiple windows are created on the same thread.
             if ole_init_result == OLE_E_WRONGCOMPOBJ {
@@ -990,9 +992,12 @@ impl<'a, T: 'static> InitData<'a, T> {
             );
 
             let handler_interface_ptr =
-                &mut (*file_drop_handler.data).interface as *mut _ as *mut c_void;
+                unsafe { &mut (*file_drop_handler.data).interface as *mut _ as *mut c_void };
 
-            assert_eq!(RegisterDragDrop(win.window.0, handler_interface_ptr), S_OK);
+            assert_eq!(
+                unsafe { RegisterDragDrop(win.window.0, handler_interface_ptr) },
+                S_OK
+            );
             Some(file_drop_handler)
         } else {
             None
@@ -1013,8 +1018,8 @@ impl<'a, T: 'static> InitData<'a, T> {
     pub unsafe fn on_nccreate(&mut self, window: HWND) -> Option<isize> {
         let runner = self.event_loop.runner_shared.clone();
         let result = runner.catch_unwind(|| {
-            let window = self.create_window(window);
-            let window_data = self.create_window_data(&window);
+            let window = unsafe { self.create_window(window) };
+            let window_data = unsafe { self.create_window_data(&window) };
             (window, window_data)
         });
 
@@ -1031,7 +1036,7 @@ impl<'a, T: 'static> InitData<'a, T> {
         // making the window transparent
         if self.attributes.transparent && !self.pl_attribs.no_redirection_bitmap {
             // Empty region for the blur effect, so the window is fully transparent
-            let region = CreateRectRgn(0, 0, -1, -1);
+            let region = unsafe { CreateRectRgn(0, 0, -1, -1) };
 
             let bb = DWM_BLURBEHIND {
                 dwFlags: DWM_BB_ENABLE | DWM_BB_BLURREGION,
@@ -1039,14 +1044,14 @@ impl<'a, T: 'static> InitData<'a, T> {
                 hRgnBlur: region,
                 fTransitionOnMaximized: false.into(),
             };
-            let hr = DwmEnableBlurBehindWindow(win.hwnd(), &bb);
+            let hr = unsafe { DwmEnableBlurBehindWindow(win.hwnd(), &bb) };
             if hr < 0 {
                 warn!(
                     "Setting transparent window is failed. HRESULT Code: 0x{:X}",
                     hr
                 );
             }
-            DeleteObject(region);
+            unsafe { DeleteObject(region) };
         }
 
         win.set_skip_taskbar(self.pl_attribs.skip_taskbar);
@@ -1067,7 +1072,7 @@ impl<'a, T: 'static> InitData<'a, T> {
 
         if attributes.fullscreen.is_some() {
             win.set_fullscreen(attributes.fullscreen.map(Into::into));
-            force_window_active(win.window.0);
+            unsafe { force_window_active(win.window.0) };
         } else {
             let size = attributes
                 .inner_size
@@ -1112,7 +1117,7 @@ where
     let title = util::encode_wide(&attributes.title);
 
     let class_name = util::encode_wide(&pl_attribs.class_name);
-    register_window_class::<T>(&class_name);
+    unsafe { register_window_class::<T>(&class_name) };
 
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
@@ -1170,20 +1175,22 @@ where
     };
 
     let (style, ex_style) = window_flags.to_window_styles();
-    let handle = CreateWindowExW(
-        ex_style,
-        class_name.as_ptr(),
-        title.as_ptr(),
-        style,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        parent.unwrap_or(0),
-        pl_attribs.menu.unwrap_or(0),
-        util::get_instance_handle(),
-        &mut initdata as *mut _ as *mut _,
-    );
+    let handle = unsafe {
+        CreateWindowExW(
+            ex_style,
+            class_name.as_ptr(),
+            title.as_ptr(),
+            style,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            CW_USEDEFAULT,
+            parent.unwrap_or(0),
+            pl_attribs.menu.unwrap_or(0),
+            util::get_instance_handle(),
+            &mut initdata as *mut _ as *mut _,
+        )
+    };
 
     // If the window creation in `InitData` panicked, then should resume panicking here
     if let Err(panic_error) = event_loop.runner_shared.take_panic_error() {
@@ -1219,7 +1226,7 @@ unsafe fn register_window_class<T: 'static>(class_name: &[u16]) {
     //  an error, and because errors here are detected during CreateWindowEx anyway.
     // Also since there is no weird element in the struct, there is no reason for this
     //  call to fail.
-    RegisterClassExW(&class);
+    unsafe { RegisterClassExW(&class) };
 }
 
 struct ComInitialized(*mut ());
@@ -1260,20 +1267,22 @@ unsafe fn taskbar_mark_fullscreen(handle: HWND, fullscreen: bool) {
         let mut task_bar_list2 = task_bar_list2_ptr.get();
 
         if task_bar_list2.is_null() {
-            let hr = CoCreateInstance(
-                &CLSID_TaskbarList,
-                ptr::null_mut(),
-                CLSCTX_ALL,
-                &IID_ITaskbarList2,
-                &mut task_bar_list2 as *mut _ as *mut _,
-            );
+            let hr = unsafe {
+                CoCreateInstance(
+                    &CLSID_TaskbarList,
+                    ptr::null_mut(),
+                    CLSCTX_ALL,
+                    &IID_ITaskbarList2,
+                    &mut task_bar_list2 as *mut _ as *mut _,
+                )
+            };
             if hr != S_OK {
                 // In visual studio retrieving the taskbar list fails
                 return;
             }
 
-            let hr_init = (*(*task_bar_list2).lpVtbl).parent.HrInit;
-            if hr_init(task_bar_list2.cast()) != S_OK {
+            let hr_init = unsafe { (*(*task_bar_list2).lpVtbl).parent.HrInit };
+            if unsafe { hr_init(task_bar_list2.cast()) } != S_OK {
                 // In some old windows, the taskbar object could not be created, we just ignore it
                 return;
             }
@@ -1281,8 +1290,8 @@ unsafe fn taskbar_mark_fullscreen(handle: HWND, fullscreen: bool) {
         }
 
         task_bar_list2 = task_bar_list2_ptr.get();
-        let mark_fullscreen_window = (*(*task_bar_list2).lpVtbl).MarkFullscreenWindow;
-        mark_fullscreen_window(task_bar_list2, handle, fullscreen.into());
+        let mark_fullscreen_window = unsafe { (*(*task_bar_list2).lpVtbl).MarkFullscreenWindow };
+        unsafe { mark_fullscreen_window(task_bar_list2, handle, fullscreen.into()) };
     })
 }
 
@@ -1292,20 +1301,22 @@ pub(crate) unsafe fn set_skip_taskbar(hwnd: HWND, skip: bool) {
         let mut task_bar_list = task_bar_list_ptr.get();
 
         if task_bar_list.is_null() {
-            let hr = CoCreateInstance(
-                &CLSID_TaskbarList,
-                ptr::null_mut(),
-                CLSCTX_ALL,
-                &IID_ITaskbarList,
-                &mut task_bar_list as *mut _ as *mut _,
-            );
+            let hr = unsafe {
+                CoCreateInstance(
+                    &CLSID_TaskbarList,
+                    ptr::null_mut(),
+                    CLSCTX_ALL,
+                    &IID_ITaskbarList,
+                    &mut task_bar_list as *mut _ as *mut _,
+                )
+            };
             if hr != S_OK {
                 // In visual studio retrieving the taskbar list fails
                 return;
             }
 
-            let hr_init = (*(*task_bar_list).lpVtbl).HrInit;
-            if hr_init(task_bar_list.cast()) != S_OK {
+            let hr_init = unsafe { (*(*task_bar_list).lpVtbl).HrInit };
+            if unsafe { hr_init(task_bar_list.cast()) } != S_OK {
                 // In some old windows, the taskbar object could not be created, we just ignore it
                 return;
             }
@@ -1314,11 +1325,11 @@ pub(crate) unsafe fn set_skip_taskbar(hwnd: HWND, skip: bool) {
 
         task_bar_list = task_bar_list_ptr.get();
         if skip {
-            let delete_tab = (*(*task_bar_list).lpVtbl).DeleteTab;
-            delete_tab(task_bar_list, hwnd);
+            let delete_tab = unsafe { (*(*task_bar_list).lpVtbl).DeleteTab };
+            unsafe { delete_tab(task_bar_list, hwnd) };
         } else {
-            let add_tab = (*(*task_bar_list).lpVtbl).AddTab;
-            add_tab(task_bar_list, hwnd);
+            let add_tab = unsafe { (*(*task_bar_list).lpVtbl).AddTab };
+            unsafe { add_tab(task_bar_list, hwnd) };
         }
     });
 }
@@ -1328,7 +1339,7 @@ unsafe fn force_window_active(handle: HWND) {
     // This is a little hack which can "steal" the foreground window permission
     // We only call this function in the window creation, so it should be fine.
     // See : https://stackoverflow.com/questions/10740346/setforegroundwindow-only-working-while-visual-studio-is-open
-    let alt_sc = MapVirtualKeyW(VK_MENU as u32, MAPVK_VK_TO_VSC);
+    let alt_sc = unsafe { MapVirtualKeyW(VK_MENU as u32, MAPVK_VK_TO_VSC) };
 
     let inputs = [
         INPUT {
@@ -1358,11 +1369,13 @@ unsafe fn force_window_active(handle: HWND) {
     ];
 
     // Simulate a key press and release
-    SendInput(
-        inputs.len() as u32,
-        inputs.as_ptr(),
-        mem::size_of::<INPUT>() as i32,
-    );
+    unsafe {
+        SendInput(
+            inputs.len() as u32,
+            inputs.as_ptr(),
+            mem::size_of::<INPUT>() as i32,
+        )
+    };
 
-    SetForegroundWindow(handle);
+    unsafe { SetForegroundWindow(handle) };
 }


### PR DESCRIPTION
Although this does increase the verbosity, it also greatly helps in auditing which parts of the codebase is actually `unsafe`, and thus need extra scrutiny. My plan is to add it to the entirety of `winit`.

[The lint](https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.UNSAFE_OP_IN_UNSAFE_FN.html) is even stated in [the documentation for the keyword `unsafe`](https://doc.rust-lang.org/std/keyword.unsafe.html), and the desire is to make it warn by default at some point in the far future.

- [ ] Tested on all platforms changed

Related: What I'm seeing from applying this lint is that a _lot_ of the Windows backend is `unsafe`, I think we should consider working on improving that.
