### PR TITLE
Use an unique window class name per winit version

### DIFF
--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -253,7 +253,7 @@ impl WindowBuilderExtWindows for WindowBuilder {
 
     #[inline]
     fn with_class_name<S: Into<String>>(mut self, class_name: S) -> WindowBuilder {
-        self.platform_specific.class_name = class_name.into();
+        self.platform_specific.class_name = Some(class_name.into());
         self
     }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -30,7 +30,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub no_redirection_bitmap: bool,
     pub drag_and_drop: bool,
     pub skip_taskbar: bool,
-    pub class_name: String,
+    pub class_name: Option<String>,
     pub decoration_shadow: bool,
 }
 
@@ -43,7 +43,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             no_redirection_bitmap: false,
             drag_and_drop: true,
             skip_taskbar: false,
-            class_name: "Window Class".to_string(),
+            class_name: None,
             decoration_shadow: false,
         }
     }


### PR DESCRIPTION
This uses an unique window class name per winit version and checks for errors when registering class names to avoid unsafety.

Fixes https://github.com/rust-windowing/winit/issues/3132