### PR TITLE
Also implement `PartialOrd` and `Ord` for `MouseButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - **Breaking:** Moved `ControlFlow` to `EventLoopWindowTarget::set_control_flow()` and `EventLoopWindowTarget::control_flow()`.
 - **Breaking:** Moved `ControlFlow::Exit` to `EventLoopWindowTarget::exit()` and `EventLoopWindowTarget::exiting()` and removed `ControlFlow::ExitWithCode(_)` entirely.
 - On Web, add `EventLoopWindowTargetExtWebSys` and `PollStrategy`, which allows to set different strategies for `ControlFlow::Poll`. By default the Prioritized Task Scheduling API is used, but an option to use `Window.requestIdleCallback` is available as well. Both use `setTimeout()`, with a trick to circumvent throttling to 4ms, as a fallback.
+- Implement `PartialOrd` and `Ord` for `MouseButton`.
 
 # 0.29.1-beta
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1029,7 +1029,7 @@ impl ElementState {
 ///
 /// **macOS:** `Back` and `Forward` might not work with all hardware.
 /// **Orbital:** `Back` and `Forward` are unsupported due to orbital not supporting them.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MouseButton {
     Left,


### PR DESCRIPTION
Basically for the same reason as #2918

I want to use the mouse buttons for a bind, which requires sorting. I assume they are also kind of hardware keys, at least that's how i used them back then with SDL2

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
