### PR TITLE
Correct set_exit() -> exit() in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Mark `startup_notify` unsafe functions as safe.
 - Fix a bug where Wayland would be chosen on Linux even if the user specified `with_x11`. (#3058)
 - **Breaking:** Moved `ControlFlow` to `EventLoopWindowTarget::set_control_flow()` and `EventLoopWindowTarget::control_flow()`.
-- **Breaking:** Moved `ControlFlow::Exit` to `EventLoopWindowTarget::set_exit()` and `EventLoopWindowTarget::exiting()` and removed `ControlFlow::ExitWithCode(_)` entirely.
+- **Breaking:** Moved `ControlFlow::Exit` to `EventLoopWindowTarget::exit()` and `EventLoopWindowTarget::exiting()` and removed `ControlFlow::ExitWithCode(_)` entirely.
 
 # 0.29.1-beta
 


### PR DESCRIPTION
Small fix for changelog entry of #3056.