### PR TITLE
Support multiple event loop instances on Windows

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -58,6 +58,7 @@ pub struct EventLoopWindowTarget<T: 'static> {
 /// easier. But note that constructing multiple event loops is not supported.
 #[derive(Default)]
 pub struct EventLoopBuilder<T: 'static> {
+    pub(crate) multiple_instances: bool,
     pub(crate) platform_specific: platform_impl::PlatformSpecificEventLoopAttributes,
     _p: PhantomData<T>,
 }
@@ -78,6 +79,7 @@ impl<T> EventLoopBuilder<T> {
     #[inline]
     pub fn with_user_event() -> Self {
         Self {
+            multiple_instances: false,
             platform_specific: Default::default(),
             _p: PhantomData,
         }
@@ -117,7 +119,7 @@ impl<T> EventLoopBuilder<T> {
     )]
     #[inline]
     pub fn build(&mut self) -> Result<EventLoop<T>, EventLoopError> {
-        if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
+        if !self.multiple_instances && EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
             return Err(EventLoopError::RecreationAttempt);
         }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -20,6 +20,12 @@ pub type HMONITOR = isize;
 
 /// Additional methods on `EventLoop` that are specific to Windows.
 pub trait EventLoopBuilderExtWindows {
+    /// Whether to allow multiple event loops to be created.
+    ///
+    /// By default, only a single event loop is allowed to be created, to make platform
+    /// compatibility easier.
+    fn with_multiple_instances(&mut self, multiple_instances: bool) -> &mut Self;
+
     /// Whether to allow the event loop to be created off of the main thread.
     ///
     /// By default, the window is only allowed to be created on the main
@@ -90,6 +96,12 @@ impl<T> EventLoopBuilderExtWindows for EventLoopBuilder<T> {
     #[inline]
     fn with_any_thread(&mut self, any_thread: bool) -> &mut Self {
         self.platform_specific.any_thread = any_thread;
+        self
+    }
+
+    #[inline]
+    fn with_multiple_instances(&mut self, multiple_instances: bool) -> &mut Self {
+        self.multiple_instances = multiple_instances;
         self
     }
 


### PR DESCRIPTION
This allows multiple event loop instances on Windows.

This is blocked on https://github.com/rust-windowing/winit/pull/3061 as currently using event loops of different types can cause unsafety.