### PR TITLE
On Web, fix context menu not being disabled by `with_prevent_default(true)` (backport to v0.29.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased` header.
 
 # Unreleased
 
+- On Web, fix context menu not being disabled by `with_prevent_default(true)`.
+
 # 0.29.5
 
 - On macOS, remove spurious error logging when handling `Fn`.

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -649,6 +649,8 @@ impl<T> EventLoopWindowTarget<T> {
         canvas.on_animation_frame(move || runner.request_redraw(RootWindowId(id)));
 
         canvas.on_touch_end();
+
+        canvas.on_context_menu(prevent_default);
     }
 
     pub fn available_monitors(&self) -> VecDequeIter<MonitorHandle> {


### PR DESCRIPTION
See https://github.com/rust-windowing/winit/pull/3282.