### PR TITLE
Install `cargo-apk` with the stable toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.toolchain }}${{ matrix.platform.host }}
-        targets: ${{ matrix.platform.target }}
-        components: clippy
-
     - name: Restore cache of cargo folder
       # We use `restore` and later `save`, so that we can create the key after
       # the cache has been downloaded.
@@ -100,11 +94,22 @@ jobs:
       with:
         path: ~/.cargo/bin/cargo-apk
         # Change this key if we update the required cargo-apk version
-        key: cargo-apk-${{ matrix.toolchain }}-${{ matrix.platform.name }}-v0-9-7
+        key: cargo-apk-v0-9-7
+
+    - uses: dtolnay/rust-toolchain@master
+      if: contains(matrix.platform.target, 'android') && (steps.cargo-apk-cache.outputs.cache-hit != 'true')
+      with:
+        toolchain: stable
 
     - name: Install cargo-apk
       if: contains(matrix.platform.target, 'android') && (steps.cargo-apk-cache.outputs.cache-hit != 'true')
       run: cargo install cargo-apk --version=^0.9.7 --locked
+
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}${{ matrix.platform.host }}
+        targets: ${{ matrix.platform.target }}
+        components: clippy
 
     - name: Check documentation
       run: cargo doc --no-deps $OPTIONS --document-private-items


### PR DESCRIPTION
I noticed that the `cargo-apk` installation fails because it's currently broken on nightly, but even if we want to test Android on nightly, we require `cargo-apk` to be installed with the nightly toolchain.

Also removed caching nightly and stable `cargo-apk` separately, the output is the same now after all.