### PR TITLE
Deploy master docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,50 @@
+name: Docs
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  docs:
+    name: Documentation
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}winit
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly
+
+      - name: Run Rustdoc
+        env:
+          RUSTDOCFLAGS: --crate-version master --cfg=docsrs
+        run: |
+          cargo doc --no-deps -Z rustdoc-map -Z rustdoc-scrape-examples --features=rwh_04,rwh_05,rwh_06,serde,mint,android-native-activity
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "target/doc" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/doc
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -254,3 +254,7 @@ web-sys = { version = "0.3.22", features = ['CanvasRenderingContext2d'] }
 members = [
     "run-wasm",
 ]
+
+[[example]]
+doc-scrape-examples = true
+name = "window"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Crates.io](https://img.shields.io/crates/v/winit.svg)](https://crates.io/crates/winit)
 [![Docs.rs](https://docs.rs/winit/badge.svg)](https://docs.rs/winit)
+[![Master Docs](https://img.shields.io/github/actions/workflow/status/rust-windowing/winit/docs.yml?branch=master&label=master%20docs
+)](https://rust-windowing.github.io/winit/winit/index.html)
 [![CI Status](https://github.com/rust-windowing/winit/workflows/CI/badge.svg)](https://github.com/rust-windowing/winit/actions)
 
 ```toml


### PR DESCRIPTION
This deploys documentation generated from the master branch to GitHub Pages.
I also added the extra couple of lines needed to [scrape examples](https://doc.rust-lang.org/1.75.0/rustdoc/scraped-examples.html), which should also be visible on docs.rs.