### PR TITLE
Remove `DeviceEvent::Text` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Implement `PartialOrd` and `Ord` for `MouseButton`.
 - On X11, fix event loop not waking up on `ControlFlow::Poll` and `ControlFlow::WaitUntil`.
 - **Breaking:** Change default `ControlFlow` from `Poll` to `Wait`.
+- **Breaking:** remove `DeviceEvent::Text`.
 
 # 0.29.1-beta
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -618,10 +618,6 @@ pub enum DeviceEvent {
     },
 
     Key(RawKeyEvent),
-
-    Text {
-        codepoint: char,
-    },
 }
 
 /// Describes a keyboard input as a raw device event.
@@ -1221,7 +1217,6 @@ mod tests {
                     button: 0,
                     state: event::ElementState::Pressed,
                 });
-                with_device_event(Text { codepoint: 'a' });
             }
         }};
     }


### PR DESCRIPTION
The event is never constructed inside the winit.
