### PR TITLE
Prefer `[foo][bar]` over `[foo](bar)` for intra-doc links

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -11,7 +11,7 @@ pub trait ApplicationHandler<T: 'static = ()> {
     /// This is a useful place to put code that should be done before you start processing
     /// events, such as updating frame timing information for benchmarking or checking the
     /// [`StartCause`] to see if a timer set by
-    /// [`ControlFlow::WaitUntil`](crate::event_loop::ControlFlow::WaitUntil) has elapsed.
+    /// [`ControlFlow::WaitUntil`][crate::event_loop::ControlFlow::WaitUntil] has elapsed.
     fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
         let _ = (event_loop, cause);
     }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -12,7 +12,7 @@ pub const MAX_CURSOR_SIZE: u16 = 2048;
 
 const PIXEL_SIZE: usize = 4;
 
-/// See [`Window::set_cursor()`](crate::window::Window::set_cursor) for more details.
+/// See [`Window::set_cursor()`][crate::window::Window::set_cursor] for more details.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub enum Cursor {
     Icon(CursorIcon),

--- a/src/event.rs
+++ b/src/event.rs
@@ -790,8 +790,8 @@ impl From<ModifiersState> for Modifiers {
 pub enum Ime {
     /// Notifies when the IME was enabled.
     ///
-    /// After getting this event you could receive [`Preedit`](Self::Preedit) and
-    /// [`Commit`](Self::Commit) events. You should also start performing IME related requests
+    /// After getting this event you could receive [`Preedit`][Self::Preedit] and
+    /// [`Commit`][Self::Commit] events. You should also start performing IME related requests
     /// like [`Window::set_ime_cursor_area`].
     Enabled,
 
@@ -811,8 +811,8 @@ pub enum Ime {
 
     /// Notifies when the IME was disabled.
     ///
-    /// After receiving this event you won't get any more [`Preedit`](Self::Preedit) or
-    /// [`Commit`](Self::Commit) events until the next [`Enabled`](Self::Enabled) event. You should
+    /// After receiving this event you won't get any more [`Preedit`][Self::Preedit] or
+    /// [`Commit`][Self::Commit] events until the next [`Enabled`][Self::Enabled] event. You should
     /// also stop issuing IME related requests like [`Window::set_ime_cursor_area`] and clear pending
     /// preedit text.
     Disabled,

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -3,7 +3,7 @@
 //!
 //! If you want to send custom events to the event loop, use
 //! [`EventLoop::create_proxy`] to acquire an [`EventLoopProxy`] and call its
-//! [`send_event`](`EventLoopProxy::send_event`) method.
+//! [`send_event`][EventLoopProxy::send_event] method.
 //!
 //! See the root-level documentation for information on how to create and use an event loop to
 //! handle events.
@@ -468,7 +468,7 @@ impl ActiveEventLoop {
 
     /// This exits the event loop.
     ///
-    /// See [`LoopExiting`](Event::LoopExiting).
+    /// See [`LoopExiting`][Event::LoopExiting].
     pub fn exit(&self) {
         let _span = tracing::debug_span!("winit::ActiveEventLoop::exit",).entered();
 
@@ -477,7 +477,7 @@ impl ActiveEventLoop {
 
     /// Returns if the [`EventLoop`] is about to stop.
     ///
-    /// See [`exit()`](Self::exit).
+    /// See [`exit()`][Self::exit].
     pub fn exiting(&self) -> bool {
         self.p.exiting()
     }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -218,7 +218,7 @@ impl PartialEq<NativeKeyCode> for NativeKey {
 
 /// Represents the location of a physical key.
 ///
-/// This type is a superset of [`KeyCode`], including an [`Unidentified`](Self::Unidentified)
+/// This type is a superset of [`KeyCode`], including an [`Unidentified`][Self::Unidentified]
 /// variant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@
 //! Note that many platforms will display garbage data in the window's client area if the
 //! application doesn't render anything to the window by the time the desktop compositor is ready to
 //! display the window to the user. If you notice this happening, you should create the window with
-//! [`visible` set to `false`](crate::window::WindowAttributes::with_visible) and explicitly make the
+//! [`visible` set to `false`][crate::window::WindowAttributes::with_visible] and explicitly make the
 //! window visible only once you're ready to render into it.
 //!
 //! # UI scaling

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,8 +3,8 @@
 //! If you want to get basic information about a monitor, you can use the
 //! [`MonitorHandle`] type. This is retrieved from one of the following
 //! methods, which return an iterator of [`MonitorHandle`]:
-//! - [`ActiveEventLoop::available_monitors`](crate::event_loop::ActiveEventLoop::available_monitors).
-//! - [`Window::available_monitors`](crate::window::Window::available_monitors).
+//! - [`ActiveEventLoop::available_monitors`][crate::event_loop::ActiveEventLoop::available_monitors].
+//! - [`Window::available_monitors`][crate::window::Window::available_monitors].
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     platform_impl,

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -252,7 +252,7 @@ impl ActiveEventLoopExtWebSys for ActiveEventLoop {
     }
 }
 
-/// Strategy used for [`ControlFlow::Poll`](crate::event_loop::ControlFlow::Poll).
+/// Strategy used for [`ControlFlow::Poll`][crate::event_loop::ControlFlow::Poll].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum PollStrategy {
     /// Uses [`Window.requestIdleCallback()`] to queue the next event loop. If not available

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -305,7 +305,7 @@ impl WindowExtWindows for Window {
 pub trait WindowAttributesExtWindows {
     /// Set an owner to the window to be created. Can be used to create a dialog box, for example.
     /// This only works when [`WindowAttributes::with_parent_window`] isn't called or set to `None`.
-    /// Can be used in combination with [`WindowExtWindows::set_enable(false)`](WindowExtWindows::set_enable)
+    /// Can be used in combination with [`WindowExtWindows::set_enable(false)`][WindowExtWindows::set_enable]
     /// on the owner window to create a modal dialog box.
     ///
     /// From MSDN:

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -54,7 +54,7 @@ pub struct Common {
     pub window: web_sys::Window,
     pub document: Document,
     /// Note: resizing the HTMLCanvasElement should go through `backend::set_canvas_size` to ensure the DPI factor is maintained.
-    /// Note: this is read-only because we use a pointer to this for [`WindowHandle`](rwh_06::WindowHandle).
+    /// Note: this is read-only because we use a pointer to this for [`WindowHandle`][rwh_06::WindowHandle].
     raw: Rc<HtmlCanvasElement>,
     style: Style,
     old_size: Rc<Cell<PhysicalSize<u32>>>,

--- a/src/window.rs
+++ b/src/window.rs
@@ -63,7 +63,7 @@ impl Drop for Window {
 
 /// Identifier of a window. Unique for each window.
 ///
-/// Can be obtained with [`window.id()`](`Window::id`).
+/// Can be obtained with [`window.id()`][`Window::id`].
 ///
 /// Whenever you receive an event specific to a window, this event contains a `WindowId` which you
 /// can then compare to the ids of your windows.
@@ -1477,7 +1477,7 @@ impl Window {
             .maybe_wait_on_main(|w| w.set_cursor_position(position))
     }
 
-    /// Set grabbing [mode](CursorGrabMode) on the cursor preventing it from leaving the window.
+    /// Set grabbing [mode][CursorGrabMode] on the cursor preventing it from leaving the window.
     ///
     /// # Example
     ///


### PR DESCRIPTION
Follow-up to a discussion here: https://github.com/rust-windowing/winit/pull/3178#discussion_r1371280634.

The logic here is that `[foo](bar)` can be used for inline links or intra-doc links, but `[foo][bar]` can be used for labels or intra-doc links, so if no label is present, it can only be a intra-doc link, making this less ambiguous and more robust to error check.