### PR TITLE
On Windows, fix examples crash when minimizing a window 

### DIFF
--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -53,6 +53,13 @@ pub(super) fn fill_window(window: &Window) {
     }
 
     GC.with(|gc| {
+        let size = window.inner_size();
+        let (Some(width), Some(height)) =
+            (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+        else {
+            return;
+        };
+
         // Either get the last context used or create a new one.
         let mut gc = gc.borrow_mut();
         let surface = gc
@@ -61,13 +68,9 @@ pub(super) fn fill_window(window: &Window) {
 
         // Fill a buffer with a solid color.
         const DARK_GRAY: u32 = 0xFF181818;
-        let size = window.inner_size();
 
         surface
-            .resize(
-                NonZeroU32::new(size.width).expect("Width must be greater than zero"),
-                NonZeroU32::new(size.height).expect("Height must be greater than zero"),
-            )
+            .resize(width, height)
             .expect("Failed to resize the softbuffer surface");
 
         let mut buffer = surface


### PR DESCRIPTION
- [ ] Tested on all platforms changed
  - Tested on macOS and Windows
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

When a window is minimized on Windows, `Resized` event is emited with zero width and zero height. But examples assume that window width/height are never zero so they crash. I fixed it in this PR.
