### PR TITLE
Properly implement Debug for `Window` and `EventLoop` types

### DIFF
--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -13,6 +13,7 @@ fn main() -> Result<(), impl std::error::Error> {
     #[path = "util/fill.rs"]
     mod fill;
 
+    #[derive(Debug)]
     struct WindowData {
         window: Box<dyn Window>,
         color: u32,
@@ -24,7 +25,7 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     }
 
-    #[derive(Default)]
+    #[derive(Default, Debug)]
     struct Application {
         parent_window_id: Option<WindowId>,
         windows: HashMap<WindowId, WindowData>,

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -46,7 +46,7 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run_app(ControlFlowDemo::default())
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ControlFlowDemo {
     mode: Mode,
     request_redraw: bool,

--- a/examples/dnd.rs
+++ b/examples/dnd.rs
@@ -20,6 +20,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 }
 
 /// Application state and event handling.
+#[derive(Debug)]
 struct Application {
     window: Option<Box<dyn Window>>,
 }

--- a/examples/pump_events.rs
+++ b/examples/pump_events.rs
@@ -16,7 +16,7 @@ fn main() -> std::process::ExitCode {
     #[path = "util/fill.rs"]
     mod fill;
 
-    #[derive(Default)]
+    #[derive(Default, Debug)]
     struct PumpDemo {
         window: Option<Box<dyn Window>>,
     }

--- a/examples/run_on_demand.rs
+++ b/examples/run_on_demand.rs
@@ -14,7 +14,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[path = "util/fill.rs"]
     mod fill;
 
-    #[derive(Default)]
+    #[derive(Default, Debug)]
     struct App {
         idx: usize,
         window_id: Option<WindowId>,

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -12,7 +12,7 @@ use winit::window::{Window, WindowAttributes, WindowId};
 #[path = "util/fill.rs"]
 mod fill;
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct App {
     window: Option<Box<dyn Window>>,
 }

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -12,6 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     #[path = "util/fill.rs"]
     mod fill;
 
+    #[derive(Debug)]
     pub struct XEmbedDemo {
         parent_window_id: u32,
         window: Option<Box<dyn Window>>,

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -43,6 +43,7 @@ use crate::window::{CustomCursor, CustomCursorSource, Theme, Window, WindowAttri
 /// [`EventLoopProxy`] allows you to wake up an `EventLoop` from another thread.
 ///
 /// [`Window`]: crate::window::Window
+#[derive(Debug)]
 pub struct EventLoop {
     pub(crate) event_loop: platform_impl::EventLoop,
     pub(crate) _marker: PhantomData<*mut ()>, // Not Send nor Sync
@@ -54,7 +55,7 @@ pub struct EventLoop {
 /// easier. But note that constructing multiple event loops is not supported.
 ///
 /// This can be created using [`EventLoop::builder`].
-#[derive(Default, PartialEq, Eq, Hash)]
+#[derive(Default, Debug, PartialEq, Eq, Hash)]
 pub struct EventLoopBuilder {
     pub(crate) platform_specific: platform_impl::PlatformSpecificEventLoopAttributes,
 }
@@ -114,18 +115,6 @@ impl EventLoopBuilder {
     #[cfg(web_platform)]
     pub(crate) fn allow_event_loop_recreation() {
         EVENT_LOOP_CREATED.store(false, Ordering::Relaxed);
-    }
-}
-
-impl fmt::Debug for EventLoopBuilder {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EventLoopBuilder").finish_non_exhaustive()
-    }
-}
-
-impl fmt::Debug for EventLoop {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EventLoop").finish_non_exhaustive()
     }
 }
 
@@ -309,7 +298,7 @@ impl AsRawFd for EventLoop {
     }
 }
 
-pub trait ActiveEventLoop: AsAny {
+pub trait ActiveEventLoop: AsAny + fmt::Debug {
     /// Creates an [`EventLoopProxy`] that can be used to dispatch user events
     /// to the main event loop, possibly from another thread.
     fn create_proxy(&self) -> EventLoopProxy;
@@ -463,21 +452,15 @@ impl PartialEq for OwnedDisplayHandle {
 
 impl Eq for OwnedDisplayHandle {}
 
-pub(crate) trait EventLoopProxyProvider: Send + Sync {
+pub(crate) trait EventLoopProxyProvider: Send + Sync + fmt::Debug {
     /// See [`EventLoopProxy::wake_up`] for details.
     fn wake_up(&self);
 }
 
 /// Control the [`EventLoop`], possibly from a different thread, without referencing it directly.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EventLoopProxy {
     pub(crate) proxy: Arc<dyn EventLoopProxyProvider>,
-}
-
-impl fmt::Debug for EventLoopProxy {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EventLoopProxy").finish_non_exhaustive()
-    }
 }
 
 impl EventLoopProxy {

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -44,7 +44,7 @@ fn min_timeout(a: Option<Duration>, b: Option<Duration>) -> Option<Duration> {
     a.map_or(b, |a_timeout| b.map_or(Some(a_timeout), |b_timeout| Some(a_timeout.min(b_timeout))))
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct SharedFlagSetter {
     flag: Arc<AtomicBool>,
 }
@@ -54,6 +54,7 @@ impl SharedFlagSetter {
     }
 }
 
+#[derive(Debug)]
 struct SharedFlag {
     flag: Arc<AtomicBool>,
 }
@@ -82,6 +83,12 @@ pub struct RedrawRequester {
     waker: AndroidAppWaker,
 }
 
+impl fmt::Debug for RedrawRequester {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RedrawRequester").field("flag", &self.flag).finish_non_exhaustive()
+    }
+}
+
 impl RedrawRequester {
     fn new(flag: &SharedFlag, waker: AndroidAppWaker) -> Self {
         RedrawRequester { flag: flag.setter(), waker }
@@ -96,6 +103,7 @@ impl RedrawRequester {
     }
 }
 
+#[derive(Debug)]
 pub struct EventLoop {
     pub(crate) android_app: AndroidApp,
     window_target: ActiveEventLoop,
@@ -639,6 +647,12 @@ pub struct EventLoopProxy {
     waker: AndroidAppWaker,
 }
 
+impl fmt::Debug for EventLoopProxy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EventLoopProxy").field("wake_up", &self.wake_up).finish_non_exhaustive()
+    }
+}
+
 impl EventLoopProxy {
     fn new(waker: AndroidAppWaker) -> Self {
         Self { wake_up: AtomicBool::new(false), waker }
@@ -652,6 +666,7 @@ impl EventLoopProxyProvider for EventLoopProxy {
     }
 }
 
+#[derive(Debug)]
 pub struct ActiveEventLoop {
     pub(crate) app: AndroidApp,
     control_flow: Cell<ControlFlow>,
@@ -744,6 +759,7 @@ impl rwh_06::HasDisplayHandle for OwnedDisplayHandle {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PlatformSpecificWindowAttributes;
 
+#[derive(Debug)]
 pub(crate) struct Window {
     app: AndroidApp,
     redraw_requester: RedrawRequester,

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::cell::Cell;
+use std::fmt;
 use std::panic::{catch_unwind, resume_unwind, RefUnwindSafe, UnwindSafe};
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
@@ -37,6 +38,12 @@ use crate::window::{CustomCursor as RootCustomCursor, CustomCursorSource, Theme}
 #[derive(Default)]
 pub struct PanicInfo {
     inner: Cell<Option<Box<dyn Any + Send + 'static>>>,
+}
+
+impl fmt::Debug for PanicInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PanicInfo").finish_non_exhaustive()
+    }
 }
 
 // WARNING:
@@ -161,6 +168,7 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     }
 }
 
+#[derive(Debug)]
 pub struct EventLoop {
     /// Store a reference to the application for convenience.
     ///

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -16,6 +16,7 @@ use crate::window::{
     WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
+#[derive(Debug)]
 pub(crate) struct Window {
     window: MainThreadBound<Retained<NSWindow>>,
     /// The window only keeps a weak reference to this, so we must keep it around here.

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -116,6 +116,7 @@ impl HasDisplayHandle for OwnedDisplayHandle {
     }
 }
 
+#[derive(Debug)]
 pub struct EventLoop {
     mtm: MainThreadMarker,
     window_target: ActiveEventLoop,

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -459,6 +459,7 @@ impl Inner {
     }
 }
 
+#[derive(Debug)]
 pub struct Window {
     inner: MainThreadBound<Inner>,
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -231,6 +231,7 @@ unsafe extern "C" fn x_error_callback(
     0
 }
 
+#[derive(Debug)]
 pub enum EventLoop {
     #[cfg(wayland_platform)]
     Wayland(Box<wayland::EventLoop>),

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -45,6 +45,7 @@ pub(crate) enum Event {
 }
 
 /// The Wayland event loop.
+#[derive(Debug)]
 pub struct EventLoop {
     /// Has `run` or `run_on_demand` been called or a call to `pump_events` that starts the loop
     loop_running: bool,
@@ -546,6 +547,7 @@ impl AsRawFd for EventLoop {
     }
 }
 
+#[derive(Debug)]
 pub struct ActiveEventLoop {
     /// Event loop proxy
     event_loop_proxy: CoreEventLoopProxy,
@@ -665,6 +667,7 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     }
 }
 
+#[derive(Debug)]
 pub struct OwnedDisplayHandle {
     pub(crate) connection: Connection,
 }

--- a/src/platform_impl/linux/wayland/event_loop/proxy.rs
+++ b/src/platform_impl/linux/wayland/event_loop/proxy.rs
@@ -7,6 +7,7 @@ use sctk::reexports::calloop::ping::Ping;
 use crate::event_loop::{EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider};
 
 /// A handle that can be sent across the threads and used to wake up the `EventLoop`.
+#[derive(Debug)]
 pub struct EventLoopProxy {
     ping: Ping,
 }

--- a/src/platform_impl/linux/wayland/event_loop/sink.rs
+++ b/src/platform_impl/linux/wayland/event_loop/sink.rs
@@ -8,7 +8,7 @@ use crate::window::WindowId;
 
 /// An event loop's sink to deliver events from the Wayland event callbacks
 /// to the winit's user.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct EventSink {
     pub(crate) window_events: Vec<Event>,
 }

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -414,6 +414,7 @@ impl WinitPointerDataExt for WlPointer {
     }
 }
 
+#[derive(Debug)]
 pub struct PointerConstraintsState {
     pointer_constraints: ZwpPointerConstraintsV1,
 }

--- a/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
@@ -16,6 +16,7 @@ use crate::event::DeviceEvent;
 use crate::platform_impl::wayland::state::WinitState;
 
 /// Wrapper around the relative pointer.
+#[derive(Debug)]
 pub struct RelativePointerState {
     manager: ZwpRelativePointerManagerV1,
 }

--- a/src/platform_impl/linux/wayland/seat/text_input/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/text_input/mod.rs
@@ -14,6 +14,7 @@ use crate::platform_impl::wayland;
 use crate::platform_impl::wayland::state::WinitState;
 use crate::window::ImePurpose;
 
+#[derive(Debug)]
 pub struct TextInputState {
     text_input_manager: ZwpTextInputManagerV3,
 }

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -36,6 +36,7 @@ use crate::platform_impl::wayland::window::{WindowRequests, WindowState};
 use crate::platform_impl::wayland::WindowId;
 
 /// Winit's Wayland state.
+#[derive(Debug)]
 pub struct WinitState {
     /// The WlRegistry.
     pub registry_state: RegistryState,

--- a/src/platform_impl/linux/wayland/types/xdg_activation.rs
+++ b/src/platform_impl/linux/wayland/types/xdg_activation.rs
@@ -16,6 +16,7 @@ use crate::event_loop::AsyncRequestSerial;
 use crate::platform_impl::wayland::state::WinitState;
 use crate::window::{ActivationToken, WindowId};
 
+#[derive(Debug)]
 pub struct XdgActivationState {
     xdg_activation: XdgActivationV1,
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod state;
 pub use state::WindowState;
 
 /// The Wayland window.
+#[derive(Debug)]
 pub struct Window {
     /// Reference to the underlying SCTK window.
     window: SctkWindow,

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -51,6 +51,7 @@ pub type WinitFrame = sctk::shell::xdg::fallback_frame::FallbackFrame<WinitState
 const MIN_WINDOW_SIZE: LogicalSize<u32> = LogicalSize::new(2, 1);
 
 /// The state of the window which is being updated from the [`WinitState`].
+#[derive(Debug)]
 pub struct WindowState {
     /// The connection to Wayland server.
     pub handle: Arc<OwnedDisplayHandle>,
@@ -1097,7 +1098,7 @@ impl Drop for WindowState {
 }
 
 /// The state of the cursor grabs.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 struct GrabState {
     /// The grab mode requested by the user.
     user_grab_mode: CursorGrabMode,

--- a/src/platform_impl/linux/x11/dnd.rs
+++ b/src/platform_impl/linux/x11/dnd.rs
@@ -39,6 +39,7 @@ impl From<io::Error> for DndDataParseError {
     }
 }
 
+#[derive(Debug)]
 pub struct Dnd {
     xconn: Arc<XConnection>,
     // Populated by XdndEnter event handler

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -45,6 +45,7 @@ pub const MAX_MOD_REPLAY_LEN: usize = 32;
 /// The X11 documentation states: "Keycodes lie in the inclusive range `[8, 255]`".
 const KEYCODE_OFFSET: u8 = 8;
 
+#[derive(Debug)]
 pub struct EventProcessor {
     pub dnd: Dnd,
     pub ime_receiver: ImeReceiver,

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -5,6 +5,7 @@ mod context;
 mod inner;
 mod input_method;
 
+use std::fmt;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 
@@ -54,6 +55,12 @@ pub(crate) struct Ime {
     // The actual meat of this struct is boxed away, since it needs to have a fixed location in
     // memory so we can pass a pointer to it around.
     inner: Box<ImeInner>,
+}
+
+impl fmt::Debug for Ime {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Ime").finish_non_exhaustive()
+    }
 }
 
 impl Ime {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -71,6 +71,7 @@ type X11rbConnection = x11rb::xcb_ffi::XCBConnection;
 
 type X11Source = Generic<BorrowedFd<'static>>;
 
+#[derive(Debug)]
 struct WakeSender<T> {
     sender: Sender<T>,
     waker: Ping,
@@ -91,6 +92,7 @@ impl<T> WakeSender<T> {
     }
 }
 
+#[derive(Debug)]
 struct PeekableReceiver<T> {
     recv: Receiver<T>,
     first: Option<T>,
@@ -127,6 +129,7 @@ impl<T> PeekableReceiver<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct ActiveEventLoop {
     xconn: Arc<XConnection>,
     wm_delete_window: xproto::Atom,
@@ -144,6 +147,7 @@ pub struct ActiveEventLoop {
     device_events: Cell<DeviceEvents>,
 }
 
+#[derive(Debug)]
 pub struct EventLoop {
     loop_running: bool,
     event_loop: Loop<'static, EventLoopState>,
@@ -157,6 +161,7 @@ pub struct EventLoop {
 
 type ActivationToken = (WindowId, crate::event_loop::AsyncRequestSerial);
 
+#[derive(Debug)]
 struct EventLoopState {
     /// The latest readiness state for the x11 file descriptor
     x11_readiness: Readiness,
@@ -762,7 +767,7 @@ impl Deref for DeviceInfo<'_> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EventLoopProxy {
     ping: Ping,
 }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -39,6 +39,7 @@ use crate::window::{
     WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
+#[derive(Debug)]
 pub(crate) struct Window(Arc<UnownedWindow>);
 
 impl Deref for Window {
@@ -411,6 +412,7 @@ impl SharedState {
 unsafe impl Send for UnownedWindow {}
 unsafe impl Sync for UnownedWindow {}
 
+#[derive(Debug)]
 pub struct UnownedWindow {
     pub(crate) xconn: Arc<XConnection>, // never changes
     xwindow: xproto::Window,            // never changes

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -165,7 +165,7 @@ bitflags! {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct EventState {
     keyboard: KeyboardModifierState,
     mouse: MouseButtonState,
@@ -274,6 +274,7 @@ impl EventState {
     }
 }
 
+#[derive(Debug)]
 pub struct EventLoop {
     windows: Vec<(Arc<RedoxSocket>, EventState)>,
     window_target: ActiveEventLoop,
@@ -661,6 +662,7 @@ impl EventLoop {
     }
 }
 
+#[derive(Debug)]
 pub struct EventLoopProxy {
     user_events_sender: mpsc::SyncSender<()>,
     pub(super) wake_socket: TimeSocket,
@@ -678,6 +680,7 @@ impl EventLoopProxyProvider for EventLoopProxy {
 
 impl Unpin for EventLoopProxy {}
 
+#[derive(Debug)]
 pub struct ActiveEventLoop {
     control_flow: Cell<ControlFlow>,
     exit: Cell<bool>,

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use crate::cursor::{
 };
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
+#[derive(Debug)]
 struct RedoxSocket {
     fd: usize,
 }
@@ -67,6 +68,7 @@ impl Drop for RedoxSocket {
     }
 }
 
+#[derive(Debug)]
 pub struct TimeSocket(RedoxSocket);
 
 impl TimeSocket {

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -20,6 +20,7 @@ const ORBITAL_FLAG_MAXIMIZED: char = 'm';
 const ORBITAL_FLAG_RESIZABLE: char = 'r';
 const ORBITAL_FLAG_TRANSPARENT: char = 't';
 
+#[derive(Debug)]
 pub struct Window {
     window_socket: Arc<RedoxSocket>,
     redraws: Arc<Mutex<VecDeque<WindowId>>>,

--- a/src/platform_impl/web/async/wrapper.rs
+++ b/src/platform_impl/web/async/wrapper.rs
@@ -9,6 +9,7 @@ use super::super::main_thread::MainThreadMarker;
 
 // Unsafe wrapper type that allows us to use `T` when it's not `Send` from other threads.
 // `value` **must** only be accessed on the main thread.
+#[derive(Debug)]
 pub struct Wrapper<V: 'static, S: Clone + Send, E> {
     value: Value<V>,
     handler: fn(&RefCell<Option<V>>, E),
@@ -16,6 +17,7 @@ pub struct Wrapper<V: 'static, S: Clone + Send, E> {
     sender_handler: fn(&S, E),
 }
 
+#[derive(Debug)]
 struct Value<V> {
     // SAFETY:
     // This value must not be accessed if not on the main thread.

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -11,6 +11,7 @@ mod window_target;
 
 pub(crate) use window_target::ActiveEventLoop;
 
+#[derive(Debug)]
 pub struct EventLoop {
     elw: ActiveEventLoop,
 }

--- a/src/platform_impl/web/event_loop/proxy.rs
+++ b/src/platform_impl/web/event_loop/proxy.rs
@@ -8,8 +8,10 @@ use crate::event_loop::EventLoopProxyProvider;
 use crate::platform_impl::web::event_loop::runner::WeakShared;
 use crate::platform_impl::web::r#async::{AtomicWaker, Wrapper};
 
+#[derive(Debug)]
 pub struct EventLoopProxy(Wrapper<WeakShared, Arc<State>, ()>);
 
+#[derive(Debug)]
 struct State {
     awoken: AtomicBool,
     waker: AtomicWaker,

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -1,9 +1,9 @@
 use std::cell::{Cell, RefCell};
 use std::collections::{HashSet, VecDeque};
-use std::iter;
 use std::ops::Deref;
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
+use std::{fmt, iter};
 
 use wasm_bindgen::prelude::Closure;
 use wasm_bindgen::JsCast;
@@ -26,6 +26,7 @@ use crate::platform_impl::platform::r#async::DispatchRunner;
 use crate::platform_impl::platform::window::Inner;
 use crate::window::WindowId;
 
+#[derive(Debug)]
 pub struct Shared(Rc<Execution>);
 
 impl Clone for Shared {
@@ -68,6 +69,12 @@ struct Execution {
     on_visibility_change: OnEventHandle<web_sys::Event>,
 }
 
+impl fmt::Debug for Execution {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Execution").finish_non_exhaustive()
+    }
+}
+
 enum RunnerEnum {
     /// The `EventLoop` is created but not being run.
     Pending,
@@ -94,6 +101,16 @@ struct Runner {
     state: State,
     app: Box<dyn ApplicationHandler>,
     event_loop: ActiveEventLoop,
+}
+
+impl fmt::Debug for Runner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Runner")
+            .field("state", &self.state)
+            .field("app", &"<ApplicationHandler>")
+            .field("event_loop", &self.event_loop)
+            .finish()
+    }
 }
 
 impl Runner {

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -25,7 +25,7 @@ use crate::platform_impl::web::event_loop::proxy::EventLoopProxy;
 use crate::platform_impl::Window;
 use crate::window::{CustomCursor as RootCustomCursor, CustomCursorSource, Theme, WindowId};
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ModifiersShared(Rc<Cell<ModifiersState>>);
 
 impl ModifiersShared {
@@ -44,7 +44,7 @@ impl Clone for ModifiersShared {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ActiveEventLoop {
     pub(crate) runner: runner::Shared,
     modifiers: ModifiersShared,

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -1,4 +1,5 @@
 use std::cell::Ref;
+use std::fmt;
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -21,6 +22,12 @@ use crate::window::{
 
 pub struct Window {
     inner: Dispatcher<Inner>,
+}
+
+impl fmt::Debug for Window {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Window").finish_non_exhaustive()
+    }
 }
 
 pub struct Inner {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -9,7 +9,7 @@ use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
-use std::{mem, panic, ptr};
+use std::{fmt, mem, panic, ptr};
 
 use windows_sys::Win32::Foundation::{
     GetLastError, FALSE, HANDLE, HWND, LPARAM, LRESULT, POINT, RECT, WAIT_FAILED, WPARAM,
@@ -147,10 +147,25 @@ pub struct EventLoop {
     high_resolution_timer: Option<OwnedHandle>,
 }
 
+impl fmt::Debug for EventLoop {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EventLoop").finish_non_exhaustive()
+    }
+}
+
 pub(crate) struct PlatformSpecificEventLoopAttributes {
     pub(crate) any_thread: bool,
     pub(crate) dpi_aware: bool,
     pub(crate) msg_hook: Option<Box<dyn FnMut(*const c_void) -> bool + 'static>>,
+}
+
+impl fmt::Debug for PlatformSpecificEventLoopAttributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PlatformSpecificEventLoopAttributes")
+            .field("any_thread", &self.any_thread)
+            .field("dpi_aware", &self.dpi_aware)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Default for PlatformSpecificEventLoopAttributes {
@@ -379,6 +394,7 @@ impl Drop for EventLoop {
 }
 
 #[repr(transparent)]
+#[derive(Debug)]
 pub(crate) struct ActiveEventLoop(pub Rc<EventLoopRunner>);
 
 impl ActiveEventLoop {
@@ -681,6 +697,7 @@ fn wait_for_messages_impl(
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct EventLoopThreadExecutor {
     thread_id: u32,
     target_window: HWND,
@@ -731,6 +748,7 @@ impl EventLoopThreadExecutor {
 
 type ThreadExecFn = Box<Box<dyn FnMut()>>;
 
+#[derive(Debug)]
 pub struct EventLoopProxy {
     target_window: HWND,
 }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
-use std::{mem, panic};
+use std::{fmt, mem, panic};
 
 use windows_sys::Win32::Foundation::HWND;
 
@@ -38,6 +38,14 @@ pub(crate) struct EventLoopRunner {
     event_buffer: RefCell<VecDeque<Event>>,
 
     panic_error: Cell<Option<PanicError>>,
+}
+
+impl fmt::Debug for EventLoopRunner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("EventLoopRunner")
+            .field("thread_msg_target", &self.thread_msg_target)
+            .finish_non_exhaustive()
+    }
 }
 
 pub type PanicError = Box<dyn Any + Send + 'static>;

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -76,7 +76,7 @@ use crate::window::{
     WindowLevel,
 };
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
 /// We need to pass the window handle to the event loop thread, which means it needs to be
 /// Send+Sync.
@@ -92,6 +92,7 @@ impl SyncWindowHandle {
 }
 
 /// The Win32 implementation of the main `Window` object.
+#[derive(Debug)]
 pub(crate) struct Window {
     /// Main handle for the window.
     window: SyncWindowHandle,

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -1,5 +1,5 @@
 use std::sync::MutexGuard;
-use std::{io, ptr};
+use std::{fmt, io, ptr};
 
 use bitflags::bitflags;
 use windows_sys::Win32::Foundation::{HWND, RECT};
@@ -23,6 +23,7 @@ use crate::platform_impl::platform::{event_loop, util, Fullscreen, SelectedCurso
 use crate::window::{Theme, WindowAttributes};
 
 /// Contains information about states and the window that the callback is going to use.
+#[derive(Debug)]
 pub(crate) struct WindowState {
     pub mouse: MouseProperties,
 
@@ -65,7 +66,13 @@ pub struct SavedWindow {
     pub placement: WINDOWPLACEMENT,
 }
 
-#[derive(Clone)]
+impl fmt::Debug for SavedWindow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SavedWindow").finish_non_exhaustive()
+    }
+}
+
+#[derive(Clone, Debug)]
 pub struct MouseProperties {
     pub(crate) selected_cursor: SelectedCursor,
     pub capture_count: u32,
@@ -129,7 +136,7 @@ bitflags! {
     }
 }
 
-#[derive(Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 pub enum ImeState {
     Disabled,
     Enabled,

--- a/src/window.rs
+++ b/src/window.rs
@@ -431,7 +431,7 @@ impl WindowAttributes {
 ///
 /// **Web:** The [`Window`], which is represented by a `HTMLElementCanvas`, can
 /// not be closed by dropping the [`Window`].
-pub trait Window: AsAny + Send + Sync {
+pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// Returns an identifier unique to the window.
     fn id(&self) -> WindowId;
 


### PR DESCRIPTION
Properly implement `Debug` for `EventLoop`, `EventLoopBuilder` and `EventLoopProxy`, and require it as a supertrait of `Window` and `ActiveEventLoop`.

It is especially useful for users to be able to know that `Window` is `Debug` (this allows them to easily make their `AppState` `Debug` too, which they could before https://github.com/rust-windowing/winit/pull/3857).