### PR TITLE
On Web, use the new `WebCanvasWindowHandle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Unreleased` header.
 - On macOS, add services menu.
 - **Breaking:** On Web, remove queuing fullscreen request in absence of transient activation.
 - On Web, fix setting cursor icon overriding cursor visibility.
+- **Breaking:** On Web, return `RawWindowHandle::WebCanvas` instead of `RawWindowHandle::Web`.
 
 # 0.29.5
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -360,14 +360,14 @@ impl Inner {
     }
 
     #[cfg(feature = "rwh_06")]
-    pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
+    pub fn raw_window_handle_rwh_06(&self) -> rwh_06::RawWindowHandle {
         let mut window_handle = rwh_06::UiKitWindowHandle::new({
             let ui_view = Id::as_ptr(&self.view) as _;
             std::ptr::NonNull::new(ui_view).expect("Id<T> should never be null")
         });
         window_handle.ui_view_controller =
             std::ptr::NonNull::new(Id::as_ptr(&self.view_controller) as _);
-        Ok(rwh_06::RawWindowHandle::UiKit(window_handle))
+        rwh_06::RawWindowHandle::UiKit(window_handle)
     }
 
     #[cfg(feature = "rwh_06")]
@@ -522,6 +522,16 @@ impl Window {
 
     pub(crate) fn maybe_wait_on_main<R: Send>(&self, f: impl FnOnce(&Inner) -> R + Send) -> R {
         self.inner.get_on_main(|inner, _mtm| f(inner))
+    }
+
+    #[cfg(feature = "rwh_06")]
+    #[inline]
+    pub(crate) fn raw_window_handle_rwh_06(
+        &self,
+    ) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
+        Ok(self
+            .maybe_wait_on_main(|w| crate::SendSyncWrapper(w.raw_window_handle_rwh_06()))
+            .0)
     }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -89,6 +89,16 @@ impl Window {
     ) -> R {
         self.window.get_on_main(|window, _mtm| f(window))
     }
