### PR TITLE
iOS: fix `request_redraw` from `RedrawRequested`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Unreleased` header.
 - **Breaking:** Rename `VideoMode` to `VideoModeHandle` to represent that it doesn't hold static data.
 - **Breaking:** No longer export `platform::x11::XNotSupported`.
 - **Breaking:** Renamed `platform::x11::XWindowType` to `platform::x11::WindowType`.
+- On iOS, fix calling `Window::request_redraw()` from `WindowEvent:RedrawRequested`.
 
 # 0.29.9
 


### PR DESCRIPTION
This fixes calling `Window::request_redraw()` from `WindowEvent:RedrawRequested` causing panics.
Instead it is queued for the next event loop, which is awoken instantly as currently iOS doesn't support #2412.