### PR TITLE
Ensure that DISPLAY vars are non-empty before using

### DIFF
--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -752,11 +752,16 @@ impl<T: 'static> EventLoop<T> {
             );
         }
 
-        // NOTE: Wayland first because of X11 could be present under wayland as well.
+        // NOTE: Wayland first because of X11 could be present under Wayland as well. Empty
+        // variables are also treated as not set.
         let backend = match (
             attributes.forced_backend,
-            env::var("WAYLAND_DISPLAY").is_ok(),
-            env::var("DISPLAY").is_ok(),
+            env::var("WAYLAND_DISPLAY")
+                .map(|var| !var.is_empty())
+                .unwrap_or(false),
+            env::var("DISPLAY")
+                .map(|var| !var.is_empty())
+                .unwrap_or(false),
         ) {
             // User is forcing a backend.
             (Some(backend), _, _) => backend,


### PR DESCRIPTION
It's common to disable Wayland by `WAYLAND_DISPLAY= <application>`.
