### PR TITLE
On X11, fix `ModifiersChanged` from xdotool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- On X11, fix `ModifiersChanged` not sent from xdotool-like input
 - On X11, keymap not updated from xmodmap.
 - On X11, reduce the amount of time spent fetching screen resources.
 - On Windows, macOS, X11, Wayland and Web, implement setting images as cursors. See the `custom_cursors.rs` example.

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -347,6 +347,7 @@ impl<T: 'static> EventLoop<T> {
             held_key_press: None,
             first_touch: None,
             active_window: None,
+            modifiers: Default::default(),
             is_composing: false,
         };
 


### PR DESCRIPTION
xdotool will update modifiers before Xkb will actually send event updating them, thus the modifiers will be updating even before the actual update, which is unfortunate.

Links: https://github.com/alacritty/alacritty/issues/7502

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

