### PR TITLE
Remove unsound `SendSyncWrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Unreleased` header.
 - **Breaking:** On Web, macOS and iOS, return `HandleError::Unavailable` when a window handle is not available.
 - **Breaking:** Bump MSRV from `1.65` to `1.70`.
 - On Web, add the ability to toggle calling `Event.preventDefault()` on `Window`.
+- **Breaking:** Remove `WindowAttributes::fullscreen()` and expose as field directly.
 
 # 0.29.6
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,18 +173,3 @@ mod platform_impl;
 pub mod window;
 
 pub mod platform;
-
-/// Wrapper for objects which winit will access on the main thread so they are effectively `Send`
-/// and `Sync`, since they always execute on a single thread.
-///
-/// # Safety
-///
-/// Winit can run only one event loop at a time, and the event loop itself is tied to some thread.
-/// The objects could be sent across the threads, but once passed to winit, they execute on the
-/// main thread if the platform demands it. Thus, marking such objects as `Send + Sync` is safe.
-#[doc(hidden)]
-#[derive(Clone, Debug)]
-pub(crate) struct SendSyncWrapper<T>(pub(crate) T);
-
-unsafe impl<T> Send for SendSyncWrapper<T> {}
-unsafe impl<T> Sync for SendSyncWrapper<T> {}

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -475,7 +475,7 @@ impl WinitUIWindow {
 
         this.setRootViewController(Some(view_controller));
 
-        match window_attributes.fullscreen.0.clone().map(Into::into) {
+        match window_attributes.fullscreen.clone().map(Into::into) {
             Some(Fullscreen::Exclusive(ref video_mode)) => {
                 let monitor = video_mode.monitor();
                 let screen = monitor.ui_screen(mtm);

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -367,15 +367,6 @@ impl Inner {
         rwh_06::RawWindowHandle::UiKit(window_handle)
     }
 
-    #[cfg(feature = "rwh_06")]
-    pub fn raw_display_handle_rwh_06(
-        &self,
-    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
-        Ok(rwh_06::RawDisplayHandle::UiKit(
-            rwh_06::UiKitDisplayHandle::new(),
-        ))
-    }
-
     pub fn theme(&self) -> Option<Theme> {
         warn!("`Window::theme` is ignored on iOS");
         None
@@ -424,7 +415,7 @@ impl Window {
         // TODO: transparency, visible
 
         let main_screen = UIScreen::main(mtm);
-        let fullscreen = window_attributes.fullscreen.0.clone().map(Into::into);
+        let fullscreen = window_attributes.fullscreen.clone().map(Into::into);
         let screen = match fullscreen {
             Some(Fullscreen::Exclusive(ref video_mode)) => video_mode.monitor.ui_screen(mtm),
             Some(Fullscreen::Borderless(Some(ref monitor))) => monitor.ui_screen(mtm),
@@ -531,6 +522,16 @@ impl Window {
         } else {
             Err(rwh_06::HandleError::Unavailable)
         }
+    }
+
+    #[cfg(feature = "rwh_06")]
+    #[inline]
+    pub(crate) fn raw_display_handle_rwh_06(
+        &self,
+    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
+        Ok(rwh_06::RawDisplayHandle::UiKit(
+            rwh_06::UiKitDisplayHandle::new(),
+        ))
     }
 }
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -152,7 +152,7 @@ impl Window {
         window_state.set_resizable(attributes.resizable);
 
         // Set startup mode.
-        match attributes.fullscreen.0.map(Into::into) {
+        match attributes.fullscreen.map(Into::into) {
             Some(Fullscreen::Exclusive(_)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland");
             }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -159,7 +159,7 @@ impl UnownedWindow {
         let xconn = &event_loop.xconn;
         let atoms = xconn.atoms();
         #[cfg(feature = "rwh_06")]
-        let root = match window_attrs.parent_window.0 {
+        let root = match window_attrs.parent_window.as_ref().map(|handle| handle.0) {
             Some(rwh_06::RawWindowHandle::Xlib(handle)) => handle.window as xproto::Window,
             Some(rwh_06::RawWindowHandle::Xcb(handle)) => handle.window.get(),
             Some(raw) => unreachable!("Invalid raw window handle {raw:?} on X11"),
@@ -557,10 +557,10 @@ impl UnownedWindow {
             if window_attrs.maximized {
                 leap!(window.set_maximized_inner(window_attrs.maximized)).ignore_error();
             }
-            if window_attrs.fullscreen.0.is_some() {
+            if window_attrs.fullscreen.is_some() {
                 if let Some(flusher) =
                     leap!(window
-                        .set_fullscreen_inner(window_attrs.fullscreen.0.clone().map(Into::into)))
+                        .set_fullscreen_inner(window_attrs.fullscreen.clone().map(Into::into)))
                 {
                     flusher.ignore_error()
                 }

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -1,6 +1,10 @@
 #![allow(clippy::unnecessary_cast)]
 
-use std::{collections::VecDeque, fmt};
+use std::{
+    collections::VecDeque,
+    fmt,
+    sync::{Arc, Mutex},
+};
 
 use core_foundation::{
     array::{CFArrayGetCount, CFArrayGetValueAtIndex},
@@ -23,7 +27,7 @@ pub struct VideoMode {
     bit_depth: u16,
     refresh_rate_millihertz: u32,
     pub(crate) monitor: MonitorHandle,
-    pub(crate) native_mode: NativeDisplayMode,
+    pub(crate) native_mode: Arc<Mutex<NativeDisplayMode>>,
 }
 
 impl PartialEq for VideoMode {
@@ -290,7 +294,7 @@ impl MonitorHandle {
                     refresh_rate_millihertz,
                     bit_depth,
                     monitor: monitor.clone(),
-                    native_mode: NativeDisplayMode(mode),
+                    native_mode: Arc::new(Mutex::new(NativeDisplayMode(mode))),
                 }
             })
         }

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -1,10 +1,6 @@
 #![allow(clippy::unnecessary_cast)]
 
-use std::{
-    collections::VecDeque,
-    fmt,
-    sync::{Arc, Mutex},
-};
+use std::{collections::VecDeque, fmt};
 
 use core_foundation::{
     array::{CFArrayGetCount, CFArrayGetValueAtIndex},
@@ -27,7 +23,7 @@ pub struct VideoMode {
     bit_depth: u16,
     refresh_rate_millihertz: u32,
     pub(crate) monitor: MonitorHandle,
-    pub(crate) native_mode: Arc<Mutex<NativeDisplayMode>>,
+    pub(crate) native_mode: NativeDisplayMode,
 }
 
 impl PartialEq for VideoMode {
@@ -64,6 +60,7 @@ impl std::fmt::Debug for VideoMode {
 pub struct NativeDisplayMode(pub ffi::CGDisplayModeRef);
 
 unsafe impl Send for NativeDisplayMode {}
+unsafe impl Sync for NativeDisplayMode {}
 
 impl Drop for NativeDisplayMode {
     fn drop(&mut self) {
@@ -294,7 +291,7 @@ impl MonitorHandle {
                     refresh_rate_millihertz,
                     bit_depth,
                     monitor: monitor.clone(),
-                    native_mode: Arc::new(Mutex::new(NativeDisplayMode(mode))),
+                    native_mode: NativeDisplayMode(mode),
                 }
             })
         }

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -142,7 +142,7 @@ impl Canvas {
             super::set_canvas_position(&common.document, &common.raw, &common.style, position);
         }
 
-        if attr.fullscreen.0.is_some() {
+        if attr.fullscreen.is_some() {
             fullscreen::request_fullscreen(&document, &canvas);
         }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -112,6 +112,16 @@ impl Window {
             })
             .ok_or(rwh_06::HandleError::Unavailable)
     }
+
+    #[cfg(feature = "rwh_06")]
+    #[inline]
+    pub(crate) fn raw_display_handle_rwh_06(
+        &self,
+    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
+        Ok(rwh_06::RawDisplayHandle::Web(
+            rwh_06::WebDisplayHandle::new(),
+        ))
+    }
 }
 
 impl Inner {
@@ -398,16 +408,6 @@ impl Inner {
     #[inline]
     pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
         rwh_05::RawDisplayHandle::Web(rwh_05::WebDisplayHandle::empty())
-    }
-
-    #[cfg(feature = "rwh_06")]
-    #[inline]
-    pub fn raw_display_handle_rwh_06(
-        &self,
-    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
-        Ok(rwh_06::RawDisplayHandle::Web(
-            rwh_06::WebDisplayHandle::new(),
-        ))
     }
 
     #[inline]

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1233,8 +1233,8 @@ impl<'a, T: 'static> InitData<'a, T> {
 
         win.set_enabled_buttons(attributes.enabled_buttons);
 
-        if attributes.fullscreen.0.is_some() {
-            win.set_fullscreen(attributes.fullscreen.0.map(Into::into));
+        if attributes.fullscreen.is_some() {
+            win.set_fullscreen(attributes.fullscreen.map(Into::into));
             unsafe { force_window_active(win.window) };
         } else {
             let size = attributes
@@ -1320,7 +1320,7 @@ where
     };
 
     #[cfg(feature = "rwh_06")]
-    let parent = match attributes.parent_window.0 {
+    let parent = match attributes.parent_window.as_ref().map(|handle| handle.0) {
         Some(rwh_06::RawWindowHandle::Win32(handle)) => {
             window_flags.set(WindowFlags::CHILD, true);
             if pl_attribs.menu.is_some() {


### PR DESCRIPTION
I noticed that `SendSyncWrapper` caused some real issues here and there. First #3270 and #3288, then #3297.

Also noticed that we simply used `SendSyncWrapper` on `Fullscreen` inside `WindowBuilder`, but there is a getter that exposes this information to the user, bypassing the `!Sync` on `Fullscreen` on MacOS, depending if this `!Sync` was correct or not, that may have been unsound.

Additionally on Web there was an issue where dropping `WindowBuilder` outside the main thread could cause it to try and drop `HtmlCanvasElement`, which is unsound as well (not entirely sure if that is correct, but it's at least semantically correct).

Additionally implementing `Debug` on `SendSyncWrapper` was unsound as well, because `Debug` could access the inner value off the only thread it was intended to be accessed on. Which was the case for `WindowBuilder` on Web with `HtmlCanvasElement` and the custom wrapper I used for `CustomCursor`.

All in all I would say `SendSyncWrapper` is a footgun and apart from the `RawWindowHandle` v0.4 and v0.5 we didn't even really need it.