### PR TITLE
On Wayland, make `wl_subcompositor` protocol optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Unreleased` header.
   misinterpreted during a drag and drop operation.
 - On X11, fix a bug where focusing the window would panic.
 - On macOS, fix `refresh_rate_millihertz`.
+- On Wayland, disable Client Side Decorations when `wl_subcompositor` is not supported.
 
 # 0.29.4
 

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -254,7 +254,7 @@ impl WindowState {
         &mut self,
         configure: WindowConfigure,
         shm: &Shm,
-        subcompositor: &Arc<SubcompositorState>,
+        subcompositor: &Option<Arc<SubcompositorState>>,
         event_sink: &mut EventSink,
     ) -> LogicalSize<u32> {
         // NOTE: when using fractional scaling or wl_compositor@v6 the scaling
@@ -265,10 +265,11 @@ impl WindowState {
             self.stateless_size = self.size;
         }
 
-        if configure.decoration_mode == DecorationMode::Client
-            && self.frame.is_none()
-            && !self.csd_fails
-        {
+        if let Some(subcompositor) = subcompositor.as_ref().filter(|_| {
+            configure.decoration_mode == DecorationMode::Client
+                && self.frame.is_none()
+                && !self.csd_fails
+        }) {
             match WinitFrame::new(
                 &self.window,
                 shm,


### PR DESCRIPTION
This protocol is only used for (optional) Client Side Decorations (where) the compositor still takes the burden of compositing various window parts together, via subsurfaces that all belong to a single window.

If this core protocol is not available, as is the case on gamescope, disable CSD.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Related:

https://github.com/Smithay/client-toolkit/issues/210
https://github.com/alacritty/alacritty/issues/5709