### PR TITLE
Add `ApplicationHandler` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, enable event propagation and let `DeviceEvent`s appear after `WindowEvent`s.
 - On Web, take all transient activations on the canvas and window into account to queue a fullscreen request.
 - On Web, remove any fullscreen requests from the queue when an external fullscreen activation was detected.
+- **Breaking:** Removed `ControlFlow`, can now be set with `set_poll()`, `set_wait()`, .. on `EventLoopWindowTarget`.
 
 # 0.29.1-beta
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ another library.
 ```rust
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -43,14 +43,14 @@ fn main() {
     let event_loop = EventLoop::new();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => *control_flow = ControlFlow::Exit,
+            } if window_id == window.id() => elwt.exit(),
             _ => (),
         }
     });

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         dpi::{LogicalPosition, LogicalSize, Position},
         event::{ElementState, Event, KeyEvent, WindowEvent},
-        event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+        event_loop::{EventLoop, EventLoopWindowTarget},
         window::raw_window_handle::HasRawWindowHandle,
         window::{Window, WindowBuilder, WindowId},
     };
@@ -46,14 +46,14 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("parent window: {parent_window:?})");
 
-    event_loop.run(move |event: Event<()>, event_loop, control_flow| {
-        *control_flow = ControlFlow::Wait;
+    event_loop.run(move |event: Event<()>, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {
                     windows.clear();
-                    *control_flow = ControlFlow::Exit;
+                    elwt.exit();
                 }
                 WindowEvent::CursorEntered { device_id: _ } => {
                     // On x11, println when the cursor entered in a window even if the child window is created
@@ -70,7 +70,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         },
                     ..
                 } => {
-                    spawn_child_window(&parent_window, event_loop, &mut windows);
+                    spawn_child_window(&parent_window, elwt, &mut windows);
                 }
                 WindowEvent::RedrawRequested => {
                     if let Some(window) = windows.get(&window_id) {

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -38,19 +38,6 @@ struct App {
 }
 
 impl ApplicationHandler for App {
-    type Suspended = Self;
-
-    fn resume(
-        suspended: Self::Suspended,
-        _elwt: &winit::event_loop::EventLoopWindowTarget,
-    ) -> Self {
-        suspended
-    }
-
-    fn suspend(self) -> Self::Suspended {
-        self
-    }
-
     fn window_event(
         &mut self,
         _elwt: &winit::event_loop::EventLoopWindowTarget,
@@ -157,7 +144,7 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Press 'Esc' to close the window.");
 
     let event_loop = EventLoop::new().unwrap();
-    event_loop.run_with::<App>(|elwt| {
+    event_loop.run_with(|elwt| {
         let window = WindowBuilder::new()
             .with_title(
                 "Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.",

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut wait_cancelled = false;
     let mut close_requested = false;
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |event, elwt| {
         use winit::event::StartCause;
         println!("{event:?}");
         match event {
@@ -104,20 +104,20 @@ fn main() -> Result<(), impl std::error::Error> {
                 }
 
                 match mode {
-                    Mode::Wait => control_flow.set_wait(),
+                    Mode::Wait => elwt.set_wait(),
                     Mode::WaitUntil => {
                         if !wait_cancelled {
-                            control_flow.set_wait_until(time::Instant::now() + WAIT_TIME);
+                            elwt.set_wait_until(time::Instant::now() + WAIT_TIME);
                         }
                     }
                     Mode::Poll => {
                         thread::sleep(POLL_SLEEP_TIME);
-                        control_flow.set_poll();
+                        elwt.set_poll();
                     }
                 };
 
                 if close_requested {
-                    control_flow.set_exit();
+                    elwt.exit();
                 }
             }
             _ => (),

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -19,8 +19,8 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut cursor_idx = 0;
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
@@ -44,7 +44,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     fill::fill_window(&window);
                 }
                 WindowEvent::CloseRequested => {
-                    control_flow.set_exit();
+                    elwt.exit();
                 }
                 _ => (),
             }

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -22,12 +22,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut modifiers = ModifiersState::default();
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         match event {
             Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {
@@ -39,7 +39,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 } => {
                     let result = match key {
                         Key::Escape => {
-                            control_flow.set_exit();
+                            elwt.exit();
                             Ok(())
                         }
                         Key::Character(ch) => match ch.to_lowercase().as_str() {

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -40,15 +40,15 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     });
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         match event {
             Event::UserEvent(event) => println!("user event: {event:?}"),
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => control_flow.set_exit(),
+            } => elwt.exit(),
             Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -21,12 +21,12 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut switched = false;
     let mut entered_id = window_2.id();
 
-    event_loop.run(move |event, _, control_flow| match event {
+    event_loop.run(move |event, elwt| match event {
         Event::NewEvents(StartCause::Init) => {
             eprintln!("Switch which window is to be dragged by pressing \"x\".")
         }
         Event::WindowEvent { event, window_id } => match event {
-            WindowEvent::CloseRequested => control_flow.set_exit(),
+            WindowEvent::CloseRequested => elwt.exit(),
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,
                 button: MouseButton::Left,

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -52,12 +52,12 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("- I\tToggle mIn size limit");
     println!("- A\tToggle mAx size limit");
 
-    event_loop.run(move |event, elwt, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {
@@ -67,7 +67,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         },
                     ..
                 } => match key {
-                    Key::Escape => control_flow.set_exit(),
+                    Key::Escape => elwt.exit(),
                     // WARNING: Consider using `key_without_modifers()` if available on your platform.
                     // See the `key_binding` example
                     Key::Character(ch) => match ch.to_lowercase().as_str() {

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -22,8 +22,8 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut close_requested = false;
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
@@ -66,7 +66,7 @@ fn main() -> Result<(), impl std::error::Error> {
                                 // event loop (i.e. if it's a multi-window application), you need to
                                 // drop the window. That closes it, and results in `Destroyed` being
                                 // sent.
-                                control_flow.set_exit();
+                                elwt.exit();
                             }
                         }
                         Key::Character("n") => {

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -5,7 +5,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{ElementState, Event, Ime, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::{Key, KeyCode},
     window::{ImePurpose, WindowBuilder},
 };
@@ -39,11 +39,11 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut cursor_position = PhysicalPosition::new(0.0, 0.0);
     let mut ime_pos = PhysicalPosition::new(0.0, 0.0);
 
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::CursorMoved { position, .. } => {
                     cursor_position = position;
                 }

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -4,7 +4,7 @@
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::{Key, ModifiersState},
     // WARNING: This is not available on all platforms (for example on the web).
     platform::modifier_supplement::KeyEventExtModifierSupplement,
@@ -31,12 +31,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut modifiers = ModifiersState::default();
 
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::ModifiersChanged(new) => {
                     modifiers = new.state();
                 }

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -34,12 +34,12 @@ In both cases the example window should move like the content of a scroll area i
 In other words, the deltas indicate the direction in which to move the content (in this case the window)."
     );
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::MouseWheel { delta, .. } => match delta {
                     winit::event::MouseScrollDelta::LineDelta(x, y) => {
                         println!("mouse wheel Line Delta: ({x},{y})");

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -173,10 +173,10 @@ fn main() -> Result<(), impl std::error::Error> {
             }
         });
     }
-    event_loop.run(move |event, _event_loop, control_flow| {
+    event_loop.run(move |event, elwt| {
         match !window_senders.is_empty() {
-            true => control_flow.set_wait(),
-            false => control_flow.set_exit(),
+            true => elwt.set_wait(),
+            false => elwt.exit(),
         };
         match event {
             Event::WindowEvent { event, window_id } => match event {

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -20,19 +20,6 @@ struct App {
 }
 
 impl ApplicationHandler for App {
-    type Suspended = Self;
-
-    fn resume(
-        suspended: Self::Suspended,
-        _elwt: &winit::event_loop::EventLoopWindowTarget,
-    ) -> Self {
-        suspended
-    }
-
-    fn suspend(self) -> Self::Suspended {
-        self
-    }
-
     fn window_event(
         &mut self,
         elwt: &winit::event_loop::EventLoopWindowTarget,
@@ -84,7 +71,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Press N to open a new window.");
 
-    event_loop.run_with::<App>(|elwt| {
+    event_loop.run_with(|elwt| {
         elwt.set_wait();
 
         let mut windows = HashMap::new();

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -26,8 +26,8 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Press N to open a new window.");
 
-    event_loop.run(move |event, event_loop, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, window_id } = event {
             match event {
@@ -38,7 +38,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     windows.remove(&window_id);
 
                     if windows.is_empty() {
-                        control_flow.set_exit();
+                        elwt.exit();
                     }
                 }
                 WindowEvent::KeyboardInput {
@@ -51,7 +51,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     is_synthetic: false,
                     ..
                 } if matches!(c.as_ref(), "n" | "N") => {
-                    let window = Window::new(event_loop).unwrap();
+                    let window = Window::new(elwt).unwrap();
                     println!("Opened a new window: {:?}", window.id());
                     windows.insert(window.id(), window);
                 }

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -4,64 +4,96 @@ use std::collections::HashMap;
 
 use simple_logger::SimpleLogger;
 use winit::{
-    event::{ElementState, Event, KeyEvent, WindowEvent},
+    event::{ElementState, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::Key,
-    window::Window,
+    window::{Window, WindowId},
+    ApplicationHandler,
 };
 
 #[path = "util/fill.rs"]
 mod fill;
 
+#[derive(Debug)]
+struct App {
+    windows: HashMap<WindowId, Window>,
+}
+
+impl ApplicationHandler for App {
+    type Suspended = Self;
+
+    fn resume(
+        suspended: Self::Suspended,
+        _elwt: &winit::event_loop::EventLoopWindowTarget,
+    ) -> Self {
+        suspended
+    }
+
+    fn suspend(self) -> Self::Suspended {
+        self
+    }
+
+    fn window_event(
+        &mut self,
+        elwt: &winit::event_loop::EventLoopWindowTarget,
+        window_id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        match event {
+            WindowEvent::CloseRequested => {
+                println!("Window {window_id:?} has received the signal to close");
+
+                // This drops the window, causing it to close.
+                self.windows.remove(&window_id);
+
+                if self.windows.is_empty() {
+                    elwt.exit();
+                }
+            }
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        state: ElementState::Pressed,
+                        logical_key: Key::Character(c),
+                        ..
+                    },
+                is_synthetic: false,
+                ..
+            } if matches!(c.as_ref(), "n" | "N") => {
+                let window = Window::new(elwt).unwrap();
+                println!("Opened a new window: {:?}", window.id());
+                self.windows.insert(window.id(), window);
+            }
+            WindowEvent::RedrawRequested => {
+                if let Some(window) = self.windows.get(&window_id) {
+                    fill::fill_window(window);
+                }
+            }
+            _ => (),
+        }
+    }
+
+    fn about_to_wait(&mut self, _elwt: &winit::event_loop::EventLoopWindowTarget) {
+        // self.window.request_redraw();
+    }
+}
+
 fn main() -> Result<(), impl std::error::Error> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let mut windows = HashMap::new();
-    for _ in 0..3 {
-        let window = Window::new(&event_loop).unwrap();
-        println!("Opened a new window: {:?}", window.id());
-        windows.insert(window.id(), window);
-    }
-
     println!("Press N to open a new window.");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run_with::<App>(|elwt| {
         elwt.set_wait();
 
-        if let Event::WindowEvent { event, window_id } = event {
-            match event {
-                WindowEvent::CloseRequested => {
-                    println!("Window {window_id:?} has received the signal to close");
-
-                    // This drops the window, causing it to close.
-                    windows.remove(&window_id);
-
-                    if windows.is_empty() {
-                        elwt.exit();
-                    }
-                }
-                WindowEvent::KeyboardInput {
-                    event:
-                        KeyEvent {
-                            state: ElementState::Pressed,
-                            logical_key: Key::Character(c),
-                            ..
-                        },
-                    is_synthetic: false,
-                    ..
-                } if matches!(c.as_ref(), "n" | "N") => {
-                    let window = Window::new(elwt).unwrap();
-                    println!("Opened a new window: {:?}", window.id());
-                    windows.insert(window.id(), window);
-                }
-                WindowEvent::RedrawRequested => {
-                    if let Some(window) = windows.get(&window_id) {
-                        fill::fill_window(window);
-                    }
-                }
-                _ => (),
-            }
+        let mut windows = HashMap::new();
+        for _ in 0..3 {
+            let window = Window::new(elwt).unwrap();
+            println!("Opened a new window: {:?}", window.id());
+            windows.insert(window.id(), window);
         }
+
+        App { windows }
     })
 }

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -19,14 +19,14 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |event, elwt| {
         println!("{event:?}");
 
-        control_flow.set_wait();
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::MouseInput {
                     state: ElementState::Released,
                     ..

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -33,16 +33,16 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     });
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |event, elwt| {
         println!("{event:?}");
 
-        control_flow.set_wait();
+        elwt.set_wait();
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => control_flow.set_exit(),
+            } => elwt.exit(),
             Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -27,12 +27,12 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -32,7 +32,7 @@ mod example {
         let mut counter = 0;
         let mut create_first_window = false;
 
-        event_loop.run(move |event, elwt, flow| {
+        event_loop.run(move |event, elwt| {
             match event {
                 Event::Resumed => create_first_window = true,
 
@@ -61,7 +61,7 @@ mod example {
                         // Remove the window from the map.
                         windows.remove(&window_id);
                         if windows.is_empty() {
-                            flow.set_exit();
+                            elwt.exit();
                             return;
                         }
                     }
@@ -103,7 +103,7 @@ mod example {
                 create_first_window = false;
             }
 
-            flow.set_wait();
+            elwt.set_wait();
         })
     }
 }

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::Key,
     window::{Theme, WindowBuilder},
 };
@@ -27,12 +27,12 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("  (L) Light theme");
     println!("  (D) Dark theme");
 
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { window_id, event } = event {
             match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::ThemeChanged(theme) if window_id == window.id() => {
                     println!("Theme is changed: {theme:?}")
                 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -27,21 +27,21 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let timer_length = Duration::new(1, 0);
 
-    event_loop.run(move |event, _, control_flow| {
+    event_loop.run(move |event, elwt| {
         println!("{event:?}");
 
         match event {
             Event::NewEvents(StartCause::Init) => {
-                control_flow.set_wait_until(Instant::now() + timer_length);
+                elwt.set_wait_until(Instant::now() + timer_length);
             }
             Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
-                control_flow.set_wait_until(Instant::now() + timer_length);
+                elwt.set_wait_until(Instant::now() + timer_length);
                 println!("\nTimer\n");
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => control_flow.set_exit(),
+            } => elwt.exit(),
             Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -19,12 +19,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Only supported on macOS at the moment.");
 
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::TouchpadMagnify { delta, .. } => {
                     if delta > 0.0 {
                         println!("Zoomed in {delta}");

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -22,13 +22,13 @@ fn main() -> Result<(), impl std::error::Error> {
 
     window.set_title("A fantastic window!");
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
         println!("{event:?}");
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -21,8 +21,8 @@ pub fn main() -> Result<(), impl std::error::Error> {
     #[cfg(wasm_platform)]
     let log_list = wasm::insert_canvas_and_create_log_list(&window);
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         #[cfg(wasm_platform)]
         wasm::log_event(&log_list, &event);
@@ -31,7 +31,7 @@ pub fn main() -> Result<(), impl std::error::Error> {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => control_flow.set_exit(),
+            } if window_id == window.id() => elwt.exit(),
             Event::AboutToWait => {
                 window.request_redraw();
             }

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -12,7 +12,7 @@ mod wasm {
     use winit::{
         dpi::PhysicalSize,
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         platform::web::WindowBuilderExtWebSys,
         window::{Window, WindowBuilder},
     };
@@ -47,8 +47,8 @@ This example demonstrates the desired future functionality which will possibly b
         // Render once with the size info we currently have
         render_circle(&canvas, window.inner_size());
 
-        let _ = event_loop.run(move |event, _, control_flow| {
-            *control_flow = ControlFlow::Wait;
+        let _ = event_loop.run(move |event, elwt| {
+            elwt.set_wait();
 
             match event {
                 Event::WindowEvent {

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -18,29 +18,18 @@ struct GraphicsContext;
 struct App {
     window: Window,
     // TODO: Put the context & surface from `fill` in here
-    _graphics_context: GraphicsContext,
-}
-
-struct SuspendedApp {
-    window: Window,
+    _graphics_context: Option<GraphicsContext>,
 }
 
 impl ApplicationHandler for App {
-    type Suspended = SuspendedApp;
-
-    fn resume(suspended: Self::Suspended, _elwt: &EventLoopWindowTarget) -> Self {
+    fn resume(&mut self, _elwt: &EventLoopWindowTarget) {
         println!("---resumed---");
-        Self {
-            window: suspended.window,
-            _graphics_context: GraphicsContext,
-        }
+        self._graphics_context = Some(GraphicsContext);
     }
 
-    fn suspend(self) -> Self::Suspended {
+    fn suspend(&mut self, _elwt: &EventLoopWindowTarget) {
         println!("---suspended---");
-        SuspendedApp {
-            window: self.window,
-        }
+        self._graphics_context = None;
     }
 
     fn window_event(
@@ -73,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    event_loop.run_with::<App>(|elwt| {
+    event_loop.run_with(|elwt| {
         elwt.set_wait();
 
         let window = WindowBuilder::new()
@@ -82,7 +71,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .build(elwt)
             .unwrap();
 
-        SuspendedApp { window }
+        App {
+            window,
+            _graphics_context: None,
+        }
     })?;
 
     Ok(())

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -2,43 +2,88 @@
 
 use simple_logger::SimpleLogger;
 use winit::{
-    event::{Event, WindowEvent},
-    event_loop::EventLoop,
-    window::WindowBuilder,
+    event::WindowEvent,
+    event_loop::{EventLoop, EventLoopWindowTarget},
+    window::{Window, WindowBuilder, WindowId},
+    ApplicationHandler,
 };
 
 #[path = "util/fill.rs"]
 mod fill;
 
-fn main() -> Result<(), impl std::error::Error> {
+#[derive(Debug)]
+struct GraphicsContext;
+
+#[derive(Debug)]
+struct App {
+    window: Window,
+    // TODO: Put the context & surface from `fill` in here
+    _graphics_context: GraphicsContext,
+}
+
+struct SuspendedApp {
+    window: Window,
+}
+
+impl ApplicationHandler for App {
+    type Suspended = SuspendedApp;
+
+    fn resume(suspended: Self::Suspended, _elwt: &EventLoopWindowTarget) -> Self {
+        println!("---resumed---");
+        Self {
+            window: suspended.window,
+            _graphics_context: GraphicsContext,
+        }
+    }
+
+    fn suspend(self) -> Self::Suspended {
+        println!("---suspended---");
+        SuspendedApp {
+            window: self.window,
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        elwt: &EventLoopWindowTarget,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        println!("{event:?}");
+        if window_id != self.window.id() {
+            return;
+        }
+        match event {
+            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::RedrawRequested => {
+                // Notify the windowing system that we'll be presenting to the window.
+                self.window.pre_present_notify();
+                fill::fill_window(&self.window);
+            }
+            _ => (),
+        }
+    }
+
+    fn about_to_wait(&mut self, _elwt: &EventLoopWindowTarget) {
+        // self.window.request_redraw();
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     SimpleLogger::new().init().unwrap();
     let event_loop = EventLoop::new().unwrap();
 
-    let window = WindowBuilder::new()
-        .with_title("A fantastic window!")
-        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
-        .build(&event_loop)
-        .unwrap();
-
-    event_loop.run(move |event, elwt| {
+    event_loop.run_with::<App>(|elwt| {
         elwt.set_wait();
-        println!("{event:?}");
 
-        match event {
-            Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => elwt.exit(),
-                WindowEvent::RedrawRequested => {
-                    // Notify the windowing system that we'll be presenting to the window.
-                    window.pre_present_notify();
-                    fill::fill_window(&window);
-                }
-                _ => (),
-            },
-            Event::AboutToWait => {
-                window.request_redraw();
-            }
+        let window = WindowBuilder::new()
+            .with_title("A fantastic window!")
+            .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
+            .build(elwt)
+            .unwrap();
 
-            _ => (),
-        }
-    })
+        SuspendedApp { window }
+    })?;
+
+    Ok(())
 }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -20,13 +20,13 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
         println!("{event:?}");
 
         match event {
             Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::RedrawRequested => {
                     // Notify the windowing system that we'll be presenting to the window.
                     window.pre_present_notify();

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -31,8 +31,8 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.listen_device_events(DeviceEvents::Always);
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { window_id, event } = event {
             match event {
@@ -59,7 +59,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     }
                     _ => (),
                 },
-                WindowEvent::CloseRequested if window_id == window.id() => control_flow.set_exit(),
+                WindowEvent::CloseRequested if window_id == window.id() => elwt.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -38,8 +38,8 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.listen_device_events(DeviceEvents::Always);
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         match event {
             // This used to use the virtual key, but the new API
@@ -115,7 +115,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         window.set_minimized(minimized);
                     }
                     "q" => {
-                        control_flow.set_exit();
+                        elwt.exit();
                     }
                     "v" => {
                         visible = !visible;
@@ -127,7 +127,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     }
                     _ => (),
                 },
-                WindowEvent::CloseRequested if window_id == window.id() => control_flow.set_exit(),
+                WindowEvent::CloseRequested if window_id == window.id() => elwt.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, MouseButton, StartCause, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::Key,
     window::{CursorIcon, ResizeDirection, WindowBuilder},
 };
@@ -27,12 +27,12 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut border = false;
     let mut cursor_location = None;
 
-    event_loop.run(move |event, _, control_flow| match event {
+    event_loop.run(move |event, elwt| match event {
         Event::NewEvents(StartCause::Init) => {
             eprintln!("Press 'B' to toggle borderless")
         }
         Event::WindowEvent { event, .. } => match event {
-            WindowEvent::CloseRequested => *control_flow = ControlFlow::Exit,
+            WindowEvent::CloseRequested => elwt.exit(),
             WindowEvent::CursorMoved { position, .. } => {
                 if !window.is_decorated() {
                     let new_location =

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -33,12 +33,12 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::DroppedFile(path) => {
                     window.set_window_icon(Some(load_icon(&path)));
                 }

--- a/examples/window_ondemand.rs
+++ b/examples/window_ondemand.rs
@@ -36,6 +36,9 @@ fn main() -> Result<(), impl std::error::Error> {
 
             if let Some(window) = &app.window {
                 match event {
+                    Event::NewEvents(winit::event::StartCause::Init) => println!("---init"),
+                    Event::Resumed => println!("---resumed"),
+                    Event::Suspended => println!("---suspended"),
                     Event::WindowEvent {
                         event: WindowEvent::CloseRequested,
                         window_id,
@@ -43,7 +46,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         println!("--------------------------------------------------------- Window {idx} CloseRequested");
                         app.window = None;
                     }
-                    Event::AboutToWait => window.request_redraw(),
+                    // Event::AboutToWait => window.request_redraw(),
                     Event::WindowEvent {
                         event: WindowEvent::RedrawRequested,
                         ..

--- a/examples/window_ondemand.rs
+++ b/examples/window_ondemand.rs
@@ -30,8 +30,8 @@ fn main() -> Result<(), impl std::error::Error> {
     fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), EventLoopError> {
         let mut app = App::default();
 
-        event_loop.run_ondemand(move |event, event_loop, control_flow| {
-            control_flow.set_wait();
+        event_loop.run_ondemand(move |event, elwt| {
+            elwt.set_wait();
             println!("Run {idx}: {:?}", event);
 
             if let Some(window) = &app.window {
@@ -60,7 +60,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     } if id == window_id => {
                         println!("--------------------------------------------------------- Window {idx} Destroyed");
                         app.window_id = None;
-                        control_flow.set_exit();
+                        elwt.exit();
                     }
                     _ => (),
                 }
@@ -68,7 +68,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 let window = WindowBuilder::new()
                         .with_title("Fantastic window number one!")
                         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
-                        .build(event_loop)
+                        .build(elwt)
                         .unwrap();
                 app.window_id = Some(window.id());
                 app.window = Some(window);

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -31,14 +31,14 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut option_as_alt = window.option_as_alt();
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => control_flow.set_exit(),
+            } if window_id == window.id() => elwt.exit(),
             Event::WindowEvent { event, .. } => match event {
                 WindowEvent::MouseInput {
                     state: ElementState::Pressed,

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -41,6 +41,9 @@ fn main() -> std::process::ExitCode {
             }
 
             match event {
+                Event::NewEvents(winit::event::StartCause::Init) => println!("---init"),
+                Event::Resumed => println!("---resumed"),
+                Event::Suspended => println!("---suspended"),
                 Event::WindowEvent {
                     event: WindowEvent::CloseRequested,
                     window_id,

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -14,7 +14,7 @@ fn main() -> std::process::ExitCode {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
         window::WindowBuilder,
     };
@@ -32,8 +32,8 @@ fn main() -> std::process::ExitCode {
 
     'main: loop {
         let timeout = Some(Duration::ZERO);
-        let status = event_loop.pump_events(timeout, |event, _, control_flow| {
-            *control_flow = ControlFlow::Wait;
+        let status = event_loop.pump_events(timeout, |event, elwt| {
+            elwt.set_wait();
 
             if let Event::WindowEvent { event, .. } = &event {
                 // Print only Window events to reduce noise
@@ -44,7 +44,7 @@ fn main() -> std::process::ExitCode {
                 Event::WindowEvent {
                     event: WindowEvent::CloseRequested,
                     window_id,
-                } if window_id == window.id() => control_flow.set_exit(),
+                } if window_id == window.id() => elwt.exit(),
                 Event::AboutToWait => {
                     window.request_redraw();
                 }

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -24,12 +24,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut has_increments = true;
 
-    event_loop.run(move |event, _, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         match event {
             Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => control_flow.set_exit(),
+                WindowEvent::CloseRequested => elwt.exit(),
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -30,8 +30,8 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Press N to open a new window.");
 
-    event_loop.run(move |event, event_loop, control_flow| {
-        control_flow.set_wait();
+    event_loop.run(move |event, elwt| {
+        elwt.set_wait();
 
         if let Event::WindowEvent { event, window_id } = event {
             match event {
@@ -42,7 +42,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     windows.remove(&window_id);
 
                     if windows.is_empty() {
-                        control_flow.set_exit();
+                        elwt.exit();
                     }
                 }
                 WindowEvent::Resized(_) => {
@@ -64,7 +64,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         let tabbing_id = windows.get(&window_id).unwrap().tabbing_identifier();
                         let window = WindowBuilder::new()
                             .with_tabbing_identifier(&tabbing_id)
-                            .build(event_loop)
+                            .build(elwt)
                             .unwrap();
                         println!("Added a new tab: {:?}", window.id());
                         windows.insert(window.id(), window);

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -32,14 +32,14 @@ mod imple {
             .build(&event_loop)
             .unwrap();
 
-        event_loop.run(move |event, _, control_flow| {
-            control_flow.set_wait();
+        event_loop.run(move |event, elwt| {
+            elwt.set_wait();
 
             match event {
                 Event::WindowEvent {
                     event: WindowEvent::CloseRequested,
                     window_id,
-                } if window_id == window.id() => control_flow.set_exit(),
+                } if window_id == window.id() => elwt.exit(),
                 Event::AboutToWait => {
                     window.request_redraw();
                 }

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,0 +1,243 @@
+// TMP: For showcase
+#![allow(unreachable_code)]
+#![allow(unused_variables)]
+#![allow(dead_code)]
+use std::fmt;
+#[cfg(not(wasm_platform))]
+use std::time::Instant;
+
+#[cfg(wasm_platform)]
+use web_time::Instant;
+
+use crate::{
+    error::EventLoopError,
+    event::{DeviceEvent, DeviceId, Event, StartCause, WindowEvent},
+    event_loop::{EventLoop, EventLoopWindowTarget},
+    window::WindowId,
+};
+
+/// TODO
+#[allow(missing_docs)]
+pub trait ApplicationHandler<T = ()> {
+    type Suspended;
+
+    fn resume(suspended: Self::Suspended, elwt: &EventLoopWindowTarget<T>) -> Self;
+
+    // Note: We do _not_ pass the elwt here, since we don't want users to
+    // create windows when the app is about to suspend.
+    fn suspend(self) -> Self::Suspended;
+
+    fn window_event(
+        &mut self,
+        elwt: &EventLoopWindowTarget<T>,
+        window_id: WindowId,
+        event: WindowEvent,
+    );
+
+    // Default noop events
+
+    fn device_event(
+        &mut self,
+        elwt: &EventLoopWindowTarget<T>,
+        device_id: DeviceId,
+        event: DeviceEvent,
+    ) {
+        let _ = elwt;
+        let _ = device_id;
+        let _ = event;
+    }
+
+    fn user_event(&mut self, elwt: &EventLoopWindowTarget<T>, event: T) {
+        let _ = elwt;
+        let _ = event;
+    }
+
+    // Unsure about these, we should probably figure out better timer support
+
+    fn start_wait_cancelled(
+        &mut self,
+        elwt: &EventLoopWindowTarget<T>,
+        start: Instant,
+        requested_resume: Option<Instant>,
+    ) {
+        let _ = elwt;
+        let _ = start;
+        let _ = requested_resume;
+    }
+
+    fn start_resume_time_reached(
+        &mut self,
+        elwt: &EventLoopWindowTarget<T>,
+        start: Instant,
+        requested_resume: Instant,
+    ) {
+        let _ = elwt;
+        let _ = start;
+        let _ = requested_resume;
+    }
+
+    fn start_poll(&mut self, elwt: &EventLoopWindowTarget<T>) {
+        let _ = elwt;
+    }
+
+    fn about_to_wait(&mut self, elwt: &EventLoopWindowTarget<T>) {
+        let _ = elwt;
+    }
+}
+
+enum State<T, A: ApplicationHandler<T>, I> {
+    /// Stores an initialization closure.
+    Uninitialized(I),
+    /// Stores the suspended state.
+    Suspended(A::Suspended),
+    /// Stores the application.
+    Running(A),
+    /// Stores nothing, the application has been dropped at this point.
+    Exited,
+}
+
+impl<T, A, I> State<T, A, I>
+where
+    A: ApplicationHandler<T>,
+    I: FnOnce(&EventLoopWindowTarget<T>) -> A::Suspended,
+{
+    // Handle the event, and possibly transition to another state
+    fn next(self, event: Event<T>, elwt: &EventLoopWindowTarget<T>) -> Self {
+        match event {
+            Event::NewEvents(StartCause::Init) => match self {
+                State::Uninitialized(init) => State::Suspended(init(elwt)),
+                state => unreachable!("invalid initialization: state was {state:?}"),
+            },
+            Event::LoopExiting => match self {
+                // Don't forward the event; users should just overwrite `Drop` for their type if they want to do something on exit.
+                State::Suspended(_) | State::Running(_) => State::Exited,
+                state => unreachable!("invalid exit: state was {state:?}"),
+            },
+            Event::Suspended => match self {
+                State::Running(app) => State::Suspended(app.suspend()),
+                state => unreachable!("invalid suspend: state was {state:?}"),
+            },
+            Event::Resumed => match self {
+                State::Suspended(suspended_state) => {
+                    State::Running(A::resume(suspended_state, elwt))
+                }
+                state => unreachable!("invalid resume: state was {state:?}"),
+            },
+            Event::WindowEvent { window_id, event } => match self {
+                State::Running(mut app) => {
+                    app.window_event(elwt, window_id, event);
+                    State::Running(app)
+                }
+                state => unreachable!("invalid window event: state was {state:?}"),
+            },
+            Event::DeviceEvent { device_id, event } => match self {
+                State::Running(mut app) => {
+                    app.device_event(elwt, device_id, event);
+                    State::Running(app)
+                }
+                state => unreachable!("invalid device event: state was {state:?}"),
+            },
+            Event::UserEvent(event) => match self {
+                State::Running(mut app) => {
+                    app.user_event(elwt, event);
+                    State::Running(app)
+                }
+                state => unreachable!("invalid user event: state was {state:?}"),
+            },
+            Event::NewEvents(StartCause::ResumeTimeReached {
+                start,
+                requested_resume,
+            }) => match self {
+                State::Running(mut app) => {
+                    app.start_resume_time_reached(elwt, start, requested_resume);
+                    State::Running(app)
+                }
+                state => unreachable!("invalid resume time reached event: state was {state:?}"),
+            },
+            Event::NewEvents(StartCause::WaitCancelled {
+                start,
+                requested_resume,
+            }) => match self {
+                State::Running(mut app) => {
+                    app.start_wait_cancelled(elwt, start, requested_resume);
+                    State::Running(app)
+                }
+                state => unreachable!("invalid wait cancelled event: state was {state:?}"),
+            },
+            Event::NewEvents(StartCause::Poll) => match self {
+                State::Running(mut app) => {
+                    app.start_poll(elwt);
+                    State::Running(app)
+                }
+                state => unreachable!("invalid poll event: state was {state:?}"),
+            },
+            Event::AboutToWait => match self {
+                State::Running(mut app) => {
+                    app.about_to_wait(elwt);
+                    State::Running(app)
+                }
+                state => unreachable!("invalid about to wait event: state was {state:?}"),
+            },
+        }
+    }
+}
+
+impl<T, A: ApplicationHandler<T>, I> fmt::Debug for State<T, A, I> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Uninitialized(_) => f.write_str("Uninitialized"),
+            Self::Suspended(_) => f.write_str("Suspended"),
+            Self::Running(_) => f.write_str("Running"),
+            Self::Exited => f.write_str("Exited"),
+        }
+    }
+}
+
+impl<T> EventLoop<T> {
+    pub fn run_with<A: ApplicationHandler<T>>(
+        self,
+        init: impl FnOnce(&EventLoopWindowTarget<T>) -> A::Suspended,
+    ) -> Result<(), EventLoopError> {
+        let mut state_storage: Option<State<T, A, _>> = Some(State::Uninitialized(init));
+
+        self.run(move |event, elwt| {
+            let state = state_storage
+                .take()
+                .expect("failed extracting state, either due to re-entrancy or because a a panic occurred previously");
+
+            state_storage = Some(state.next(event, elwt));
+        })
+    }
+}
+
+// Extensions
+
+// Simpler version of the State enum above, used for communicating the current
+// state to the user when using `pump_events`.
+//
+// The intention is that the application is always dropped by the user
+// themselves, and the application is never returned in a suspended state.
+enum PumpEventStatus<A, I> {
+    Uninitialized(I),
+    Running(A),
+}
+
+struct ShouldExit(pub bool);
+
+impl<T> EventLoop<T> {
+    fn pump_events_with<A: ApplicationHandler<T>>(
+        self,
+        status: &mut PumpEventStatus<A, impl FnOnce(&EventLoopWindowTarget<T>) -> A::Suspended>,
+    ) -> Result<ShouldExit, EventLoopError> {
+        *status = PumpEventStatus::Running(todo!());
+        Ok(ShouldExit(false))
+    }
+
+    // Same signature and semantics as `run_with`, except for taking `&mut self`.
+    fn run_ondemand_with<A: ApplicationHandler<T>>(
+        &mut self,
+        init: impl FnOnce(&EventLoopWindowTarget<T>) -> A::Suspended,
+    ) -> Result<(), EventLoopError> {
+        todo!()
+    }
+}

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -46,7 +46,7 @@ pub struct EventLoop<T: 'static> {
 /// your callback. [`EventLoop`] will coerce into this type (`impl<T> Deref for
 /// EventLoop<T>`), so functions that take this as a parameter can also take
 /// `&EventLoop`.
