### PR TITLE
X11: Add `#[deny(unsafe_op_in_unsafe_fn)]`

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -572,7 +572,8 @@ impl DeviceId {
     ///
     /// **Passing this into a winit function will result in undefined behavior.**
     pub const unsafe fn dummy() -> Self {
-        DeviceId(platform_impl::DeviceId::dummy())
+        #[allow(unused_unsafe)]
+        DeviceId(unsafe { platform_impl::DeviceId::dummy() })
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,7 @@
 #![deny(rust_2018_idioms)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::all)]
+#![deny(unsafe_op_in_unsafe_fn)]
 #![cfg_attr(feature = "cargo-clippy", deny(warnings))]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]

--- a/src/platform_impl/ios/uikit/mod.rs
+++ b/src/platform_impl/ios/uikit/mod.rs
@@ -1,4 +1,3 @@
-#![deny(unsafe_op_in_unsafe_fn)]
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -1,5 +1,4 @@
 #![cfg(free_unix)]
-#![deny(unsafe_op_in_unsafe_fn)]
 
 #[cfg(all(not(x11_platform), not(wayland_platform)))]
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -122,12 +122,14 @@ impl<T: 'static> EventProcessor<T> {
             1
         }
 
-        let result = (wt.xconn.xlib.XCheckIfEvent)(
-            wt.xconn.display,
-            event_ptr,
-            Some(predicate),
-            std::ptr::null_mut(),
-        );
+        let result = unsafe {
+            (wt.xconn.xlib.XCheckIfEvent)(
+                wt.xconn.display,
+                event_ptr,
+                Some(predicate),
+                std::ptr::null_mut(),
+            )
+        };
 
         result != 0
     }

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -217,15 +217,19 @@ impl ImeContext {
         }));
 
         let ic = match style as _ {
-            Style::Preedit(style) => ImeContext::create_preedit_ic(
-                xconn,
-                im,
-                style,
-                window,
-                client_data as ffi::XPointer,
-            ),
-            Style::Nothing(style) => ImeContext::create_nothing_ic(xconn, im, style, window),
-            Style::None(style) => ImeContext::create_none_ic(xconn, im, style, window),
+            Style::Preedit(style) => unsafe {
+                ImeContext::create_preedit_ic(
+                    xconn,
+                    im,
+                    style,
+                    window,
+                    client_data as ffi::XPointer,
+                )
+            },
+            Style::Nothing(style) => unsafe {
+                ImeContext::create_nothing_ic(xconn, im, style, window)
+            },
+            Style::None(style) => unsafe { ImeContext::create_none_ic(xconn, im, style, window) },
         }
         .ok_or(ImeContextCreationError::Null)?;
 
@@ -237,7 +241,7 @@ impl ImeContext {
             ic,
             ic_spot: ffi::XPoint { x: 0, y: 0 },
             style,
-            _client_data: Box::from_raw(client_data),
+            _client_data: unsafe { Box::from_raw(client_data) },
         };
 
         // Set the spot location, if it's present.
@@ -254,14 +258,16 @@ impl ImeContext {
         style: XIMStyle,
         window: ffi::Window,
     ) -> Option<ffi::XIC> {
-        let ic = (xconn.xlib.XCreateIC)(
-            im,
-            ffi::XNInputStyle_0.as_ptr() as *const _,
-            style,
-            ffi::XNClientWindow_0.as_ptr() as *const _,
-            window,
-            ptr::null_mut::<()>(),
-        );
+        let ic = unsafe {
+            (xconn.xlib.XCreateIC)(
+                im,
+                ffi::XNInputStyle_0.as_ptr() as *const _,
+                style,
+                ffi::XNClientWindow_0.as_ptr() as *const _,
+                window,
+                ptr::null_mut::<()>(),
+            )
+        };
 
         (!ic.is_null()).then_some(ic)
     }
@@ -274,8 +280,7 @@ impl ImeContext {
         client_data: ffi::XPointer,
     ) -> Option<ffi::XIC> {
         let preedit_callbacks = PreeditCallbacks::new(client_data);
-        let preedit_attr = util::memory::XSmartPointer::new(
-            xconn,
+        let preedit_attr = util::memory::XSmartPointer::new(xconn, unsafe {
             (xconn.xlib.XVaCreateNestedList)(
                 0,
                 ffi::XNPreeditStartCallback_0.as_ptr() as *const _,
@@ -287,20 +292,22 @@ impl ImeContext {
                 ffi::XNPreeditDrawCallback_0.as_ptr() as *const _,
                 &(preedit_callbacks.draw_callback) as *const _,
                 ptr::null_mut::<()>(),
-            ),
-        )
+            )
+        })
         .expect("XVaCreateNestedList returned NULL");
 
-        let ic = (xconn.xlib.XCreateIC)(
-            im,
-            ffi::XNInputStyle_0.as_ptr() as *const _,
-            style,
-            ffi::XNClientWindow_0.as_ptr() as *const _,
-            window,
-            ffi::XNPreeditAttributes_0.as_ptr() as *const _,
-            preedit_attr.ptr,
-            ptr::null_mut::<()>(),
-        );
+        let ic = unsafe {
+            (xconn.xlib.XCreateIC)(
+                im,
+                ffi::XNInputStyle_0.as_ptr() as *const _,
+                style,
+                ffi::XNClientWindow_0.as_ptr() as *const _,
+                window,
+                ffi::XNPreeditAttributes_0.as_ptr() as *const _,
+                preedit_attr.ptr,
+                ptr::null_mut::<()>(),
+            )
+        };
 
         (!ic.is_null()).then_some(ic)
     }
