### PR TITLE
On Wayland, fix `RedrawRequsted` loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased` header.
 # Unreleased
 
 - On Windows, fix deadlock when accessing the state during `Cursor{Enter,Leave}`.
+- On Wayland, fix `RedrawRequsted` being always sent without decorations and `sctk-adwaita` feature.
 
 # 0.29.2
 

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -537,7 +537,7 @@ impl WindowState {
     /// Refresh the decorations frame if it's present returning whether the client should redraw.
     pub fn refresh_frame(&mut self) -> bool {
         if let Some(frame) = self.frame.as_mut() {
-            if frame.is_dirty() {
+            if !frame.is_hidden() && frame.is_dirty() {
                 return frame.draw();
             }
         }


### PR DESCRIPTION
The `dirty` is never cleared when decorations are hidden without `sctk-adwaita`.

Fixes #3177.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
