### PR TITLE
Begin transition to a trait-based system (`ApplicationHandler`, `WindowHandler`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- **Breaking:** Removed unnecessary generic parameter `T` from `EventLoopWindowTarget`.
 - On Windows, macOS, X11, Wayland and Web, implement setting images as cursors. See the `custom_cursors.rs` example.
   - Add `Window::set_custom_cursor`
   - Add `CustomCursor`

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -53,12 +53,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("parent window: {parent_window:?})");
 
-    event_loop.run(move |event: Event<()>, elwt| {
+    event_loop.run(move |event: Event<()>, event_loop| {
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {
                     windows.clear();
-                    elwt.exit();
+                    event_loop.exit();
                 }
                 WindowEvent::CursorEntered { device_id: _ } => {
                     // On x11, println when the cursor entered in a window even if the child window is created
@@ -75,7 +75,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         },
                     ..
                 } => {
-                    spawn_child_window(&parent_window, elwt, &mut windows);
+                    spawn_child_window(&parent_window, event_loop, &mut windows);
                 }
                 WindowEvent::RedrawRequested => {
                     if let Some(window) = windows.get(&window_id) {

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     fn spawn_child_window(
         parent: &Window,
-        event_loop: &EventLoopWindowTarget<()>,
+        event_loop: &EventLoopWindowTarget,
         windows: &mut HashMap<WindowId, Window>,
     ) {
         let parent = parent.raw_window_handle().unwrap();

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -16,14 +16,14 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::{
         dpi::{LogicalPosition, LogicalSize, Position},
         event::{ElementState, Event, KeyEvent, WindowEvent},
-        event_loop::{EventLoop, EventLoopWindowTarget},
+        event_loop::{ActiveEventLoop, EventLoop},
         raw_window_handle::HasRawWindowHandle,
         window::{Window, WindowBuilder, WindowId},
     };
 
     fn spawn_child_window(
         parent: &Window,
-        event_loop: &EventLoopWindowTarget,
+        event_loop: ActiveEventLoop<'_>,
         windows: &mut HashMap<WindowId, Window>,
     ) {
         let parent = parent.raw_window_handle().unwrap();

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut wait_cancelled = false;
     let mut close_requested = false;
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         use winit::event::StartCause;
         println!("{event:?}");
         match event {
@@ -104,22 +104,22 @@ fn main() -> Result<(), impl std::error::Error> {
                 }
 
                 match mode {
-                    Mode::Wait => elwt.set_control_flow(ControlFlow::Wait),
+                    Mode::Wait => event_loop.set_control_flow(ControlFlow::Wait),
                     Mode::WaitUntil => {
                         if !wait_cancelled {
-                            elwt.set_control_flow(ControlFlow::WaitUntil(
+                            event_loop.set_control_flow(ControlFlow::WaitUntil(
                                 time::Instant::now() + WAIT_TIME,
                             ));
                         }
                     }
                     Mode::Poll => {
                         thread::sleep(POLL_SLEEP_TIME);
-                        elwt.set_control_flow(ControlFlow::Poll);
+                        event_loop.set_control_flow(ControlFlow::Poll);
                     }
                 };
 
                 if close_requested {
-                    elwt.exit();
+                    event_loop.exit();
                 }
             }
             _ => (),

--- a/examples/cursor.rs
+++ b/examples/cursor.rs
@@ -19,7 +19,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut cursor_idx = 0;
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::KeyboardInput {
@@ -42,7 +42,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     fill::fill_window(&window);
                 }
                 WindowEvent::CloseRequested => {
-                    elwt.exit();
+                    event_loop.exit();
                 }
                 _ => (),
             }

--- a/examples/cursor_grab.rs
+++ b/examples/cursor_grab.rs
@@ -22,9 +22,9 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut modifiers = ModifiersState::default();
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::WindowEvent { event, .. } => match event {
-            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::KeyboardInput {
                 event:
                     KeyEvent {
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
             } => {
                 let result = match key {
                     Key::Named(NamedKey::Escape) => {
-                        elwt.exit();
+                        event_loop.exit();
                         Ok(())
                     }
                     Key::Character(ch) => match ch.to_lowercase().as_str() {

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -9,7 +9,7 @@ use winit::{
     window::{CustomCursor, WindowBuilder},
 };
 
-fn decode_cursor<T>(bytes: &[u8], window_target: &EventLoopWindowTarget<T>) -> CustomCursor {
+fn decode_cursor(bytes: &[u8], window_target: &EventLoopWindowTarget) -> CustomCursor {
     let img = image::load_from_memory(bytes).unwrap().to_rgba8();
     let samples = img.into_flat_samples();
     let (_, w, h) = samples.extents();

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -4,19 +4,18 @@
 use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{EventLoop, EventLoopWindowTarget},
+    event_loop::EventLoop,
     keyboard::Key,
     window::{CustomCursor, WindowBuilder},
 };
 
-fn decode_cursor(bytes: &[u8], window_target: &EventLoopWindowTarget) -> CustomCursor {
+fn decode_cursor(bytes: &[u8], event_loop: &EventLoop<()>) -> CustomCursor {
     let img = image::load_from_memory(bytes).unwrap().to_rgba8();
     let samples = img.into_flat_samples();
     let (_, w, h) = samples.extents();
     let (w, h) = (w as u16, h as u16);
     let builder = CustomCursor::from_rgba(samples.samples, w, h, w / 2, h / 2).unwrap();
-
-    builder.build(window_target)
+    builder.build(event_loop)
 }
 
 #[cfg(not(wasm_platform))]

--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -48,7 +48,7 @@ fn main() -> Result<(), impl std::error::Error> {
         decode_cursor(include_bytes!("data/cross2.png"), &event_loop),
     ];
 
-    event_loop.run(move |event, _elwt| match event {
+    event_loop.run(move |event, _event_loop| match event {
         Event::WindowEvent { event, .. } => match event {
             WindowEvent::KeyboardInput {
                 event:
@@ -81,7 +81,7 @@ fn main() -> Result<(), impl std::error::Error> {
             }
             WindowEvent::CloseRequested => {
                 #[cfg(not(wasm_platform))]
-                _elwt.exit();
+                _event_loop.exit();
             }
             _ => (),
         },

--- a/examples/custom_events.rs
+++ b/examples/custom_events.rs
@@ -40,12 +40,12 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     });
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::UserEvent(event) => println!("user event: {event:?}"),
         Event::WindowEvent {
             event: WindowEvent::CloseRequested,
             ..
-        } => elwt.exit(),
+        } => event_loop.exit(),
         Event::WindowEvent {
             event: WindowEvent::RedrawRequested,
             ..

--- a/examples/drag_window.rs
+++ b/examples/drag_window.rs
@@ -22,12 +22,12 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut entered_id = window_2.id();
     let mut cursor_location = None;
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::NewEvents(StartCause::Init) => {
             eprintln!("Switch which window is to be dragged by pressing \"x\".")
         }
         Event::WindowEvent { event, window_id } => match event {
-            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::CursorMoved { position, .. } => cursor_location = Some(position),
             WindowEvent::MouseInput { state, button, .. } => {
                 let window = if (window_id == window_1.id() && switched)

--- a/examples/focus.rs
+++ b/examples/focus.rs
@@ -27,7 +27,7 @@ fn main() -> Result<(), impl std::error::Error> {
         .unwrap();
 
     let mut deadline = time::Instant::now() + time::Duration::from_secs(3);
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         match event {
             Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
                 // Timeout reached; focus the window.
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 window.focus_window();
             }
             Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     // Notify the windowing system that we'll be presenting to the window.
                     window.pre_present_notify();
@@ -51,6 +51,6 @@ fn main() -> Result<(), impl std::error::Error> {
             _ => (),
         }
 
-        elwt.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(deadline));
+        event_loop.set_control_flow(winit::event_loop::ControlFlow::WaitUntil(deadline));
     })
 }

--- a/examples/fullscreen.rs
+++ b/examples/fullscreen.rs
@@ -52,10 +52,10 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("- I\tToggle mIn size limit");
     println!("- A\tToggle mAx size limit");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {
@@ -65,7 +65,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         },
                     ..
                 } => match key {
-                    Key::Named(NamedKey::Escape) => elwt.exit(),
+                    Key::Named(NamedKey::Escape) => event_loop.exit(),
                     // WARNING: Consider using `key_without_modifers()` if available on your platform.
                     // See the `key_binding` example
                     Key::Character(ch) => match ch.to_lowercase().as_str() {
@@ -88,12 +88,14 @@ fn main() -> Result<(), impl std::error::Error> {
                         }
                         "s" => {
                             monitor_index += 1;
-                            if let Some(mon) = elwt.available_monitors().nth(monitor_index) {
+                            if let Some(mon) = event_loop.available_monitors().nth(monitor_index) {
                                 monitor = mon;
                             } else {
                                 monitor_index = 0;
-                                monitor =
-                                    elwt.available_monitors().next().expect("no monitor found!");
+                                monitor = event_loop
+                                    .available_monitors()
+                                    .next()
+                                    .expect("no monitor found!");
                             }
                             println!("Monitor: {:?}", monitor.name());
 

--- a/examples/handling_close.rs
+++ b/examples/handling_close.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut close_requested = false;
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
                 WindowEvent::CloseRequested => {
@@ -64,7 +64,7 @@ fn main() -> Result<(), impl std::error::Error> {
                                 // event loop (i.e. if it's a multi-window application), you need to
                                 // drop the window. That closes it, and results in `Destroyed` being
                                 // sent.
-                                elwt.exit();
+                                event_loop.exit();
                             }
                         }
                         Key::Character("n") => {

--- a/examples/ime.rs
+++ b/examples/ime.rs
@@ -39,10 +39,10 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut cursor_position = PhysicalPosition::new(0.0, 0.0);
     let mut ime_pos = PhysicalPosition::new(0.0, 0.0);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::CursorMoved { position, .. } => {
                     cursor_position = position;
                 }

--- a/examples/key_binding.rs
+++ b/examples/key_binding.rs
@@ -31,10 +31,10 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut modifiers = ModifiersState::default();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::ModifiersChanged(new) => {
                     modifiers = new.state();
                 }

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -34,10 +34,10 @@ In both cases the example window should move like the content of a scroll area i
 In other words, the deltas indicate the direction in which to move the content (in this case the window)."
     );
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::MouseWheel { delta, .. } => match delta {
                     winit::event::MouseScrollDelta::LineDelta(x, y) => {
                         println!("mouse wheel Line Delta: ({x},{y})");

--- a/examples/multithreaded.rs
+++ b/examples/multithreaded.rs
@@ -173,9 +173,9 @@ fn main() -> Result<(), impl std::error::Error> {
             }
         });
     }
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if window_senders.is_empty() {
-            elwt.exit()
+            event_loop.exit()
         }
         match event {
             Event::WindowEvent { event, window_id } => match event {

--- a/examples/multiwindow.rs
+++ b/examples/multiwindow.rs
@@ -26,7 +26,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Press N to open a new window.");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     windows.remove(&window_id);
 
                     if windows.is_empty() {
-                        elwt.exit();
+                        event_loop.exit();
                     }
                 }
                 WindowEvent::KeyboardInput {
@@ -44,9 +44,9 @@ fn main() -> Result<(), impl std::error::Error> {
                     is_synthetic: false,
                     ..
                 } if event.state == ElementState::Pressed => match event.logical_key {
-                    Key::Named(NamedKey::Escape) => elwt.exit(),
+                    Key::Named(NamedKey::Escape) => event_loop.exit(),
                     Key::Character(c) if c == "n" || c == "N" => {
-                        let window = Window::new(elwt).unwrap();
+                        let window = Window::new(event_loop).unwrap();
                         println!("Opened a new window: {:?}", window.id());
                         windows.insert(window.id(), window);
                     }

--- a/examples/request_redraw.rs
+++ b/examples/request_redraw.rs
@@ -19,12 +19,12 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::MouseInput {
                     state: ElementState::Released,
                     ..

--- a/examples/request_redraw_threaded.rs
+++ b/examples/request_redraw_threaded.rs
@@ -33,14 +33,14 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     });
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         match event {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => elwt.exit(),
+            } => event_loop.exit(),
             Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..

--- a/examples/resizable.rs
+++ b/examples/resizable.rs
@@ -27,10 +27,10 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::KeyboardInput {
                     event:
                         KeyEvent {

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -31,7 +31,7 @@ mod example {
         let mut counter = 0;
         let mut create_first_window = false;
 
-        event_loop.run(move |event, elwt| {
+        event_loop.run(move |event, event_loop| {
             match event {
                 Event::Resumed => create_first_window = true,
 
@@ -60,7 +60,7 @@ mod example {
                         // Remove the window from the map.
                         windows.remove(&window_id);
                         if windows.is_empty() {
-                            elwt.exit();
+                            event_loop.exit();
                             return;
                         }
                     }
@@ -92,7 +92,7 @@ mod example {
                         builder = builder.with_activation_token(token);
                     }
 
-                    Rc::new(builder.build(elwt).unwrap())
+                    Rc::new(builder.build(event_loop).unwrap())
                 };
 
                 // Add the window to the map.

--- a/examples/theme.rs
+++ b/examples/theme.rs
@@ -27,10 +27,10 @@ fn main() -> Result<(), impl std::error::Error> {
     println!("  (L) Light theme");
     println!("  (D) Dark theme");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { window_id, event } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::ThemeChanged(theme) if window_id == window.id() => {
                     println!("Theme is changed: {theme:?}")
                 }

--- a/examples/timer.rs
+++ b/examples/timer.rs
@@ -27,21 +27,21 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let timer_length = Duration::new(1, 0);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         match event {
             Event::NewEvents(StartCause::Init) => {
-                elwt.set_control_flow(ControlFlow::WaitUntil(Instant::now() + timer_length));
+                event_loop.set_control_flow(ControlFlow::WaitUntil(Instant::now() + timer_length));
             }
             Event::NewEvents(StartCause::ResumeTimeReached { .. }) => {
-                elwt.set_control_flow(ControlFlow::WaitUntil(Instant::now() + timer_length));
+                event_loop.set_control_flow(ControlFlow::WaitUntil(Instant::now() + timer_length));
                 println!("\nTimer\n");
             }
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
-            } => elwt.exit(),
+            } => event_loop.exit(),
             Event::WindowEvent {
                 event: WindowEvent::RedrawRequested,
                 ..

--- a/examples/touchpad_gestures.rs
+++ b/examples/touchpad_gestures.rs
@@ -19,10 +19,10 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Only supported on macOS at the moment.");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::TouchpadMagnify { delta, .. } => {
                     if delta > 0.0 {
                         println!("Zoomed in {delta}");

--- a/examples/transparent.rs
+++ b/examples/transparent.rs
@@ -22,12 +22,12 @@ fn main() -> Result<(), impl std::error::Error> {
 
     window.set_title("A fantastic window!");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -21,7 +21,7 @@ pub fn main() -> Result<(), impl std::error::Error> {
     #[cfg(wasm_platform)]
     let log_list = wasm::insert_canvas_and_create_log_list(&window);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         #[cfg(wasm_platform)]
         wasm::log_event(&log_list, &event);
 
@@ -29,7 +29,7 @@ pub fn main() -> Result<(), impl std::error::Error> {
             Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 window_id,
-            } if window_id == window.id() => elwt.exit(),
+            } if window_id == window.id() => event_loop.exit(),
             Event::AboutToWait => {
                 window.request_redraw();
             }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -20,12 +20,12 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         println!("{event:?}");
 
         match event {
             Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     // Notify the windowing system that we'll be presenting to the window.
                     window.pre_present_notify();

--- a/examples/window_buttons.rs
+++ b/examples/window_buttons.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.listen_device_events(DeviceEvents::Always);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { window_id, event } = event {
             match event {
                 WindowEvent::KeyboardInput {
@@ -57,7 +57,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     }
                     _ => (),
                 },
-                WindowEvent::CloseRequested if window_id == window.id() => elwt.exit(),
+                WindowEvent::CloseRequested if window_id == window.id() => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/window_debug.rs
+++ b/examples/window_debug.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     event_loop.listen_device_events(DeviceEvents::Always);
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         match event {
             // This used to use the virtual key, but the new API
             // only provides the `physical_key` (`Code`).
@@ -113,7 +113,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         window.set_minimized(minimized);
                     }
                     "q" => {
-                        elwt.exit();
+                        event_loop.exit();
                     }
                     "v" => {
                         visible = !visible;
@@ -125,7 +125,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     }
                     _ => (),
                 },
-                WindowEvent::CloseRequested if window_id == window.id() => elwt.exit(),
+                WindowEvent::CloseRequested if window_id == window.id() => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     fill::fill_window(&window);
                 }

--- a/examples/window_drag_resize.rs
+++ b/examples/window_drag_resize.rs
@@ -27,12 +27,12 @@ fn main() -> Result<(), impl std::error::Error> {
     let mut border = false;
     let mut cursor_location = None;
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::NewEvents(StartCause::Init) => {
             eprintln!("Press 'B' to toggle borderless")
         }
         Event::WindowEvent { event, .. } => match event {
-            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::CursorMoved { position, .. } => {
                 if !window.is_decorated() {
                     let new_location =

--- a/examples/window_icon.rs
+++ b/examples/window_icon.rs
@@ -33,10 +33,10 @@ fn main() -> Result<(), impl std::error::Error> {
         .build(&event_loop)
         .unwrap();
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, .. } = event {
             match event {
-                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::DroppedFile(path) => {
                     window.set_window_icon(Some(load_icon(&path)));
                 }

--- a/examples/window_on_demand.rs
+++ b/examples/window_on_demand.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), impl std::error::Error> {
     fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), EventLoopError> {
         let mut app = App::default();
 
-        event_loop.run_on_demand(move |event, elwt| {
+        event_loop.run_on_demand(move |event, event_loop| {
             println!("Run {idx}: {:?}", event);
 
             if let Some(window) = &app.window {
@@ -59,7 +59,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     } if id == window_id => {
                         println!("--------------------------------------------------------- Window {idx} Destroyed");
                         app.window_id = None;
-                        elwt.exit();
+                        event_loop.exit();
                     }
                     _ => (),
                 }
@@ -67,7 +67,7 @@ fn main() -> Result<(), impl std::error::Error> {
                 let window = WindowBuilder::new()
                         .with_title("Fantastic window number one!")
                         .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
-                        .build(elwt)
+                        .build(event_loop)
                         .unwrap();
                 app.window_id = Some(window.id());
                 app.window = Some(window);

--- a/examples/window_option_as_alt.rs
+++ b/examples/window_option_as_alt.rs
@@ -31,11 +31,11 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut option_as_alt = window.option_as_alt();
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::WindowEvent {
             event: WindowEvent::CloseRequested,
             window_id,
-        } if window_id == window.id() => elwt.exit(),
+        } if window_id == window.id() => event_loop.exit(),
         Event::WindowEvent { event, .. } => match event {
             WindowEvent::MouseInput {
                 state: ElementState::Pressed,

--- a/examples/window_pump_events.rs
+++ b/examples/window_pump_events.rs
@@ -32,7 +32,7 @@ fn main() -> std::process::ExitCode {
 
     'main: loop {
         let timeout = Some(Duration::ZERO);
-        let status = event_loop.pump_events(timeout, |event, elwt| {
+        let status = event_loop.pump_events(timeout, |event, event_loop| {
             if let Event::WindowEvent { event, .. } = &event {
                 // Print only Window events to reduce noise
                 println!("{event:?}");
@@ -42,7 +42,7 @@ fn main() -> std::process::ExitCode {
                 Event::WindowEvent {
                     event: WindowEvent::CloseRequested,
                     window_id,
-                } if window_id == window.id() => elwt.exit(),
+                } if window_id == window.id() => event_loop.exit(),
                 Event::AboutToWait => {
                     window.request_redraw();
                 }

--- a/examples/window_resize_increments.rs
+++ b/examples/window_resize_increments.rs
@@ -24,9 +24,9 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let mut has_increments = true;
 
-    event_loop.run(move |event, elwt| match event {
+    event_loop.run(move |event, event_loop| match event {
         Event::WindowEvent { event, window_id } if window_id == window.id() => match event {
-            WindowEvent::CloseRequested => elwt.exit(),
+            WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::KeyboardInput { event, .. }
                 if event.logical_key == NamedKey::Space
                     && event.state == ElementState::Released =>

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -30,7 +30,7 @@ fn main() -> Result<(), impl std::error::Error> {
 
     println!("Press N to open a new window.");
 
-    event_loop.run(move |event, elwt| {
+    event_loop.run(move |event, event_loop| {
         if let Event::WindowEvent { event, window_id } = event {
             match event {
                 WindowEvent::CloseRequested => {
@@ -40,7 +40,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     windows.remove(&window_id);
 
                     if windows.is_empty() {
-                        elwt.exit();
+                        event_loop.exit();
                     }
                 }
                 WindowEvent::Resized(_) => {
@@ -62,7 +62,7 @@ fn main() -> Result<(), impl std::error::Error> {
                         let tabbing_id = windows.get(&window_id).unwrap().tabbing_identifier();
                         let window = WindowBuilder::new()
                             .with_tabbing_identifier(&tabbing_id)
-                            .build(elwt)
+                            .build(event_loop)
                             .unwrap();
                         println!("Added a new tab: {:?}", window.id());
                         windows.insert(window.id(), window);

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -32,12 +32,12 @@ mod imple {
             .build(&event_loop)
             .unwrap();
 
-        event_loop.run(move |event, elwt| {
+        event_loop.run(move |event, event_loop| {
             match event {
                 Event::WindowEvent {
                     event: WindowEvent::CloseRequested,
                     window_id,
-                } if window_id == window.id() => elwt.exit(),
+                } if window_id == window.id() => event_loop.exit(),
                 Event::AboutToWait => {
                     window.request_redraw();
                 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -87,7 +87,7 @@ pub struct CustomCursorBuilder {
 }
 
 impl CustomCursorBuilder {
-    pub fn build<T>(self, window_target: &EventLoopWindowTarget<T>) -> CustomCursor {
+    pub fn build(self, window_target: &EventLoopWindowTarget) -> CustomCursor {
         CustomCursor {
             inner: PlatformCustomCursor::build(self.inner, &window_target.p),
         }
@@ -189,10 +189,7 @@ impl Eq for OnlyCursorImage {}
 
 #[allow(dead_code)]
 impl OnlyCursorImage {
-    fn build<T>(
-        builder: OnlyCursorImageBuilder,
-        _: &platform_impl::EventLoopWindowTarget<T>,
-    ) -> Self {
+    fn build(builder: OnlyCursorImageBuilder, _: &platform_impl::EventLoopWindowTarget) -> Self {
         Self(Arc::new(builder.0))
     }
 }
@@ -272,7 +269,7 @@ impl NoCustomCursor {
         Ok(Self)
     }
 
-    fn build<T>(self, _: &platform_impl::EventLoopWindowTarget<T>) -> NoCustomCursor {
+    fn build(self, _: &platform_impl::EventLoopWindowTarget) -> NoCustomCursor {
         self
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -3,7 +3,7 @@ use std::hash::Hasher;
 use std::sync::Arc;
 use std::{error::Error, hash::Hash};
 
-use crate::event_loop::EventLoopWindowTarget;
+use crate::event_loop::MaybeActiveEventLoop;
 use crate::platform_impl::{self, PlatformCustomCursor, PlatformCustomCursorBuilder};
 
 /// The maximum width and height for a cursor when using [`CustomCursor::from_rgba`].
@@ -87,9 +87,9 @@ pub struct CustomCursorBuilder {
 }
 
 impl CustomCursorBuilder {
-    pub fn build(self, window_target: &EventLoopWindowTarget) -> CustomCursor {
+    pub fn build<'a>(self, event_loop: impl MaybeActiveEventLoop<'a>) -> CustomCursor {
         CustomCursor {
-            inner: PlatformCustomCursor::build(self.inner, &window_target.p),
+            inner: PlatformCustomCursor::build(self.inner, event_loop.__inner()),
         }
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -9,22 +9,22 @@
 //! ```rust,ignore
 //! let mut start_cause = StartCause::Init;
 //!
-//! while !elwt.exiting() {
-//!     event_handler(NewEvents(start_cause), elwt);
+//! while !event_loop.exiting() {
+//!     event_handler(NewEvents(start_cause), event_loop);
 //!
 //!     for e in (window events, user events, device events) {
-//!         event_handler(e, elwt);
+//!         event_handler(e, event_loop);
 //!     }
 //!
 //!     for w in (redraw windows) {
-//!         event_handler(RedrawRequested(w), elwt);
+//!         event_handler(RedrawRequested(w), event_loop);
 //!     }
 //!
-//!     event_handler(AboutToWait, elwt);
+//!     event_handler(AboutToWait, event_loop);
 //!     start_cause = wait_if_necessary();
 //! }
 //!
-//! event_handler(LoopExiting, elwt);
+//! event_handler(LoopExiting, event_loop);
 //! ```
 //!
 //! This leaves out timing details like [`ControlFlow::WaitUntil`] but hopefully

--- a/src/event_helper.rs
+++ b/src/event_helper.rs
@@ -1,0 +1,257 @@
+//! Helpers to convert between closure-style and handler trait style.
+//!
+//! This is only in the interim, and will be removed in the future.
+use std::marker::PhantomData;
+#[cfg(not(wasm_platform))]
+use std::time::Instant;
+
+use crate::{
+    event::{
+        AxisId, ButtonId, DeviceEvent, DeviceId, ElementState, Event, MouseScrollDelta,
+        RawKeyEvent, StartCause, WindowEvent,
+    },
+    event_loop::ActiveEventLoop,
+    handler::{ApplicationHandler, DeviceEventHandler},
+    window::WindowId,
+};
+
+#[cfg(wasm_platform)]
+use web_time::Instant;
+
+pub(crate) fn map_event<T, A: ?Sized + ApplicationHandler<T>>(
+    handler: &mut A,
+    event: Event<T>,
+    active: ActiveEventLoop<'_>,
+) {
+    match event {
+        Event::NewEvents(StartCause::Init) => handler.init(active),
+        Event::LoopExiting => handler.exit(active),
+        Event::Suspended => handler.suspend(active),
+        Event::Resumed => handler.resume(active),
+        Event::WindowEvent { window_id, event } => handler.window_event(active, window_id, event),
+        Event::DeviceEvent { device_id, event } => {
+            if let Some(handler) = handler.device_event() {
+                match event {
+                    DeviceEvent::Added => handler.added(active, device_id),
+                    DeviceEvent::Removed => handler.removed(active, device_id),
+                    DeviceEvent::MouseMotion { delta } => {
+                        handler.mouse_motion(active, device_id, delta)
+                    }
+                    DeviceEvent::MouseWheel { delta } => {
+                        handler.mouse_wheel(active, device_id, delta)
+                    }
+                    DeviceEvent::Motion { axis, value } => {
+                        handler.motion(active, device_id, axis, value)
+                    }
+                    DeviceEvent::Button { button, state } => {
+                        handler.button(active, device_id, button, state)
+                    }
+                    DeviceEvent::Key(raw) => handler.key(active, device_id, raw),
+                }
+            }
+        }
+        Event::UserEvent(event) => handler.user_event(active, event),
+        Event::NewEvents(StartCause::ResumeTimeReached {
+            start,
+            requested_resume,
+        }) => handler.start_resume_time_reached(active, start, requested_resume),
+        Event::NewEvents(StartCause::WaitCancelled {
+            start,
+            requested_resume,
+        }) => handler.start_wait_cancelled(active, start, requested_resume),
+        Event::NewEvents(StartCause::Poll) => handler.start_poll(active),
+        Event::AboutToWait => handler.about_to_wait(active),
+        Event::MemoryWarning => handler.memory_warning(active),
+    }
+}
+
+/// Introduce helper type around closure.
+///
+/// This is done to avoid implementing these traits on the closures directly,
+/// since we don't want that implementation to be part of the public API.
+pub(crate) struct MapEventHelper<T, F> {
+    p: PhantomData<T>,
+    f: F,
+}
+
+impl<T, F> MapEventHelper<T, F> {
+    pub(crate) fn new(f: F) -> Self {
+        Self { p: PhantomData, f }
+    }
+}
+
+impl<T: 'static, F> ApplicationHandler<T> for MapEventHelper<T, F>
+where
+    F: FnMut(Event<T>, ActiveEventLoop<'_>),
+{
+    fn window_event(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        (self.f)(Event::WindowEvent { window_id, event }, active)
+    }
+
+    fn init(&mut self, active: ActiveEventLoop<'_>) {
+        (self.f)(Event::NewEvents(StartCause::Init), active)
+    }
+
+    fn resume(&mut self, active: ActiveEventLoop<'_>) {
+        (self.f)(Event::Resumed, active)
+    }
+
+    fn suspend(&mut self, active: ActiveEventLoop<'_>) {
+        (self.f)(Event::Suspended, active)
+    }
+
+    fn user_event(&mut self, active: ActiveEventLoop<'_>, event: T) {
+        (self.f)(Event::UserEvent(event), active)
+    }
+
+    fn exit(&mut self, active: ActiveEventLoop<'_>) {
+        (self.f)(Event::LoopExiting, active)
+    }
+
+    fn start_wait_cancelled(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        start: Instant,
+        requested_resume: Option<Instant>,
+    ) {
+        (self.f)(
+            Event::NewEvents(StartCause::WaitCancelled {
+                start,
+                requested_resume,
+            }),
+            active,
+        )
+    }
+
+    fn start_resume_time_reached(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        start: Instant,
+        requested_resume: Instant,
+    ) {
+        (self.f)(
+            Event::NewEvents(StartCause::ResumeTimeReached {
+                start,
+                requested_resume,
+            }),
+            active,
+        )
+    }
+
+    fn start_poll(&mut self, active: ActiveEventLoop<'_>) {
+        (self.f)(Event::NewEvents(StartCause::Poll), active)
+    }
+
+    fn about_to_wait(&mut self, active: ActiveEventLoop<'_>) {
+        (self.f)(Event::AboutToWait, active)
+    }
+
+    fn memory_warning(&mut self, active: ActiveEventLoop<'_>) {
+        (self.f)(Event::MemoryWarning, active)
+    }
+
+    fn device_event(&mut self) -> Option<&mut dyn DeviceEventHandler> {
+        Some(self)
+    }
+}
+
+impl<T: 'static, F: FnMut(Event<T>, ActiveEventLoop<'_>)> DeviceEventHandler
+    for MapEventHelper<T, F>
+{
+    fn added(&mut self, active: ActiveEventLoop<'_>, device_id: DeviceId) {
+        (self.f)(
+            Event::DeviceEvent {
+                device_id,
+                event: DeviceEvent::Added,
+            },
+            active,
+        )
+    }
+
+    fn removed(&mut self, active: ActiveEventLoop<'_>, device_id: DeviceId) {
+        (self.f)(
+            Event::DeviceEvent {
+                device_id,
+                event: DeviceEvent::Removed,
+            },
+            active,
+        )
+    }
+
+    fn mouse_motion(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        device_id: DeviceId,
+        delta: (f64, f64),
+    ) {
+        (self.f)(
+            Event::DeviceEvent {
+                device_id,
+                event: DeviceEvent::MouseMotion { delta },
+            },
+            active,
+        )
+    }
+
+    fn mouse_wheel(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        device_id: DeviceId,
+        delta: MouseScrollDelta,
+    ) {
+        (self.f)(
+            Event::DeviceEvent {
+                device_id,
+                event: DeviceEvent::MouseWheel { delta },
+            },
+            active,
+        )
+    }
+
+    fn motion(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        device_id: DeviceId,
+        axis: AxisId,
+        value: f64,
+    ) {
+        (self.f)(
+            Event::DeviceEvent {
+                device_id,
+                event: DeviceEvent::Motion { axis, value },
+            },
+            active,
+        )
+    }
+
+    fn button(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        device_id: DeviceId,
+        button: ButtonId,
+        state: ElementState,
+    ) {
+        (self.f)(
+            Event::DeviceEvent {
+                device_id,
+                event: DeviceEvent::Button { button, state },
+            },
+            active,
+        )
+    }
+
+    fn key(&mut self, active: ActiveEventLoop<'_>, device_id: DeviceId, raw: RawKeyEvent) {
+        (self.f)(
+            Event::DeviceEvent {
+                device_id,
+                event: DeviceEvent::Key(raw),
+            },
+            active,
+        )
+    }
+}

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -50,7 +50,7 @@ pub struct EventLoop<T: 'static> {
 /// `&EventLoop`.
 pub struct EventLoopWindowTarget<T: 'static> {
     pub(crate) p: platform_impl::EventLoopWindowTarget<T>,
-    pub(crate) _marker: PhantomData<*mut ()>, // Not Send nor Sync
+    pub(crate) _marker: PhantomData<*mut T>, // Not Send nor Sync + invariant over T
 }
 
 /// Object that allows building the event loop.

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,0 +1,159 @@
+#[cfg(not(wasm_platform))]
+use std::time::Instant;
+
+use crate::{
+    event::{AxisId, ButtonId, DeviceId, ElementState, MouseScrollDelta, RawKeyEvent, WindowEvent},
+    event_loop::ActiveEventLoop,
+    window::WindowId,
+};
+
+#[cfg(wasm_platform)]
+use web_time::Instant;
+
+// Design choice: Always pass `ActiveEventLoop<'_>`, never allow the user to
+// store that, to make it possible for backends to migrate to `&mut`.
+pub trait ApplicationHandler<T = ()> {
+    // TODO: Migrate this to a trait too
+    fn window_event(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        window_id: WindowId,
+        event: WindowEvent,
+    );
+
+    // Default noop events
+
+    fn init(&mut self, active: ActiveEventLoop<'_>) {
+        let _ = active;
+    }
+
+    fn resume(&mut self, active: ActiveEventLoop<'_>) {
+        let _ = active;
+    }
+
+    fn suspend(&mut self, active: ActiveEventLoop<'_>) {
+        let _ = active;
+    }
+
+    fn user_event(&mut self, active: ActiveEventLoop<'_>, event: T) {
+        let _ = active;
+        let _ = event;
+    }
+
+    fn memory_warning(&mut self, active: ActiveEventLoop<'_>) {
+        let _ = active;
+    }
+
+    // TODO: Migrate this to `Drop`
+    fn exit(&mut self, active: ActiveEventLoop<'_>) {
+        let _ = active;
+    }
+
+    // TODO: Figure out better timer support
+
+    fn start_wait_cancelled(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        start: Instant,
+        requested_resume: Option<Instant>,
+    ) {
+        let _ = active;
+        let _ = start;
+        let _ = requested_resume;
+    }
+
+    fn start_resume_time_reached(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        start: Instant,
+        requested_resume: Instant,
+    ) {
+        let _ = active;
+        let _ = start;
+        let _ = requested_resume;
+    }
+
+    fn start_poll(&mut self, active: ActiveEventLoop<'_>) {
+        let _ = active;
+    }
+
+    fn about_to_wait(&mut self, active: ActiveEventLoop<'_>) {
+        let _ = active;
+    }
+
+    // TODO: Consider returning `&mut dyn DeviceEventHandler` instead,
+    // and have this return a noop implementation by default.
+    //
+    // Note that we cannot return `impl DeviceEventHandler`, since
+    // `ApplicationHandler` has to remain object safe.
+    #[inline(always)]
+    fn device_event(&mut self) -> Option<&mut dyn DeviceEventHandler> {
+        None
+    }
+}
+
+pub trait DeviceEventHandler {
+    fn added(&mut self, active: ActiveEventLoop<'_>, device_id: DeviceId) {
+        let _ = active;
+        let _ = device_id;
+    }
+
+    fn removed(&mut self, active: ActiveEventLoop<'_>, device_id: DeviceId) {
+        let _ = active;
+        let _ = device_id;
+    }
+
+    fn mouse_motion(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        device_id: DeviceId,
+        delta: (f64, f64),
+    ) {
+        let _ = active;
+        let _ = device_id;
+        let _ = delta;
+    }
+
+    fn mouse_wheel(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        device_id: DeviceId,
+        delta: MouseScrollDelta,
+    ) {
+        let _ = active;
+        let _ = device_id;
+        let _ = delta;
+    }
+
+    fn motion(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        device_id: DeviceId,
+        axis: AxisId,
+        value: f64,
+    ) {
+        let _ = active;
+        let _ = device_id;
+        let _ = axis;
+        let _ = value;
+    }
+
+    fn button(
+        &mut self,
+        active: ActiveEventLoop<'_>,
+        device_id: DeviceId,
+        button: ButtonId,
+        state: ElementState,
+    ) {
+        let _ = active;
+        let _ = device_id;
+        let _ = button;
+        let _ = state;
+    }
+
+    fn key(&mut self, active: ActiveEventLoop<'_>, device_id: DeviceId, raw: RawKeyEvent) {
+        let _ = active;
+        let _ = device_id;
+        let _ = raw;
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,14 +78,14 @@
 //! // input, and uses significantly less power/CPU time than ControlFlow::Poll.
 //! event_loop.set_control_flow(ControlFlow::Wait);
 //!
-//! event_loop.run(move |event, elwt| {
+//! event_loop.run(move |event, event_loop| {
 //!     match event {
 //!         Event::WindowEvent {
 //!             event: WindowEvent::CloseRequested,
 //!             ..
 //!         } => {
 //!             println!("The close button was pressed; stopping");
-//!             elwt.exit();
+//!             event_loop.exit();
 //!         },
 //!         Event::AboutToWait => {
 //!             // Application update code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,8 @@ extern crate serde;
 extern crate bitflags;
 
 pub mod dpi;
+mod event_helper;
+pub mod handler;
 #[macro_use]
 pub mod error;
 mod cursor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@
 //! [`EventLoop`]: event_loop::EventLoop
 //! [`EventLoop::new()`]: event_loop::EventLoop::new
 //! [`EventLoop::run()`]: event_loop::EventLoop::run
-//! [`exit()`]: event_loop::EventLoopWindowTarget::exit
+//! [`exit()`]: event_loop::ActiveEventLoop::exit
 //! [`Window`]: window::Window
 //! [`WindowId`]: window::WindowId
 //! [`WindowBuilder`]: window::WindowBuilder

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -3,7 +3,8 @@
 //! If you want to get basic information about a monitor, you can use the
 //! [`MonitorHandle`] type. This is retrieved from one of the following
 //! methods, which return an iterator of [`MonitorHandle`]:
-//! - [`EventLoopWindowTarget::available_monitors`](crate::event_loop::EventLoopWindowTarget::available_monitors).
+//! - [`EventLoop::available_monitors`](crate::event_loop::EventLoop::available_monitors).
+//! - [`ActiveEventLoop::available_monitors`](crate::event_loop::ActiveEventLoop::available_monitors).
 //! - [`Window::available_monitors`](crate::window::Window::available_monitors).
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -30,7 +30,7 @@ impl WindowExtAndroid for Window {
     }
 }
 
-impl<T> EventLoopWindowTargetExtAndroid for EventLoopWindowTarget<T> {}
+impl EventLoopWindowTargetExtAndroid for EventLoopWindowTarget {}
 
 /// Additional methods on [`WindowBuilder`] that are specific to Android.
 pub trait WindowBuilderExtAndroid {}

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,5 +1,5 @@
 use crate::{
-    event_loop::{EventLoop, EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{EventLoop, EventLoopBuilder},
     window::{Window, WindowBuilder},
 };
 
@@ -9,9 +9,6 @@ use android_activity::{AndroidApp, ConfigurationRef, Rect};
 pub trait EventLoopExtAndroid {}
 
 impl<T> EventLoopExtAndroid for EventLoop<T> {}
-
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to Android.
-pub trait EventLoopWindowTargetExtAndroid {}
 
 /// Additional methods on [`Window`] that are specific to Android.
 pub trait WindowExtAndroid {
@@ -29,8 +26,6 @@ impl WindowExtAndroid for Window {
         self.window.config()
     }
 }
-
-impl EventLoopWindowTargetExtAndroid for EventLoopWindowTarget {}
 
 /// Additional methods on [`WindowBuilder`] that are specific to Android.
 pub trait WindowBuilderExtAndroid {}

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -4,7 +4,7 @@ use icrate::Foundation::MainThreadMarker;
 use objc2::rc::Id;
 
 use crate::{
-    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{ActiveEventLoop, EventLoopBuilder},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };
@@ -372,8 +372,8 @@ impl MonitorHandleExtMacOS for MonitorHandle {
     }
 }
 
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to macOS.
-pub trait EventLoopWindowTargetExtMacOS {
+/// Additional methods on [`ActiveEventLoop`] that are specific to macOS.
+pub trait ActiveEventLoopExtMacOS {
     /// Hide the entire application. In most applications this is typically triggered with Command-H.
     fn hide_application(&self);
     /// Hide the other applications. In most applications this is typically triggered with Command+Option-H.
@@ -386,21 +386,21 @@ pub trait EventLoopWindowTargetExtMacOS {
     fn allows_automatic_window_tabbing(&self) -> bool;
 }
 
-impl EventLoopWindowTargetExtMacOS for EventLoopWindowTarget {
+impl ActiveEventLoopExtMacOS for ActiveEventLoop<'_> {
     fn hide_application(&self) {
-        self.p.hide_application()
+        self.inner.hide_application()
     }
 
     fn hide_other_applications(&self) {
-        self.p.hide_other_applications()
+        self.inner.hide_other_applications()
     }
 
     fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
-        self.p.set_allows_automatic_window_tabbing(enabled);
+        self.inner.set_allows_automatic_window_tabbing(enabled);
     }
 
     fn allows_automatic_window_tabbing(&self) -> bool {
-        self.p.allows_automatic_window_tabbing()
+        self.inner.allows_automatic_window_tabbing()
     }
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -386,7 +386,7 @@ pub trait EventLoopWindowTargetExtMacOS {
     fn allows_automatic_window_tabbing(&self) -> bool;
 }
 
-impl<T> EventLoopWindowTargetExtMacOS for EventLoopWindowTarget<T> {
+impl EventLoopWindowTargetExtMacOS for EventLoopWindowTarget {
     fn hide_application(&self) {
         self.p.hide_application()
     }

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -63,7 +63,7 @@ pub trait EventLoopExtPumpEvents {
     ///
     ///     'main: loop {
     ///         let timeout = Some(Duration::ZERO);
-    ///         let status = event_loop.pump_events(timeout, |event, elwt| {
+    ///         let status = event_loop.pump_events(timeout, |event, event_loop| {
     /// #            if let Event::WindowEvent { event, .. } = &event {
     /// #                // Print only Window events to reduce noise
     /// #                println!("{event:?}");
@@ -73,7 +73,7 @@ pub trait EventLoopExtPumpEvents {
     ///                 Event::WindowEvent {
     ///                     event: WindowEvent::CloseRequested,
     ///                     window_id,
-    ///                 } if window_id == window.id() => elwt.exit(),
+    ///                 } if window_id == window.id() => event_loop.exit(),
     ///                 Event::AboutToWait => {
     ///                     window.request_redraw();
     ///                 }

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -174,7 +174,7 @@ pub trait EventLoopExtPumpEvents {
     ///   callback.
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget);
 }
 
 impl<T> EventLoopExtPumpEvents for EventLoop<T> {
@@ -182,7 +182,7 @@ impl<T> EventLoopExtPumpEvents for EventLoop<T> {
 
     fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget),
     {
         self.event_loop.pump_events(timeout, event_handler)
     }

--- a/src/platform/run_on_demand.rs
+++ b/src/platform/run_on_demand.rs
@@ -66,7 +66,7 @@ pub trait EventLoopExtRunOnDemand {
     /// [`set_control_flow()`]: EventLoopWindowTarget::set_control_flow()
     fn run_on_demand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget);
 }
 
 impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
@@ -74,7 +74,7 @@ impl<T> EventLoopExtRunOnDemand for EventLoop<T> {
 
     fn run_on_demand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
+        F: FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget),
     {
         self.event_loop.run_on_demand(event_handler)
     }

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -55,7 +55,7 @@ pub trait WindowBuilderExtStartupNotify {
     fn with_activation_token(self, token: ActivationToken) -> Self;
 }
 
-impl<T> EventLoopExtStartupNotify for EventLoopWindowTarget<T> {
+impl EventLoopExtStartupNotify for EventLoopWindowTarget {
     fn read_token_from_env(&self) -> Option<ActivationToken> {
         match self.p {
             #[cfg(wayland_platform)]

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -1,5 +1,5 @@
 use crate::{
-    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };
@@ -8,16 +8,29 @@ use crate::platform_impl::{ApplicationName, Backend};
 
 pub use crate::window::Theme;
 
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to Wayland.
-pub trait EventLoopWindowTargetExtWayland {
-    /// True if the [`EventLoopWindowTarget`] uses Wayland.
+/// Additional methods on [`EventLoop`] that are specific to Wayland.
+pub trait EventLoopExtWayland {
+    /// True if the [`EventLoop`] uses Wayland.
     fn is_wayland(&self) -> bool;
 }
 
-impl EventLoopWindowTargetExtWayland for EventLoopWindowTarget {
+impl<T: 'static> EventLoopExtWayland for EventLoop<T> {
     #[inline]
     fn is_wayland(&self) -> bool {
-        self.p.is_wayland()
+        self.event_loop.window_target().is_wayland()
+    }
+}
+
+/// Additional methods on [`ActiveEventLoop`] that are specific to Wayland.
+pub trait ActiveEventLoopExtWayland {
+    /// True if the [`ActiveEventLoop`] uses Wayland.
+    fn is_wayland(&self) -> bool;
+}
+
+impl ActiveEventLoopExtWayland for ActiveEventLoop<'_> {
+    #[inline]
+    fn is_wayland(&self) -> bool {
+        self.inner.is_wayland()
     }
 }
 

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -14,7 +14,7 @@ pub trait EventLoopWindowTargetExtWayland {
     fn is_wayland(&self) -> bool;
 }
 
-impl<T> EventLoopWindowTargetExtWayland for EventLoopWindowTarget<T> {
+impl EventLoopWindowTargetExtWayland for EventLoopWindowTarget {
     #[inline]
     fn is_wayland(&self) -> bool {
         self.p.is_wayland()

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -136,7 +136,7 @@ pub trait EventLoopExtWebSys {
     /// [^1]: `run()` is _not_ available on WASM when the target supports `exception-handling`.
     fn spawn<F>(self, event_handler: F)
     where
-        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>);
+        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget);
 }
 
 impl<T> EventLoopExtWebSys for EventLoop<T> {
@@ -144,7 +144,7 @@ impl<T> EventLoopExtWebSys for EventLoop<T> {
 
     fn spawn<F>(self, event_handler: F)
     where
-        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget<Self::UserEvent>),
+        F: 'static + FnMut(Event<Self::UserEvent>, &EventLoopWindowTarget),
     {
         self.event_loop.spawn(event_handler)
     }
@@ -166,7 +166,7 @@ pub trait EventLoopWindowTargetExtWebSys {
     fn poll_strategy(&self) -> PollStrategy;
 }
 
-impl<T> EventLoopWindowTargetExtWebSys for EventLoopWindowTarget<T> {
+impl EventLoopWindowTargetExtWebSys for EventLoopWindowTarget {
     #[inline]
     fn set_poll_strategy(&self, strategy: PollStrategy) {
         self.p.set_poll_strategy(strategy);

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -1,5 +1,5 @@
 use crate::{
-    event_loop::{EventLoopBuilder, EventLoopWindowTarget},
+    event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder},
     monitor::MonitorHandle,
     window::{Window, WindowBuilder},
 };
@@ -42,16 +42,29 @@ pub fn register_xlib_error_hook(hook: XlibErrorHook) {
     }
 }
 
-/// Additional methods on [`EventLoopWindowTarget`] that are specific to X11.
-pub trait EventLoopWindowTargetExtX11 {
-    /// True if the [`EventLoopWindowTarget`] uses X11.
+/// Additional methods on [`EventLoop`] that are specific to X11.
+pub trait EventLoopExtX11 {
+    /// True if the [`EventLoop`] uses X11.
     fn is_x11(&self) -> bool;
 }
 
-impl EventLoopWindowTargetExtX11 for EventLoopWindowTarget {
+impl<T> EventLoopExtX11 for EventLoop<T> {
     #[inline]
     fn is_x11(&self) -> bool {
-        !self.p.is_wayland()
+        !self.event_loop.window_target().is_wayland()
+    }
+}
+
+/// Additional methods on [`ActiveEventLoop`] that are specific to X11.
+pub trait ActiveEventLoopExtX11 {
+    /// True if the [`ActiveEventLoop`] uses X11.
+    fn is_x11(&self) -> bool;
+}
+
+impl ActiveEventLoopExtX11 for ActiveEventLoop<'_> {
+    #[inline]
+    fn is_x11(&self) -> bool {
+        !self.inner.is_wayland()
     }
 }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -48,7 +48,7 @@ pub trait EventLoopWindowTargetExtX11 {
     fn is_x11(&self) -> bool;
 }
 
-impl<T> EventLoopWindowTargetExtX11 for EventLoopWindowTarget<T> {
+impl EventLoopWindowTargetExtX11 for EventLoopWindowTarget {
     #[inline]
     fn is_x11(&self) -> bool {
         !self.p.is_wayland()

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error,
     event::{self, Force, InnerSizeWriter, StartCause},
-    event_loop::{self, ControlFlow, DeviceEvents, EventLoopWindowTarget as RootELW},
+    event_loop::{self, ControlFlow, DeviceEvents},
     platform::pump_events::PumpStatus,
     window::{
         self, CursorGrabMode, ImePurpose, ResizeDirection, Theme, WindowButtons, WindowLevel,
@@ -138,7 +138,7 @@ pub struct KeyEventExtra {}
 
 pub struct EventLoop<T: 'static> {
     android_app: AndroidApp,
-    window_target: event_loop::EventLoopWindowTarget,
+    window_target: EventLoopWindowTarget,
     redraw_flag: SharedFlag,
     user_events_sender: mpsc::Sender<T>,
     user_events_receiver: PeekableReceiver<T>, //must wake looper whenever something gets sent
@@ -176,16 +176,11 @@ impl<T: 'static> EventLoop<T> {
 
         Ok(Self {
             android_app: android_app.clone(),
-            window_target: event_loop::EventLoopWindowTarget {
-                p: EventLoopWindowTarget {
-                    app: android_app.clone(),
-                    control_flow: Cell::new(ControlFlow::default()),
-                    exit: Cell::new(false),
-                    redraw_requester: RedrawRequester::new(
-                        &redraw_flag,
-                        android_app.create_waker(),
-                    ),
-                },
+            window_target: EventLoopWindowTarget {
+                app: android_app.clone(),
+                control_flow: Cell::new(ControlFlow::default()),
+                exit: Cell::new(false),
+                redraw_requester: RedrawRequester::new(&redraw_flag, android_app.create_waker()),
             },
             redraw_flag,
             user_events_sender,
@@ -201,7 +196,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn single_iteration<F>(&mut self, main_event: Option<MainEvent<'_>>, callback: &mut F)
     where
-        F: FnMut(event::Event<T>, &RootELW),
+        F: FnMut(event::Event<T>, &EventLoopWindowTarget),
     {
         trace!("Mainloop iteration");
 
@@ -373,7 +368,7 @@ impl<T: 'static> EventLoop<T> {
         callback: &mut F,
     ) -> InputStatus
     where
-        F: FnMut(event::Event<T>, &RootELW),
+        F: FnMut(event::Event<T>, &EventLoopWindowTarget),
     {
         let mut input_status = InputStatus::Handled;
         match event {
@@ -478,14 +473,14 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
+        F: FnMut(event::Event<T>, &EventLoopWindowTarget),
     {
         self.run_on_demand(event_handler)
     }
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
+        F: FnMut(event::Event<T>, &EventLoopWindowTarget),
     {
         if self.loop_running {
             return Err(EventLoopError::AlreadyRunning);
@@ -508,7 +503,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut callback: F) -> PumpStatus
     where
-        F: FnMut(event::Event<T>, &RootELW),
+        F: FnMut(event::Event<T>, &EventLoopWindowTarget),
     {
         if !self.loop_running {
             self.loop_running = true;
@@ -541,7 +536,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn poll_events_with_timeout<F>(&mut self, mut timeout: Option<Duration>, mut callback: F)
     where
-        F: FnMut(event::Event<T>, &RootELW),
+        F: FnMut(event::Event<T>, &EventLoopWindowTarget),
     {
         let start = Instant::now();
 
@@ -617,7 +612,7 @@ impl<T: 'static> EventLoop<T> {
         });
     }
 
-    pub fn window_target(&self) -> &event_loop::EventLoopWindowTarget {
+    pub fn window_target(&self) -> &EventLoopWindowTarget {
         &self.window_target
     }
 
@@ -629,11 +624,11 @@ impl<T: 'static> EventLoop<T> {
     }
 
     fn control_flow(&self) -> ControlFlow {
-        self.window_target.p.control_flow()
+        self.window_target.control_flow()
     }
 
     fn exiting(&self) -> bool {
-        self.window_target.p.exiting()
+        self.window_target.exiting()
     }
 }
 
@@ -660,6 +655,8 @@ impl<T> EventLoopProxy<T> {
         Ok(())
     }
 }
+
+pub type ActiveEventLoop<'a> = &'a EventLoopWindowTarget;
 
 pub struct EventLoopWindowTarget {
     app: AndroidApp,

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -138,7 +138,7 @@ pub struct KeyEventExtra {}
 
 pub struct EventLoop<T: 'static> {
     android_app: AndroidApp,
-    window_target: event_loop::EventLoopWindowTarget<T>,
+    window_target: event_loop::EventLoopWindowTarget,
     redraw_flag: SharedFlag,
     user_events_sender: mpsc::Sender<T>,
     user_events_receiver: PeekableReceiver<T>, //must wake looper whenever something gets sent
@@ -185,9 +185,7 @@ impl<T: 'static> EventLoop<T> {
                         &redraw_flag,
                         android_app.create_waker(),
                     ),
-                    _marker: std::marker::PhantomData,
                 },
-                _marker: std::marker::PhantomData,
             },
             redraw_flag,
             user_events_sender,
@@ -203,7 +201,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn single_iteration<F>(&mut self, main_event: Option<MainEvent<'_>>, callback: &mut F)
     where
-        F: FnMut(event::Event<T>, &RootELW<T>),
+        F: FnMut(event::Event<T>, &RootELW),
     {
         trace!("Mainloop iteration");
 
@@ -375,7 +373,7 @@ impl<T: 'static> EventLoop<T> {
         callback: &mut F,
     ) -> InputStatus
     where
-        F: FnMut(event::Event<T>, &RootELW<T>),
+        F: FnMut(event::Event<T>, &RootELW),
     {
         let mut input_status = InputStatus::Handled;
         match event {
@@ -480,14 +478,14 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>),
+        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
     {
         self.run_on_demand(event_handler)
     }
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>),
+        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
     {
         if self.loop_running {
             return Err(EventLoopError::AlreadyRunning);
@@ -510,7 +508,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut callback: F) -> PumpStatus
     where
-        F: FnMut(event::Event<T>, &RootELW<T>),
+        F: FnMut(event::Event<T>, &RootELW),
     {
         if !self.loop_running {
             self.loop_running = true;
@@ -543,7 +541,7 @@ impl<T: 'static> EventLoop<T> {
 
     fn poll_events_with_timeout<F>(&mut self, mut timeout: Option<Duration>, mut callback: F)
     where
-        F: FnMut(event::Event<T>, &RootELW<T>),
+        F: FnMut(event::Event<T>, &RootELW),
     {
         let start = Instant::now();
 
@@ -619,7 +617,7 @@ impl<T: 'static> EventLoop<T> {
         });
     }
 
-    pub fn window_target(&self) -> &event_loop::EventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &event_loop::EventLoopWindowTarget {
         &self.window_target
     }
 
@@ -663,15 +661,14 @@ impl<T> EventLoopProxy<T> {
     }
 }
 
-pub struct EventLoopWindowTarget<T: 'static> {
+pub struct EventLoopWindowTarget {
     app: AndroidApp,
     control_flow: Cell<ControlFlow>,
     exit: Cell<bool>,
     redraw_requester: RedrawRequester,
-    _marker: std::marker::PhantomData<T>,
 }
 
-impl<T: 'static> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         Some(MonitorHandle::new(self.app.clone()))
     }
@@ -757,8 +754,8 @@ pub(crate) struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T: 'static>(
-        el: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        el: &EventLoopWindowTarget,
         _window_attrs: window::WindowAttributes,
         _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -70,7 +70,8 @@ use std::fmt;
 
 pub(crate) use self::{
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget,
+        PlatformSpecificEventLoopAttributes,
     },
     monitor::{MonitorHandle, VideoMode},
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -409,8 +409,8 @@ pub struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T>(
-        event_loop: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop: &EventLoopWindowTarget,
         window_attributes: WindowAttributes,
         platform_attributes: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, RootOsError> {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -20,10 +20,7 @@ use crate::{
     dpi::{PhysicalPosition, PhysicalSize, Position, Size},
     error::{EventLoopError, ExternalError, NotSupportedError, OsError as RootOsError},
     event::KeyEvent,
-    event_loop::{
-        AsyncRequestSerial, ControlFlow, DeviceEvents, EventLoopClosed,
-        EventLoopWindowTarget as RootELW,
-    },
+    event_loop::{AsyncRequestSerial, ControlFlow, DeviceEvents, EventLoopClosed},
     icon::Icon,
     keyboard::{Key, PhysicalKey},
     platform::{
@@ -816,26 +813,26 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW),
+        F: FnMut(crate::event::Event<T>, &EventLoopWindowTarget),
     {
         self.run_on_demand(callback)
     }
 
     pub fn run_on_demand<F>(&mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW),
+        F: FnMut(crate::event::Event<T>, &EventLoopWindowTarget),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_on_demand(callback))
     }
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(crate::event::Event<T>, &RootELW),
+        F: FnMut(crate::event::Event<T>, &EventLoopWindowTarget),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.pump_events(timeout, callback))
     }
 
-    pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget {
+    pub fn window_target(&self) -> &EventLoopWindowTarget {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.window_target())
     }
 }
@@ -857,6 +854,8 @@ impl<T: 'static> EventLoopProxy<T> {
         x11_or_wayland!(match self; EventLoopProxy(proxy) => proxy.send_event(event))
     }
 }
+
+pub type ActiveEventLoop<'a> = &'a EventLoopWindowTarget;
 
 pub enum EventLoopWindowTarget {
     #[cfg(wayland_platform)]

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -291,8 +291,8 @@ impl VideoMode {
 
 impl Window {
     #[inline]
-    pub(crate) fn new<T>(
-        window_target: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        window_target: &EventLoopWindowTarget,
         attribs: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
@@ -816,26 +816,26 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>),
+        F: FnMut(crate::event::Event<T>, &RootELW),
     {
         self.run_on_demand(callback)
     }
 
     pub fn run_on_demand<F>(&mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>),
+        F: FnMut(crate::event::Event<T>, &RootELW),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_on_demand(callback))
     }
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(crate::event::Event<T>, &RootELW<T>),
+        F: FnMut(crate::event::Event<T>, &RootELW),
     {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.pump_events(timeout, callback))
     }
 
-    pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &crate::event_loop::EventLoopWindowTarget {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.window_target())
     }
 }
@@ -858,14 +858,14 @@ impl<T: 'static> EventLoopProxy<T> {
     }
 }
 
-pub enum EventLoopWindowTarget<T> {
+pub enum EventLoopWindowTarget {
     #[cfg(wayland_platform)]
-    Wayland(wayland::EventLoopWindowTarget<T>),
+    Wayland(wayland::EventLoopWindowTarget),
     #[cfg(x11_platform)]
-    X(x11::EventLoopWindowTarget<T>),
+    X(x11::EventLoopWindowTarget),
 }
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     #[inline]
     pub fn is_wayland(&self) -> bool {
         match *self {

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -9,7 +9,7 @@ use crate::platform_impl::platform::VideoMode as PlatformVideoMode;
 
 use super::event_loop::EventLoopWindowTarget;
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
         self.state

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -79,8 +79,8 @@ pub struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T>(
-        event_loop_window_target: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop_window_target: &EventLoopWindowTarget,
         attributes: WindowAttributes,
         platform_attributes: PlatformAttributes,
     ) -> Result<Self, RootOsError> {

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -36,7 +36,7 @@ use crate::{
 /// The X11 documentation states: "Keycodes lie in the inclusive range `[8, 255]`".
 const KEYCODE_OFFSET: u8 = 8;
 
-pub(super) struct EventProcessor<T: 'static> {
+pub(super) struct EventProcessor {
     pub(super) dnd: Dnd,
     pub(super) ime_receiver: ImeReceiver,
     pub(super) ime_event_receiver: ImeEventReceiver,
@@ -44,7 +44,7 @@ pub(super) struct EventProcessor<T: 'static> {
     pub(super) devices: RefCell<HashMap<DeviceId, Device>>,
     pub(super) xi2ext: ExtensionInformation,
     pub(super) xkbext: ExtensionInformation,
-    pub(super) target: Rc<RootELW<T>>,
+    pub(super) target: Rc<RootELW>,
     pub(super) kb_state: KbdState,
     // Number of touch events currently in progress
     pub(super) num_touch: u32,
@@ -59,7 +59,7 @@ pub(super) struct EventProcessor<T: 'static> {
     pub(super) is_composing: bool,
 }
 
-impl<T: 'static> EventProcessor<T> {
+impl EventProcessor {
     pub(super) fn init_device(&self, device: xinput::DeviceId) {
         let wt = get_xtarget(&self.target);
         let mut devices = self.devices.borrow_mut();
@@ -134,7 +134,7 @@ impl<T: 'static> EventProcessor<T> {
         result != 0
     }
 
-    pub(super) fn process_event<F>(&mut self, xev: &mut ffi::XEvent, mut callback: F)
+    pub(super) fn process_event<T: 'static, F>(&mut self, xev: &mut ffi::XEvent, mut callback: F)
     where
         F: FnMut(Event<T>),
     {
@@ -1377,8 +1377,8 @@ impl<T: 'static> EventProcessor<T> {
         }
     }
 
-    fn handle_pressed_keys<F>(
-        wt: &super::EventLoopWindowTarget<T>,
+    fn handle_pressed_keys<T: 'static, F>(
+        wt: &super::EventLoopWindowTarget,
         window_id: crate::window::WindowId,
         state: ElementState,
         kb_state: &mut KbdState,
@@ -1408,7 +1408,7 @@ impl<T: 'static> EventProcessor<T> {
         }
     }
 
-    fn process_dpi_change<F>(&self, callback: &mut F)
+    fn process_dpi_change<T: 'static, F>(&self, callback: &mut F)
     where
         F: FnMut(Event<T>),
     {

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -21,10 +21,10 @@ use super::{
     Dnd, DndState, GenericEventCookie, ImeReceiver, ScrollOrientation, UnownedWindow, WindowId,
 };
 
+use crate::platform_impl::EventLoopWindowTarget as PlatformEventLoopWindowTarget;
 use crate::{
     dpi::{PhysicalPosition, PhysicalSize},
     event::{DeviceEvent, ElementState, Event, Ime, RawKeyEvent, TouchPhase, WindowEvent},
-    event_loop::EventLoopWindowTarget as RootELW,
     keyboard::ModifiersState,
     platform_impl::platform::common::{keymap, xkb_state::KbdState},
 };
@@ -44,7 +44,7 @@ pub(super) struct EventProcessor {
     pub(super) devices: RefCell<HashMap<DeviceId, Device>>,
     pub(super) xi2ext: ExtensionInformation,
     pub(super) xkbext: ExtensionInformation,
-    pub(super) target: Rc<RootELW>,
+    pub(super) target: Rc<PlatformEventLoopWindowTarget>,
     pub(super) kb_state: KbdState,
     // Number of touch events currently in progress
     pub(super) num_touch: u32,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -150,8 +150,8 @@ macro_rules! leap {
 
 impl UnownedWindow {
     #[allow(clippy::unnecessary_cast)]
-    pub(crate) fn new<T>(
-        event_loop: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop: &EventLoopWindowTarget,
         window_attrs: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<UnownedWindow, RootOsError> {

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -19,12 +19,12 @@ use once_cell::sync::Lazy;
 
 use super::{
     event::dummy_event, event_loop::PanicInfo, menu, observer::EventLoopWaker, util::Never,
-    window::WinitWindow,
+    window::WinitWindow, EventLoopWindowTarget,
 };
 use crate::{
     dpi::PhysicalSize,
     event::{Event, InnerSizeWriter, StartCause, WindowEvent},
-    event_loop::{ControlFlow, EventLoopWindowTarget as RootWindowTarget},
+    event_loop::ControlFlow,
     window::WindowId,
 };
 
@@ -45,18 +45,21 @@ pub trait EventHandler: Debug {
     fn handle_user_events(&mut self);
 }
 
-pub(crate) type Callback<T> = RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>;
+pub(crate) type Callback<T> = RefCell<dyn FnMut(Event<T>, &EventLoopWindowTarget)>;
 
 struct EventLoopHandler<T: 'static> {
     callback: Weak<Callback<T>>,
-    window_target: Rc<RootWindowTarget>,
+    window_target: Rc<EventLoopWindowTarget>,
     receiver: Rc<mpsc::Receiver<T>>,
 }
 
 impl<T> EventLoopHandler<T> {
     fn with_callback<F>(&mut self, f: F)
     where
-        F: FnOnce(&mut EventLoopHandler<T>, RefMut<'_, dyn FnMut(Event<T>, &RootWindowTarget)>),
+        F: FnOnce(
+            &mut EventLoopHandler<T>,
+            RefMut<'_, dyn FnMut(Event<T>, &EventLoopWindowTarget)>,
+        ),
     {
         // `NSApplication` and our `HANDLER` are global state and so it's possible
         // that we could get a delegate callback after the application has exit an
@@ -370,7 +373,7 @@ impl AppState {
     /// a call to `clear_callback` before returning to avoid undefined behaviour.
     pub unsafe fn set_callback<T>(
         callback: Weak<Callback<T>>,
-        window_target: Rc<RootWindowTarget>,
+        window_target: Rc<EventLoopWindowTarget>,
         receiver: Rc<mpsc::Receiver<T>>,
     ) {
         *HANDLER.callback.lock().unwrap() = Some(Box::new(EventLoopHandler {

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -45,18 +45,18 @@ pub trait EventHandler: Debug {
     fn handle_user_events(&mut self);
 }
 
-pub(crate) type Callback<T> = RefCell<dyn FnMut(Event<T>, &RootWindowTarget<T>)>;
+pub(crate) type Callback<T> = RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>;
 
 struct EventLoopHandler<T: 'static> {
     callback: Weak<Callback<T>>,
-    window_target: Rc<RootWindowTarget<T>>,
+    window_target: Rc<RootWindowTarget>,
     receiver: Rc<mpsc::Receiver<T>>,
 }
 
 impl<T> EventLoopHandler<T> {
     fn with_callback<F>(&mut self, f: F)
     where
-        F: FnOnce(&mut EventLoopHandler<T>, RefMut<'_, dyn FnMut(Event<T>, &RootWindowTarget<T>)>),
+        F: FnOnce(&mut EventLoopHandler<T>, RefMut<'_, dyn FnMut(Event<T>, &RootWindowTarget)>),
     {
         // `NSApplication` and our `HANDLER` are global state and so it's possible
         // that we could get a delegate callback after the application has exit an
@@ -370,7 +370,7 @@ impl AppState {
     /// a call to `clear_callback` before returning to avoid undefined behaviour.
     pub unsafe fn set_callback<T>(
         callback: Weak<Callback<T>>,
-        window_target: Rc<RootWindowTarget<T>>,
+        window_target: Rc<RootWindowTarget>,
         receiver: Rc<mpsc::Receiver<T>>,
     ) {
         *HANDLER.callback.lock().unwrap() = Some(Box::new(EventLoopHandler {

--- a/src/platform_impl/macos/cursor.rs
+++ b/src/platform_impl/macos/cursor.rs
@@ -24,10 +24,7 @@ unsafe impl Send for CustomCursor {}
 unsafe impl Sync for CustomCursor {}
 
 impl CustomCursor {
-    pub(crate) fn build<T>(
-        cursor: OnlyCursorImageBuilder,
-        _: &EventLoopWindowTarget<T>,
-    ) -> CustomCursor {
+    pub(crate) fn build(cursor: OnlyCursorImageBuilder, _: &EventLoopWindowTarget) -> CustomCursor {
         Self(cursor_from_image(&cursor.0))
     }
 }

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -31,9 +31,7 @@ use super::event::dummy_event;
 use crate::{
     error::EventLoopError,
     event::Event,
-    event_loop::{
-        ControlFlow, DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootWindowTarget,
-    },
+    event_loop::{ControlFlow, DeviceEvents, EventLoopClosed},
     platform::{macos::ActivationPolicy, pump_events::PumpStatus},
     platform_impl::platform::{
         app::WinitApplication,
@@ -76,6 +74,8 @@ impl PanicInfo {
 pub struct EventLoopWindowTarget {
     mtm: MainThreadMarker,
 }
+
+pub type ActiveEventLoop<'a> = &'a EventLoopWindowTarget;
 
 impl EventLoopWindowTarget {
     #[inline]
@@ -157,7 +157,7 @@ pub struct EventLoop<T: 'static> {
     sender: mpsc::Sender<T>,
     receiver: Rc<mpsc::Receiver<T>>,
 
-    window_target: Rc<RootWindowTarget>,
+    window_target: Rc<EventLoopWindowTarget>,
     panic_info: Rc<PanicInfo>,
 
     /// We make sure that the callback closure is dropped during a panic
@@ -225,21 +225,19 @@ impl<T> EventLoop<T> {
             _delegate: delegate,
             sender,
             receiver: Rc::new(receiver),
-            window_target: Rc::new(RootWindowTarget {
-                p: EventLoopWindowTarget { mtm },
-            }),
+            window_target: Rc::new(EventLoopWindowTarget { mtm }),
             panic_info,
             _callback: None,
         })
     }
 
-    pub fn window_target(&self) -> &RootWindowTarget {
+    pub fn window_target(&self) -> &EventLoopWindowTarget {
         &self.window_target
     }
 
     pub fn run<F>(mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootWindowTarget),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
         self.run_on_demand(callback)
     }
@@ -250,7 +248,7 @@ impl<T> EventLoop<T> {
     // redundant wake ups.
     pub fn run_on_demand<F>(&mut self, callback: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootWindowTarget),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
         if AppState::is_running() {
             return Err(EventLoopError::AlreadyRunning);
@@ -267,8 +265,8 @@ impl<T> EventLoop<T> {
 
         let callback = unsafe {
             mem::transmute::<
-                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>>,
-                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &EventLoopWindowTarget)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &EventLoopWindowTarget)>>,
             >(Rc::new(RefCell::new(callback)))
         };
 
@@ -334,7 +332,7 @@ impl<T> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, callback: F) -> PumpStatus
     where
-        F: FnMut(Event<T>, &RootWindowTarget),
+        F: FnMut(Event<T>, &EventLoopWindowTarget),
     {
         // # Safety
         // We are erasing the lifetime of the application callback here so that we
@@ -347,8 +345,8 @@ impl<T> EventLoop<T> {
 
         let callback = unsafe {
             mem::transmute::<
-                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>>,
-                Rc<RefCell<dyn FnMut(Event<T>, &RootWindowTarget)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &EventLoopWindowTarget)>>,
+                Rc<RefCell<dyn FnMut(Event<T>, &EventLoopWindowTarget)>>,
             >(Rc::new(RefCell::new(callback)))
         };
 

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -20,7 +20,8 @@ use std::fmt;
 pub(crate) use self::{
     event::KeyEventExtra,
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget,
+        PlatformSpecificEventLoopAttributes,
     },
     monitor::{MonitorHandle, VideoMode},
     window::{PlatformSpecificWindowBuilderAttributes, WindowId},

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -68,8 +68,8 @@ impl Drop for Window {
 }
 
 impl Window {
-    pub(crate) fn new<T: 'static>(
-        _window_target: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        _window_target: &EventLoopWindowTarget,
         attributes: WindowAttributes,
         pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -14,7 +14,7 @@ use orbclient::{
 use crate::{
     error::EventLoopError,
     event::{self, Ime, Modifiers, StartCause},
-    event_loop::{self, ControlFlow, DeviceEvents},
+    event_loop::{ControlFlow, DeviceEvents, EventLoopClosed},
     keyboard::{
         Key, KeyCode, KeyLocation, ModifiersKeys, ModifiersState, NativeKey, NativeKeyCode,
         PhysicalKey,
@@ -272,7 +272,7 @@ impl EventState {
 
 pub struct EventLoop<T> {
     windows: Vec<(Arc<RedoxSocket>, EventState)>,
-    window_target: event_loop::EventLoopWindowTarget,
+    window_target: EventLoopWindowTarget,
     user_events_sender: mpsc::Sender<T>,
     user_events_receiver: mpsc::Receiver<T>,
 }
@@ -304,16 +304,14 @@ impl<T: 'static> EventLoop<T> {
 
         Ok(Self {
             windows: Vec::new(),
-            window_target: event_loop::EventLoopWindowTarget {
-                p: EventLoopWindowTarget {
-                    control_flow: Cell::new(ControlFlow::default()),
-                    exit: Cell::new(false),
-                    creates: Mutex::new(VecDeque::new()),
-                    redraws: Arc::new(Mutex::new(VecDeque::new())),
-                    destroys: Arc::new(Mutex::new(VecDeque::new())),
-                    event_socket,
-                    wake_socket,
-                },
+            window_target: EventLoopWindowTarget {
+                control_flow: Cell::new(ControlFlow::default()),
+                exit: Cell::new(false),
+                creates: Mutex::new(VecDeque::new()),
+                redraws: Arc::new(Mutex::new(VecDeque::new())),
+                destroys: Arc::new(Mutex::new(VecDeque::new())),
+                event_socket,
+                wake_socket,
             },
             user_events_sender,
             user_events_receiver,
@@ -463,10 +461,10 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, mut event_handler_inner: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
+        F: FnMut(event::Event<T>, &EventLoopWindowTarget),
     {
         let mut event_handler =
-            move |event: event::Event<T>, window_target: &event_loop::EventLoopWindowTarget| {
+            move |event: event::Event<T>, window_target: &EventLoopWindowTarget| {
                 event_handler_inner(event, window_target);
             };
 
@@ -481,7 +479,7 @@ impl<T: 'static> EventLoop<T> {
 
             // Handle window creates.
             while let Some(window) = {
-                let mut creates = self.window_target.p.creates.lock().unwrap();
+                let mut creates = self.window_target.creates.lock().unwrap();
                 creates.pop_front()
             } {
                 let window_id = WindowId {
@@ -515,7 +513,7 @@ impl<T: 'static> EventLoop<T> {
 
             // Handle window destroys.
             while let Some(destroy_id) = {
-                let mut destroys = self.window_target.p.destroys.lock().unwrap();
+                let mut destroys = self.window_target.destroys.lock().unwrap();
                 destroys.pop_front()
             } {
                 event_handler(
@@ -570,7 +568,7 @@ impl<T: 'static> EventLoop<T> {
                         .expect("failed to acknowledge resize");
 
                     // Require redraw after resize.
-                    let mut redraws = self.window_target.p.redraws.lock().unwrap();
+                    let mut redraws = self.window_target.redraws.lock().unwrap();
                     if !redraws.contains(&window_id) {
                         redraws.push_back(window_id);
                     }
@@ -586,7 +584,7 @@ impl<T: 'static> EventLoop<T> {
 
             // To avoid deadlocks the redraws lock is not held during event processing.
             while let Some(window_id) = {
-                let mut redraws = self.window_target.p.redraws.lock().unwrap();
+                let mut redraws = self.window_target.redraws.lock().unwrap();
                 redraws.pop_front()
             } {
                 event_handler(
@@ -600,11 +598,11 @@ impl<T: 'static> EventLoop<T> {
 
             event_handler(event::Event::AboutToWait, &self.window_target);
 
-            if self.window_target.p.exiting() {
+            if self.window_target.exiting() {
                 break;
             }
 
-            let requested_resume = match self.window_target.p.control_flow() {
+            let requested_resume = match self.window_target.control_flow() {
                 ControlFlow::Poll => {
                     start_cause = StartCause::Poll;
                     continue;
@@ -618,7 +616,6 @@ impl<T: 'static> EventLoop<T> {
             let timeout_socket = TimeSocket::open().unwrap();
 
             self.window_target
-                .p
                 .event_socket
                 .write(&syscall::Event {
                     id: timeout_socket.0.fd,
@@ -646,7 +643,7 @@ impl<T: 'static> EventLoop<T> {
 
             // Wait for event if needed.
             let mut event = syscall::Event::default();
-            self.window_target.p.event_socket.read(&mut event).unwrap();
+            self.window_target.event_socket.read(&mut event).unwrap();
 
             // TODO: handle spurious wakeups (redraw caused wakeup but redraw already handled)
             match requested_resume {
@@ -673,14 +670,14 @@ impl<T: 'static> EventLoop<T> {
         Ok(())
     }
 
-    pub fn window_target(&self) -> &event_loop::EventLoopWindowTarget {
+    pub fn window_target(&self) -> &EventLoopWindowTarget {
         &self.window_target
     }
 
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         EventLoopProxy {
             user_events_sender: self.user_events_sender.clone(),
-            wake_socket: self.window_target.p.wake_socket.clone(),
+            wake_socket: self.window_target.wake_socket.clone(),
         }
     }
 }
@@ -691,10 +688,10 @@ pub struct EventLoopProxy<T: 'static> {
 }
 
 impl<T> EventLoopProxy<T> {
-    pub fn send_event(&self, event: T) -> Result<(), event_loop::EventLoopClosed<T>> {
+    pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
         self.user_events_sender
             .send(event)
-            .map_err(|mpsc::SendError(x)| event_loop::EventLoopClosed(x))?;
+            .map_err(|mpsc::SendError(x)| EventLoopClosed(x))?;
 
         self.wake_socket.wake().unwrap();
 
@@ -712,6 +709,8 @@ impl<T> Clone for EventLoopProxy<T> {
 }
 
 impl<T> Unpin for EventLoopProxy<T> {}
+
+pub type ActiveEventLoop<'a> = &'a EventLoopWindowTarget;
 
 pub struct EventLoopWindowTarget {
     control_flow: Cell<ControlFlow>,

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -1,7 +1,6 @@
 use std::{
     cell::Cell,
     collections::VecDeque,
-    marker::PhantomData,
     mem, slice,
     sync::{mpsc, Arc, Mutex},
     time::Instant,
@@ -271,9 +270,9 @@ impl EventState {
     }
 }
 
-pub struct EventLoop<T: 'static> {
+pub struct EventLoop<T> {
     windows: Vec<(Arc<RedoxSocket>, EventState)>,
-    window_target: event_loop::EventLoopWindowTarget<T>,
+    window_target: event_loop::EventLoopWindowTarget,
     user_events_sender: mpsc::Sender<T>,
     user_events_receiver: mpsc::Receiver<T>,
 }
@@ -314,9 +313,7 @@ impl<T: 'static> EventLoop<T> {
                     destroys: Arc::new(Mutex::new(VecDeque::new())),
                     event_socket,
                     wake_socket,
-                    p: PhantomData,
                 },
-                _marker: PhantomData,
             },
             user_events_sender,
             user_events_receiver,
@@ -466,10 +463,10 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn run<F>(mut self, mut event_handler_inner: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget<T>),
+        F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
     {
         let mut event_handler =
-            move |event: event::Event<T>, window_target: &event_loop::EventLoopWindowTarget<T>| {
+            move |event: event::Event<T>, window_target: &event_loop::EventLoopWindowTarget| {
                 event_handler_inner(event, window_target);
             };
 
@@ -676,7 +673,7 @@ impl<T: 'static> EventLoop<T> {
         Ok(())
     }
 
-    pub fn window_target(&self) -> &event_loop::EventLoopWindowTarget<T> {
+    pub fn window_target(&self) -> &event_loop::EventLoopWindowTarget {
         &self.window_target
     }
 
@@ -716,7 +713,7 @@ impl<T> Clone for EventLoopProxy<T> {
 
 impl<T> Unpin for EventLoopProxy<T> {}
 
-pub struct EventLoopWindowTarget<T: 'static> {
+pub struct EventLoopWindowTarget {
     control_flow: Cell<ControlFlow>,
     exit: Cell<bool>,
     pub(super) creates: Mutex<VecDeque<Arc<RedoxSocket>>>,
@@ -724,10 +721,9 @@ pub struct EventLoopWindowTarget<T: 'static> {
     pub(super) destroys: Arc<Mutex<VecDeque<WindowId>>>,
     pub(super) event_socket: Arc<RedoxSocket>,
     pub(super) wake_socket: Arc<TimeSocket>,
-    p: PhantomData<T>,
 }
 
-impl<T: 'static> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         Some(MonitorHandle)
     }

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 
-pub use self::event_loop::{EventLoop, EventLoopProxy, EventLoopWindowTarget};
+pub use self::event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget};
 mod event_loop;
 
 pub use self::window::Window;

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -33,8 +33,8 @@ pub struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T: 'static>(
-        el: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        el: &EventLoopWindowTarget,
         attrs: window::WindowAttributes,
         _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {

--- a/src/platform_impl/web/cursor.rs
+++ b/src/platform_impl/web/cursor.rs
@@ -68,9 +68,9 @@ impl PartialEq for CustomCursor {
 impl Eq for CustomCursor {}
 
 impl CustomCursor {
-    pub(crate) fn build<T>(
+    pub(crate) fn build(
         builder: CustomCursorBuilder,
-        window_target: &EventLoopWindowTarget<T>,
+        window_target: &EventLoopWindowTarget,
     ) -> Self {
         Lazy::force(&DROP_HANDLER);
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -207,7 +207,7 @@ impl Shared {
 
     // Set the event callback to use for the event loop runner
     // This the event callback is a fairly thin layer over the user-provided callback that closes
-    // over a RootEventLoopWindowTarget reference
+    // over a EventLoopWindowTarget reference
     pub fn set_listener(&self, event_handler: Box<EventHandler>) {
         {
             let mut runner = self.0.runner.borrow_mut();

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -2,7 +2,6 @@ use std::cell::{Cell, RefCell};
 use std::clone::Clone;
 use std::collections::{vec_deque::IntoIter as VecDequeIter, VecDeque};
 use std::iter;
-use std::marker::PhantomData;
 use std::rc::{Rc, Weak};
 
 use super::runner::{EventWrapper, Execution};
@@ -41,28 +40,17 @@ impl Clone for ModifiersShared {
     }
 }
 
-pub struct EventLoopWindowTarget<T: 'static> {
+#[derive(Clone)]
+pub struct EventLoopWindowTarget {
     pub(crate) runner: runner::Shared,
     modifiers: ModifiersShared,
-    _marker: PhantomData<T>,
 }
 
-impl<T> Clone for EventLoopWindowTarget<T> {
-    fn clone(&self) -> Self {
-        Self {
-            runner: self.runner.clone(),
-            modifiers: self.modifiers.clone(),
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     pub fn new() -> Self {
         Self {
             runner: runner::Shared::new(),
             modifiers: ModifiersShared::default(),
-            _marker: PhantomData,
         }
     }
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -47,7 +47,7 @@ pub struct EventLoopWindowTarget {
 }
 
 impl EventLoopWindowTarget {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             runner: runner::Shared::new(),
             modifiers: ModifiersShared::default(),

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -32,7 +32,8 @@ mod backend;
 pub use self::device::DeviceId;
 pub use self::error::OsError;
 pub(crate) use self::event_loop::{
-    EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+    ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget,
+    PlatformSpecificEventLoopAttributes,
 };
 pub use self::monitor::{MonitorHandle, VideoMode};
 pub use self::window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId};

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -30,8 +30,8 @@ pub struct Inner {
 }
 
 impl Window {
-    pub(crate) fn new<T>(
-        target: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        target: &EventLoopWindowTarget,
         attr: WindowAttributes,
         platform_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOE> {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -110,7 +110,7 @@ use super::{window::set_skip_taskbar, SelectedCursor};
 /// as a placeholder so user events can be buffered as usual,
 /// the real `UserEvent` is pulled from the mpsc channel directly
 /// when the placeholder event is delivered to the event handler
-type UserEventPlaceholder = ();
+pub(crate) struct UserEventPlaceholder;
 
 // here below, the generic `EventLoopRunnerShared<T>` is replaced with
 // `EventLoopRunnerShared<UserEventPlaceholder>` so we can get rid
@@ -2408,7 +2408,7 @@ unsafe extern "system" fn thread_event_target_callback(
             // user event is still in the mpsc channel and will be pulled
             // once the placeholder event is delivered to the wrapper
             // `event_handler`
-            userdata.send_event(Event::UserEvent(()));
+            userdata.send_event(Event::UserEvent(UserEventPlaceholder));
             0
         }
         _ if msg == EXEC_MSG_ID.get() => {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -6,7 +6,6 @@ use std::{
     cell::Cell,
     collections::VecDeque,
     ffi::c_void,
-    marker::PhantomData,
     mem, panic, ptr,
     rc::Rc,
     sync::{
@@ -158,7 +157,7 @@ pub(crate) enum ProcResult {
 pub struct EventLoop<T: 'static> {
     user_event_sender: Sender<T>,
     user_event_receiver: Receiver<T>,
-    window_target: RootELW<T>,
+    window_target: RootELW,
     msg_hook: Option<Box<dyn FnMut(*const c_void) -> bool + 'static>>,
 }
 
@@ -178,11 +177,10 @@ impl Default for PlatformSpecificEventLoopAttributes {
     }
 }
 
-pub struct EventLoopWindowTarget<T: 'static> {
+pub struct EventLoopWindowTarget {
     thread_id: u32,
     thread_msg_target: HWND,
     pub(crate) runner_shared: EventLoopRunnerShared<UserEventPlaceholder>,
-    _marker: PhantomData<T>,
 }
 
 impl<T: 'static> EventLoop<T> {
@@ -223,28 +221,26 @@ impl<T: 'static> EventLoop<T> {
                     thread_id,
                     thread_msg_target,
                     runner_shared,
-                    _marker: PhantomData,
                 },
-                _marker: PhantomData,
             },
             msg_hook: attributes.msg_hook.take(),
         })
     }
 
-    pub fn window_target(&self) -> &RootELW<T> {
+    pub fn window_target(&self) -> &RootELW {
         &self.window_target
     }
 
     pub fn run<F>(mut self, event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootELW<T>),
+        F: FnMut(Event<T>, &RootELW),
     {
         self.run_on_demand(event_handler)
     }
 
     pub fn run_on_demand<F>(&mut self, mut event_handler: F) -> Result<(), EventLoopError>
     where
-        F: FnMut(Event<T>, &RootELW<T>),
+        F: FnMut(Event<T>, &RootELW),
     {
         {
             let runner = &self.window_target.p.runner_shared;
@@ -309,7 +305,7 @@ impl<T: 'static> EventLoop<T> {
 
     pub fn pump_events<F>(&mut self, timeout: Option<Duration>, mut event_handler: F) -> PumpStatus
     where
-        F: FnMut(Event<T>, &RootELW<T>),
+        F: FnMut(Event<T>, &RootELW),
     {
         {
             let runner = &self.window_target.p.runner_shared;
@@ -529,7 +525,7 @@ impl<T: 'static> EventLoop<T> {
     }
 }
 
-impl<T> EventLoopWindowTarget<T> {
+impl EventLoopWindowTarget {
     #[inline(always)]
     pub(crate) fn create_thread_executor(&self) -> EventLoopThreadExecutor {
         EventLoopThreadExecutor {
@@ -979,7 +975,7 @@ unsafe fn lose_active_focus(window: HWND, userdata: &WindowData) {
 //
 // Returning 0 tells the Win32 API that the message has been processed.
 // FIXME: detect WM_DWMCOMPOSITIONCHANGED and call DwmEnableBlurBehindWindow if necessary
-pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
+pub(super) unsafe extern "system" fn public_window_callback(
     window: HWND,
     msg: u32,
     wparam: WPARAM,
@@ -990,7 +986,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
     let userdata_ptr = match (userdata, msg) {
         (0, WM_NCCREATE) => {
             let createstruct = unsafe { &mut *(lparam as *mut CREATESTRUCTW) };
-            let initdata = unsafe { &mut *(createstruct.lpCreateParams as *mut InitData<'_, T>) };
+            let initdata = unsafe { &mut *(createstruct.lpCreateParams as *mut InitData<'_>) };
 
             let result = match unsafe { initdata.on_nccreate(window) } {
                 Some(userdata) => unsafe {
@@ -1008,7 +1004,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
         (_, WM_CREATE) => unsafe {
             let createstruct = &mut *(lparam as *mut CREATESTRUCTW);
             let initdata = createstruct.lpCreateParams;
-            let initdata = &mut *(initdata as *mut InitData<'_, T>);
+            let initdata = &mut *(initdata as *mut InitData<'_>);
 
             initdata.on_create();
             return DefWindowProcW(window, msg, wparam, lparam);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -207,7 +207,7 @@ impl<T: 'static> EventLoop<T> {
             become_dpi_aware();
         }
 
-        let thread_msg_target = create_event_target_window::<T>();
+        let thread_msg_target = create_event_target_window();
 
         let runner_shared = Rc::new(EventLoopRunner::new(thread_msg_target));
 
@@ -830,7 +830,7 @@ static THREAD_EVENT_TARGET_WINDOW_CLASS: Lazy<Vec<u16>> =
 /// <https://docs.microsoft.com/en-us/windows/win32/shell/taskbar#taskbar-creation-notification>
 pub static TASKBAR_CREATED: LazyMessageId = LazyMessageId::new("TaskbarCreated\0");
 
-fn create_event_target_window<T: 'static>() -> HWND {
+fn create_event_target_window() -> HWND {
     use windows_sys::Win32::UI::WindowsAndMessaging::CS_HREDRAW;
     use windows_sys::Win32::UI::WindowsAndMessaging::CS_VREDRAW;
     unsafe {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -182,10 +182,7 @@ pub struct EventLoopWindowTarget<T: 'static> {
     thread_id: u32,
     thread_msg_target: HWND,
     pub(crate) runner_shared: EventLoopRunnerShared<UserEventPlaceholder>,
-    // TODO
-    // eventually should be removed after all the backends refactored,
-    // but for now should this be invariant or contra-variant to T?
-    _marker: PhantomData<*mut T>,
+    _marker: PhantomData<T>,
 }
 
 impl<T: 'static> EventLoop<T> {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -98,17 +98,38 @@ use self::runner::RunnerState;
 
 use super::{window::set_skip_taskbar, SelectedCursor};
 
-pub(crate) struct WindowData<T: 'static> {
+/// some backends like macos uses an uninhabited `Never` type,
+/// on windows, `UserEvent`s are also dispatched through the
+/// WNDPROC callback, and due to the re-entrant nature of the
+/// callback, recursively delivered events must be queued in a
+/// buffer, the current implementation put this queue in
+/// `EventLoopRunner`, which is shared between the event pumping
+/// loop and the callback. because it's hard to decide from the
+/// outside whether a event needs to be buffered, I decided not
+/// use `Event<Never>` for the shared runner state, but use unit
+/// as a placeholder so user events can be buffered as usual,
+/// the real `UserEvent` is pulled from the mpsc channel directly
+/// when the placeholder event is delivered to the event handler
+type UserEventPlaceholder = ();
+
+// here below, the generic `EventLoopRunnerShared<T>` is replaced with
+// `EventLoopRunnerShared<UserEventPlaceholder>` so we can get rid
+// of the generic parameter T in types which don't depend on T.
+// this is the approach which requires minimum changes to current
+// backend implementation. it should be considered transitional
+// and should be refactored and cleaned up eventually, I hope.
+
+pub(crate) struct WindowData {
     pub window_state: Arc<Mutex<WindowState>>,
-    pub event_loop_runner: EventLoopRunnerShared<T>,
+    pub event_loop_runner: EventLoopRunnerShared<UserEventPlaceholder>,
     pub key_event_builder: KeyEventBuilder,
     pub _file_drop_handler: Option<FileDropHandler>,
     pub userdata_removed: Cell<bool>,
     pub recurse_depth: Cell<u32>,
 }
 
-impl<T> WindowData<T> {
-    fn send_event(&self, event: Event<T>) {
+impl WindowData {
+    fn send_event(&self, event: Event<UserEventPlaceholder>) {
         self.event_loop_runner.send_event(event);
     }
 
@@ -117,13 +138,12 @@ impl<T> WindowData<T> {
     }
 }
 
-struct ThreadMsgTargetData<T: 'static> {
-    event_loop_runner: EventLoopRunnerShared<T>,
-    user_event_receiver: Receiver<T>,
+struct ThreadMsgTargetData {
+    event_loop_runner: EventLoopRunnerShared<UserEventPlaceholder>,
 }
 
-impl<T> ThreadMsgTargetData<T> {
-    fn send_event(&self, event: Event<T>) {
+impl ThreadMsgTargetData {
+    fn send_event(&self, event: Event<UserEventPlaceholder>) {
         self.event_loop_runner.send_event(event);
     }
 }
@@ -136,7 +156,8 @@ pub(crate) enum ProcResult {
 }
 
 pub struct EventLoop<T: 'static> {
-    thread_msg_sender: Sender<T>,
+    user_event_sender: Sender<T>,
+    user_event_receiver: Receiver<T>,
     window_target: RootELW<T>,
     msg_hook: Option<Box<dyn FnMut(*const c_void) -> bool + 'static>>,
 }
@@ -160,7 +181,11 @@ impl Default for PlatformSpecificEventLoopAttributes {
 pub struct EventLoopWindowTarget<T: 'static> {
     thread_id: u32,
     thread_msg_target: HWND,
-    pub(crate) runner_shared: EventLoopRunnerShared<T>,
+    pub(crate) runner_shared: EventLoopRunnerShared<UserEventPlaceholder>,
+    // TODO
+    // eventually should be removed after all the backends refactored,
+    // but for now should this be invariant or contra-variant to T?
+    _marker: PhantomData<*mut T>,
 }
 
 impl<T: 'static> EventLoop<T> {
@@ -186,20 +211,22 @@ impl<T: 'static> EventLoop<T> {
 
         let runner_shared = Rc::new(EventLoopRunner::new(thread_msg_target));
 
-        let thread_msg_sender =
-            insert_event_target_window_data::<T>(thread_msg_target, runner_shared.clone());
+        let (user_event_sender, user_event_receiver) = mpsc::channel();
+        insert_event_target_window_data(thread_msg_target, runner_shared.clone());
         raw_input::register_all_mice_and_keyboards_for_raw_input(
             thread_msg_target,
             Default::default(),
         );
 
         Ok(EventLoop {
-            thread_msg_sender,
+            user_event_sender,
+            user_event_receiver,
             window_target: RootELW {
                 p: EventLoopWindowTarget {
                     thread_id,
                     thread_msg_target,
                     runner_shared,
+                    _marker: PhantomData,
                 },
                 _marker: PhantomData,
             },
@@ -229,11 +256,28 @@ impl<T: 'static> EventLoop<T> {
             }
 
             let event_loop_windows_ref = &self.window_target;
+            let user_event_receiver = &self.user_event_receiver;
             // # Safety
             // We make sure to call runner.clear_event_handler() before
             // returning
             unsafe {
-                runner.set_event_handler(move |event| event_handler(event, event_loop_windows_ref));
+                runner.set_event_handler(move |event| {
+                    // the shared `EventLoopRunner` is not parameterized
+                    // `EventLoopProxy::send_event()` calls `PostMessage`
+                    // to wakeup and dispatch a placeholder `UserEvent`,
+                    // when we received the placeholder event here, the
+                    // real UserEvent(T) should already be put in the
+                    // mpsc channel and ready to be pulled
+                    let event = match event.map_nonuser_event() {
+                        Ok(non_user_event) => non_user_event,
+                        Err(_user_event_placeholder) => Event::UserEvent(
+                            user_event_receiver
+                                .try_recv()
+                                .expect("user event signaled but not received"),
+                        ),
+                    };
+                    event_handler(event, event_loop_windows_ref)
+                });
             }
         }
 
@@ -273,6 +317,7 @@ impl<T: 'static> EventLoop<T> {
         {
             let runner = &self.window_target.p.runner_shared;
             let event_loop_windows_ref = &self.window_target;
+            let user_event_receiver = &self.user_event_receiver;
 
             // # Safety
             // We make sure to call runner.clear_event_handler() before
@@ -282,7 +327,17 @@ impl<T: 'static> EventLoop<T> {
             // to leave the runner in an unsound state with an associated
             // event handler.
             unsafe {
-                runner.set_event_handler(move |event| event_handler(event, event_loop_windows_ref));
+                runner.set_event_handler(move |event| {
+                    let event = match event.map_nonuser_event() {
+                        Ok(non_user_event) => non_user_event,
+                        Err(_user_event_placeholder) => Event::UserEvent(
+                            user_event_receiver
+                                .recv()
+                                .expect("user event signaled but not received"),
+                        ),
+                    };
+                    event_handler(event, event_loop_windows_ref)
+                });
                 runner.wakeup();
             }
         }
@@ -468,7 +523,7 @@ impl<T: 'static> EventLoop<T> {
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         EventLoopProxy {
             target_window: self.window_target.p.thread_msg_target,
-            event_send: self.thread_msg_sender.clone(),
+            event_send: self.user_event_sender.clone(),
         }
     }
 
@@ -782,7 +837,7 @@ fn create_event_target_window<T: 'static>() -> HWND {
         let class = WNDCLASSEXW {
             cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
             style: CS_HREDRAW | CS_VREDRAW,
-            lpfnWndProc: Some(thread_event_target_callback::<T>),
+            lpfnWndProc: Some(thread_event_target_callback),
             cbClsExtra: 0,
             cbWndExtra: 0,
             hInstance: util::get_instance_handle(),
@@ -835,21 +890,14 @@ fn create_event_target_window<T: 'static>() -> HWND {
     }
 }
 
-fn insert_event_target_window_data<T>(
+fn insert_event_target_window_data(
     thread_msg_target: HWND,
-    event_loop_runner: EventLoopRunnerShared<T>,
-) -> Sender<T> {
-    let (tx, rx) = mpsc::channel();
-
-    let userdata = ThreadMsgTargetData {
-        event_loop_runner,
-        user_event_receiver: rx,
-    };
+    event_loop_runner: EventLoopRunnerShared<UserEventPlaceholder>,
+) {
+    let userdata = ThreadMsgTargetData { event_loop_runner };
     let input_ptr = Box::into_raw(Box::new(userdata));
 
     unsafe { super::set_window_long(thread_msg_target, GWL_USERDATA, input_ptr as isize) };
-
-    tx
 }
 
 /// Capture mouse input, allowing `window` to receive mouse events when the cursor is outside of
@@ -879,7 +927,7 @@ fn normalize_pointer_pressure(pressure: u32) -> Option<Force> {
 
 /// Emit a `ModifiersChanged` event whenever modifiers have changed.
 /// Returns the current modifier state
-fn update_modifiers<T>(window: HWND, userdata: &WindowData<T>) {
+fn update_modifiers(window: HWND, userdata: &WindowData) {
     use crate::event::WindowEvent::ModifiersChanged;
 
     let modifiers = {
@@ -901,7 +949,7 @@ fn update_modifiers<T>(window: HWND, userdata: &WindowData<T>) {
     }
 }
 
-unsafe fn gain_active_focus<T>(window: HWND, userdata: &WindowData<T>) {
+unsafe fn gain_active_focus(window: HWND, userdata: &WindowData) {
     use crate::event::WindowEvent::Focused;
 
     update_modifiers(window, userdata);
@@ -912,7 +960,7 @@ unsafe fn gain_active_focus<T>(window: HWND, userdata: &WindowData<T>) {
     });
 }
 
-unsafe fn lose_active_focus<T>(window: HWND, userdata: &WindowData<T>) {
+unsafe fn lose_active_focus(window: HWND, userdata: &WindowData) {
     use crate::event::WindowEvent::{Focused, ModifiersChanged};
 
     userdata.window_state_lock().modifiers_state = ModifiersState::empty();
@@ -969,7 +1017,7 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
             return DefWindowProcW(window, msg, wparam, lparam);
         },
         (0, _) => return unsafe { DefWindowProcW(window, msg, wparam, lparam) },
-        _ => userdata as *mut WindowData<T>,
+        _ => userdata as *mut WindowData,
     };
 
     let (result, userdata_removed, recurse_depth) = {
@@ -993,12 +1041,12 @@ pub(super) unsafe extern "system" fn public_window_callback<T: 'static>(
     result
 }
 
-unsafe fn public_window_callback_inner<T: 'static>(
+unsafe fn public_window_callback_inner(
     window: HWND,
     msg: u32,
     wparam: WPARAM,
     lparam: LPARAM,
-    userdata: &WindowData<T>,
+    userdata: &WindowData,
 ) -> LRESULT {
     let mut result = ProcResult::DefWindowProc(wparam);
 
@@ -2295,14 +2343,14 @@ unsafe fn public_window_callback_inner<T: 'static>(
     }
 }
 
-unsafe extern "system" fn thread_event_target_callback<T: 'static>(
+unsafe extern "system" fn thread_event_target_callback(
     window: HWND,
     msg: u32,
     wparam: WPARAM,
     lparam: LPARAM,
 ) -> LRESULT {
     let userdata_ptr =
-        unsafe { super::get_window_long(window, GWL_USERDATA) } as *mut ThreadMsgTargetData<T>;
+        unsafe { super::get_window_long(window, GWL_USERDATA) } as *mut ThreadMsgTargetData;
     if userdata_ptr.is_null() {
         // `userdata_ptr` will always be null for the first `WM_GETMINMAXINFO`, as well as `WM_NCCREATE` and
         // `WM_CREATE`.
@@ -2355,9 +2403,12 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
         }
 
         _ if msg == USER_EVENT_MSG_ID.get() => {
-            if let Ok(event) = userdata.user_event_receiver.recv() {
-                userdata.send_event(Event::UserEvent(event));
-            }
+            // synthesis a placeholder UserEvent, so that if the callback is
+            // re-entered it can be buffered for later delivery. the real
+            // user event is still in the mpsc channel and will be pulled
+            // once the placeholder event is delivered to the wrapper
+            // `event_handler`
+            userdata.send_event(Event::UserEvent(()));
             0
         }
         _ if msg == EXEC_MSG_ID.get() => {
@@ -2380,7 +2431,7 @@ unsafe extern "system" fn thread_event_target_callback<T: 'static>(
     result
 }
 
-unsafe fn handle_raw_input<T: 'static>(userdata: &ThreadMsgTargetData<T>, data: RAWINPUT) {
+unsafe fn handle_raw_input(userdata: &ThreadMsgTargetData, data: RAWINPUT) {
     use crate::event::{
         DeviceEvent::{Button, Key, Motion, MouseMotion, MouseWheel},
         ElementState::{Pressed, Released},

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -412,7 +412,7 @@ impl<T> BufferedEvent<T> {
 
                 let window_flags = unsafe {
                     let userdata =
-                        get_window_long(window_id.0.into(), GWL_USERDATA) as *mut WindowData<T>;
+                        get_window_long(window_id.0.into(), GWL_USERDATA) as *mut WindowData;
                     (*userdata).window_state_lock().window_flags
                 };
                 window_flags.set_size((window_id.0).0, inner_size);

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -8,7 +8,8 @@ use windows_sys::Win32::{
 
 pub(crate) use self::{
     event_loop::{
-        EventLoop, EventLoopProxy, EventLoopWindowTarget, PlatformSpecificEventLoopAttributes,
+        ActiveEventLoop, EventLoop, EventLoopProxy, EventLoopWindowTarget,
+        PlatformSpecificEventLoopAttributes,
     },
     icon::{SelectedCursor, WinIcon},
     monitor::{MonitorHandle, VideoMode},

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1122,7 +1122,7 @@ impl<'a, T: 'static> InitData<'a, T> {
         }
     }
 
-    unsafe fn create_window_data(&self, win: &Window) -> event_loop::WindowData<T> {
+    unsafe fn create_window_data(&self, win: &Window) -> event_loop::WindowData {
         let file_drop_handler = if self.pl_attribs.drag_and_drop {
             let ole_init_result = unsafe { OleInitialize(ptr::null_mut()) };
             // It is ok if the initialize result is `S_FALSE` because it might happen that

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -94,8 +94,8 @@ pub(crate) struct Window {
 }
 
 impl Window {
-    pub(crate) fn new<T: 'static>(
-        event_loop: &EventLoopWindowTarget<T>,
+    pub(crate) fn new(
+        event_loop: &EventLoopWindowTarget,
         w_attr: WindowAttributes,
         pl_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, RootOsError> {
@@ -1069,9 +1069,9 @@ impl Drop for Window {
     }
 }
 
-pub(super) struct InitData<'a, T: 'static> {
+pub(super) struct InitData<'a> {
     // inputs
-    pub event_loop: &'a EventLoopWindowTarget<T>,
+    pub event_loop: &'a EventLoopWindowTarget,
     pub attributes: WindowAttributes,
     pub pl_attribs: PlatformSpecificWindowBuilderAttributes,
     pub window_flags: WindowFlags,
@@ -1079,7 +1079,7 @@ pub(super) struct InitData<'a, T: 'static> {
     pub window: Option<Window>,
 }
 
-impl<'a, T: 'static> InitData<'a, T> {
+impl<'a> InitData<'a> {
     unsafe fn create_window(&self, window: HWND) -> Window {
         // Register for touch events if applicable
         {
@@ -1262,18 +1262,15 @@ impl<'a, T: 'static> InitData<'a, T> {
         }
     }
 }
-unsafe fn init<T>(
+unsafe fn init(
     attributes: WindowAttributes,
     pl_attribs: PlatformSpecificWindowBuilderAttributes,
-    event_loop: &EventLoopWindowTarget<T>,
-) -> Result<Window, RootOsError>
-where
-    T: 'static,
-{
+    event_loop: &EventLoopWindowTarget,
+) -> Result<Window, RootOsError> {
     let title = util::encode_wide(&attributes.title);
 
     let class_name = util::encode_wide(&pl_attribs.class_name);
-    unsafe { register_window_class::<T>(&class_name) };
+    unsafe { register_window_class(&class_name) };
 
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
@@ -1368,11 +1365,11 @@ where
     Ok(initdata.window.unwrap())
 }
 
-unsafe fn register_window_class<T: 'static>(class_name: &[u16]) {
+unsafe fn register_window_class(class_name: &[u16]) {
     let class = WNDCLASSEXW {
         cbSize: mem::size_of::<WNDCLASSEXW>() as u32,
         style: CS_HREDRAW | CS_VREDRAW,
-        lpfnWndProc: Some(super::event_loop::public_window_callback::<T>),
+        lpfnWndProc: Some(super::event_loop::public_window_callback),
         cbClsExtra: 0,
         cbWndExtra: 0,
         hInstance: util::get_instance_handle(),

--- a/src/window.rs
+++ b/src/window.rs
@@ -506,10 +506,7 @@ impl WindowBuilder {
     /// - **Web:** The window is created but not inserted into the web page automatically. Please
     ///   see the web platform module for more information.
     #[inline]
-    pub fn build<T: 'static>(
-        self,
-        window_target: &EventLoopWindowTarget<T>,
-    ) -> Result<Window, OsError> {
+    pub fn build(self, window_target: &EventLoopWindowTarget) -> Result<Window, OsError> {
         let window =
             platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)?;
         window.maybe_queue_on_main(|w| w.request_redraw());
@@ -533,7 +530,7 @@ impl Window {
     ///
     /// [`WindowBuilder::new().build(event_loop)`]: WindowBuilder::build
     #[inline]
-    pub fn new<T: 'static>(event_loop: &EventLoopWindowTarget<T>) -> Result<Window, OsError> {
+    pub fn new(event_loop: &EventLoopWindowTarget) -> Result<Window, OsError> {
         let builder = WindowBuilder::new();
         builder.build(event_loop)
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -42,12 +42,12 @@ pub use cursor_icon::{CursorIcon, ParseError as CursorIconParseError};
 /// event_loop.set_control_flow(ControlFlow::Wait);
 /// let window = Window::new(&event_loop).unwrap();
 ///
-/// event_loop.run(move |event, elwt| {
+/// event_loop.run(move |event, event_loop| {
 ///     match event {
 ///         Event::WindowEvent {
 ///             event: WindowEvent::CloseRequested,
 ///             ..
-///         } => elwt.exit(),
+///         } => event_loop.exit(),
 ///         _ => (),
 ///     }
 /// });


### PR DESCRIPTION
Part of https://github.com/rust-windowing/winit/issues/3367. Blocked on https://github.com/rust-windowing/winit/pull/3299, since I want to keep the active handle being passed around as simple as possible.

Add a trait `ApplicationHandler<T>` which replaces the closure `impl FnMut(Event<T>, ActiveEventLoop<'_>)` matching on `Event<T>`s. This trait is fully compatible with the closure, and all backends and most examples still use the old event design. But it should be possible to slowly migrate things from here.

Note that _this will not be the final design of the trait_, `exit` will probably be replaced by `Drop` (you shouldn't need to access the `ActiveEventLoop<'_>` from there anyhow, and it's more "Rusty"), we'll probably introduce a closure at the beginning instead of `init`, there are events that should be changed to have return types, and so on.
But we need to keep these APIs around mostly as-is, so that we can convert between the trait and the closure, at least until we've gathered experience, and are ready to remove the closure-based API.

TODO:
- [ ] Gather feedback.
- [ ] Finish implementation (I should probably add a `WindowHandler` in this PR too).
- [ ] Prepare at least one backend to migrate to this, to see that it is possible.
- [ ] Add changelog entry and docs.
- [ ] Update all examples (can probably be done in another PR).
