### PR TITLE
On macOS, fix globe key triggering assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Implement `AsFd`/`AsRawFd` for `EventLoop<T>` on X11 and Wayland.
 - **Breaking:** Bump `ndk` version to `0.8.0`, ndk-sys to `0.5.0`, `android-activity` to `0.5.0`.
 - Make `WindowBuilder` `Send + Sync`.
+- On macOS, fix assertion when pressing `Globe` key.
 
 # 0.29.1-beta
 

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -918,8 +918,13 @@ impl WinitView {
 
         // This function was called form the flagsChanged event, which is triggered
         // when the user presses/releases a modifier even if the same kind of modifier
-        // has already been pressed
-        if is_flags_changed_event {
+        // has already been pressed.
+        //
+        // When flags changed event has key code of zero it means that event doesn't carry any key
+        // event, thus we can't generate regular presses based on that. The `ModifiersChanged`
+        // later will work though, since the flags are attached to the event and contain valid
+        // information.
+        if is_flags_changed_event && ns_event.key_code() != 0 {
             let scancode = ns_event.key_code();
             let keycode = KeyCode::from_scancode(scancode as u32);
 


### PR DESCRIPTION
Sometimes FlagsChanged events don't carry any KeyCode information, thus we can't create a synthetic presses events for them.

However in such cases, modifiers information is still accurate, thus propagate it.

Fixes #2872.
