### PR TITLE
On X11, fix IME input lagging behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- On X11, fix IME input lagging behind.
 - On X11, fix `ModifiersChanged` not sent from xdotool-like input
 - On X11, keymap not updated from xmodmap.
 - On X11, reduce the amount of time spent fetching screen resources.


### PR DESCRIPTION
IME events and requests where drained on one-by-one basis, however we should drain all of them at once and send to user.

Links: https://github.com/alacritty/alacritty/issues/7514

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