@@ -311,14 +318,16 @@ impl ImeContext {
         style: XIMStyle,
         window: ffi::Window,
     ) -> Option<ffi::XIC> {
-        let ic = (xconn.xlib.XCreateIC)(
-            im,
-            ffi::XNInputStyle_0.as_ptr() as *const _,
-            style,
-            ffi::XNClientWindow_0.as_ptr() as *const _,
-            window,
-            ptr::null_mut::<()>(),
-        );
+        let ic = unsafe {
+            (xconn.xlib.XCreateIC)(
+                im,
+                ffi::XNInputStyle_0.as_ptr() as *const _,
+                style,
+                ffi::XNClientWindow_0.as_ptr() as *const _,
+                window,
+                ptr::null_mut::<()>(),
+            )
+        };
 
         (!ic.is_null()).then_some(ic)
     }

--- a/src/platform_impl/linux/x11/ime/inner.rs
+++ b/src/platform_impl/linux/x11/ime/inner.rs
@@ -9,12 +9,12 @@ use super::{
 use crate::platform_impl::platform::x11::ime::ImeEventSender;
 
 pub(crate) unsafe fn close_im(xconn: &Arc<XConnection>, im: ffi::XIM) -> Result<(), XError> {
-    (xconn.xlib.XCloseIM)(im);
+    unsafe { (xconn.xlib.XCloseIM)(im) };
     xconn.check_errors()
 }
 
 pub(crate) unsafe fn destroy_ic(xconn: &Arc<XConnection>, ic: ffi::XIC) -> Result<(), XError> {
-    (xconn.xlib.XDestroyIC)(ic);
+    unsafe { (xconn.xlib.XDestroyIC)(ic) };
     xconn.check_errors()
 }
 
@@ -52,7 +52,7 @@ impl ImeInner {
 
     pub unsafe fn close_im_if_necessary(&self) -> Result<bool, XError> {
         if !self.is_destroyed && self.im.is_some() {
-            close_im(&self.xconn, self.im.as_ref().unwrap().im).map(|_| true)
+            unsafe { close_im(&self.xconn, self.im.as_ref().unwrap().im) }.map(|_| true)
         } else {
             Ok(false)
         }
@@ -60,7 +60,7 @@ impl ImeInner {
 
     pub unsafe fn destroy_ic_if_necessary(&self, ic: ffi::XIC) -> Result<bool, XError> {
         if !self.is_destroyed {
-            destroy_ic(&self.xconn, ic).map(|_| true)
+            unsafe { destroy_ic(&self.xconn, ic) }.map(|_| true)
         } else {
             Ok(false)
         }
@@ -68,7 +68,7 @@ impl ImeInner {
 
     pub unsafe fn destroy_all_contexts_if_necessary(&self) -> Result<bool, XError> {
         for context in self.contexts.values().flatten() {
-            self.destroy_ic_if_necessary(context.ic)?;
+            unsafe { self.destroy_ic_if_necessary(context.ic)? };
         }
         Ok(!self.is_destroyed)
     }

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -1,5 +1,3 @@
-#![deny(unsafe_op_in_unsafe_fn)]
-
 #[macro_use]
 mod util;
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1,5 +1,4 @@
 #![cfg(windows_platform)]
-#![deny(unsafe_op_in_unsafe_fn)]
 
 use smol_str::SmolStr;
 use windows_sys::Win32::{

--- a/src/window.rs
+++ b/src/window.rs
@@ -101,7 +101,8 @@ impl WindowId {
     ///
     /// **Passing this into a winit function will result in undefined behavior.**
     pub const unsafe fn dummy() -> Self {
-        WindowId(platform_impl::WindowId::dummy())
+        #[allow(unused_unsafe)]
+        WindowId(unsafe { platform_impl::WindowId::dummy() })
     }
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/rust-windowing/winit/pull/3070, add `#[deny(unsafe_op_in_unsafe_fn)]` on the remaining platform X11, such that we can now enable it for the entirety of `winit`.

CC @notgull since this may impact your x11rb work?

- [ ] Tested on all platforms changed
