### PR TITLE
On Wayland, improve initial user size handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ Unreleased` header.
 
 # Unreleased
 
+- On Wayland, apply correct scale to `PhysicalSize` passed in `WindowBuilder::with_inner_size` when possible.
 - On Wayland, fix `RedrawRequsted` being always sent without decorations and `sctk-adwaita` feature.
+- On Wayland, ignore resize requests when the window is fully tiled.
+- On Wayland, use `configure_bounds` to constrain `with_inner_size` when compositor wants users to pick size.
 - On Windows, fix deadlock when accessing the state during `Cursor{Enter,Leave}`.
 - On macOS, fix deadlock when entering a nested event loop from an event handler.
 

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -393,7 +393,7 @@ impl<T: 'static> EventLoop<T> {
                     self.with_state(|state| {
                         let windows = state.windows.get_mut();
                         let mut window = windows.get(&window_id).unwrap().lock().unwrap();
-                        window.resize(new_logical_size);
+                        window.request_inner_size(new_logical_size.into());
                     });
                 }
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -97,11 +97,9 @@ impl Window {
             .map(|activation_state| activation_state.global().clone());
         let display = event_loop_window_target.connection.display();
 
-        // XXX The initial scale factor must be 1, but it might cause sizing issues on HiDPI.
-        let size: LogicalSize<u32> = attributes
+        let size: Size = attributes
             .inner_size
-            .map(|size| size.to_logical::<u32>(1.))
-            .unwrap_or((800, 600).into());
+            .unwrap_or(LogicalSize::new(800., 600.).into());
 
         // We prefer server side decorations, however to not have decorations we ask for client
         // side decorations instead.
@@ -141,7 +139,8 @@ impl Window {
         // Set the window title.
         window_state.set_title(attributes.title);
 
-        // Set the min and max sizes.
+        // Set the min and max sizes. We must set the hints upon creating a window, so
+        // we use the default `1.` scaling...
         let min_size = attributes.min_inner_size.map(|size| size.to_logical(1.));
         let max_size = attributes.max_inner_size.map(|size| size.to_logical(1.));
         window_state.set_min_inner_size(min_size);
@@ -315,12 +314,9 @@ impl Window {
     #[inline]
     pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let mut window_state = self.window_state.lock().unwrap();
-        let scale_factor = window_state.scale_factor();
-        window_state.resize(size.to_logical::<u32>(scale_factor));
-
+        let new_size = window_state.request_inner_size(size);
         self.request_redraw();
-
-        Some(window_state.inner_size().to_physical(scale_factor))
+        Some(new_size)
     }
 
     /// Set the minimum inner size for the window.

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -212,7 +212,7 @@ impl XConnection {
             return Ok(MonitorHandle::dummy());
         }
 
-        let default = monitors.get(0).unwrap();
+        let default = monitors.first().unwrap();
 
         let window_rect = match window_rect {
             Some(rect) => rect,


### PR DESCRIPTION
Keep the user provided size in the original values and convert only when we're getting a `configure` event. On some compositors will have a scale available, so it'll work, however with some we'll still have old 'pick 1` as default.

Also configure_bounds when compositor tells the user to pick the size, that will ensure that initial `with_inner_size` won't grow beyond the working area.

Fixes #3187.

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


@dhardy can you test this? It should probably make the `PhysicalSize` work on at least some systems and if you pass the big `with_inner_size` winit will constrain to the the size compositor wants.