### PR TITLE
On Winows, Fix deedlock with `WM_MOUSEMOVE`

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1496,7 +1496,7 @@ unsafe fn public_window_callback_inner<T: 'static>(
                             },
                         });
                     }
-                    PointerMoveKind::None => (),
+                    PointerMoveKind::None => drop(w),
                 }
 
                 // handle spurious WM_MOUSEMOVE messages


### PR DESCRIPTION
The lock was still present in `None` path.

Fixes: d37d1a03b(On Windows, fix deadlock during `Cursor{Enter,Leave}`)
