### PR TITLE
Make default `WindowBuilder` `Send` and `Sync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Wayland, support `Occluded` event with xdg-shell v6
 - Implement `AsFd`/`AsRawFd` for `EventLoop<T>` on X11 and Wayland.
 - **Breaking:** Bump `ndk` version to `0.8.0`, ndk-sys to `0.5.0`, `android-activity` to `0.5.0`.
+- Make `WindowBuilder` `Send + Sync`.
 
 # 0.29.1-beta
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,3 +163,18 @@ mod platform_impl;
 pub mod window;
 
 pub mod platform;
+
+/// Wrapper for objects which winit will access on the main thread so they are effectively `Send`
+/// and `Sync`, since they always excute on a single thread.
+///
+/// # Safety
+///
+/// Winit can run only one event loop at the time and the event loop itself is tied to some thread.
+/// The objects could be send across the threads, but once passed to winit, they execute on the
+/// mean thread if the platform demands it. Thus marking such objects as `Send + Sync` is safe.
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub(crate) struct SendSyncWrapper<T>(pub(crate) T);
+
+unsafe impl<T> Send for SendSyncWrapper<T> {}
+unsafe impl<T> Sync for SendSyncWrapper<T> {}

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -31,6 +31,7 @@ use crate::event::Event;
 use crate::event_loop::EventLoop;
 use crate::event_loop::EventLoopWindowTarget;
 use crate::window::{Window, WindowBuilder};
+use crate::SendSyncWrapper;
 
 use web_sys::HtmlCanvasElement;
 
@@ -81,26 +82,22 @@ pub trait WindowBuilderExtWebSys {
 
 impl WindowBuilderExtWebSys for WindowBuilder {
     fn with_canvas(mut self, canvas: Option<HtmlCanvasElement>) -> Self {
-        self.platform_specific.canvas = canvas;
-
+        self.platform_specific.canvas = SendSyncWrapper(canvas);
         self
     }
 
     fn with_prevent_default(mut self, prevent_default: bool) -> Self {
         self.platform_specific.prevent_default = prevent_default;
-
         self
     }
 
     fn with_focusable(mut self, focusable: bool) -> Self {
         self.platform_specific.focusable = focusable;
-
         self
     }
 
     fn with_append(mut self, append: bool) -> Self {
         self.platform_specific.append = append;
-
         self
     }
 }

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -473,7 +473,7 @@ impl WinitUIWindow {
 
         this.setRootViewController(Some(view_controller));
 
-        match window_attributes.fullscreen.clone().map(Into::into) {
+        match window_attributes.fullscreen.0.clone().map(Into::into) {
             Some(Fullscreen::Exclusive(ref video_mode)) => {
                 let monitor = video_mode.monitor();
                 let screen = monitor.ui_screen(mtm);

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -422,7 +422,7 @@ impl Window {
         // TODO: transparency, visible
 
         let main_screen = UIScreen::main(mtm);
-        let fullscreen = window_attributes.fullscreen.clone().map(Into::into);
+        let fullscreen = window_attributes.fullscreen.0.clone().map(Into::into);
         let screen = match fullscreen {
             Some(Fullscreen::Exclusive(ref video_mode)) => video_mode.monitor.ui_screen(mtm),
             Some(Fullscreen::Borderless(Some(ref monitor))) => monitor.ui_screen(mtm),

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -151,7 +151,7 @@ impl Window {
         window_state.set_resizable(attributes.resizable);
 
         // Set startup mode.
-        match attributes.fullscreen.map(Into::into) {
+        match attributes.fullscreen.0.map(Into::into) {
             Some(Fullscreen::Exclusive(_)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland");
             }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -150,7 +150,7 @@ impl UnownedWindow {
         let xconn = &event_loop.xconn;
         let atoms = xconn.atoms();
         #[cfg(feature = "rwh_06")]
-        let root = match window_attrs.parent_window {
+        let root = match window_attrs.parent_window.0 {
             Some(rwh_06::RawWindowHandle::Xlib(handle)) => handle.window as xproto::Window,
             Some(rwh_06::RawWindowHandle::Xcb(handle)) => handle.window.get(),
             Some(raw) => unreachable!("Invalid raw window handle {raw:?} on X11"),
@@ -547,10 +547,10 @@ impl UnownedWindow {
             if window_attrs.maximized {
                 leap!(window.set_maximized_inner(window_attrs.maximized)).ignore_error();
             }
-            if window_attrs.fullscreen.is_some() {
+            if window_attrs.fullscreen.0.is_some() {
                 if let Some(flusher) =
                     leap!(window
-                        .set_fullscreen_inner(window_attrs.fullscreen.clone().map(Into::into)))
+                        .set_fullscreen_inner(window_attrs.fullscreen.0.clone().map(Into::into)))
                 {
                     flusher.ignore_error()
                 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -295,7 +295,7 @@ impl WinitWindow {
         trace_scope!("WinitWindow::new");
 
         let this = autoreleasepool(|_| {
-            let screen = match attrs.fullscreen.clone().map(Into::into) {
+            let screen = match attrs.fullscreen.0.clone().map(Into::into) {
                 Some(Fullscreen::Borderless(Some(monitor)))
                 | Some(Fullscreen::Exclusive(VideoMode { monitor, .. })) => {
                     monitor.ns_screen().or_else(NSScreen::main)
@@ -449,7 +449,7 @@ impl WinitWindow {
         .ok_or_else(|| os_error!(OsError::CreationError("Couldn't create `NSWindow`")))?;
 
         #[cfg(feature = "rwh_06")]
-        match attrs.parent_window {
+        match attrs.parent_window.0 {
             Some(rwh_06::RawWindowHandle::AppKit(handle)) => {
                 // SAFETY: Caller ensures the pointer is valid or NULL
                 // Unwrap is fine, since the pointer comes from `NonNull`.
@@ -520,14 +520,14 @@ impl WinitWindow {
             }
         }
 
-        let delegate = WinitWindowDelegate::new(&this, attrs.fullscreen.is_some());
+        let delegate = WinitWindowDelegate::new(&this, attrs.fullscreen.0.is_some());
 
         // XXX Send `Focused(false)` right after creating the window delegate, so we won't
         // obscure the real focused events on the startup.
         delegate.queue_event(WindowEvent::Focused(false));
 
         // Set fullscreen mode after we setup everything
-        this.set_fullscreen(attrs.fullscreen.map(Into::into));
+        this.set_fullscreen(attrs.fullscreen.0.map(Into::into));
 
         // Setting the window as key has to happen *after* we set the fullscreen
         // state, since otherwise we'll briefly see the window at normal size

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -63,7 +63,7 @@ impl Canvas {
         attr: &WindowAttributes,
         platform_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOE> {
-        let canvas = match platform_attr.canvas {
+        let canvas = match platform_attr.canvas.0 {
             Some(canvas) => canvas,
             None => document
                 .create_element("canvas")
@@ -127,7 +127,7 @@ impl Canvas {
             super::set_canvas_position(&common.document, &common.raw, &common.style, position);
         }
 
-        if attr.fullscreen.is_some() {
+        if attr.fullscreen.0.is_some() {
             common.fullscreen_handler.request_fullscreen();
         }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -5,6 +5,7 @@ use crate::window::{
     CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     WindowAttributes, WindowButtons, WindowId as RootWI, WindowLevel,
 };
+use crate::SendSyncWrapper;
 
 use web_sys::HtmlCanvasElement;
 
@@ -455,7 +456,7 @@ impl From<u64> for WindowId {
 
 #[derive(Clone)]
 pub struct PlatformSpecificWindowBuilderAttributes {
-    pub(crate) canvas: Option<backend::RawCanvasType>,
+    pub(crate) canvas: SendSyncWrapper<Option<backend::RawCanvasType>>,
     pub(crate) prevent_default: bool,
     pub(crate) focusable: bool,
     pub(crate) append: bool,
@@ -464,7 +465,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
 impl Default for PlatformSpecificWindowBuilderAttributes {
     fn default() -> Self {
         Self {
-            canvas: None,
+            canvas: SendSyncWrapper(None),
             prevent_default: true,
             focusable: true,
             append: false,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1185,8 +1185,8 @@ impl<'a, T: 'static> InitData<'a, T> {
 
         win.set_enabled_buttons(attributes.enabled_buttons);
 
-        if attributes.fullscreen.is_some() {
-            win.set_fullscreen(attributes.fullscreen.map(Into::into));
+        if attributes.fullscreen.0.is_some() {
+            win.set_fullscreen(attributes.fullscreen.0.map(Into::into));
             unsafe { force_window_active(win.window.0) };
         } else {
             let size = attributes
@@ -1272,7 +1272,7 @@ where
     };
 
     #[cfg(feature = "rwh_06")]
-    let parent = match attributes.parent_window {
+    let parent = match attributes.parent_window.0 {
         Some(rwh_06::RawWindowHandle::Win32(handle)) => {
             window_flags.set(WindowFlags::CHILD, true);
             if pl_attribs.menu.is_some() {

--- a/tests/send_objects.rs
+++ b/tests/send_objects.rs
@@ -17,6 +17,11 @@ fn window_send() {
 }
 
 #[test]
+fn window_builder_send() {
+    needs_send::<winit::window::WindowBuilder>();
+}
+
+#[test]
 fn ids_send() {
     // ensures that the various `..Id` types implement `Send`
     needs_send::<winit::window::WindowId>();

--- a/tests/sync_object.rs
+++ b/tests/sync_object.rs
@@ -6,3 +6,8 @@ fn window_sync() {
     // ensures that `winit::Window` implements `Sync`
     needs_sync::<winit::window::Window>();
 }
+
+#[test]
+fn window_builder_sync() {
+    needs_sync::<winit::window::WindowBuilder>();
+}


### PR DESCRIPTION
The default window builder is neither `Send` nor `Sync` due to use of `RawWindowHandle` internally. While we could ensure to make the handle `Send + Sync` within our use, we can't guarantee that the same will hold true in the future.

Thus add a generic to split the builder into `MT-safe` and not `MT-safe` versions.

This could also help with the lifetimes, since default could be bound by static lifetime.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