-pub struct EventLoopWindowTarget<T: 'static> {
+pub struct EventLoopWindowTarget<T: 'static = ()> {
     pub(crate) p: platform_impl::EventLoopWindowTarget<T>,
     pub(crate) _marker: PhantomData<*mut ()>, // Not Send nor Sync
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,7 @@ extern crate bitflags;
 pub mod dpi;
 #[macro_use]
 pub mod error;
+mod application;
 pub mod event;
 pub mod event_loop;
 mod icon;
@@ -160,3 +161,5 @@ mod platform_impl;
 pub mod window;
 
 pub mod platform;
+
+pub use self::application::ApplicationHandler;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,7 @@
 //!
 //! You can retrieve events by calling [`EventLoop::run`][event_loop_run]. This function will
 //! dispatch events for every [`Window`] that was created with that particular [`EventLoop`], and
-//! will run until the `control_flow` argument given to the closure is set to
-//! [`ControlFlow`]`::`[`ExitWithCode`] (which [`ControlFlow`]`::`[`Exit`] aliases to), at which
+//! will run until [`exit()`] is used, at which
 //! point [`Event`]`::`[`LoopExiting`] is emitted and the entire program terminates.
 //!
 //! Winit no longer uses a `EventLoop::poll_events() -> impl Iterator<Event>`-based event loop
