### PR TITLE
macOS: Clean up coordinate system calculations

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -11,4 +11,5 @@ disallowed-methods = [
     { path = "web_sys::Document::exit_fullscreen", reason = "Doesn't account for compatibility with Safari" },
     { path = "web_sys::Document::fullscreen_element", reason = "Doesn't account for compatibility with Safari" },
     { path = "icrate::AppKit::NSView::visibleRect", reason = "We expose a render target to the user, and visibility is not really relevant to that (and can break if you don't use the rectangle position as well). Use `frame` instead." },
+    { path = "icrate::AppKit::NSWindow::setFrameTopLeftPoint", reason = "Not sufficient when working with Winit's coordinate system, use `flip_window_screen_coordinates` instead" },
 ]

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::single_match)]
 
 use simple_logger::SimpleLogger;
-use winit::dpi::PhysicalSize;
+use winit::dpi::LogicalSize;
 use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
 use winit::event_loop::EventLoop;
 use winit::keyboard::{Key, NamedKey};
@@ -126,7 +126,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         "i" => {
                             with_min_size = !with_min_size;
                             let min_size = if with_min_size {
-                                Some(PhysicalSize::new(100, 100))
+                                Some(LogicalSize::new(100, 100))
                             } else {
                                 None
                             };
@@ -139,7 +139,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         "a" => {
                             with_max_size = !with_max_size;
                             let max_size = if with_max_size {
-                                Some(PhysicalSize::new(200, 200))
+                                Some(LogicalSize::new(200, 200))
                             } else {
                                 None
                             };

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -96,21 +96,13 @@ fn main() -> Result<(), impl std::error::Error> {
                                     )),
                                     (false, _) => None,
                                 }),
