### PR TITLE
Remove obsolete docs about wayland CSD env variable

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -394,8 +394,8 @@ impl WindowBuilder {
     /// ## Platform-specific
     ///
     /// - **macOS:** This is an app-wide setting.
-    /// - **Wayland:** This control only CSD. You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
-    ///   Possible values for env variable are: "dark" and "light".
+    /// - **Wayland:** This controls only CSD. When using `None` it'll try to use dbus to get the
+    ///   system preference. When explicit theme is used, this will avoid dbus all together.
     /// - **x11:** Build window with `_GTK_THEME_VARIANT` hint set to `dark` or `light`.
     /// - **iOS / Android / Web / x11 / Orbital:** Ignored.
     #[inline]
@@ -1244,8 +1244,8 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **macOS:** This is an app-wide setting.
-    /// - **Wayland:** You can also use `WINIT_WAYLAND_CSD_THEME` env variable to set the theme.
-    ///   Possible values for env variable are: "dark" and "light". When unspecified, a theme is automatically selected.
+    /// - **Wayland:** Sets the theme for the client side decorations. Using `None` will use dbus
+    ///   to get the system preference.
     /// - **X11:** Sets `_GTK_THEME_VARIANT` hint to `dark` or `light` and if `None` is used, it will default to  [`Theme::Dark`].
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     #[inline]


### PR DESCRIPTION
The env variable was removed a while ago, yet it was still present in the user docs.
