### PR TITLE
Update Redox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@ Unreleased` header.
 - **Breaking:** Rename `VideoMode` to `VideoModeHandle` to represent that it doesn't hold static data.
 - **Breaking:** No longer export `platform::x11::XNotSupported`.
 - **Breaking:** Renamed `platform::x11::XWindowType` to `platform::x11::WindowType`.
-- On Redox, Update `redox_syscall` from 0.3 to 0.4.1
-- On Redox, Update `orbclient` from 0.3.42 to 0.3.47
 
 # 0.29.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ Unreleased` header.
 - **Breaking:** Rename `VideoMode` to `VideoModeHandle` to represent that it doesn't hold static data.
 - **Breaking:** No longer export `platform::x11::XNotSupported`.
 - **Breaking:** Renamed `platform::x11::XWindowType` to `platform::x11::WindowType`.
+- On Redox, Update `redox_syscall` from 0.3 to 0.4.1
+- On Redox, Update `orbclient` from 0.3.42 to 0.3.47
 
 # 0.29.9
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,8 +192,8 @@ x11rb = { version = "0.13.0", default-features = false, features = ["allow-unsaf
 xkbcommon-dl = "0.4.0"
 
 [target.'cfg(target_os = "redox")'.dependencies]
-orbclient = { version = "0.3.42", default-features = false }
-redox_syscall = "0.3"
+orbclient = { version = "0.3.47", default-features = false }
+redox_syscall = "0.4.1"
 
 [target.'cfg(target_family = "wasm")'.dependencies.web_sys]
 package = "web-sys"

--- a/deny.toml
+++ b/deny.toml
@@ -34,7 +34,6 @@ skip = [
     { name = "raw-window-handle" },    # we intentionally have multiple versions of this
     { name = "bitflags" },             # the ecosystem is in the process of migrating.
     { name = "libloading" },           # x11rb uses a different version until the next update
-    { name = "redox_syscall" },        # https://gitlab.redox-os.org/redox-os/orbclient/-/issues/46
 ]
 skip-tree = []
 


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

`orbclient` has dropped `redox_syscall` dependency

Should close https://github.com/rust-windowing/winit/pull/3181 
