### PR TITLE
fix refresh_rate_millihertz on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Unreleased` header.
 - On X11, fix an issue where floating point data from the server is
   misinterpreted during a drag and drop operation.
 - On X11, fix a bug where focusing the window would panic.
+- On macOS, fix `refresh_rate_millihertz`.
 
 # 0.29.4
 

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -219,10 +219,9 @@ impl MonitorHandle {
     pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         unsafe {
             let current_display_mode = NativeDisplayMode(CGDisplayCopyDisplayMode(self.0) as _);
-            let refresh_rate =
-                ffi::CGDisplayModeGetRefreshRate(current_display_mode.0).round() as u32;
-            if refresh_rate > 0 {
-                return Some(refresh_rate * 1000);
+            let refresh_rate = ffi::CGDisplayModeGetRefreshRate(current_display_mode.0);
+            if refresh_rate > 0.0 {
+                return Some((refresh_rate * 1000.0).round() as u32);
             }
 
             let mut display_link = std::ptr::null_mut();


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

When the monitor refresh rate changes, `CVDisplayLinkGetNominalOutputVideoRefreshPeriod` still returns the previous value unless the process is restarted. I don't know the reason, but `CGDisplayModeGetRefreshRate` can return the correct result.