### PR TITLE
On macOS, report correct logical key when Ctrl or Cmd is pressed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Unreleased` header.
 - **Breaking:** Rename `VideoMode` to `VideoModeHandle` to represent that it doesn't hold static data.
 - **Breaking:** No longer export `platform::x11::XNotSupported`.
 - **Breaking:** Renamed `platform::x11::XWindowType` to `platform::x11::WindowType`.
+- On macOS, report correct logical key when Ctrl or Cmd is pressed.
 
 # 0.29.8
 

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -115,18 +115,12 @@ pub(crate) fn create_key_event(
     let scancode = unsafe { ns_event.keyCode() };
     let mut physical_key = key_override.unwrap_or_else(|| scancode_to_physicalkey(scancode as u32));
 
-    // NOTE:
-    // The logical key should be the key resulting from applying all modifiers.
-    // Consider these cases:
-    // 1) Pressing the A key: logical key should be "a"
-    // 2) Pressing SHIFT A: logical key should be "A"
-    // 3) Pressing CTRL SHIFT A: logical key should also be "A"
-    // `ns_event.characters()` gets 3) wrong, returning "a" instead of "A".
-    // In fact it gets it wrong anytime CTRL or CMD is pressed.
-    // `ns_event.charactersIgnoringModifiers()` gets everything right,
-    // because it ignores all modifiers except for shift.
-    // https://developer.apple.com/documentation/appkit/nsevent/1524605-charactersignoringmodifiers
-    // https://github.com/rust-windowing/winit/issues/3078
+    // NOTE: The logical key should heed both SHIFT and ALT if possible.
+    // For instance:
+    // * Pressing the A key: logical key should be "a"
+    // * Pressing SHIFT A: logical key should be "A"
+    // * Pressing CTRL SHIFT A: logical key should also be "A"
+    // This is not easy to tease out of `NSEvent`, but we do our best.
 
     // `text_with_all_modifiers` is unreliable when ctrl or cmd is pressed
     let text_with_all_modifiers: Option<SmolStr> = if key_override.is_some() {

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -123,8 +123,10 @@ pub(crate) fn create_key_event(
         // 3) Pressing CTRL SHIFT A: logical key should also be "A"
         // `ns_event.characters()` gets 3) wrong, returning "a" instead of "A".
         // In fact it gets it wrong anytime CTRL or CMD is pressed.
-        // `ns_event.charactersIgnoringModifiers()` gets everything right.
-        // See https://github.com/rust-windowing/winit/issues/3078
+        // `ns_event.charactersIgnoringModifiers()` gets everything right,
+        // because it ignores all modifiers except for shift.
+        // https://developer.apple.com/documentation/appkit/nsevent/1524605-charactersignoringmodifiers
+        // https://github.com/rust-windowing/winit/issues/3078
         let characters = unsafe { ns_event.charactersIgnoringModifiers() }
             .map(|s| s.to_string())
             .unwrap_or_default();

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -122,7 +122,6 @@ pub(crate) fn create_key_event(
     // * Pressing CTRL SHIFT A: logical key should also be "A"
     // This is not easy to tease out of `NSEvent`, but we do our best.
 
-    // `text_with_all_modifiers` is unreliable when ctrl or cmd is pressed
     let text_with_all_modifiers: Option<SmolStr> = if key_override.is_some() {
         None
     } else {


### PR DESCRIPTION
* Closes https://github.com/rust-windowing/winit/issues/3078

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
