### PR TITLE
MacOS: cache custom cursor

### DIFF
--- a/src/platform_impl/macos/cursor.rs
+++ b/src/platform_impl/macos/cursor.rs
@@ -1,0 +1,17 @@
+use objc2::rc::Id;
+
+use super::appkit::NSCursor;
+use super::EventLoopWindowTarget;
+use crate::cursor::OnlyCursorImageBuilder;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CustomCursor(pub(crate) Id<NSCursor>);
+
+impl CustomCursor {
+    pub(crate) fn build<T>(
+        cursor: OnlyCursorImageBuilder,
+        _: &EventLoopWindowTarget<T>,
+    ) -> CustomCursor {
+        Self(NSCursor::from_image(&cursor.0))
+    }
+}

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -5,6 +5,7 @@ mod app;
 mod app_delegate;
 mod app_state;
 mod appkit;
+mod cursor;
 mod event;
 mod event_loop;
 mod ffi;
@@ -27,8 +28,8 @@ pub(crate) use self::{
 };
 use crate::event::DeviceId as RootDeviceId;
 
+pub(crate) use self::cursor::CustomCursor as PlatformCustomCursor;
 pub(crate) use self::window::Window;
-pub(crate) use crate::cursor::OnlyCursorImage as PlatformCustomCursor;
 pub(crate) use crate::cursor::OnlyCursorImageBuilder as PlatformCustomCursorBuilder;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -849,7 +849,7 @@ impl WinitWindow {
     #[inline]
     pub(crate) fn set_custom_cursor(&self, cursor: PlatformCustomCursor) {
         let view = self.view();
-        view.set_cursor_icon(NSCursor::from_image(&cursor.0));
+        view.set_cursor_icon(cursor.0.clone());
         self.invalidateCursorRectsForView(&view);
     }
 


### PR DESCRIPTION
This moves the creation of `NSCursor` to `CustomCursorBuilder::build()`.

Note: no public API changes.