### PR TITLE
Specify rwh_05 min version 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ log = "0.4"
 mint = { version = "0.5.6", optional = true }
 once_cell = "1.12"
 rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
-rwh_05 = { package = "raw-window-handle", version = "0.5", features = ["std"], optional = true }
+rwh_05 = { package = "raw-window-handle", version = "0.5.2", features = ["std"], optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"], optional = true }
 serde = { version = "1", optional = true, features = ["serde_derive"] }
 smol_str = "0.2.0"


### PR DESCRIPTION
Correct rwh_05 minimum version to support "std" feature. Fixes some scenarios where downstream bins don't `cargo update` and try to build with rwh_05 `0.5.0` or `0.5.1` which both lack the "std" feature required in the winit manifest.

Resolves #3223

- ~Tested on all platforms changed~ rwh_05 version already tested
- ~Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users~ n/a
- ~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~ n/a
- ~Created or updated an example program if it would help users understand this functionality~ n/a
- ~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~ n/a
