### PR TITLE
On macOS, fix tabGroup misuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - Make `WindowBuilder` `Send + Sync`.
 - On macOS, fix assertion when pressing `Globe` key.
 - On Windows, updated `WM_MOUSEMOVE` to detect when cursor Enter or Leave window client area while captured and send the corresponding events. (#3153)
+- On macOS, fix crash when accessing tabbing APIs.
 
 # 0.29.1-beta
 

--- a/src/platform_impl/macos/appkit/tab_group.rs
+++ b/src/platform_impl/macos/appkit/tab_group.rs
@@ -23,7 +23,7 @@ extern_methods!(
         pub fn selectPreviousTab(&self);
 
         #[method_id(windows)]
-        pub fn tabbedWindows(&self) -> Id<NSArray<NSWindow>>;
+        pub fn tabbedWindows(&self) -> Option<Id<NSArray<NSWindow>>>;
 
         #[method(setSelectedWindow:)]
         pub fn setSelectedWindow(&self, window: &NSWindow);

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -218,7 +218,7 @@ extern_methods!(
         pub(crate) fn tabbingIdentifier(&self) -> Id<NSString>;
 
         #[method_id(tabGroup)]
-        pub(crate) fn tabGroup(&self) -> Id<NSWindowTabGroup>;
+        pub(crate) fn tabGroup(&self) -> Option<Id<NSWindowTabGroup>>;
 
         #[method(isDocumentEdited)]
         pub(crate) fn isDocumentEdited(&self) -> bool;

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1525,27 +1525,35 @@ impl WindowExtMacOS for WinitWindow {
 
     #[inline]
     fn select_next_tab(&self) {
-        self.tabGroup().selectNextTab();
+        if let Some(group) = self.tabGroup() {
+            group.selectNextTab();
+        }
     }
 
     #[inline]
     fn select_previous_tab(&self) {
-        self.tabGroup().selectPreviousTab();
+        if let Some(group) = self.tabGroup() {
+            group.selectPreviousTab()
+        }
     }
 
     #[inline]
     fn select_tab_at_index(&self, index: usize) {
-        let tab_group = self.tabGroup();
-        let windows = tab_group.tabbedWindows();
-        if index < windows.len() {
-            tab_group.setSelectedWindow(&windows[index]);
+        if let Some(group) = self.tabGroup() {
+            if let Some(windows) = group.tabbedWindows() {
+                if index < windows.len() {
+                    group.setSelectedWindow(&windows[index]);
+                }
+            }
         }
     }
 
     #[inline]
     fn num_tabs(&self) -> usize {
-        let tab_group = self.tabGroup();
-        tab_group.tabbedWindows().len()
+        self.tabGroup()
+            .and_then(|group| group.tabbedWindows())
+            .map(|windows| windows.len())
+            .unwrap_or(1)
     }
 
     fn is_document_edited(&self) -> bool {


### PR DESCRIPTION
The property is marked as `Weak`, however we used strong `Id`.

Links: https://github.com/alacritty/alacritty/issues/7249
