### PR TITLE
Revise Key, KeyCode enums

### DIFF
--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -6,7 +6,7 @@ use winit::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{ElementState, Event, Ime, WindowEvent},
     event_loop::EventLoop,
-    keyboard::{Key, KeyCode},
+    keyboard::Key,
     window::{ImePurpose, WindowBuilder},
 };
 
@@ -69,7 +69,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 WindowEvent::KeyboardInput { event, .. } => {
                     println!("key: {event:?}");
 
-                    if event.state == ElementState::Pressed && event.physical_key == KeyCode::F2 {
+                    if event.state == ElementState::Pressed && event.logical_key == Key::F2 {
                         ime_allowed = !ime_allowed;
                         window.set_ime_allowed(ime_allowed);
                         println!("\nIME allowed: {ime_allowed}\n");

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -5,7 +5,7 @@ use winit::{
     dpi::LogicalSize,
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
-    keyboard::KeyCode,
+    keyboard::{KeyCode, PhysicalKey},
     window::WindowBuilder,
 };
 
@@ -34,7 +34,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {
-                            physical_key: KeyCode::Space,
+                            physical_key: PhysicalKey::Code(KeyCode::Space),
                             state: ElementState::Released,
                             ..
                         },

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -3,7 +3,7 @@
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
-    keyboard::KeyCode,
+    keyboard::Key,
     window::{Fullscreen, WindowBuilder},
 };
 
@@ -39,13 +39,13 @@ pub fn main() -> Result<(), impl std::error::Error> {
                     WindowEvent::KeyboardInput {
                         event:
                             KeyEvent {
-                                physical_key: KeyCode::KeyF,
+                                logical_key: Key::Character(c),
                                 state: ElementState::Released,
                                 ..
                             },
                         ..
                     },
-            } if window_id == window.id() => {
+            } if window_id == window.id() && c == "f" => {
                 if window.fullscreen().is_some() {
                     window.set_fullscreen(None);
                 } else {

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -7,7 +7,7 @@ use winit::{
     dpi::{LogicalSize, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, KeyEvent, RawKeyEvent, WindowEvent},
     event_loop::{DeviceEvents, EventLoop},
-    keyboard::{Key, KeyCode},
+    keyboard::{Key, KeyCode, PhysicalKey},
     window::{Fullscreen, WindowBuilder},
 };
 
@@ -51,14 +51,14 @@ fn main() -> Result<(), impl std::error::Error> {
                     }),
                 ..
             } => match physical_key {
-                KeyCode::KeyM => {
+                PhysicalKey::Code(KeyCode::KeyM) => {
                     if minimized {
                         minimized = !minimized;
                         window.set_minimized(minimized);
                         window.focus_window();
                     }
                 }
-                KeyCode::KeyV => {
+                PhysicalKey::Code(KeyCode::KeyV) => {
                     if !visible {
                         visible = !visible;
                         window.set_visible(visible);

--- a/src/event.rs
+++ b/src/event.rs
@@ -671,7 +671,7 @@ pub enum DeviceEvent {
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct RawKeyEvent {
-    pub physical_key: keyboard::KeyCode,
+    pub physical_key: keyboard::PhysicalKey,
     pub state: ElementState,
 }
 
@@ -703,7 +703,7 @@ pub struct KeyEvent {
     /// `Fn` and `FnLock` key events are *exceedingly unlikely* to be emitted by Winit. These keys
     /// are usually handled at the hardware or OS level, and aren't surfaced to applications. If
     /// you somehow see this in the wild, we'd like to know :)
-    pub physical_key: keyboard::KeyCode,
+    pub physical_key: keyboard::PhysicalKey,
 
     // Allowing `broken_intra_doc_links` for `logical_key`, because
     // `key_without_modifiers` is not available on all platforms

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -187,24 +187,34 @@ impl std::fmt::Debug for NativeKey {
 
 /// Represents the location of a physical key.
 ///
+/// This type is a superset of [`KeyCode`], including an [`Unidentified`](Self::Unidentified)
+/// variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum PhysicalKey {
+    /// A known key code
+    Code(KeyCode),
+    /// This variant is used when the key cannot be translated to a [`KeyCode`]
+    ///
+    /// The native keycode is provided (if available) so you're able to more reliably match
+    /// key-press and key-release events by hashing the [`PhysicalKey`]. It is also possible to use
+    /// this for keybinds for non-standard keys, but such keybinds are tied to a given platform.
+    Unidentified(NativeKeyCode),
+}
+
+/// Code representing the location of a physical key
+///
 /// This mostly conforms to the UI Events Specification's [`KeyboardEvent.code`] with a few
 /// exceptions:
 /// - The keys that the specification calls "MetaLeft" and "MetaRight" are named "SuperLeft" and
 ///   "SuperRight" here.
 /// - The key that the specification calls "Super" is reported as `Unidentified` here.
-/// - The `Unidentified` variant here, can still identify a key through it's `NativeKeyCode`.
 ///
 /// [`KeyboardEvent.code`]: https://w3c.github.io/uievents-code/#code-value-tables
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum KeyCode {
-    /// This variant is used when the key cannot be translated to any other variant.
-    ///
-    /// The native keycode is provided (if available) so you're able to more reliably match
-    /// key-press and key-release events by hashing the [`KeyCode`]. It is also possible to use
-    /// this for keybinds for non-standard keys, but such keybinds are tied to a given platform.
-    Unidentified(NativeKeyCode),
     /// <kbd>`</kbd> on a US keyboard. This is also called a backtick or grave.
     /// This is the <kbd>半角</kbd>/<kbd>全角</kbd>/<kbd>漢字</kbd>
     /// (hankaku/zenkaku/kanji) key on Japanese keyboards

--- a/src/platform/scancode.rs
+++ b/src/platform/scancode.rs
@@ -1,14 +1,14 @@
 #![cfg(any(windows_platform, macos_platform, x11_platform, wayland_platform))]
 
-use crate::keyboard::KeyCode;
+use crate::keyboard::{KeyCode, PhysicalKey};
 
 // TODO: Describe what this value contains for each platform
 
-/// Additional methods for the [`KeyCode`] type that allow the user to access the platform-specific
+/// Additional methods for the [`PhysicalKey`] type that allow the user to access the platform-specific
 /// scancode.
 ///
-/// [`KeyCode`]: crate::keyboard::KeyCode
-pub trait KeyCodeExtScancode {
+/// [`PhysicalKey`]: crate::keyboard::PhysicalKey
+pub trait PhysicalKeyExtScancode {
     /// The raw value of the platform-specific physical key identifier.
     ///
     /// Returns `Some(key_id)` if the conversion was succesful; returns `None` otherwise.
@@ -18,13 +18,28 @@ pub trait KeyCodeExtScancode {
     /// - **Wayland/X11**: A 32-bit linux scancode, which is X11/Wayland keycode subtracted by 8.
     fn to_scancode(self) -> Option<u32>;
 
-    /// Constructs a `KeyCode` from a platform-specific physical key identifier.
+    /// Constructs a `PhysicalKey` from a platform-specific physical key identifier.
     ///
-    /// Note that this conversion may be lossy, i.e. converting the returned `KeyCode` back
+    /// Note that this conversion may be lossy, i.e. converting the returned `PhysicalKey` back
     /// using `to_scancode` might not yield the original value.
     ///
     /// ## Platform-specific
     /// - **Wayland/X11**: A 32-bit linux scancode. When building from X11/Wayland keycode subtract
     ///                    `8` to get the value you wanted.
-    fn from_scancode(scancode: u32) -> KeyCode;
+    fn from_scancode(scancode: u32) -> PhysicalKey;
+}
+
+impl PhysicalKeyExtScancode for KeyCode
+where
+    PhysicalKey: PhysicalKeyExtScancode,
+{
+    #[inline]
+    fn from_scancode(scancode: u32) -> PhysicalKey {
+        <PhysicalKey as PhysicalKeyExtScancode>::from_scancode(scancode)
+    }
+
+    #[inline]
+    fn to_scancode(self) -> Option<u32> {
+        <PhysicalKey as PhysicalKeyExtScancode>::to_scancode(PhysicalKey::Code(self))
+    }
 }

--- a/src/platform_impl/android/keycodes.rs
+++ b/src/platform_impl/android/keycodes.rs
@@ -3,10 +3,10 @@ use android_activity::{
     AndroidApp,
 };
 
-use crate::keyboard::{Key, KeyCode, KeyLocation, NativeKey, NativeKeyCode};
+use crate::keyboard::{Key, KeyCode, KeyLocation, NativeKey, NativeKeyCode, PhysicalKey};
 
-pub fn to_physical_keycode(keycode: Keycode) -> KeyCode {
-    match keycode {
+pub fn to_physical_key(keycode: Keycode) -> PhysicalKey {
+    PhysicalKey::Code(match keycode {
         Keycode::A => KeyCode::KeyA,
         Keycode::B => KeyCode::KeyB,
         Keycode::C => KeyCode::KeyC,
@@ -155,8 +155,8 @@ pub fn to_physical_keycode(keycode: Keycode) -> KeyCode {
         Keycode::Sleep => KeyCode::Sleep, // what about SoftSleep?
         Keycode::Wakeup => KeyCode::WakeUp,
 
-        keycode => KeyCode::Unidentified(NativeKeyCode::Android(keycode.into())),
-    }
+        keycode => return PhysicalKey::Unidentified(NativeKeyCode::Android(keycode.into())),
+    })
 }
 
 /// Tries to map the `key_event` to a `KeyMapChar` containing a unicode character or dead key accent

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -459,7 +459,7 @@ impl<T: 'static> EventLoop<T> {
                                 device_id: event::DeviceId(DeviceId(key.device_id())),
                                 event: event::KeyEvent {
                                     state,
-                                    physical_key: keycodes::to_physical_keycode(keycode),
+                                    physical_key: keycodes::to_physical_key(keycode),
                                     logical_key: keycodes::to_logical(key_char, keycode),
                                     location: keycodes::to_location(keycode),
                                     repeat: key.repeat_count() > 0,

--- a/src/platform_impl/linux/common/xkb_state.rs
+++ b/src/platform_impl/linux/common/xkb_state.rs
@@ -22,7 +22,7 @@ use crate::platform_impl::common::keymap;
 use crate::platform_impl::KeyEventExtra;
 use crate::{
     event::ElementState,
-    keyboard::{Key, KeyCode, KeyLocation},
+    keyboard::{Key, KeyLocation, PhysicalKey},
 };
 
 // TODO: Wire this up without using a static `AtomicBool`.
@@ -391,7 +391,7 @@ impl KbdState {
     ) -> KeyEvent {
         let mut event =
             KeyEventResults::new(self, keycode, !repeat && state == ElementState::Pressed);
-        let physical_key = event.keycode();
+        let physical_key = event.physical_key();
         let (logical_key, location) = event.key();
         let text = event.text();
         let (key_without_modifiers, _) = event.key_without_modifiers();
@@ -498,8 +498,8 @@ impl<'a> KeyEventResults<'a> {
         }
     }
 
-    fn keycode(&mut self) -> KeyCode {
-        keymap::raw_keycode_to_keycode(self.keycode)
+    fn physical_key(&mut self) -> PhysicalKey {
+        keymap::raw_keycode_to_physicalkey(self.keycode)
     }
 
     pub fn key(&mut self) -> (Key, KeyLocation) {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -25,10 +25,10 @@ use crate::{
         EventLoopWindowTarget as RootELW,
     },
     icon::Icon,
-    keyboard::{Key, KeyCode},
+    keyboard::{Key, PhysicalKey},
     platform::{
         modifier_supplement::KeyEventExtModifierSupplement, pump_events::PumpStatus,
-        scancode::KeyCodeExtScancode,
+        scancode::PhysicalKeyExtScancode,
     },
     window::{
         ActivationToken, CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme,
@@ -633,13 +633,13 @@ impl KeyEventExtModifierSupplement for KeyEvent {
     }
 }
 
-impl KeyCodeExtScancode for KeyCode {
-    fn from_scancode(scancode: u32) -> KeyCode {
+impl PhysicalKeyExtScancode for PhysicalKey {
+    fn from_scancode(scancode: u32) -> PhysicalKey {
         common::keymap::scancode_to_keycode(scancode)
     }
 
     fn to_scancode(self) -> Option<u32> {
-        common::keymap::keycode_to_scancode(self)
+        common::keymap::physicalkey_to_scancode(self)
     }
 }
 

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1201,7 +1201,7 @@ impl<T: 'static> EventProcessor<T> {
                         if keycode < KEYCODE_OFFSET as u32 {
                             return;
                         }
-                        let physical_key = keymap::raw_keycode_to_keycode(keycode);
+                        let physical_key = keymap::raw_keycode_to_physicalkey(keycode);
 
                         callback(Event::DeviceEvent {
                             device_id,

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -26,9 +26,9 @@ use crate::{
         DeviceEvent, ElementState, Event, Ime, Modifiers, MouseButton, MouseScrollDelta,
         TouchPhase, WindowEvent,
     },
-    keyboard::{Key, KeyCode, KeyLocation, ModifiersState},
+    keyboard::{Key, KeyCode, KeyLocation, ModifiersState, PhysicalKey},
     platform::macos::{OptionAsAlt, WindowExtMacOS},
-    platform::scancode::KeyCodeExtScancode,
+    platform::scancode::PhysicalKeyExtScancode,
     platform_impl::platform::{
         app_state::AppState,
         event::{create_key_event, event_mods},
@@ -921,16 +921,16 @@ impl WinitView {
         // has already been pressed
         if is_flags_changed_event {
             let scancode = ns_event.key_code();
-            let keycode = KeyCode::from_scancode(scancode as u32);
+            let physical_key = PhysicalKey::from_scancode(scancode as u32);
 
             // We'll correct the `is_press` later.
-            let mut event = create_key_event(ns_event, false, false, Some(keycode));
+            let mut event = create_key_event(ns_event, false, false, Some(physical_key));
 
-            let key = code_to_key(keycode, scancode);
+            let key = code_to_key(physical_key, scancode);
             let event_modifier = key_to_modifier(&key);
-            event.physical_key = keycode;
+            event.physical_key = physical_key;
             event.logical_key = key.clone();
-            event.location = code_to_location(keycode);
+            event.location = code_to_location(physical_key);
             let location_mask = ModLocationMask::from_location(event.location);
 
             let mut phys_mod_state = self.state.phys_modifiers.borrow_mut();

--- a/src/platform_impl/web/keyboard.rs
+++ b/src/platform_impl/web/keyboard.rs
@@ -1,6 +1,6 @@
 use smol_str::SmolStr;
 
-use crate::keyboard::{Key, KeyCode, NativeKey, NativeKeyCode};
+use crate::keyboard::{Key, KeyCode, NativeKey, NativeKeyCode, PhysicalKey};
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub(crate) struct KeyEventExtra;
@@ -320,9 +320,9 @@ impl Key {
     }
 }
 
-impl KeyCode {
+impl PhysicalKey {
     pub fn from_key_code_attribute_value(kcav: &str) -> Self {
-        match kcav {
+        PhysicalKey::Code(match kcav {
             "Backquote" => KeyCode::Backquote,
             "Backslash" => KeyCode::Backslash,
             "BracketLeft" => KeyCode::BracketLeft,
@@ -516,7 +516,7 @@ impl KeyCode {
             "F33" => KeyCode::F33,
             "F34" => KeyCode::F34,
             "F35" => KeyCode::F35,
-            _ => KeyCode::Unidentified(NativeKeyCode::Unidentified),
-        }
+            _ => return PhysicalKey::Unidentified(NativeKeyCode::Unidentified),
+        })
     }
 }

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -12,7 +12,7 @@ use web_sys::{
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
 use crate::event::{Force, InnerSizeWriter, MouseButton, MouseScrollDelta};
-use crate::keyboard::{Key, KeyCode, KeyLocation, ModifiersState};
+use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
 use crate::platform_impl::{OsError, PlatformSpecificWindowBuilderAttributes};
 use crate::window::{WindowAttributes, WindowId as RootWindowId};
 
@@ -259,7 +259,7 @@ impl Canvas {
 
     pub fn on_keyboard_release<F>(&mut self, mut handler: F, prevent_default: bool)
     where
-        F: 'static + FnMut(KeyCode, Key, Option<SmolStr>, KeyLocation, bool, ModifiersState),
+        F: 'static + FnMut(PhysicalKey, Key, Option<SmolStr>, KeyLocation, bool, ModifiersState),
     {
         self.on_keyboard_release =
             Some(self.common.add_event("keyup", move |event: KeyboardEvent| {
@@ -281,7 +281,7 @@ impl Canvas {
 
     pub fn on_keyboard_press<F>(&mut self, mut handler: F, prevent_default: bool)
     where
-        F: 'static + FnMut(KeyCode, Key, Option<SmolStr>, KeyLocation, bool, ModifiersState),
+        F: 'static + FnMut(PhysicalKey, Key, Option<SmolStr>, KeyLocation, bool, ModifiersState),
     {
         self.on_keyboard_press = Some(self.common.add_transient_event(
             "keydown",

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -1,6 +1,6 @@
 use crate::dpi::LogicalPosition;
 use crate::event::{MouseButton, MouseScrollDelta};
-use crate::keyboard::{Key, KeyCode, KeyLocation, ModifiersState};
+use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
 
 use once_cell::unsync::OnceCell;
 use smol_str::SmolStr;
@@ -149,9 +149,9 @@ pub fn mouse_scroll_delta(
     }
 }
 
-pub fn key_code(event: &KeyboardEvent) -> KeyCode {
+pub fn key_code(event: &KeyboardEvent) -> PhysicalKey {
     let code = event.code();
-    KeyCode::from_key_code_attribute_value(&code)
+    PhysicalKey::from_key_code_attribute_value(&code)
 }
 
 pub fn key(event: &KeyboardEvent) -> Key {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -81,8 +81,8 @@ use crate::{
         WindowEvent,
     },
     event_loop::{ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
-    keyboard::{KeyCode, ModifiersState},
-    platform::{pump_events::PumpStatus, scancode::KeyCodeExtScancode},
+    keyboard::{KeyCode, ModifiersState, PhysicalKey},
+    platform::{pump_events::PumpStatus, scancode::PhysicalKeyExtScancode},
     platform_impl::platform::{
         dark_mode::try_theme,
         dpi::{become_dpi_aware, dpi_to_scale_factor},
@@ -2494,7 +2494,7 @@ unsafe fn handle_raw_input<T: 'static>(userdata: &ThreadMsgTargetData<T>, data: 
             // https://devblogs.microsoft.com/oldnewthing/20080211-00/?p=23503
             return;
         }
-        let code = if keyboard.VKey == VK_NUMLOCK {
+        let physical_key = if keyboard.VKey == VK_NUMLOCK {
             // Historically, the NumLock and the Pause key were one and the same physical key.
             // The user could trigger Pause by pressing Ctrl+NumLock.
             // Now these are often physically separate and the two keys can be differentiated by
@@ -2507,47 +2507,50 @@ unsafe fn handle_raw_input<T: 'static>(userdata: &ThreadMsgTargetData<T>, data: 
             // For more on this, read the article by Raymond Chen, titled:
             // "Why does Ctrl+ScrollLock cancel dialogs?"
             // https://devblogs.microsoft.com/oldnewthing/20080211-00/?p=23503
-            KeyCode::NumLock
+            PhysicalKey::Code(KeyCode::NumLock)
         } else {
-            KeyCode::from_scancode(scancode as u32)
+            PhysicalKey::from_scancode(scancode as u32)
         };
         if keyboard.VKey == VK_SHIFT {
-            match code {
-                KeyCode::NumpadDecimal
-                | KeyCode::Numpad0
-                | KeyCode::Numpad1
-                | KeyCode::Numpad2
-                | KeyCode::Numpad3
-                | KeyCode::Numpad4
-                | KeyCode::Numpad5
-                | KeyCode::Numpad6
-                | KeyCode::Numpad7
-                | KeyCode::Numpad8
-                | KeyCode::Numpad9 => {
-                    // On Windows, holding the Shift key makes numpad keys behave as if NumLock
-                    // wasn't active. The way this is exposed to applications by the system is that
-                    // the application receives a fake key release event for the shift key at the
-                    // moment when the numpad key is pressed, just before receiving the numpad key
-                    // as well.
-                    //
-                    // The issue is that in the raw device event (here), the fake shift release
-                    // event reports the numpad key as the scancode. Unfortunately, the event doesn't
-                    // have any information to tell whether it's the left shift or the right shift
-                    // that needs to get the fake release (or press) event so we don't forward this
-                    // event to the application at all.
-                    //
-                    // For more on this, read the article by Raymond Chen, titled:
-                    // "The shift key overrides NumLock"
-                    // https://devblogs.microsoft.com/oldnewthing/20040906-00/?p=37953
-                    return;
-                }
+            match physical_key {
+                PhysicalKey::Code(code) => match code {
+                    KeyCode::NumpadDecimal
+                    | KeyCode::Numpad0
+                    | KeyCode::Numpad1
+                    | KeyCode::Numpad2
+                    | KeyCode::Numpad3
+                    | KeyCode::Numpad4
+                    | KeyCode::Numpad5
+                    | KeyCode::Numpad6
+                    | KeyCode::Numpad7
+                    | KeyCode::Numpad8
+                    | KeyCode::Numpad9 => {
+                        // On Windows, holding the Shift key makes numpad keys behave as if NumLock
+                        // wasn't active. The way this is exposed to applications by the system is that
+                        // the application receives a fake key release event for the shift key at the
+                        // moment when the numpad key is pressed, just before receiving the numpad key
+                        // as well.
+                        //
+                        // The issue is that in the raw device event (here), the fake shift release
+                        // event reports the numpad key as the scancode. Unfortunately, the event doesn't
+                        // have any information to tell whether it's the left shift or the right shift
+                        // that needs to get the fake release (or press) event so we don't forward this
+                        // event to the application at all.
+                        //
+                        // For more on this, read the article by Raymond Chen, titled:
+                        // "The shift key overrides NumLock"
+                        // https://devblogs.microsoft.com/oldnewthing/20040906-00/?p=37953
+                        return;
+                    }
+                    _ => (),
+                },
                 _ => (),
             }
         }
         userdata.send_event(Event::DeviceEvent {
             device_id,
             event: Key(RawKeyEvent {
-                physical_key: code,
+                physical_key,
                 state,
             }),
         });

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -338,6 +338,7 @@ impl LayoutCache {
             }
             let keycode = match PhysicalKey::from_scancode(scancode) {
                 PhysicalKey::Code(code) => code,
+                // TODO: validate that we can skip on unidentified keys (probably never occurs?)
                 _ => continue,
             };
             if !is_numpad_specific(vk as VIRTUAL_KEY) && NUMPAD_KEYCODES.contains(&keycode) {
@@ -389,6 +390,7 @@ impl LayoutCache {
                 let native_code = NativeKey::Windows(vk as VIRTUAL_KEY);
                 let key_code = match PhysicalKey::from_scancode(scancode) {
                     PhysicalKey::Code(code) => code,
+                    // TODO: validate that we can skip on unidentified keys (probably never occurs?)
                     _ => continue,
                 };
                 // Let's try to get the key from just the scancode and vk
@@ -741,6 +743,7 @@ fn keycode_to_vkey(keycode: KeyCode, hkl: u64) -> VIRTUAL_KEY {
         KeyCode::F33 => 0,
         KeyCode::F34 => 0,
         KeyCode::F35 => 0,
+        // TODO: validate removal of KeyCode::Unidentified(_) => 0,
         _ => 0,
     }
 }

--- a/tests/serde_objects.rs
+++ b/tests/serde_objects.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use winit::{
     dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize},
     event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase},
-    keyboard::{Key, KeyCode, KeyLocation, ModifiersState},
+    keyboard::{Key, KeyCode, KeyLocation, ModifiersState, PhysicalKey},
     window::CursorIcon,
 };
 
@@ -24,6 +24,7 @@ fn events_serde() {
     needs_serde::<MouseScrollDelta>();
     needs_serde::<Key>();
     needs_serde::<KeyCode>();
+    needs_serde::<PhysicalKey>();
     needs_serde::<KeyLocation>();
     needs_serde::<ModifiersState>();
 }


### PR DESCRIPTION
- Tested on all platforms changed:
  - [x] Wayland
  - [x] Web
  - [ ] X11
  - [ ] Windows
  - [ ] MacOS
  - [ ] Android
  - [ ] Orbital
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

Implement desired changes from #2995:

- [x] Split `enum KeyCode` into `PhysicalKey`, `KeyCode`
- [ ] Split `enum Key` into `Key`, `Action` (names?)

WIP.