### PR TITLE
🐉 Support window dragging from outside the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased` header.
 
 # Unreleased
 
+- On Windows, fix so `drag_window` and `drag_resize_window` can be called from another thread.
+
 # 0.29.3
 
 - On Wayland, apply correct scale to `PhysicalSize` passed in `WindowBuilder::with_inner_size` when possible.

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -472,27 +472,41 @@ impl Window {
     }
 
     unsafe fn handle_os_dragging(&self, wparam: WPARAM) {
-        let points = {
-            let mut pos = unsafe { mem::zeroed() };
-            unsafe { GetCursorPos(&mut pos) };
-            pos
-        };
-        let points = POINTS {
-            x: points.x as i16,
-            y: points.y as i16,
-        };
-        unsafe { ReleaseCapture() };
+        let window = self.window.clone();
+        let window_state = self.window_state.clone();
 
-        self.window_state_lock().dragging = true;
+        self.thread_executor.execute_in_thread(move || {
+            {
+                let mut guard = window_state.lock().unwrap();
+                if !guard.dragging {
+                    guard.dragging = true;
+                } else {
+                    return;
+                }
+            }
 
-        unsafe {
-            PostMessageW(
-                self.hwnd(),
-                WM_NCLBUTTONDOWN,
-                wparam,
-                &points as *const _ as LPARAM,
-            )
-        };
+            let points = {
+                let mut pos = unsafe { mem::zeroed() };
+                unsafe { GetCursorPos(&mut pos) };
+                pos
+            };
+            let points = POINTS {
+                x: points.x as i16,
+                y: points.y as i16,
+            };
+
+            // ReleaseCapture needs to execute on the main thread
+            unsafe { ReleaseCapture() };
+
+            unsafe {
+                PostMessageW(
+                    window.0,
+                    WM_NCLBUTTONDOWN,
+                    wparam,
+                    &points as *const _ as LPARAM,
+                )
+            };
+        });
     }
 
     #[inline]


### PR DESCRIPTION
On Windows, at least, `ReleaseCapture` is documented to release the capture of the mouse on the current thread. In our application we were calling `drag_window` on another thread because we've separated the event loop out to a different thread.


- [X] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
