### PR TITLE
Bump MSRV to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, nightly, '1.65.0']
+        toolchain: [stable, nightly, '1.70.0']
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
           - { name: 'Windows 64bit MSVC', target: x86_64-pc-windows-msvc,   os: windows-latest,  }
@@ -43,10 +43,10 @@ jobs:
           - { name: 'web',                target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
         exclude:
           # Android is tested on stable-3
-          - toolchain: '1.65.0'
+          - toolchain: '1.70.0'
             platform: { name: 'Android', target: aarch64-linux-android, os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
         include:
-          - toolchain: '1.69.0'
+          - toolchain: '1.70.0'
             platform: { name: 'Android', target: aarch64-linux-android, os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
 
     env:
@@ -120,7 +120,7 @@ jobs:
     - name: Build tests
       if: >
         !contains(matrix.platform.target, 'redox') &&
-        matrix.toolchain != '1.65.0'
+        matrix.toolchain != '1.70.0'
       run: cargo $CMD test --no-run $OPTIONS
 
     - name: Run tests
@@ -129,7 +129,7 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
-        matrix.toolchain != '1.65.0'
+        matrix.toolchain != '1.70.0'
       run: cargo $CMD test $OPTIONS
 
     - name: Lint with clippy
@@ -139,7 +139,7 @@ jobs:
     - name: Build tests with serde enabled
       if: >
         !contains(matrix.platform.target, 'redox') &&
-        matrix.toolchain != '1.65.0'
+        matrix.toolchain != '1.70.0'
       run: cargo $CMD test --no-run $OPTIONS --features serde
 
     - name: Run tests with serde enabled
@@ -148,7 +148,7 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
-        matrix.toolchain != '1.65.0'
+        matrix.toolchain != '1.70.0'
       run: cargo $CMD test $OPTIONS --features serde
 
     # See restore step above

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Unreleased` header.
 - On Web, fix setting cursor icon overriding cursor visibility.
 - **Breaking:** On Web, return `RawWindowHandle::WebCanvas` instead of `RawWindowHandle::Web`.
 - **Breaking:** On Web, macOS and iOS, return `HandleError::Unavailable` when a window handle is not available.
+- **Breaking:** Bump MSRV from `1.65` to `1.70`.
 
 # 0.29.5
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ your description of the issue as detailed as possible:
 
 When making a code contribution to winit, before opening your pull request, please make sure that:
 
-- your patch builds with Winit's minimal supported rust version - Rust 1.65.
+- your patch builds with Winit's minimal supported rust version - Rust 1.70.
 - you tested your modifications on all the platforms impacted, or if not possible, detail which platforms
   were not tested, and what should be tested, so that a maintainer or another contributor can test them
 - you updated any relevant documentation in winit

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 repository = "https://github.com/rust-windowing/winit"
 documentation = "https://docs.rs/winit"
 categories = ["gui"]
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 [package.metadata.docs.rs]
 features = [

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Winit provides the following features, which can be enabled in your `Cargo.toml`
 
 ## MSRV Policy
 
-This crate's Minimum Supported Rust Version (MSRV) is **1.65**. Changes to
+This crate's Minimum Supported Rust Version (MSRV) is **1.70**. Changes to
 the MSRV will be accompanied by a minor version bump.
 
 As a **tentative** policy, the upper bound of the MSRV is given by the following


### PR DESCRIPTION
This bumps the MSRV from v1.65 to v1.70.
Which our current [MSRV policy](https://github.com/rust-windowing/winit/tree/4ee11018c28efccb059c9cfb577fce9305ac8f06#msrv-policy) allows.

I'm doing this mainly to get access to [`Arc::into_inner()`](https://doc.rust-lang.org/1.73.0/std/sync/struct.Arc.html#method.into_inner), so it's not totally necessary.