### PR TITLE
On Web, fix setting cursor icon overriding cursor visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Unreleased` header.
 - On X11, fix `Xft.dpi` detection from Xresources.
 - On Windows, fix consecutive calls to `window.set_fullscreen(Some(Fullscreen::Borderless(None)))` resulting in losing previous window state when eventually exiting fullscreen using `window.set_fullscreen(None)`.
 - On Web, remove queuing fullscreen request in absence of transient activation.
+- On Web, fix setting cursor icon overriding cursor visibility.
 
 # 0.29.4
 


### PR DESCRIPTION
Currently, on Web, when using `Window::set_cursor_icon()` or `Window::set_custom_cursor()`, cursor visibility is overridden instead of changing the cursor behind the scenes.

This PR changes that so that changing the cursor does not override cursor visibility and brings the Web backend in line with the others.

Fixes #3227.