### PR TITLE
On Windows, fix IME APIs MT-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ And please only add new entries to the top of this list, right below the `# Unre
 - On Windows, updated `WM_MOUSEMOVE` to detect when cursor Enter or Leave window client area while captured and send the corresponding events. (#3153)
 - On macOS, fix crash when accessing tabbing APIs.
 - On Windows, fix `RedrawRequested` not being delivered when calling `Window::request_redraw` from `RedrawRequested`.
+- On Windows, fix IME APIs not working when from non event loop thread.
 
 # 0.29.1-beta
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -872,17 +872,22 @@ impl Window {
 
     #[inline]
     pub fn set_ime_cursor_area(&self, spot: Position, size: Size) {
-        unsafe {
-            ImeContext::current(self.hwnd()).set_ime_cursor_area(spot, size, self.scale_factor());
-        }
+        let window = self.window.clone();
+        let state = self.window_state.clone();
+        self.thread_executor.execute_in_thread(move || unsafe {
+            let scale_factor = state.lock().unwrap().scale_factor;
+            ImeContext::current(window.0).set_ime_cursor_area(spot, size, scale_factor);
+        });
     }
 
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
-        self.window_state_lock().ime_allowed = allowed;
-        unsafe {
-            ImeContext::set_ime_allowed(self.hwnd(), allowed);
-        }
+        let window = self.window.clone();
+        let state = self.window_state.clone();
+        self.thread_executor.execute_in_thread(move || unsafe {
+            state.lock().unwrap().ime_allowed = allowed;
+            ImeContext::set_ime_allowed(window.0, allowed);
+        })
     }
 
     #[inline]


### PR DESCRIPTION
Execute the calls to the IME from the main thread.

Fixes #3123.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
