### PR TITLE
Doc: Update Usage in README.md to adjust to new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,25 +35,23 @@ another library.
 ```rust
 use winit::{
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::EventLoop,
     window::WindowBuilder,
 };
 
 fn main() {
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().unwrap();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    event_loop.run(move |event, elwt| {
-        elwt.set_control_flow(ControlFlow::Wait);
-
+    event_loop.run(move |event, _elwt, cf| {
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => elwt.exit(),
-            _ => (),
-        }
-    });
+            } if window_id == window.id() => cf.set_exit(),
+                _ => (),
+            }
+    }).unwrap();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Winit is designed to be a low-level brick in a hierarchy of libraries. Consequen
 show something on the window you need to use the platform-specific getters provided by winit, or
 another library.
 
-```rust, ignore
+```rust, no_run
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -189,7 +189,7 @@ android_logger = "0.11.0"
 ```
 
 And, for example, define an entry point for your library like this:
-```rust
+```rust, no_run
 #[cfg(target_os = "android")]
 use winit::platform::android::activity::AndroidApp;
 

--- a/README.md
+++ b/README.md
@@ -39,19 +39,23 @@ use winit::{
     window::WindowBuilder,
 };
 
-fn main() {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let event_loop = EventLoop::new().unwrap();
-    let window = WindowBuilder::new().build(&event_loop).unwrap();
+    let window = WindowBuilder::new().build(&event_loop)?;
 
     event_loop
         .run(move |event, _elwt, cf| match event {
+            Event::RedrawRequested(_) => {
+                println!("Redraw requested");
+            }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
             } if window_id == window.id() => cf.set_exit(),
             _ => (),
-        })
-        .unwrap();
+        })?;
+        
+    Ok(())
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the MSRV will be accompanied by a minor version bump.
 As a **tentative** policy, the upper bound of the MSRV is given by the following
 formula:
 
-```
+```ignore
 min(sid, stable - 3)
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Winit is designed to be a low-level brick in a hierarchy of libraries. Consequen
 show something on the window you need to use the platform-specific getters provided by winit, or
 another library.
 
-```rust
+```rust, ignore
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ fn main() {
     let event_loop = EventLoop::new().unwrap();
     let window = WindowBuilder::new().build(&event_loop).unwrap();
 
-    event_loop.run(move |event, _elwt, cf| {
-        match event {
+    event_loop
+        .run(move |event, _elwt, cf| match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
             } if window_id == window.id() => cf.set_exit(),
-                _ => (),
-            }
-    }).unwrap();
+            _ => (),
+        })
+        .unwrap();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Winit is designed to be a low-level brick in a hierarchy of libraries. Consequen
 show something on the window you need to use the platform-specific getters provided by winit, or
 another library.
 
-```rust, no_run
+```rust
 use winit::{
     event::{Event, WindowEvent},
     event_loop::EventLoop,
@@ -77,7 +77,7 @@ the MSRV will be accompanied by a minor version bump.
 As a **tentative** policy, the upper bound of the MSRV is given by the following
 formula:
 
-```ignore
+```
 min(sid, stable - 3)
 ```
 
@@ -189,7 +189,7 @@ android_logger = "0.11.0"
 ```
 
 And, for example, define an entry point for your library like this:
-```rust, no_run
+```rust
 #[cfg(target_os = "android")]
 use winit::platform::android::activity::AndroidApp;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,3 +159,7 @@ mod platform_impl;
 pub mod window;
 
 pub mod platform;
+
+#[cfg(doctest)]
+#[doc = include_str!("../README.md")]
+extern "C" {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,3 @@ mod platform_impl;
 pub mod window;
 
 pub mod platform;
-
-#[cfg(doctest)]
-#[doc = include_str!("../README.md")]
-extern "C" {}


### PR DESCRIPTION
I found that the usage example in README.md is for a past version of `winit`. Since the version displayed in README.md of master branch is `0.29.1-beta`, I'm trying to edit the example to make it suit this version.
Note: There is also some discussion whether the doc should be removed entirely. But before that I believe it's better to correct the mistake at first because it may confuse some people.