### PR TITLE
On Wayland, fix wl_surface being dropped first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Unreleased` header.
 - On Windows, fix so `drag_window` and `drag_resize_window` can be called from another thread.
 - On Windows, fix `set_control_flow` in `AboutToWait` not being taken in account.
 - On macOS, send a `Resized` event after each `ScaleFactorChanged` event.
+- On Wayland, fix `wl_surface` being destroyed before associated objects.
 
 # 0.29.3
 


### PR DESCRIPTION
The surface was automatically dropped due to new RAII type in SCTK when dropping the Window, which was not the case at some point with SCTK.

Thus destroying objects associated with it where causing issues with some window managers.

Links: https://github.com/neovide/neovide/issues/2109

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
