### PR TITLE
Link to areweguiyet.com and arewegameyet.rs instead of winit's wiki page

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ winit = "0.29.1-beta"
 
 For features _within_ the scope of winit, see [FEATURES.md](FEATURES.md).
 
-For features _outside_ the scope of winit, see [Missing features provided by other crates](https://github.com/rust-windowing/winit/wiki/Missing-features-provided-by-other-crates) in the wiki.
+For features _outside_ the scope of winit, see [Are we GUI Yet?](https://areweguiyet.com/) and [Are we game yet?](https://arewegameyet.rs/), depending on what kind of project you're looking to do.
 
 ## Contact Us
 
@@ -67,8 +67,8 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 
 ## MSRV Policy
 
-The Minimum Supported Rust Version (MSRV) of this crate is **1.65**. Changes to 
-the MSRV will be accompanied by a minor version bump. 
+The Minimum Supported Rust Version (MSRV) of this crate is **1.65**. Changes to
+the MSRV will be accompanied by a minor version bump.
 
 As a **tentative** policy, the upper bound of the MSRV is given by the following
 formula:
@@ -83,13 +83,13 @@ event of a major ecosystem shift or a security vulnerability.
 
 [Debian Sid]: https://packages.debian.org/sid/rustc
 
-The exception to this is for the Android platform, where a higher Rust version 
-must be used for certain Android features. In this case, the MSRV will be 
-capped at the latest stable version of Rust minus three. This inconsistency is 
-not reflected in Cargo metadata, as it is not powerful enough to expose this 
+The exception to this is for the Android platform, where a higher Rust version
+must be used for certain Android features. In this case, the MSRV will be
+capped at the latest stable version of Rust minus three. This inconsistency is
+not reflected in Cargo metadata, as it is not powerful enough to expose this
 restriction.
 
-All crates in the [`rust-windowing`] organizations have the 
+All crates in the [`rust-windowing`] organizations have the
 same MSRV policy.
 
 [`rust-windowing`]: https://github.com/rust-windowing


### PR DESCRIPTION
The [Missing features provided by other crates](https://github.com/rust-windowing/winit/wiki/Missing-features-provided-by-other-crates) wiki page is woefully out of date, and IMO hard to maintain; so I propose we link to better maintained resources like https://areweguiyet.com and https://arewegameyet.rs (I'm maintaining the former), which will likely serve user's needs better.

I have made sure that all information contained in that page is moved to these two projects, so I'm intending to delete the page after this PR is merged.

I'm also considering deleting the [Software that uses winit](https://github.com/rust-windowing/winit/wiki/Software-that-uses-winit) page, since only four of the seven listed projects are actually maintained, and hence it's not really a good list for users that want to view examples of how to use `winit` in larger projects.