### PR TITLE
Add option to use `Window.requestIdleCallback()` for `ControlFlow::Poll`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 
 - Make iOS `MonitorHandle` and `VideoMode` usable from other threads.
 - Fix window size sometimes being invalid when resizing on macOS.
-- On Web, `ControlFlow::Poll` and `ControlFlow::WaitUntil` are now using the Prioritized Task Scheduling API. `setTimeout()` with a trick to circumvent throttling to 4ms is used as a fallback.
+- On Web, `ControlFlow::WaitUntil` now uses the Prioritized Task Scheduling API. `setTimeout()`, with a trick to circumvent throttling to 4ms, is used as a fallback.
 - On Web, never return a `MonitorHandle`.
 - **Breaking:** Move `Event::RedrawRequested` to `WindowEvent::RedrawRequested`.
 - On macOS, fix crash in `window.set_minimized(false)`.
@@ -22,6 +22,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Fix a bug where Wayland would be chosen on Linux even if the user specified `with_x11`. (#3058)
 - **Breaking:** Moved `ControlFlow` to `EventLoopWindowTarget::set_control_flow()` and `EventLoopWindowTarget::control_flow()`.
 - **Breaking:** Moved `ControlFlow::Exit` to `EventLoopWindowTarget::exit()` and `EventLoopWindowTarget::exiting()` and removed `ControlFlow::ExitWithCode(_)` entirely.
+- On Web, add `EventLoopWindowTargetExtWebSys` and `PollType`, which allows to set different strategies for `ControlFlow::Poll`. By default the Prioritized Task Scheduling API is used, but an option to use `Window.requestIdleCallback` is available as well. Both use `setTimeout()`, with a trick to circumvent throttling to 4ms, as a fallback.
 
 # 0.29.1-beta
 

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -134,3 +134,57 @@ impl<T> EventLoopExtWebSys for EventLoop<T> {
         self.event_loop.spawn(event_handler)
     }
 }
+
+pub trait EventLoopWindowTargetExtWebSys {
+    /// Sets the strategy for [`ControlFlow::Poll`].
+    ///
+    /// See [`PollType`].
+    ///
+    /// [`ControlFlow::Poll`]: crate::event_loop::ControlFlow::Poll
+    fn set_poll_type(&self, poll_type: PollType);
+
+    /// Gets the strategy for [`ControlFlow::Poll`].
+    ///
+    /// See [`PollType`].
+    ///
+    /// [`ControlFlow::Poll`]: crate::event_loop::ControlFlow::Poll
+    fn poll_type(&self) -> PollType;
+}
+
+impl<T> EventLoopWindowTargetExtWebSys for EventLoopWindowTarget<T> {
+    #[inline]
+    fn set_poll_type(&self, poll_type: PollType) {
+        self.p.set_poll_type(poll_type);
+    }
+
+    #[inline]
+    fn poll_type(&self) -> PollType {
+        self.p.poll_type()
+    }
+}
+
+/// Strategy used for [`ControlFlow::Poll`](crate::event_loop::ControlFlow::Poll).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum PollType {
+    /// Uses [`Window.requestIdleCallback()`] to queue the next event loop. If not available
+    /// this will fallback to [`setTimeout()`].
+    ///
+    /// This strategy will wait for the browser to enter an idle period before running and might
+    /// be affected by browser throttling.
+    ///
+    /// [`Window.requestIdleCallback()`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
+    /// [`setTimeout()`]: https://developer.mozilla.org/en-US/docs/Web/API/setTimeout
+    IdleCallback,
+    /// Uses the [Prioritized Task Scheduling API] to queue the next event loop. If not available
+    /// this will fallback to [`setTimeout()`].
+    ///
+    /// This strategy will run as fast as possible without disturbing users from interacting with
+    /// the page and is not affected by browser throttling.
+    ///
+    /// This is the default strategy.
+    ///
+    /// [Prioritized Task Scheduling API]: https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API
+    /// [`setTimeout()`]: https://developer.mozilla.org/en-US/docs/Web/API/setTimeout
+    #[default]
+    Scheduler,
+}

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -21,6 +21,7 @@ use crate::event::{
 };
 use crate::event_loop::{ControlFlow, DeviceEvents};
 use crate::keyboard::ModifiersState;
+use crate::platform::web::PollType;
 use crate::window::{Theme, WindowId as RootWindowId};
 
 #[derive(Default)]
@@ -693,5 +694,13 @@ impl<T> EventLoopWindowTarget<T> {
 
     pub(crate) fn exiting(&self) -> bool {
         self.runner.exiting()
+    }
+
+    pub(crate) fn set_poll_type(&self, poll_type: PollType) {
+        self.runner.set_poll_type(poll_type)
+    }
+
+    pub(crate) fn poll_type(&self) -> PollType {
+        self.runner.poll_type()
     }
 }

--- a/src/platform_impl/web/web_sys/schedule.rs
+++ b/src/platform_impl/web/web_sys/schedule.rs
@@ -6,41 +6,61 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{AbortController, AbortSignal, MessageChannel, MessagePort};
 
+use crate::platform::web::PollType;
+
 #[derive(Debug)]
