### PR TITLE
Move `PlatformSpecificWindowBuilderAttributes` into `WindowAttributes`

### DIFF
--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -217,38 +217,39 @@ pub trait WindowBuilderExtIOS {
 impl WindowBuilderExtIOS for WindowBuilder {
     #[inline]
     fn with_scale_factor(mut self, scale_factor: f64) -> Self {
-        self.platform_specific.scale_factor = Some(scale_factor);
+        self.window.platform_specific.scale_factor = Some(scale_factor);
         self
     }
 
     #[inline]
     fn with_valid_orientations(mut self, valid_orientations: ValidOrientations) -> Self {
-        self.platform_specific.valid_orientations = valid_orientations;
+        self.window.platform_specific.valid_orientations = valid_orientations;
         self
     }
 
     #[inline]
     fn with_prefers_home_indicator_hidden(mut self, hidden: bool) -> Self {
-        self.platform_specific.prefers_home_indicator_hidden = hidden;
+        self.window.platform_specific.prefers_home_indicator_hidden = hidden;
         self
     }
 
     #[inline]
     fn with_preferred_screen_edges_deferring_system_gestures(mut self, edges: ScreenEdge) -> Self {
-        self.platform_specific
+        self.window
+            .platform_specific
             .preferred_screen_edges_deferring_system_gestures = edges;
         self
     }
 
     #[inline]
     fn with_prefers_status_bar_hidden(mut self, hidden: bool) -> Self {
-        self.platform_specific.prefers_status_bar_hidden = hidden;
+        self.window.platform_specific.prefers_status_bar_hidden = hidden;
         self
     }
 
     #[inline]
     fn with_preferred_status_bar_style(mut self, status_bar_style: StatusBarStyle) -> Self {
-        self.platform_specific.preferred_status_bar_style = status_bar_style;
+        self.window.platform_specific.preferred_status_bar_style = status_bar_style;
         self
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -212,61 +212,62 @@ pub trait WindowBuilderExtMacOS {
 impl WindowBuilderExtMacOS for WindowBuilder {
     #[inline]
     fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> Self {
-        self.platform_specific.movable_by_window_background = movable_by_window_background;
+        self.window.platform_specific.movable_by_window_background = movable_by_window_background;
         self
     }
 
     #[inline]
     fn with_titlebar_transparent(mut self, titlebar_transparent: bool) -> Self {
-        self.platform_specific.titlebar_transparent = titlebar_transparent;
+        self.window.platform_specific.titlebar_transparent = titlebar_transparent;
         self
     }
 
     #[inline]
     fn with_titlebar_hidden(mut self, titlebar_hidden: bool) -> Self {
-        self.platform_specific.titlebar_hidden = titlebar_hidden;
+        self.window.platform_specific.titlebar_hidden = titlebar_hidden;
         self
     }
 
     #[inline]
     fn with_titlebar_buttons_hidden(mut self, titlebar_buttons_hidden: bool) -> Self {
-        self.platform_specific.titlebar_buttons_hidden = titlebar_buttons_hidden;
+        self.window.platform_specific.titlebar_buttons_hidden = titlebar_buttons_hidden;
         self
     }
 
     #[inline]
     fn with_title_hidden(mut self, title_hidden: bool) -> Self {
-        self.platform_specific.title_hidden = title_hidden;
+        self.window.platform_specific.title_hidden = title_hidden;
         self
     }
 
     #[inline]
     fn with_fullsize_content_view(mut self, fullsize_content_view: bool) -> Self {
-        self.platform_specific.fullsize_content_view = fullsize_content_view;
+        self.window.platform_specific.fullsize_content_view = fullsize_content_view;
         self
     }
 
     #[inline]
     fn with_disallow_hidpi(mut self, disallow_hidpi: bool) -> Self {
-        self.platform_specific.disallow_hidpi = disallow_hidpi;
+        self.window.platform_specific.disallow_hidpi = disallow_hidpi;
         self
     }
 
     #[inline]
     fn with_has_shadow(mut self, has_shadow: bool) -> Self {
-        self.platform_specific.has_shadow = has_shadow;
+        self.window.platform_specific.has_shadow = has_shadow;
         self
     }
 
     #[inline]
     fn with_accepts_first_mouse(mut self, accepts_first_mouse: bool) -> Self {
-        self.platform_specific.accepts_first_mouse = accepts_first_mouse;
+        self.window.platform_specific.accepts_first_mouse = accepts_first_mouse;
         self
     }
 
     #[inline]
     fn with_tabbing_identifier(mut self, tabbing_identifier: &str) -> Self {
-        self.platform_specific
+        self.window
+            .platform_specific
             .tabbing_identifier
             .replace(tabbing_identifier.to_string());
         self
@@ -274,7 +275,7 @@ impl WindowBuilderExtMacOS for WindowBuilder {
 
     #[inline]
     fn with_option_as_alt(mut self, option_as_alt: OptionAsAlt) -> Self {
-        self.platform_specific.option_as_alt = option_as_alt;
+        self.window.platform_specific.option_as_alt = option_as_alt;
         self
     }
 }

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -76,7 +76,7 @@ impl WindowExtStartupNotify for Window {
 
 impl WindowBuilderExtStartupNotify for WindowBuilder {
     fn with_activation_token(mut self, token: ActivationToken) -> Self {
-        self.platform_specific.activation_token = Some(token);
+        self.window.platform_specific.activation_token = Some(token);
         self
     }
 }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -65,7 +65,7 @@ pub trait WindowBuilderExtWayland {
 impl WindowBuilderExtWayland for WindowBuilder {
     #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
-        self.platform_specific.name = Some(crate::platform_impl::ApplicationName::new(
+        self.window.platform_specific.name = Some(crate::platform_impl::ApplicationName::new(
             general.into(),
             instance.into(),
         ));

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -121,22 +121,22 @@ pub trait WindowBuilderExtWebSys {
 
 impl WindowBuilderExtWebSys for WindowBuilder {
     fn with_canvas(mut self, canvas: Option<HtmlCanvasElement>) -> Self {
-        self.platform_specific.set_canvas(canvas);
+        self.window.platform_specific.set_canvas(canvas);
         self
     }
 
     fn with_prevent_default(mut self, prevent_default: bool) -> Self {
-        self.platform_specific.prevent_default = prevent_default;
+        self.window.platform_specific.prevent_default = prevent_default;
         self
     }
 
     fn with_focusable(mut self, focusable: bool) -> Self {
-        self.platform_specific.focusable = focusable;
+        self.window.platform_specific.focusable = focusable;
         self
     }
 
     fn with_append(mut self, append: bool) -> Self {
-        self.platform_specific.append = append;
+        self.window.platform_specific.append = append;
         self
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -222,49 +222,49 @@ pub trait WindowBuilderExtWindows {
 impl WindowBuilderExtWindows for WindowBuilder {
     #[inline]
     fn with_owner_window(mut self, parent: HWND) -> Self {
-        self.platform_specific.owner = Some(parent);
+        self.window.platform_specific.owner = Some(parent);
         self
     }
 
     #[inline]
     fn with_menu(mut self, menu: HMENU) -> Self {
-        self.platform_specific.menu = Some(menu);
+        self.window.platform_specific.menu = Some(menu);
         self
     }
 
     #[inline]
     fn with_taskbar_icon(mut self, taskbar_icon: Option<Icon>) -> Self {
-        self.platform_specific.taskbar_icon = taskbar_icon;
+        self.window.platform_specific.taskbar_icon = taskbar_icon;
         self
     }
 
     #[inline]
     fn with_no_redirection_bitmap(mut self, flag: bool) -> Self {
-        self.platform_specific.no_redirection_bitmap = flag;
+        self.window.platform_specific.no_redirection_bitmap = flag;
         self
     }
 
     #[inline]
     fn with_drag_and_drop(mut self, flag: bool) -> Self {
-        self.platform_specific.drag_and_drop = flag;
+        self.window.platform_specific.drag_and_drop = flag;
         self
     }
 
     #[inline]
     fn with_skip_taskbar(mut self, skip: bool) -> Self {
-        self.platform_specific.skip_taskbar = skip;
+        self.window.platform_specific.skip_taskbar = skip;
         self
     }
 
     #[inline]
     fn with_class_name<S: Into<String>>(mut self, class_name: S) -> Self {
-        self.platform_specific.class_name = class_name.into();
+        self.window.platform_specific.class_name = class_name.into();
         self
     }
 
     #[inline]
     fn with_undecorated_shadow(mut self, shadow: bool) -> Self {
-        self.platform_specific.decoration_shadow = shadow;
+        self.window.platform_specific.decoration_shadow = shadow;
         self
     }
 }

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -190,19 +190,19 @@ pub trait WindowBuilderExtX11 {
 impl WindowBuilderExtX11 for WindowBuilder {
     #[inline]
     fn with_x11_visual(mut self, visual_id: XVisualID) -> Self {
-        self.platform_specific.x11.visual_id = Some(visual_id);
+        self.window.platform_specific.x11.visual_id = Some(visual_id);
         self
     }
 
     #[inline]
     fn with_x11_screen(mut self, screen_id: i32) -> Self {
-        self.platform_specific.x11.screen_id = Some(screen_id);
+        self.window.platform_specific.x11.screen_id = Some(screen_id);
         self
     }
 
     #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
-        self.platform_specific.name = Some(crate::platform_impl::ApplicationName::new(
+        self.window.platform_specific.name = Some(crate::platform_impl::ApplicationName::new(
             general.into(),
             instance.into(),
         ));
@@ -211,25 +211,25 @@ impl WindowBuilderExtX11 for WindowBuilder {
 
     #[inline]
     fn with_override_redirect(mut self, override_redirect: bool) -> Self {
-        self.platform_specific.x11.override_redirect = override_redirect;
+        self.window.platform_specific.x11.override_redirect = override_redirect;
         self
     }
 
     #[inline]
     fn with_x11_window_type(mut self, x11_window_types: Vec<WindowType>) -> Self {
-        self.platform_specific.x11.x11_window_types = x11_window_types;
+        self.window.platform_specific.x11.x11_window_types = x11_window_types;
         self
     }
 
     #[inline]
     fn with_base_size<S: Into<Size>>(mut self, base_size: S) -> Self {
-        self.platform_specific.x11.base_size = Some(base_size.into());
+        self.window.platform_specific.x11.base_size = Some(base_size.into());
         self
     }
 
     #[inline]
     fn with_embed_parent_window(mut self, parent_window_id: XWindow) -> Self {
-        self.platform_specific.x11.embed_window = Some(parent_window_id);
+        self.window.platform_specific.x11.embed_window = Some(parent_window_id);
         self
     }
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -788,7 +788,6 @@ impl Window {
     pub(crate) fn new(
         el: &EventLoopWindowTarget,
         _window_attrs: window::WindowAttributes,
-        _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {
         // FIXME this ignores requested window attributes
 

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -22,7 +22,6 @@ use crate::{
     platform::ios::ValidOrientations,
     platform_impl::platform::{
         ffi::{UIRectEdge, UIUserInterfaceIdiom},
-        window::PlatformSpecificWindowBuilderAttributes,
         Fullscreen, DEVICE_ID,
     },
     window::{WindowAttributes, WindowId as RootWindowId},
@@ -264,8 +263,7 @@ extern_methods!(
 impl WinitView {
     pub(crate) fn new(
         _mtm: MainThreadMarker,
-        _window_attributes: &WindowAttributes,
-        platform_attributes: &PlatformSpecificWindowBuilderAttributes,
+        window_attributes: &WindowAttributes,
         frame: CGRect,
     ) -> Id<Self> {
         let this = Self::alloc().set_ivars(WinitViewState {
@@ -277,7 +275,7 @@ impl WinitView {
 
         this.setMultipleTouchEnabled(true);
 
-        if let Some(scale_factor) = platform_attributes.scale_factor {
+        if let Some(scale_factor) = window_attributes.platform_specific.scale_factor {
             this.setContentScaleFactor(scale_factor as _);
         }
 
@@ -515,8 +513,7 @@ impl WinitViewController {
 
     pub(crate) fn new(
         mtm: MainThreadMarker,
-        _window_attributes: &WindowAttributes,
-        platform_attributes: &PlatformSpecificWindowBuilderAttributes,
+        window_attributes: &WindowAttributes,
         view: &UIView,
     ) -> Id<Self> {
         // These are set properly below, we just to set them to something in the meantime.
@@ -529,18 +526,33 @@ impl WinitViewController {
         });
         let this: Id<Self> = unsafe { msg_send_id![super(this), init] };
 
-        this.set_prefers_status_bar_hidden(platform_attributes.prefers_status_bar_hidden);
+        this.set_prefers_status_bar_hidden(
+            window_attributes
+                .platform_specific
+                .prefers_status_bar_hidden,
+        );
 
-        this.set_preferred_status_bar_style(platform_attributes.preferred_status_bar_style.into());
+        this.set_preferred_status_bar_style(
+            window_attributes
+                .platform_specific
+                .preferred_status_bar_style
+                .into(),
+        );
 
-        this.set_supported_interface_orientations(mtm, platform_attributes.valid_orientations);
+        this.set_supported_interface_orientations(
+            mtm,
+            window_attributes.platform_specific.valid_orientations,
+        );
 
         this.set_prefers_home_indicator_auto_hidden(
-            platform_attributes.prefers_home_indicator_hidden,
+            window_attributes
+                .platform_specific
+                .prefers_home_indicator_hidden,
         );
 
         this.set_preferred_screen_edges_deferring_system_gestures(
-            platform_attributes
+            window_attributes
+                .platform_specific
                 .preferred_screen_edges_deferring_system_gestures
                 .into(),
         );
@@ -597,7 +609,6 @@ impl WinitUIWindow {
     pub(crate) fn new(
         mtm: MainThreadMarker,
         window_attributes: &WindowAttributes,
-        _platform_attributes: &PlatformSpecificWindowBuilderAttributes,
         frame: CGRect,
         view_controller: &UIViewController,
     ) -> Id<Self> {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -401,7 +401,6 @@ impl Window {
     pub(crate) fn new(
         event_loop: &EventLoopWindowTarget,
         window_attributes: WindowAttributes,
-        platform_attributes: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, RootOsError> {
         let mtm = event_loop.mtm;
 
@@ -439,7 +438,7 @@ impl Window {
             None => screen_bounds,
         };
 
-        let view = WinitView::new(mtm, &window_attributes, &platform_attributes, frame);
+        let view = WinitView::new(mtm, &window_attributes, frame);
 
         let gl_or_metal_backed = unsafe {
             let layer_class = WinitView::layerClass();
@@ -448,15 +447,8 @@ impl Window {
             is_metal || is_gl
         };
 
-        let view_controller =
-            WinitViewController::new(mtm, &window_attributes, &platform_attributes, &view);
-        let window = WinitUIWindow::new(
-            mtm,
-            &window_attributes,
-            &platform_attributes,
-            frame,
-            &view_controller,
-        );
+        let view_controller = WinitViewController::new(mtm, &window_attributes, &view);
+        let window = WinitUIWindow::new(mtm, &window_attributes, frame, &view_controller);
 
         app_state::set_key_window(mtm, &window);
 
@@ -685,7 +677,7 @@ impl From<&AnyObject> for WindowId {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub scale_factor: Option<f64>,
     pub valid_orientations: ValidOrientations,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -71,7 +71,7 @@ impl ApplicationName {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub name: Option<ApplicationName>,
     pub activation_token: Option<ActivationToken>,
@@ -79,7 +79,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub x11: X11WindowBuilderAttributes,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg(x11_platform)]
 pub struct X11WindowBuilderAttributes {
     pub visual_id: Option<x11rb::protocol::xproto::Visualid>,
@@ -288,16 +288,15 @@ impl Window {
     pub(crate) fn new(
         window_target: &EventLoopWindowTarget,
         attribs: WindowAttributes,
-        pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
         match *window_target {
             #[cfg(wayland_platform)]
             EventLoopWindowTarget::Wayland(ref window_target) => {
-                wayland::Window::new(window_target, attribs, pl_attribs).map(Window::Wayland)
+                wayland::Window::new(window_target, attribs).map(Window::Wayland)
             }
             #[cfg(x11_platform)]
             EventLoopWindowTarget::X(ref window_target) => {
-                x11::Window::new(window_target, attribs, pl_attribs).map(Window::X)
+                x11::Window::new(window_target, attribs).map(Window::X)
             }
         }
     }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -23,7 +23,6 @@ use crate::event::{Ime, WindowEvent};
 use crate::event_loop::AsyncRequestSerial;
 use crate::platform_impl::{
     Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError, PlatformIcon,
-    PlatformSpecificWindowBuilderAttributes as PlatformAttributes,
 };
 use crate::window::{
     Cursor, CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType,
@@ -84,7 +83,6 @@ impl Window {
     pub(crate) fn new(
         event_loop_window_target: &EventLoopWindowTarget,
         attributes: WindowAttributes,
-        platform_attributes: PlatformAttributes,
     ) -> Result<Self, RootOsError> {
         let queue_handle = event_loop_window_target.queue_handle.clone();
         let mut state = event_loop_window_target.state.borrow_mut();
@@ -134,7 +132,7 @@ impl Window {
         window_state.set_decorate(attributes.decorations);
 
         // Set the app_id.
-        if let Some(name) = platform_attributes.name.map(|name| name.general) {
+        if let Some(name) = attributes.platform_specific.name.map(|name| name.general) {
             window.set_app_id(name);
         }
 
@@ -177,7 +175,7 @@ impl Window {
         // Activate the window when the token is passed.
         if let (Some(xdg_activation), Some(token)) = (
             xdg_activation.as_ref(),
-            platform_attributes.activation_token,
+            attributes.platform_specific.activation_token,
         ) {
             xdg_activation.activate(token._token, &surface);
         }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -72,10 +72,7 @@ use crate::{
     event::{Event, StartCause, WindowEvent},
     event_loop::{DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
     platform::pump_events::PumpStatus,
-    platform_impl::{
-        platform::{min_timeout, WindowId},
-        PlatformSpecificWindowBuilderAttributes,
-    },
+    platform_impl::platform::{min_timeout, WindowId},
     window::WindowAttributes,
 };
 
@@ -843,9 +840,8 @@ impl Window {
     pub(crate) fn new(
         event_loop: &EventLoopWindowTarget,
         attribs: WindowAttributes,
-        pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
-        let window = Arc::new(UnownedWindow::new(event_loop, attribs, pl_attribs)?);
+        let window = Arc::new(UnownedWindow::new(event_loop, attribs)?);
         event_loop
             .windows
             .borrow_mut()

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -33,8 +33,7 @@ use crate::{
             X11Error,
         },
         Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError, PlatformCustomCursor,
-        PlatformIcon, PlatformSpecificWindowBuilderAttributes,
-        VideoModeHandle as PlatformVideoModeHandle,
+        PlatformIcon, VideoModeHandle as PlatformVideoModeHandle,
     },
     window::{
         CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
@@ -156,7 +155,6 @@ impl UnownedWindow {
     pub(crate) fn new(
         event_loop: &EventLoopWindowTarget,
         window_attrs: WindowAttributes,
-        pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<UnownedWindow, RootOsError> {
         let xconn = &event_loop.xconn;
         let atoms = xconn.atoms();
@@ -229,7 +227,7 @@ impl UnownedWindow {
             dimensions
         };
 
-        let screen_id = match pl_attribs.x11.screen_id {
+        let screen_id = match window_attrs.platform_specific.x11.screen_id {
             Some(id) => id,
             None => xconn.default_screen_index() as c_int,
         };
@@ -249,7 +247,11 @@ impl UnownedWindow {
             });
 
         // creating
-        let (visualtype, depth, require_colormap) = match pl_attribs.x11.visual_id {
+        let (visualtype, depth, require_colormap) = match window_attrs
+            .platform_specific
+            .x11
+            .visual_id
+        {
             Some(vi) => {
                 // Find this specific visual.
                 let (visualtype, depth) = all_visuals
@@ -291,12 +293,12 @@ impl UnownedWindow {
 
             aux = aux.event_mask(event_mask).border_pixel(0);
 
-            if pl_attribs.x11.override_redirect {
+            if window_attrs.platform_specific.x11.override_redirect {
                 aux = aux.override_redirect(true as u32);
             }
 
             // Add a colormap if needed.
-            let colormap_visual = match pl_attribs.x11.visual_id {
+            let colormap_visual = match window_attrs.platform_specific.x11.visual_id {
                 Some(vi) => Some(vi),
                 None if require_colormap => Some(visual),
                 _ => None,
@@ -319,7 +321,11 @@ impl UnownedWindow {
         };
 
         // Figure out the window's parent.
-        let parent = pl_attribs.x11.embed_window.unwrap_or(root);
+        let parent = window_attrs
+            .platform_specific
+            .x11
+            .embed_window
+            .unwrap_or(root);
 
         // finally creating the window
         let xwindow = {
@@ -381,7 +387,7 @@ impl UnownedWindow {
         }
 
         // Embed the window if needed.
-        if pl_attribs.x11.embed_window.is_some() {
+        if window_attrs.platform_specific.x11.embed_window.is_some() {
             window.embed_window()?;
         }
 
@@ -402,7 +408,7 @@ impl UnownedWindow {
 
             // WM_CLASS must be set *before* mapping the window, as per ICCCM!
             {
-                let (class, instance) = if let Some(name) = pl_attribs.name {
+                let (class, instance) = if let Some(name) = window_attrs.platform_specific.name {
                     (name.instance, name.general)
                 } else {
                     let class = env::args_os()
@@ -435,7 +441,8 @@ impl UnownedWindow {
                 flusher.ignore_error()
             }
 
-            leap!(window.set_window_types(pl_attribs.x11.x11_window_types)).ignore_error();
+            leap!(window.set_window_types(window_attrs.platform_specific.x11.x11_window_types))
+                .ignore_error();
 
             // Set size hints.
             let mut min_inner_size = window_attrs
@@ -458,7 +465,7 @@ impl UnownedWindow {
             shared_state.min_inner_size = min_inner_size.map(Into::into);
             shared_state.max_inner_size = max_inner_size.map(Into::into);
             shared_state.resize_increments = window_attrs.resize_increments;
-            shared_state.base_size = pl_attribs.x11.base_size;
+            shared_state.base_size = window_attrs.platform_specific.x11.base_size;
 
             let normal_hints = WmSizeHints {
                 position: position.map(|PhysicalPosition { x, y }| {
@@ -474,7 +481,8 @@ impl UnownedWindow {
                 size_increment: window_attrs
                     .resize_increments
                     .map(|size| cast_size_to_hint(size, scale_factor)),
-                base_size: pl_attribs
+                base_size: window_attrs
+                    .platform_specific
                     .x11
                     .base_size
                     .map(|size| cast_size_to_hint(size, scale_factor)),
@@ -580,7 +588,7 @@ impl UnownedWindow {
         window.set_cursor(window_attrs.cursor);
 
         // Remove the startup notification if we have one.
-        if let Some(startup) = pl_attribs.activation_token.as_ref() {
+        if let Some(startup) = window_attrs.platform_specific.activation_token.as_ref() {
             leap!(xconn.remove_activation_token(xwindow, &startup._token));
         }
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -7,7 +7,6 @@ use objc2::{declare_class, mutability, ClassType, DeclaredClass};
 
 use super::event_loop::EventLoopWindowTarget;
 use super::window_delegate::WindowDelegate;
-use super::PlatformSpecificWindowBuilderAttributes;
 use crate::error::OsError as RootOsError;
 use crate::window::WindowAttributes;
 
@@ -28,10 +27,9 @@ impl Window {
     pub(crate) fn new(
         window_target: &EventLoopWindowTarget,
         attributes: WindowAttributes,
-        pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
         let mtm = window_target.mtm;
-        let delegate = autoreleasepool(|_| WindowDelegate::new(attributes, pl_attribs, mtm))?;
+        let delegate = autoreleasepool(|_| WindowDelegate::new(attributes, mtm))?;
         Ok(Window {
             window: MainThreadBound::new(delegate.window().retain(), mtm),
             delegate: MainThreadBound::new(delegate, mtm),

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -13,8 +13,7 @@ use crate::{
 };
 
 use super::{
-    EventLoopWindowTarget, MonitorHandle, PlatformSpecificWindowBuilderAttributes, RedoxSocket,
-    TimeSocket, WindowId, WindowProperties,
+    EventLoopWindowTarget, MonitorHandle, RedoxSocket, TimeSocket, WindowId, WindowProperties,
 };
 
 // These values match the values uses in the `window_new` function in orbital:
@@ -37,7 +36,6 @@ impl Window {
     pub(crate) fn new(
         el: &EventLoopWindowTarget,
         attrs: window::WindowAttributes,
-        _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {
         let scale = MonitorHandle.scale_factor();
 

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -14,7 +14,7 @@ use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
 use crate::event::{Force, InnerSizeWriter, MouseButton, MouseScrollDelta};
 use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
-use crate::platform_impl::{OsError, PlatformSpecificWindowBuilderAttributes};
+use crate::platform_impl::OsError;
 use crate::window::{WindowAttributes, WindowId as RootWindowId};
 
 use super::super::cursor::CursorHandler;
@@ -73,10 +73,9 @@ impl Canvas {
         id: WindowId,
         window: web_sys::Window,
         document: Document,
-        attr: &WindowAttributes,
-        mut platform_attr: PlatformSpecificWindowBuilderAttributes,
+        attr: &mut WindowAttributes,
     ) -> Result<Self, RootOE> {
-        let canvas = match platform_attr.canvas.take().map(|canvas| {
+        let canvas = match attr.platform_specific.canvas.take().map(|canvas| {
             Arc::try_unwrap(canvas)
                 .map(|canvas| canvas.into_inner(main_thread))
                 .unwrap_or_else(|canvas| canvas.get(main_thread).clone())
@@ -88,7 +87,7 @@ impl Canvas {
                 .unchecked_into(),
         };
 
-        if platform_attr.append && !document.contains(Some(&canvas)) {
+        if attr.platform_specific.append && !document.contains(Some(&canvas)) {
             document
                 .body()
                 .expect("Failed to get body from document")
@@ -101,7 +100,7 @@ impl Canvas {
         // sequential keyboard navigation, but its order is defined by the
         // document's source order.
         // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
-        if platform_attr.focusable {
+        if attr.platform_specific.focusable {
             canvas
                 .set_attribute("tabindex", "0")
                 .map_err(|_| os_error!(OsError("Failed to set a tabindex".to_owned())))?;
@@ -152,7 +151,7 @@ impl Canvas {
             common,
             id,
             has_focus: Rc::new(Cell::new(false)),
-            prevent_default: Rc::new(Cell::new(platform_attr.prevent_default)),
+            prevent_default: Rc::new(Cell::new(attr.platform_specific.prevent_default)),
             is_intersecting: None,
             on_touch_start: None,
             on_blur: None,

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -30,8 +30,7 @@ pub struct Inner {
 impl Window {
     pub(crate) fn new(
         target: &EventLoopWindowTarget,
-        attr: WindowAttributes,
-        platform_attr: PlatformSpecificWindowBuilderAttributes,
+        mut attr: WindowAttributes,
     ) -> Result<Self, RootOE> {
         let id = target.generate_id();
 
@@ -42,8 +41,7 @@ impl Window {
             id,
             window.clone(),
             document.clone(),
-            &attr,
-            platform_attr,
+            &mut attr,
         )?;
         let canvas = Rc::new(RefCell::new(canvas));
 
@@ -467,7 +465,7 @@ impl From<u64> for WindowId {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub(crate) canvas: Option<Arc<MainThreadSafe<backend::RawCanvasType>>>,
     pub(crate) prevent_default: bool,

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -26,7 +26,7 @@ use crate::event::DeviceId as RootDeviceId;
 use crate::icon::Icon;
 use crate::keyboard::Key;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub owner: Option<HWND>,
     pub menu: Option<HMENU>,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -75,7 +75,7 @@ use crate::{
         monitor::{self, MonitorHandle},
         util,
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
-        Fullscreen, PlatformSpecificWindowBuilderAttributes, SelectedCursor, WindowId,
+        Fullscreen, SelectedCursor, WindowId,
     },
     window::{
         CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
@@ -99,13 +99,12 @@ impl Window {
     pub(crate) fn new(
         event_loop: &EventLoopWindowTarget,
         w_attr: WindowAttributes,
-        pl_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, RootOsError> {
         // We dispatch an `init` function because of code style.
         // First person to remove the need for cloning here gets a cookie!
         //
         // done. you owe me -- ossi
-        unsafe { init(w_attr, pl_attr, event_loop) }
+        unsafe { init(w_attr, event_loop) }
     }
 
     pub(crate) fn maybe_queue_on_main(&self, f: impl FnOnce(&Self) + Send + 'static) {
@@ -1078,7 +1077,6 @@ pub(super) struct InitData<'a> {
     // inputs
     pub event_loop: &'a EventLoopWindowTarget,
     pub attributes: WindowAttributes,
-    pub pl_attribs: PlatformSpecificWindowBuilderAttributes,
     pub window_flags: WindowFlags,
     // outputs
     pub window: Option<Window>,
@@ -1128,7 +1126,7 @@ impl<'a> InitData<'a> {
     }
 
     unsafe fn create_window_data(&self, win: &Window) -> event_loop::WindowData {
-        let file_drop_handler = if self.pl_attribs.drag_and_drop {
+        let file_drop_handler = if self.attributes.platform_specific.drag_and_drop {
             let ole_init_result = unsafe { OleInitialize(ptr::null_mut()) };
             // It is ok if the initialize result is `S_FALSE` because it might happen that
             // multiple windows are created on the same thread.
@@ -1195,7 +1193,7 @@ impl<'a> InitData<'a> {
         let win = self.window.as_mut().expect("failed window creation");
 
         // making the window transparent
-        if self.attributes.transparent && !self.pl_attribs.no_redirection_bitmap {
+        if self.attributes.transparent && !self.attributes.platform_specific.no_redirection_bitmap {
             // Empty region for the blur effect, so the window is fully transparent
             let region = unsafe { CreateRectRgn(0, 0, -1, -1) };
 
@@ -1215,9 +1213,9 @@ impl<'a> InitData<'a> {
             unsafe { DeleteObject(region) };
         }
 
-        win.set_skip_taskbar(self.pl_attribs.skip_taskbar);
+        win.set_skip_taskbar(self.attributes.platform_specific.skip_taskbar);
         win.set_window_icon(self.attributes.window_icon.clone());
-        win.set_taskbar_icon(self.pl_attribs.taskbar_icon.clone());
+        win.set_taskbar_icon(self.attributes.platform_specific.taskbar_icon.clone());
 
         let attributes = self.attributes.clone();
 
@@ -1271,19 +1269,18 @@ impl<'a> InitData<'a> {
 }
 unsafe fn init(
     attributes: WindowAttributes,
-    pl_attribs: PlatformSpecificWindowBuilderAttributes,
     event_loop: &EventLoopWindowTarget,
 ) -> Result<Window, RootOsError> {
     let title = util::encode_wide(&attributes.title);
 
-    let class_name = util::encode_wide(&pl_attribs.class_name);
+    let class_name = util::encode_wide(&attributes.platform_specific.class_name);
     unsafe { register_window_class(&class_name) };
 
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
     window_flags.set(
         WindowFlags::MARKER_UNDECORATED_SHADOW,
-        pl_attribs.decoration_shadow,
+        attributes.platform_specific.decoration_shadow,
     );
     window_flags.set(
         WindowFlags::ALWAYS_ON_TOP,
@@ -1295,7 +1292,7 @@ unsafe fn init(
     );
     window_flags.set(
         WindowFlags::NO_BACK_BUFFER,
-        pl_attribs.no_redirection_bitmap,
+        attributes.platform_specific.no_redirection_bitmap,
     );
     window_flags.set(WindowFlags::MARKER_ACTIVATE, attributes.active);
     window_flags.set(WindowFlags::TRANSPARENT, attributes.transparent);
@@ -1305,7 +1302,7 @@ unsafe fn init(
     // so the diffing later can work.
     window_flags.set(WindowFlags::CLOSABLE, true);
 
-    let mut fallback_parent = || match pl_attribs.owner {
+    let mut fallback_parent = || match attributes.platform_specific.owner {
         Some(parent) => {
             window_flags.set(WindowFlags::POPUP, true);
             Some(parent)
@@ -1320,7 +1317,7 @@ unsafe fn init(
     let parent = match attributes.parent_window.as_ref().map(|handle| handle.0) {
         Some(rwh_06::RawWindowHandle::Win32(handle)) => {
             window_flags.set(WindowFlags::CHILD, true);
-            if pl_attribs.menu.is_some() {
+            if attributes.platform_specific.menu.is_some() {
                 warn!("Setting a menu on a child window is unsupported");
             }
             Some(handle.hwnd.get() as HWND)
@@ -1332,10 +1329,10 @@ unsafe fn init(
     #[cfg(not(feature = "rwh_06"))]
     let parent = fallback_parent();
 
+    let menu = attributes.platform_specific.menu;
     let mut initdata = InitData {
         event_loop,
         attributes,
-        pl_attribs: pl_attribs.clone(),
         window_flags,
         window: None,
     };
@@ -1352,7 +1349,7 @@ unsafe fn init(
             CW_USEDEFAULT,
             CW_USEDEFAULT,
             parent.unwrap_or(0),
-            pl_attribs.menu.unwrap_or(0),
+            menu.unwrap_or(0),
             util::get_instance_handle(),
             &mut initdata as *mut _ as *mut _,
         )


### PR DESCRIPTION
Fixes #3313.
Any unsoundness this expands on is addressed by #3303.

This doesn't actually implement any getters, these can be implemented in follow-ups as needed.