### PR TITLE
Change how our `raw-window-handle` dependency is exposed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,9 +55,31 @@ cursor-icon = "1.0.0"
 log = "0.4"
 mint = { version = "0.5.6", optional = true }
 once_cell = "1.12"
-raw_window_handle = { package = "raw-window-handle", version = "0.5", features = ["std"] }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 smol_str = "0.2.0"
+
+# Enable support for different versions of `raw-window-handle`.
+#
+# Old ones will be deprecated (and removed in major versions) slowly as
+# `winit` moves towards newer releases of `raw-window-handle`.
+#
+# Note that this whole thing is only necessary because `raw-window-handle` is
+# still unstable, once it reaches a stable v1.0, the need for these features
+# will disappear.
+
+# Enable version 0.4 support by using the "rwh-0-4" feature.
+[dependencies.rwh-0-4]
+package = "raw-window-handle"
+version = "0.4"
+features = ["alloc"]
+optional = true
+
+# Enable version 0.5 support by using the "rwh-0-5" feature.
+[dependencies.rwh-0-5]
+package = "raw-window-handle"
+version = "0.5"
+features = ["std"]
+optional = true
 
 [dev-dependencies]
 image = { version = "0.24.0", default-features = false, features = ["png"] }
@@ -211,3 +233,7 @@ web-sys = { version = "0.3.22", features = ['CanvasRenderingContext2d'] }
 members = [
     "run-wasm",
 ]
+
+[[example]]
+name = "child_window"
+required-features = ["rwh-0-5"]

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), impl std::error::Error> {
         dpi::{LogicalPosition, LogicalSize, Position},
         event::{ElementState, Event, KeyEvent, WindowEvent},
         event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
-        window::raw_window_handle::HasRawWindowHandle,
+        raw_window_handle_0_5::HasRawWindowHandle,
         window::{Window, WindowBuilder, WindowId},
     };
 
@@ -26,7 +26,7 @@ fn main() -> Result<(), impl std::error::Error> {
             .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
             .with_visible(true);
         // `with_parent_window` is unsafe. Parent window must be a valid window.
-        builder = unsafe { builder.with_parent_window(Some(parent)) };
+        builder = unsafe { builder.with_parent_rwh_0_5(Some(parent)) };
         let child_window = builder.build(event_loop).unwrap();
 
         let id = child_window.id();

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -9,6 +9,21 @@
 
 use winit::window::Window;
 
+#[cfg(not(feature = "rwh-0-5"))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+pub(super) fn fill_window(_window: &Window) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    static HAS_WARNED: AtomicBool = AtomicBool::new(false);
+    if !HAS_WARNED.load(Ordering::Relaxed) {
+        // Don't worry about emitting the error twice in multithreaded situations
+        HAS_WARNED.store(true, Ordering::Relaxed);
+        log::warn!(
+            "not drawing to window in example. Please enable the `rwh-0-5` feature to do this!"
+        );
+    }
+}
+
+#[cfg(feature = "rwh-0-5")]
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 pub(super) fn fill_window(window: &Window) {
     use softbuffer::{Context, Surface};

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -12,7 +12,6 @@ use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{error, fmt};
 
-use raw_window_handle::{HasRawDisplayHandle, RawDisplayHandle};
 #[cfg(not(wasm_platform))]
 use std::time::{Duration, Instant};
 #[cfg(wasm_platform)]
@@ -324,10 +323,11 @@ impl<T> EventLoop<T> {
     }
 }
 
