### PR TITLE
Make `ControlFlow::Wait` the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, add `EventLoopWindowTargetExtWebSys` and `PollStrategy`, which allows to set different strategies for `ControlFlow::Poll`. By default the Prioritized Task Scheduling API is used, but an option to use `Window.requestIdleCallback` is available as well. Both use `setTimeout()`, with a trick to circumvent throttling to 4ms, as a fallback.
 - Implement `PartialOrd` and `Ord` for `MouseButton`.
 - On X11, fix event loop not waking up on `ControlFlow::Poll` and `ControlFlow::WaitUntil`.
+- **Breaking:** Change default `ControlFlow` to `Wait`.
 
 # 0.29.1-beta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Web, add `EventLoopWindowTargetExtWebSys` and `PollStrategy`, which allows to set different strategies for `ControlFlow::Poll`. By default the Prioritized Task Scheduling API is used, but an option to use `Window.requestIdleCallback` is available as well. Both use `setTimeout()`, with a trick to circumvent throttling to 4ms, as a fallback.
 - Implement `PartialOrd` and `Ord` for `MouseButton`.
 - On X11, fix event loop not waking up on `ControlFlow::Poll` and `ControlFlow::WaitUntil`.
-- **Breaking:** Change default `ControlFlow` to `Wait`.
+- **Breaking:** Change default `ControlFlow` from `Poll` to `Wait`.
 
 # 0.29.1-beta
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ another library.
 ```rust
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -44,8 +44,6 @@ fn main() {
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         dpi::{LogicalPosition, LogicalSize, Position},
         event::{ElementState, Event, KeyEvent, WindowEvent},
-        event_loop::{ControlFlow, EventLoop, EventLoopWindowTarget},
+        event_loop::{EventLoop, EventLoopWindowTarget},
         window::raw_window_handle::HasRawWindowHandle,
         window::{Window, WindowBuilder, WindowId},
     };
@@ -47,8 +47,6 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("parent window: {parent_window:?})");
 
     event_loop.run(move |event: Event<()>, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::{CursorIcon, WindowBuilder},
 };
 
@@ -20,8 +20,6 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut cursor_idx = 0;
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::KeyboardInput {

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{DeviceEvent, ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::{Key, ModifiersState},
     window::{CursorGrabMode, WindowBuilder},
 };
@@ -22,56 +22,52 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut modifiers = ModifiersState::default();
 
-    event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
-        match event {
-            Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => elwt.exit(),
-                WindowEvent::KeyboardInput {
-                    event:
-                        KeyEvent {
-                            logical_key: key,
-                            state: ElementState::Released,
-                            ..
-                        },
-                    ..
-                } => {
-                    let result = match key {
-                        Key::Escape => {
-                            elwt.exit();
+    event_loop.run(move |event, elwt| match event {
+        Event::WindowEvent { event, .. } => match event {
+            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        logical_key: key,
+                        state: ElementState::Released,
+                        ..
+                    },
+                ..
+            } => {
+                let result = match key {
+                    Key::Escape => {
+                        elwt.exit();
+                        Ok(())
+                    }
+                    Key::Character(ch) => match ch.to_lowercase().as_str() {
+                        "g" => window.set_cursor_grab(CursorGrabMode::Confined),
+                        "l" => window.set_cursor_grab(CursorGrabMode::Locked),
+                        "a" => window.set_cursor_grab(CursorGrabMode::None),
+                        "h" => {
+                            window.set_cursor_visible(modifiers.shift_key());
                             Ok(())
                         }
-                        Key::Character(ch) => match ch.to_lowercase().as_str() {
-                            "g" => window.set_cursor_grab(CursorGrabMode::Confined),
-                            "l" => window.set_cursor_grab(CursorGrabMode::Locked),
-                            "a" => window.set_cursor_grab(CursorGrabMode::None),
-                            "h" => {
-                                window.set_cursor_visible(modifiers.shift_key());
-                                Ok(())
-                            }
-                            _ => Ok(()),
-                        },
                         _ => Ok(()),
-                    };
+                    },
+                    _ => Ok(()),
+                };
 
-                    if let Err(err) = result {
-                        println!("error: {err}");
-                    }
+                if let Err(err) = result {
+                    println!("error: {err}");
                 }
-                WindowEvent::ModifiersChanged(new) => modifiers = new.state(),
-                WindowEvent::RedrawRequested => fill::fill_window(&window),
-                _ => (),
-            },
-            Event::DeviceEvent { event, .. } => match event {
-                DeviceEvent::MouseMotion { delta } => println!("mouse moved: {delta:?}"),
-                DeviceEvent::Button { button, state } => match state {
-                    ElementState::Pressed => println!("mouse button {button} pressed"),
-                    ElementState::Released => println!("mouse button {button} released"),
-                },
-                _ => (),
+            }
+            WindowEvent::ModifiersChanged(new) => modifiers = new.state(),
+            WindowEvent::RedrawRequested => fill::fill_window(&window),
+            _ => (),
+        },
+        Event::DeviceEvent { event, .. } => match event {
+            DeviceEvent::MouseMotion { delta } => println!("mouse moved: {delta:?}"),
+            DeviceEvent::Button { button, state } => match state {
+                ElementState::Pressed => println!("mouse button {button} pressed"),
+                ElementState::Released => println!("mouse button {button} released"),
             },
             _ => (),
-        }
+        },
+        _ => (),
     })
 }

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -5,7 +5,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoopBuilder},
+        event_loop::EventLoopBuilder,
         window::WindowBuilder,
     };
 
@@ -40,23 +40,19 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     });
 
-    event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
-        match event {
-            Event::UserEvent(event) => println!("user event: {event:?}"),
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => elwt.exit(),
-            Event::WindowEvent {
-                event: WindowEvent::RedrawRequested,
-                ..
-            } => {
-                fill::fill_window(&window);
-            }
-            _ => (),
+    event_loop.run(move |event, elwt| match event {
+        Event::UserEvent(event) => println!("user event: {event:?}"),
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            ..
+        } => elwt.exit(),
+        Event::WindowEvent {
+            event: WindowEvent::RedrawRequested,
+            ..
+        } => {
+            fill::fill_window(&window);
         }
+        _ => (),
     })
 }
 

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::dpi::PhysicalSize;
 use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoop};
+use winit::event_loop::EventLoop;
 use winit::keyboard::Key;
 use winit::window::{Fullscreen, WindowBuilder};
 
@@ -53,8 +53,6 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("- A\tToggle mAx size limit");
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => elwt.exit(),

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::Key,
     window::WindowBuilder,
 };
@@ -23,8 +23,6 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut close_requested = false;
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => {

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -5,7 +5,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{ElementState, Event, Ime, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::{Key, KeyCode},
     window::{ImePurpose, WindowBuilder},
 };
@@ -40,7 +40,6 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut ime_pos = PhysicalPosition::new(0.0, 0.0);
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => elwt.exit(),

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -4,7 +4,7 @@
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::{Key, ModifiersState},
     // WARNING: This is not available on all platforms (for example on the web).
     platform::modifier_supplement::KeyEventExtModifierSupplement,
@@ -32,8 +32,6 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut modifiers = ModifiersState::default();
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => elwt.exit(),

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -35,8 +35,6 @@ In other words, the deltas indicate the direction in which to move the content (
     );
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => elwt.exit(),

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         dpi::{PhysicalPosition, PhysicalSize, Position, Size},
         event::{ElementState, Event, KeyEvent, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         keyboard::{Key, ModifiersState},
         window::{CursorGrabMode, CursorIcon, Fullscreen, WindowBuilder, WindowLevel},
     };
@@ -174,10 +174,9 @@ fn main() -> Result<(), impl std::error::Error> {
         });
     }
     event_loop.run(move |event, elwt| {
-        match !window_senders.is_empty() {
-            true => elwt.set_control_flow(ControlFlow::Wait),
-            false => elwt.exit(),
-        };
+        if window_senders.is_empty() {
+            elwt.exit()
+        }
         match event {
             Event::WindowEvent { event, window_id } => match event {
                 WindowEvent::CloseRequested

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::Key,
     window::Window,
 };
@@ -27,8 +27,6 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Press N to open a new window.");
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -21,8 +21,6 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.run(move |event, elwt| {
         println!("{event:?}");
-
-        elwt.set_control_flow(ControlFlow::Wait);
 
         if let Event::WindowEvent { event, .. } = event {
             match event {

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         window::WindowBuilder,
     };
 
@@ -35,8 +35,6 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.run(move |event, elwt| {
         println!("{event:?}");
-
-        elwt.set_control_flow(ControlFlow::Wait);
 
         match event {
             Event::WindowEvent {

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -4,7 +4,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::KeyCode,
     window::WindowBuilder,
 };
@@ -28,8 +28,6 @@ fn main() -> Result<(), impl std::error::Error> {
         .unwrap();
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => elwt.exit(),

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -10,7 +10,7 @@ mod example {
     use std::rc::Rc;
 
     use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
-    use winit::event_loop::{ControlFlow, EventLoop};
+    use winit::event_loop::EventLoop;
     use winit::keyboard::Key;
     use winit::platform::startup_notify::{
         EventLoopExtStartupNotify, WindowBuilderExtStartupNotify, WindowExtStartupNotify,
@@ -102,8 +102,6 @@ mod example {
                 counter += 1;
                 create_first_window = false;
             }
-
-            elwt.set_control_flow(ControlFlow::Wait);
         })
     }
 }

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::Key,
     window::{Theme, WindowBuilder},
 };
@@ -28,8 +28,6 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("  (D) Dark theme");
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { window_id, event } = event {
             match event {
                 WindowEvent::CloseRequested => elwt.exit(),

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -1,7 +1,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -20,8 +20,6 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Only supported on macOS at the moment.");
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => elwt.exit(),

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -23,7 +23,6 @@ fn main() -> Result<(), impl std::error::Error> {
     window.set_title("A fantastic window!");
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
         println!("{event:?}");
 
         if let Event::WindowEvent { event, .. } = event {

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -2,7 +2,7 @@
 
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::KeyCode,
     window::{Fullscreen, WindowBuilder},
 };
@@ -22,8 +22,6 @@ pub fn main() -> Result<(), impl std::error::Error> {
     let log_list = wasm::insert_canvas_and_create_log_list(&window);
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         #[cfg(wasm_platform)]
         wasm::log_event(&log_list, &event);
 

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -12,7 +12,7 @@ mod wasm {
     use winit::{
         dpi::PhysicalSize,
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         platform::web::WindowBuilderExtWebSys,
         window::{Window, WindowBuilder},
     };
@@ -47,18 +47,14 @@ This example demonstrates the desired future functionality which will possibly b
         // Render once with the size info we currently have
         render_circle(&canvas, window.inner_size());
 
-        let _ = event_loop.run(move |event, elwt| {
-            elwt.set_control_flow(ControlFlow::Wait);
-
-            match event {
-                Event::WindowEvent {
-                    event: WindowEvent::Resized(resize),
-                    window_id,
-                } if window_id == window.id() => {
-                    render_circle(&canvas, resize);
-                }
-                _ => (),
+        let _ = event_loop.run(move |event, _| match event {
+            Event::WindowEvent {
+                event: WindowEvent::Resized(resize),
+                window_id,
+            } if window_id == window.id() => {
+                render_circle(&canvas, resize);
             }
+            _ => (),
         });
     }
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -3,7 +3,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -21,7 +21,6 @@ fn main() -> Result<(), impl std::error::Error> {
         .unwrap();
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
         println!("{event:?}");
 
         match event {

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -6,7 +6,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, DeviceEvents, EventLoop},
+    event_loop::{DeviceEvents, EventLoop},
     keyboard::Key,
     window::{WindowBuilder, WindowButtons},
 };
@@ -32,8 +32,6 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.listen_device_events(DeviceEvents::Always);
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { window_id, event } = event {
             match event {
                 WindowEvent::KeyboardInput {

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -6,7 +6,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::{LogicalSize, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, KeyEvent, RawKeyEvent, WindowEvent},
-    event_loop::{ControlFlow, DeviceEvents, EventLoop},
+    event_loop::{DeviceEvents, EventLoop},
     keyboard::{Key, KeyCode},
     window::{Fullscreen, WindowBuilder},
 };
@@ -39,8 +39,6 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.listen_device_events(DeviceEvents::Always);
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         match event {
             // This used to use the virtual key, but the new API
             // only provides the `physical_key` (`Code`).

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use simple_logger::SimpleLogger;
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::{Icon, WindowBuilder},
 };
 
@@ -34,8 +34,6 @@ fn main() -> Result<(), impl std::error::Error> {
         .unwrap();
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => elwt.exit(),

--- a/examples/window_ondemand.rs
+++ b/examples/window_ondemand.rs
@@ -10,7 +10,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         error::EventLoopError,
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         platform::run_ondemand::EventLoopExtRunOnDemand,
         window::{Window, WindowBuilder, WindowId},
     };
@@ -31,7 +31,6 @@ fn main() -> Result<(), impl std::error::Error> {
         let mut app = App::default();
 
         event_loop.run_ondemand(move |event, elwt| {
-            elwt.set_control_flow(ControlFlow::Wait);
             println!("Run {idx}: {:?}", event);
 
             if let Some(window) = &app.window {

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -7,7 +7,7 @@ use winit::platform::macos::{OptionAsAlt, WindowExtMacOS};
 use winit::{
     event::ElementState,
     event::{Event, MouseButton, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
@@ -31,42 +31,38 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut option_as_alt = window.option_as_alt();
 
-    event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
+    event_loop.run(move |event, elwt| match event {
+        Event::WindowEvent {
+            event: WindowEvent::CloseRequested,
+            window_id,
+        } if window_id == window.id() => elwt.exit(),
+        Event::WindowEvent { event, .. } => match event {
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Left,
+                ..
+            } => {
+                option_as_alt = match option_as_alt {
+                    OptionAsAlt::None => OptionAsAlt::OnlyLeft,
+                    OptionAsAlt::OnlyLeft => OptionAsAlt::OnlyRight,
+                    OptionAsAlt::OnlyRight => OptionAsAlt::Both,
+                    OptionAsAlt::Both => OptionAsAlt::None,
+                };
 
-        match event {
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                window_id,
-            } if window_id == window.id() => elwt.exit(),
-            Event::WindowEvent { event, .. } => match event {
-                WindowEvent::MouseInput {
-                    state: ElementState::Pressed,
-                    button: MouseButton::Left,
-                    ..
-                } => {
-                    option_as_alt = match option_as_alt {
-                        OptionAsAlt::None => OptionAsAlt::OnlyLeft,
-                        OptionAsAlt::OnlyLeft => OptionAsAlt::OnlyRight,
-                        OptionAsAlt::OnlyRight => OptionAsAlt::Both,
-                        OptionAsAlt::Both => OptionAsAlt::None,
-                    };
-
-                    println!("Received Mouse click, toggling option_as_alt to: {option_as_alt:?}");
-                    window.set_option_as_alt(option_as_alt);
-                }
-                WindowEvent::KeyboardInput { .. } => println!("KeyboardInput: {event:?}"),
-                WindowEvent::RedrawRequested => {
-                    fill::fill_window(&window);
-                }
-                _ => (),
-            },
-            Event::AboutToWait => {
-                window.request_redraw();
+                println!("Received Mouse click, toggling option_as_alt to: {option_as_alt:?}");
+                window.set_option_as_alt(option_as_alt);
             }
-
+            WindowEvent::KeyboardInput { .. } => println!("KeyboardInput: {event:?}"),
+            WindowEvent::RedrawRequested => {
+                fill::fill_window(&window);
+            }
             _ => (),
+        },
+        Event::AboutToWait => {
+            window.request_redraw();
         }
+
+        _ => (),
     })
 }
 

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -14,7 +14,7 @@ fn main() -> std::process::ExitCode {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         platform::pump_events::{EventLoopExtPumpEvents, PumpStatus},
         window::WindowBuilder,
     };
@@ -33,8 +33,6 @@ fn main() -> std::process::ExitCode {
     'main: loop {
         let timeout = Some(Duration::ZERO);
         let status = event_loop.pump_events(timeout, |event, elwt| {
-            elwt.set_control_flow(ControlFlow::Wait);
-
             if let Event::WindowEvent { event, .. } = &event {
                 // Print only Window events to reduce noise
                 println!("{event:?}");

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -3,7 +3,7 @@ use simple_logger::SimpleLogger;
 use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::Key,
     window::WindowBuilder,
 };
@@ -24,38 +24,34 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut has_increments = true;
 
-    event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
+    event_loop.run(move |event, elwt| match event {
+        Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
+            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        logical_key: Key::Space,
+                        state: ElementState::Released,
+                        ..
+                    },
+                ..
+            } => {
+                has_increments = !has_increments;
 
-        match event {
-            Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => elwt.exit(),
-                WindowEvent::KeyboardInput {
-                    event:
-                        KeyEvent {
-                            logical_key: Key::Space,
-                            state: ElementState::Released,
-                            ..
-                        },
-                    ..
-                } => {
-                    has_increments = !has_increments;
-
-                    let new_increments = match window.resize_increments() {
-                        Some(_) => None,
-                        None => Some(LogicalSize::new(25.0, 25.0)),
-                    };
-                    debug!("Had increments: {}", new_increments.is_none());
-                    window.set_resize_increments(new_increments);
-                }
-                WindowEvent::RedrawRequested => {
-                    fill::fill_window(&window);
-                }
-                _ => (),
-            },
-            Event::AboutToWait => window.request_redraw(),
-
+                let new_increments = match window.resize_increments() {
+                    Some(_) => None,
+                    None => Some(LogicalSize::new(25.0, 25.0)),
+                };
+                debug!("Had increments: {}", new_increments.is_none());
+                window.set_resize_increments(new_increments);
+            }
+            WindowEvent::RedrawRequested => {
+                fill::fill_window(&window);
+            }
             _ => (),
-        }
+        },
+        Event::AboutToWait => window.request_redraw(),
+
+        _ => (),
     })
 }

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -8,7 +8,7 @@ use simple_logger::SimpleLogger;
 #[cfg(target_os = "macos")]
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     keyboard::Key,
     platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS},
     window::{Window, WindowBuilder},
@@ -31,8 +31,6 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("Press N to open a new window.");
 
     event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -10,7 +10,7 @@ mod imple {
     use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
-        event_loop::{ControlFlow, EventLoop},
+        event_loop::EventLoop,
         platform::x11::WindowBuilderExtX11,
         window::WindowBuilder,
     };
@@ -33,8 +33,6 @@ mod imple {
             .unwrap();
 
         event_loop.run(move |event, elwt| {
-            elwt.set_control_flow(ControlFlow::Wait);
-
             match event {
                 Event::WindowEvent {
                     event: WindowEvent::CloseRequested,

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -151,9 +151,9 @@ impl<T> fmt::Debug for EventLoopWindowTarget<T> {
 ///
 /// Indicates the desired behavior of the event loop after [`Event::AboutToWait`] is emitted.
 ///
-/// Defaults to [`Poll`].
+/// Defaults to [`Wait`].
 ///
-/// [`Poll`]: Self::Poll
+/// [`Wait`]: Self::Wait
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum ControlFlow {
     /// When the current loop iteration finishes, immediately begin a new iteration regardless of
@@ -193,7 +193,7 @@ impl ControlFlow {
 impl Default for ControlFlow {
     #[inline(always)]
     fn default() -> Self {
-        Self::Poll
+        Self::Wait
     }
 }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -154,13 +154,14 @@ impl<T> fmt::Debug for EventLoopWindowTarget<T> {
 /// Defaults to [`Wait`].
 ///
 /// [`Wait`]: Self::Wait
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub enum ControlFlow {
     /// When the current loop iteration finishes, immediately begin a new iteration regardless of
     /// whether or not new events are available to process.
     Poll,
 
     /// When the current loop iteration finishes, suspend the thread until another event arrives.
+    #[default]
     Wait,
 
     /// When the current loop iteration finishes, suspend the thread until either another event
@@ -187,13 +188,6 @@ impl ControlFlow {
             Some(instant) => Self::WaitUntil(instant),
             None => Self::Wait,
         }
-    }
-}
-
-impl Default for ControlFlow {
-    #[inline(always)]
-    fn default() -> Self {
-        Self::Wait
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -40,7 +40,7 @@ pub use raw_window_handle;
 /// ```no_run
 /// use winit::{
 ///     event::{Event, WindowEvent},
-///     event_loop::{ControlFlow, EventLoop},
+///     event_loop::EventLoop,
 ///     window::Window,
 /// };
 ///
@@ -48,8 +48,6 @@ pub use raw_window_handle;
 /// let window = Window::new(&event_loop).unwrap();
 ///
 /// event_loop.run(move |event, elwt| {
-///     elwt.set_control_flow(ControlFlow::Wait);
-///
 ///     match event {
 ///         Event::WindowEvent {
 ///             event: WindowEvent::CloseRequested,


### PR DESCRIPTION
After some discussion in https://github.com/rust-windowing/winit/issues/3105 I was asking myself why `Poll` is the default. So I wanted to know what everybody thinks about switching the default to `Wait`.

I will make a follow-up to try and improve the documentation around our recommendations on which `ControlFlow` to choose, but wanted to keep it separate.