### PR TITLE
Fix WaitUntil on X11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Moved `ControlFlow::Exit` to `EventLoopWindowTarget::exit()` and `EventLoopWindowTarget::exiting()` and removed `ControlFlow::ExitWithCode(_)` entirely.
 - On Web, add `EventLoopWindowTargetExtWebSys` and `PollStrategy`, which allows to set different strategies for `ControlFlow::Poll`. By default the Prioritized Task Scheduling API is used, but an option to use `Window.requestIdleCallback` is available as well. Both use `setTimeout()`, with a trick to circumvent throttling to 4ms, as a fallback.
 - Implement `PartialOrd` and `Ord` for `MouseButton`.
+- On X11, fix event loop not waking up on `ControlFlow::Poll` and `ControlFlow::WaitUntil`.
 
 # 0.29.1-beta
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -537,8 +537,10 @@ impl<T: 'static> EventLoop<T> {
         // running a loop iteration.
         // If we don't have any pending `_receiver`
         if !self.has_pending()
-            && !self.state.x11_readiness.readable
-            && !matches!(&cause, StartCause::ResumeTimeReached { .. })
+            && !matches!(
+                &cause,
+                StartCause::ResumeTimeReached { .. } | StartCause::Poll
+            )
         {
             return;
         }


### PR DESCRIPTION
It seems that WaitUntil is currently broken on X11: no events are received when the timer expires, unless there is an actual window event. This issue seems to be introduced in c47d08. This PR adds an additional condition to the spurious wake up check, recognizing ResumeTimeReached as a valid cause to wake up.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
