### PR TITLE
Use the right atom type in focus_window()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Unreleased` header.
 - On macOS, remove spurious error logging when handling `Fn`.
 - On X11, fix an issue where floating point data from the server is
   misinterpreted during a drag and drop operation.
+- On X11, fix a bug where focusing the window would panic.
 
 # 0.29.4
 

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -3,7 +3,10 @@
 //! Example for focusing a window.
 
 use simple_logger::SimpleLogger;
-use std::time::{Duration, Instant};
+#[cfg(not(wasm_platform))]
+use std::time;
+#[cfg(wasm_platform)]
+use web_time as time;
 use winit::{
     event::{Event, StartCause, WindowEvent},
     event_loop::EventLoop,
@@ -23,13 +26,13 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    let mut deadline = Instant::now() + Duration::from_secs(3);
+    let mut deadline = time::Instant::now() + time::Duration::from_secs(3);
     event_loop.run(move |event, elwt| {
         match event {
             Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
                 // Timeout reached; focus the window.
                 println!("Re-focusing the window.");
-                deadline += Duration::from_secs(3);
+                deadline += time::Duration::from_secs(3);
                 window.focus_window();
             }
             Event::WindowEvent { event, window_id } if window_id == window.id() => match event {

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -1,0 +1,53 @@
+#![allow(clippy::single_match)]
+
+//! Example for focusing a window.
+
+use simple_logger::SimpleLogger;
+use std::time::{Duration, Instant};
+use winit::{
+    event::{Event, StartCause, WindowEvent},
+    event_loop::EventLoop,
+    window::WindowBuilder,
+};
+
+#[path = "util/fill.rs"]
+mod fill;
+
+fn main() -> Result<(), impl std::error::Error> {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new().unwrap();
+
+    let window = WindowBuilder::new()
+        .with_title("A fantastic window!")
+        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
+        .build(&event_loop)
+        .unwrap();
+
+    let mut deadline = Instant::now() + Duration::from_secs(3);
+    event_loop.run(move |event, elwt| {
+        match event {
+            Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
+                // Timeout reached; focus the window.
+                println!("Re-focusing the window.");
+                deadline += Duration::from_secs(3);
+                window.focus_window();
+            }
+            Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
+                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::RedrawRequested => {
+                    // Notify the windowing system that we'll be presenting to the window.
+                    window.pre_present_notify();
+                    fill::fill_window(&window);
+                }
+                _ => (),
+            },
+            Event::AboutToWait => {
+                window.request_redraw();
+            }
+
+            _ => (),
+        }
+
+        elwt.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(deadline));
+    })
+}

--- a/src/platform_impl/linux/x11/ffi.rs
+++ b/src/platform_impl/linux/x11/ffi.rs
@@ -1,6 +1,1 @@
-use x11_dl::xmd::CARD32;
 pub use x11_dl::{error::OpenError, xcursor::*, xinput2::*, xlib::*, xlib_xcb::*};
-
-// Isn't defined by x11_dl
-#[allow(non_upper_case_globals)]
-pub const IconicState: CARD32 = 3;

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -81,6 +81,7 @@ use crate::{
 // Xinput constants not defined in x11rb
 const ALL_DEVICES: u16 = 0;
 const ALL_MASTER_DEVICES: u16 = 1;
+const ICONIC_STATE: u32 = 3;
 
 type X11Source = Generic<BorrowedFd<'static>>;
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1780,8 +1780,6 @@ impl UnownedWindow {
 
     #[inline]
     pub fn focus_window(&self) {
-        const ICONIC_STATE: u32 = 3;
-
         let atoms = self.xconn.atoms();
         let state_atom = atoms[WM_STATE];
         let state_type_atom = atoms[CARD32];
@@ -1789,7 +1787,7 @@ impl UnownedWindow {
             self.xconn
                 .get_property::<u32>(self.xwindow, state_atom, state_type_atom)
         {
-            state.contains(&ICONIC_STATE)
+            state.contains(&super::ICONIC_STATE)
         } else {
             false
         };

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1780,14 +1780,16 @@ impl UnownedWindow {
 
     #[inline]
     pub fn focus_window(&self) {
+        const ICONIC_STATE: u32 = 3;
+
         let atoms = self.xconn.atoms();
         let state_atom = atoms[WM_STATE];
         let state_type_atom = atoms[CARD32];
         let is_minimized = if let Ok(state) =
             self.xconn
-                .get_property(self.xwindow, state_atom, state_type_atom)
+                .get_property::<u32>(self.xwindow, state_atom, state_type_atom)
         {
-            state.contains(&(ffi::IconicState as c_ulong))
+            state.contains(&ICONIC_STATE)
         } else {
             false
         };


### PR DESCRIPTION
Closes #3248 by removing an Xlibism I forgot about

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
