### PR TITLE
On Web, add `Window::(set_)prevent_default()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Unreleased` header.
 - **Breaking:** On Web, return `RawWindowHandle::WebCanvas` instead of `RawWindowHandle::Web`.
 - **Breaking:** On Web, macOS and iOS, return `HandleError::Unavailable` when a window handle is not available.
 - **Breaking:** Bump MSRV from `1.65` to `1.70`.
+- On Web, add the ability to toggle calling `Event.preventDefault()` on `Window`.
 
 # 0.29.6
 

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -42,12 +42,35 @@ pub trait WindowExtWebSys {
     /// Only returns the canvas if called from inside the window context (the
     /// main thread).
     fn canvas(&self) -> Option<HtmlCanvasElement>;
+
+    /// Returns [`true`] if calling `event.preventDefault()` is enabled.
+    ///
+    /// See [`Window::set_prevent_default()`] for more details.
+    fn prevent_default(&self) -> bool;
+
+    /// Sets whether `event.preventDefault()` should be called on events on the
+    /// canvas that have side effects.
+    ///
+    /// For example, by default using the mouse wheel would cause the page to scroll, enabling this
+    /// would prevent that.
+    ///
+    /// Some events are impossible to prevent. E.g. Firefox allows to access the native browser
+    /// context menu with Shift+Rightclick.
+    fn set_prevent_default(&self, prevent_default: bool);
 }
 
 impl WindowExtWebSys for Window {
     #[inline]
     fn canvas(&self) -> Option<HtmlCanvasElement> {
         self.window.canvas()
+    }
+
+    fn prevent_default(&self) -> bool {
+        self.window.prevent_default()
+    }
+
+    fn set_prevent_default(&self, prevent_default: bool) {
+        self.window.set_prevent_default(prevent_default)
     }
 }
 
@@ -60,14 +83,10 @@ pub trait WindowBuilderExtWebSys {
     /// [`None`] by default.
     fn with_canvas(self, canvas: Option<HtmlCanvasElement>) -> Self;
 
-    /// Whether `event.preventDefault()` should be called on events on the
+    /// Sets whether `event.preventDefault()` should be called on events on the
     /// canvas that have side effects.
     ///
-    /// For example, by default using the mouse wheel would cause the page to scroll, enabling this
-    /// would prevent that.
-    ///
-    /// Some events are impossible to prevent. E.g. Firefox allows to access the native browser
-    /// context menu with Shift+Rightclick.
+    /// See [`Window::set_prevent_default()`] for more details.
     ///
     /// Enabled by default.
     fn with_prevent_default(self, prevent_default: bool) -> Self;

--- a/src/platform_impl/web/web_sys/pointer.rs
+++ b/src/platform_impl/web/web_sys/pointer.rs
@@ -1,3 +1,6 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
 use super::canvas::Common;
 use super::event;
 use super::event_handle::EventListenerHandle;
@@ -110,7 +113,7 @@ impl PointerHandler {
         mut modifier_handler: MOD,
         mut mouse_handler: M,
         mut touch_handler: T,
-        prevent_default: bool,
+        prevent_default: Rc<Cell<bool>>,
     ) where
         MOD: 'static + FnMut(ModifiersState),
         M: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, MouseButton),
@@ -121,7 +124,7 @@ impl PointerHandler {
         self.on_pointer_press = Some(canvas_common.add_event(
             "pointerdown",
             move |event: PointerEvent| {
-                if prevent_default {
+                if prevent_default.get() {
                     // prevent text selection
                     event.prevent_default();
                     // but still focus element
@@ -165,7 +168,7 @@ impl PointerHandler {
         mut mouse_handler: M,
         mut touch_handler: T,
         mut button_handler: B,
-        prevent_default: bool,
+        prevent_default: Rc<Cell<bool>>,
     ) where
         MOD: 'static + FnMut(ModifiersState),
         M: 'static + FnMut(ModifiersState, i32, &mut dyn Iterator<Item = PhysicalPosition<f64>>),
@@ -197,7 +200,7 @@ impl PointerHandler {
                         "expect pointer type of a chorded button event to be a mouse"
                     );
 
-                    if prevent_default {
+                    if prevent_default.get() {
                         // prevent text selection
                         event.prevent_default();
                         // but still focus element

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -36,8 +36,6 @@ impl Window {
     ) -> Result<Self, RootOE> {
         let id = target.generate_id();
 
-        let prevent_default = platform_attr.prevent_default;
-
         let window = target.runner.window();
         let document = target.runner.document();
         let canvas =
@@ -45,7 +43,7 @@ impl Window {
         let canvas = Rc::new(RefCell::new(canvas));
         let cursor = CursorState::new(canvas.borrow().style().clone());
 
-        target.register(&canvas, id, prevent_default);
+        target.register(&canvas, id);
 
         let runner = target.runner.clone();
         let destroy_fn = Box::new(move || runner.notify_destroy_window(RootWI(id)));
@@ -82,6 +80,16 @@ impl Window {
         self.inner
             .value()
             .map(|inner| inner.canvas.borrow().raw().clone())
+    }
+
+    pub(crate) fn prevent_default(&self) -> bool {
+        self.inner
+            .queue(|inner| inner.canvas.borrow().prevent_default.get())
+    }
+
+    pub(crate) fn set_prevent_default(&self, prevent_default: bool) {
+        self.inner
+            .dispatch(move |inner| inner.canvas.borrow().prevent_default.set(prevent_default))
     }
 
     #[cfg(feature = "rwh_06")]


### PR DESCRIPTION
Current controlling if `Event.preventDefault()` is called or not could only be changed in `WindowBuilder`.
This PR introduces `Window::set_prevent_default()`, so now it can be dynamically adjusted.