### PR TITLE
On Windows, fix `set_fullscreen` early return for `Fullscreen::Borderless(None)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Unreleased` header.
   misinterpreted during a drag and drop operation.
 - On X11, fix a bug where focusing the window would panic.
 - On macOS, fix `refresh_rate_millihertz`.
+- On Windows, fix consecutive calls to `window.set_fullscreen(Some(Fullscreen::Borderless(None)))` resulting in losing previous window state when eventually exiting fullscreen using `window.set_fullscreen(None)`.
 
 # 0.29.4
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -686,9 +686,19 @@ impl Window {
 
         let mut window_state_lock = window_state.lock().unwrap();
         let old_fullscreen = window_state_lock.fullscreen.clone();
-        if window_state_lock.fullscreen == fullscreen {
-            return;
+
+        match (&old_fullscreen, &fullscreen) {
+            // Return if we already in the same fullscreen mode
+            _ if old_fullscreen == fullscreen => return,
+            // Return if saved Borderless(monitor) is the same as current monitor when requested fullscreen is Borderless(None)
+            (Some(Fullscreen::Borderless(Some(monitor))), Some(Fullscreen::Borderless(None)))
+                if *monitor == monitor::current_monitor(window.0) =>
+            {
+                return
+            }
+            _ => {}
         }
+
         window_state_lock.fullscreen = fullscreen.clone();
         drop(window_state_lock);
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -688,7 +688,7 @@ impl Window {
         let old_fullscreen = window_state_lock.fullscreen.clone();
 
         match (&old_fullscreen, &fullscreen) {
-            // Return if we already in the same fullscreen mode
+            // Return if we already are in the same fullscreen mode
             _ if old_fullscreen == fullscreen => return,
             // Return if saved Borderless(monitor) is the same as current monitor when requested fullscreen is Borderless(None)
             (Some(Fullscreen::Borderless(Some(monitor))), Some(Fullscreen::Borderless(None)))


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
