### PR TITLE
Remove generic parameter `T` from `EventLoopWindowTarget`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- **Breaking:** Removed unnecessary generic parameter `T` from `EventLoopWindowTarget`.
 - On Windows, macOS, X11, Wayland and Web, implement setting images as cursors. See the `custom_cursors.rs` example.
   - **Breaking:** Remove `Window::set_cursor_icon`
   - Add `WindowBuilder::with_cursor` and `Window::set_cursor` which takes a `CursorIcon` or `CustomCursor`

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     fn spawn_child_window(
         parent: &Window,
-        event_loop: &EventLoopWindowTarget<()>,
+        event_loop: &EventLoopWindowTarget,
         windows: &mut HashMap<WindowId, Window>,
     ) {
         let parent = parent.raw_window_handle().unwrap();

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -18,7 +18,7 @@ use {
 #[cfg(wasm_platform)]
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
-fn decode_cursor<T>(bytes: &[u8], window_target: &EventLoopWindowTarget<T>) -> CustomCursor {
+fn decode_cursor(bytes: &[u8], window_target: &EventLoopWindowTarget) -> CustomCursor {
     let img = image::load_from_memory(bytes).unwrap().to_rgba8();
     let samples = img.into_flat_samples();
     let (_, w, h) = samples.extents();

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -111,7 +111,7 @@ pub struct CustomCursorBuilder {
 }
 
 impl CustomCursorBuilder {
-    pub fn build<T>(self, window_target: &EventLoopWindowTarget<T>) -> CustomCursor {
+    pub fn build(self, window_target: &EventLoopWindowTarget) -> CustomCursor {
         CustomCursor {
             inner: PlatformCustomCursor::build(self.inner, &window_target.p),
         }
@@ -213,10 +213,7 @@ impl Eq for OnlyCursorImage {}
 
 #[allow(dead_code)]
 impl OnlyCursorImage {
-    fn build<T>(
-        builder: OnlyCursorImageBuilder,
-        _: &platform_impl::EventLoopWindowTarget<T>,
-    ) -> Self {
+    fn build(builder: OnlyCursorImageBuilder, _: &platform_impl::EventLoopWindowTarget) -> Self {
         Self(Arc::new(builder.0))
     }
 }
@@ -296,7 +293,7 @@ impl NoCustomCursor {
         Ok(Self)
     }
 
-    fn build<T>(self, _: &platform_impl::EventLoopWindowTarget<T>) -> NoCustomCursor {
+    fn build(self, _: &platform_impl::EventLoopWindowTarget) -> NoCustomCursor {
         self
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -48,9 +48,9 @@ pub struct EventLoop<T: 'static> {
 /// your callback. [`EventLoop`] will coerce into this type (`impl<T> Deref for
 /// EventLoop<T>`), so functions that take this as a parameter can also take
 /// `&EventLoop`.
-pub struct EventLoopWindowTarget<T: 'static> {
-    pub(crate) p: platform_impl::EventLoopWindowTarget<T>,
-    pub(crate) _marker: PhantomData<*mut T>, // Not Send nor Sync + invariant over T
+pub struct EventLoopWindowTarget {
+    pub(crate) p: platform_impl::EventLoopWindowTarget,
+    pub(crate) _marker: PhantomData<*mut ()>, // Not Send nor Sync
 }
 
 /// Object that allows building the event loop.
@@ -142,7 +142,7 @@ impl<T> fmt::Debug for EventLoop<T> {
     }
 }
 
-impl<T> fmt::Debug for EventLoopWindowTarget<T> {
+impl fmt::Debug for EventLoopWindowTarget {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad("EventLoopWindowTarget { .. }")
     }
@@ -241,7 +241,7 @@ impl<T> EventLoop<T> {
     #[cfg(not(all(wasm_platform, target_feature = "exception-handling")))]
     pub fn run<F>(self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &EventLoopWindowTarget<T>),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
         self.event_loop.run(event_handler)
     }
@@ -298,13 +298,13 @@ impl<T> AsRawFd for EventLoop<T> {
 }
 
 impl<T> Deref for EventLoop<T> {
-    type Target = EventLoopWindowTarget<T>;
-    fn deref(&self) -> &EventLoopWindowTarget<T> {
+    type Target = EventLoopWindowTarget;
+    fn deref(&self) -> &EventLoopWindowTarget {
         self.event_loop.window_target()
     }
 }
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     /// Returns the list of all the monitors available on the system.
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
@@ -370,7 +370,7 @@ impl<T> EventLoopWindowTarget<T> {
 }
 
 #[cfg(feature = "rwh_06")]
-impl<T> rwh_06::HasDisplayHandle for EventLoopWindowTarget<T> {
+impl rwh_06::HasDisplayHandle for EventLoopWindowTarget {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.p.raw_display_handle_rwh_06()?;
         // SAFETY: The display will never be deallocated while the event loop is alive.
@@ -379,7 +379,7 @@ impl<T> rwh_06::HasDisplayHandle for EventLoopWindowTarget<T> {
 }
 
 #[cfg(feature = "rwh_05")]
-unsafe impl<T> rwh_05::HasRawDisplayHandle for EventLoopWindowTarget<T> {
+unsafe impl rwh_05::HasRawDisplayHandle for EventLoopWindowTarget {
     /// Returns a [`rwh_05::RawDisplayHandle`] for the event loop.
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
         self.p.raw_display_handle_rwh_05()

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -30,7 +30,7 @@ impl WindowExtAndroid for Window {
     }
 }
 
-impl<T> EventLoopWindowTargetExtAndroid for EventLoopWindowTarget<T> {}
+impl EventLoopWindowTargetExtAndroid for EventLoopWindowTarget {}
 
 /// Additional methods on [`WindowBuilder`] that are specific to Android.
 pub trait WindowBuilderExtAndroid {}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -388,7 +388,7 @@ pub trait EventLoopWindowTargetExtMacOS {
     fn allows_automatic_window_tabbing(&self) -> bool;
 }
 
-impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
+impl EventLoopWindowTargetExtMacOS for EventLoopWindowTarget {
     fn hide_application(&self) {
         self.p.hide_application()
     }

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -174,7 +174,7 @@ pub trait EventLoopExtPumpEvents {
     ///   callback.
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget);
 }
 
 impl<T> EventLoopExtPumpEvents for EventLoop<T> {
@@ -182,7 +182,7 @@ impl<T> EventLoopExtPumpEvents for EventLoop<T> {
 
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget),
     {
         self.event_loop.pump_events(timeout, event_handler)
     }

--- a/src/platform/run_on_demand.rs
+++ b/src/platform/run_on_demand.rs
@@ -66,7 +66,7 @@ pub trait EventLoopExtRunOnDemand {
     /// [`set_control_flow()`]: EventLoopWindowTarget::set_control_flow()
     fn run_on_demand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget);
 }
 
 impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
@@ -74,14 +74,14 @@ impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
 
     fn run_on_demand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget),
     {
         self.event_loop.window_target().clear_exit();
         self.event_loop.run_on_demand(event_handler)
     }
 }
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     /// Clear exit status.
     pub(crate) fn clear_exit(&self) {
         self.p.clear_exit()

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -55,7 +55,7 @@ pub trait WindowBuilderExtStartupNotify {
     fn with_activation_token(self, token: ActivationToken) -> Self;
 }
 
-impl<T> EventLoopExtStartupNotify for EventLoopWindowTarget<T> {
+impl EventLoopExtStartupNotify for EventLoopWindowTarget {
     fn read_token_from_env(&self) -> Option<ActivationToken> {
         match self.p {
             #[cfg(wayland_platform)]

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -12,7 +12,7 @@ pub trait EventLoopWindowTargetExtWayland {
     fn is_wayland(&self) -> bool;
 }
 
-impl<T> EventLoopWindowTargetExtWayland for EventLoopWindowTarget<T> {
+impl EventLoopWindowTargetExtWayland for EventLoopWindowTarget {
     #[inline]
     fn is_wayland(&self) -> bool {
         self.p.is_wayland()

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -172,7 +172,7 @@ pub trait EventLoopExtWebSys {
     /// [^1]: `run()` is _not_ available on WASM when the target supports `exception-handling`.
     fn spawn<F>(self, event_handler: F)
     where
-        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
+        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget);
 }
 
 impl<T> EventLoopExtWebSys for EventLoop<T> {
@@ -180,7 +180,7 @@ impl<T> EventLoopExtWebSys for EventLoop<T> {
 
     fn spawn<F>(self, event_handler: F)
     where
-        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
+        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget),
     {
         self.event_loop.spawn(event_handler)
     }
@@ -202,7 +202,7 @@ pub trait EventLoopWindowTargetExtWebSys {
     fn poll_strategy(&self) -> PollStrategy;
 }
 
-impl<T> EventLoopWindowTargetExtWebSys for EventLoopWindowTarget<T> {
+impl EventLoopWindowTargetExtWebSys for EventLoopWindowTarget {
     #[inline]
     fn set_poll_strategy(&self, strategy: PollStrategy) {
         self.p.set_poll_strategy(strategy);
@@ -315,11 +315,11 @@ impl Error for BadAnimation {}
 pub trait CustomCursorBuilderExtWebSys {
     /// Async version of [`CustomCursorBuilder::build()`] which waits until the
     /// cursor has completely finished loading.
-    fn build_async<T>(self, window_target: &EventLoopWindowTarget<T>) -> CustomCursorFuture;
+    fn build_async(self, window_target: &EventLoopWindowTarget) -> CustomCursorFuture;
 }
 
 impl CustomCursorBuilderExtWebSys for CustomCursorBuilder {
-    fn build_async<T>(self, window_target: &EventLoopWindowTarget<T>) -> CustomCursorFuture {
+    fn build_async(self, window_target: &EventLoopWindowTarget) -> CustomCursorFuture {
         CustomCursorFuture(PlatformCustomCursor::build_async(
             self.inner,
             &window_target.p,

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -95,7 +95,7 @@ pub trait EventLoopWindowTargetExtX11 {
     fn is_x11(&self) -> bool;
 }
 
-impl<T> EventLoopWindowTargetExtX11 for EventLoopWindowTarget<T> {
+impl EventLoopWindowTargetExtX11 for EventLoopWindowTarget {
     #[inline]
     fn is_x11(&self) -> bool {
         !self.p.is_wayland()

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -4,6 +4,7 @@ use std::{
     cell::Cell,
     collections::VecDeque,
     hash::Hash,
+    marker::PhantomData,
     sync::{
         atomic::{AtomicBool, Ordering},
         mpsc, Arc, Mutex, RwLock,
@@ -140,7 +141,7 @@ pub struct KeyEventExtra {}
 
 pub struct EventLoop<T: 'static> {
     android_app: AndroidApp,
-    window_target: event_loop::EventLoopWindowTarget<T>,
+    window_target: event_loop::EventLoopWindowTarget,
     redraw_flag: SharedFlag,
     user_events_sender: mpsc::Sender<T>,
     user_events_receiver: PeekableReceiver<T>, //must wake looper whenever something gets sent
@@ -187,9 +188,8 @@ impl<T: 'static> EventLoop<T> {
                         &redraw_flag,
                         android_app.create_waker(),
                     ),
-                    _marker: std::marker::PhantomData,
                 },
-                _marker: std::marker::PhantomData,
+                _marker: PhantomData,
             },
             redraw_flag,
             user_events_sender,
@@ -205,7 +205,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn single_iteration<F>(&mut self, main_event: Option<MainEvent<'_>>, callback: &mut F)
     where
-        F: FnMut(event::Event<T>, &RootELW<T>),
+        F: FnMut(event::Event<T>, &RootELW),
     {
         trace!("Mainloop iteration");
 
@@ -377,7 +377,7 @@ impl<T: 'static> EventLoop<T> {
         callback: &mut F,
     ) -> InputStatus
     where
-        F: FnMut(event::Event<T>, &RootELW<T>),
+        F: FnMut(event::Event<T>, &RootELW),
     {
         let mut input_status = InputStatus::Handled;
         match event {
@@ -482,14 +482,14 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>),
+        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
     {
         self.run_on_demand(event_handler)
     }
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>),
+        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
     {
         if self.loop_running {
             return Err(EventLoopError::AlreadyRunning);
@@ -512,7 +512,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut callback: F) -> PumpStatus
     where
-        F: FnMut(event::Event<T>, &RootELW<T>),
+        F: FnMut(event::Event<T>, &RootELW),
     {
         if !self.loop_running {
             self.loop_running = true;
@@ -545,7 +545,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn poll_events_with_timeout<F>(&mut self, mut timeout: Option<Duration>, mut callback: F)
     where
-        F: FnMut(event::Event<T>, &RootELW<T>),
+        F: FnMut(event::Event<T>, &RootELW),
     {
         let start = Instant::now();
 
@@ -621,7 +621,7 @@ impl<T: 'static> EventLoop<T> {
         });
     }
 
-    pub fn window_target(&self) -> &event_loop::EventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &event_loop::EventLoopWindowTarget {
         &self.window_target
     }
 
@@ -665,15 +665,14 @@ impl<T> EventLoopProxy<T> {
     }
 }
 
-pub struct EventLoopWindowTarget<T: 'static> {
+pub struct EventLoopWindowTarget {
     app: AndroidApp,
     control_flow: Cell<ControlFlow>,
     exit: Cell<bool>,
     redraw_requester: RedrawRequester,
-    _marker: std::marker::PhantomData<T>,
 }
 
-impl<T: 'static> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         Some(MonitorHandle::new(self.app.clone()))
     }
@@ -763,8 +762,8 @@ pub(crate) struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T: 'static>(
-        el: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        el: &EventLoopWindowTarget,
         _window_attrs: window::WindowAttributes,
         _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -34,12 +34,11 @@ use super::{
 };
 
 #[derive(Debug)]
-pub struct EventLoopWindowTarget<T: 'static> {
+pub struct EventLoopWindowTarget {
     pub(super) mtm: MainThreadMarker,
-    p: PhantomData<T>,
 }
 
-impl<T: 'static> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         monitor::uiscreens(self.mtm)
     }
@@ -90,7 +89,7 @@ pub struct EventLoop<T: 'static> {
     mtm: MainThreadMarker,
     sender: Sender<T>,
     receiver: Receiver<T>,
-    window_target: RootEventLoopWindowTarget<T>,
+    window_target: RootEventLoopWindowTarget,
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -123,10 +122,7 @@ impl<T: 'static> EventLoop<T> {
             sender,
             receiver,
             window_target: RootEventLoopWindowTarget {
-                p: EventLoopWindowTarget {
-                    mtm,
-                    p: PhantomData,
-                },
+                p: EventLoopWindowTarget { mtm },
                 _marker: PhantomData,
             },
         })
@@ -134,7 +130,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(self, event_handler: F) -> !
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>),
+        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
     {
         unsafe {
             let application = UIApplication::shared(self.mtm);
@@ -146,7 +142,7 @@ impl<T: 'static> EventLoop<T> {
             );
 
             let event_handler = std::mem::transmute::<
-                Box<dyn FnMut(Event<T>, &RootEventLoopWindowTarget<T>)>,
+                Box<dyn FnMut(Event<T>, &RootEventLoopWindowTarget)>,
                 Box<EventHandlerCallback<T>>,
             >(Box::new(event_handler));
 
@@ -175,7 +171,7 @@ impl<T: 'static> EventLoop<T> {
         EventLoopProxy::new(self.sender.clone())
     }
 
-    pub fn window_target(&self) -> &RootEventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &RootEventLoopWindowTarget {
         &self.window_target
     }
 }
@@ -346,7 +342,7 @@ fn setup_control_flow_observers() {
 #[derive(Debug)]
 pub enum Never {}
 
-type EventHandlerCallback<T> = dyn FnMut(Event<T>, &RootEventLoopWindowTarget<T>) + 'static;
+type EventHandlerCallback<T> = dyn FnMut(Event<T>, &RootEventLoopWindowTarget) + 'static;
 
 pub trait EventHandler: Debug {
     fn handle_nonuser_event(&mut self, event: Event<Never>);
@@ -356,7 +352,7 @@ pub trait EventHandler: Debug {
 struct EventLoopHandler<T: 'static> {
     f: Box<EventHandlerCallback<T>>,
     receiver: Receiver<T>,
-    event_loop: RootEventLoopWindowTarget<T>,
+    event_loop: RootEventLoopWindowTarget,
 }
 
 impl<T: 'static> Debug for EventLoopHandler<T> {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -398,8 +398,8 @@ pub struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T>(
-        event_loop: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop: &EventLoopWindowTarget,
         window_attributes: WindowAttributes,
         platform_attributes: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, RootOsError> {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -286,8 +286,8 @@ impl VideoModeHandle {
 
 impl Window {
     #[inline]
-    pub(crate) fn new<T>(
-        window_target: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        window_target: &EventLoopWindowTarget,
         attribs: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
@@ -781,26 +781,26 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>),
+        F: FnMut(crate::event::Event<T>, &RootELW),
     {
         self.run_on_demand(callback)
     }
 
     pub fn run_on_demand<F>(&mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>),
+        F: FnMut(crate::event::Event<T>, &RootELW),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_on_demand(callback))
     }
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>),
+        F: FnMut(crate::event::Event<T>, &RootELW),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.pump_events(timeout, callback))
     }
 
-    pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.window_target())
     }
 }
@@ -823,14 +823,14 @@ impl<T: 'static> EventLoopProxy<T> {
     }
 }
 
-pub enum EventLoopWindowTarget<T> {
+pub enum EventLoopWindowTarget {
     #[cfg(wayland_platform)]
-    Wayland(wayland::EventLoopWindowTarget<T>),
+    Wayland(wayland::EventLoopWindowTarget),
     #[cfg(x11_platform)]
-    X(x11::EventLoopWindowTarget<T>),
+    X(x11::EventLoopWindowTarget),
 }
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     #[inline]
     pub fn is_wayland(&self) -> bool {
         match *self {

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -63,7 +63,7 @@ pub struct EventLoop<T: 'static> {
     connection: Connection,
 
     /// Event loop window target.
-    window_target: RootEventLoopWindowTarget<T>,
+    window_target: RootEventLoopWindowTarget,
 
     // XXX drop after everything else, just to be safe.
     /// Calloop's event loop.
@@ -167,7 +167,6 @@ impl<T: 'static> EventLoop<T> {
             control_flow: Cell::new(ControlFlow::default()),
             exit: Cell::new(None),
             state: RefCell::new(winit_state),
-            _marker: PhantomData,
         };
 
         let event_loop = Self {
@@ -191,7 +190,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>),
+        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
     {
         if self.loop_running {
             return Err(EventLoopError::AlreadyRunning);
@@ -222,7 +221,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut callback: F) -> PumpStatus
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>),
+        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
     {
         if !self.loop_running {
             self.loop_running = true;
@@ -249,7 +248,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn poll_events_with_timeout<F>(&mut self, mut timeout: Option<Duration>, mut callback: F)
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>),
+        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
     {
         let cause = loop {
             let start = Instant::now();
@@ -325,7 +324,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn single_iteration<F>(&mut self, callback: &mut F, cause: StartCause)
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>),
+        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
     {
         // NOTE currently just indented to simplify the diff
 
@@ -530,7 +529,7 @@ impl<T: 'static> EventLoop<T> {
     }
 
     #[inline]
-    pub fn window_target(&self) -> &RootEventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &RootEventLoopWindowTarget {
         &self.window_target
     }
 
@@ -602,7 +601,7 @@ impl<T> AsRawFd for EventLoop<T> {
     }
 }
 
-pub struct EventLoopWindowTarget<T> {
+pub struct EventLoopWindowTarget {
     /// The event loop wakeup source.
     pub event_loop_awakener: calloop::ping::Ping,
 
@@ -624,11 +623,9 @@ pub struct EventLoopWindowTarget<T> {
 
     /// Connection to the wayland server.
     pub connection: Connection,
-
-    _marker: std::marker::PhantomData<T>,
 }
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     pub(crate) fn set_control_flow(&self, control_flow: ControlFlow) {
         self.control_flow.set(control_flow)
     }

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -8,7 +8,7 @@ use crate::platform_impl::platform::VideoModeHandle as PlatformVideoModeHandle;
 
 use super::event_loop::EventLoopWindowTarget;
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
         self.state

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -81,8 +81,8 @@ pub struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T>(
-        event_loop_window_target: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop_window_target: &EventLoopWindowTarget,
         attributes: WindowAttributes,
         platform_attributes: PlatformAttributes,
     ) -> Result<Self, RootOsError> {

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -36,7 +36,7 @@ use crate::{
 /// The X11 documentation states: "Keycodes lie in the inclusive range `[8, 255]`".
 const KEYCODE_OFFSET: u8 = 8;
 
-pub(super) struct EventProcessor<T: 'static> {
+pub(super) struct EventProcessor {
     pub(super) dnd: Dnd,
     pub(super) ime_receiver: ImeReceiver,
     pub(super) ime_event_receiver: ImeEventReceiver,
@@ -44,7 +44,7 @@ pub(super) struct EventProcessor<T: 'static> {
     pub(super) devices: RefCell<HashMap<DeviceId, Device>>,
     pub(super) xi2ext: ExtensionInformation,
     pub(super) xkbext: ExtensionInformation,
-    pub(super) target: Rc<RootELW<T>>,
+    pub(super) target: Rc<RootELW>,
     pub(super) kb_state: KbdState,
     // Number of touch events currently in progress
     pub(super) num_touch: u32,
@@ -61,7 +61,7 @@ pub(super) struct EventProcessor<T: 'static> {
     pub(super) is_composing: bool,
 }
 
-impl<T: 'static> EventProcessor<T> {
+impl EventProcessor {
     pub(super) fn init_device(&self, device: xinput::DeviceId) {
         let wt = get_xtarget(&self.target);
         let mut devices = self.devices.borrow_mut();
@@ -136,7 +136,7 @@ impl<T: 'static> EventProcessor<T> {
         result != 0
     }
 
-    pub(super) fn process_event<F>(&mut self, xev: &mut ffi::XEvent, mut callback: F)
+    pub(super) fn process_event<T: 'static, F>(&mut self, xev: &mut ffi::XEvent, mut callback: F)
     where
         F: FnMut(Event<T>),
     {
@@ -1370,7 +1370,11 @@ impl<T: 'static> EventProcessor<T> {
     /// Send modifiers for the active window.
     ///
     /// The event won't be send when the `modifiers` match the previosly `sent` modifiers value.
-    fn send_modifiers<F: FnMut(Event<T>)>(&self, modifiers: ModifiersState, callback: &mut F) {
+    fn send_modifiers<T: 'static, F: FnMut(Event<T>)>(
+        &self,
+        modifiers: ModifiersState,
+        callback: &mut F,
+    ) {
         let window_id = match self.active_window {
             Some(window) => mkwid(window),
             None => return,
@@ -1384,8 +1388,8 @@ impl<T: 'static> EventProcessor<T> {
         }
     }
 
-    fn handle_pressed_keys<F>(
-        wt: &super::EventLoopWindowTarget<T>,
+    fn handle_pressed_keys<T: 'static, F>(
+        wt: &super::EventLoopWindowTarget,
         window_id: crate::window::WindowId,
         state: ElementState,
         kb_state: &mut KbdState,
@@ -1415,7 +1419,7 @@ impl<T: 'static> EventProcessor<T> {
         }
     }
 
-    fn process_dpi_change<F>(&self, callback: &mut F)
+    fn process_dpi_change<T: 'static, F>(&self, callback: &mut F)
     where
         F: FnMut(Event<T>),
     {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -27,6 +27,7 @@ use std::{
     collections::{HashMap, HashSet},
     ffi::CStr,
     fmt,
+    marker::PhantomData,
     mem::MaybeUninit,
     ops::Deref,
     os::{
@@ -142,7 +143,7 @@ impl<T> PeekableReceiver<T> {
     }
 }
 
-pub struct EventLoopWindowTarget<T> {
+pub struct EventLoopWindowTarget {
     xconn: Arc<XConnection>,
     wm_delete_window: xproto::Atom,
     net_wm_ping: xproto::Atom,
@@ -155,19 +156,18 @@ pub struct EventLoopWindowTarget<T> {
     redraw_sender: WakeSender<WindowId>,
     activation_sender: WakeSender<ActivationToken>,
     device_events: Cell<DeviceEvents>,
-    _marker: ::std::marker::PhantomData<T>,
 }
 
 pub struct EventLoop<T: 'static> {
     loop_running: bool,
     event_loop: Loop<'static, EventLoopState>,
     waker: calloop::ping::Ping,
-    event_processor: EventProcessor<T>,
+    event_processor: EventProcessor,
     redraw_receiver: PeekableReceiver<WindowId>,
     user_receiver: PeekableReceiver<T>,
     activation_receiver: PeekableReceiver<ActivationToken>,
     user_sender: Sender<T>,
-    target: Rc<RootELW<T>>,
+    target: Rc<RootELW>,
 
     /// The current state of the event loop.
     state: EventLoopState,
@@ -307,7 +307,6 @@ impl<T: 'static> EventLoop<T> {
             control_flow: Cell::new(ControlFlow::default()),
             exit: Cell::new(None),
             windows: Default::default(),
-            _marker: ::std::marker::PhantomData,
             ime_sender,
             xconn,
             wm_delete_window,
@@ -328,7 +327,7 @@ impl<T: 'static> EventLoop<T> {
 
         let target = Rc::new(RootELW {
             p: super::EventLoopWindowTarget::X(window_target),
-            _marker: ::std::marker::PhantomData,
+            _marker: PhantomData,
         });
 
         let event_processor = EventProcessor {
@@ -397,13 +396,13 @@ impl<T: 'static> EventLoop<T> {
         }
     }
 
-    pub(crate) fn window_target(&self) -> &RootELW<T> {
+    pub(crate) fn window_target(&self) -> &RootELW {
         &self.target
     }
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootELW<T>),
+        F: FnMut(Event<T>, &RootELW),
     {
         if self.loop_running {
             return Err(EventLoopError::AlreadyRunning);
@@ -437,7 +436,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut callback: F) -> PumpStatus
     where
-        F: FnMut(Event<T>, &RootELW<T>),
+        F: FnMut(Event<T>, &RootELW),
     {
         if !self.loop_running {
             self.loop_running = true;
@@ -470,7 +469,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn poll_events_with_timeout<F>(&mut self, mut timeout: Option<Duration>, mut callback: F)
     where
-        F: FnMut(Event<T>, &RootELW<T>),
+        F: FnMut(Event<T>, &RootELW),
     {
         let start = Instant::now();
 
@@ -548,7 +547,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn single_iteration<F>(&mut self, callback: &mut F, cause: StartCause)
     where
-        F: FnMut(Event<T>, &RootELW<T>),
+        F: FnMut(Event<T>, &RootELW),
     {
         callback(crate::event::Event::NewEvents(cause), &self.target);
 
@@ -622,7 +621,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn drain_events<F>(&mut self, callback: &mut F)
     where
-        F: FnMut(Event<T>, &RootELW<T>),
+        F: FnMut(Event<T>, &RootELW),
     {
         let target = &self.target;
         let mut xev = MaybeUninit::uninit();
@@ -673,7 +672,7 @@ impl<T> AsRawFd for EventLoop<T> {
     }
 }
 
-pub(crate) fn get_xtarget<T>(target: &RootELW<T>) -> &EventLoopWindowTarget<T> {
+pub(crate) fn get_xtarget(target: &RootELW) -> &EventLoopWindowTarget {
     match target.p {
         super::EventLoopWindowTarget::X(ref target) => target,
         #[cfg(wayland_platform)]
@@ -681,7 +680,7 @@ pub(crate) fn get_xtarget<T>(target: &RootELW<T>) -> &EventLoopWindowTarget<T> {
     }
 }
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     /// Returns the `XConnection` of this events loop.
     #[inline]
     pub(crate) fn x_connection(&self) -> &Arc<XConnection> {
@@ -840,8 +839,8 @@ impl Deref for Window {
 }
 
 impl Window {
-    pub(crate) fn new<T>(
-        event_loop: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop: &EventLoopWindowTarget,
         attribs: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -152,8 +152,8 @@ macro_rules! leap {
 
 impl UnownedWindow {
     #[allow(clippy::unnecessary_cast)]
-    pub(crate) fn new<T>(
-        event_loop: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop: &EventLoopWindowTarget,
         window_attrs: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<UnownedWindow, RootOsError> {

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -46,18 +46,18 @@ pub trait EventHandler: Debug {
     fn handle_user_events(&mut self);
 }
 
-pub(crate) type Callback<T> = RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>)>;
+pub(crate) type Callback<T> = RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>;
 
 struct EventLoopHandler<T: 'static> {
     callback: Weak<Callback<T>>,
-    window_target: Rc<RootWindowTarget<T>>,
+    window_target: Rc<RootWindowTarget>,
     receiver: Rc<mpsc::Receiver<T>>,
 }
 
 impl<T> EventLoopHandler<T> {
     fn with_callback<F>(&mut self, f: F)
     where
-        F: FnOnce(&mut EventLoopHandler<T>, RefMut<'_, dyn FnMut(Event<T>, &RootWindowTarget<T>)>),
+        F: FnOnce(&mut EventLoopHandler<T>, RefMut<'_, dyn FnMut(Event<T>, &RootWindowTarget)>),
     {
         // `NSApplication` and our `HANDLER` are global state and so it's possible
         // that we could get a delegate callback after the application has exit an
@@ -375,7 +375,7 @@ impl AppState {
     /// a call to `clear_callback` before returning to avoid undefined behaviour.
     pub unsafe fn set_callback<T>(
         callback: Weak<Callback<T>>,
-        window_target: Rc<RootWindowTarget<T>>,
+        window_target: Rc<RootWindowTarget>,
         receiver: Rc<mpsc::Receiver<T>>,
     ) {
         *HANDLER.callback.lock().unwrap() = Some(Box::new(EventLoopHandler {

--- a/src/platform_impl/macos/cursor.rs
+++ b/src/platform_impl/macos/cursor.rs
@@ -24,10 +24,7 @@ unsafe impl Send for CustomCursor {}
 unsafe impl Sync for CustomCursor {}
 
 impl CustomCursor {
-    pub(crate) fn build<T>(
-        cursor: OnlyCursorImageBuilder,
-        _: &EventLoopWindowTarget<T>,
-    ) -> CustomCursor {
+    pub(crate) fn build(cursor: OnlyCursorImageBuilder, _: &EventLoopWindowTarget) -> CustomCursor {
         Self(cursor_from_image(&cursor.0))
     }
 }

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -74,12 +74,11 @@ impl PanicInfo {
 }
 
 #[derive(Debug)]
-pub struct EventLoopWindowTarget<T: 'static> {
+pub struct EventLoopWindowTarget {
     mtm: MainThreadMarker,
-    p: PhantomData<T>,
 }
 
-impl<T: 'static> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     #[inline]
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         monitor::available_monitors()
@@ -131,7 +130,7 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     }
 }
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     pub(crate) fn hide_application(&self) {
         NSApplication::sharedApplication(self.mtm).hide(None)
     }
@@ -163,7 +162,7 @@ pub struct EventLoop<T: 'static> {
     sender: mpsc::Sender<T>,
     receiver: Rc<mpsc::Receiver<T>>,
 
-    window_target: Rc<RootWindowTarget<T>>,
+    window_target: Rc<RootWindowTarget>,
     panic_info: Rc<PanicInfo>,
 
     /// We make sure that the callback closure is dropped during a panic
@@ -232,10 +231,7 @@ impl<T> EventLoop<T> {
             sender,
             receiver: Rc::new(receiver),
             window_target: Rc::new(RootWindowTarget {
-                p: EventLoopWindowTarget {
-                    mtm,
-                    p: PhantomData,
-                },
+                p: EventLoopWindowTarget { mtm },
                 _marker: PhantomData,
             }),
             panic_info,
@@ -243,13 +239,13 @@ impl<T> EventLoop<T> {
         })
     }
 
-    pub fn window_target(&self) -> &RootWindowTarget<T> {
+    pub fn window_target(&self) -> &RootWindowTarget {
         &self.window_target
     }
 
     pub fn run<F>(mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootWindowTarget<T>),
+        F: FnMut(Event<T>, &RootWindowTarget),
     {
         self.run_on_demand(callback)
     }
@@ -260,7 +256,7 @@ impl<T> EventLoop<T> {
     // redundant wake ups.
     pub fn run_on_demand<F>(&mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootWindowTarget<T>),
+        F: FnMut(Event<T>, &RootWindowTarget),
     {
         if AppState::is_running() {
             return Err(EventLoopError::AlreadyRunning);
@@ -277,8 +273,8 @@ impl<T> EventLoop<T> {
 
         let callback = unsafe {
             mem::transmute::<
-                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>)>>,
-                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>>,
             >(Rc::new(RefCell::new(callback)))
         };
 
@@ -344,7 +340,7 @@ impl<T> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(Event<T>, &RootWindowTarget<T>),
+        F: FnMut(Event<T>, &RootWindowTarget),
     {
         // # Safety
         // We are erasing the lifetime of the application callback here so that we
@@ -357,8 +353,8 @@ impl<T> EventLoop<T> {
 
         let callback = unsafe {
             mem::transmute::<
-                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>)>>,
-                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>>,
             >(Rc::new(RefCell::new(callback)))
         };
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -69,8 +69,8 @@ impl Drop for Window {
 }
 
 impl Window {
-    pub(crate) fn new<T: 'static>(
-        _window_target: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        _window_target: &EventLoopWindowTarget,
         attributes: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -34,8 +34,8 @@ pub struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T: 'static>(
-        el: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        el: &EventLoopWindowTarget,
         attrs: window::WindowAttributes,
         _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {

--- a/src/platform_impl/web/cursor.rs
+++ b/src/platform_impl/web/cursor.rs
@@ -75,9 +75,9 @@ impl PartialEq for CustomCursor {
 impl Eq for CustomCursor {}
 
 impl CustomCursor {
-    pub(crate) fn build<T>(
+    pub(crate) fn build(
         builder: CustomCursorBuilder,
-        window_target: &EventLoopWindowTarget<T>,
+        window_target: &EventLoopWindowTarget,
     ) -> Self {
         match builder {
             CustomCursorBuilder::Image(image) => Self::build_spawn(
@@ -110,8 +110,8 @@ impl CustomCursor {
         }
     }
 
-    fn build_spawn<T, F, S>(
-        window_target: &EventLoopWindowTarget<T>,
+    fn build_spawn<F, S>(
+        window_target: &EventLoopWindowTarget,
         task: F,
         animation: bool,
     ) -> CustomCursor
@@ -170,9 +170,9 @@ impl CustomCursor {
         this
     }
 
-    pub(crate) fn build_async<T>(
+    pub(crate) fn build_async(
         builder: CustomCursorBuilder,
-        window_target: &EventLoopWindowTarget<T>,
+        window_target: &EventLoopWindowTarget,
     ) -> CustomCursorFuture {
         let CustomCursor { animation, state } = Self::build(builder, window_target);
         let binding = state.get(window_target.runner.main_thread()).borrow();

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -16,7 +16,7 @@ pub use proxy::EventLoopProxy;
 pub use window_target::EventLoopWindowTarget;
 
 pub struct EventLoop<T: 'static> {
-    elw: RootEventLoopWindowTarget<T>,
+    elw: RootEventLoopWindowTarget,
     user_event_sender: Sender<T>,
     user_event_receiver: Receiver<T>,
 }
@@ -40,7 +40,7 @@ impl<T> EventLoop<T> {
 
     pub fn run<F>(self, mut event_handler: F) -> !
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget<T>),
+        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
     {
         let target = RootEventLoopWindowTarget {
             p: self.elw.p.clone(),
@@ -77,7 +77,7 @@ impl<T> EventLoop<T> {
 
     pub fn spawn<F>(self, mut event_handler: F)
     where
-        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget<T>),
+        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget),
     {
         let target = RootEventLoopWindowTarget {
             p: self.elw.p.clone(),
@@ -105,7 +105,7 @@ impl<T> EventLoop<T> {
         EventLoopProxy::new(self.elw.p.waker(), self.user_event_sender.clone())
     }
 
-    pub fn window_target(&self) -> &RootEventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &RootEventLoopWindowTarget {
         &self.elw
     }
 }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -2,7 +2,6 @@ use std::cell::{Cell, RefCell};
 use std::clone::Clone;
 use std::collections::{vec_deque::IntoIter as VecDequeIter, VecDeque};
 use std::iter;
-use std::marker::PhantomData;
 use std::rc::{Rc, Weak};
 
 use web_sys::Element;
@@ -43,28 +42,17 @@ impl Clone for ModifiersShared {
     }
 }
 
-pub struct EventLoopWindowTarget<T: 'static> {
+#[derive(Clone)]
+pub struct EventLoopWindowTarget {
     pub(crate) runner: runner::Shared,
     modifiers: ModifiersShared,
-    _marker: PhantomData<T>,
 }
 
-impl<T> Clone for EventLoopWindowTarget<T> {
-    fn clone(&self) -> Self {
-        Self {
-            runner: self.runner.clone(),
-            modifiers: self.modifiers.clone(),
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     pub fn new() -> Self {
         Self {
             runner: runner::Shared::new(),
             modifiers: ModifiersShared::default(),
-            _marker: PhantomData,
         }
     }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -28,8 +28,8 @@ pub struct Inner {
 }
 
 impl Window {
-    pub(crate) fn new<T>(
-        target: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        target: &EventLoopWindowTarget,
         attr: WindowAttributes,
         platform_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOE> {

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -237,7 +237,7 @@ impl WinCursor {
         }
     }
 
-    pub(crate) fn build<T>(cursor: OnlyCursorImageBuilder, _: &EventLoopWindowTarget<T>) -> Self {
+    pub(crate) fn build(cursor: OnlyCursorImageBuilder, _: &EventLoopWindowTarget) -> Self {
         match Self::new(&cursor.0) {
             Ok(cursor) => cursor,
             Err(err) => {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -96,8 +96,8 @@ pub(crate) struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T: 'static>(
-        event_loop: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop: &EventLoopWindowTarget,
         w_attr: WindowAttributes,
         pl_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, RootOsError> {
@@ -1074,9 +1074,9 @@ impl Drop for Window {
     }
 }
 
-pub(super) struct InitData<'a, T: 'static> {
+pub(super) struct InitData<'a> {
     // inputs
-    pub event_loop: &'a EventLoopWindowTarget<T>,
+    pub event_loop: &'a EventLoopWindowTarget,
     pub attributes: WindowAttributes,
     pub pl_attribs: PlatformSpecificWindowBuilderAttributes,
     pub window_flags: WindowFlags,
@@ -1084,7 +1084,7 @@ pub(super) struct InitData<'a, T: 'static> {
     pub window: Option<Window>,
 }
 
-impl<'a, T: 'static> InitData<'a, T> {
+impl<'a> InitData<'a> {
     unsafe fn create_window(&self, window: HWND) -> Window {
         // Register for touch events if applicable
         {
@@ -1269,18 +1269,15 @@ impl<'a, T: 'static> InitData<'a, T> {
         }
     }
 }
-unsafe fn init<T>(
+unsafe fn init(
     attributes: WindowAttributes,
     pl_attribs: PlatformSpecificWindowBuilderAttributes,
-    event_loop: &EventLoopWindowTarget<T>,
-) -> Result<Window, RootOsError>
-where
-    T: 'static,
-{
+    event_loop: &EventLoopWindowTarget,
+) -> Result<Window, RootOsError> {
     let title = util::encode_wide(&attributes.title);
 
     let class_name = util::encode_wide(&pl_attribs.class_name);
-    unsafe { register_window_class::<T>(&class_name) };
+    unsafe { register_window_class(&class_name) };
 
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
@@ -1375,11 +1372,11 @@ where
     Ok(initdata.window.unwrap())
 }
 
-unsafe fn register_window_class<T: 'static>(class_name: &[u16]) {
+unsafe fn register_window_class(class_name: &[u16]) {
     let class = WNDCLASSEXW {
         cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
         style: CS_HREDRAW | CS_VREDRAW,
-        lpfnWndProc: Some(super::event_loop::public_window_callback::<T>),
+        lpfnWndProc: Some(super::event_loop::public_window_callback),
         cbClsExtra: 0,
         cbWndExtra: 0,
         hInstance: util::get_instance_handle(),

--- a/src/window.rs
+++ b/src/window.rs
@@ -531,10 +531,7 @@ impl WindowBuilder {
     /// - **Web:** The window is created but not inserted into the web page automatically. Please
     ///   see the web platform module for more information.
     #[inline]
-    pub fn build<T: 'static>(
-        self,
-        window_target: &EventLoopWindowTarget<T>,
-    ) -> Result<Window, OsError> {
+    pub fn build(self, window_target: &EventLoopWindowTarget) -> Result<Window, OsError> {
         let window =
             platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)?;
         window.maybe_queue_on_main(|w| w.request_redraw());
@@ -558,7 +555,7 @@ impl Window {
     ///
     /// [`WindowBuilder::new().build(event_loop)`]: WindowBuilder::build
     #[inline]
-    pub fn new<T: 'static>(event_loop: &EventLoopWindowTarget<T>) -> Result<Window, OsError> {
+    pub fn new(event_loop: &EventLoopWindowTarget) -> Result<Window, OsError> {
         let builder = WindowBuilder::new();
         builder.build(event_loop)
     }


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/3053.

~Blocked on https://github.com/rust-windowing/winit/pull/3061.~

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
