### PR TITLE
Fix crash when running iPad build on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- Fix crash when running iOS app on macOS.
 - On X11, check common alternative cursor names when loading cursor.
 - On Windows, fix so `drag_window` and `drag_resize_window` can be called from another thread.
 - On Windows, fix `set_control_flow` in `AboutToWait` not being taken in account.

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -289,7 +289,7 @@ fn setup_control_flow_observers() {
             #[allow(non_upper_case_globals)]
             match activity {
                 kCFRunLoopBeforeWaiting => app_state::handle_main_events_cleared(mtm),
-                kCFRunLoopExit => unimplemented!(), // not expected to ever happen
+                kCFRunLoopExit => {} // may happen when running on macOS
                 _ => unreachable!(),
             }
         }
@@ -304,7 +304,7 @@ fn setup_control_flow_observers() {
             #[allow(non_upper_case_globals)]
             match activity {
                 kCFRunLoopBeforeWaiting => app_state::handle_events_cleared(mtm),
-                kCFRunLoopExit => unimplemented!(), // not expected to ever happen
+                kCFRunLoopExit => {} // may happen when running on macOS
                 _ => unreachable!(),
             }
         }


### PR DESCRIPTION
Newer versions of macOS have a feature that allows them to run iOS apps in an iPad-like form factor. Unfortunately, my game built with Bevy and winit used to [immediately crash](https://github.com/Couch-Chilis/sudoku-pi/issues/12) when trying this out. This PR fixes the crashes.

The changes in `event_loop.rs` were necessary to get the app to start, while the changes in `app_state.rs` allow the app to also exit cleanly without crashing when pressing Cmd+Q.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
