### PR TITLE
Remove `extern crate` statements

### DIFF
--- a/src/dpi.rs
+++ b/src/dpi.rs
@@ -104,6 +104,9 @@
 //! [android_1]: https://developer.android.com/training/multiscreen/screendensities
 //! [web_1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub trait Pixel: Copy + Into<f64> {
     fn from_f64(f: f64) -> Self;
     fn cast<P: Pixel>(self) -> P {

--- a/src/event.rs
+++ b/src/event.rs
@@ -37,6 +37,8 @@ use std::sync::{Mutex, Weak};
 #[cfg(not(wasm_platform))]
 use std::time::Instant;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 #[cfg(wasm_platform)]
 use web_time::Instant;

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -69,6 +69,9 @@
 //
 // --------- END OF W3C SHORT NOTICE ---------------------------------------------------------------
 
+use bitflags::bitflags;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 pub use smol_str::SmolStr;
 
 /// Contains the platform-native physical key identifier

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,15 +160,6 @@
 #[cfg(feature = "rwh_06")]
 pub use rwh_06 as raw_window_handle;
 
-#[allow(unused_imports)]
-#[macro_use]
-extern crate log;
-#[cfg(feature = "serde")]
-#[macro_use]
-extern crate serde;
-#[macro_use]
-extern crate bitflags;
-
 pub mod dpi;
 #[macro_use]
 pub mod error;

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -283,7 +283,7 @@ pub enum Idiom {
     CarPlay,
 }
 
-bitflags! {
+bitflags::bitflags! {
     /// The [edges] of a screen.
     ///
     /// [edges]: https://developer.apple.com/documentation/uikit/uirectedge?language=objc

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -2,6 +2,8 @@ use std::os::raw::c_void;
 
 use icrate::Foundation::MainThreadMarker;
 use objc2::rc::Id;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -15,6 +15,7 @@ use android_activity::input::{InputEvent, KeyAction, Keycode, MotionAction};
 use android_activity::{
     AndroidApp, AndroidAppWaker, ConfigurationRef, InputStatus, MainEvent, Rect,
 };
+use log::{debug, trace, warn};
 use once_cell::sync::Lazy;
 
 use crate::{

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -78,7 +78,7 @@ impl<T: 'static> EventLoopWindowTarget<T> {
     pub(crate) fn exit(&self) {
         // https://developer.apple.com/library/archive/qa/qa1561/_index.html
         // it is not possible to quit an iOS app gracefully and programatically
-        warn!("`ControlFlow::Exit` ignored on iOS");
+        log::warn!("`ControlFlow::Exit` ignored on iOS");
     }
 
     pub(crate) fn exiting(&self) -> bool {

--- a/src/platform_impl/ios/uikit/view_controller.rs
+++ b/src/platform_impl/ios/uikit/view_controller.rs
@@ -39,7 +39,7 @@ extern_methods!(
     }
 );
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Clone, Copy)]
     pub struct UIInterfaceOrientationMask: NSUInteger {
         const Portrait = 1 << 1;

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -3,6 +3,7 @@
 use std::collections::VecDeque;
 
 use icrate::Foundation::{CGFloat, CGPoint, CGRect, CGSize, MainThreadBound, MainThreadMarker};
+use log::{debug, warn};
 use objc2::rc::Id;
 use objc2::runtime::AnyObject;
 use objc2::{class, msg_send};

--- a/src/platform_impl/linux/common/xkb_state.rs
+++ b/src/platform_impl/linux/common/xkb_state.rs
@@ -682,7 +682,7 @@ fn byte_slice_to_smol_str(bytes: &[u8]) -> Option<SmolStr> {
     std::str::from_utf8(bytes)
         .map(SmolStr::new)
         .map_err(|e| {
-            warn!(
+            log::warn!(
                 "UTF-8 received from libxkbcommon ({:?}) was invalid: {e}",
                 bytes
             )

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -712,7 +712,7 @@ unsafe extern "C" fn x_error_callback(
 
         // Don't log error.
         if !error_handled {
-            error!("X11 error: {:#?}", error);
+            log::error!("X11 error: {:#?}", error);
             // XXX only update the error, if it wasn't handled by any of the hooks.
             *xconn.latest_error.lock().unwrap() = Some(error);
         }

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -552,7 +552,7 @@ impl<T: 'static> EventLoop<T> {
         };
 
         self.event_loop.dispatch(timeout, state).map_err(|error| {
-            error!("Error dispatching event loop: {}", error);
+            log::error!("Error dispatching event loop: {}", error);
             error.into()
         })
     }

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -135,7 +135,7 @@ impl WinitState {
         ) {
             Ok(c) => Some(c),
             Err(e) => {
-                warn!("Subcompositor protocol not available, ignoring CSD: {e:?}");
+                log::warn!("Subcompositor protocol not available, ignoring CSD: {e:?}");
                 None
             }
         };

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -15,6 +15,8 @@ use sctk::shell::xdg::window::Window as SctkWindow;
 use sctk::shell::xdg::window::WindowDecorations;
 use sctk::shell::WaylandSurface;
 
+use log::warn;
+
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
 use crate::event::{Ime, WindowEvent};

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -86,7 +86,7 @@ extern "C" fn preedit_draw_callback(
     let chg_range =
         call_data.chg_first as usize..(call_data.chg_first + call_data.chg_length) as usize;
     if chg_range.start > client_data.text.len() || chg_range.end > client_data.text.len() {
-        warn!(
+        log::warn!(
             "invalid chg range: buffer length={}, but chg_first={} chg_lengthg={}",
             client_data.text.len(),
             call_data.chg_first,

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -10,6 +10,10 @@ use std::sync::{
     Arc,
 };
 
+use log::debug;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::{ffi, util, XConnection, XError};
 
 pub use self::context::ImeContextCreationError;

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -22,6 +22,7 @@ pub use self::xdisplay::{XError, XNotSupported};
 use calloop::generic::Generic;
 use calloop::EventLoop as Loop;
 use calloop::{ping::Ping, Readiness};
+use log::warn;
 
 use std::{
     cell::{Cell, RefCell},

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -1,5 +1,8 @@
 use std::sync::Arc;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 use super::*;
 
 #[derive(Debug)]

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -45,7 +45,7 @@ impl XConnection {
             self.flush_requests()?;
             Ok(true)
         } else {
-            error!("Could not select XKB events: The XKB extension is not initialized!");
+            log::error!("Could not select XKB events: The XKB extension is not initialized!");
             Ok(false)
         }
     }

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -4,6 +4,7 @@ use super::*;
 use crate::platform_impl::platform::x11::monitor;
 use crate::{dpi::validate_scale_factor, platform_impl::platform::x11::VideoMode};
 
+use log::warn;
 use x11rb::protocol::randr::{self, ConnectionExt as _};
 
 /// Represents values of `WINIT_HIDPI_FACTOR`.

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -7,6 +7,7 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
+use log::{debug, info, warn};
 use x11rb::{
     connection::Connection,
     properties::{WmHints, WmHintsState, WmSizeHints, WmSizeHintsSpecification},

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -14,6 +14,7 @@ use std::{
 use core_foundation::runloop::{CFRunLoopGetMain, CFRunLoopWakeUp};
 use icrate::AppKit::{NSApplication, NSApplicationActivationPolicy};
 use icrate::Foundation::{is_main_thread, MainThreadMarker, NSSize};
+use log::trace;
 use objc2::rc::{autoreleasepool, Id};
 use once_cell::sync::Lazy;
 

--- a/src/platform_impl/macos/cursor.rs
+++ b/src/platform_impl/macos/cursor.rs
@@ -74,7 +74,7 @@ unsafe fn try_cursor_from_selector(sel: Sel) -> Option<Id<NSCursor>> {
         let cursor: Id<NSCursor> = unsafe { msg_send_id![cls, performSelector: sel] };
         Some(cursor)
     } else {
-        warn!("cursor `{sel}` appears to be invalid");
+        log::warn!("cursor `{sel}` appears to be invalid");
         None
     }
 }

--- a/src/platform_impl/macos/util.rs
+++ b/src/platform_impl/macos/util.rs
@@ -1,4 +1,5 @@
 use icrate::Foundation::{NSNotFound, NSRange, NSUInteger};
+use log::trace;
 
 // Replace with `!` once stable
 #[derive(Debug)]

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -73,7 +73,7 @@ enum ImeState {
     Commited,
 }
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq)]
     struct ModLocationMask: u8 {
         const LEFT     = 0b0001;
@@ -338,7 +338,7 @@ declare_class!(
                 // Leave the Preedit self.ivars()
                 self.ivars().ime_state.set(ImeState::Ground);
             } else {
-                warn!("Expected to have IME enabled when receiving unmarkText");
+                log::warn!("Expected to have IME enabled when receiving unmarkText");
             }
         }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -46,6 +46,7 @@ use icrate::Foundation::{
     CGFloat, MainThreadBound, MainThreadMarker, NSArray, NSCopying, NSObject, NSPoint, NSRect,
     NSSize, NSString,
 };
+use log::trace;
 use objc2::rc::{autoreleasepool, Id};
 use objc2::{declare_class, msg_send, msg_send_id, mutability, sel, ClassType, DeclaredClass};
 

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -7,6 +7,7 @@ use std::{
     time::Instant,
 };
 
+use bitflags::bitflags;
 use orbclient::{
     ButtonEvent, EventOption, FocusEvent, HoverEvent, KeyEvent, MouseEvent, MoveEvent, QuitEvent,
     ResizeEvent, ScrollEvent, TextInputEvent,
@@ -459,7 +460,7 @@ impl<T: 'static> EventLoop<T> {
                 }
             }
             other => {
-                warn!("unhandled event: {:?}", other);
+                log::warn!("unhandled event: {:?}", other);
             }
         }
     }

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -9,7 +9,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{KeyboardEvent, MouseEvent, PointerEvent, WheelEvent};
 
-bitflags! {
+bitflags::bitflags! {
     // https://www.w3.org/TR/pointerevents3/#the-buttons-property
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct ButtonsState: u16 {
@@ -178,7 +178,7 @@ pub fn key_location(event: &KeyboardEvent) -> KeyLocation {
         KeyboardEvent::DOM_KEY_LOCATION_NUMPAD => KeyLocation::Numpad,
         KeyboardEvent::DOM_KEY_LOCATION_STANDARD => KeyLocation::Standard,
         location => {
-            warn!("Unexpected key location: {location}");
+            log::warn!("Unexpected key location: {location}");
             KeyLocation::Standard
         }
     }

--- a/src/platform_impl/web/web_sys/resize_scaling.rs
+++ b/src/platform_impl/web/web_sys/resize_scaling.rs
@@ -1,4 +1,5 @@
 use js_sys::{Array, Object};
+use log::warn;
 use wasm_bindgen::prelude::{wasm_bindgen, Closure};
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -18,6 +18,8 @@ use windows_sys::{
     },
 };
 
+use log::debug;
+
 use crate::platform_impl::platform::{
     definitions::{IDataObjectVtbl, IDropTarget, IDropTargetVtbl, IUnknownVtbl},
     WindowId,

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -32,6 +32,7 @@ use windows_sys::Win32::{
     },
 };
 
+use log::{trace, warn};
 use smol_str::SmolStr;
 use unicode_segmentation::UnicodeSegmentation;
 

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -104,7 +104,7 @@ static NUMPAD_KEYCODES: Lazy<HashSet<KeyCode>> = Lazy::new(|| {
     keycodes
 });
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Clone, Copy, PartialEq, Eq, Hash)]
     pub struct WindowsModifiers : u8 {
         const SHIFT = 1 << 0;

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -54,6 +54,8 @@ use windows_sys::Win32::{
     },
 };
 
+use log::warn;
+
 use crate::{
     cursor::Cursor,
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -5,6 +5,7 @@ use crate::{
     platform_impl::platform::{event_loop, util, Fullscreen, SelectedCursor},
     window::{Theme, WindowAttributes},
 };
+use bitflags::bitflags;
 use std::io;
 use std::sync::MutexGuard;
 use windows_sys::Win32::{

--- a/src/window.rs
+++ b/src/window.rs
@@ -14,6 +14,8 @@ pub use crate::icon::{BadIcon, Icon};
 
 #[doc(inline)]
 pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 /// Represents a window.
 ///
@@ -1674,7 +1676,7 @@ pub enum UserAttentionType {
     Informational,
 }
 
-bitflags! {
+bitflags::bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
     pub struct WindowButtons: u32 {
         const CLOSE  = 1 << 0;


### PR DESCRIPTION
This was phased out in the 2018 edition for better hygiene, see [The Rust Edition Guide](https://doc.rust-lang.org/edition-guide/rust-2018/path-changes.html#no-more-extern-crate).