@@ -51,15 +50,15 @@
 //! let event_loop = EventLoop::new().unwrap();
 //! let window = WindowBuilder::new().build(&event_loop).unwrap();
 //!
-//! event_loop.run(move |event, _, control_flow| {
-//!     // ControlFlow::Poll continuously runs the event loop, even if the OS hasn't
+//! event_loop.run(move |event, elwt| {
+//!     // `set_poll()` continuously runs the event loop, even if the OS hasn't
 //!     // dispatched any events. This is ideal for games and similar applications.
-//!     control_flow.set_poll();
+//!     elwt.set_poll();
 //!
-//!     // ControlFlow::Wait pauses the event loop if no events are available to process.
+//!     // `set_wait()` pauses the event loop if no events are available to process.
 //!     // This is ideal for non-game applications that only update in response to user
-//!     // input, and uses significantly less power/CPU time than ControlFlow::Poll.
-//!     control_flow.set_wait();
+//!     // input, and uses significantly less power/CPU time than `set_poll()`.
+//!     elwt.set_wait();
 //!
 //!     match event {
 //!         Event::WindowEvent {
@@ -67,7 +66,7 @@
 //!             ..
 //!         } => {
 //!             println!("The close button was pressed; stopping");
-//!             control_flow.set_exit();
+//!             elwt.exit();
 //!         },
 //!         Event::AboutToWait => {
 //!             // Application update code.
