### PR TITLE
Update to x11rb 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ wayland-client = { version = "0.31.1", optional = true }
 wayland-protocols = { version = "0.31.0", features = [ "staging"], optional = true }
 wayland-protocols-plasma = { version = "0.2.0", features = [ "client" ], optional = true }
 x11-dl = { version = "2.18.5", optional = true }
-x11rb = { version = "0.12.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "randr", "resource_manager", "xinput", "xkb"], optional = true }
+x11rb = { version = "0.13.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "randr", "resource_manager", "xinput", "xkb"], optional = true }
 xkbcommon-dl = "0.4.0"
 
 [target.'cfg(target_os = "redox")'.dependencies]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1377,7 +1377,8 @@ impl UnownedWindow {
             self.xwindow as xproto::Window,
             xproto::AtomEnum::WM_NORMAL_HINTS,
         )?
-        .reply()?;
+        .reply()?
+        .unwrap_or_default();
         callback(&mut normal_hints);
         normal_hints
             .set(
@@ -1430,6 +1431,7 @@ impl UnownedWindow {
         )
         .ok()
         .and_then(|cookie| cookie.reply().ok())
+        .flatten()
         .and_then(|hints| hints.size_increment)
         .map(|(width, height)| (width as u32, height as u32).into())
     }
@@ -1824,6 +1826,7 @@ impl UnownedWindow {
             WmHints::get(self.xconn.xcb_connection(), self.xwindow as xproto::Window)
                 .ok()
                 .and_then(|cookie| cookie.reply().ok())
+                .flatten()
                 .unwrap_or_default();
 
         wm_hints.urgent = request_type.is_some();


### PR DESCRIPTION
The only breaking change is that x11rb no longer reports an error when querying the `WmSizeHints` of a window that does not have this property set. For this reason, the return type of `WmSizeHintsCookie::reply()` changed from `Result<WmSizeHints, SomeError>` to
`Result<Option<WmSizeHints>, SomeError>`.

In `update_normal_hints()`, previously a cryptic error would be reported to the caller. Instead, this now uses `unwrap_or_default()` to get a `WmSizeHints`. All fields of `WmSizeHints` are `Option`s, so this produces an empty object.

`resize_increments()` queries a value from the window and returns an Option. Previously, the error for "missing property" was turned into None via `.ok()`. This commit adds a call to `flatten()` to also turn "property not set" into None.

Finally, `request_user_attention()` queries a window's `WmHints` property and updates one field of it. The code already uses `unwrap_or_default()` to deal with missing properties, so just a call to `flatten()` is needed to merge "missing property" and "error while querying" into one.

Other changes in x11rb do not seem to affect this crate.

x11rb's MSRV increased from 1.56 to 1.63, which is still below the MSRV of this crate, which is 1.65.

- [ ] Tested on all platforms changed (all I did was `cargo run --example window_debug` and `cursor` and each of those opened a window; dunno if that counts as "tested")
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
