### PR TITLE
Custom cursor improvements

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -80,7 +80,7 @@ impl CustomCursor {
         hotspot_y: u16,
     ) -> Result<CustomCursorBuilder, BadImage> {
         Ok(CustomCursorBuilder {
-            inner: PlatformCustomCursor::from_rgba(
+            inner: PlatformCustomCursorBuilder::from_rgba(
                 rgba.into(),
                 width,
                 height,
@@ -102,7 +102,7 @@ pub struct CustomCursorBuilder {
 impl CustomCursorBuilder {
     pub fn build<T>(self, window_target: &EventLoopWindowTarget<T>) -> CustomCursor {
         CustomCursor {
-            inner: self.inner.build(&window_target.p),
+            inner: PlatformCustomCursor::build(self.inner, &window_target.p),
         }
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -154,11 +154,11 @@ impl Error for BadImage {}
 
 /// Platforms export this directly as `PlatformCustomCursorBuilder` if they need to only work with images.
 #[derive(Debug)]
-pub struct OnlyCursorImageBuilder(pub CursorImage);
+pub(crate) struct OnlyCursorImageBuilder(pub(crate) CursorImage);
 
 #[allow(dead_code)]
 impl OnlyCursorImageBuilder {
-    pub fn from_rgba(
+    pub(crate) fn from_rgba(
         rgba: Vec<u8>,
         width: u16,
         height: u16,
@@ -171,7 +171,7 @@ impl OnlyCursorImageBuilder {
 
 /// Platforms export this directly as `PlatformCustomCursor` if they don't implement caching.
 #[derive(Debug, Clone)]
-pub struct OnlyCursorImage(pub Arc<CursorImage>);
+pub(crate) struct OnlyCursorImage(pub(crate) Arc<CursorImage>);
 
 impl Hash for OnlyCursorImage {
     fn hash<H: Hasher>(&self, state: &mut H) {
@@ -199,7 +199,7 @@ impl OnlyCursorImage {
 
 #[derive(Debug)]
 #[allow(dead_code)]
-pub struct CursorImage {
+pub(crate) struct CursorImage {
     pub(crate) rgba: Vec<u8>,
     pub(crate) width: u16,
     pub(crate) height: u16,
@@ -208,7 +208,7 @@ pub struct CursorImage {
 }
 
 impl CursorImage {
-    pub fn from_rgba(
+    pub(crate) fn from_rgba(
         rgba: Vec<u8>,
         width: u16,
         height: u16,
@@ -261,7 +261,7 @@ pub(crate) struct NoCustomCursor;
 
 #[allow(dead_code)]
 impl NoCustomCursor {
-    pub fn from_rgba(
+    pub(crate) fn from_rgba(
         rgba: Vec<u8>,
         width: u16,
         height: u16,

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -906,7 +906,7 @@ impl Window {
 
     pub fn set_cursor_icon(&self, _: window::CursorIcon) {}
 
-    pub(crate) fn set_custom_cursor(&self, _: Arc<PlatformCustomCursor>) {}
+    pub(crate) fn set_custom_cursor(&self, _: PlatformCustomCursor) {}
 
     pub fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::unnecessary_cast)]
 
 use std::collections::VecDeque;
-use std::sync::Arc;
 
 use icrate::Foundation::{CGFloat, CGPoint, CGRect, CGSize, MainThreadBound, MainThreadMarker};
 use objc2::rc::Id;
@@ -178,7 +177,7 @@ impl Inner {
         debug!("`Window::set_cursor_icon` ignored on iOS")
     }
 
-    pub(crate) fn set_custom_cursor(&self, _: Arc<PlatformCustomCursor>) {
+    pub(crate) fn set_custom_cursor(&self, _: PlatformCustomCursor) {
         debug!("`Window::set_custom_cursor` ignored on iOS")
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -40,8 +40,8 @@ pub use x11::XNotSupported;
 #[cfg(x11_platform)]
 use x11::{util::WindowType as XWindowType, X11Error, XConnection, XError};
 
-pub(crate) use crate::cursor::CursorImage as PlatformCustomCursorBuilder;
-pub(crate) use crate::cursor::CursorImage as PlatformCustomCursor;
+pub(crate) use crate::cursor::OnlyCursorImage as PlatformCustomCursor;
+pub(crate) use crate::cursor::OnlyCursorImageBuilder as PlatformCustomCursorBuilder;
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
@@ -427,7 +427,7 @@ impl Window {
     }
 
     #[inline]
-    pub(crate) fn set_custom_cursor(&self, cursor: Arc<PlatformCustomCursor>) {
+    pub(crate) fn set_custom_cursor(&self, cursor: PlatformCustomCursor) {
         x11_or_wayland!(match self; Window(w) => w.set_custom_cursor(cursor))
     }
 

--- a/src/platform_impl/linux/wayland/types/cursor.rs
+++ b/src/platform_impl/linux/wayland/types/cursor.rs
@@ -27,7 +27,7 @@ pub struct CustomCursor {
 }
 
 impl CustomCursor {
-    pub fn new(pool: &mut SlotPool, image: &CursorImage) -> Self {
+    pub(crate) fn new(pool: &mut SlotPool, image: &CursorImage) -> Self {
         let (buffer, canvas) = pool
             .create_buffer(
                 image.width as i32,

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -507,8 +507,11 @@ impl Window {
     }
 
     #[inline]
-    pub(crate) fn set_custom_cursor(&self, cursor: Arc<PlatformCustomCursor>) {
-        self.window_state.lock().unwrap().set_custom_cursor(&cursor);
+    pub(crate) fn set_custom_cursor(&self, cursor: PlatformCustomCursor) {
+        self.window_state
+            .lock()
+            .unwrap()
+            .set_custom_cursor(&cursor.0);
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -726,7 +726,7 @@ impl WindowState {
     }
 
     /// Set the custom cursor icon.
-    pub fn set_custom_cursor(&mut self, cursor: &CursorImage) {
+    pub(crate) fn set_custom_cursor(&mut self, cursor: &CursorImage) {
         let cursor = {
             let mut pool = self.custom_cursor_pool.lock().unwrap();
             CustomCursor::new(&mut pool, cursor)

--- a/src/platform_impl/linux/x11/util/cursor.rs
+++ b/src/platform_impl/linux/x11/util/cursor.rs
@@ -19,7 +19,7 @@ impl XConnection {
             .expect("Failed to set cursor");
     }
 
-    pub fn set_custom_cursor(&self, window: xproto::Window, cursor: &CustomCursor) {
+    pub(crate) fn set_custom_cursor(&self, window: xproto::Window, cursor: &CustomCursor) {
         self.update_cursor(window, cursor.inner.cursor)
             .expect("Failed to set cursor");
     }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1550,8 +1550,8 @@ impl UnownedWindow {
     }
 
     #[inline]
-    pub(crate) fn set_custom_cursor(&self, cursor: Arc<PlatformCustomCursor>) {
-        let new_cursor = unsafe { CustomCursor::new(&self.xconn, &cursor) };
+    pub(crate) fn set_custom_cursor(&self, cursor: PlatformCustomCursor) {
+        let new_cursor = unsafe { CustomCursor::new(&self.xconn, &cursor.0) };
 
         #[allow(clippy::mutex_atomic)]
         if *self.cursor_visible.lock().unwrap() {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -28,8 +28,8 @@ pub(crate) use self::{
 use crate::event::DeviceId as RootDeviceId;
 
 pub(crate) use self::window::Window;
-pub(crate) use crate::cursor::CursorImage as PlatformCustomCursor;
-pub(crate) use crate::cursor::CursorImage as PlatformCustomCursorBuilder;
+pub(crate) use crate::cursor::OnlyCursorImage as PlatformCustomCursor;
+pub(crate) use crate::cursor::OnlyCursorImageBuilder as PlatformCustomCursorBuilder;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -5,7 +5,6 @@ use std::f64;
 use std::ops;
 use std::os::raw::c_void;
 use std::ptr::NonNull;
-use std::sync::Arc;
 use std::sync::{Mutex, MutexGuard};
 
 use crate::{
@@ -848,9 +847,9 @@ impl WinitWindow {
     }
 
     #[inline]
-    pub(crate) fn set_custom_cursor(&self, cursor: Arc<PlatformCustomCursor>) {
+    pub(crate) fn set_custom_cursor(&self, cursor: PlatformCustomCursor) {
         let view = self.view();
-        view.set_cursor_icon(NSCursor::from_image(&cursor));
+        view.set_cursor_icon(NSCursor::from_image(&cursor.0));
         self.invalidateCursorRectsForView(&view);
     }
 

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -352,7 +352,7 @@ impl Window {
     #[inline]
     pub fn set_cursor_icon(&self, _: window::CursorIcon) {}
 
-    pub(crate) fn set_custom_cursor(&self, _: Arc<PlatformCustomCursor>) {}
+    pub(crate) fn set_custom_cursor(&self, _: PlatformCustomCursor) {}
 
     #[inline]
     pub fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {

--- a/src/platform_impl/web/cursor.rs
+++ b/src/platform_impl/web/cursor.rs
@@ -27,7 +27,7 @@ use self::thread_safe::ThreadSafe;
 use super::{backend::Style, r#async::AsyncSender, EventLoopWindowTarget};
 
 #[derive(Debug)]
-pub enum CustomCursorBuilder {
+pub(crate) enum CustomCursorBuilder {
     Image(CursorImage),
     Url {
         url: String,
@@ -68,7 +68,7 @@ impl PartialEq for CustomCursor {
 impl Eq for CustomCursor {}
 
 impl CustomCursor {
-    pub fn build<T>(
+    pub(crate) fn build<T>(
         builder: CustomCursorBuilder,
         window_target: &EventLoopWindowTarget<T>,
     ) -> Self {
@@ -154,7 +154,7 @@ impl CursorState {
         this.set_style();
     }
 
-    pub fn set_custom_cursor(&self, cursor: CustomCursor) {
+    pub(crate) fn set_custom_cursor(&self, cursor: CustomCursor) {
         let mut this = self.0.borrow_mut();
 
         match cursor.0.get().borrow_mut().deref_mut() {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -16,7 +16,6 @@ use web_sys::HtmlCanvasElement;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::sync::Arc;
 
 pub struct Window {
     inner: Dispatcher<Inner>,
@@ -218,7 +217,7 @@ impl Inner {
     }
 
     #[inline]
-    pub(crate) fn set_custom_cursor(&self, cursor: Arc<PlatformCustomCursor>) {
+    pub(crate) fn set_custom_cursor(&self, cursor: PlatformCustomCursor) {
         self.cursor.set_custom_cursor(cursor)
     }
 

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -194,7 +194,7 @@ impl WinCursor {
         }
     }
 
-    pub fn new(image: &CursorImage) -> Result<Self, io::Error> {
+    pub(crate) fn new(image: &CursorImage) -> Result<Self, io::Error> {
         let mut bgra = image.rgba.clone();
         bgra.chunks_exact_mut(4).for_each(|chunk| chunk.swap(0, 2));
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -16,8 +16,8 @@ pub(crate) use self::{
 };
 
 pub use self::icon::WinIcon as PlatformIcon;
-pub(crate) use crate::cursor::CursorImage as PlatformCustomCursor;
-pub(crate) use crate::cursor::CursorImage as PlatformCustomCursorBuilder;
+pub(crate) use crate::cursor::OnlyCursorImage as PlatformCustomCursor;
+pub(crate) use crate::cursor::OnlyCursorImageBuilder as PlatformCustomCursorBuilder;
 use crate::platform_impl::Fullscreen;
 
 use crate::event::DeviceId as RootDeviceId;

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -405,8 +405,8 @@ impl Window {
     }
 
     #[inline]
-    pub(crate) fn set_custom_cursor(&self, cursor: Arc<PlatformCustomCursor>) {
-        let new_cursor = match WinCursor::new(&cursor) {
+    pub(crate) fn set_custom_cursor(&self, cursor: PlatformCustomCursor) {
+        let new_cursor = match WinCursor::new(&cursor.0) {
             Ok(cursor) => cursor,
             Err(err) => {
                 warn!("Failed to create custom cursor: {err}");

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,5 +1,5 @@
 //! The [`Window`] struct and associated types.
-use std::{fmt, sync::Arc};
+use std::fmt;
 
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
@@ -1355,7 +1355,7 @@ impl Window {
     /// - **iOS / Android / Orbital:** Unsupported.
     #[inline]
     pub fn set_custom_cursor(&self, cursor: &CustomCursor) {
-        let cursor = Arc::clone(&cursor.inner);
+        let cursor = cursor.inner.clone();
         self.window
             .maybe_queue_on_main(move |w| w.set_custom_cursor(cursor))
     }


### PR DESCRIPTION
- Move `PlatformCustomCursorBuilder::build()` to `PlatformCustomCursor` so platforms can implement their own caching if they want to. See #3291.
- Move `Arc` in `CustomCursor` to platform implementations so platforms who have their own reference counting can use  that. E.g. MacOS with [`Id`](https://docs.rs/objc2/0.5.0/objc2/rc/struct.Id.html).

No public API or backend changes.