### PR TITLE
Implement `WindowEvent::Minimized` and `WindowEvent::Restored` for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased` header.
 
 # Unreleased
 
+- On Windows, implement `WindowEvent::Minimized` and `WindowEvent::Restored`.
+
 # 0.29.3
 
 - On Wayland, apply correct scale to `PhysicalSize` passed in `WindowBuilder::with_inner_size` when possible.

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -53,6 +53,13 @@ pub(super) fn fill_window(window: &Window) {
     }
 
     GC.with(|gc| {
+        let size = window.inner_size();
+        let (Some(width), Some(height)) =
+            (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+        else {
+            return;
+        };
+
         // Either get the last context used or create a new one.
         let mut gc = gc.borrow_mut();
         let surface = gc
@@ -61,13 +68,9 @@ pub(super) fn fill_window(window: &Window) {
 
         // Fill a buffer with a solid color.
         const DARK_GRAY: u32 = 0xFF181818;
-        let size = window.inner_size();
 
         surface
-            .resize(
-                NonZeroU32::new(size.width).expect("Width must be greater than zero"),
-                NonZeroU32::new(size.height).expect("Height must be greater than zero"),
-            )
+            .resize(width, height)
             .expect("Failed to resize the softbuffer surface");
 
         let mut buffer = surface

--- a/src/event.rs
+++ b/src/event.rs
@@ -591,6 +591,20 @@ pub enum WindowEvent {
     /// Winit will aggregate duplicate redraw requests into a single event, to
     /// help avoid duplicating rendering work.
     RedrawRequested,
+
+    /// Emitted when a window is minimized.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Only available on **Windows**.
+    Minimized,
+
+    /// Emitted when a window is restored from minimized state.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Only available on **Windows**.
+    Restored,
 }
 
 /// Identifier of an input device.


### PR DESCRIPTION
- [ ] Tested on all platforms changed
  - I only tested this change on Windows since the implementation affects only Windows
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This PR partially implements #1578 by adding new window events `WindowEvent::Minimized` and `WindowEvent::Restored`.