@@ -115,9 +114,7 @@
 //! [`EventLoopExtPumpEvents::pump_events`]: ./platform/pump_events/trait.EventLoopExtPumpEvents.html#tymethod.pump_events
 //! [`EventLoop::new()`]: event_loop::EventLoop::new
 //! [event_loop_run]: event_loop::EventLoop::run
-//! [`ControlFlow`]: event_loop::ControlFlow
-//! [`Exit`]: event_loop::ControlFlow::Exit
-//! [`ExitWithCode`]: event_loop::ControlFlow::ExitWithCode
+//! [`exit()`]: event_loop::EventLoopWindowTarget::exit
 //! [`Window`]: window::Window
 //! [`WindowId`]: window::WindowId
 //! [`WindowBuilder`]: window::WindowBuilder

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::{
     event::Event,
-    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+    event_loop::{EventLoop, EventLoopWindowTarget},
 };
 
 /// The return status for `pump_events`
@@ -63,7 +63,7 @@ pub trait EventLoopExtPumpEvents {
     ///
     ///     'main: loop {
     ///         let timeout = Some(Duration::ZERO);
-    ///         let status = event_loop.pump_events(timeout, |event, _, control_flow| {
+    ///         let status = event_loop.pump_events(timeout, |event, elwt| {
     /// #            if let Event::WindowEvent { event, .. } = &event {
     /// #                // Print only Window events to reduce noise
     /// #                println!("{event:?}");
@@ -73,7 +73,7 @@ pub trait EventLoopExtPumpEvents {
     ///                 Event::WindowEvent {
     ///                     event: WindowEvent::CloseRequested,
     ///                     window_id,
-    ///                 } if window_id == window.id() => control_flow.set_exit(),
+    ///                 } if window_id == window.id() => elwt.exit(),
     ///                 Event::AboutToWait => {
     ///                     window.request_redraw();
     ///                 }
@@ -174,7 +174,7 @@ pub trait EventLoopExtPumpEvents {
     ///   callback.
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
 }
 
 impl<T> EventLoopExtPumpEvents for EventLoop<T> {
@@ -182,7 +182,7 @@ impl<T> EventLoopExtPumpEvents for EventLoop<T> {
 
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
     {
         self.event_loop.pump_events(timeout, event_handler)
     }

--- a/src/platform/run_ondemand.rs
+++ b/src/platform/run_ondemand.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::EventLoopError,
     event::Event,
-    event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+    event_loop::{EventLoop, EventLoopWindowTarget},
 };
 
 #[cfg(doc)]
@@ -17,7 +17,7 @@ pub trait EventLoopExtRunOnDemand {
     ///
     /// Unlike [`EventLoop::run`], this function accepts non-`'static` (i.e. non-`move`) closures
     /// and it is possible to return control back to the caller without
-    /// consuming the `EventLoop` (by setting the `control_flow` to [`ControlFlow::Exit`]) and
+    /// consuming the `EventLoop` (by using [`exit()`]) and
     /// so the event loop can be re-run after it has exit.
     ///
     /// It's expected that each run of the loop will be for orthogonal instantiations of your
@@ -32,8 +32,8 @@ pub trait EventLoopExtRunOnDemand {
     /// `NewEvents(Init)` and `Resumed` event (even on platforms that have no suspend/resume
     /// lifecycle) - which can be used to consistently initialize application state.
     ///
-    /// See the [`ControlFlow`] docs for information on how changes to `&mut ControlFlow` impact the
-    /// event loop's behavior.
+    /// See the [`set_poll()`], [`set_wait_timeout()`], [`exit()`] docs for information on how
+    /// they impact the event loop's behavior.
     ///
     /// # Caveats
     /// - This extension isn't available on all platforms, since it's not always possible to
@@ -57,9 +57,13 @@ pub trait EventLoopExtRunOnDemand {
     ///   polled to ask for new events. Events are delivered via callbacks based
     ///   on an event loop that is internal to the browser itself.
     /// - **iOS:** It's not possible to stop and start an `NSApplication` repeatedly on iOS.
+    ///
+    /// [`set_poll()`]: EventLoopWindowTarget::set_poll
+    /// [`set_wait_timeout()`]: EventLoopWindowTarget::set_wait_timeout
+    /// [`exit()`]: EventLoopWindowTarget::exit
     fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
 }
 
 impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
@@ -67,7 +71,7 @@ impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
 
     fn run_ondemand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
     {
         self.event_loop.run_ondemand(event_handler)
     }

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -28,7 +28,6 @@
 //! [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
 
 use crate::event::Event;
-use crate::event_loop::ControlFlow;
 use crate::event_loop::EventLoop;
 use crate::event_loop::EventLoopWindowTarget;
 use crate::window::{Window, WindowBuilder};
@@ -122,8 +121,7 @@ pub trait EventLoopExtWebSys {
     /// event loop when switching between tabs on a single page application.
     fn spawn<F>(self, event_handler: F)
     where
-        F: 'static
-            + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow);
+        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
 }
 
 impl<T> EventLoopExtWebSys for EventLoop<T> {
@@ -131,8 +129,7 @@ impl<T> EventLoopExtWebSys for EventLoop<T> {
 
     fn spawn<F>(self, event_handler: F)
     where
-        F: 'static
-            + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>, &mut ControlFlow),
+        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
     {
         self.event_loop.spawn(event_handler)
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -4,7 +4,7 @@
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{collections::VecDeque, env, fmt};
 #[cfg(x11_platform)]
 use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Mutex};
@@ -19,10 +19,9 @@ use crate::platform::x11::XlibErrorHook;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{EventLoopError, ExternalError, NotSupportedError, OsError as RootOsError},
-    event::{Event, KeyEvent},
+    event::KeyEvent,
     event_loop::{
-        AsyncRequestSerial, ControlFlow, DeviceEvents, EventLoopClosed,
-        EventLoopWindowTarget as RootELW,
+        AsyncRequestSerial, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
     keyboard::{Key, KeyCode},
@@ -789,21 +788,21 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(crate::event::Event<T>, &RootELW<T>),
     {
         self.run_ondemand(callback)
     }
 
     pub fn run_ondemand<F>(&mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(crate::event::Event<T>, &RootELW<T>),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_ondemand(callback))
     }
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>, &mut ControlFlow),
+        F: FnMut(crate::event::Event<T>, &RootELW<T>),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.pump_events(timeout, callback))
     }
@@ -882,22 +881,44 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
         x11_or_wayland!(match self; Self(evlp) => evlp.raw_display_handle())
     }
+
+    fn control_flow(&self) -> ControlFlow {
+        x11_or_wayland!(match self; Self(evlp) => evlp.control_flow())
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        x11_or_wayland!(match self; Self(evlp) => evlp.set_control_flow(control_flow))
+    }
+
+    pub(crate) fn set_poll(&self) {
+        self.set_control_flow(ControlFlow::Poll)
+    }
+
+    pub(crate) fn set_wait(&self) {
+        self.set_control_flow(ControlFlow::Wait)
+    }
+
+    pub(crate) fn set_wait_until(&self, instant: Instant) {
+        self.set_control_flow(ControlFlow::WaitUntil(instant))
+    }
+
+    pub(crate) fn exit(&self) {
+        self.set_control_flow(ControlFlow::ExitWithCode(0))
+    }
 }
 
