### PR TITLE
Web: forbid additional functions in favor of caching them

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -6,6 +6,7 @@ disallowed-methods = [
     { path = "web_sys::HtmlCanvasElement::set_height", reason = "Winit shouldn't touch the internal canvas size" },
     { path = "web_sys::Window::document", reason = "cache this to reduce calls to JS" },
     { path = "web_sys::Window::get_computed_style", reason = "cache this to reduce calls to JS" },
+    { path = "web_sys::HtmlElement::style", reason = "cache this to reduce calls to JS" },
     { path = "web_sys::Element::request_fullscreen", reason = "Doesn't account for compatibility with Safari" },
     { path = "web_sys::Document::exit_fullscreen", reason = "Doesn't account for compatibility with Safari" },
     { path = "web_sys::Document::fullscreen_element", reason = "Doesn't account for compatibility with Safari" },

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -196,7 +196,7 @@ impl Inner {
     #[inline]
     pub fn set_cursor_icon(&self, cursor: CursorIcon) {
         *self.previous_pointer.borrow_mut() = cursor.name();
-        backend::set_canvas_style_property(self.canvas.borrow().raw(), "cursor", cursor.name());
+        self.canvas.borrow().style().set("cursor", cursor.name());
     }
 
     #[inline]
@@ -223,13 +223,12 @@ impl Inner {
     #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         if !visible {
-            backend::set_canvas_style_property(self.canvas.borrow().raw(), "cursor", "none");
+            self.canvas.borrow().style().set("cursor", "none");
         } else {
-            backend::set_canvas_style_property(
-                self.canvas.borrow().raw(),
-                "cursor",
-                &self.previous_pointer.borrow(),
-            );
+            self.canvas
+                .borrow()
+                .style()
+                .set("cursor", &self.previous_pointer.borrow());
         }
     }
 


### PR DESCRIPTION
Follow-up from here: https://github.com/rust-windowing/winit/pull/3218#discussion_r1389897492.
Let's not repeatedly call things that should be cached.

This is a bit weird because `HtmlElement.style` vs `Window.getComputedStyle` isn't the same, but that's why we should probably not use `HtmlElement.style` at all.