### PR TITLE
Web: support Firefox `privacy.resistFingerprinting`

### DIFF
--- a/src/platform_impl/web/web_sys/resize_scaling.rs
+++ b/src/platform_impl/web/web_sys/resize_scaling.rs
@@ -127,7 +127,7 @@ impl ResizeScaleInternal {
              (-webkit-device-pixel-ratio: {current_scale})",
         );
         let mql = MediaQueryListHandle::new(window, &media_query, closure);
-        assert!(
+        debug_assert!(
             mql.mql().matches(),
             "created media query doesn't match, {current_scale} != {}",
             super::scale_factor(window)


### PR DESCRIPTION
This only changes an `assert!` to a `debug_assert!` avoiding a Firefox bug.
No functional changes.

Fixes #3345.