### PR TITLE
Revert select_xkb_events to its previous impl

### DIFF
--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -1,8 +1,7 @@
 use std::{slice, str};
-use x11rb::errors::{ConnectionError, ReplyError};
 use x11rb::protocol::{
     xinput::{self, ConnectionExt as _},
-    xkb::{self, ConnectionExt as _},
+    xkb,
 };
 
 use super::*;
@@ -38,31 +37,16 @@ impl XConnection {
         device_id: xkb::DeviceSpec,
         mask: xkb::EventType,
     ) -> Result<bool, X11Error> {
-        let result = self
-            .xcb_connection()
-            .xkb_select_events(
-                device_id,
-                xkb::EventType::from(0u8),
-                mask,
-                xkb::MapPart::from(u16::from(mask)),
-                xkb::MapPart::EXPLICIT_COMPONENTS
-                    | xkb::MapPart::KEY_ACTIONS
-                    | xkb::MapPart::KEY_BEHAVIORS
-                    | xkb::MapPart::VIRTUAL_MODS
-                    | xkb::MapPart::MODIFIER_MAP
-                    | xkb::MapPart::VIRTUAL_MOD_MAP,
-                &xkb::SelectEventsAux::new(),
-            )
-            .map_err(ReplyError::from)
-            .and_then(|x| x.check());
+        let mask = u16::from(mask) as _;
+        let status =
+            unsafe { (self.xlib.XkbSelectEvents)(self.display, device_id as _, mask, mask) };
 
-        match result {
-            Ok(()) => Ok(true),
-            Err(ReplyError::ConnectionError(ConnectionError::UnsupportedExtension)) => {
-                error!("Could not select XKB events: The XKB extension is not initialized!");
-                Ok(false)
-            }
-            Err(e) => Err(e.into()),
+        if status == ffi::True {
+            self.flush_requests()?;
+            Ok(true)
+        } else {
+            error!("Could not select XKB events: The XKB extension is not initialized!");
+            Ok(false)
         }
     }
 


### PR DESCRIPTION
The new implementation of select_xkb_events apparently misconfigures the server. This commit does a temporary fix by just reverting it to its previous implementation.

This is temporary until I can figure out what Xlib is doing behind the scenes or until I read xkbproto.pdf.

Closes #3079 for now

- [x] Tested on all platforms changed
- [] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
