### PR TITLE
Fix Window::focus_window method on X11 crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- On X11, fix `Window::focus_window` method crashing.
 - On macOS, add services menu.
 - On macOS, remove spurious error logging when handling `Fn`.
 

--- a/src/platform_impl/linux/x11/util/window_property.rs
+++ b/src/platform_impl/linux/x11/util/window_property.rs
@@ -116,6 +116,7 @@ impl<'a, C: Connection + ?Sized, T: Pod> PropIterator<'a, C, T> {
             1 => 8,
             2 => 16,
             4 => 32,
+            8 => 64,
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
Fixes #3248


- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Simple bug fix, no documentation changes necessary.