### PR TITLE
Mark `startup_notify` unsafe functions as safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, take all transient activations on the canvas and window into account to queue a fullscreen request.
 - On Web, remove any fullscreen requests from the queue when an external fullscreen activation was detected.
 - On Wayland, fix `TouchPhase::Canceled` being sent for moved events.
+- Mark `startup_notify` unsafe functions as safe.
 
 # 0.29.1-beta
 

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -85,12 +85,7 @@ impl WindowBuilderExtStartupNotify for WindowBuilder {
 ///
 /// This is wise to do before running child processes,
 /// which may not to support the activation token.
-///
-/// # Safety
-///
-/// While the function is safe internally, it mutates the global environment
-/// state for the process, hence unsafe.
-pub unsafe fn reset_activation_token_env() {
+pub fn reset_activation_token_env() {
     env::remove_var(X11_VAR);
     env::remove_var(WAYLAND_VAR);
 }
@@ -98,12 +93,7 @@ pub unsafe fn reset_activation_token_env() {
 /// Set environment variables responsible for activation token.
 ///
 /// This could be used before running daemon processes.
-///
-/// # Safety
-///
-/// While the function is safe internally, it mutates the global environment
-/// state for the process, hence unsafe.
-pub unsafe fn set_activation_token_env(token: ActivationToken) {
+pub fn set_activation_token_env(token: ActivationToken) {
     env::set_var(X11_VAR, &token._token);
     env::set_var(WAYLAND_VAR, token._token);
 }


### PR DESCRIPTION
They are safe, since they use the rust `std::env` stuff. Making them safe lets downstream to determine that `std::env` is used and not the `libc` env manipulation routines, which are unsafe.
