### PR TITLE
Remove unused .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deps/apk-builder"]
-	path = deps/apk-builder
-	url = https://github.com/rust-windowing/android-rs-glue


### PR DESCRIPTION
This was added way back in https://github.com/rust-windowing/glutin/pull/30, and basically not touched since.

I don't think it's used for anything any more?