### PR TITLE
On macOS, fix deadlock during nested event loops (e.g. rfd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased` header.
 # Unreleased
 
 - On Windows, fix deadlock when accessing the state during `Cursor{Enter,Leave}`.
+- On macOS, fix deadlock when entering a nested event loop from an event handler.
 
 # 0.29.2
 

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -494,9 +494,9 @@ impl AppState {
 
         // Return when in callback due to https://github.com/rust-windowing/winit/issues/1779
         if panic_info.is_panicking()
+            || HANDLER.get_in_callback()
             || !HANDLER.have_callback()
             || !HANDLER.is_running()
-            || HANDLER.get_in_callback()
         {
             return;
         }
@@ -601,9 +601,9 @@ impl AppState {
         // XXX: how does it make sense that `get_in_callback()` can ever return `true` here if we're
         // about to return to the `CFRunLoop` to poll for new events?
         if panic_info.is_panicking()
+            || HANDLER.get_in_callback()
             || !HANDLER.have_callback()
             || !HANDLER.is_running()
-            || HANDLER.get_in_callback()
         {
             return;
         }


### PR DESCRIPTION
Calling [`have_callback()`](https://github.com/rust-windowing/winit/blob/62ed51a138aeb2dc7d64950e6f9877ba9d57646e/src/platform_impl/macos/app_state.rs#L308C8-L310) during the callback deadlocks. Reorder the [`get_in_callback()`](https://github.com/rust-windowing/winit/blob/62ed51a138aeb2dc7d64950e6f9877ba9d57646e/src/platform_impl/macos/app_state.rs#L300-L302) call first to avoid the deadlock.

Fixes: #3179

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented