### PR TITLE
Add deprecated `Window::set_cursor_icon()`

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -1374,6 +1374,13 @@ impl Window {
             .maybe_queue_on_main(move |w| w.set_cursor(cursor))
     }
 
+    /// Deprecated! Use [`Window::set_cursor()`] instead.
+    #[deprecated = "Renamed to `set_cursor`"]
+    #[inline]
+    pub fn set_cursor_icon(&self, icon: CursorIcon) {
+        self.set_cursor(icon)
+    }
+
     /// Changes the position of the cursor in window coordinates.
     ///
     /// ```no_run


### PR DESCRIPTION
In the spirit of https://github.com/rust-windowing/winit/pull/3328#discussion_r1436613136.

Addresses #3306.