### PR TITLE
MacOS: check if cursor changed before applying

### DIFF
--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -841,6 +841,10 @@ impl WinitView {
             .unwrap_or_default()
     }
 
+    pub(super) fn cursor_icon(&self) -> Id<NSCursor> {
+        self.ivars().cursor_state.borrow().cursor.clone()
+    }
+
     pub(super) fn set_cursor_icon(&self, icon: Id<NSCursor>) {
         let mut cursor_state = self.ivars().cursor_state.borrow_mut();
         cursor_state.cursor = icon;

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -798,18 +798,19 @@ impl WinitWindow {
     }
 
     pub fn set_cursor(&self, cursor: Cursor) {
-        match cursor {
-            Cursor::Icon(icon) => {
-                let view = self.view();
-                view.set_cursor_icon(cursor_from_icon(icon));
-                self.invalidateCursorRectsForView(&view);
-            }
-            Cursor::Custom(cursor) => {
-                let view = self.view();
-                view.set_cursor_icon(cursor.inner.0.clone());
-                self.invalidateCursorRectsForView(&view);
-            }
+        let view = self.view();
+
+        let cursor = match cursor {
+            Cursor::Icon(icon) => cursor_from_icon(icon),
+            Cursor::Custom(cursor) => cursor.inner.0,
+        };
+
+        if view.cursor_icon() == cursor {
+            return;
         }
+
+        view.set_cursor_icon(cursor);
+        self.invalidateCursorRectsForView(&view);
     }
 
     #[inline]


### PR DESCRIPTION
This just adds a check to make sure the cursor actually changed before applying it.

Addresses #3306.