### PR TITLE
Windows: cache custom cursor

### DIFF
--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -16,8 +16,8 @@ pub(crate) use self::{
     window::Window,
 };
 
+pub(crate) use self::icon::WinCursor as PlatformCustomCursor;
 pub use self::icon::WinIcon as PlatformIcon;
-pub(crate) use crate::cursor::OnlyCursorImage as PlatformCustomCursor;
 pub(crate) use crate::cursor::OnlyCursorImageBuilder as PlatformCustomCursorBuilder;
 use crate::platform_impl::Fullscreen;
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -407,10 +407,10 @@ impl Window {
                 });
             }
             Cursor::Custom(cursor) => {
-                let new_cursor = match WinCursor::new(&cursor.inner.0) {
-                    Ok(cursor) => cursor,
-                    Err(err) => {
-                        warn!("Failed to create custom cursor: {err}");
+                let new_cursor = match cursor.inner {
+                    WinCursor::Cursor(cursor) => cursor,
+                    WinCursor::Failed => {
+                        warn!("Requested to apply failed cursor");
                         return;
                     }
                 };


### PR DESCRIPTION
We might want to let `CustomCursorBuilder::build()` be able to return an error, but that's a discussion for the future.
For now, the behavior doesn't actually change, because before this PR we didn't return an error from `Window::set_custom_cursor()` as well.