### PR TITLE
Replace `EventLoopWindowTarget` with `ActiveEventLoop`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ Unreleased` header.
 
 # Unreleased
 
-- **Breaking:** Removed unnecessary generic parameter `T` from `EventLoopWindowTarget`.
+- **Breaking:** Removed `EventLoopWindowTarget<T>`, and replaced it with `ActiveEventLoop<'app>`, which allows Winit to clearly define a boundary between what is possible when the application is not running, and when it is.
+- Added `MaybeActiveEventLoop<'app>` trait to help be generic over `EventLoop<T>` and `ActiveEventLoop<'app>`.
+- Added `ActiveEventLoopExtWayland` and `ActiveEventLoopExtX11` to mimic the similar traits on the `EventLoop`.
 - On Windows, macOS, X11, Wayland and Web, implement setting images as cursors. See the `custom_cursors.rs` example.
   - **Breaking:** Remove `Window::set_cursor_icon`
   - Add `WindowBuilder::with_cursor` and `Window::set_cursor` which takes a `CursorIcon` or `CustomCursor`

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -16,14 +16,14 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         dpi::{LogicalPosition, LogicalSize, Position},
         event::{ElementState, Event, KeyEvent, WindowEvent},
-        event_loop::{EventLoop, EventLoopWindowTarget},
+        event_loop::{ActiveEventLoop, EventLoop},
         raw_window_handle::HasRawWindowHandle,
         window::{Window, WindowBuilder, WindowId},
     };
 
     fn spawn_child_window(
         parent: &Window,
-        event_loop: &EventLoopWindowTarget,
+        event_loop: ActiveEventLoop<'_>,
         windows: &mut HashMap<WindowId, Window>,
     ) {
         let parent = parent.raw_window_handle().unwrap();

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -53,12 +53,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("parent window: {parent_window:?})");
 
-    event_loop.run(move |event: Event<()>, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {
                     windows.clear();
-                    elwt.exit();
+                    event_loop.exit();
                 }
                 WindowEvent::CursorEntered { device_id: _ } => {
                     // On x11, println when the cursor entered in a window even if the child window is created
@@ -75,7 +75,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         },
                     ..
                 } => {
-                    spawn_child_window(&parent_window, elwt, &mut windows);
+                    spawn_child_window(&parent_window, event_loop, &mut windows);
                 }
                 WindowEvent::RedrawRequested => {
                     if let Some(window) = windows.get(&window_id) {

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut wait_cancelled = false;
     let mut close_requested = false;
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         use winit::event::StartCause;
         println!("{event:?}");
         match event {
@@ -104,22 +104,22 @@ fn main() -> Result<(), impl std::error::Error> {
                 }
 
                 match mode {
-                    Mode::Wait => elwt.set_control_flow(ControlFlow::Wait),
+                    Mode::Wait => event_loop.set_control_flow(ControlFlow::Wait),
                     Mode::WaitUntil => {
                         if !wait_cancelled {
-                            elwt.set_control_flow(ControlFlow::WaitUntil(
+                            event_loop.set_control_flow(ControlFlow::WaitUntil(
                                 time::Instant::now() + WAIT_TIME,
                             ));
                         }
                     }
                     Mode::Poll => {
                         thread::sleep(POLL_SLEEP_TIME);
-                        elwt.set_control_flow(ControlFlow::Poll);
+                        event_loop.set_control_flow(ControlFlow::Poll);
                     }
                 };
 
                 if close_requested {
-                    elwt.exit();
+                    event_loop.exit();
                 }
             }
             _ => (),

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut cursor_idx = 0;
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::KeyboardInput {
@@ -42,7 +42,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     fill::fill_window(&window);
                 }
                 WindowEvent::CloseRequested => {
-                    elwt.exit();
+                    event_loop.exit();
                 }
                 _ => (),
             }

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -22,9 +22,9 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut modifiers = ModifiersState::default();
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::WindowEvent { event, .. } => match event {
-            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::KeyboardInput {
                 event:
                     KeyEvent {
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
             } => {
                 let result = match key {
                     Key::Named(NamedKey::Escape) => {
-                        elwt.exit();
+                        event_loop.exit();
                         Ok(())
                     }
                     Key::Character(ch) => match ch.to_lowercase().as_str() {

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -57,7 +57,7 @@ fn main() -> Result<(), impl std::error::Error> {
         decode_cursor(include_bytes!("data/cross2.png"), &event_loop),
     ];
 
-    event_loop.run(move |event, _elwt| match event {
+    event_loop.run(move |event, _event_loop| match event {
         Event::WindowEvent { event, .. } => match event {
             WindowEvent::KeyboardInput {
                 event:
@@ -94,7 +94,7 @@ fn main() -> Result<(), impl std::error::Error> {
                             64,
                             64,
                         )
-                        .build(_elwt),
+                        .build(_event_loop),
                     );
                 }
                 #[cfg(web_platform)]
@@ -114,11 +114,11 @@ fn main() -> Result<(), impl std::error::Error> {
                                     64,
                                     64,
                                 )
-                                .build(_elwt),
+                                .build(_event_loop),
                             ],
                         )
                         .unwrap()
-                        .build(_elwt),
+                        .build(_event_loop),
                     );
                 }
                 _ => {}
@@ -129,7 +129,7 @@ fn main() -> Result<(), impl std::error::Error> {
             }
             WindowEvent::CloseRequested => {
                 #[cfg(not(web_platform))]
-                _elwt.exit();
+                _event_loop.exit();
             }
             _ => (),
         },

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -4,7 +4,7 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{EventLoop, EventLoopWindowTarget},
+    event_loop::EventLoop,
     keyboard::Key,
     window::{CursorIcon, CustomCursor, WindowBuilder},
 };
@@ -18,14 +18,13 @@ use {
 #[cfg(web_platform)]
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
-fn decode_cursor(bytes: &[u8], window_target: &EventLoopWindowTarget) -> CustomCursor {
+fn decode_cursor(bytes: &[u8], event_loop: &EventLoop<()>) -> CustomCursor {
     let img = image::load_from_memory(bytes).unwrap().to_rgba8();
     let samples = img.into_flat_samples();
     let (_, w, h) = samples.extents();
     let (w, h) = (w as u16, h as u16);
     let builder = CustomCursor::from_rgba(samples.samples, w, h, w / 2, h / 2).unwrap();
-
-    builder.build(window_target)
+    builder.build(event_loop)
 }
 
 #[cfg(not(web_platform))]

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -40,12 +40,12 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     });
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::UserEvent(event) => println!("user event: {event:?}"),
         Event::WindowEvent {
             event: WindowEvent::CloseRequested,
             ..
-        } => elwt.exit(),
+        } => event_loop.exit(),
         Event::WindowEvent {
             event: WindowEvent::RedrawRequested,
             ..

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -22,12 +22,12 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut entered_id = window_2.id();
     let mut cursor_location = None;
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::NewEvents(StartCause::Init) => {
             eprintln!("Switch which window is to be dragged by pressing \"x\".")
         }
         Event::WindowEvent { event, window_id } => match event {
-            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::CursorMoved { position, .. } => cursor_location = Some(position),
             WindowEvent::MouseInput { state, button, .. } => {
                 let window = if (window_id == window_1.id() && switched)

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), impl std::error::Error> {
         .unwrap();
 
     let mut deadline = time::Instant::now() + time::Duration::from_secs(3);
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         match event {
             Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
                 // Timeout reached; focus the window.
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 window.focus_window();
             }
             Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     // Notify the windowing system that we'll be presenting to the window.
                     window.pre_present_notify();
@@ -51,6 +51,6 @@ fn main() -> Result<(), impl std::error::Error> {
             _ => (),
         }
 
-        elwt.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(deadline));
+        event_loop.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(deadline));
     })
 }

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -52,10 +52,10 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("- I\tToggle mIn size limit");
     println!("- A\tToggle mAx size limit");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {
@@ -65,7 +65,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         },
                     ..
                 } => match key {
-                    Key::Named(NamedKey::Escape) => elwt.exit(),
+                    Key::Named(NamedKey::Escape) => event_loop.exit(),
                     // WARNING: Consider using `key_without_modifers()` if available on your platform.
                     // See the `key_binding` example
                     Key::Character(ch) => match ch.to_lowercase().as_str() {
@@ -88,12 +88,14 @@ fn main() -> Result<(), impl std::error::Error> {
                         }
                         "s" => {
                             monitor_index += 1;
-                            if let Some(mon) = elwt.available_monitors().nth(monitor_index) {
+                            if let Some(mon) = event_loop.available_monitors().nth(monitor_index) {
                                 monitor = mon;
                             } else {
                                 monitor_index = 0;
-                                monitor =
-                                    elwt.available_monitors().next().expect("no monitor found!");
+                                monitor = event_loop
+                                    .available_monitors()
+                                    .next()
+                                    .expect("no monitor found!");
                             }
                             println!("Monitor: {:?}", monitor.name());
 

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut close_requested = false;
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => {
@@ -64,7 +64,7 @@ fn main() -> Result<(), impl std::error::Error> {
                                 // event loop (i.e. if it's a multi-window application), you need to
                                 // drop the window. That closes it, and results in `Destroyed` being
                                 // sent.
-                                elwt.exit();
+                                event_loop.exit();
                             }
                         }
                         Key::Character("n") => {

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -39,10 +39,10 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut cursor_position = PhysicalPosition::new(0.0, 0.0);
     let mut ime_pos = PhysicalPosition::new(0.0, 0.0);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::CursorMoved { position, .. } => {
                     cursor_position = position;
                 }

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -31,10 +31,10 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut modifiers = ModifiersState::default();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::ModifiersChanged(new) => {
                     modifiers = new.state();
                 }

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -34,10 +34,10 @@ In both cases the example window should move like the content of a scroll area i
 In other words, the deltas indicate the direction in which to move the content (in this case the window)."
     );
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::MouseWheel { delta, .. } => match delta {
                     winit::event::MouseScrollDelta::LineDelta(x, y) => {
                         println!("mouse wheel Line Delta: ({x},{y})");

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -175,9 +175,9 @@ fn main() -> Result<(), impl std::error::Error> {
             }
         });
     }
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if window_senders.is_empty() {
-            elwt.exit()
+            event_loop.exit()
         }
         match event {
             Event::WindowEvent { event, window_id } => match event {

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Press N to open a new window.");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     windows.remove(&window_id);
 
                     if windows.is_empty() {
-                        elwt.exit();
+                        event_loop.exit();
                     }
                 }
                 WindowEvent::KeyboardInput {
@@ -44,9 +44,9 @@ fn main() -> Result<(), impl std::error::Error> {
                     is_synthetic: false,
                     ..
                 } if event.state == ElementState::Pressed => match event.logical_key {
-                    Key::Named(NamedKey::Escape) => elwt.exit(),
+                    Key::Named(NamedKey::Escape) => event_loop.exit(),
                     Key::Character(c) if c == "n" || c == "N" => {
-                        let window = Window::new(elwt).unwrap();
+                        let window = Window::new(event_loop).unwrap();
                         println!("Opened a new window: {:?}", window.id());
                         windows.insert(window.id(), window);
                     }

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -19,12 +19,12 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::MouseInput {
                     state: ElementState::Released,
                     ..

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -33,14 +33,14 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     });
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => elwt.exit(),
+            } => event_loop.exit(),
             Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -27,10 +27,10 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -31,7 +31,7 @@ mod example {
         let mut counter = 0;
         let mut create_first_window = false;
 
-        event_loop.run(move |event, elwt| {
+        event_loop.run(move |event, event_loop| {
             match event {
                 Event::Resumed => create_first_window = true,
 
@@ -60,7 +60,7 @@ mod example {
                         // Remove the window from the map.
                         windows.remove(&window_id);
                         if windows.is_empty() {
-                            elwt.exit();
+                            event_loop.exit();
                             return;
                         }
                     }
@@ -92,7 +92,7 @@ mod example {
                         builder = builder.with_activation_token(token);
                     }
 
-                    Rc::new(builder.build(elwt).unwrap())
+                    Rc::new(builder.build(event_loop).unwrap())
                 };
 
                 // Add the window to the map.

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -27,10 +27,10 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("  (L) Light theme");
     println!("  (D) Dark theme");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { window_id, event } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::ThemeChanged(theme) if window_id == window.id() => {
                     println!("Theme is changed: {theme:?}")
                 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -27,21 +27,21 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let timer_length = Duration::new(1, 0);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         match event {
             Event::NewEvents(StartCause::Init) => {
-                elwt.set_control_flow(ControlFlow::WaitUntil(Instant::now() + timer_length));
+                event_loop.set_control_flow(ControlFlow::WaitUntil(Instant::now() + timer_length));
             }
             Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
-                elwt.set_control_flow(ControlFlow::WaitUntil(Instant::now() + timer_length));
+                event_loop.set_control_flow(ControlFlow::WaitUntil(Instant::now() + timer_length));
                 println!("\nTimer\n");
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => elwt.exit(),
+            } => event_loop.exit(),
             Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -19,10 +19,10 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Only supported on macOS at the moment.");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::TouchpadMagnify { delta, .. } => {
                     if delta > 0.0 {
                         println!("Zoomed in {delta}");

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -22,12 +22,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     window.set_title("A fantastic window!");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -21,7 +21,7 @@ pub fn main() -> Result<(), impl std::error::Error> {
     #[cfg(web_platform)]
     let log_list = wasm::insert_canvas_and_create_log_list(&window);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         #[cfg(web_platform)]
         wasm::log_event(&log_list, &event);
 
@@ -29,7 +29,7 @@ pub fn main() -> Result<(), impl std::error::Error> {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => elwt.exit(),
+            } if window_id == window.id() => event_loop.exit(),
             Event::AboutToWait => {
                 window.request_redraw();
             }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -20,12 +20,12 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         match event {
             Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     // Notify the windowing system that we'll be presenting to the window.
                     window.pre_present_notify();

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.listen_device_events(DeviceEvents::Always);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { window_id, event } = event {
             match event {
                 WindowEvent::KeyboardInput {
@@ -57,7 +57,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     }
                     _ => (),
                 },
-                WindowEvent::CloseRequested if window_id == window.id() => elwt.exit(),
+                WindowEvent::CloseRequested if window_id == window.id() => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.listen_device_events(DeviceEvents::Always);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         match event {
             // This used to use the virtual key, but the new API
             // only provides the `physical_key` (`Code`).
@@ -113,7 +113,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         window.set_minimized(minimized);
                     }
                     "q" => {
-                        elwt.exit();
+                        event_loop.exit();
                     }
                     "v" => {
                         visible = !visible;
@@ -125,7 +125,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     }
                     _ => (),
                 },
-                WindowEvent::CloseRequested if window_id == window.id() => elwt.exit(),
+                WindowEvent::CloseRequested if window_id == window.id() => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -27,12 +27,12 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut border = false;
     let mut cursor_location = None;
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::NewEvents(StartCause::Init) => {
             eprintln!("Press 'B' to toggle borderless")
         }
         Event::WindowEvent { event, .. } => match event {
-            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::CursorMoved { position, .. } => {
                 if !window.is_decorated() {
                     let new_location =

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -33,10 +33,10 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::DroppedFile(path) => {
                     window.set_window_icon(Some(load_icon(&path)));
                 }

--- a/examples/window_on_demand.rs
+++ b/examples/window_on_demand.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), impl std::error::Error> {
     fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), EventLoopError> {
         let mut app = App::default();
 
-        event_loop.run_on_demand(move |event, elwt| {
+        event_loop.run_on_demand(move |event, event_loop| {
             println!("Run {idx}: {:?}", event);
 
             if let Some(window) = &app.window {
@@ -60,7 +60,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     } if id == window_id => {
                         println!("--------------------------------------------------------- Window {idx} Destroyed");
                         app.window_id = None;
-                        elwt.exit();
+                        event_loop.exit();
                     }
                     _ => (),
                 }
@@ -68,7 +68,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 let window = WindowBuilder::new()
                         .with_title("Fantastic window number one!")
                         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
-                        .build(elwt)
+                        .build(event_loop)
                         .unwrap();
                 app.window_id = Some(window.id());
                 app.window = Some(window);

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -31,11 +31,11 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut option_as_alt = window.option_as_alt();
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::WindowEvent {
             event: WindowEvent::CloseRequested,
             window_id,
-        } if window_id == window.id() => elwt.exit(),
+        } if window_id == window.id() => event_loop.exit(),
         Event::WindowEvent { event, .. } => match event {
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -32,7 +32,7 @@ fn main() -> std::process::ExitCode {
 
     'main: loop {
         let timeout = Some(Duration::ZERO);
-        let status = event_loop.pump_events(timeout, |event, elwt| {
+        let status = event_loop.pump_events(timeout, |event, event_loop| {
             if let Event::WindowEvent { event, .. } = &event {
                 // Print only Window events to reduce noise
                 println!("{event:?}");
@@ -42,7 +42,7 @@ fn main() -> std::process::ExitCode {
                 Event::WindowEvent {
                     event: WindowEvent::CloseRequested,
                     window_id,
-                } if window_id == window.id() => elwt.exit(),
+                } if window_id == window.id() => event_loop.exit(),
                 Event::AboutToWait => {
                     window.request_redraw();
                 }

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -24,9 +24,9 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut has_increments = true;
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::KeyboardInput { event, .. }
                 if event.logical_key == NamedKey::Space
                     && event.state == ElementState::Released =>

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Press N to open a new window.");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {
@@ -40,7 +40,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     windows.remove(&window_id);
 
                     if windows.is_empty() {
-                        elwt.exit();
+                        event_loop.exit();
                     }
                 }
                 WindowEvent::Resized(_) => {
@@ -62,7 +62,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         let tabbing_id = windows.get(&window_id).unwrap().tabbing_identifier();
                         let window = WindowBuilder::new()
                             .with_tabbing_identifier(&tabbing_id)
-                            .build(elwt)
+                            .build(event_loop)
                             .unwrap();
                         println!("Added a new tab: {:?}", window.id());
                         windows.insert(window.id(), window);

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -32,12 +32,12 @@ mod imple {
             .build(&event_loop)
             .unwrap();
 
-        event_loop.run(move |event, elwt| {
+        event_loop.run(move |event, event_loop| {
             match event {
                 Event::WindowEvent {
                     event: WindowEvent::CloseRequested,
                     window_id,
-                } if window_id == window.id() => elwt.exit(),
+                } if window_id == window.id() => event_loop.exit(),
                 Event::AboutToWait => {
                     window.request_redraw();
                 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -5,7 +5,7 @@ use std::{error::Error, hash::Hash};
 
 use cursor_icon::CursorIcon;
 
-use crate::event_loop::EventLoopWindowTarget;
+use crate::event_loop::MaybeActiveEventLoop;
 use crate::platform_impl::{self, PlatformCustomCursor, PlatformCustomCursorBuilder};
 
 /// The maximum width and height for a cursor when using [`CustomCursor::from_rgba`].
@@ -111,9 +111,9 @@ pub struct CustomCursorBuilder {
 }
 
 impl CustomCursorBuilder {
-    pub fn build(self, window_target: &EventLoopWindowTarget) -> CustomCursor {
+    pub fn build<'a>(self, mut event_loop: impl MaybeActiveEventLoop<'a>) -> CustomCursor {
         CustomCursor {
-            inner: PlatformCustomCursor::build(self.inner, &window_target.p),
+            inner: PlatformCustomCursor::build(self.inner, event_loop.__inner()),
         }
     }
 }
@@ -213,7 +213,7 @@ impl Eq for OnlyCursorImage {}
 
 #[allow(dead_code)]
 impl OnlyCursorImage {
-    fn build(builder: OnlyCursorImageBuilder, _: &platform_impl::EventLoopWindowTarget) -> Self {
+    fn build(builder: OnlyCursorImageBuilder, _: platform_impl::ActiveEventLoop<'_>) -> Self {
         Self(Arc::new(builder.0))
     }
 }
@@ -293,7 +293,7 @@ impl NoCustomCursor {
         Ok(Self)
     }
 
-    fn build(self, _: &platform_impl::EventLoopWindowTarget) -> NoCustomCursor {
+    fn build(self, _: platform_impl::ActiveEventLoop<'_>) -> NoCustomCursor {
         self
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,22 +9,22 @@
 //! ```rust,ignore
 //! let mut start_cause = StartCause::Init;
 //!
-//! while !elwt.exiting() {
-//!     event_handler(NewEvents(start_cause), elwt);
+//! while !event_loop.exiting() {
+//!     event_handler(NewEvents(start_cause), event_loop);
 //!
 //!     for e in (window events, user events, device events) {
-//!         event_handler(e, elwt);
+//!         event_handler(e, event_loop);
 //!     }
 //!
 //!     for w in (redraw windows) {
-//!         event_handler(RedrawRequested(w), elwt);
+//!         event_handler(RedrawRequested(w), event_loop);
 //!     }
 //!
-//!     event_handler(AboutToWait, elwt);
+//!     event_handler(AboutToWait, event_loop);
 //!     start_cause = wait_if_necessary();
 //! }
 //!
-//! event_handler(LoopExiting, elwt);
+//! event_handler(LoopExiting, event_loop);
 //! ```
 //!
 //! This leaves out timing details like [`ControlFlow::WaitUntil`] but hopefully

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -8,7 +8,6 @@
 //! See the root-level documentation for information on how to create and use an event loop to
 //! handle events.
 use std::marker::PhantomData;
-use std::ops::Deref;
 #[cfg(any(x11_platform, wayland_platform))]
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -37,20 +36,98 @@ use crate::{event::Event, monitor::MonitorHandle, platform_impl};
 /// [`EventLoopProxy`] allows you to wake up an `EventLoop` from another thread.
 ///
 /// [`Window`]: crate::window::Window
+// TODO: Don't allow window creation from this, since that is broken on macOS/iOS.
 pub struct EventLoop<T: 'static> {
     pub(crate) event_loop: platform_impl::EventLoop<T>,
     pub(crate) _marker: PhantomData<*mut ()>, // Not Send nor Sync
 }
 
-/// Target that associates windows with an [`EventLoop`].
+/// An active event loop.
 ///
-/// This type exists to allow you to create new windows while Winit executes
-/// your callback. [`EventLoop`] will coerce into this type (`impl<T> Deref for
-/// EventLoop<T>`), so functions that take this as a parameter can also take
-/// `&EventLoop`.
-pub struct EventLoopWindowTarget {
-    pub(crate) p: platform_impl::EventLoopWindowTarget,
-    pub(crate) _marker: PhantomData<*mut ()>, // Not Send nor Sync
+/// This type exists to differentiate between functionality available when Winit
+/// is executing your callback, and outside of it.
+#[derive(Copy, Clone)]
+pub struct ActiveEventLoop<'a> {
+    pub(crate) inner: platform_impl::ActiveEventLoop<'a>,
+    _marker: PhantomData<*mut ()>, // Not Send nor Sync
+}
+
+impl fmt::Debug for ActiveEventLoop<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad("ActiveEventLoop { .. }")
+    }
+}
+
+impl<'a> ActiveEventLoop<'a> {
+    pub(crate) fn new(inner: platform_impl::ActiveEventLoop<'a>) -> Self {
+        Self {
+            inner,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Sets the [`ControlFlow`].
+    pub fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.inner.set_control_flow(control_flow)
+    }
+
+    /// Gets the current [`ControlFlow`].
+    pub fn control_flow(&self) -> ControlFlow {
+        self.inner.control_flow()
+    }
+
+    /// This exits the event loop.
+    ///
+    /// See [`LoopExiting`](Event::LoopExiting).
+    pub fn exit(&self) {
+        self.inner.exit()
+    }
+
+    /// Returns if the [`EventLoop`] is about to stop.
+    ///
+    /// See [`exit()`](Self::exit).
+    pub fn exiting(&self) -> bool {
+        self.inner.exiting()
+    }
+
+    /// Returns the primary monitor of the system.
+    ///
+    /// Returns `None` if it can't identify any monitor as a primary one.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **Wayland / Web:** Always returns `None`.
+    #[inline]
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        self.inner
+            .primary_monitor()
+            .map(|inner| MonitorHandle { inner })
+    }
+
+    /// Returns the list of all the monitors available on the system.
+    #[inline]
+    pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
+        #[allow(clippy::useless_conversion)] // false positive on some platforms
+        self.inner
+            .available_monitors()
+            .into_iter()
+            .map(|inner| MonitorHandle { inner })
+    }
+
+    /// Change if or when [`DeviceEvent`]s are captured.
+    ///
+    /// Since the [`DeviceEvent`] capture can lead to high CPU usage for unfocused windows, winit
+    /// will ignore them by default for unfocused windows on Linux/BSD. This method allows changing
+    /// this at runtime to explicitly capture them again.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland / macOS / iOS / Android / Orbital:** Unsupported.
+    ///
+    /// [`DeviceEvent`]: crate::event::DeviceEvent
+    pub fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.inner.listen_device_events(allowed);
+    }
 }
 
 /// Object that allows building the event loop.
@@ -142,13 +219,7 @@ impl<T> fmt::Debug for EventLoop<T> {
     }
 }
 
-impl fmt::Debug for EventLoopWindowTarget {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.pad("EventLoopWindowTarget { .. }")
-    }
-}
-
-/// Set through [`EventLoopWindowTarget::set_control_flow()`].
+/// Set through [`ActiveEventLoop::set_control_flow()`].
 ///
 /// Indicates the desired behavior of the event loop after [`Event::AboutToWait`] is emitted.
 ///
@@ -234,16 +305,67 @@ impl<T> EventLoop<T> {
     ///
     ///   This function won't be available with `target_feature = "exception-handling"`.
     ///
-    /// [`set_control_flow()`]: EventLoopWindowTarget::set_control_flow()
+    /// [`set_control_flow()`]: ActiveEventLoop::set_control_flow()
     /// [`run()`]: Self::run()
     /// [^1]: `EventLoopExtWebSys::spawn()` is only available on Web.
     #[inline]
     #[cfg(not(all(web_platform, target_feature = "exception-handling")))]
-    pub fn run<F>(self, event_handler: F) -> Result<(), EventLoopError>
+    pub fn run<F>(self, mut handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &EventLoopWindowTarget),
+        F: FnMut(Event<T>, ActiveEventLoop<'_>),
     {
-        self.event_loop.run(event_handler)
+        self.event_loop
+            .run(move |event, inner| handler(event, ActiveEventLoop::new(inner)))
+    }
+
+    /// Set the initial [`ControlFlow`].
+    pub fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.event_loop
+            .window_target()
+            .set_control_flow(control_flow)
+    }
+
+    /// Returns the primary monitor of the system.
+    ///
+    /// Returns `None` if it can't identify any monitor as a primary one.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **Wayland / Web:** Always returns `None`.
+    #[inline]
+    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        self.event_loop
+            .window_target()
+            .primary_monitor()
+            .map(|inner| MonitorHandle { inner })
+    }
+
+    /// Returns the list of all the monitors available on the system.
+    #[inline]
+    pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
+        #[allow(clippy::useless_conversion)] // false positive on some platforms
+        self.event_loop
+            .window_target()
+            .available_monitors()
+            .into_iter()
+            .map(|inner| MonitorHandle { inner })
+    }
+
+    /// Change if or when [`DeviceEvent`]s are captured.
+    ///
+    /// Since the [`DeviceEvent`] capture can lead to high CPU usage for unfocused windows, winit
+    /// will ignore them by default for unfocused windows on Linux/BSD. This method allows changing
+    /// this at runtime to explicitly capture them again.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Wayland / macOS / iOS / Android / Orbital:** Unsupported.
+    ///
+    /// [`DeviceEvent`]: crate::event::DeviceEvent
+    pub fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.event_loop
+            .window_target()
+            .listen_device_events(allowed);
     }
 
     /// Creates an [`EventLoopProxy`] that can be used to dispatch user events to the main event loop.
@@ -257,7 +379,12 @@ impl<T> EventLoop<T> {
 #[cfg(feature = "rwh_06")]
 impl<T> rwh_06::HasDisplayHandle for EventLoop<T> {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        rwh_06::HasDisplayHandle::display_handle(&**self)
+        let raw = self
+            .event_loop
+            .window_target()
+            .raw_display_handle_rwh_06()?;
+        // SAFETY: The display will never be deallocated while the event loop is alive.
+        Ok(unsafe { rwh_06::DisplayHandle::borrow_raw(raw) })
     }
 }
 
@@ -265,7 +392,7 @@ impl<T> rwh_06::HasDisplayHandle for EventLoop<T> {
 unsafe impl<T> rwh_05::HasRawDisplayHandle for EventLoop<T> {
     /// Returns a [`rwh_05::RawDisplayHandle`] for the event loop.
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::HasRawDisplayHandle::raw_display_handle(&**self)
+        self.event_loop.window_target().raw_display_handle_rwh_05()
     }
 }
 
@@ -297,92 +424,51 @@ impl<T> AsRawFd for EventLoop<T> {
     }
 }
 
-impl<T> Deref for EventLoop<T> {
-    type Target = EventLoopWindowTarget;
-    fn deref(&self) -> &EventLoopWindowTarget {
-        self.event_loop.window_target()
-    }
-}
-
-impl EventLoopWindowTarget {
-    /// Returns the list of all the monitors available on the system.
-    #[inline]
-    pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
-        #[allow(clippy::useless_conversion)] // false positive on some platforms
-        self.p
-            .available_monitors()
-            .into_iter()
-            .map(|inner| MonitorHandle { inner })
-    }
-
-    /// Returns the primary monitor of the system.
-    ///
-    /// Returns `None` if it can't identify any monitor as a primary one.
-    ///
-    /// ## Platform-specific
-    ///
-    /// **Wayland / Web:** Always returns `None`.
-    #[inline]
-    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        self.p
-            .primary_monitor()
-            .map(|inner| MonitorHandle { inner })
-    }
-
-    /// Change if or when [`DeviceEvent`]s are captured.
-    ///
-    /// Since the [`DeviceEvent`] capture can lead to high CPU usage for unfocused windows, winit
-    /// will ignore them by default for unfocused windows on Linux/BSD. This method allows changing
-    /// this at runtime to explicitly capture them again.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Wayland / macOS / iOS / Android / Orbital:** Unsupported.
-    ///
-    /// [`DeviceEvent`]: crate::event::DeviceEvent
-    pub fn listen_device_events(&self, allowed: DeviceEvents) {
-        self.p.listen_device_events(allowed);
-    }
-
-    /// Sets the [`ControlFlow`].
-    pub fn set_control_flow(&self, control_flow: ControlFlow) {
-        self.p.set_control_flow(control_flow)
-    }
-
-    /// Gets the current [`ControlFlow`].
-    pub fn control_flow(&self) -> ControlFlow {
-        self.p.control_flow()
-    }
-
-    /// This exits the event loop.
-    ///
-    /// See [`LoopExiting`](Event::LoopExiting).
-    pub fn exit(&self) {
-        self.p.exit()
-    }
-
-    /// Returns if the [`EventLoop`] is about to stop.
-    ///
-    /// See [`exit()`](Self::exit).
-    pub fn exiting(&self) -> bool {
-        self.p.exiting()
-    }
-}
-
 #[cfg(feature = "rwh_06")]
-impl rwh_06::HasDisplayHandle for EventLoopWindowTarget {
+impl rwh_06::HasDisplayHandle for ActiveEventLoop<'_> {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        let raw = self.p.raw_display_handle_rwh_06()?;
+        let raw = self.inner.raw_display_handle_rwh_06()?;
         // SAFETY: The display will never be deallocated while the event loop is alive.
         Ok(unsafe { rwh_06::DisplayHandle::borrow_raw(raw) })
     }
 }
 
 #[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawDisplayHandle for EventLoopWindowTarget {
+unsafe impl rwh_05::HasRawDisplayHandle for ActiveEventLoop<'_> {
     /// Returns a [`rwh_05::RawDisplayHandle`] for the event loop.
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        self.p.raw_display_handle_rwh_05()
+        self.inner.raw_display_handle_rwh_05()
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// Trait to allow functions to be generic over [`EventLoop`] and [`ActiveEventLoop`].
+pub trait MaybeActiveEventLoop<'a>: private::Sealed {
+    #[doc(hidden)]
+    fn __inner(&mut self) -> platform_impl::ActiveEventLoop<'a>;
+}
+
+impl<T: 'static> private::Sealed for &EventLoop<T> {}
+impl<'a, T: 'static> MaybeActiveEventLoop<'a> for &'a EventLoop<T> {
+    fn __inner(&mut self) -> platform_impl::ActiveEventLoop<'a> {
+        self.event_loop.window_target()
+    }
+}
+
+impl private::Sealed for ActiveEventLoop<'_> {}
+impl<'a> MaybeActiveEventLoop<'a> for ActiveEventLoop<'a> {
+    fn __inner(&mut self) -> platform_impl::ActiveEventLoop<'a> {
+        self.inner
+    }
+}
+
+impl<'a, T: MaybeActiveEventLoop<'a>> private::Sealed for &mut T {}
+impl<'a, T: MaybeActiveEventLoop<'a>> MaybeActiveEventLoop<'a> for &mut T {
+    fn __inner(&mut self) -> platform_impl::ActiveEventLoop<'a> {
+        T::__inner(self)
     }
 }
 
@@ -468,5 +554,17 @@ impl AsyncRequestSerial {
         // in the loop u64::MAX times that's issue is considered on them.
         let serial = CURRENT_SERIAL.fetch_add(1, Ordering::Relaxed);
         Self { serial }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[allow(unused)]
+    fn assert_active_event_loop_covariance<'b>(
+        event_loop: ActiveEventLoop<'static>,
+    ) -> ActiveEventLoop<'b> {
+        event_loop
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,14 +78,14 @@
 //! // input, and uses significantly less power/CPU time than ControlFlow::Poll.
 //! event_loop.set_control_flow(ControlFlow::Wait);
 //!
-//! event_loop.run(move |event, elwt| {
+//! event_loop.run(move |event, event_loop| {
 //!     match event {
 //!         Event::WindowEvent {
 //!             event: WindowEvent::CloseRequested,
 //!             ..
 //!         } => {
 //!             println!("The close button was pressed; stopping");
-//!             elwt.exit();
+//!             event_loop.exit();
 //!         },
 //!         Event::AboutToWait => {
 //!             // Application update code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 //! [`EventLoop`]: event_loop::EventLoop
 //! [`EventLoop::new()`]: event_loop::EventLoop::new
 //! [`EventLoop::run()`]: event_loop::EventLoop::run
-//! [`exit()`]: event_loop::EventLoopWindowTarget::exit
+//! [`exit()`]: event_loop::ActiveEventLoop::exit
 //! [`Window`]: window::Window
 //! [`WindowId`]: window::WindowId
 //! [`WindowBuilder`]: window::WindowBuilder

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,7 +3,8 @@
 //! If you want to get basic information about a monitor, you can use the
 //! [`MonitorHandle`] type. This is retrieved from one of the following
 //! methods, which return an iterator of [`MonitorHandle`]:
-//! - [`EventLoopWindowTarget::available_monitors`](crate::event_loop::EventLoopWindowTarget::available_monitors).
+//! - [`EventLoop::available_monitors`](crate::event_loop::EventLoop::available_monitors).
+//! - [`ActiveEventLoop::available_monitors`](crate::event_loop::ActiveEventLoop::available_monitors).
 //! - [`Window::available_monitors`](crate::window::Window::available_monitors).
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,5 +1,5 @@
 use crate::{
-    event_loop::{EventLoop, EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{EventLoop, EventLoopBuilder},
     window::{Window, WindowBuilder},
 };
 
@@ -9,9 +9,6 @@ use self::activity::{AndroidApp, ConfigurationRef, Rect};
 pub trait EventLoopExtAndroid {}
 
 impl<T> EventLoopExtAndroid for EventLoop<T> {}
-
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to Android.
-pub trait EventLoopWindowTargetExtAndroid {}
 
 /// Additional methods on [`Window`] that are specific to Android.
 pub trait WindowExtAndroid {
@@ -29,8 +26,6 @@ impl WindowExtAndroid for Window {
         self.window.config()
     }
 }
-
-impl EventLoopWindowTargetExtAndroid for EventLoopWindowTarget {}
 
 /// Additional methods on [`WindowBuilder`] that are specific to Android.
 pub trait WindowBuilderExtAndroid {}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,7 +4,7 @@ use std::os::raw::c_void;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{ActiveEventLoop, EventLoopBuilder},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };
@@ -374,8 +374,8 @@ impl MonitorHandleExtMacOS for MonitorHandle {
     }
 }
 
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to macOS.
-pub trait EventLoopWindowTargetExtMacOS {
+/// Additional methods on [`ActiveEventLoop`] that are specific to macOS.
+pub trait ActiveEventLoopExtMacOS {
     /// Hide the entire application. In most applications this is typically triggered with Command-H.
     fn hide_application(&self);
     /// Hide the other applications. In most applications this is typically triggered with Command+Option-H.
@@ -388,21 +388,21 @@ pub trait EventLoopWindowTargetExtMacOS {
     fn allows_automatic_window_tabbing(&self) -> bool;
 }
 
-impl EventLoopWindowTargetExtMacOS for EventLoopWindowTarget {
+impl ActiveEventLoopExtMacOS for ActiveEventLoop<'_> {
     fn hide_application(&self) {
-        self.p.hide_application()
+        self.inner.hide_application()
     }
 
     fn hide_other_applications(&self) {
-        self.p.hide_other_applications()
+        self.inner.hide_other_applications()
     }
 
     fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
-        self.p.set_allows_automatic_window_tabbing(enabled);
+        self.inner.set_allows_automatic_window_tabbing(enabled);
     }
 
     fn allows_automatic_window_tabbing(&self) -> bool {
-        self.p.allows_automatic_window_tabbing()
+        self.inner.allows_automatic_window_tabbing()
     }
 }
 

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -63,7 +63,7 @@ pub trait EventLoopExtPumpEvents {
     ///
     ///     'main: loop {
     ///         let timeout = Some(Duration::ZERO);
-    ///         let status = event_loop.pump_events(timeout, |event, elwt| {
+    ///         let status = event_loop.pump_events(timeout, |event, event_loop| {
     /// #            if let Event::WindowEvent { event, .. } = &event {
     /// #                // Print only Window events to reduce noise
     /// #                println!("{event:?}");
@@ -73,7 +73,7 @@ pub trait EventLoopExtPumpEvents {
     ///                 Event::WindowEvent {
     ///                     event: WindowEvent::CloseRequested,
     ///                     window_id,
-    ///                 } if window_id == window.id() => elwt.exit(),
+    ///                 } if window_id == window.id() => event_loop.exit(),
     ///                 Event::AboutToWait => {
     ///                     window.request_redraw();
     ///                 }

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use crate::{
     event::Event,
-    event_loop::{EventLoop, EventLoopWindowTarget},
+    event_loop::{ActiveEventLoop, EventLoop},
 };
 
 /// The return status for `pump_events`
@@ -174,16 +174,18 @@ pub trait EventLoopExtPumpEvents {
     ///   callback.
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget);
+        F: FnMut(Event<Self::UserEvent>, ActiveEventLoop<'_>);
 }
 
 impl<T> EventLoopExtPumpEvents for EventLoop<T> {
     type UserEvent = T;
 
-    fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
+    fn pump_events<F>(&mut self, timeout: Option<Duration>, mut event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget),
+        F: FnMut(Event<Self::UserEvent>, ActiveEventLoop<'_>),
     {
-        self.event_loop.pump_events(timeout, event_handler)
+        self.event_loop.pump_events(timeout, move |event, inner| {
+            event_handler(event, ActiveEventLoop::new(inner))
+        })
     }
 }

--- a/src/platform/run_on_demand.rs
+++ b/src/platform/run_on_demand.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::EventLoopError,
     event::Event,
-    event_loop::{EventLoop, EventLoopWindowTarget},
+    event_loop::{ActiveEventLoop, EventLoop},
 };
 
 #[cfg(doc)]
@@ -62,28 +62,22 @@ pub trait EventLoopExtRunOnDemand {
         doc = "[^1]: `spawn()` is only available on `wasm` platforms."
     )]
     ///
-    /// [`exit()`]: EventLoopWindowTarget::exit()
-    /// [`set_control_flow()`]: EventLoopWindowTarget::set_control_flow()
+    /// [`exit()`]: ActiveEventLoop::exit()
+    /// [`set_control_flow()`]: ActiveEventLoop::set_control_flow()
     fn run_on_demand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget);
+        F: FnMut(Event<Self::UserEvent>, ActiveEventLoop<'_>);
 }
 
 impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
     type UserEvent = T;
 
-    fn run_on_demand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
+    fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget),
+        F: FnMut(Event<Self::UserEvent>, ActiveEventLoop<'_>),
     {
         self.event_loop.window_target().clear_exit();
-        self.event_loop.run_on_demand(event_handler)
-    }
-}
-
-impl EventLoopWindowTarget {
-    /// Clear exit status.
-    pub(crate) fn clear_exit(&self) {
-        self.p.clear_exit()
+        self.event_loop
+            .run_on_demand(move |event, inner| event_handler(event, ActiveEventLoop::new(inner)))
     }
 }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -1,21 +1,34 @@
 use crate::{
-    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };
 
 pub use crate::window::Theme;
 
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to Wayland.
-pub trait EventLoopWindowTargetExtWayland {
-    /// True if the [`EventLoopWindowTarget`] uses Wayland.
+/// Additional methods on [`EventLoop`] that are specific to Wayland.
+pub trait EventLoopExtWayland {
+    /// True if the [`EventLoop`] uses Wayland.
     fn is_wayland(&self) -> bool;
 }
 
-impl EventLoopWindowTargetExtWayland for EventLoopWindowTarget {
+impl<T: 'static> EventLoopExtWayland for EventLoop<T> {
     #[inline]
     fn is_wayland(&self) -> bool {
-        self.p.is_wayland()
+        self.event_loop.window_target().is_wayland()
+    }
+}
+
+/// Additional methods on [`ActiveEventLoop`] that are specific to Wayland.
+pub trait ActiveEventLoopExtWayland {
+    /// True if the [`ActiveEventLoop`] uses Wayland.
+    fn is_wayland(&self) -> bool;
+}
+
+impl ActiveEventLoopExtWayland for ActiveEventLoop<'_> {
+    #[inline]
+    fn is_wayland(&self) -> bool {
+        self.inner.is_wayland()
     }
 }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };
@@ -89,16 +89,29 @@ pub fn register_xlib_error_hook(hook: XlibErrorHook) {
     }
 }
 
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to X11.
-pub trait EventLoopWindowTargetExtX11 {
-    /// True if the [`EventLoopWindowTarget`] uses X11.
+/// Additional methods on [`EventLoop`] that are specific to X11.
+pub trait EventLoopExtX11 {
+    /// True if the [`EventLoop`] uses X11.
     fn is_x11(&self) -> bool;
 }
 
-impl EventLoopWindowTargetExtX11 for EventLoopWindowTarget {
+impl<T> EventLoopExtX11 for EventLoop<T> {
     #[inline]
     fn is_x11(&self) -> bool {
-        !self.p.is_wayland()
+        !self.event_loop.window_target().is_wayland()
+    }
+}
+
+/// Additional methods on [`ActiveEventLoop`] that are specific to X11.
+pub trait ActiveEventLoopExtX11 {
+    /// True if the [`ActiveEventLoop`] uses X11.
+    fn is_x11(&self) -> bool;
+}
+
+impl ActiveEventLoopExtX11 for ActiveEventLoop<'_> {
+    #[inline]
+    fn is_x11(&self) -> bool {
+        !self.inner.is_wayland()
     }
 }
 

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -2,7 +2,6 @@ use std::{
     collections::VecDeque,
     ffi::c_void,
     fmt::{self, Debug},
-    marker::PhantomData,
     ptr,
     sync::mpsc::{self, Receiver, Sender},
 };
@@ -20,10 +19,7 @@ use objc2::ClassType;
 use crate::{
     error::EventLoopError,
     event::Event,
-    event_loop::{
-        ControlFlow, DeviceEvents, EventLoopClosed,
-        EventLoopWindowTarget as RootEventLoopWindowTarget,
-    },
+    event_loop::{ControlFlow, DeviceEvents, EventLoopClosed},
     platform::ios::Idiom,
 };
 
@@ -32,6 +28,8 @@ use super::{
     app_state::AppState,
     uikit::{UIApplication, UIApplicationMain, UIDevice, UIScreen},
 };
+
+pub type ActiveEventLoop<'a> = &'a EventLoopWindowTarget;
 
 #[derive(Debug)]
 pub struct EventLoopWindowTarget {
@@ -89,7 +87,7 @@ pub struct EventLoop<T: 'static> {
     mtm: MainThreadMarker,
     sender: Sender<T>,
     receiver: Receiver<T>,
-    window_target: RootEventLoopWindowTarget,
+    window_target: EventLoopWindowTarget,
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
@@ -121,16 +119,13 @@ impl<T: 'static> EventLoop<T> {
             mtm,
             sender,
             receiver,
-            window_target: RootEventLoopWindowTarget {
-                p: EventLoopWindowTarget { mtm },
-                _marker: PhantomData,
-            },
+            window_target: EventLoopWindowTarget { mtm },
         })
     }
 
     pub fn run<F>(self, event_handler: F) -> !
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
         unsafe {
             let application = UIApplication::shared(self.mtm);
@@ -142,7 +137,7 @@ impl<T: 'static> EventLoop<T> {
             );
 
             let event_handler = std::mem::transmute::<
-                Box<dyn FnMut(Event<T>, &RootEventLoopWindowTarget)>,
+                Box<dyn FnMut(Event<T>, &EventLoopWindowTarget)>,
                 Box<EventHandlerCallback<T>>,
             >(Box::new(event_handler));
 
@@ -171,7 +166,7 @@ impl<T: 'static> EventLoop<T> {
         EventLoopProxy::new(self.sender.clone())
     }
 
-    pub fn window_target(&self) -> &RootEventLoopWindowTarget {
+    pub fn window_target(&self) -> &EventLoopWindowTarget {
         &self.window_target
     }
 }
@@ -342,7 +337,7 @@ fn setup_control_flow_observers() {
 #[derive(Debug)]
 pub enum Never {}
 
-type EventHandlerCallback<T> = dyn FnMut(Event<T>, &RootEventLoopWindowTarget) + 'static;
+type EventHandlerCallback<T> = dyn FnMut(Event<T>, &EventLoopWindowTarget) + 'static;
 
 pub trait EventHandler: Debug {
     fn handle_nonuser_event(&mut self, event: Event<Never>);
@@ -352,7 +347,7 @@ pub trait EventHandler: Debug {
 struct EventLoopHandler<T: 'static> {
     f: Box<EventHandlerCallback<T>>,
     receiver: Receiver<T>,
-    event_loop: RootEventLoopWindowTarget,
+    event_loop: EventLoopWindowTarget,
 }
 
 impl<T: 'static> Debug for EventLoopHandler<T> {

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -70,7 +70,8 @@ use std::fmt;
 
 pub(crate) use self::{
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget,
+        PlatformSpecificEventLoopAttributes,
     },
     monitor::{MonitorHandle, VideoModeHandle},
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -21,10 +21,7 @@ use crate::platform::x11::{WindowType as XWindowType, XlibErrorHook};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{EventLoopError, ExternalError, NotSupportedError, OsError as RootOsError},
-    event_loop::{
-        AsyncRequestSerial, ControlFlow, DeviceEvents, EventLoopClosed,
-        EventLoopWindowTarget as RootELW,
-    },
+    event_loop::{AsyncRequestSerial, ControlFlow, DeviceEvents, EventLoopClosed},
     icon::Icon,
     keyboard::Key,
     platform::pump_events::PumpStatus,
@@ -781,26 +778,26 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW),
+        F: FnMut(crate::event::Event<T>, &EventLoopWindowTarget),
     {
         self.run_on_demand(callback)
     }
 
     pub fn run_on_demand<F>(&mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW),
+        F: FnMut(crate::event::Event<T>, &EventLoopWindowTarget),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_on_demand(callback))
     }
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(crate::event::Event<T>, &RootELW),
+        F: FnMut(crate::event::Event<T>, &EventLoopWindowTarget),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.pump_events(timeout, callback))
     }
 
-    pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget {
+    pub fn window_target(&self) -> &EventLoopWindowTarget {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.window_target())
     }
 }
@@ -822,6 +819,8 @@ impl<T: 'static> EventLoopProxy<T> {
         x11_or_wayland!(match self; EventLoopProxy(proxy) => proxy.send_event(event))
     }
 }
+
+pub type ActiveEventLoop<'a> = &'a EventLoopWindowTarget;
 
 pub enum EventLoopWindowTarget {
     #[cfg(wayland_platform)]

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -2,7 +2,6 @@
 
 use std::cell::{Cell, RefCell};
 use std::io::Result as IOResult;
-use std::marker::PhantomData;
 use std::mem;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::rc::Rc;
@@ -19,9 +18,7 @@ use sctk::reexports::client::{Connection, QueueHandle};
 use crate::dpi::LogicalSize;
 use crate::error::{EventLoopError, OsError as RootOsError};
 use crate::event::{Event, InnerSizeWriter, StartCause, WindowEvent};
-use crate::event_loop::{
-    ControlFlow, DeviceEvents, EventLoopWindowTarget as RootEventLoopWindowTarget,
-};
+use crate::event_loop::{ControlFlow, DeviceEvents};
 use crate::platform::pump_events::PumpStatus;
 use crate::platform_impl::platform::min_timeout;
 use crate::platform_impl::{EventLoopWindowTarget as PlatformEventLoopWindowTarget, OsError};
@@ -63,7 +60,7 @@ pub struct EventLoop<T: 'static> {
     connection: Connection,
 
     /// Event loop window target.
-    window_target: RootEventLoopWindowTarget,
+    window_target: PlatformEventLoopWindowTarget,
 
     // XXX drop after everything else, just to be safe.
     /// Calloop's event loop.
@@ -179,10 +176,7 @@ impl<T: 'static> EventLoop<T> {
             user_events_sender,
             pending_user_events,
             event_loop,
-            window_target: RootEventLoopWindowTarget {
-                p: PlatformEventLoopWindowTarget::Wayland(window_target),
-                _marker: PhantomData,
-            },
+            window_target: PlatformEventLoopWindowTarget::Wayland(window_target),
         };
 
         Ok(event_loop)
@@ -190,7 +184,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         if self.loop_running {
             return Err(EventLoopError::AlreadyRunning);
@@ -221,7 +215,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut callback: F) -> PumpStatus
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         if !self.loop_running {
             self.loop_running = true;
@@ -248,7 +242,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn poll_events_with_timeout<F>(&mut self, mut timeout: Option<Duration>, mut callback: F)
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         let cause = loop {
             let start = Instant::now();
@@ -324,7 +318,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn single_iteration<F>(&mut self, callback: &mut F, cause: StartCause)
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         // NOTE currently just indented to simplify the diff
 
@@ -529,12 +523,12 @@ impl<T: 'static> EventLoop<T> {
     }
 
     #[inline]
-    pub fn window_target(&self) -> &RootEventLoopWindowTarget {
+    pub fn window_target(&self) -> &PlatformEventLoopWindowTarget {
         &self.window_target
     }
 
     fn with_state<'a, U: 'a, F: FnOnce(&'a mut WinitState) -> U>(&'a mut self, callback: F) -> U {
-        let state = match &mut self.window_target.p {
+        let state = match &mut self.window_target {
             PlatformEventLoopWindowTarget::Wayland(window_target) => window_target.state.get_mut(),
             #[cfg(x11_platform)]
             _ => unreachable!(),
@@ -544,7 +538,7 @@ impl<T: 'static> EventLoop<T> {
     }
 
     fn loop_dispatch<D: Into<Option<std::time::Duration>>>(&mut self, timeout: D) -> IOResult<()> {
-        let state = match &mut self.window_target.p {
+        let state = match &mut self.window_target {
             PlatformEventLoopWindowTarget::Wayland(window_target) => window_target.state.get_mut(),
             #[cfg(feature = "x11")]
             _ => unreachable!(),
@@ -557,7 +551,7 @@ impl<T: 'static> EventLoop<T> {
     }
 
     fn roundtrip(&mut self) -> Result<usize, RootOsError> {
-        let state = match &mut self.window_target.p {
+        let state = match &mut self.window_target {
             PlatformEventLoopWindowTarget::Wayland(window_target) => window_target.state.get_mut(),
             #[cfg(feature = "x11")]
             _ => unreachable!(),
@@ -573,19 +567,19 @@ impl<T: 'static> EventLoop<T> {
     }
 
     fn control_flow(&self) -> ControlFlow {
-        self.window_target.p.control_flow()
+        self.window_target.control_flow()
     }
 
     fn exiting(&self) -> bool {
-        self.window_target.p.exiting()
+        self.window_target.exiting()
     }
 
     fn set_exit_code(&self, code: i32) {
-        self.window_target.p.set_exit_code(code)
+        self.window_target.set_exit_code(code)
     }
 
     fn exit_code(&self) -> Option<i32> {
-        self.window_target.p.exit_code()
+        self.window_target.exit_code()
     }
 }
 

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -21,10 +21,10 @@ use super::{
     Dnd, DndState, GenericEventCookie, ImeReceiver, ScrollOrientation, UnownedWindow, WindowId,
 };
 
+use crate::platform_impl::EventLoopWindowTarget as PlatformEventLoopWindowTarget;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, Ime, RawKeyEvent, TouchPhase, WindowEvent},
-    event_loop::EventLoopWindowTarget as RootELW,
     keyboard::ModifiersState,
     platform_impl::platform::common::{keymap, xkb_state::KbdState},
 };
@@ -44,7 +44,7 @@ pub(super) struct EventProcessor {
     pub(super) devices: RefCell<HashMap<DeviceId, Device>>,
     pub(super) xi2ext: ExtensionInformation,
     pub(super) xkbext: ExtensionInformation,
-    pub(super) target: Rc<RootELW>,
+    pub(super) target: Rc<PlatformEventLoopWindowTarget>,
     pub(super) kb_state: KbdState,
     // Number of touch events currently in progress
     pub(super) num_touch: u32,

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -27,7 +27,6 @@ use std::{
     collections::{HashMap, HashSet},
     ffi::CStr,
     fmt,
-    marker::PhantomData,
     mem::MaybeUninit,
     ops::Deref,
     os::{
@@ -69,10 +68,11 @@ use super::{common::xkb_state::KbdState, ControlFlow, OsError};
 use crate::{
     error::{EventLoopError, OsError as RootOsError},
     event::{Event, StartCause, WindowEvent},
-    event_loop::{DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
+    event_loop::{DeviceEvents, EventLoopClosed},
     platform::pump_events::PumpStatus,
     platform_impl::{
         platform::{min_timeout, WindowId},
+        EventLoopWindowTarget as PlatformEventLoopWindowTarget,
         PlatformSpecificWindowBuilderAttributes,
     },
     window::WindowAttributes,
@@ -167,7 +167,7 @@ pub struct EventLoop<T: 'static> {
     user_receiver: PeekableReceiver<T>,
     activation_receiver: PeekableReceiver<ActivationToken>,
     user_sender: Sender<T>,
-    target: Rc<RootELW>,
+    target: Rc<PlatformEventLoopWindowTarget>,
 
     /// The current state of the event loop.
     state: EventLoopState,
@@ -325,10 +325,7 @@ impl<T: 'static> EventLoop<T> {
         // Set initial device event filter.
         window_target.update_listen_device_events(true);
 
-        let target = Rc::new(RootELW {
-            p: super::EventLoopWindowTarget::X(window_target),
-            _marker: PhantomData,
-        });
+        let target = Rc::new(PlatformEventLoopWindowTarget::X(window_target));
 
         let event_processor = EventProcessor {
             target: target.clone(),
@@ -396,13 +393,13 @@ impl<T: 'static> EventLoop<T> {
         }
     }
 
-    pub(crate) fn window_target(&self) -> &RootELW {
+    pub(crate) fn window_target(&self) -> &PlatformEventLoopWindowTarget {
         &self.target
     }
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootELW),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         if self.loop_running {
             return Err(EventLoopError::AlreadyRunning);
@@ -436,7 +433,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut callback: F) -> PumpStatus
     where
-        F: FnMut(Event<T>, &RootELW),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         if !self.loop_running {
             self.loop_running = true;
@@ -469,7 +466,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn poll_events_with_timeout<F>(&mut self, mut timeout: Option<Duration>, mut callback: F)
     where
-        F: FnMut(Event<T>, &RootELW),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         let start = Instant::now();
 
@@ -547,7 +544,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn single_iteration<F>(&mut self, callback: &mut F, cause: StartCause)
     where
-        F: FnMut(Event<T>, &RootELW),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         callback(crate::event::Event::NewEvents(cause), &self.target);
 
@@ -621,7 +618,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn drain_events<F>(&mut self, callback: &mut F)
     where
-        F: FnMut(Event<T>, &RootELW),
+        F: FnMut(Event<T>, &PlatformEventLoopWindowTarget),
     {
         let target = &self.target;
         let mut xev = MaybeUninit::uninit();
@@ -644,19 +641,19 @@ impl<T: 'static> EventLoop<T> {
     }
 
     fn control_flow(&self) -> ControlFlow {
-        self.target.p.control_flow()
+        self.target.control_flow()
     }
 
     fn exiting(&self) -> bool {
-        self.target.p.exiting()
+        self.target.exiting()
     }
 
     fn set_exit_code(&self, code: i32) {
-        self.target.p.set_exit_code(code)
+        self.target.set_exit_code(code)
     }
 
     fn exit_code(&self) -> Option<i32> {
-        self.target.p.exit_code()
+        self.target.exit_code()
     }
 }
 
@@ -672,8 +669,8 @@ impl<T> AsRawFd for EventLoop<T> {
     }
 }
 
-pub(crate) fn get_xtarget(target: &RootELW) -> &EventLoopWindowTarget {
-    match target.p {
+pub(crate) fn get_xtarget(target: &PlatformEventLoopWindowTarget) -> &EventLoopWindowTarget {
+    match target {
         super::EventLoopWindowTarget::X(ref target) => target,
         #[cfg(wayland_platform)]
         _ => unreachable!(),

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -19,7 +19,8 @@ use std::fmt;
 pub(crate) use self::{
     event::{physicalkey_to_scancode, scancode_to_physicalkey, KeyEventExtra},
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget,
+        PlatformSpecificEventLoopAttributes,
     },
     monitor::{MonitorHandle, VideoModeHandle},
     window::WindowId,

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 
-pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
+pub use self::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget};
 mod event_loop;
 
 pub use self::window::Window;

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -1,9 +1,7 @@
-use std::marker::PhantomData;
 use std::sync::mpsc::{self, Receiver, Sender};
 
 use crate::error::EventLoopError;
 use crate::event::Event;
-use crate::event_loop::EventLoopWindowTarget as RootEventLoopWindowTarget;
 
 use super::{backend, device, window};
 
@@ -15,8 +13,10 @@ mod window_target;
 pub use proxy::EventLoopProxy;
 pub use window_target::EventLoopWindowTarget;
 
+pub type ActiveEventLoop<'a> = &'a EventLoopWindowTarget;
+
 pub struct EventLoop<T: 'static> {
-    elw: RootEventLoopWindowTarget,
+    elw: EventLoopWindowTarget,
     user_event_sender: Sender<T>,
     user_event_receiver: Receiver<T>,
 }
@@ -27,12 +27,8 @@ pub(crate) struct PlatformSpecificEventLoopAttributes {}
 impl<T> EventLoop<T> {
     pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> Result<Self, EventLoopError> {
         let (user_event_sender, user_event_receiver) = mpsc::channel();
-        let elw = RootEventLoopWindowTarget {
-            p: EventLoopWindowTarget::new(),
-            _marker: PhantomData,
-        };
         Ok(EventLoop {
-            elw,
+            elw: EventLoopWindowTarget::new(),
             user_event_sender,
             user_event_receiver,
         })
@@ -40,12 +36,9 @@ impl<T> EventLoop<T> {
 
     pub fn run<F>(self, mut event_handler: F) -> !
     where
-        F: FnMut(Event<T>, &RootEventLoopWindowTarget),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
-        let target = RootEventLoopWindowTarget {
-            p: self.elw.p.clone(),
-            _marker: PhantomData,
-        };
+        let target = self.elw.clone();
 
         // SAFETY: Don't use `move` to make sure we leak the `event_handler` and `target`.
         let handler: Box<dyn FnMut(Event<()>)> = Box::new(|event| {
@@ -64,7 +57,7 @@ impl<T> EventLoop<T> {
         // because this function will never return and all resources not cleaned up by the point we
         // `throw` will leak, making this actually `'static`.
         let handler = unsafe { std::mem::transmute(handler) };
-        self.elw.p.run(handler, false);
+        self.elw.run(handler, false);
 
         // Throw an exception to break out of Rust execution and use unreachable to tell the
         // compiler this function won't return, giving it a return type of '!'
@@ -77,14 +70,11 @@ impl<T> EventLoop<T> {
 
     pub fn spawn<F>(self, mut event_handler: F)
     where
-        F: 'static + FnMut(Event<T>, &RootEventLoopWindowTarget),
+        F: 'static + FnMut(Event<T>, &EventLoopWindowTarget),
     {
-        let target = RootEventLoopWindowTarget {
-            p: self.elw.p.clone(),
-            _marker: PhantomData,
-        };
+        let target = self.elw.clone();
 
-        self.elw.p.run(
+        self.elw.run(
             Box::new(move |event| {
                 let event = match event.map_nonuser_event() {
                     Ok(event) => event,
@@ -102,10 +92,10 @@ impl<T> EventLoop<T> {
     }
 
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
-        EventLoopProxy::new(self.elw.p.waker(), self.user_event_sender.clone())
+        EventLoopProxy::new(self.elw.waker(), self.user_event_sender.clone())
     }
 
-    pub fn window_target(&self) -> &RootEventLoopWindowTarget {
+    pub fn window_target(&self) -> &EventLoopWindowTarget {
         &self.elw
     }
 }

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -215,7 +215,7 @@ impl Shared {
 
     // Set the event callback to use for the event loop runner
     // This the event callback is a fairly thin layer over the user-provided callback that closes
-    // over a RootEventLoopWindowTarget reference
+    // over a EventLoopWindowTarget reference
     pub fn set_listener(&self, event_handler: Box<EventHandler>) {
         {
             let mut runner = self.0.runner.borrow_mut();

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -49,7 +49,7 @@ pub struct EventLoopWindowTarget {
 }
 
 impl EventLoopWindowTarget {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             runner: runner::Shared::new(),
             modifiers: ModifiersShared::default(),

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -33,7 +33,8 @@ mod backend;
 pub use self::device::DeviceId;
 pub use self::error::OsError;
 pub(crate) use self::event_loop::{
-    EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+    ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget,
+    PlatformSpecificEventLoopAttributes,
 };
 pub use self::monitor::{MonitorHandle, VideoModeHandle};
 pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId};

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -6,7 +6,6 @@ use std::{
     cell::Cell,
     collections::VecDeque,
     ffi::c_void,
-    marker::PhantomData,
     mem, panic, ptr,
     rc::Rc,
     sync::{
@@ -74,7 +73,7 @@ use crate::{
         DeviceEvent, Event, Force, Ime, InnerSizeWriter, RawKeyEvent, Touch, TouchPhase,
         WindowEvent,
     },
-    event_loop::{ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
+    event_loop::{ControlFlow, DeviceEvents, EventLoopClosed},
     keyboard::ModifiersState,
     platform::pump_events::PumpStatus,
     platform_impl::platform::{
@@ -158,7 +157,7 @@ pub(crate) enum ProcResult {
 pub struct EventLoop<T: 'static> {
     user_event_sender: Sender<T>,
     user_event_receiver: Receiver<T>,
-    window_target: RootELW,
+    window_target: EventLoopWindowTarget,
     msg_hook: Option<Box<dyn FnMut(*const c_void) -> bool + 'static>>,
 }
 
@@ -177,6 +176,8 @@ impl Default for PlatformSpecificEventLoopAttributes {
         }
     }
 }
+
+pub type ActiveEventLoop<'a> = &'a EventLoopWindowTarget;
 
 pub struct EventLoopWindowTarget {
     thread_id: u32,
@@ -217,35 +218,32 @@ impl<T: 'static> EventLoop<T> {
         Ok(EventLoop {
             user_event_sender,
             user_event_receiver,
-            window_target: RootELW {
-                p: EventLoopWindowTarget {
-                    thread_id,
-                    thread_msg_target,
-                    runner_shared,
-                },
-                _marker: PhantomData,
+            window_target: EventLoopWindowTarget {
+                thread_id,
+                thread_msg_target,
+                runner_shared,
             },
             msg_hook: attributes.msg_hook.take(),
         })
     }
 
-    pub fn window_target(&self) -> &RootELW {
+    pub fn window_target(&self) -> &EventLoopWindowTarget {
         &self.window_target
     }
 
     pub fn run<F>(mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootELW),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
         self.run_on_demand(event_handler)
     }
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootELW),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
         {
-            let runner = &self.window_target.p.runner_shared;
+            let runner = &self.window_target.runner_shared;
             if runner.state() != RunnerState::Uninitialized {
                 return Err(EventLoopError::AlreadyRunning);
             }
@@ -290,7 +288,7 @@ impl<T: 'static> EventLoop<T> {
             }
         };
 
-        let runner = &self.window_target.p.runner_shared;
+        let runner = &self.window_target.runner_shared;
         runner.loop_destroyed();
 
         // # Safety
@@ -307,10 +305,10 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<T>, &RootELW),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
         {
-            let runner = &self.window_target.p.runner_shared;
+            let runner = &self.window_target.runner_shared;
             let event_loop_windows_ref = &self.window_target;
             let user_event_receiver = &self.user_event_receiver;
 
@@ -343,7 +341,7 @@ impl<T: 'static> EventLoop<T> {
             self.dispatch_peeked_messages();
         }
 
-        let runner = &self.window_target.p.runner_shared;
+        let runner = &self.window_target.runner_shared;
 
         let status = if let Some(code) = runner.exit_code() {
             runner.loop_destroyed();
@@ -405,7 +403,7 @@ impl<T: 'static> EventLoop<T> {
             }
         }
 
-        let runner = &self.window_target.p.runner_shared;
+        let runner = &self.window_target.runner_shared;
 
         // We aim to be consistent with the MacOS backend which has a RunLoop
         // observer that will dispatch AboutToWait when about to wait for
@@ -467,7 +465,7 @@ impl<T: 'static> EventLoop<T> {
 
     /// Dispatch all queued messages via `PeekMessageW`
     fn dispatch_peeked_messages(&mut self) {
-        let runner = &self.window_target.p.runner_shared;
+        let runner = &self.window_target.runner_shared;
 
         // We generally want to continue dispatching all pending messages
         // but we also allow dispatching to be interrupted as a means to
@@ -517,13 +515,13 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         EventLoopProxy {
-            target_window: self.window_target.p.thread_msg_target,
+            target_window: self.window_target.thread_msg_target,
             event_send: self.user_event_sender.clone(),
         }
     }
 
     fn exit_code(&self) -> Option<i32> {
-        self.window_target.p.exit_code()
+        self.window_target.exit_code()
     }
 }
 
@@ -671,7 +669,7 @@ fn dur2timeout(dur: Duration) -> u32 {
 impl<T> Drop for EventLoop<T> {
     fn drop(&mut self) {
         unsafe {
-            DestroyWindow(self.window_target.p.thread_msg_target);
+            DestroyWindow(self.window_target.thread_msg_target);
         }
     }
 }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -8,7 +8,8 @@ use windows_sys::Win32::{
 
 pub(crate) use self::{
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget,
+        PlatformSpecificEventLoopAttributes,
     },
     icon::{SelectedCursor, WinIcon},
     keyboard::{physicalkey_to_scancode, scancode_to_physicalkey},

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,7 +4,7 @@ use std::fmt;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError},
-    event_loop::EventLoopWindowTarget,
+    event_loop::MaybeActiveEventLoop,
     monitor::{MonitorHandle, VideoModeHandle},
     platform_impl,
 };
@@ -531,9 +531,12 @@ impl WindowBuilder {
     /// - **Web:** The window is created but not inserted into the web page automatically. Please
     ///   see the web platform module for more information.
     #[inline]
-    pub fn build(self, window_target: &EventLoopWindowTarget) -> Result<Window, OsError> {
+    pub fn build<'a>(
+        self,
+        mut event_loop: impl MaybeActiveEventLoop<'a>,
+    ) -> Result<Window, OsError> {
         let window =
-            platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)?;
+            platform_impl::Window::new(event_loop.__inner(), self.window, self.platform_specific)?;
         window.maybe_queue_on_main(|w| w.request_redraw());
         Ok(Window { window })
     }
@@ -555,7 +558,7 @@ impl Window {
     ///
     /// [`WindowBuilder::new().build(event_loop)`]: WindowBuilder::build
     #[inline]
-    pub fn new(event_loop: &EventLoopWindowTarget) -> Result<Window, OsError> {
+    pub fn new<'a>(event_loop: impl MaybeActiveEventLoop<'a>) -> Result<Window, OsError> {
         let builder = WindowBuilder::new();
         builder.build(event_loop)
     }
@@ -1515,9 +1518,9 @@ impl Window {
 
     /// Returns the list of all the monitors available on the system.
     ///
-    /// This is the same as [`EventLoopWindowTarget::available_monitors`], and is provided for convenience.
+    /// This is the same as [`ActiveEventLoop::available_monitors`], and is provided for convenience.
     ///
-    /// [`EventLoopWindowTarget::available_monitors`]: crate::event_loop::EventLoopWindowTarget::available_monitors
+    /// [`ActiveEventLoop::available_monitors`]: crate::event_loop::ActiveEventLoop::available_monitors
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
         self.window.maybe_wait_on_main(|w| {
@@ -1531,13 +1534,13 @@ impl Window {
     ///
     /// Returns `None` if it can't identify any monitor as a primary one.
     ///
-    /// This is the same as [`EventLoopWindowTarget::primary_monitor`], and is provided for convenience.
+    /// This is the same as [`ActiveEventLoop::primary_monitor`], and is provided for convenience.
     ///
     /// ## Platform-specific
     ///
     /// **Wayland / Web:** Always returns `None`.
     ///
-    /// [`EventLoopWindowTarget::primary_monitor`]: crate::event_loop::EventLoopWindowTarget::primary_monitor
+    /// [`ActiveEventLoop::primary_monitor`]: crate::event_loop::ActiveEventLoop::primary_monitor
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         self.window

--- a/src/window.rs
+++ b/src/window.rs
@@ -44,12 +44,12 @@ use serde::{Deserialize, Serialize};
 /// event_loop.set_control_flow(ControlFlow::Wait);
 /// let window = Window::new(&event_loop).unwrap();
 ///
-/// event_loop.run(move |event, elwt| {
+/// event_loop.run(move |event, event_loop| {
 ///     match event {
 ///         Event::WindowEvent {
 ///             event: WindowEvent::CloseRequested,
 ///             ..
-///         } => elwt.exit(),
+///         } => event_loop.exit(),
 ///         _ => (),
 ///     }
 /// });


### PR DESCRIPTION
This is done for several reasons:
- To in the future allow restricting window creation to `ActiveEventLoop` (which resolves a bunch of long-standing issues on macOS and iOS).
- To avoid the `Deref` on `EventLoop`, which is discouraged by the [C-DEREF](https://rust-lang.github.io/api-guidelines/predictability.html#c-deref) guideline.
- To allow further flexibility in each platform, as we are now no longer required to store `crate::event_loop::EventLoopWindowTarget` in the platform's own `EventLoop`.
  - At some point we could perhaps even change `ActiveEventLoop` to contain `&mut`.

~Blocked on https://github.com/rust-windowing/winit/pull/3298.~

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
