### PR TITLE
Window handle: Return an error when not on main thread on macOS and iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Unreleased` header.
 - **Breaking:** On Web, remove queuing fullscreen request in absence of transient activation.
 - On Web, fix setting cursor icon overriding cursor visibility.
 - **Breaking:** On Web, return `RawWindowHandle::WebCanvas` instead of `RawWindowHandle::Web`.
+- **Breaking:** On Web, macOS and iOS, return `HandleError::Unavailable` when a window handle is not available.
 
 # 0.29.5
 

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -529,9 +529,11 @@ impl Window {
     pub(crate) fn raw_window_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
-        Ok(self
-            .maybe_wait_on_main(|w| crate::SendSyncWrapper(w.raw_window_handle_rwh_06()))
-            .0)
+        if let Some(mtm) = MainThreadMarker::new() {
+            Ok(self.inner.get(mtm).raw_window_handle_rwh_06())
+        } else {
+            Err(rwh_06::HandleError::Unavailable)
+        }
     }
 }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -95,9 +95,11 @@ impl Window {
     pub(crate) fn raw_window_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
-        Ok(self
-            .maybe_wait_on_main(|w| crate::SendSyncWrapper(w.raw_window_handle_rwh_06()))
-            .0)
+        if let Some(mtm) = MainThreadMarker::new() {
+            Ok(self.window.get(mtm).raw_window_handle_rwh_06())
+        } else {
+            Err(rwh_06::HandleError::Unavailable)
+        }
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1532,7 +1532,8 @@ impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = self.window.raw_window_handle_rwh_06()?;
 
-        // SAFETY: The window handle will never be deallocated while the window is alive.
+        // SAFETY: The window handle will never be deallocated while the window is alive,
+        // and the main thread safety requirements are upheld internally by each platform.
         Ok(unsafe { rwh_06::WindowHandle::borrow_raw(raw) })
     }
 }


### PR DESCRIPTION
Follow-up to https://github.com/rust-windowing/winit/pull/3270.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
