### PR TITLE
Fix typo in `get_xft_dpi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Unreleased` header.
 - On X11, fix a bug where focusing the window would panic.
 - On macOS, fix `refresh_rate_millihertz`.
 - On Wayland, disable Client Side Decorations when `wl_subcompositor` is not supported.
+- On X11, fix `Xft.dpi` detection from Xresources.
 
 # 0.29.4
 

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -38,7 +38,7 @@ impl XConnection {
     // Retrieve DPI from Xft.dpi property
     pub fn get_xft_dpi(&self) -> Option<f64> {
         self.database()
-            .get_string("Xfi.dpi", "")
+            .get_string("Xft.dpi", "")
             .and_then(|s| f64::from_str(s).ok())
     }
     pub fn get_output_info(


### PR DESCRIPTION
Scale factor detection breaks for me in X11 after upgrading from `0.28.6` to `0.29.4`.

I think I corrected a typo that fixes the issue, at least for me.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented