### PR TITLE
On Windows, fix `RedrawRequested` delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On macOS, fix assertion when pressing `Globe` key.
 - On Windows, updated `WM_MOUSEMOVE` to detect when cursor Enter or Leave window client area while captured and send the corresponding events. (#3153)
 - On macOS, fix crash when accessing tabbing APIs.
+- On Windows, fix `RedrawRequested` not being delivered when calling `Window::request_redraw` from `RedrawRequested`.
 
 # 0.29.1-beta
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -149,6 +149,8 @@ impl Window {
 
     #[inline]
     pub fn request_redraw(&self) {
+        // NOTE: mark that we requested a redraw to handle requests during `WM_PAINT` handling.
+        self.window_state.lock().unwrap().redraw_requested = true;
         unsafe {
             RedrawWindow(self.hwnd(), ptr::null(), 0, RDW_INTERNALPAINT);
         }

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -52,6 +52,9 @@ pub(crate) struct WindowState {
     pub is_active: bool,
     pub is_focused: bool,
 
+    // Flag whether redraw was requested.
+    pub redraw_requested: bool,
+
     pub dragging: bool,
 
     pub skip_taskbar: bool,
@@ -166,6 +169,7 @@ impl WindowState {
 
             is_active: false,
             is_focused: false,
+            redraw_requested: false,
 
             dragging: false,
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -585,8 +585,7 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **Windows** This API uses `RedrawWindow` to request a `WM_PAINT` message and `RedrawRequested`
-    ///   is emitted in sync with any `WM_PAINT` messages. **Calling this method from `RedrawRequested`
-    ///   event handler won't produce a `RedrawRequested` event**.
+    ///   is emitted in sync with any `WM_PAINT` messages.
     /// - **iOS:** Can only be called on the main thread.
     /// - **Wayland:** The events are aligned with the frame callbacks when [`Window::pre_present_notify`]
     ///                is used.


### PR DESCRIPTION
When calling `Window::request_redraw` from the `RedrawRequested` handler the `RedrawWindow` won't result in `WM_PAINT` being delivered due since user callback is run before `DefWindowProcW` is called.

Track whether the user called `Window::request_redraw` and ask for `RedrawWindow` after running the said function during `WM_PAINT` handling.

Fixes #3150.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
