### PR TITLE
Web: increase cursor position accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Unreleased` header.
 - **Breaking:** Rename `VideoMode` to `VideoModeHandle` to represent that it doesn't hold static data.
 - **Breaking:** No longer export `platform::x11::XNotSupported`.
 - **Breaking:** Renamed `platform::x11::XWindowType` to `platform::x11::WindowType`.
+- On Web, increase cursor position accuracy.
 
 # 0.29.9
 

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -81,9 +81,22 @@ impl MouseButton {
 }
 
 pub fn mouse_position(event: &MouseEvent) -> LogicalPosition<f64> {
+    #[wasm_bindgen]
+    extern "C" {
+        type MouseEventExt;
+
+        #[wasm_bindgen(method, getter, js_name = offsetX)]
+        fn offset_x(this: &MouseEventExt) -> f64;
+
+        #[wasm_bindgen(method, getter, js_name = offsetY)]
+        fn offset_y(this: &MouseEventExt) -> f64;
+    }
+
+    let event: &MouseEventExt = event.unchecked_ref();
+
     LogicalPosition {
-        x: event.offset_x() as f64,
-        y: event.offset_y() as f64,
+        x: event.offset_x(),
+        y: event.offset_y(),
     }
 }
 


### PR DESCRIPTION
The current API used to get the cursor position was converting doubles to integers, therefor truncating the number and making conversions between logical and physical positions inaccurate.

Unfortunately this was caused because the `web-sys` API incorrectly returns an integer, which has happened because the spec `web-sys` gets the API from had a mistake.

This PR fixes this by redefining the API to correctly return a double.