-pub struct Schedule(Inner);
+pub struct Schedule {
+    _closure: Closure<dyn FnMut()>,
+    inner: Inner,
+}
 
 #[derive(Debug)]
 enum Inner {
     Scheduler {
         controller: AbortController,
-        _closure: Closure<dyn FnMut()>,
+    },
+    IdleCallback {
+        window: web_sys::Window,
+        handle: u32,
     },
     Timeout {
         window: web_sys::Window,
         handle: i32,
         port: MessagePort,
-        _message_closure: Closure<dyn FnMut()>,
         _timeout_closure: Closure<dyn FnMut()>,
     },
 }
 
 impl Schedule {
-    pub fn new<F>(window: web_sys::Window, f: F, duration: Option<Duration>) -> Schedule
+    pub fn new<F>(poll_type: PollType, window: &web_sys::Window, f: F) -> Schedule
     where
         F: 'static + FnMut(),
     {
-        if has_scheduler_support(&window) {
-            Self::new_scheduler(window, f, duration)
+        if poll_type == PollType::Scheduler && has_scheduler_support(window) {
+            Self::new_scheduler(window, f, None)
+        } else if poll_type == PollType::IdleCallback && has_idle_callback_support(window) {
+            Self::new_idle_callback(window.clone(), f)
         } else {
-            Self::new_timeout(window, f, duration)
+            Self::new_timeout(window.clone(), f, None)
         }
     }
 
-    fn new_scheduler<F>(window: web_sys::Window, f: F, duration: Option<Duration>) -> Schedule
+    pub fn new_with_duration<F>(window: &web_sys::Window, f: F, duration: Duration) -> Schedule
     where
         F: 'static + FnMut(),
     {
-        let window: WindowSupportExt = window.unchecked_into();
+        if has_scheduler_support(window) {
+            Self::new_scheduler(window, f, Some(duration))
+        } else {
+            Self::new_timeout(window.clone(), f, Some(duration))
+        }
+    }
+
+    fn new_scheduler<F>(window: &web_sys::Window, f: F, duration: Option<Duration>) -> Schedule
+    where
+        F: 'static + FnMut(),
+    {
+        let window: &WindowSupportExt = window.unchecked_ref();
         let scheduler = window.scheduler();
 
         let closure = Closure::new(f);
@@ -61,10 +81,25 @@ impl Schedule {
                 .catch(handler);
         });
 
-        Schedule(Inner::Scheduler {
-            controller,
+        Schedule {
             _closure: closure,
-        })
+            inner: Inner::Scheduler { controller },
+        }
+    }
+
+    fn new_idle_callback<F>(window: web_sys::Window, f: F) -> Schedule
+    where
+        F: 'static + FnMut(),
+    {
+        let closure = Closure::new(f);
+        let handle = window
+            .request_idle_callback(closure.as_ref().unchecked_ref())
+            .expect("Failed to request idle callback");
+
+        Schedule {
+            _closure: closure,
+            inner: Inner::IdleCallback { window, handle },
+        }
     }
 
     fn new_timeout<F>(window: web_sys::Window, f: F, duration: Option<Duration>) -> Schedule
@@ -72,10 +107,10 @@ impl Schedule {
         F: 'static + FnMut(),
     {
         let channel = MessageChannel::new().unwrap();
-        let message_closure = Closure::new(f);
+        let closure = Closure::new(f);
         let port_1 = channel.port1();
         port_1
-            .add_event_listener_with_callback("message", message_closure.as_ref().unchecked_ref())
+            .add_event_listener_with_callback("message", closure.as_ref().unchecked_ref())
             .expect("Failed to set message handler");
         port_1.start();
 
@@ -95,20 +130,23 @@ impl Schedule {
         }
         .expect("Failed to set timeout");
 
-        Schedule(Inner::Timeout {
-            window,
-            handle,
-            port: port_1,
-            _message_closure: message_closure,
-            _timeout_closure: timeout_closure,
-        })
+        Schedule {
+            _closure: closure,
+            inner: Inner::Timeout {
+                window,
+                handle,
+                port: port_1,
+                _timeout_closure: timeout_closure,
+            },
+        }
     }
 }
 
 impl Drop for Schedule {
     fn drop(&mut self) {
-        match &self.0 {
+        match &self.inner {
             Inner::Scheduler { controller, .. } => controller.abort(),
+            Inner::IdleCallback { window, handle, .. } => window.cancel_idle_callback(*handle),
             Inner::Timeout {
                 window,
                 handle,
@@ -140,6 +178,27 @@ fn has_scheduler_support(window: &web_sys::Window) -> bool {
             let support: &SchedulerSupport = window.unchecked_ref();
 
             !support.has_scheduler().is_undefined()
+        })
+    })
+}
+
+fn has_idle_callback_support(window: &web_sys::Window) -> bool {
+    thread_local! {
+        static IDLE_CALLBACK_SUPPORT: OnceCell<bool> = OnceCell::new();
+    }
+
+    IDLE_CALLBACK_SUPPORT.with(|support| {
+        *support.get_or_init(|| {
+            #[wasm_bindgen]
+            extern "C" {
+                type IdleCallbackSupport;
+
+                #[wasm_bindgen(method, getter, js_name = requestIdleCallback)]
+                fn has_request_idle_callback(this: &IdleCallbackSupport) -> JsValue;
+            }
+
+            let support: &IdleCallbackSupport = window.unchecked_ref();
+            !support.has_request_idle_callback().is_undefined()
         })
     })
 }


### PR DESCRIPTION
This PR builds on top of #3056 and adds a new extension method on `EventLoopWindowTarget` to set the strategy for `ControlFlow::Poll`. By default the [Prioritized Task Scheduling API](https://developer.mozilla.org/en-US/docs/Web/API/Prioritized_Task_Scheduling_API) is used, this adds the option to use [`Window.requestIdleCallback()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) instead.

Both strategies fallback on [`setTimeout()`](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout) when not available.

Cc @GloopShlugger.
Originally implemented in #2880 and then reverted in #3044.
Requires #3056.