### PR TITLE
Web: Fix missing text content in KeyEvent for backspace and escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Unreleased` header.
 - **Breaking:** No longer export `platform::x11::XNotSupported`.
 - **Breaking:** Renamed `platform::x11::XWindowType` to `platform::x11::WindowType`.
 - On Web, increase cursor position accuracy.
+- On Web, fix missing text content in KeyEvent for backspace and escape.
 
 # 0.29.9
 

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -1,6 +1,6 @@
 use crate::dpi::LogicalPosition;
 use crate::event::{MouseButton, MouseScrollDelta};
-use crate::keyboard::{Key, KeyLocation, ModifiersState, NamedKey, PhysicalKey};
+use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
 
 use smol_str::SmolStr;
 use std::cell::OnceCell;

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -174,14 +174,7 @@ pub fn key(event: &KeyboardEvent) -> Key {
 pub fn key_text(event: &KeyboardEvent) -> Option<SmolStr> {
     let key = event.key();
     let key = Key::from_key_attribute_value(&key);
-    match &key {
-        Key::Character(text) => Some(text.clone()),
-        Key::Named(NamedKey::Tab) => Some(SmolStr::new("\t")),
-        Key::Named(NamedKey::Enter) => Some(SmolStr::new("\r")),
-        Key::Named(NamedKey::Space) => Some(SmolStr::new(" ")),
-        _ => None,
-    }
-    .map(SmolStr::new)
+    key.to_text().map(SmolStr::new)
 }
 
 pub fn key_location(event: &KeyboardEvent) -> KeyLocation {


### PR DESCRIPTION
Fixes #3381 

This seems like a fairly straightforward fix. But I'm new here, so let me know if I've missed something.

I looked over the docs for `KeyEvent`, and I don't think any changes are necessary there.

- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
