### PR TITLE
Rename `VideoMode` to `VideoModeHandle`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Unreleased` header.
 - **Breaking:** Bump MSRV from `1.65` to `1.70`.
 - On Web, add the ability to toggle calling `Event.preventDefault()` on `Window`.
 - **Breaking:** Remove `WindowAttributes::fullscreen()` and expose as field directly.
+- **Breaking:** Rename `VideoMode` to `VideoModeHandle` to represent that it doesn't hold static data.
 
 # 0.29.6
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -10,28 +10,32 @@ use crate::{
     platform_impl,
 };
 
+/// Deprecated! Use `VideoModeHandle` instead.
+#[deprecated = "Renamed to `VideoModeHandle`"]
+pub type VideoMode = VideoModeHandle;
+
 /// Describes a fullscreen video mode of a monitor.
 ///
 /// Can be acquired with [`MonitorHandle::video_modes`].
 #[derive(Clone, PartialEq, Eq, Hash)]
-pub struct VideoMode {
-    pub(crate) video_mode: platform_impl::VideoMode,
+pub struct VideoModeHandle {
+    pub(crate) video_mode: platform_impl::VideoModeHandle,
 }
 
-impl std::fmt::Debug for VideoMode {
+impl std::fmt::Debug for VideoModeHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.video_mode.fmt(f)
     }
 }
 
-impl PartialOrd for VideoMode {
-    fn partial_cmp(&self, other: &VideoMode) -> Option<std::cmp::Ordering> {
+impl PartialOrd for VideoModeHandle {
+    fn partial_cmp(&self, other: &VideoModeHandle) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for VideoMode {
-    fn cmp(&self, other: &VideoMode) -> std::cmp::Ordering {
+impl Ord for VideoModeHandle {
+    fn cmp(&self, other: &VideoModeHandle) -> std::cmp::Ordering {
         self.monitor().cmp(&other.monitor()).then(
             self.size()
                 .cmp(&other.size())
@@ -45,7 +49,7 @@ impl Ord for VideoMode {
     }
 }
 
-impl VideoMode {
+impl VideoModeHandle {
     /// Returns the resolution of this video mode.
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
@@ -81,7 +85,7 @@ impl VideoMode {
     }
 }
 
-impl std::fmt::Display for VideoMode {
+impl std::fmt::Display for VideoModeHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
@@ -131,8 +135,8 @@ impl MonitorHandle {
     /// Return `Some` if succeed, or `None` if failed, which usually happens when the monitor
     /// the window is on is removed.
     ///
-    /// When using exclusive fullscreen, the refresh rate of the [`VideoMode`] that was used to
-    /// enter fullscreen should be used instead.
+    /// When using exclusive fullscreen, the refresh rate of the [`VideoModeHandle`] that was
+    /// used to enter fullscreen should be used instead.
     #[inline]
     pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         self.inner.refresh_rate_millihertz()
@@ -161,9 +165,9 @@ impl MonitorHandle {
     ///
     /// - **Web:** Always returns an empty iterator
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
         self.inner
             .video_modes()
-            .map(|video_mode| VideoMode { video_mode })
+            .map(|video_mode| VideoModeHandle { video_mode })
     }
 }

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -5,7 +5,7 @@ use objc2::rc::Id;
 
 use crate::{
     event_loop::EventLoop,
-    monitor::{MonitorHandle, VideoMode},
+    monitor::{MonitorHandle, VideoModeHandle},
     window::{Window, WindowBuilder},
 };
 
@@ -230,10 +230,10 @@ pub trait MonitorHandleExtIOS {
     /// [`UIScreen`]: https://developer.apple.com/documentation/uikit/uiscreen?language=objc
     fn ui_screen(&self) -> *mut c_void;
 
-    /// Returns the preferred [`VideoMode`] for this monitor.
+    /// Returns the preferred [`VideoModeHandle`] for this monitor.
     ///
     /// This translates to a call to [`-[UIScreen preferredMode]`](https://developer.apple.com/documentation/uikit/uiscreen/1617823-preferredmode?language=objc).
-    fn preferred_video_mode(&self) -> VideoMode;
+    fn preferred_video_mode(&self) -> VideoModeHandle;
 }
 
 impl MonitorHandleExtIOS for MonitorHandle {
@@ -245,8 +245,8 @@ impl MonitorHandleExtIOS for MonitorHandle {
     }
 
     #[inline]
-    fn preferred_video_mode(&self) -> VideoMode {
-        VideoMode {
+    fn preferred_video_mode(&self) -> VideoModeHandle {
+        VideoModeHandle {
             video_mode: self.inner.preferred_video_mode(),
         }
     }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -1090,11 +1090,11 @@ impl MonitorHandle {
         None
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(VideoMode {
+        std::iter::once(VideoModeHandle {
             size,
             bit_depth: 32,
             refresh_rate_millihertz: 60000,
@@ -1104,14 +1104,14 @@ impl MonitorHandle {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct VideoMode {
+pub struct VideoModeHandle {
     size: (u32, u32),
     bit_depth: u16,
     refresh_rate_millihertz: u32,
     monitor: MonitorHandle,
 }
 
-impl VideoMode {
+impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
     }

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -72,7 +72,7 @@ pub(crate) use self::{
     event_loop::{
         EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
     },
-    monitor::{MonitorHandle, VideoMode},
+    monitor::{MonitorHandle, VideoModeHandle},
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},
 };
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -254,38 +254,38 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoMode>> {
+    pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoModeHandle>> {
         x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum VideoMode {
+pub enum VideoModeHandle {
     #[cfg(x11_platform)]
-    X(x11::VideoMode),
+    X(x11::VideoModeHandle),
     #[cfg(wayland_platform)]
-    Wayland(wayland::VideoMode),
+    Wayland(wayland::VideoModeHandle),
 }
 
-impl VideoMode {
+impl VideoModeHandle {
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
-        x11_or_wayland!(match self; VideoMode(m) => m.size())
+        x11_or_wayland!(match self; VideoModeHandle(m) => m.size())
     }
 
     #[inline]
     pub fn bit_depth(&self) -> u16 {
-        x11_or_wayland!(match self; VideoMode(m) => m.bit_depth())
+        x11_or_wayland!(match self; VideoModeHandle(m) => m.bit_depth())
     }
 
     #[inline]
     pub fn refresh_rate_millihertz(&self) -> u32 {
-        x11_or_wayland!(match self; VideoMode(m) => m.refresh_rate_millihertz())
+        x11_or_wayland!(match self; VideoModeHandle(m) => m.refresh_rate_millihertz())
     }
 
     #[inline]
     pub fn monitor(&self) -> MonitorHandle {
-        x11_or_wayland!(match self; VideoMode(m) => m.monitor(); as MonitorHandle)
+        x11_or_wayland!(match self; VideoModeHandle(m) => m.monitor(); as MonitorHandle)
     }
 }
 

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -11,7 +11,7 @@ use sctk::reexports::client::{self, ConnectError, DispatchError, Proxy};
 
 pub use crate::platform_impl::platform::{OsError, WindowId};
 pub use event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
-pub use output::{MonitorHandle, VideoMode};
+pub use output::{MonitorHandle, VideoModeHandle};
 pub use window::Window;
 
 mod event_loop;

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -4,7 +4,7 @@ use sctk::reexports::client::Proxy;
 use sctk::output::OutputData;
 
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
-use crate::platform_impl::platform::VideoMode as PlatformVideoMode;
+use crate::platform_impl::platform::VideoModeHandle as PlatformVideoModeHandle;
 
 use super::event_loop::EventLoopWindowTarget;
 
@@ -98,14 +98,14 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoModeHandle> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         let modes = output_data.with_output_info(|info| info.modes.clone());
 
         let monitor = self.clone();
 
         modes.into_iter().map(move |mode| {
-            PlatformVideoMode::Wayland(VideoMode {
+            PlatformVideoModeHandle::Wayland(VideoModeHandle {
                 size: (mode.dimensions.0 as u32, mode.dimensions.1 as u32).into(),
                 refresh_rate_millihertz: mode.refresh_rate as u32,
                 bit_depth: 32,
@@ -142,14 +142,14 @@ impl std::hash::Hash for MonitorHandle {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct VideoMode {
+pub struct VideoModeHandle {
     pub(crate) size: PhysicalSize<u32>,
     pub(crate) bit_depth: u16,
     pub(crate) refresh_rate_millihertz: u32,
     pub(crate) monitor: MonitorHandle,
 }
 
-impl VideoMode {
+impl VideoModeHandle {
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         self.size

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -12,7 +12,7 @@ mod window;
 mod xdisplay;
 
 pub(crate) use self::{
-    monitor::{MonitorHandle, VideoMode},
+    monitor::{MonitorHandle, VideoModeHandle},
     window::UnownedWindow,
     xdisplay::XConnection,
 };

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -1,7 +1,7 @@
 use super::{util, X11Error, XConnection};
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
-    platform_impl::VideoMode as PlatformVideoMode,
+    platform_impl::VideoModeHandle as PlatformVideoModeHandle,
 };
 use x11rb::{
     connection::RequestConnection,
@@ -22,7 +22,7 @@ impl XConnection {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct VideoMode {
+pub struct VideoModeHandle {
     pub(crate) size: (u32, u32),
     pub(crate) bit_depth: u16,
     pub(crate) refresh_rate_millihertz: u32,
@@ -30,7 +30,7 @@ pub struct VideoMode {
     pub(crate) monitor: Option<MonitorHandle>,
 }
 
-impl VideoMode {
+impl VideoModeHandle {
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
@@ -71,7 +71,7 @@ pub struct MonitorHandle {
     /// Used to determine which windows are on this monitor
     pub(crate) rect: util::AaRect,
     /// Supported video modes on this monitor
-    video_modes: Vec<VideoMode>,
+    video_modes: Vec<VideoModeHandle>,
 }
 
 impl PartialEq for MonitorHandle {
@@ -191,11 +191,11 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoModeHandle> {
         let monitor = self.clone();
         self.video_modes.clone().into_iter().map(move |mut x| {
             x.monitor = Some(monitor.clone());
-            PlatformVideoMode::X(x)
+            PlatformVideoModeHandle::X(x)
         })
     }
 }

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -2,7 +2,7 @@ use std::{env, str, str::FromStr};
 
 use super::*;
 use crate::platform_impl::platform::x11::monitor;
-use crate::{dpi::validate_scale_factor, platform_impl::platform::x11::VideoMode};
+use crate::{dpi::validate_scale_factor, platform_impl::platform::x11::VideoModeHandle};
 
 use log::warn;
 use x11rb::protocol::randr::{self, ConnectionExt as _};
@@ -46,7 +46,7 @@ impl XConnection {
         &self,
         resources: &monitor::ScreenResources,
         crtc: &randr::GetCrtcInfoReply,
-    ) -> Option<(String, f64, Vec<VideoMode>)> {
+    ) -> Option<(String, f64, Vec<VideoModeHandle>)> {
         let output_info = match self
             .xcb_connection()
             .randr_get_output_info(crtc.outputs[0], x11rb::CURRENT_TIME)
@@ -70,7 +70,7 @@ impl XConnection {
             // modes in the array in XRRScreenResources
             .filter(|x| output_modes.iter().any(|id| x.id == *id))
             .map(|mode| {
-                VideoMode {
+                VideoModeHandle {
                     size: (mode.width.into(), mode.height.into()),
                     refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode)
                         .unwrap_or(0),

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -32,7 +32,7 @@ use crate::{
             X11Error,
         },
         Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError, PlatformIcon,
-        PlatformSpecificWindowBuilderAttributes, VideoMode as PlatformVideoMode,
+        PlatformSpecificWindowBuilderAttributes, VideoModeHandle as PlatformVideoModeHandle,
     },
     window::{
         CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
@@ -754,10 +754,10 @@ impl UnownedWindow {
             // fullscreen, so we can restore it upon exit, as XRandR does not
             // provide a mechanism to set this per app-session or restore this
             // to the desktop video mode as macOS and Windows do
-            (&None, &Some(Fullscreen::Exclusive(PlatformVideoMode::X(ref video_mode))))
+            (&None, &Some(Fullscreen::Exclusive(PlatformVideoModeHandle::X(ref video_mode))))
             | (
                 &Some(Fullscreen::Borderless(_)),
-                &Some(Fullscreen::Exclusive(PlatformVideoMode::X(ref video_mode))),
+                &Some(Fullscreen::Exclusive(PlatformVideoModeHandle::X(ref video_mode))),
             ) => {
                 let monitor = video_mode.monitor.as_ref().unwrap();
                 shared_state_lock.desktop_video_mode = Some((
@@ -793,7 +793,7 @@ impl UnownedWindow {
             }
             Some(fullscreen) => {
                 let (video_mode, monitor) = match fullscreen {
-                    Fullscreen::Exclusive(PlatformVideoMode::X(ref video_mode)) => {
+                    Fullscreen::Exclusive(PlatformVideoModeHandle::X(ref video_mode)) => {
                         (Some(video_mode), video_mode.monitor.clone().unwrap())
                     }
                     Fullscreen::Borderless(Some(PlatformMonitorHandle::X(monitor))) => {

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use self::{
     event_loop::{
         EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
     },
-    monitor::{MonitorHandle, VideoMode},
+    monitor::{MonitorHandle, VideoModeHandle},
     window::{PlatformSpecificWindowBuilderAttributes, WindowId},
 };
 use crate::event::DeviceId as RootDeviceId;

--- a/src/platform_impl/macos/monitor.rs
+++ b/src/platform_impl/macos/monitor.rs
@@ -18,7 +18,7 @@ use super::ffi;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 
 #[derive(Clone)]
-pub struct VideoMode {
+pub struct VideoModeHandle {
     size: PhysicalSize<u32>,
     bit_depth: u16,
     refresh_rate_millihertz: u32,
@@ -26,7 +26,7 @@ pub struct VideoMode {
     pub(crate) native_mode: NativeDisplayMode,
 }
 
-impl PartialEq for VideoMode {
+impl PartialEq for VideoModeHandle {
     fn eq(&self, other: &Self) -> bool {
         self.size == other.size
             && self.bit_depth == other.bit_depth
@@ -35,9 +35,9 @@ impl PartialEq for VideoMode {
     }
 }
 
-impl Eq for VideoMode {}
+impl Eq for VideoModeHandle {}
 
-impl std::hash::Hash for VideoMode {
+impl std::hash::Hash for VideoModeHandle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.size.hash(state);
         self.bit_depth.hash(state);
@@ -46,9 +46,9 @@ impl std::hash::Hash for VideoMode {
     }
 }
 
-impl std::fmt::Debug for VideoMode {
+impl std::fmt::Debug for VideoModeHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VideoMode")
+        f.debug_struct("VideoModeHandle")
             .field("size", &self.size)
             .field("bit_depth", &self.bit_depth)
             .field("refresh_rate_millihertz", &self.refresh_rate_millihertz)
@@ -79,7 +79,7 @@ impl Clone for NativeDisplayMode {
     }
 }
 
-impl VideoMode {
+impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
         self.size
     }
@@ -239,7 +239,7 @@ impl MonitorHandle {
         }
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
         let refresh_rate_millihertz = self.refresh_rate_millihertz().unwrap_or(0);
         let monitor = self.clone();
 
@@ -283,7 +283,7 @@ impl MonitorHandle {
                     unimplemented!()
                 };
 
-                VideoMode {
+                VideoModeHandle {
                     size: PhysicalSize::new(
                         ffi::CGDisplayModeGetPixelWidth(mode) as u32,
                         ffi::CGDisplayModeGetPixelHeight(mode) as u32,

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -18,7 +18,7 @@ use crate::{
         app_state::AppState,
         event_loop::EventLoopWindowTarget,
         ffi,
-        monitor::{self, MonitorHandle, VideoMode},
+        monitor::{self, MonitorHandle, VideoModeHandle},
         view::WinitView,
         window_delegate::WinitWindowDelegate,
         Fullscreen, OsError,
@@ -294,7 +294,7 @@ impl WinitWindow {
         let this = autoreleasepool(|_| {
             let screen = match attrs.fullscreen.clone().map(Into::into) {
                 Some(Fullscreen::Borderless(Some(monitor)))
-                | Some(Fullscreen::Exclusive(VideoMode { monitor, .. })) => {
+                | Some(Fullscreen::Exclusive(VideoModeHandle { monitor, .. })) => {
                     monitor.ns_screen(mtm).or_else(|| NSScreen::mainScreen(mtm))
                 }
                 Some(Fullscreen::Borderless(None)) => NSScreen::mainScreen(mtm),

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -1,4 +1,4 @@
-use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode as RootVideoMode};
+use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoModeHandle as RootVideoModeHandle};
 use crate::window::Fullscreen as RootFullscreen;
 
 #[cfg(windows_platform)]
@@ -25,10 +25,10 @@ mod platform;
 
 pub use self::platform::*;
 
-/// Helper for converting between platform-specific and generic VideoMode/MonitorHandle
+/// Helper for converting between platform-specific and generic [`VideoModeHandle`]/[`MonitorHandle`]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Fullscreen {
-    Exclusive(VideoMode),
+    Exclusive(VideoModeHandle),
     Borderless(Option<MonitorHandle>),
 }
 
@@ -45,7 +45,9 @@ impl From<RootFullscreen> for Fullscreen {
 impl From<Fullscreen> for RootFullscreen {
     fn from(f: Fullscreen) -> Self {
         match f {
-            Fullscreen::Exclusive(video_mode) => Self::Exclusive(RootVideoMode { video_mode }),
+            Fullscreen::Exclusive(video_mode) => {
+                Self::Exclusive(RootVideoModeHandle { video_mode })
+            }
             Fullscreen::Borderless(Some(inner)) => {
                 Self::Borderless(Some(RootMonitorHandle { inner }))
             }

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -222,11 +222,11 @@ impl MonitorHandle {
         None
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(VideoMode {
+        std::iter::once(VideoModeHandle {
             size,
             bit_depth: 32,
             refresh_rate_millihertz: 60000,
@@ -236,14 +236,14 @@ impl MonitorHandle {
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct VideoMode {
+pub struct VideoModeHandle {
     size: (u32, u32),
     bit_depth: u16,
     refresh_rate_millihertz: u32,
     monitor: MonitorHandle,
 }
 
-impl VideoMode {
+impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
     }

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -35,7 +35,7 @@ pub use self::error::OsError;
 pub(crate) use self::event_loop::{
     EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
 };
-pub use self::monitor::{MonitorHandle, VideoMode};
+pub use self::monitor::{MonitorHandle, VideoModeHandle};
 pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId};
 
 pub(crate) use self::keyboard::KeyEventExtra;

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -26,15 +26,15 @@ impl MonitorHandle {
         unreachable!()
     }
 
-    pub fn video_modes(&self) -> Empty<VideoMode> {
+    pub fn video_modes(&self) -> Empty<VideoModeHandle> {
         unreachable!()
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct VideoMode;
+pub struct VideoModeHandle;
 
-impl VideoMode {
+impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
         unreachable!();
     }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use self::{
         EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
     },
     icon::{SelectedCursor, WinIcon},
-    monitor::{MonitorHandle, VideoMode},
+    monitor::{MonitorHandle, VideoModeHandle},
     window::Window,
 };
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -5,7 +5,7 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{ExternalError, NotSupportedError, OsError},
     event_loop::EventLoopWindowTarget,
-    monitor::{MonitorHandle, VideoMode},
+    monitor::{MonitorHandle, VideoModeHandle},
     platform_impl,
 };
 
@@ -1669,7 +1669,7 @@ impl From<ResizeDirection> for CursorIcon {
 /// Fullscreen modes.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Fullscreen {
-    Exclusive(VideoMode),
+    Exclusive(VideoModeHandle),
 
     /// Providing `None` to `Borderless` will fullscreen on the current monitor.
     Borderless(Option<MonitorHandle>),


### PR DESCRIPTION
The point here is to reflect that `VideoMode` is not a static blob of information, but a handle that dynamically accesses that information. This is in line with our other `MonitorHandle` type.
Addresses #3258.

Cc @madsmtm.