### PR TITLE
Disable `default-features` for the `ndk` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ softbuffer = "0.3.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = "0.5.0"
-ndk = "0.8.0"
+ndk = { version = "0.8.0", default-features = false }
 ndk-sys = "0.5.0"
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]


### PR DESCRIPTION
We decided to add `rwh_06` to the `default` list of features in the `ndk` to [nudge users to upgrade], but this forces `winit` to always (transitively) include `raw-window-handle 0.6` even if the user has set a different `rwh_xx` feature on the `winit` crate.  `winit` already forwards the respective `rwh_xx` feaure to the `ndk` crate anyway, so this default should just be turned off.

At the time of writing this is the only `default` feature of the `ndk`.

[nudge users to upgrade]: https://github.com/rust-mobile/ndk/pull/434#issuecomment-1752089087

@kchibisov what's the right way to mark this to be backported to `0.29` - open another PR targeting that branch or can you cherry-pick it?
