### PR TITLE
On X11, update keymap on XkbMapNotify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- On X11, keymap not updated from xmodmap.
 - On X11, reduce the amount of time spent fetching screen resources.
 - On Windows, macOS, X11, Wayland and Web, implement setting images as cursors. See the `custom_cursors.rs` example.
   - **Breaking:** Remove `Window::set_cursor_icon`

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -365,7 +365,9 @@ impl<T: 'static> EventLoop<T> {
             .xconn
             .select_xkb_events(
                 0x100, // Use the "core keyboard device"
-                xkb::EventType::NEW_KEYBOARD_NOTIFY | xkb::EventType::STATE_NOTIFY,
+                xkb::EventType::NEW_KEYBOARD_NOTIFY
+                    | xkb::EventType::MAP_NOTIFY
+                    | xkb::EventType::STATE_NOTIFY,
             )
             .unwrap();
 


### PR DESCRIPTION
This is required to handle xmodmap.

Fixes #3338.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users