### PR TITLE
Fix transparet windows in X11

### DIFF
--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -242,7 +242,7 @@ impl UnownedWindow {
                 // Find a suitable visual, true color with 32 bits of depth.
                 all_visuals
                     .find_map(|(visual, depth)| {
-                        (visual.class == xproto::VisualClass::TRUE_COLOR)
+                        (depth == 32 && visual.class == xproto::VisualClass::TRUE_COLOR)
                             .then_some((Some(visual), depth, true))
                     })
                     .unwrap_or_else(|| {

--- a/src/window.rs
+++ b/src/window.rs
@@ -875,7 +875,8 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **Windows / X11 / Web / iOS / Android / Orbital:** Unsupported.
+    /// - **Windows / Web / iOS / Android / Orbital:** Unsupported.
+    /// - **X11:** Can only be set while building the window, with [`WindowBuilder::with_transparent`].
     #[inline]
     pub fn set_transparent(&self, transparent: bool) {
         self.window


### PR DESCRIPTION
It looks like 584aab4cd0da167f18e3907edfa8981885d7f92c broke transparent windows in X11 (at least on my computer). I fixed it, and updated the docs of `set_transparent` to note that transparent windows do work in X11.

- [x] Tested on all platforms changed
  - I tested this on my computer, running X11, which is the only platform affected.
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
  - This is a fix of a regression, I didn't add anything to the changelog.
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
  - `examples/transparent.rs` still works to show this.
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
  - No features were changed.