-fn sticky_exit_callback<T, F>(
-    evt: Event<T>,
-    target: &RootELW<T>,
-    control_flow: &mut ControlFlow,
-    callback: &mut F,
-) where
-    F: FnMut(Event<T>, &RootELW<T>, &mut ControlFlow),
-{
-    // make ControlFlow::ExitWithCode sticky by providing a dummy
-    // control flow reference if it is already ExitWithCode.
-    if let ControlFlow::ExitWithCode(code) = *control_flow {
-        callback(evt, target, &mut ControlFlow::ExitWithCode(code))
-    } else {
-        callback(evt, target, control_flow)
+#[derive(Clone, Copy)]
+pub(crate) enum ControlFlow {
+    Poll,
+    Wait,
+    WaitUntil(Instant),
+    ExitWithCode(i32),
+}
+
+impl Default for ControlFlow {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::Poll
     }
 }
 

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -7,6 +7,7 @@ use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::platform_impl::platform::{
     MonitorHandle as PlatformMonitorHandle, VideoMode as PlatformVideoMode,
 };
+use crate::platform_impl::ControlFlow;
 
 use super::event_loop::EventLoopWindowTarget;
 
@@ -25,6 +26,16 @@ impl<T> EventLoopWindowTarget<T> {
     pub fn primary_monitor(&self) -> Option<PlatformMonitorHandle> {
         // There's no primary monitor on Wayland.
         None
+    }
+
+    pub(crate) fn control_flow(&self) -> ControlFlow {
+        self.control_flow.get()
+    }
+
+    pub(crate) fn set_control_flow(&self, control_flow: ControlFlow) {
+        if !matches!(self.control_flow.get(), ControlFlow::ExitWithCode(_)) {
+            self.control_flow.set(control_flow)
+        }
     }
 }
 

--- a/src/platform_impl/web/event_loop/state.rs
+++ b/src/platform_impl/web/event_loop/state.rs
@@ -1,5 +1,4 @@
 use super::backend;
-use crate::event_loop::ControlFlow;
 
 use web_time::Instant;
 
@@ -23,15 +22,5 @@ pub enum State {
 impl State {
     pub fn is_exit(&self) -> bool {
         matches!(self, State::Exit)
-    }
-
-    pub fn control_flow(&self) -> ControlFlow {
-        match self {
-            State::Init => ControlFlow::Poll,
-            State::WaitUntil { end, .. } => ControlFlow::WaitUntil(*end),
-            State::Wait { .. } => ControlFlow::Wait,
-            State::Poll { .. } => ControlFlow::Poll,
-            State::Exit => ControlFlow::Exit,
-        }
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -47,14 +47,14 @@ pub use raw_window_handle;
 /// let mut event_loop = EventLoop::new().unwrap();
 /// let window = Window::new(&event_loop).unwrap();
 ///
-/// event_loop.run(move |event, _, control_flow| {
-///     control_flow.set_wait();
+/// event_loop.run(move |event, elwt| {
+///     elwt.set_wait();
 ///
 ///     match event {
 ///         Event::WindowEvent {
 ///             event: WindowEvent::CloseRequested,
 ///             ..
-///         } => control_flow.set_exit(),
+///         } => elwt.exit(),
 ///         _ => (),
 ///     }
 /// });


### PR DESCRIPTION
Part of https://github.com/rust-windowing/winit/issues/2903.

Builds upon https://github.com/rust-windowing/winit/pull/3056, so see the last commit(s) for the changes in this PR.

Add an `ApplicationHandler<T>` trait that replaces the `Event<T>` enum (should probably be kept around for at least one release, but be marked deprecated) by encoding these events as callbacks on a user-specified mutable application object instead.
This allows us to fix many outstanding issues with the current event loop design, including ensuring that windows are only created after initialization, and helping users to properly suspended/resume their application (also here: recreating surfaces and such).

TODO:
- [ ] Figure out what to do about timing.
- [x] Experiment with returning a closure on suspend, instead of having to manually specify the suspended data.
  - https://github.com/rust-windowing/winit/pull/3074
- [ ] Should we do application initialization differently?
- [ ] How exactly should pump_events work?
- [ ] The user currently has to type a lot compared to the old closure, can we make things even nicer?
- [ ] How do we do platform-specific extensions?
- [ ] Naming things.
- [ ] Test on all platforms that the events are actually delivered in the order we want.
- [ ] Changelog entry and update examples.
- [ ] ...
