### PR TITLE
Windows: move prepare_wait before querying the control_flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased` header.
 
 - On X11, check common alternative cursor names when loading cursor.
 - On Windows, fix so `drag_window` and `drag_resize_window` can be called from another thread.
+- On Windows, fix `set_control_flow` in `AboutToWait` not being taken in account.
 - On macOS, send a `Resized` event after each `ScaleFactorChanged` event.
 
 # 0.29.3


### PR DESCRIPTION
In case the AboutToWait event sets the control flow to another value

Fixes https://github.com/rust-windowing/winit/issues/3215

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