+
+    #[cfg(feature = "rwh_06")]
+    #[inline]
+    pub(crate) fn raw_window_handle_rwh_06(
+        &self,
+    ) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
+        Ok(self
+            .maybe_wait_on_main(|w| crate::SendSyncWrapper(w.raw_window_handle_rwh_06()))
+            .0)
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1386,12 +1396,12 @@ impl WinitWindow {
 
     #[cfg(feature = "rwh_06")]
     #[inline]
-    pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
+    pub fn raw_window_handle_rwh_06(&self) -> rwh_06::RawWindowHandle {
         let window_handle = rwh_06::AppKitWindowHandle::new({
             let ptr = Id::as_ptr(&self.contentView()) as *mut _;
             std::ptr::NonNull::new(ptr).expect("Id<T> should never be null")
         });
-        Ok(rwh_06::RawWindowHandle::AppKit(window_handle))
+        rwh_06::RawWindowHandle::AppKit(window_handle)
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -83,6 +83,7 @@ impl<T> EventLoopWindowTarget<T> {
     ) {
         let canvas_clone = canvas.clone();
         let mut canvas = canvas.borrow_mut();
+        #[cfg(any(feature = "rwh_04", feature = "rwh_05"))]
         canvas.set_attribute("data-raw-handle", &id.0.to_string());
 
         canvas.on_touch_start(prevent_default);

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -1,4 +1,5 @@
 use std::cell::Cell;
+use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
@@ -49,7 +50,8 @@ pub struct Common {
     pub window: web_sys::Window,
     pub document: Document,
     /// Note: resizing the HTMLCanvasElement should go through `backend::set_canvas_size` to ensure the DPI factor is maintained.
-    pub raw: HtmlCanvasElement,
+    /// Note: this is read-only because we use a pointer to this for [`WindowHandle`](rwh_06::WindowHandle).
+    raw: Rc<HtmlCanvasElement>,
     style: Style,
     old_size: Rc<Cell<PhysicalSize<u32>>>,
     current_size: Rc<Cell<PhysicalSize<u32>>>,
@@ -101,7 +103,7 @@ impl Canvas {
         let common = Common {
             window: window.clone(),
             document: document.clone(),
-            raw: canvas.clone(),
+            raw: Rc::new(canvas.clone()),
             style,
             old_size: Rc::default(),
             current_size: Rc::default(),
@@ -539,7 +541,11 @@ impl Common {
         E: 'static + AsRef<web_sys::Event> + wasm_bindgen::convert::FromWasmAbi,
         F: 'static + FnMut(E),
     {
-        EventListenerHandle::new(self.raw.clone(), event_name, Closure::new(handler))
+        EventListenerHandle::new(self.raw.deref().clone(), event_name, Closure::new(handler))
+    }
+
+    pub fn raw(&self) -> &HtmlCanvasElement {
+        &self.raw
     }
 }
 

--- a/src/platform_impl/web/web_sys/pointer.rs
+++ b/src/platform_impl/web/web_sys/pointer.rs
@@ -117,7 +117,7 @@ impl PointerHandler {
         T: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, Force),
     {
         let window = canvas_common.window.clone();
-        let canvas = canvas_common.raw.clone();
+        let canvas = canvas_common.raw().clone();
         self.on_pointer_press = Some(canvas_common.add_event(
             "pointerdown",
             move |event: PointerEvent| {
@@ -174,7 +174,7 @@ impl PointerHandler {
         B: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, ButtonsState, MouseButton),
     {
         let window = canvas_common.window.clone();
-        let canvas = canvas_common.raw.clone();
+        let canvas = canvas_common.raw().clone();
         self.on_cursor_move = Some(canvas_common.add_event(
             "pointermove",
             move |event: PointerEvent| {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -93,6 +93,7 @@ impl Window {
             .value()
             .map(|inner| {
                 let canvas = inner.canvas.borrow();
+                // SAFETY: This will only work if the reference to `HtmlCanvasElement` stays valid.
                 let canvas: &wasm_bindgen::JsValue = canvas.raw();
                 let window_handle =
                     rwh_06::WebCanvasWindowHandle::new(std::ptr::NonNull::from(canvas).cast());

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -381,8 +381,11 @@ impl Inner {
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
-        let window_handle = rwh_06::WebWindowHandle::new(self.id.0);
-        Ok(rwh_06::RawWindowHandle::Web(window_handle))
+        let canvas = self.canvas.borrow();
+        let canvas: &wasm_bindgen::JsValue = canvas.raw();
+        let window_handle =
+            rwh_06::WebCanvasWindowHandle::new(std::ptr::NonNull::from(canvas).cast());
+        Ok(rwh_06::RawWindowHandle::WebCanvas(window_handle))
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -85,6 +85,21 @@ impl Window {
             .value()
             .map(|inner| inner.canvas.borrow().raw().clone())
     }
+
+    #[cfg(feature = "rwh_06")]
+    #[inline]
+    pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
+        self.inner
+            .value()
+            .map(|inner| {
+                let canvas = inner.canvas.borrow();
+                let canvas: &wasm_bindgen::JsValue = canvas.raw();
+                let window_handle =
+                    rwh_06::WebCanvasWindowHandle::new(std::ptr::NonNull::from(canvas).cast());
+                rwh_06::RawWindowHandle::WebCanvas(window_handle)
+            })
+            .ok_or(rwh_06::HandleError::Unavailable)
+    }
 }
 
 impl Inner {
@@ -376,16 +391,6 @@ impl Inner {
     #[inline]
     pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
         rwh_05::RawDisplayHandle::Web(rwh_05::WebDisplayHandle::empty())
-    }
-
-    #[cfg(feature = "rwh_06")]
-    #[inline]
-    pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
-        let canvas = self.canvas.borrow();
-        let canvas: &wasm_bindgen::JsValue = canvas.raw();
-        let window_handle =
-            rwh_06::WebCanvasWindowHandle::new(std::ptr::NonNull::from(canvas).cast());
-        Ok(rwh_06::RawWindowHandle::WebCanvas(window_handle))
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/window.rs
+++ b/src/window.rs
@@ -1530,10 +1530,7 @@ impl Window {
 #[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
-        let raw = self
-            .window
-            .maybe_wait_on_main(|w| w.raw_window_handle_rwh_06().map(SendSyncWrapper))?
-            .0;
+        let raw = self.window.raw_window_handle_rwh_06()?;
 
         // SAFETY: The window handle will never be deallocated while the window is alive.
         Ok(unsafe { rwh_06::WindowHandle::borrow_raw(raw) })


### PR DESCRIPTION
Now we don't have to set `data-raw-handle` on the canvas anymore.