### PR TITLE
Web: improve custom cursor handling and add animated cursors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Unreleased` header.
   - Add `CustomCursor`
   - Add `CustomCursor::from_rgba` to allow creating cursor images from RGBA data.
   - Add `CustomCursorExtWebSys::from_url` to allow loading cursor images from URLs.
+  - Add `CustomCursorExtWebSys::from_animation` to allow creating animated cursors from other `CustomCursor`s.
 - On macOS, add services menu.
 - **Breaking:** On Web, remove queuing fullscreen request in absence of transient activation.
 - On Web, fix setting cursor icon overriding cursor visibility.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,7 @@ features = [
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 atomic-waker = "1"
+concurrent-queue = { version = "2", default-features = false }
 js-sys = "0.3.64"
 pin-project = "1"
 wasm-bindgen = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -242,6 +242,7 @@ features = [
 [target.'cfg(target_family = "wasm")'.dependencies]
 atomic-waker = "1"
 js-sys = "0.3.64"
+pin-project = "1"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-time = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -240,13 +240,15 @@ features = [
 ]
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-atomic-waker = "1"
-concurrent-queue = { version = "2", default-features = false }
 js-sys = "0.3.64"
 pin-project = "1"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 web-time = "0.2"
+
+[target.'cfg(all(target_family = "wasm", target_feature = "atomics"))'.dependencies]
+atomic-waker = "1"
+concurrent-queue = { version = "2", default-features = false }
 
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 console_log = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,6 +205,7 @@ features = [
     'console',
     'CssStyleDeclaration',
     'Document',
+    'DomException',
     'DomRect',
     'DomRectReadOnly',
     'Element',

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -74,6 +74,25 @@ fn main() -> Result<(), impl std::error::Error> {
                     log::debug!("Setting cursor visibility to {:?}", cursor_visible);
                     window.set_cursor_visible(cursor_visible);
                 }
+                #[cfg(wasm_platform)]
+                Key::Character("4") => {
+                    use std::sync::atomic::{AtomicU64, Ordering};
+                    use winit::platform::web::CustomCursorExtWebSys;
+                    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+                    log::debug!("Setting cursor to a random image from an URL");
+                    window.set_cursor(
+                        CustomCursor::from_url(
+                            format!(
+                                "https://picsum.photos/128?random={}",
+                                COUNTER.fetch_add(1, Ordering::Relaxed)
+                            ),
+                            64,
+                            64,
+                        )
+                        .build(_elwt),
+                    );
+                }
                 _ => {}
             },
             WindowEvent::RedrawRequested => {

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -8,6 +8,15 @@ use winit::{
     keyboard::Key,
     window::{CursorIcon, CustomCursor, WindowBuilder},
 };
+#[cfg(wasm_platform)]
+use {
+    std::sync::atomic::{AtomicU64, Ordering},
+    std::time::Duration,
+    winit::platform::web::CustomCursorExtWebSys,
+};
+
+#[cfg(wasm_platform)]
+static COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn decode_cursor<T>(bytes: &[u8], window_target: &EventLoopWindowTarget<T>) -> CustomCursor {
     let img = image::load_from_memory(bytes).unwrap().to_rgba8();
@@ -76,10 +85,6 @@ fn main() -> Result<(), impl std::error::Error> {
                 }
                 #[cfg(wasm_platform)]
                 Key::Character("4") => {
-                    use std::sync::atomic::{AtomicU64, Ordering};
-                    use winit::platform::web::CustomCursorExtWebSys;
-                    static COUNTER: AtomicU64 = AtomicU64::new(0);
-
                     log::debug!("Setting cursor to a random image from an URL");
                     window.set_cursor(
                         CustomCursor::from_url(
@@ -90,6 +95,30 @@ fn main() -> Result<(), impl std::error::Error> {
                             64,
                             64,
                         )
+                        .build(_elwt),
+                    );
+                }
+                #[cfg(wasm_platform)]
+                Key::Character("5") => {
+                    log::debug!("Setting cursor to an animation");
+                    window.set_cursor(
+                        CustomCursor::from_animation(
+                            Duration::from_secs(3),
+                            vec![
+                                custom_cursors[0].clone(),
+                                custom_cursors[1].clone(),
+                                CustomCursor::from_url(
+                                    format!(
+                                        "https://picsum.photos/128?random={}",
+                                        COUNTER.fetch_add(1, Ordering::Relaxed)
+                                    ),
+                                    64,
+                                    64,
+                                )
+                                .build(_elwt),
+                            ],
+                        )
+                        .unwrap()
                         .build(_elwt),
                     );
                 }

--- a/src/platform_impl/web/async/abortable.rs
+++ b/src/platform_impl/web/async/abortable.rs
@@ -70,6 +70,25 @@ impl AbortHandle {
     }
 }
 
+#[derive(Debug)]
+pub struct DropAbortHandle(AbortHandle);
+
+impl DropAbortHandle {
+    pub fn new(handle: AbortHandle) -> Self {
+        Self(handle)
+    }
+
+    pub fn handle(&self) -> AbortHandle {
+        self.0.clone()
+    }
+}
+
+impl Drop for DropAbortHandle {
+    fn drop(&mut self) {
+        self.0.abort()
+    }
+}
+
 #[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Aborted;
 

--- a/src/platform_impl/web/async/abortable.rs
+++ b/src/platform_impl/web/async/abortable.rs
@@ -1,0 +1,82 @@
+use std::error::Error;
+use std::fmt::{self, Display, Formatter};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use atomic_waker::AtomicWaker;
+use pin_project::pin_project;
+
+#[pin_project]
+pub struct Abortable<F: Future> {
+    #[pin]
+    future: F,
+    shared: Arc<Shared>,
+}
+
+impl<F: Future> Abortable<F> {
+    pub fn new(handle: AbortHandle, future: F) -> Self {
+        Self {
+            future,
+            shared: handle.0,
+        }
+    }
+}
+
+impl<F: Future> Future for Abortable<F> {
+    type Output = Result<F::Output, Aborted>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.shared.aborted.load(Ordering::Relaxed) {
+            return Poll::Ready(Err(Aborted));
+        }
+
+        if let Poll::Ready(value) = self.as_mut().project().future.poll(cx) {
+            return Poll::Ready(Ok(value));
+        }
+
+        self.shared.waker.register(cx.waker());
+
+        if self.shared.aborted.load(Ordering::Relaxed) {
+            return Poll::Ready(Err(Aborted));
+        }
+
+        Poll::Pending
+    }
+}
+
+#[derive(Debug)]
+struct Shared {
+    waker: AtomicWaker,
+    aborted: AtomicBool,
+}
+
+#[derive(Clone, Debug)]
+pub struct AbortHandle(Arc<Shared>);
+
+impl AbortHandle {
+    pub fn new() -> Self {
+        Self(Arc::new(Shared {
+            waker: AtomicWaker::new(),
+            aborted: AtomicBool::new(false),
+        }))
+    }
+
+    pub fn abort(&self) {
+        self.0.aborted.store(true, Ordering::Relaxed);
+        self.0.waker.wake()
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Aborted;
+
+impl Display for Aborted {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "`Abortable` future has been aborted")
+    }
+}
+
+impl Error for Aborted {}

--- a/src/platform_impl/web/async/abortable.rs
+++ b/src/platform_impl/web/async/abortable.rs
@@ -6,8 +6,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use atomic_waker::AtomicWaker;
 use pin_project::pin_project;
+
+use super::AtomicWaker;
 
 #[pin_project]
 pub struct Abortable<F: Future> {

--- a/src/platform_impl/web/async/atomic_waker.rs
+++ b/src/platform_impl/web/async/atomic_waker.rs
@@ -1,0 +1,35 @@
+use std::cell::RefCell;
+use std::ops::Deref;
+use std::task::Waker;
+
+#[derive(Debug)]
+pub struct AtomicWaker(RefCell<Option<Waker>>);
+
+impl AtomicWaker {
+    pub const fn new() -> Self {
+        Self(RefCell::new(None))
+    }
+
+    pub fn register(&self, waker: &Waker) {
+        let mut this = self.0.borrow_mut();
+
+        if let Some(old_waker) = this.deref() {
+            if old_waker.will_wake(waker) {
+                return;
+            }
+        }
+
+        *this = Some(waker.clone());
+    }
+
+    pub fn wake(&self) {
+        if let Some(waker) = self.0.borrow_mut().take() {
+            waker.wake();
+        }
+    }
+}
+
+// SAFETY: Wasm without the `atomics` target feature is single-threaded.
+unsafe impl Send for AtomicWaker {}
+// SAFETY: Wasm without the `atomics` target feature is single-threaded.
+unsafe impl Sync for AtomicWaker {}

--- a/src/platform_impl/web/async/channel.rs
+++ b/src/platform_impl/web/async/channel.rs
@@ -1,10 +1,11 @@
-use atomic_waker::AtomicWaker;
 use std::future;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, RecvError, SendError, TryRecvError};
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
+
+use super::AtomicWaker;
 
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     let (sender, receiver) = mpsc::channel();

--- a/src/platform_impl/web/async/channel.rs
+++ b/src/platform_impl/web/async/channel.rs
@@ -2,22 +2,22 @@ use atomic_waker::AtomicWaker;
 use std::future;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, Receiver, RecvError, SendError, Sender, TryRecvError};
+use std::sync::mpsc::{self, RecvError, SendError, TryRecvError};
 use std::sync::{Arc, Mutex};
 use std::task::Poll;
 
-pub fn channel<T>() -> (AsyncSender<T>, AsyncReceiver<T>) {
+pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     let (sender, receiver) = mpsc::channel();
     let shared = Arc::new(Shared {
         closed: AtomicBool::new(false),
         waker: AtomicWaker::new(),
     });
 
-    let sender = AsyncSender(Arc::new(SenderInner {
+    let sender = Sender(Arc::new(SenderInner {
         sender: Mutex::new(sender),
         shared: Arc::clone(&shared),
     }));
-    let receiver = AsyncReceiver {
+    let receiver = Receiver {
         receiver: Rc::new(receiver),
         shared,
     };
@@ -25,18 +25,18 @@ pub fn channel<T>() -> (AsyncSender<T>, AsyncReceiver<T>) {
     (sender, receiver)
 }
 
-pub struct AsyncSender<T>(Arc<SenderInner<T>>);
+pub struct Sender<T>(Arc<SenderInner<T>>);
 
 struct SenderInner<T> {
     // We need to wrap it into a `Mutex` to make it `Sync`. So the sender can't
     // be accessed on the main thread, as it could block. Additionally we need
     // to wrap `Sender` in an `Arc` to make it clonable on the main thread without
     // having to block.
-    sender: Mutex<Sender<T>>,
+    sender: Mutex<mpsc::Sender<T>>,
     shared: Arc<Shared>,
 }
 
-impl<T> AsyncSender<T> {
+impl<T> Sender<T> {
     pub fn send(&self, event: T) -> Result<(), SendError<T>> {
         self.0.sender.lock().unwrap().send(event)?;
         self.0.shared.waker.wake();
@@ -52,7 +52,7 @@ impl<T> SenderInner<T> {
     }
 }
 
-impl<T> Clone for AsyncSender<T> {
+impl<T> Clone for Sender<T> {
     fn clone(&self) -> Self {
         Self(Arc::clone(&self.0))
     }
@@ -64,12 +64,12 @@ impl<T> Drop for SenderInner<T> {
     }
 }
 
-pub struct AsyncReceiver<T> {
-    receiver: Rc<Receiver<T>>,
+pub struct Receiver<T> {
+    receiver: Rc<mpsc::Receiver<T>>,
     shared: Arc<Shared>,
 }
 
-impl<T> AsyncReceiver<T> {
+impl<T> Receiver<T> {
     pub async fn next(&self) -> Result<T, RecvError> {
         future::poll_fn(|cx| match self.receiver.try_recv() {
             Ok(event) => Poll::Ready(Ok(event)),
@@ -102,7 +102,7 @@ impl<T> AsyncReceiver<T> {
     }
 }
 
-impl<T> Clone for AsyncReceiver<T> {
+impl<T> Clone for Receiver<T> {
     fn clone(&self) -> Self {
         Self {
             receiver: Rc::clone(&self.receiver),
@@ -111,7 +111,7 @@ impl<T> Clone for AsyncReceiver<T> {
     }
 }
 
-impl<T> Drop for AsyncReceiver<T> {
+impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         self.shared.closed.store(true, Ordering::Relaxed);
     }

--- a/src/platform_impl/web/async/concurrent_queue.rs
+++ b/src/platform_impl/web/async/concurrent_queue.rs
@@ -1,0 +1,55 @@
+use std::cell::{Cell, RefCell};
+
+#[derive(Debug)]
+pub struct ConcurrentQueue<T> {
+    queue: RefCell<Vec<T>>,
+    closed: Cell<bool>,
+}
+
+pub enum PushError<T> {
+    #[allow(dead_code)]
+    Full(T),
+    Closed(T),
+}
+
+pub enum PopError {
+    Empty,
+    Closed,
+}
+
+impl<T> ConcurrentQueue<T> {
+    pub fn unbounded() -> Self {
+        Self {
+            queue: RefCell::new(Vec::new()),
+            closed: Cell::new(false),
+        }
+    }
+
+    pub fn push(&self, value: T) -> Result<(), PushError<T>> {
+        if self.closed.get() {
+            return Err(PushError::Closed(value));
+        }
+
+        self.queue.borrow_mut().push(value);
+        Ok(())
+    }
+
+    pub fn pop(&self) -> Result<T, PopError> {
+        self.queue.borrow_mut().pop().ok_or_else(|| {
+            if self.closed.get() {
+                PopError::Closed
+            } else {
+                PopError::Empty
+            }
+        })
+    }
+
+    pub fn close(&self) -> bool {
+        !self.closed.replace(true)
+    }
+}
+
+// SAFETY: Wasm without the `atomics` target feature is single-threaded.
+unsafe impl<T> Send for ConcurrentQueue<T> {}
+// SAFETY: Wasm without the `atomics` target feature is single-threaded.
+unsafe impl<T> Sync for ConcurrentQueue<T> {}

--- a/src/platform_impl/web/async/dispatcher.rs
+++ b/src/platform_impl/web/async/dispatcher.rs
@@ -1,11 +1,11 @@
 use super::super::main_thread::MainThreadMarker;
-use super::{channel, AsyncReceiver, AsyncSender, Wrapper};
+use super::{channel, Receiver, Sender, Wrapper};
 use std::{
     cell::Ref,
     sync::{Arc, Condvar, Mutex},
 };
 
-pub struct Dispatcher<T: 'static>(Wrapper<true, T, AsyncSender<Closure<T>>, Closure<T>>);
+pub struct Dispatcher<T: 'static>(Wrapper<true, T, Sender<Closure<T>>, Closure<T>>);
 
 struct Closure<T>(Box<dyn FnOnce(&T) + Send>);
 
@@ -85,8 +85,8 @@ impl<T> Dispatcher<T> {
 }
 
 pub struct DispatchRunner<T: 'static> {
-    wrapper: Wrapper<true, T, AsyncSender<Closure<T>>, Closure<T>>,
-    receiver: AsyncReceiver<Closure<T>>,
+    wrapper: Wrapper<true, T, Sender<Closure<T>>, Closure<T>>,
+    receiver: Receiver<Closure<T>>,
 }
 
 impl<T> DispatchRunner<T> {

--- a/src/platform_impl/web/async/mod.rs
+++ b/src/platform_impl/web/async/mod.rs
@@ -1,11 +1,13 @@
 mod abortable;
 mod channel;
 mod dispatcher;
+mod notifier;
 mod waker;
 mod wrapper;
 
-pub use self::abortable::{AbortHandle, Abortable};
+pub use self::abortable::{AbortHandle, Abortable, DropAbortHandle};
 pub use self::channel::{channel, Receiver, Sender};
 pub use self::dispatcher::{DispatchRunner, Dispatcher};
+pub use self::notifier::Notifier;
 pub use self::waker::{Waker, WakerSpawner};
 use self::wrapper::Wrapper;

--- a/src/platform_impl/web/async/mod.rs
+++ b/src/platform_impl/web/async/mod.rs
@@ -1,5 +1,9 @@
 mod abortable;
+#[cfg(not(target_feature = "atomics"))]
+mod atomic_waker;
 mod channel;
+#[cfg(not(target_feature = "atomics"))]
+mod concurrent_queue;
 mod dispatcher;
 mod notifier;
 mod waker;
@@ -11,3 +15,5 @@ pub use self::dispatcher::{DispatchRunner, Dispatcher};
 pub use self::notifier::Notifier;
 pub use self::waker::{Waker, WakerSpawner};
 use self::wrapper::Wrapper;
+use atomic_waker::AtomicWaker;
+use concurrent_queue::{ConcurrentQueue, PushError};

--- a/src/platform_impl/web/async/mod.rs
+++ b/src/platform_impl/web/async/mod.rs
@@ -12,7 +12,7 @@ mod wrapper;
 pub use self::abortable::{AbortHandle, Abortable, DropAbortHandle};
 pub use self::channel::{channel, Receiver, Sender};
 pub use self::dispatcher::{DispatchRunner, Dispatcher};
-pub use self::notifier::Notifier;
+pub use self::notifier::{Notified, Notifier};
 pub use self::waker::{Waker, WakerSpawner};
 use self::wrapper::Wrapper;
 use atomic_waker::AtomicWaker;

--- a/src/platform_impl/web/async/mod.rs
+++ b/src/platform_impl/web/async/mod.rs
@@ -5,7 +5,7 @@ mod waker;
 mod wrapper;
 
 pub use self::abortable::{AbortHandle, Abortable};
-pub use self::channel::{channel, AsyncReceiver, AsyncSender};
+pub use self::channel::{channel, Receiver, Sender};
 pub use self::dispatcher::{DispatchRunner, Dispatcher};
 pub use self::waker::{Waker, WakerSpawner};
 use self::wrapper::Wrapper;

--- a/src/platform_impl/web/async/mod.rs
+++ b/src/platform_impl/web/async/mod.rs
@@ -1,8 +1,10 @@
+mod abortable;
 mod channel;
 mod dispatcher;
 mod waker;
 mod wrapper;
 
+pub use self::abortable::{AbortHandle, Abortable};
 pub use self::channel::{channel, AsyncReceiver, AsyncSender};
 pub use self::dispatcher::{DispatchRunner, Dispatcher};
 pub use self::waker::{Waker, WakerSpawner};

--- a/src/platform_impl/web/async/notifier.rs
+++ b/src/platform_impl/web/async/notifier.rs
@@ -1,0 +1,76 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::task::Waker;
+
+use concurrent_queue::ConcurrentQueue;
+use concurrent_queue::PushError;
+
+#[derive(Debug)]
+pub struct Notifier(Arc<Inner>);
+
+impl Notifier {
+    pub fn new() -> Self {
+        Self(Arc::new(Inner {
+            queue: ConcurrentQueue::unbounded(),
+            ready: AtomicBool::new(false),
+        }))
+    }
+
+    pub fn notify(self) {
+        self.0.ready.store(true, Ordering::Relaxed);
+
+        self.0.queue.close();
+
+        while let Ok(waker) = self.0.queue.pop() {
+            waker.wake()
+        }
+    }
+
+    pub fn notified(&self) -> Notified {
+        Notified(Some(Arc::clone(&self.0)))
+    }
+}
+
+#[derive(Clone)]
+pub struct Notified(Option<Arc<Inner>>);
+
+impl Future for Notified {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.0.take().expect("`Receiver` polled after completion");
+
+        if this.ready.load(Ordering::Relaxed) {
+            return Poll::Ready(());
+        }
+
+        match this.queue.push(cx.waker().clone()) {
+            Ok(()) => {
+                if this.ready.load(Ordering::Relaxed) {
+                    return Poll::Ready(());
+                }
+
+                self.0 = Some(this);
+                Poll::Pending
+            }
+            Err(PushError::Closed(_)) => {
+                debug_assert!(this.ready.load(Ordering::Relaxed));
+                Poll::Ready(())
+            }
+            Err(PushError::Full(_)) => {
+                unreachable!("found full queue despite using unbounded queue")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Inner {
+    queue: ConcurrentQueue<Waker>,
+    ready: AtomicBool,
+}

--- a/src/platform_impl/web/async/notifier.rs
+++ b/src/platform_impl/web/async/notifier.rs
@@ -7,8 +7,7 @@ use std::task::Context;
 use std::task::Poll;
 use std::task::Waker;
 
-use concurrent_queue::ConcurrentQueue;
-use concurrent_queue::PushError;
+use super::{ConcurrentQueue, PushError};
 
 #[derive(Debug)]
 pub struct Notifier(Arc<Inner>);

--- a/src/platform_impl/web/async/waker.rs
+++ b/src/platform_impl/web/async/waker.rs
@@ -1,10 +1,10 @@
-use super::super::main_thread::MainThreadMarker;
-use super::Wrapper;
-use atomic_waker::AtomicWaker;
 use std::future;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::task::Poll;
+
+use super::super::main_thread::MainThreadMarker;
+use super::{AtomicWaker, Wrapper};
 
 pub struct WakerSpawner<T: 'static>(Wrapper<false, Handler<T>, Sender, usize>);
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -1,4 +1,3 @@
-use super::super::cursor::CustomCursorHandle;
 use super::super::main_thread::MainThreadMarker;
 use super::super::DeviceId;
 use super::{backend, state::State};
@@ -138,16 +137,6 @@ impl Runner {
                         size,
                         scale,
                     )
-                }
-            }
-            EventWrapper::CursorReady(result) => {
-                for (_, canvas, _) in runner.0.all_canvases.borrow().deref() {
-                    if let Some(canvas) = canvas.upgrade() {
-                        canvas
-                            .borrow_mut()
-                            .cursor
-                            .handle_cursor_ready(result.clone())
-                    }
                 }
             }
         }
@@ -822,19 +811,6 @@ impl Shared {
     pub(crate) fn waker(&self) -> Waker<Weak<Execution>> {
         self.0.proxy_spawner.waker()
     }
-
-    pub(crate) fn weak(&self) -> WeakShared {
-        WeakShared(Rc::downgrade(&self.0))
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct WeakShared(Weak<Execution>);
-
-impl WeakShared {
-    pub(crate) fn upgrade(&self) -> Option<Shared> {
-        self.0.upgrade().map(Shared)
-    }
 }
 
 pub(crate) enum EventWrapper {
@@ -844,7 +820,6 @@ pub(crate) enum EventWrapper {
         size: PhysicalSize<u32>,
         scale: f64,
     },
-    CursorReady(Result<CustomCursorHandle, CustomCursorHandle>),
 }
 
 impl From<Event<()>> for EventWrapper {

--- a/src/platform_impl/web/main_thread.rs
+++ b/src/platform_impl/web/main_thread.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 
-use super::r#async::{self, AsyncSender};
+use super::r#async::{self, Sender};
 
 thread_local! {
     static MAIN_THREAD: bool = {
@@ -85,7 +85,7 @@ impl<T> Drop for MainThreadSafe<T> {
 unsafe impl<T> Send for MainThreadSafe<T> {}
 unsafe impl<T> Sync for MainThreadSafe<T> {}
 
-static DROP_HANDLER: OnceLock<AsyncSender<DropBox>> = OnceLock::new();
+static DROP_HANDLER: OnceLock<Sender<DropBox>> = OnceLock::new();
 
 struct DropBox(#[allow(dead_code)] Box<dyn Any>);
 

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -43,3 +43,4 @@ pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 pub(crate) use cursor::CustomCursor as PlatformCustomCursor;
 pub(crate) use cursor::CustomCursorBuilder as PlatformCustomCursorBuilder;
+pub(crate) use cursor::CustomCursorFuture;

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -109,7 +109,7 @@ impl Canvas {
 
         let style = Style::new(&window, &canvas);
 
-        let cursor = CursorHandler::new(main_thread, style.clone());
+        let cursor = CursorHandler::new(main_thread, canvas.clone(), style.clone());
 
         let common = Common {
             window: window.clone(),

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -18,7 +18,6 @@ use crate::platform_impl::{OsError, PlatformSpecificWindowBuilderAttributes};
 use crate::window::{WindowAttributes, WindowId as RootWindowId};
 
 use super::super::cursor::CursorHandler;
-use super::super::event_loop::runner::WeakShared;
 use super::super::main_thread::MainThreadMarker;
 use super::super::WindowId;
 use super::animation_frame::AnimationFrameHandler;
@@ -71,7 +70,6 @@ pub struct Style {
 impl Canvas {
     pub(crate) fn create(
         main_thread: MainThreadMarker,
-        runner: WeakShared,
         id: WindowId,
         window: web_sys::Window,
         document: Document,
@@ -111,7 +109,7 @@ impl Canvas {
 
         let style = Style::new(&window, &canvas);
 
-        let cursor = CursorHandler::new(main_thread, runner, style.clone());
+        let cursor = CursorHandler::new(main_thread, style.clone());
 
         let common = Common {
             window: window.clone(),

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -39,7 +39,6 @@ impl Window {
         let document = target.runner.document();
         let canvas = backend::Canvas::create(
             target.runner.main_thread(),
-            target.runner.weak(),
             id,
             window.clone(),
             document.clone(),


### PR DESCRIPTION
- Added something similar to [`futures::future::Abortable`](https://docs.rs/futures/0.3.30/futures/future/struct.Abortable.html) to abort `Future`s as soon as possible.
- Custom cursors are now await per window with a `wasm_bindgen_futures::spawn_local()` instead of going through a custom event loop event.
- Conditionally removed dependencies that aren't necessary in single-threaded Wasm (`atomic-waker` and `concurrent-queue`).
- Add `CustomCursorBuilder::build_async()`, to allow users to wait until a cursor has actually loaded and receive an appropriate error if loading wasn't successful.
- Add `CustomCursor::from_animation()` to create animated cursors from `CustomCursor`s using the [Web Animations API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Animations_API).

Addresses #3306.