### PR TITLE
On Web, fix context menu not being disabled by `with_prevent_default(true)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Unreleased` header.
 - On Windows, fix consecutive calls to `window.set_fullscreen(Some(Fullscreen::Borderless(None)))` resulting in losing previous window state when eventually exiting fullscreen using `window.set_fullscreen(None)`.
 - On Wayland, fix resize being sent on focus change.
 - On Windows, fix `set_ime_cursor_area`.
+- On Web, fix context menu not being disabled by `with_prevent_default(true)`.
 
 # 0.29.4
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -647,6 +647,8 @@ impl<T> EventLoopWindowTarget<T> {
 
         let runner = self.runner.clone();
         canvas.on_animation_frame(move || runner.request_redraw(RootWindowId(id)));
+
+        canvas.on_context_menu(prevent_default);
     }
 
     pub fn available_monitors(&self) -> VecDequeIter<MonitorHandle> {


### PR DESCRIPTION
A bit unfortunate that this didn't make into v0.29.5.