### PR TITLE
On macOS, add support for `Window::set_blur`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Unreleased` header.
 - On Windows, fix deadlock when accessing the state during `Cursor{Enter,Leave}`.
 - On Windows, add support for `Window::set_transparent`.
 - On macOS, fix deadlock when entering a nested event loop from an event handler.
+- On macOS, add support for `Window::set_blur`.
 
 # 0.29.2
 

--- a/src/platform_impl/macos/appkit/window.rs
+++ b/src/platform_impl/macos/appkit/window.rs
@@ -36,6 +36,9 @@ extern_methods!(
         #[method(frame)]
         pub(crate) fn frame(&self) -> NSRect;
 
+        #[method(windowNumber)]
+        pub(crate) fn windowNumber(&self) -> NSInteger;
+
         #[method(backingScaleFactor)]
         pub(crate) fn backingScaleFactor(&self) -> CGFloat;
 

--- a/src/platform_impl/macos/ffi.rs
+++ b/src/platform_impl/macos/ffi.rs
@@ -11,6 +11,7 @@ use core_graphics::{
     base::CGError,
     display::{CGDirectDisplayID, CGDisplayConfigRef},
 };
+use objc2::{ffi::NSInteger, runtime::AnyObject};
 
 pub type CGDisplayFadeInterval = f32;
 pub type CGDisplayReservationInterval = f32;
@@ -113,6 +114,14 @@ extern "C" {
     pub fn CGDisplayModeCopyPixelEncoding(mode: CGDisplayModeRef) -> CFStringRef;
     pub fn CGDisplayModeRetain(mode: CGDisplayModeRef);
     pub fn CGDisplayModeRelease(mode: CGDisplayModeRef);
+
+    // Wildly used private APIs; Apple uses them for their Terminal.app.
+    pub fn CGSMainConnectionID() -> *mut AnyObject;
+    pub fn CGSSetWindowBackgroundBlurRadius(
+        connection_id: *mut AnyObject,
+        window_id: NSInteger,
+        radius: i64,
+    ) -> i32;
 }
 
 mod core_video {

--- a/src/window.rs
+++ b/src/window.rs
@@ -918,7 +918,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **Android / iOS / macOS / X11 / Web / Windows:** Unsupported.
+    /// - **Android / iOS / X11 / Web / Windows:** Unsupported.
     /// - **Wayland:** Only works with org_kde_kwin_blur_manager protocol.
     #[inline]
     pub fn set_blur(&self, blur: bool) {


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


--

I researched alternatives and given that apple is doing the same as well as a lot of other apps it's probably safe for the time being. The `NSVisualEffectsView` is a bit more involved and not sure that it'll provide much value. it's also not clear how it all interacts with each other.