### PR TITLE
Fix examples not render on Wayland

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ smol_str = "0.2.0"
 [dev-dependencies]
 image = { version = "0.24.0", default-features = false, features = ["png"] }
 simple_logger = { version = "4.2.0", default_features = false }
+winit = { path = ".", features = ["rwh_05"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dev-dependencies]
 softbuffer = "0.3.0"


### PR DESCRIPTION
The `rwh_05` feature was not enabled.

Fixes: e41fac825c2 (Update to new raw-window-handle strategy)