### PR TITLE
Android: allow EventLoop recreation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- On Android, allow EventLoop recreation after destruction
 - On X11 and Wayland, fix arrow up on keypad reported as `ArrowLeft`.
 - On Windows, macOS, X11, Wayland and Web, implement setting images as cursors. See the `custom_cursors.rs` example.
   - **Breaking:** Remove `Window::set_cursor_icon`

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -106,6 +106,9 @@ impl<T> EventLoopBuilder<T> {
     ///                    or `DISPLAY` respectively when building the event loop.
     /// - **Android:** must be configured with an `AndroidApp` from `android_main()` by calling
     ///     [`.with_android_app(app)`] before calling `.build()`, otherwise it'll panic.
+    ///     Due to android platform-specific behaviour, it's possible to recreate the EventLoop
+    ///     after the previous one has been destroyed, this is to prevent bugs when multiple
+    ///     activities are used.
     ///
     /// [`platform`]: crate::platform
     #[cfg_attr(
@@ -130,7 +133,7 @@ impl<T> EventLoopBuilder<T> {
         })
     }
 
-    #[cfg(wasm_platform)]
+    #[cfg(any(wasm_platform, android_platform))]
     pub(crate) fn allow_event_loop_recreation() {
         EVENT_LOOP_CREATED.store(false, Ordering::Relaxed);
     }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -641,6 +641,12 @@ impl<T: 'static> EventLoop<T> {
     }
 }
 
+impl<T> Drop for EventLoop<T> {
+    fn drop(&mut self) {
+        crate::event_loop::EventLoopBuilder::<()>::allow_event_loop_recreation();
+    }
+}
+
 pub struct EventLoopProxy<T: 'static> {
     user_events_sender: mpsc::Sender<T>,
     waker: AndroidAppWaker,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I've added this as the default behavior because it's what is expected in android when you call `event_loop.exit()` and reopening the activity, is it better suited for a sort of `EventLoopBuilderExtAndroid`?

Closes #3325 