-unsafe impl<T> HasRawDisplayHandle for EventLoop<T> {
-    /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
-    fn raw_display_handle(&self) -> RawDisplayHandle {
-        self.event_loop.window_target().p.raw_display_handle()
+#[cfg(feature = "rwh-0-5")]
+unsafe impl<T> rwh_0_5::HasRawDisplayHandle for EventLoop<T> {
+    /// Returns a [`rwh_0_5::RawDisplayHandle`] for the event loop.
+    fn raw_display_handle(&self) -> rwh_0_5::RawDisplayHandle {
+        self.event_loop.window_target().p.rwh_0_5_display()
     }
 }
 
@@ -379,10 +379,11 @@ impl<T> EventLoopWindowTarget<T> {
     }
 }
 
-unsafe impl<T> HasRawDisplayHandle for EventLoopWindowTarget<T> {
-    /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
-    fn raw_display_handle(&self) -> RawDisplayHandle {
-        self.p.raw_display_handle()
+#[cfg(feature = "rwh-0-5")]
+unsafe impl<T> rwh_0_5::HasRawDisplayHandle for EventLoopWindowTarget<T> {
+    /// Returns a [`rwh_0_5::RawDisplayHandle`] for the event loop.
+    fn raw_display_handle(&self) -> rwh_0_5::RawDisplayHandle {
+        self.p.rwh_0_5_display()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,12 @@ extern crate serde;
 #[macro_use]
 extern crate bitflags;
 
+#[cfg(feature = "rwh-0-4")]
+compile_error!("support for `raw-window-handle` v0.4 has been removed in this version of `winit`.\nIf you need it, don't hesitate to open an issue about it!");
+
+#[cfg(feature = "rwh-0-5")]
+pub extern crate rwh_0_5 as raw_window_handle_0_5;
+
 pub mod dpi;
 #[macro_use]
 pub mod error;

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -15,9 +15,6 @@ use android_activity::{
     AndroidApp, AndroidAppWaker, ConfigurationRef, InputStatus, MainEvent, Rect,
 };
 use once_cell::sync::Lazy;
-use raw_window_handle::{
-    AndroidDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
-};
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
@@ -746,8 +743,9 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::Android(AndroidDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::Android(rwh_0_5::AndroidDisplayHandle::empty())
     }
 }
 
@@ -972,16 +970,20 @@ impl Window {
         ))
     }
 
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_window(&self) -> rwh_0_5::RawWindowHandle {
         if let Some(native_window) = self.app.native_window().as_ref() {
+            // Note: When we have to do upgrade to `raw-window-handle` v0.6,
+            // we'll need to manually create the handle from this.
             native_window.raw_window_handle()
         } else {
             panic!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
         }
     }
 
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::Android(AndroidDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::Android(rwh_0_5::AndroidDisplayHandle::empty())
     }
 
     pub fn config(&self) -> ConfigurationRef {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -16,7 +16,6 @@ use core_foundation::runloop::{
 };
 use icrate::Foundation::{MainThreadMarker, NSString};
 use objc2::ClassType;
-use raw_window_handle::{RawDisplayHandle, UiKitDisplayHandle};
 
 use crate::{
     error::EventLoopError,
@@ -49,8 +48,9 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::UiKit(UiKitDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::UiKit(rwh_0_5::UiKitDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -6,7 +6,6 @@ use icrate::Foundation::{CGFloat, CGPoint, CGRect, CGSize, MainThreadBound, Main
 use objc2::rc::Id;
 use objc2::runtime::AnyObject;
 use objc2::{class, msg_send};
-use raw_window_handle::{RawDisplayHandle, RawWindowHandle, UiKitDisplayHandle, UiKitWindowHandle};
 
 use super::app_state::EventWrapper;
 use super::uikit::{UIApplication, UIScreen, UIScreenOverscanCompensation};
@@ -325,16 +324,18 @@ impl Inner {
         self.window.id()
     }
 
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut window_handle = UiKitWindowHandle::empty();
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_window(&self) -> rwh_0_5::RawWindowHandle {
+        let mut window_handle = rwh_0_5::UiKitWindowHandle::empty();
         window_handle.ui_window = Id::as_ptr(&self.window) as _;
         window_handle.ui_view = Id::as_ptr(&self.view) as _;
         window_handle.ui_view_controller = Id::as_ptr(&self.view_controller) as _;
-        RawWindowHandle::UiKit(window_handle)
+        rwh_0_5::RawWindowHandle::UiKit(window_handle)
     }
 
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::UiKit(UiKitDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::UiKit(rwh_0_5::UiKitDisplayHandle::empty())
     }
 
     pub fn theme(&self) -> Option<Theme> {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -11,7 +11,6 @@ use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Mutex};
 
 #[cfg(x11_platform)]
 use once_cell::sync::Lazy;
-use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 use smol_str::SmolStr;
 
 #[cfg(x11_platform)]
@@ -571,13 +570,15 @@ impl Window {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
-        x11_or_wayland!(match self; Window(window) => window.raw_window_handle())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_window(&self) -> rwh_0_5::RawWindowHandle {
+        x11_or_wayland!(match self; Window(window) => window.rwh_0_5_window())
     }
 
     #[inline]
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        x11_or_wayland!(match self; Window(window) => window.raw_display_handle())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        x11_or_wayland!(match self; Window(window) => window.rwh_0_5_display())
     }
 
     #[inline]
@@ -829,8 +830,9 @@ impl<T> EventLoopWindowTarget<T> {
         x11_or_wayland!(match self; Self(evlp) => evlp.listen_device_events(allowed))
     }
 
-    pub fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
-        x11_or_wayland!(match self; Self(evlp) => evlp.raw_display_handle())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        x11_or_wayland!(match self; Self(evlp) => evlp.rwh_0_5_display())
     }
 }
 

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -9,12 +9,10 @@ use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use raw_window_handle::{RawDisplayHandle, WaylandDisplayHandle};
-
 use sctk::reexports::calloop;
 use sctk::reexports::calloop::Error as CalloopError;
 use sctk::reexports::client::globals;
-use sctk::reexports::client::{Connection, Proxy, QueueHandle, WaylandSource};
+use sctk::reexports::client::{Connection, QueueHandle, WaylandSource};
 
 use crate::dpi::{LogicalSize, PhysicalSize};
 use crate::error::{EventLoopError, OsError as RootOsError};
@@ -686,10 +684,12 @@ impl<T> EventLoopWindowTarget<T> {
     #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        let mut display_handle = WaylandDisplayHandle::empty();
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        use sctk::reexports::client::Proxy;
+        let mut display_handle = rwh_0_5::WaylandDisplayHandle::empty();
         display_handle.display = self.connection.display().id().as_ptr() as *mut _;
-        RawDisplayHandle::Wayland(display_handle)
+        rwh_0_5::RawDisplayHandle::Wayland(display_handle)
     }
 }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -45,7 +45,6 @@ use std::{
 use libc::{self, setlocale, LC_CTYPE};
 
 use atoms::*;
-use raw_window_handle::{RawDisplayHandle, XlibDisplayHandle};
 
 use x11rb::x11_utils::X11Error as LogicalError;
 use x11rb::{
@@ -737,11 +736,12 @@ impl<T> EventLoopWindowTarget<T> {
             .expect_then_ignore_error("Failed to update device event filter");
     }
 
-    pub fn raw_display_handle(&self) -> raw_window_handle::RawDisplayHandle {
-        let mut display_handle = XlibDisplayHandle::empty();
+    #[cfg(feature = "rwh-0-5")]
+    pub fn raw_display_handle(&self) -> rwh_0_5::RawDisplayHandle {
+        let mut display_handle = rwh_0_5::XlibDisplayHandle::empty();
         display_handle.display = self.xconn.display as *mut _;
         display_handle.screen = self.xconn.default_screen_index() as c_int;
-        RawDisplayHandle::Xlib(display_handle)
+        rwh_0_5::RawDisplayHandle::Xlib(display_handle)
     }
 }
 

--- a/src/platform_impl/macos/appkit/mod.rs
+++ b/src/platform_impl/macos/appkit/mod.rs
@@ -10,6 +10,7 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::enum_variant_names)]
 #![allow(non_upper_case_globals)]
+#![allow(unused_imports)]
 
 mod appearance;
 mod application;

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -21,7 +21,6 @@ use icrate::Foundation::MainThreadMarker;
 use objc2::rc::{autoreleasepool, Id};
 use objc2::runtime::NSObjectProtocol;
 use objc2::{msg_send_id, ClassType};
-use raw_window_handle::{AppKitDisplayHandle, RawDisplayHandle};
 
 use super::appkit::{NSApp, NSApplication, NSApplicationActivationPolicy, NSEvent, NSWindow};
 use crate::{
@@ -90,8 +89,9 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
     #[inline]
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::AppKit(AppKitDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::AppKit(rwh_0_5::AppKitDisplayHandle::empty())
     }
 }
 

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -10,7 +10,6 @@ use orbclient::{
     ButtonEvent, EventOption, FocusEvent, HoverEvent, KeyEvent, MouseEvent, MoveEvent, QuitEvent,
     ResizeEvent, ScrollEvent, TextInputEvent,
 };
-use raw_window_handle::{OrbitalDisplayHandle, RawDisplayHandle};
 
 use crate::{
     error::EventLoopError,
@@ -768,7 +767,8 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::Orbital(OrbitalDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::Orbital(rwh_0_5::OrbitalDisplayHandle::empty())
     }
 }

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -3,10 +3,6 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use raw_window_handle::{
-    OrbitalDisplayHandle, OrbitalWindowHandle, RawDisplayHandle, RawWindowHandle,
-};
-
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error,
@@ -395,15 +391,17 @@ impl Window {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut handle = OrbitalWindowHandle::empty();
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_window(&self) -> rwh_0_5::RawWindowHandle {
+        let mut handle = rwh_0_5::OrbitalWindowHandle::empty();
         handle.window = self.window_socket.fd as *mut _;
-        RawWindowHandle::Orbital(handle)
+        rwh_0_5::RawWindowHandle::Orbital(handle)
     }
 
     #[inline]
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::Orbital(OrbitalDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::Orbital(rwh_0_5::OrbitalDisplayHandle::empty())
     }
 
     #[inline]

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -5,8 +5,6 @@ use std::iter;
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 
-use raw_window_handle::{RawDisplayHandle, WebDisplayHandle};
-
 use super::runner::EventWrapper;
 use super::{
     super::{monitor::MonitorHandle, KeyEventExtra},
@@ -672,8 +670,9 @@ impl<T> EventLoopWindowTarget<T> {
         None
     }
 
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::Web(WebDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::Web(rwh_0_5::WebDisplayHandle::empty())
     }
 
     pub fn listen_device_events(&self, allowed: DeviceEvents) {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -6,7 +6,6 @@ use crate::window::{
     WindowAttributes, WindowButtons, WindowId as RootWI, WindowLevel,
 };
 
-use raw_window_handle::{RawDisplayHandle, RawWindowHandle, WebDisplayHandle, WebWindowHandle};
 use web_sys::HtmlCanvasElement;
 
 use super::r#async::Dispatcher;
@@ -354,15 +353,17 @@ impl Inner {
     }
 
     #[inline]
-    pub fn raw_window_handle(&self) -> RawWindowHandle {
-        let mut window_handle = WebWindowHandle::empty();
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_window(&self) -> rwh_0_5::RawWindowHandle {
+        let mut window_handle = rwh_0_5::WebWindowHandle::empty();
         window_handle.id = self.id.0;
-        RawWindowHandle::Web(window_handle)
+        rwh_0_5::RawWindowHandle::Web(window_handle)
     }
 
     #[inline]
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::Web(WebDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::Web(rwh_0_5::WebDisplayHandle::empty())
     }
 
     #[inline]

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -18,7 +18,6 @@ use std::{
 };
 
 use once_cell::sync::Lazy;
-use raw_window_handle::{RawDisplayHandle, WindowsDisplayHandle};
 
 use windows_sys::Win32::{
     Devices::HumanInterfaceDevice::MOUSE_MOVE_RELATIVE,
@@ -540,8 +539,9 @@ impl<T> EventLoopWindowTarget<T> {
         Some(monitor)
     }
 
-    pub fn raw_display_handle(&self) -> RawDisplayHandle {
-        RawDisplayHandle::Windows(WindowsDisplayHandle::empty())
+    #[cfg(feature = "rwh-0-5")]
+    pub fn rwh_0_5_display(&self) -> rwh_0_5::RawDisplayHandle {
+        rwh_0_5::RawDisplayHandle::Windows(rwh_0_5::WindowsDisplayHandle::empty())
     }
 
     pub fn listen_device_events(&self, allowed: DeviceEvents) {


### PR DESCRIPTION
`raw-window-handle` has yet to reach v1.0, and I doubt it will do so in the near future. This causes many problems to downstream users, as they must upgrade their `winit` version in lockstep with their `wgpu` (or similar) version.
In the past, we've been able to do the semver trick in `raw-window-handle`, but with the current API that's no longer possible.

So, until `raw-window-handle` becomes stable, I propose we make dependency on any version of `raw-window-handle` optional, and behind it's own feature flag, to make it possible for the user to select the version that they want.

This allows us to provide a much better support strategy, where instead of immediately removing support for older versions of `raw-window-handle` and forcing users to upgrade their rendering library, we instead slowly deprecate, perhaps over several releases if deemed necessary.

TODO:
- [x] Finish the implementation.
- [ ] Add an entry to `CHANGELOG.md`
- [ ] Figure out how to do examples now
