### PR TITLE
Add a note on `Window::request_redraw` on Windows

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -572,7 +572,8 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **Windows** This API uses `RedrawWindow` to request a `WM_PAINT` message and `RedrawRequested`
-    ///   is emitted in sync with any `WM_PAINT` messages
+    ///   is emitted in sync with any `WM_PAINT` messages. **Calling this method from `RedrawRequested`
+    ///   event handler won't produce a `RedrawRequested` event**.
     /// - **iOS:** Can only be called on the main thread.
     /// - **Wayland:** The events are aligned with the frame callbacks when [`Window::pre_present_notify`]
     ///                is used.


### PR DESCRIPTION
Fixing this could require a massive rework to how redraw is handled on windows to the point of removing `WM_PAINT`, since it's not reliable by any means for our use case.

For now at least document that the API is broken. It was broken like that for a long while.
