### PR TITLE
Mac: Remove error log when pressing Fn key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased` header.
 
 # Unreleased
 
+- Remove spurious error logging ("`UCKeyTranslate` was succesful but gave a string of 0 length.") on Mac
+
 # 0.29.4
 
 - Fix crash when running iOS app on macOS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
-- Remove spurious error logging ("`UCKeyTranslate` was succesful but gave a string of 0 length.") on Mac
+- On macOS, remove spurious error logging when handling `Fn`.
 
 # 0.29.4
 

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -88,7 +88,9 @@ pub fn get_modifierless_char(scancode: u16) -> Key {
         return Key::Unidentified(NativeKey::MacOS(scancode));
     }
     if result_len == 0 {
-        log::error!("`UCKeyTranslate` was succesful but gave a string of 0 length.");
+        // This is fine - not all keys have text representation.
+        // For instance, users that have mapped the `Fn` key to toggle
+        // keyboard layouts will hit this code path.
         return Key::Unidentified(NativeKey::MacOS(scancode));
     }
     let chars = String::from_utf16_lossy(&string[0..result_len as usize]);


### PR DESCRIPTION
* Closes https://github.com/rust-windowing/winit/issues/3246

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
