### PR TITLE
Implement `AsFd`/`AsRawFd` for `EventLoop<T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On iOS, send events `WindowEvent::Occluded(false)`, `WindowEvent::Occluded(true)` when application enters/leaves foreground.
 - **Breaking** add `Event::MemoryWarning`; implemented on iOS/Android.
 - On Wayland, support `Occluded` event with xdg-shell v6
+- Implement `AsFd`/`AsRawFd` for `EventLoop<T>` on X11 and Wayland.
 
 # 0.29.1-beta
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -9,6 +9,8 @@
 //! handle events.
 use std::marker::PhantomData;
 use std::ops::Deref;
+#[cfg(any(x11_platform, wayland_platform))]
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::{error, fmt};
 
@@ -259,6 +261,34 @@ unsafe impl<T> rwh_05::HasRawDisplayHandle for EventLoop<T> {
     /// Returns a [`raw_window_handle::RawDisplayHandle`] for the event loop.
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
         rwh_05::HasRawDisplayHandle::raw_display_handle(&**self)
+    }
+}
+
+#[cfg(any(x11_platform, wayland_platform))]
+impl<T> AsFd for EventLoop<T> {
+    /// Get the underlying [EventLoop]'s `fd` which you can register
+    /// into other event loop, like [`calloop`] or [`mio`]. When doing so, the
+    /// loop must be polled with the [`pump_events`] API.
+    ///
+    /// [`calloop`]: https://crates.io/crates/calloop
+    /// [`mio`]: https://crates.io/crates/mio
+    /// [`pump_events`]: crate::platform::pump_events::EventLoopExtPumpEvents::pump_events
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.event_loop.as_fd()
+    }
+}
+
+#[cfg(any(x11_platform, wayland_platform))]
+impl<T> AsRawFd for EventLoop<T> {
+    /// Get the underlying [EventLoop]'s raw `fd` which you can register
+    /// into other event loop, like [`calloop`] or [`mio`]. When doing so, the
+    /// loop must be polled with the [`pump_events`] API.
+    ///
+    /// [`calloop`]: https://crates.io/crates/calloop
+    /// [`mio`]: https://crates.io/crates/mio
+    /// [`pump_events`]: crate::platform::pump_events::EventLoopExtPumpEvents::pump_events
+    fn as_raw_fd(&self) -> RawFd {
+        self.event_loop.as_raw_fd()
     }
 }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -3,6 +3,7 @@
 #[cfg(all(not(x11_platform), not(wayland_platform)))]
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{collections::VecDeque, env, fmt};
@@ -824,6 +825,18 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget<T> {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.window_target())
+    }
+}
+
+impl<T> AsFd for EventLoop<T> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        x11_or_wayland!(match self; EventLoop(evlp) => evlp.as_fd())
+    }
+}
+
+impl<T> AsRawFd for EventLoop<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        x11_or_wayland!(match self; EventLoop(evlp) => evlp.as_raw_fd())
     }
 }
 

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -4,6 +4,7 @@ use std::cell::{Cell, RefCell};
 use std::io::Result as IOResult;
 use std::marker::PhantomData;
 use std::mem;
+use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::rc::Rc;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
@@ -586,6 +587,18 @@ impl<T: 'static> EventLoop<T> {
 
     fn exit_code(&self) -> Option<i32> {
         self.window_target.p.exit_code()
+    }
+}
+
+impl<T> AsFd for EventLoop<T> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.event_loop.as_fd()
+    }
+}
+
+impl<T> AsRawFd for EventLoop<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.event_loop.as_raw_fd()
     }
 }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -32,7 +32,7 @@ use std::{
     ops::Deref,
     os::{
         raw::*,
-        unix::io::{AsRawFd, BorrowedFd},
+        unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd},
     },
     ptr,
     rc::Rc,
@@ -655,6 +655,18 @@ impl<T: 'static> EventLoop<T> {
 
     fn exit_code(&self) -> Option<i32> {
         self.target.p.exit_code()
+    }
+}
+
+impl<T> AsFd for EventLoop<T> {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.event_loop.as_fd()
+    }
+}
+
+impl<T> AsRawFd for EventLoop<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.event_loop.as_raw_fd()
     }
 }
 


### PR DESCRIPTION
This should help other crates to integrate winit's event loop into their bigger event loop without adding an extra thread.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
