### PR TITLE
Web: Remove `T` from `EventLoopTargetWindow`

### DIFF
--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::sync::mpsc::{self, Receiver, Sender};
 
 use crate::error::EventLoopError;
 use crate::event::Event;
@@ -16,6 +17,8 @@ pub use window_target::EventLoopWindowTarget;
 
 pub struct EventLoop<T: 'static> {
     elw: RootEventLoopWindowTarget<T>,
+    user_event_sender: Sender<T>,
+    user_event_receiver: Receiver<T>,
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -23,11 +26,14 @@ pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
 impl<T> EventLoop<T> {
     pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> Result<Self, EventLoopError> {
+        let (user_event_sender, user_event_receiver) = mpsc::channel();
         Ok(EventLoop {
             elw: RootEventLoopWindowTarget {
                 p: EventLoopWindowTarget::new(),
                 _marker: PhantomData,
             },
+            user_event_sender,
+            user_event_receiver,
         })
     }
 
@@ -41,8 +47,18 @@ impl<T> EventLoop<T> {
         };
 
         // SAFETY: Don't use `move` to make sure we leak the `event_handler` and `target`.
-        let handler: Box<dyn FnMut(_, _)> =
-            Box::new(|event, flow| event_handler(event, &target, flow));
+        let handler: Box<dyn FnMut(Event<()>, _)> = Box::new(|event, flow| {
+            let event = match event.map_nonuser_event() {
+                Ok(event) => event,
+                Err(Event::UserEvent(())) => Event::UserEvent(
+                    self.user_event_receiver
+                        .try_recv()
+                        .expect("handler woken up without user event"),
+                ),
+                Err(_) => unreachable!(),
+            };
+            event_handler(event, &target, flow)
+        });
         // SAFETY: The `transmute` is necessary because `run()` requires `'static`. This is safe
         // because this function will never return and all resources not cleaned up by the point we
         // `throw` will leak, making this actually `'static`.
@@ -68,13 +84,24 @@ impl<T> EventLoop<T> {
         };
 
         self.elw.p.run(
-            Box::new(move |event, flow| event_handler(event, &target, flow)),
+            Box::new(move |event, flow| {
+                let event = match event.map_nonuser_event() {
+                    Ok(event) => event,
+                    Err(Event::UserEvent(())) => Event::UserEvent(
+                        self.user_event_receiver
+                            .try_recv()
+                            .expect("handler woken up without user event"),
+                    ),
+                    Err(_) => unreachable!(),
+                };
+                event_handler(event, &target, flow)
+            }),
             true,
         );
     }
 
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
-        self.elw.p.proxy()
+        EventLoopProxy::new(self.elw.p.runner.clone(), self.user_event_sender.clone())
     }
 
     pub fn window_target(&self) -> &RootEventLoopWindowTarget<T> {

--- a/src/platform_impl/web/event_loop/proxy.rs
+++ b/src/platform_impl/web/event_loop/proxy.rs
@@ -1,24 +1,30 @@
+use std::sync::mpsc::Sender;
+
 use super::runner;
 use crate::event::Event;
 use crate::event_loop::EventLoopClosed;
 use crate::platform_impl::platform::r#async::Channel;
 
 pub struct EventLoopProxy<T: 'static> {
-    runner: Channel<runner::Shared<T>, T>,
+    // used to wake the event loop handler, not to actually pass data
+    runner: Channel<runner::Shared, ()>,
+    sender: Sender<T>,
 }
 
 impl<T: 'static> EventLoopProxy<T> {
-    pub fn new(runner: runner::Shared<T>) -> Self {
+    pub fn new(runner: runner::Shared, sender: Sender<T>) -> Self {
         Self {
             runner: Channel::new(runner, |runner, event| {
                 runner.send_event(Event::UserEvent(event))
             })
             .unwrap(),
+            sender,
         }
     }
 
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
-        self.runner.send(event);
+        self.sender.send(event).unwrap();
+        self.runner.send(());
         Ok(())
     }
 }
@@ -27,6 +33,7 @@ impl<T: 'static> Clone for EventLoopProxy<T> {
     fn clone(&self) -> Self {
         Self {
             runner: self.runner.clone(),
+            sender: self.sender.clone(),
         }
     }
 }

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -463,10 +463,10 @@ impl Canvas {
         self.animation_frame_handler.request();
     }
 
-    pub(crate) fn handle_scale_change<T: 'static>(
+    pub(crate) fn handle_scale_change(
         &self,
-        runner: &super::super::event_loop::runner::Shared<T>,
-        event_handler: impl FnOnce(crate::event::Event<T>),
+        runner: &super::super::event_loop::runner::Shared,
+        event_handler: impl FnOnce(crate::event::Event<()>),
         current_size: PhysicalSize<u32>,
         scale: f64,
     ) {


### PR DESCRIPTION
Thanks to @nerditation.

Currently our custom `Channel` type actually uses an `std::mpsc` channel to send `()` to wake up the event loop. This is obviously nonsense because the actual user event already uses an `std::mpsc` and that way it can only handle a single user event at a time. I'm working currently on a rework that simply uses a `AtomicUsize` to figure out exactly how many user events have been sent without any channel to begin with. Or maybe some other idea I can come up with :sweat_smile:.

Fixes the Web backend for #3053.