-                                "l" if state => {
-                                    if let Err(err) = window.set_cursor_grab(CursorGrabMode::Locked)
-                                    {
-                                        println!("error: {err}");
-                                    }
-                                }
-                                "g" if state => {
-                                    if let Err(err) =
-                                        window.set_cursor_grab(CursorGrabMode::Confined)
-                                    {
-                                        println!("error: {err}");
-                                    }
-                                }
-                                "g" | "l" if !state => {
-                                    if let Err(err) = window.set_cursor_grab(CursorGrabMode::None) {
+                                ch @ ("g" | "l") => {
+                                    let mode = match (ch, state) {
+                                        ("l", true) => CursorGrabMode::Locked,
+                                        ("g", true) => CursorGrabMode::Confined,
+                                        (_, _) => CursorGrabMode::None,
+                                    };
+                                    if let Err(err) = window.set_cursor_grab(mode) {
                                         println!("error: {err}");
                                     }
                                 }
@@ -123,10 +115,6 @@ fn main() -> Result<(), impl std::error::Error> {
                                     println!("-> inner_size     : {:?}", window.inner_size());
                                     println!("-> fullscreen     : {:?}", window.fullscreen());
                                 }
-                                "l" => window.set_min_inner_size(match state {
-                                    true => Some(WINDOW_SIZE),
-                                    false => None,
-                                }),
                                 "m" => window.set_maximized(state),
                                 "p" => window.set_outer_position({
                                     let mut position = window.outer_position().unwrap();
@@ -140,12 +128,26 @@ fn main() -> Result<(), impl std::error::Error> {
                                 "s" => {
                                     let _ = window.request_inner_size(match state {
                                         true => PhysicalSize::new(
-                                            WINDOW_SIZE.width + 100,
-                                            WINDOW_SIZE.height + 100,
+                                            WINDOW_SIZE.width + 50,
+                                            WINDOW_SIZE.height + 50,
                                         ),
                                         false => WINDOW_SIZE,
                                     });
                                 }
+                                "k" => window.set_min_inner_size(match state {
+                                    true => Some(PhysicalSize::new(
+                                        WINDOW_SIZE.width - 100,
+                                        WINDOW_SIZE.height - 100,
+                                    )),
+                                    false => None,
+                                }),
+                                "o" => window.set_max_inner_size(match state {
+                                    true => Some(PhysicalSize::new(
+                                        WINDOW_SIZE.width + 100,
+                                        WINDOW_SIZE.height + 100,
+                                    )),
+                                    false => None,
+                                }),
                                 "w" => {
                                     if let Size::Physical(size) = WINDOW_SIZE.into() {
                                         window

--- a/src/platform_impl/ios/monitor.rs
+++ b/src/platform_impl/ios/monitor.rs
@@ -135,24 +135,13 @@ impl Ord for MonitorHandle {
 
 impl fmt::Debug for MonitorHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Do this using the proper fmt API
-        #[derive(Debug)]
-        #[allow(dead_code)]
-        struct MonitorHandle {
-            name: Option<String>,
-            size: PhysicalSize<u32>,
-            position: PhysicalPosition<i32>,
-            scale_factor: f64,
-        }
-
-        let monitor_id_proxy = MonitorHandle {
-            name: self.name(),
-            size: self.size(),
-            position: self.position(),
-            scale_factor: self.scale_factor(),
-        };
-
-        monitor_id_proxy.fmt(f)
+        f.debug_struct("MonitorHandle")
+            .field("name", &self.name())
+            .field("size", &self.size())
+            .field("position", &self.position())
+            .field("scale_factor", &self.scale_factor())
+            .field("refresh_rate_millihertz", &self.refresh_rate_millihertz())
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -19,9 +19,9 @@ use crate::dpi::{PhysicalPosition, PhysicalSize};
 
 #[derive(Clone)]
 pub struct VideoMode {
-    pub(crate) size: (u32, u32),
-    pub(crate) bit_depth: u16,
-    pub(crate) refresh_rate_millihertz: u32,
+    size: PhysicalSize<u32>,
+    bit_depth: u16,
+    refresh_rate_millihertz: u32,
     pub(crate) monitor: MonitorHandle,
     pub(crate) native_mode: NativeDisplayMode,
 }
@@ -80,7 +80,7 @@ impl Clone for NativeDisplayMode {
 
 impl VideoMode {
     pub fn size(&self) -> PhysicalSize<u32> {
-        self.size.into()
+        self.size
     }
 
     pub fn bit_depth(&self) -> u16 {
@@ -154,26 +154,14 @@ pub fn primary_monitor() -> MonitorHandle {
 
 impl fmt::Debug for MonitorHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Do this using the proper fmt API
-        #[derive(Debug)]
-        #[allow(dead_code)]
-        struct MonitorHandle {
-            name: Option<String>,
-            native_identifier: u32,
-            size: PhysicalSize<u32>,
-            position: PhysicalPosition<i32>,
-            scale_factor: f64,
-        }
-
-        let monitor_id_proxy = MonitorHandle {
-            name: self.name(),
-            native_identifier: self.native_identifier(),
-            size: self.size(),
-            position: self.position(),
-            scale_factor: self.scale_factor(),
-        };
-
-        monitor_id_proxy.fmt(f)
+        f.debug_struct("MonitorHandle")
+            .field("name", &self.name())
+            .field("native_identifier", &self.native_identifier())
+            .field("size", &self.size())
+            .field("position", &self.position())
+            .field("scale_factor", &self.scale_factor())
+            .field("refresh_rate_millihertz", &self.refresh_rate_millihertz())
+            .finish_non_exhaustive()
     }
 }
 
@@ -182,6 +170,8 @@ impl MonitorHandle {
         MonitorHandle(id)
     }
 
+    // TODO: Be smarter about this:
+    // <https://github.com/glfw/glfw/blob/57cbded0760a50b9039ee0cb3f3c14f60145567c/src/cocoa_monitor.m#L44-L126>
     pub fn name(&self) -> Option<String> {
         let MonitorHandle(display_id) = *self;
         let screen_num = CGDisplay::new(display_id).model_number();
@@ -268,13 +258,12 @@ impl MonitorHandle {
             };
 
             modes.into_iter().map(move |mode| {
-                let cg_refresh_rate_millihertz =
-                    ffi::CGDisplayModeGetRefreshRate(mode).round() as i64;
+                let cg_refresh_rate_hertz = ffi::CGDisplayModeGetRefreshRate(mode).round() as i64;
 
                 // CGDisplayModeGetRefreshRate returns 0.0 for any display that
                 // isn't a CRT
-                let refresh_rate_millihertz = if cg_refresh_rate_millihertz > 0 {
-                    (cg_refresh_rate_millihertz * 1000) as u32
+                let refresh_rate_millihertz = if cg_refresh_rate_hertz > 0 {
+                    (cg_refresh_rate_hertz * 1000) as u32
                 } else {
                     refresh_rate_millihertz
                 };
@@ -293,7 +282,7 @@ impl MonitorHandle {
                 };
 
                 VideoMode {
-                    size: (
+                    size: PhysicalSize::new(
                         ffi::CGDisplayModeGetPixelWidth(mode) as u32,
                         ffi::CGDisplayModeGetPixelHeight(mode) as u32,
                     ),

--- a/src/platform_impl/macos/util.rs
+++ b/src/platform_impl/macos/util.rs
@@ -1,7 +1,4 @@
-use core_graphics::display::CGDisplay;
-use icrate::Foundation::{CGFloat, NSNotFound, NSPoint, NSRange, NSRect, NSUInteger};
-
-use crate::dpi::LogicalPosition;
+use icrate::Foundation::{NSNotFound, NSRange, NSUInteger};
 
 // Replace with `!` once stable
 #[derive(Debug)]
@@ -39,22 +36,4 @@ impl Drop for TraceGuard {
     fn drop(&mut self) {
         trace!(target: self.module_path, "Completed `{}`", self.called_from_fn);
     }
-}
-
-// For consistency with other platforms, this will...
-// 1. translate the bottom-left window corner into the top-left window corner
-// 2. translate the coordinate from a bottom-left origin coordinate system to a top-left one
-#[allow(clippy::unnecessary_cast)]
-pub fn bottom_left_to_top_left(rect: NSRect) -> f64 {
-    CGDisplay::main().pixels_high() as f64 - (rect.origin.y + rect.size.height) as f64
-}
-
-/// Converts from winit screen-coordinates to macOS screen-coordinates.
-/// Winit: top-left is (0, 0) and y increasing downwards
-/// macOS: bottom-left is (0, 0) and y increasing upwards
-pub fn window_position(position: LogicalPosition<f64>) -> NSPoint {
-    NSPoint::new(
-        position.x as CGFloat,
-        CGDisplay::main().pixels_high() as CGFloat - position.y as CGFloat,
-    )
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -1273,7 +1273,11 @@ impl WinitWindow {
     pub fn set_ime_cursor_area(&self, spot: Position, size: Size) {
         let scale_factor = self.scale_factor();
         let logical_spot = spot.to_logical(scale_factor);
+        let logical_spot = NSPoint::new(logical_spot.x, logical_spot.y);
+
         let size = size.to_logical(scale_factor);
+        let size = NSSize::new(size.width, size.height);
+
         self.view().set_ime_cursor_area(logical_spot, size);
     }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -7,16 +7,18 @@ use icrate::AppKit::{
     NSApplicationPresentationHideMenuBar, NSApplicationPresentationOptions, NSDraggingDestination,
     NSFilenamesPboardType, NSPasteboard, NSWindowDelegate, NSWindowOcclusionStateVisible,
 };
-use icrate::Foundation::{MainThreadMarker, NSArray, NSObject, NSObjectProtocol, NSSize, NSString};
+use icrate::Foundation::{
+    MainThreadMarker, NSArray, NSObject, NSObjectProtocol, NSPoint, NSSize, NSString,
+};
 use objc2::rc::{autoreleasepool, Id};
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{
     class, declare_class, msg_send, msg_send_id, mutability, sel, ClassType, DeclaredClass,
 };
 
+use super::monitor::flip_window_screen_coordinates;
 use super::{
     app_state::AppState,
-    util,
     window::{get_ns_theme, WinitWindow},
     Fullscreen,
 };
@@ -35,7 +37,9 @@ pub(crate) struct State {
     initial_fullscreen: Cell<bool>,
 
     // During `windowDidResize`, we use this to only send Moved if the position changed.
-    previous_position: Cell<Option<(f64, f64)>>,
+    //
+    // This is expressed in native screen coordinates.
+    previous_position: Cell<Option<NSPoint>>,
 
     // Used to prevent redundant events.
     previous_scale_factor: Cell<f64>,
@@ -467,14 +471,16 @@ impl WinitWindowDelegate {
     }
 
     fn emit_move_event(&self) {
-        let rect = self.ivars().window.frame();
-        let x = rect.origin.x as f64;
-        let y = util::bottom_left_to_top_left(rect);
-        if self.ivars().previous_position.get() != Some((x, y)) {
-            self.ivars().previous_position.set(Some((x, y)));
-            let scale_factor = self.ivars().window.scale_factor();
-            let physical_pos = LogicalPosition::<f64>::from((x, y)).to_physical(scale_factor);
-            self.queue_event(WindowEvent::Moved(physical_pos));
+        let window = &self.ivars().window;
+        let frame = window.frame();
+        if self.ivars().previous_position.get() == Some(frame.origin) {
+            return;
         }
+        self.ivars().previous_position.set(Some(frame.origin));
+
+        let position = flip_window_screen_coordinates(frame);
+        let position =
+            LogicalPosition::new(position.x, position.y).to_physical(window.scale_factor());
+        self.queue_event(WindowEvent::Moved(position));
     }
 }

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -450,16 +450,18 @@ impl WinitWindowDelegate {
     }
 
     fn queue_static_scale_factor_changed_event(&self) {
-        let scale_factor = self.ivars().window.scale_factor();
+        let window = &self.ivars().window;
+        let scale_factor = window.scale_factor();
         if scale_factor == self.ivars().previous_scale_factor.get() {
             return;
         };
 
         self.ivars().previous_scale_factor.set(scale_factor);
-        let suggested_size = self.view_size();
+        let content_size = window.contentRectForFrameRect(window.frame()).size;
+        let content_size = LogicalSize::new(content_size.width, content_size.height);
         AppState::queue_static_scale_factor_changed_event(
-            self.ivars().window.clone(),
-            suggested_size.to_physical(scale_factor),
+            window.clone(),
+            content_size.to_physical(scale_factor),
             scale_factor,
         );
     }
@@ -474,10 +476,5 @@ impl WinitWindowDelegate {
             let physical_pos = LogicalPosition::<f64>::from((x, y)).to_physical(scale_factor);
             self.queue_event(WindowEvent::Moved(physical_pos));
         }
-    }
-
-    fn view_size(&self) -> LogicalSize<f64> {
-        let size = self.ivars().window.contentView().unwrap().frame().size;
-        LogicalSize::new(size.width as f64, size.height as f64)
     }
 }


### PR DESCRIPTION
Instead of adding and subtracting heights haphazardly, let's use the built-in methods that AppKit has!

- [x] Tested on all platforms changed
