### PR TITLE
Properly interpret float data in drag ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Unreleased` header.
 
 - On macOS, add services menu.
 - On macOS, remove spurious error logging when handling `Fn`.
+- On X11, fix an issue where floating point data from the server is
+  misinterpreted during a drag and drop operation.
 
 # 0.29.4
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -1128,3 +1128,9 @@ impl Device {
         }
     }
 }
+
+/// Convert the raw X11 representation for a 32-bit floating point to a double.
+#[inline]
+fn xinput_fp1616_to_float(fp: xinput::Fp1616) -> f64 {
+    (fp as f64) / ((1 << 16) as f64)
+}

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1739,8 +1739,8 @@ impl UnownedWindow {
                         | xproto::EventMask::SUBSTRUCTURE_NOTIFY,
                 ),
                 [
-                    (window.x as u32 + pointer.win_x as u32),
-                    (window.y as u32 + pointer.win_y as u32),
+                    (window.x as u32 + xinput_fp1616_to_float(pointer.win_x) as u32),
+                    (window.y as u32 + xinput_fp1616_to_float(pointer.win_y) as u32),
                     action.try_into().unwrap(),
                     1, // Button 1
                     1,
@@ -1962,4 +1962,10 @@ fn cast_size_to_hint(size: Size, scale_factor: f64) -> (i32, i32) {
         Size::Physical(size) => cast_physical_size_to_hint(size),
         Size::Logical(size) => size.to_physical::<i32>(scale_factor).into(),
     }
+}
+
+/// Convert the raw X11 representation for a 32-bit floating point to a double.
+#[inline]
+fn xinput_fp1616_to_float(fp: xinput::Fp1616) -> f64 {
+    (fp as f64) / ((1 << 16) as f64)
 }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -25,7 +25,10 @@ use crate::{
     event::{Event, InnerSizeWriter, WindowEvent},
     event_loop::AsyncRequestSerial,
     platform_impl::{
-        x11::{atoms::*, MonitorHandle as X11MonitorHandle, WakeSender, X11Error},
+        x11::{
+            atoms::*, xinput_fp1616_to_float, MonitorHandle as X11MonitorHandle, WakeSender,
+            X11Error,
+        },
         Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError, PlatformIcon,
         PlatformSpecificWindowBuilderAttributes, VideoMode as PlatformVideoMode,
     },
@@ -1962,10 +1965,4 @@ fn cast_size_to_hint(size: Size, scale_factor: f64) -> (i32, i32) {
         Size::Physical(size) => cast_physical_size_to_hint(size),
         Size::Logical(size) => size.to_physical::<i32>(scale_factor).into(),
     }
-}
-
-/// Convert the raw X11 representation for a 32-bit floating point to a double.
-#[inline]
-fn xinput_fp1616_to_float(fp: xinput::Fp1616) -> f64 {
-    (fp as f64) / ((1 << 16) as f64)
 }


### PR DESCRIPTION
Closes #3245

notgull forgot to properly interpret float data from the X server, making him tonight's biggest loser.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
