### PR TITLE
Remove `WindowBuilder` in favour of `WindowAttributes`

### DIFF
--- a/examples/custom_cursors.rs
+++ b/examples/custom_cursors.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), impl std::error::Error> {
     let builder = WindowBuilder::new().with_title("A fantastic window!");
     #[cfg(wasm_platform)]
     let builder = {
-        use winit::platform::web::WindowBuilderExtWebSys;
+        use winit::platform::web::WindowAttributesExtWebSys;
         builder.with_append(true)
     };
     let window = builder.build(&event_loop).unwrap();

--- a/examples/startup_notification.rs
+++ b/examples/startup_notification.rs
@@ -12,7 +12,7 @@ mod example {
     use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
     use winit::event_loop::EventLoop;
     use winit::platform::startup_notify::{
-        EventLoopExtStartupNotify, WindowBuilderExtStartupNotify, WindowExtStartupNotify,
+        EventLoopExtStartupNotify, WindowAttributesExtStartupNotify, WindowExtStartupNotify,
     };
     use winit::window::{Window, WindowBuilder, WindowId};
 

--- a/examples/web.rs
+++ b/examples/web.rs
@@ -13,7 +13,7 @@ pub fn main() -> Result<(), impl std::error::Error> {
     let builder = WindowBuilder::new().with_title("A fantastic window!");
     #[cfg(wasm_platform)]
     let builder = {
-        use winit::platform::web::WindowBuilderExtWebSys;
+        use winit::platform::web::WindowAttributesExtWebSys;
         builder.with_append(true)
     };
     let window = builder.build(&event_loop).unwrap();

--- a/examples/web_aspect_ratio.rs
+++ b/examples/web_aspect_ratio.rs
@@ -13,7 +13,7 @@ mod wasm {
         dpi::PhysicalSize,
         event::{Event, WindowEvent},
         event_loop::EventLoop,
-        platform::web::WindowBuilderExtWebSys,
+        platform::web::WindowAttributesExtWebSys,
         window::{Window, WindowBuilder},
     };
 

--- a/examples/window_tabbing.rs
+++ b/examples/window_tabbing.rs
@@ -10,7 +10,7 @@ use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::EventLoop,
     keyboard::{Key, NamedKey},
-    platform::macos::{WindowBuilderExtMacOS, WindowExtMacOS},
+    platform::macos::{WindowAttributesExtMacOS, WindowExtMacOS},
     window::{Window, WindowBuilder},
 };
 

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -11,7 +11,7 @@ mod imple {
     use winit::{
         event::{Event, WindowEvent},
         event_loop::EventLoop,
-        platform::x11::WindowBuilderExtX11,
+        platform::x11::WindowAttributesExtX11,
         window::WindowBuilder,
     };
 

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,6 +1,6 @@
 use crate::{
     event_loop::{EventLoop, EventLoopBuilder, EventLoopWindowTarget},
-    window::{Window, WindowBuilder},
+    window::Window,
 };
 
 use android_activity::{AndroidApp, ConfigurationRef, Rect};
@@ -31,11 +31,6 @@ impl WindowExtAndroid for Window {
 }
 
 impl<T> EventLoopWindowTargetExtAndroid for EventLoopWindowTarget<T> {}
-
-/// Additional methods on [`WindowBuilder`] that are specific to Android.
-pub trait WindowBuilderExtAndroid {}
-
-impl WindowBuilderExtAndroid for WindowBuilder {}
 
 pub trait EventLoopBuilderExtAndroid {
     /// Associates the `AndroidApp` that was passed to `android_main()` with the event loop

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -187,38 +187,39 @@ pub trait WindowBuilderExtIOS {
 impl WindowBuilderExtIOS for WindowBuilder {
     #[inline]
     fn with_scale_factor(mut self, scale_factor: f64) -> Self {
-        self.platform_specific.scale_factor = Some(scale_factor);
+        self.window.platform_specific.scale_factor = Some(scale_factor);
         self
     }
 
     #[inline]
     fn with_valid_orientations(mut self, valid_orientations: ValidOrientations) -> Self {
-        self.platform_specific.valid_orientations = valid_orientations;
+        self.window.platform_specific.valid_orientations = valid_orientations;
         self
     }
 
     #[inline]
     fn with_prefers_home_indicator_hidden(mut self, hidden: bool) -> Self {
-        self.platform_specific.prefers_home_indicator_hidden = hidden;
+        self.window.platform_specific.prefers_home_indicator_hidden = hidden;
         self
     }
 
     #[inline]
     fn with_preferred_screen_edges_deferring_system_gestures(mut self, edges: ScreenEdge) -> Self {
-        self.platform_specific
+        self.window
+            .platform_specific
             .preferred_screen_edges_deferring_system_gestures = edges;
         self
     }
 
     #[inline]
     fn with_prefers_status_bar_hidden(mut self, hidden: bool) -> Self {
-        self.platform_specific.prefers_status_bar_hidden = hidden;
+        self.window.platform_specific.prefers_status_bar_hidden = hidden;
         self
     }
 
     #[inline]
     fn with_preferred_status_bar_style(mut self, status_bar_style: StatusBarStyle) -> Self {
-        self.platform_specific.preferred_status_bar_style = status_bar_style;
+        self.window.platform_specific.preferred_status_bar_style = status_bar_style;
         self
     }
 }

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -6,7 +6,7 @@ use objc2::rc::Id;
 use crate::{
     event_loop::EventLoop,
     monitor::{MonitorHandle, VideoModeHandle},
-    window::{Window, WindowBuilder},
+    window::{Window, WindowAttributes},
 };
 
 /// Additional methods on [`EventLoop`] that are specific to iOS.
@@ -129,8 +129,8 @@ impl WindowExtIOS for Window {
     }
 }
 
-/// Additional methods on [`WindowBuilder`] that are specific to iOS.
-pub trait WindowBuilderExtIOS {
+/// Additional methods on [`WindowAttributes`] that are specific to iOS.
+pub trait WindowAttributesExtIOS {
     /// Sets the [`contentScaleFactor`] of the underlying [`UIWindow`] to `scale_factor`.
     ///
     /// The default value is device dependent, and it's recommended GLES or Metal applications set
@@ -184,42 +184,41 @@ pub trait WindowBuilderExtIOS {
     fn with_preferred_status_bar_style(self, status_bar_style: StatusBarStyle) -> Self;
 }
 
-impl WindowBuilderExtIOS for WindowBuilder {
+impl WindowAttributesExtIOS for WindowAttributes {
     #[inline]
     fn with_scale_factor(mut self, scale_factor: f64) -> Self {
-        self.window.platform_specific.scale_factor = Some(scale_factor);
+        self.platform_specific.scale_factor = Some(scale_factor);
         self
     }
 
     #[inline]
     fn with_valid_orientations(mut self, valid_orientations: ValidOrientations) -> Self {
-        self.window.platform_specific.valid_orientations = valid_orientations;
+        self.platform_specific.valid_orientations = valid_orientations;
         self
     }
 
     #[inline]
     fn with_prefers_home_indicator_hidden(mut self, hidden: bool) -> Self {
-        self.window.platform_specific.prefers_home_indicator_hidden = hidden;
+        self.platform_specific.prefers_home_indicator_hidden = hidden;
         self
     }
 
     #[inline]
     fn with_preferred_screen_edges_deferring_system_gestures(mut self, edges: ScreenEdge) -> Self {
-        self.window
-            .platform_specific
+        self.platform_specific
             .preferred_screen_edges_deferring_system_gestures = edges;
         self
     }
 
     #[inline]
     fn with_prefers_status_bar_hidden(mut self, hidden: bool) -> Self {
-        self.window.platform_specific.prefers_status_bar_hidden = hidden;
+        self.platform_specific.prefers_status_bar_hidden = hidden;
         self
     }
 
     #[inline]
     fn with_preferred_status_bar_style(mut self, status_bar_style: StatusBarStyle) -> Self {
-        self.window.platform_specific.preferred_status_bar_style = status_bar_style;
+        self.platform_specific.preferred_status_bar_style = status_bar_style;
         self
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -214,61 +214,62 @@ pub trait WindowBuilderExtMacOS {
 impl WindowBuilderExtMacOS for WindowBuilder {
     #[inline]
     fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> Self {
-        self.platform_specific.movable_by_window_background = movable_by_window_background;
+        self.window.platform_specific.movable_by_window_background = movable_by_window_background;
         self
     }
 
     #[inline]
     fn with_titlebar_transparent(mut self, titlebar_transparent: bool) -> Self {
-        self.platform_specific.titlebar_transparent = titlebar_transparent;
+        self.window.platform_specific.titlebar_transparent = titlebar_transparent;
         self
     }
 
     #[inline]
     fn with_titlebar_hidden(mut self, titlebar_hidden: bool) -> Self {
-        self.platform_specific.titlebar_hidden = titlebar_hidden;
+        self.window.platform_specific.titlebar_hidden = titlebar_hidden;
         self
     }
 
     #[inline]
     fn with_titlebar_buttons_hidden(mut self, titlebar_buttons_hidden: bool) -> Self {
-        self.platform_specific.titlebar_buttons_hidden = titlebar_buttons_hidden;
+        self.window.platform_specific.titlebar_buttons_hidden = titlebar_buttons_hidden;
         self
     }
 
     #[inline]
     fn with_title_hidden(mut self, title_hidden: bool) -> Self {
-        self.platform_specific.title_hidden = title_hidden;
+        self.window.platform_specific.title_hidden = title_hidden;
         self
     }
 
     #[inline]
     fn with_fullsize_content_view(mut self, fullsize_content_view: bool) -> Self {
-        self.platform_specific.fullsize_content_view = fullsize_content_view;
+        self.window.platform_specific.fullsize_content_view = fullsize_content_view;
         self
     }
 
     #[inline]
     fn with_disallow_hidpi(mut self, disallow_hidpi: bool) -> Self {
-        self.platform_specific.disallow_hidpi = disallow_hidpi;
+        self.window.platform_specific.disallow_hidpi = disallow_hidpi;
         self
     }
 
     #[inline]
     fn with_has_shadow(mut self, has_shadow: bool) -> Self {
-        self.platform_specific.has_shadow = has_shadow;
+        self.window.platform_specific.has_shadow = has_shadow;
         self
     }
 
     #[inline]
     fn with_accepts_first_mouse(mut self, accepts_first_mouse: bool) -> Self {
-        self.platform_specific.accepts_first_mouse = accepts_first_mouse;
+        self.window.platform_specific.accepts_first_mouse = accepts_first_mouse;
         self
     }
 
     #[inline]
     fn with_tabbing_identifier(mut self, tabbing_identifier: &str) -> Self {
-        self.platform_specific
+        self.window
+            .platform_specific
             .tabbing_identifier
             .replace(tabbing_identifier.to_string());
         self
@@ -276,7 +277,7 @@ impl WindowBuilderExtMacOS for WindowBuilder {
 
     #[inline]
     fn with_option_as_alt(mut self, option_as_alt: OptionAsAlt) -> Self {
-        self.platform_specific.option_as_alt = option_as_alt;
+        self.window.platform_specific.option_as_alt = option_as_alt;
         self
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
     monitor::MonitorHandle,
-    window::{Window, WindowBuilder},
+    window::{Window, WindowAttributes},
 };
 
 /// Additional methods on [`Window`] that are specific to MacOS.
@@ -176,15 +176,16 @@ pub enum ActivationPolicy {
     Prohibited,
 }
 
-/// Additional methods on [`WindowBuilder`] that are specific to MacOS.
+/// Additional methods on [`WindowAttributes`] that are specific to MacOS.
 ///
-/// **Note:** Properties dealing with the titlebar will be overwritten by the [`WindowBuilder::with_decorations`] method:
+/// **Note:** Properties dealing with the titlebar will be overwritten by the
+/// [`WindowAttributes::with_decorations`] method:
 /// - `with_titlebar_transparent`
 /// - `with_title_hidden`
 /// - `with_titlebar_hidden`
 /// - `with_titlebar_buttons_hidden`
 /// - `with_fullsize_content_view`
-pub trait WindowBuilderExtMacOS {
+pub trait WindowAttributesExtMacOS {
     /// Enables click-and-drag behavior for the entire window, not just the titlebar.
     fn with_movable_by_window_background(self, movable_by_window_background: bool) -> Self;
     /// Makes the titlebar transparent and allows the content to appear behind it.
@@ -211,65 +212,64 @@ pub trait WindowBuilderExtMacOS {
     fn with_option_as_alt(self, option_as_alt: OptionAsAlt) -> Self;
 }
 
-impl WindowBuilderExtMacOS for WindowBuilder {
+impl WindowAttributesExtMacOS for WindowAttributes {
     #[inline]
     fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> Self {
-        self.window.platform_specific.movable_by_window_background = movable_by_window_background;
+        self.platform_specific.movable_by_window_background = movable_by_window_background;
         self
     }
 
     #[inline]
     fn with_titlebar_transparent(mut self, titlebar_transparent: bool) -> Self {
-        self.window.platform_specific.titlebar_transparent = titlebar_transparent;
+        self.platform_specific.titlebar_transparent = titlebar_transparent;
         self
     }
 
     #[inline]
     fn with_titlebar_hidden(mut self, titlebar_hidden: bool) -> Self {
-        self.window.platform_specific.titlebar_hidden = titlebar_hidden;
+        self.platform_specific.titlebar_hidden = titlebar_hidden;
         self
     }
 
     #[inline]
     fn with_titlebar_buttons_hidden(mut self, titlebar_buttons_hidden: bool) -> Self {
-        self.window.platform_specific.titlebar_buttons_hidden = titlebar_buttons_hidden;
+        self.platform_specific.titlebar_buttons_hidden = titlebar_buttons_hidden;
         self
     }
 
     #[inline]
     fn with_title_hidden(mut self, title_hidden: bool) -> Self {
-        self.window.platform_specific.title_hidden = title_hidden;
+        self.platform_specific.title_hidden = title_hidden;
         self
     }
 
     #[inline]
     fn with_fullsize_content_view(mut self, fullsize_content_view: bool) -> Self {
-        self.window.platform_specific.fullsize_content_view = fullsize_content_view;
+        self.platform_specific.fullsize_content_view = fullsize_content_view;
         self
     }
 
     #[inline]
     fn with_disallow_hidpi(mut self, disallow_hidpi: bool) -> Self {
-        self.window.platform_specific.disallow_hidpi = disallow_hidpi;
+        self.platform_specific.disallow_hidpi = disallow_hidpi;
         self
     }
 
     #[inline]
     fn with_has_shadow(mut self, has_shadow: bool) -> Self {
-        self.window.platform_specific.has_shadow = has_shadow;
+        self.platform_specific.has_shadow = has_shadow;
         self
     }
 
     #[inline]
     fn with_accepts_first_mouse(mut self, accepts_first_mouse: bool) -> Self {
-        self.window.platform_specific.accepts_first_mouse = accepts_first_mouse;
+        self.platform_specific.accepts_first_mouse = accepts_first_mouse;
         self
     }
 
     #[inline]
     fn with_tabbing_identifier(mut self, tabbing_identifier: &str) -> Self {
-        self.window
-            .platform_specific
+        self.platform_specific
             .tabbing_identifier
             .replace(tabbing_identifier.to_string());
         self
@@ -277,7 +277,7 @@ impl WindowBuilderExtMacOS for WindowBuilder {
 
     #[inline]
     fn with_option_as_alt(mut self, option_as_alt: OptionAsAlt) -> Self {
-        self.window.platform_specific.option_as_alt = option_as_alt;
+        self.platform_specific.option_as_alt = option_as_alt;
         self
     }
 }

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -76,7 +76,7 @@ impl WindowExtStartupNotify for Window {
 
 impl WindowBuilderExtStartupNotify for WindowBuilder {
     fn with_activation_token(mut self, token: ActivationToken) -> Self {
-        self.platform_specific.activation_token = Some(token);
+        self.window.platform_specific.activation_token = Some(token);
         self
     }
 }

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -25,7 +25,7 @@ use std::env;
 
 use crate::error::NotSupportedError;
 use crate::event_loop::{AsyncRequestSerial, EventLoopWindowTarget};
-use crate::window::{ActivationToken, Window, WindowBuilder};
+use crate::window::{ActivationToken, Window, WindowAttributes};
 
 /// The variable which is used mostly on X11.
 const X11_VAR: &str = "DESKTOP_STARTUP_ID";
@@ -47,7 +47,7 @@ pub trait WindowExtStartupNotify {
     fn request_activation_token(&self) -> Result<AsyncRequestSerial, NotSupportedError>;
 }
 
-pub trait WindowBuilderExtStartupNotify {
+pub trait WindowAttributesExtStartupNotify {
     /// Use this [`ActivationToken`] during window creation.
     ///
     /// Not using such a token upon a window could make your window not gaining
@@ -74,9 +74,9 @@ impl WindowExtStartupNotify for Window {
     }
 }
 
-impl WindowBuilderExtStartupNotify for WindowBuilder {
+impl WindowAttributesExtStartupNotify for WindowAttributes {
     fn with_activation_token(mut self, token: ActivationToken) -> Self {
-        self.window.platform_specific.activation_token = Some(token);
+        self.platform_specific.activation_token = Some(token);
         self
     }
 }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -67,7 +67,8 @@ pub trait WindowBuilderExtWayland {
 impl WindowBuilderExtWayland for WindowBuilder {
     #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
-        self.platform_specific.name = Some(ApplicationName::new(general.into(), instance.into()));
+        self.window.platform_specific.name =
+            Some(ApplicationName::new(general.into(), instance.into()));
         self
     }
 }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -1,7 +1,7 @@
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
     monitor::MonitorHandle,
-    window::{Window, WindowBuilder},
+    window::{Window, WindowAttributes},
 };
 
 use crate::platform_impl::{ApplicationName, Backend};
@@ -52,8 +52,8 @@ pub trait WindowExtWayland {}
 
 impl WindowExtWayland for Window {}
 
-/// Additional methods on [`WindowBuilder`] that are specific to Wayland.
-pub trait WindowBuilderExtWayland {
+/// Additional methods on [`WindowAttributes`] that are specific to Wayland.
+pub trait WindowAttributesExtWayland {
     /// Build window with the given name.
     ///
     /// The `general` name sets an application ID, which should match the `.desktop`
@@ -64,11 +64,10 @@ pub trait WindowBuilderExtWayland {
     fn with_name(self, general: impl Into<String>, instance: impl Into<String>) -> Self;
 }
 
-impl WindowBuilderExtWayland for WindowBuilder {
+impl WindowAttributesExtWayland for WindowAttributes {
     #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
-        self.window.platform_specific.name =
-            Some(ApplicationName::new(general.into(), instance.into()));
+        self.platform_specific.name = Some(ApplicationName::new(general.into(), instance.into()));
         self
     }
 }

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -104,22 +104,22 @@ pub trait WindowBuilderExtWebSys {
 
 impl WindowBuilderExtWebSys for WindowBuilder {
     fn with_canvas(mut self, canvas: Option<HtmlCanvasElement>) -> Self {
-        self.platform_specific.set_canvas(canvas);
+        self.window.platform_specific.set_canvas(canvas);
         self
     }
 
     fn with_prevent_default(mut self, prevent_default: bool) -> Self {
-        self.platform_specific.prevent_default = prevent_default;
+        self.window.platform_specific.prevent_default = prevent_default;
         self
     }
 
     fn with_focusable(mut self, focusable: bool) -> Self {
-        self.platform_specific.focusable = focusable;
+        self.window.platform_specific.focusable = focusable;
         self
     }
 
     fn with_append(mut self, append: bool) -> Self {
-        self.platform_specific.append = append;
+        self.window.platform_specific.append = append;
         self
     }
 }

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -33,7 +33,7 @@ use crate::event_loop::EventLoop;
 use crate::event_loop::EventLoopWindowTarget;
 use crate::platform_impl::PlatformCustomCursorBuilder;
 use crate::window::CustomCursor;
-use crate::window::{Window, WindowBuilder};
+use crate::window::{Window, WindowAttributes};
 
 use web_sys::HtmlCanvasElement;
 
@@ -73,7 +73,7 @@ impl WindowExtWebSys for Window {
     }
 }
 
-pub trait WindowBuilderExtWebSys {
+pub trait WindowAttributesExtWebSys {
     /// Pass an [`HtmlCanvasElement`] to be used for this [`Window`]. If [`None`],
     /// [`WindowBuilder::build()`] will create one.
     ///
@@ -102,24 +102,24 @@ pub trait WindowBuilderExtWebSys {
     fn with_append(self, append: bool) -> Self;
 }
 
-impl WindowBuilderExtWebSys for WindowBuilder {
+impl WindowAttributesExtWebSys for WindowAttributes {
     fn with_canvas(mut self, canvas: Option<HtmlCanvasElement>) -> Self {
-        self.window.platform_specific.set_canvas(canvas);
+        self.platform_specific.set_canvas(canvas);
         self
     }
 
     fn with_prevent_default(mut self, prevent_default: bool) -> Self {
-        self.window.platform_specific.prevent_default = prevent_default;
+        self.platform_specific.prevent_default = prevent_default;
         self
     }
 
     fn with_focusable(mut self, focusable: bool) -> Self {
-        self.window.platform_specific.focusable = focusable;
+        self.platform_specific.focusable = focusable;
         self
     }
 
     fn with_append(mut self, append: bool) -> Self {
-        self.window.platform_specific.append = append;
+        self.platform_specific.append = append;
         self
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -218,49 +218,49 @@ pub trait WindowBuilderExtWindows {
 impl WindowBuilderExtWindows for WindowBuilder {
     #[inline]
     fn with_owner_window(mut self, parent: HWND) -> Self {
-        self.platform_specific.owner = Some(parent);
+        self.window.platform_specific.owner = Some(parent);
         self
     }
 
     #[inline]
     fn with_menu(mut self, menu: HMENU) -> Self {
-        self.platform_specific.menu = Some(menu);
+        self.window.platform_specific.menu = Some(menu);
         self
     }
 
     #[inline]
     fn with_taskbar_icon(mut self, taskbar_icon: Option<Icon>) -> Self {
-        self.platform_specific.taskbar_icon = taskbar_icon;
+        self.window.platform_specific.taskbar_icon = taskbar_icon;
         self
     }
 
     #[inline]
     fn with_no_redirection_bitmap(mut self, flag: bool) -> Self {
-        self.platform_specific.no_redirection_bitmap = flag;
+        self.window.platform_specific.no_redirection_bitmap = flag;
         self
     }
 
     #[inline]
     fn with_drag_and_drop(mut self, flag: bool) -> Self {
-        self.platform_specific.drag_and_drop = flag;
+        self.window.platform_specific.drag_and_drop = flag;
         self
     }
 
     #[inline]
     fn with_skip_taskbar(mut self, skip: bool) -> Self {
-        self.platform_specific.skip_taskbar = skip;
+        self.window.platform_specific.skip_taskbar = skip;
         self
     }
 
     #[inline]
     fn with_class_name<S: Into<String>>(mut self, class_name: S) -> Self {
-        self.platform_specific.class_name = class_name.into();
+        self.window.platform_specific.class_name = class_name.into();
         self
     }
 
     #[inline]
     fn with_undecorated_shadow(mut self, shadow: bool) -> Self {
-        self.platform_specific.decoration_shadow = shadow;
+        self.window.platform_specific.decoration_shadow = shadow;
         self
     }
 }

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -8,7 +8,7 @@ use crate::{
     monitor::MonitorHandle,
     platform::modifier_supplement::KeyEventExtModifierSupplement,
     platform_impl::WinIcon,
-    window::{BadIcon, Icon, Window, WindowBuilder},
+    window::{BadIcon, Icon, Window, WindowAttributes},
 };
 
 /// Window Handle type used by Win32 API
@@ -160,9 +160,9 @@ impl WindowExtWindows for Window {
     }
 }
 
-/// Additional methods on `WindowBuilder` that are specific to Windows.
+/// Additional methods on `WindowAttributes` that are specific to Windows.
 #[allow(rustdoc::broken_intra_doc_links)]
-pub trait WindowBuilderExtWindows {
+pub trait WindowAttributesExtWindows {
     /// Set an owner to the window to be created. Can be used to create a dialog box, for example.
     /// This only works when [`WindowBuilder::with_parent_window`] isn't called or set to `None`.
     /// Can be used in combination with [`WindowExtWindows::set_enable(false)`](WindowExtWindows::set_enable)
@@ -215,52 +215,52 @@ pub trait WindowBuilderExtWindows {
     fn with_undecorated_shadow(self, shadow: bool) -> Self;
 }
 
-impl WindowBuilderExtWindows for WindowBuilder {
+impl WindowAttributesExtWindows for WindowAttributes {
     #[inline]
     fn with_owner_window(mut self, parent: HWND) -> Self {
-        self.window.platform_specific.owner = Some(parent);
+        self.platform_specific.owner = Some(parent);
         self
     }
 
     #[inline]
     fn with_menu(mut self, menu: HMENU) -> Self {
-        self.window.platform_specific.menu = Some(menu);
+        self.platform_specific.menu = Some(menu);
         self
     }
 
     #[inline]
     fn with_taskbar_icon(mut self, taskbar_icon: Option<Icon>) -> Self {
-        self.window.platform_specific.taskbar_icon = taskbar_icon;
+        self.platform_specific.taskbar_icon = taskbar_icon;
         self
     }
 
     #[inline]
     fn with_no_redirection_bitmap(mut self, flag: bool) -> Self {
-        self.window.platform_specific.no_redirection_bitmap = flag;
+        self.platform_specific.no_redirection_bitmap = flag;
         self
     }
 
     #[inline]
     fn with_drag_and_drop(mut self, flag: bool) -> Self {
-        self.window.platform_specific.drag_and_drop = flag;
+        self.platform_specific.drag_and_drop = flag;
         self
     }
 
     #[inline]
     fn with_skip_taskbar(mut self, skip: bool) -> Self {
-        self.window.platform_specific.skip_taskbar = skip;
+        self.platform_specific.skip_taskbar = skip;
         self
     }
 
     #[inline]
     fn with_class_name<S: Into<String>>(mut self, class_name: S) -> Self {
-        self.window.platform_specific.class_name = class_name.into();
+        self.platform_specific.class_name = class_name.into();
         self
     }
 
     #[inline]
     fn with_undecorated_shadow(mut self, shadow: bool) -> Self {
-        self.window.platform_specific.decoration_shadow = shadow;
+        self.platform_specific.decoration_shadow = shadow;
         self
     }
 }

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -143,43 +143,44 @@ pub trait WindowBuilderExtX11 {
 impl WindowBuilderExtX11 for WindowBuilder {
     #[inline]
     fn with_x11_visual(mut self, visual_id: XVisualID) -> Self {
-        self.platform_specific.x11.visual_id = Some(visual_id);
+        self.window.platform_specific.x11.visual_id = Some(visual_id);
         self
     }
 
     #[inline]
     fn with_x11_screen(mut self, screen_id: i32) -> Self {
-        self.platform_specific.x11.screen_id = Some(screen_id);
+        self.window.platform_specific.x11.screen_id = Some(screen_id);
         self
     }
 
     #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
-        self.platform_specific.name = Some(ApplicationName::new(general.into(), instance.into()));
+        self.window.platform_specific.name =
+            Some(ApplicationName::new(general.into(), instance.into()));
         self
     }
 
     #[inline]
     fn with_override_redirect(mut self, override_redirect: bool) -> Self {
-        self.platform_specific.x11.override_redirect = override_redirect;
+        self.window.platform_specific.x11.override_redirect = override_redirect;
         self
     }
 
     #[inline]
     fn with_x11_window_type(mut self, x11_window_types: Vec<XWindowType>) -> Self {
-        self.platform_specific.x11.x11_window_types = x11_window_types;
+        self.window.platform_specific.x11.x11_window_types = x11_window_types;
         self
     }
 
     #[inline]
     fn with_base_size<S: Into<Size>>(mut self, base_size: S) -> Self {
-        self.platform_specific.x11.base_size = Some(base_size.into());
+        self.window.platform_specific.x11.base_size = Some(base_size.into());
         self
     }
 
     #[inline]
     fn with_embed_parent_window(mut self, parent_window_id: XWindow) -> Self {
-        self.platform_specific.x11.embed_window = Some(parent_window_id);
+        self.window.platform_specific.x11.embed_window = Some(parent_window_id);
         self
     }
 }

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -1,7 +1,7 @@
 use crate::{
     event_loop::{EventLoopBuilder, EventLoopWindowTarget},
     monitor::MonitorHandle,
-    window::{Window, WindowBuilder},
+    window::{Window, WindowAttributes},
 };
 
 use crate::dpi::Size;
@@ -86,8 +86,8 @@ pub trait WindowExtX11 {}
 
 impl WindowExtX11 for Window {}
 
-/// Additional methods on [`WindowBuilder`] that are specific to X11.
-pub trait WindowBuilderExtX11 {
+/// Additional methods on [`WindowAttributes`] that are specific to X11.
+pub trait WindowAttributesExtX11 {
     /// Create this window with a specific X11 visual.
     fn with_x11_visual(self, visual_id: XVisualID) -> Self;
 
@@ -140,47 +140,46 @@ pub trait WindowBuilderExtX11 {
     fn with_embed_parent_window(self, parent_window_id: XWindow) -> Self;
 }
 
-impl WindowBuilderExtX11 for WindowBuilder {
+impl WindowAttributesExtX11 for WindowAttributes {
     #[inline]
     fn with_x11_visual(mut self, visual_id: XVisualID) -> Self {
-        self.window.platform_specific.x11.visual_id = Some(visual_id);
+        self.platform_specific.x11.visual_id = Some(visual_id);
         self
     }
 
     #[inline]
     fn with_x11_screen(mut self, screen_id: i32) -> Self {
-        self.window.platform_specific.x11.screen_id = Some(screen_id);
+        self.platform_specific.x11.screen_id = Some(screen_id);
         self
     }
 
     #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
-        self.window.platform_specific.name =
-            Some(ApplicationName::new(general.into(), instance.into()));
+        self.platform_specific.name = Some(ApplicationName::new(general.into(), instance.into()));
         self
     }
 
     #[inline]
     fn with_override_redirect(mut self, override_redirect: bool) -> Self {
-        self.window.platform_specific.x11.override_redirect = override_redirect;
+        self.platform_specific.x11.override_redirect = override_redirect;
         self
     }
 
     #[inline]
     fn with_x11_window_type(mut self, x11_window_types: Vec<XWindowType>) -> Self {
-        self.window.platform_specific.x11.x11_window_types = x11_window_types;
+        self.platform_specific.x11.x11_window_types = x11_window_types;
         self
     }
 
     #[inline]
     fn with_base_size<S: Into<Size>>(mut self, base_size: S) -> Self {
-        self.window.platform_specific.x11.base_size = Some(base_size.into());
+        self.platform_specific.x11.base_size = Some(base_size.into());
         self
     }
 
     #[inline]
     fn with_embed_parent_window(mut self, parent_window_id: XWindow) -> Self {
-        self.window.platform_specific.x11.embed_window = Some(parent_window_id);
+        self.platform_specific.x11.embed_window = Some(parent_window_id);
         self
     }
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -766,7 +766,6 @@ impl Window {
     pub(crate) fn new<T: 'static>(
         el: &EventLoopWindowTarget<T>,
         _window_attrs: window::WindowAttributes,
-        _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {
         // FIXME this ignores requested window attributes
 

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -21,7 +21,6 @@ use crate::{
     platform::ios::ValidOrientations,
     platform_impl::platform::{
         ffi::{UIRectEdge, UIUserInterfaceIdiom},
-        window::PlatformSpecificWindowBuilderAttributes,
         DeviceId, Fullscreen,
     },
     window::{WindowAttributes, WindowId as RootWindowId},
@@ -182,15 +181,14 @@ extern_methods!(
 impl WinitView {
     pub(crate) fn new(
         _mtm: MainThreadMarker,
-        _window_attributes: &WindowAttributes,
-        platform_attributes: &PlatformSpecificWindowBuilderAttributes,
+        window_attributes: &WindowAttributes,
         frame: CGRect,
     ) -> Id<Self> {
         let this: Id<Self> = unsafe { msg_send_id![Self::alloc(), initWithFrame: frame] };
 
         this.setMultipleTouchEnabled(true);
 
-        if let Some(scale_factor) = platform_attributes.scale_factor {
+        if let Some(scale_factor) = window_attributes.platform_specific.scale_factor {
             this.setContentScaleFactor(scale_factor as _);
         }
 
@@ -385,8 +383,7 @@ impl WinitViewController {
 
     pub(crate) fn new(
         mtm: MainThreadMarker,
-        _window_attributes: &WindowAttributes,
-        platform_attributes: &PlatformSpecificWindowBuilderAttributes,
+        window_attributes: &WindowAttributes,
         view: &UIView,
     ) -> Id<Self> {
         // These are set properly below, we just to set them to something in the meantime.
@@ -399,18 +396,33 @@ impl WinitViewController {
         });
         let this: Id<Self> = unsafe { msg_send_id![super(this), init] };
 
-        this.set_prefers_status_bar_hidden(platform_attributes.prefers_status_bar_hidden);
+        this.set_prefers_status_bar_hidden(
+            window_attributes
+                .platform_specific
+                .prefers_status_bar_hidden,
+        );
 
-        this.set_preferred_status_bar_style(platform_attributes.preferred_status_bar_style.into());
+        this.set_preferred_status_bar_style(
+            window_attributes
+                .platform_specific
+                .preferred_status_bar_style
+                .into(),
+        );
 
-        this.set_supported_interface_orientations(mtm, platform_attributes.valid_orientations);
+        this.set_supported_interface_orientations(
+            mtm,
+            window_attributes.platform_specific.valid_orientations,
+        );
 
         this.set_prefers_home_indicator_auto_hidden(
-            platform_attributes.prefers_home_indicator_hidden,
+            window_attributes
+                .platform_specific
+                .prefers_home_indicator_hidden,
         );
 
         this.set_preferred_screen_edges_deferring_system_gestures(
-            platform_attributes
+            window_attributes
+                .platform_specific
                 .preferred_screen_edges_deferring_system_gestures
                 .into(),
         );
@@ -467,7 +479,6 @@ impl WinitUIWindow {
     pub(crate) fn new(
         mtm: MainThreadMarker,
         window_attributes: &WindowAttributes,
-        _platform_attributes: &PlatformSpecificWindowBuilderAttributes,
         frame: CGRect,
         view_controller: &UIViewController,
     ) -> Id<Self> {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -401,7 +401,6 @@ impl Window {
     pub(crate) fn new<T>(
         event_loop: &EventLoopWindowTarget<T>,
         window_attributes: WindowAttributes,
-        platform_attributes: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, RootOsError> {
         let mtm = event_loop.mtm;
 
@@ -439,7 +438,7 @@ impl Window {
             None => screen_bounds,
         };
 
-        let view = WinitView::new(mtm, &window_attributes, &platform_attributes, frame);
+        let view = WinitView::new(mtm, &window_attributes, frame);
 
         let gl_or_metal_backed = unsafe {
             let layer_class = WinitView::layerClass();
@@ -448,15 +447,8 @@ impl Window {
             is_metal || is_gl
         };
 
-        let view_controller =
-            WinitViewController::new(mtm, &window_attributes, &platform_attributes, &view);
-        let window = WinitUIWindow::new(
-            mtm,
-            &window_attributes,
-            &platform_attributes,
-            frame,
-            &view_controller,
-        );
+        let view_controller = WinitViewController::new(mtm, &window_attributes, &view);
+        let window = WinitUIWindow::new(mtm, &window_attributes, frame, &view_controller);
 
         app_state::set_key_window(mtm, &window);
 
@@ -673,7 +665,7 @@ impl From<&AnyObject> for WindowId {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub scale_factor: Option<f64>,
     pub valid_orientations: ValidOrientations,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -77,7 +77,7 @@ impl ApplicationName {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub name: Option<ApplicationName>,
     pub activation_token: Option<ActivationToken>,
@@ -85,7 +85,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub x11: X11WindowBuilderAttributes,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 #[cfg(x11_platform)]
 pub struct X11WindowBuilderAttributes {
     pub visual_id: Option<x11rb::protocol::xproto::Visualid>,
@@ -294,16 +294,15 @@ impl Window {
     pub(crate) fn new<T>(
         window_target: &EventLoopWindowTarget<T>,
         attribs: WindowAttributes,
-        pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
         match *window_target {
             #[cfg(wayland_platform)]
             EventLoopWindowTarget::Wayland(ref window_target) => {
-                wayland::Window::new(window_target, attribs, pl_attribs).map(Window::Wayland)
+                wayland::Window::new(window_target, attribs).map(Window::Wayland)
             }
             #[cfg(x11_platform)]
             EventLoopWindowTarget::X(ref window_target) => {
-                x11::Window::new(window_target, attribs, pl_attribs).map(Window::X)
+                x11::Window::new(window_target, attribs).map(Window::X)
             }
         }
     }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -23,7 +23,6 @@ use crate::event::{Ime, WindowEvent};
 use crate::event_loop::AsyncRequestSerial;
 use crate::platform_impl::{
     Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError, PlatformIcon,
-    PlatformSpecificWindowBuilderAttributes as PlatformAttributes,
 };
 use crate::window::{
     Cursor, CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType,
@@ -84,7 +83,6 @@ impl Window {
     pub(crate) fn new<T>(
         event_loop_window_target: &EventLoopWindowTarget<T>,
         attributes: WindowAttributes,
-        platform_attributes: PlatformAttributes,
     ) -> Result<Self, RootOsError> {
         let queue_handle = event_loop_window_target.queue_handle.clone();
         let mut state = event_loop_window_target.state.borrow_mut();
@@ -134,7 +132,7 @@ impl Window {
         window_state.set_decorate(attributes.decorations);
 
         // Set the app_id.
-        if let Some(name) = platform_attributes.name.map(|name| name.general) {
+        if let Some(name) = attributes.platform_specific.name.map(|name| name.general) {
             window.set_app_id(name);
         }
 
@@ -177,7 +175,7 @@ impl Window {
         // Activate the window when the token is passed.
         if let (Some(xdg_activation), Some(token)) = (
             xdg_activation.as_ref(),
-            platform_attributes.activation_token,
+            attributes.platform_specific.activation_token,
         ) {
             xdg_activation.activate(token._token, &surface);
         }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -72,10 +72,7 @@ use crate::{
     event::{Event, StartCause, WindowEvent},
     event_loop::{DeviceEvents, EventLoopClosed, EventLoopWindowTarget as RootELW},
     platform::pump_events::PumpStatus,
-    platform_impl::{
-        platform::{min_timeout, WindowId},
-        PlatformSpecificWindowBuilderAttributes,
-    },
+    platform_impl::platform::{min_timeout, WindowId},
     window::WindowAttributes,
 };
 
@@ -842,9 +839,8 @@ impl Window {
     pub(crate) fn new<T>(
         event_loop: &EventLoopWindowTarget<T>,
         attribs: WindowAttributes,
-        pl_attribs: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, RootOsError> {
-        let window = Arc::new(UnownedWindow::new(event_loop, attribs, pl_attribs)?);
+        let window = Arc::new(UnownedWindow::new(event_loop, attribs)?);
         event_loop
             .windows
             .borrow_mut()

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -13,8 +13,7 @@ use crate::{
 };
 
 use super::{
-    EventLoopWindowTarget, MonitorHandle, PlatformSpecificWindowBuilderAttributes, RedoxSocket,
-    TimeSocket, WindowId, WindowProperties,
+    EventLoopWindowTarget, MonitorHandle, RedoxSocket, TimeSocket, WindowId, WindowProperties,
 };
 
 // These values match the values uses in the `window_new` function in orbital:
@@ -37,7 +36,6 @@ impl Window {
     pub(crate) fn new<T: 'static>(
         el: &EventLoopWindowTarget<T>,
         attrs: window::WindowAttributes,
-        _: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Self, error::OsError> {
         let scale = MonitorHandle.scale_factor();
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -30,8 +30,7 @@ pub struct Inner {
 impl Window {
     pub(crate) fn new<T>(
         target: &EventLoopWindowTarget<T>,
-        attr: WindowAttributes,
-        platform_attr: PlatformSpecificWindowBuilderAttributes,
+        mut attr: WindowAttributes,
     ) -> Result<Self, RootOE> {
         let id = target.generate_id();
 
@@ -43,8 +42,7 @@ impl Window {
             id,
             window.clone(),
             document.clone(),
-            &attr,
-            platform_attr,
+            &mut attr,
         )?;
         let canvas = Rc::new(RefCell::new(canvas));
 
@@ -468,7 +466,7 @@ impl From<u64> for WindowId {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub(crate) canvas: Option<Arc<MainThreadSafe<backend::RawCanvasType>>>,
     pub(crate) prevent_default: bool,

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -24,7 +24,7 @@ use crate::event::DeviceId as RootDeviceId;
 use crate::icon::Icon;
 use crate::keyboard::Key;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PlatformSpecificWindowBuilderAttributes {
     pub owner: Option<HWND>,
     pub menu: Option<HMENU>,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -75,7 +75,7 @@ use crate::{
         monitor::{self, MonitorHandle},
         util,
         window_state::{CursorFlags, SavedWindow, WindowFlags, WindowState},
-        Fullscreen, PlatformSpecificWindowBuilderAttributes, SelectedCursor, WindowId,
+        Fullscreen, SelectedCursor, WindowId,
     },
     window::{
         CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
@@ -99,13 +99,12 @@ impl Window {
     pub(crate) fn new<T: 'static>(
         event_loop: &EventLoopWindowTarget<T>,
         w_attr: WindowAttributes,
-        pl_attr: PlatformSpecificWindowBuilderAttributes,
     ) -> Result<Window, RootOsError> {
         // We dispatch an `init` function because of code style.
         // First person to remove the need for cloning here gets a cookie!
         //
         // done. you owe me -- ossi
-        unsafe { init(w_attr, pl_attr, event_loop) }
+        unsafe { init(w_attr, event_loop) }
     }
 
     pub(crate) fn maybe_queue_on_main(&self, f: impl FnOnce(&Self) + Send + 'static) {
@@ -1078,7 +1077,6 @@ pub(super) struct InitData<'a, T: 'static> {
     // inputs
     pub event_loop: &'a EventLoopWindowTarget<T>,
     pub attributes: WindowAttributes,
-    pub pl_attribs: PlatformSpecificWindowBuilderAttributes,
     pub window_flags: WindowFlags,
     // outputs
     pub window: Option<Window>,
@@ -1128,7 +1126,7 @@ impl<'a, T: 'static> InitData<'a, T> {
     }
 
     unsafe fn create_window_data(&self, win: &Window) -> event_loop::WindowData<T> {
-        let file_drop_handler = if self.pl_attribs.drag_and_drop {
+        let file_drop_handler = if self.attributes.platform_specific.drag_and_drop {
             let ole_init_result = unsafe { OleInitialize(ptr::null_mut()) };
             // It is ok if the initialize result is `S_FALSE` because it might happen that
             // multiple windows are created on the same thread.
@@ -1195,7 +1193,7 @@ impl<'a, T: 'static> InitData<'a, T> {
         let win = self.window.as_mut().expect("failed window creation");
 
         // making the window transparent
-        if self.attributes.transparent && !self.pl_attribs.no_redirection_bitmap {
+        if self.attributes.transparent && !self.attributes.platform_specific.no_redirection_bitmap {
             // Empty region for the blur effect, so the window is fully transparent
             let region = unsafe { CreateRectRgn(0, 0, -1, -1) };
 
@@ -1215,9 +1213,9 @@ impl<'a, T: 'static> InitData<'a, T> {
             unsafe { DeleteObject(region) };
         }
 
-        win.set_skip_taskbar(self.pl_attribs.skip_taskbar);
+        win.set_skip_taskbar(self.attributes.platform_specific.skip_taskbar);
         win.set_window_icon(self.attributes.window_icon.clone());
-        win.set_taskbar_icon(self.pl_attribs.taskbar_icon.clone());
+        win.set_taskbar_icon(self.attributes.platform_specific.taskbar_icon.clone());
 
         let attributes = self.attributes.clone();
 
@@ -1271,7 +1269,6 @@ impl<'a, T: 'static> InitData<'a, T> {
 }
 unsafe fn init<T>(
     attributes: WindowAttributes,
-    pl_attribs: PlatformSpecificWindowBuilderAttributes,
     event_loop: &EventLoopWindowTarget<T>,
 ) -> Result<Window, RootOsError>
 where
@@ -1279,14 +1276,14 @@ where
 {
     let title = util::encode_wide(&attributes.title);
 
-    let class_name = util::encode_wide(&pl_attribs.class_name);
+    let class_name = util::encode_wide(&attributes.platform_specific.class_name);
     unsafe { register_window_class::<T>(&class_name) };
 
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
     window_flags.set(
         WindowFlags::MARKER_UNDECORATED_SHADOW,
-        pl_attribs.decoration_shadow,
+        attributes.platform_specific.decoration_shadow,
     );
     window_flags.set(
         WindowFlags::ALWAYS_ON_TOP,
@@ -1298,7 +1295,7 @@ where
     );
     window_flags.set(
         WindowFlags::NO_BACK_BUFFER,
-        pl_attribs.no_redirection_bitmap,
+        attributes.platform_specific.no_redirection_bitmap,
     );
     window_flags.set(WindowFlags::MARKER_ACTIVATE, attributes.active);
     window_flags.set(WindowFlags::TRANSPARENT, attributes.transparent);
@@ -1308,7 +1305,7 @@ where
     // so the diffing later can work.
     window_flags.set(WindowFlags::CLOSABLE, true);
 
-    let mut fallback_parent = || match pl_attribs.owner {
+    let mut fallback_parent = || match attributes.platform_specific.owner {
         Some(parent) => {
             window_flags.set(WindowFlags::POPUP, true);
             Some(parent)
@@ -1323,7 +1320,7 @@ where
     let parent = match attributes.parent_window.as_ref().map(|handle| handle.0) {
         Some(rwh_06::RawWindowHandle::Win32(handle)) => {
             window_flags.set(WindowFlags::CHILD, true);
-            if pl_attribs.menu.is_some() {
+            if attributes.platform_specific.menu.is_some() {
                 warn!("Setting a menu on a child window is unsupported");
             }
             Some(handle.hwnd.get() as HWND)
@@ -1335,10 +1332,10 @@ where
     #[cfg(not(feature = "rwh_06"))]
     let parent = fallback_parent();
 
+    let menu = attributes.platform_specific.menu;
     let mut initdata = InitData {
         event_loop,
         attributes,
-        pl_attribs: pl_attribs.clone(),
         window_flags,
         window: None,
     };
@@ -1355,7 +1352,7 @@ where
             CW_USEDEFAULT,
             CW_USEDEFAULT,
             parent.unwrap_or(0),
-            pl_attribs.menu.unwrap_or(0),
+            menu.unwrap_or(0),
             util::get_instance_handle(),
             &mut initdata as *mut _ as *mut _,
         )

--- a/src/window.rs
+++ b/src/window.rs
@@ -121,9 +121,6 @@ impl From<u64> for WindowId {
 pub struct WindowBuilder {
     /// The attributes to use to create the window.
     pub(crate) window: WindowAttributes,
-
-    // Platform-specific configuration.
-    pub(crate) platform_specific: platform_impl::PlatformSpecificWindowBuilderAttributes,
 }
 
 impl fmt::Debug for WindowBuilder {
@@ -159,6 +156,9 @@ pub struct WindowAttributes {
     #[cfg(feature = "rwh_06")]
     pub(crate) parent_window: Option<SendSyncRawWindowHandle>,
     pub fullscreen: Option<Fullscreen>,
+    // Platform-specific configuration.
+    #[allow(dead_code)]
+    pub(crate) platform_specific: platform_impl::PlatformSpecificWindowBuilderAttributes,
 }
 
 impl Default for WindowAttributes {
@@ -187,6 +187,7 @@ impl Default for WindowAttributes {
             #[cfg(feature = "rwh_06")]
             parent_window: None,
             active: true,
+            platform_specific: Default::default(),
         }
     }
 }
@@ -535,8 +536,7 @@ impl WindowBuilder {
         self,
         window_target: &EventLoopWindowTarget<T>,
     ) -> Result<Window, OsError> {
-        let window =
-            platform_impl::Window::new(&window_target.p, self.window, self.platform_specific)?;
+        let window = platform_impl::Window::new(&window_target.p, self.window)?;
         window.maybe_queue_on_main(|w| w.request_redraw());
         Ok(Window { window })
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -115,24 +115,12 @@ impl From<u64> for WindowId {
     }
 }
 
-/// Object that allows building windows.
-#[derive(Clone, Default)]
-#[must_use]
-pub struct WindowBuilder {
-    /// The attributes to use to create the window.
-    pub(crate) window: WindowAttributes,
-}
+#[deprecated = "use `WindowAttributes` directly"]
+pub type WindowBuilder = WindowAttributes;
 
-impl fmt::Debug for WindowBuilder {
-    fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmtr.debug_struct("WindowBuilder")
-            .field("window", &self.window)
-            .finish()
-    }
-}
-
-/// Attributes to use when creating a window.
+/// Attributes to use when creating a new window.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct WindowAttributes {
     pub inner_size: Option<Size>,
     pub min_inner_size: Option<Size>,
@@ -196,7 +184,7 @@ impl Default for WindowAttributes {
 ///
 /// # Safety
 ///
-/// The user has to account for that when using [`WindowBuilder::with_parent_window()`],
+/// The user has to account for that when using [`WindowAttributes::with_parent_window()`],
 /// which is `unsafe`.
 #[derive(Debug, Clone)]
 #[cfg(feature = "rwh_06")]
@@ -215,20 +203,15 @@ impl WindowAttributes {
     }
 }
 
-impl WindowBuilder {
-    /// Initializes a new builder with default values.
+impl WindowAttributes {
+    /// Initializes new attributes with default values.
     #[inline]
     pub fn new() -> Self {
         Default::default()
     }
 }
 
-impl WindowBuilder {
-    /// Get the current window attributes.
-    pub fn window_attributes(&self) -> &WindowAttributes {
-        &self.window
-    }
-
+impl WindowAttributes {
     /// Requests the window to be of specific dimensions.
     ///
     /// If this is not set, some platform-specific dimensions will be used.
@@ -236,7 +219,7 @@ impl WindowBuilder {
     /// See [`Window::request_inner_size`] for details.
     #[inline]
     pub fn with_inner_size<S: Into<Size>>(mut self, size: S) -> Self {
-        self.window.inner_size = Some(size.into());
+        self.inner_size = Some(size.into());
         self
     }
 
@@ -248,7 +231,7 @@ impl WindowBuilder {
     /// See [`Window::set_min_inner_size`] for details.
     #[inline]
     pub fn with_min_inner_size<S: Into<Size>>(mut self, min_size: S) -> Self {
-        self.window.min_inner_size = Some(min_size.into());
+        self.min_inner_size = Some(min_size.into());
         self
     }
 
@@ -260,7 +243,7 @@ impl WindowBuilder {
     /// See [`Window::set_max_inner_size`] for details.
     #[inline]
     pub fn with_max_inner_size<S: Into<Size>>(mut self, max_size: S) -> Self {
-        self.window.max_inner_size = Some(max_size.into());
+        self.max_inner_size = Some(max_size.into());
         self
     }
 
@@ -288,7 +271,7 @@ impl WindowBuilder {
     /// - **Others:** Ignored.
     #[inline]
     pub fn with_position<P: Into<Position>>(mut self, position: P) -> Self {
-        self.window.position = Some(position.into());
+        self.position = Some(position.into());
         self
     }
 
@@ -299,7 +282,7 @@ impl WindowBuilder {
     /// See [`Window::set_resizable`] for details.
     #[inline]
     pub fn with_resizable(mut self, resizable: bool) -> Self {
-        self.window.resizable = resizable;
+        self.resizable = resizable;
         self
     }
 
@@ -310,7 +293,7 @@ impl WindowBuilder {
     /// See [`Window::set_enabled_buttons`] for details.
     #[inline]
     pub fn with_enabled_buttons(mut self, buttons: WindowButtons) -> Self {
-        self.window.enabled_buttons = buttons;
+        self.enabled_buttons = buttons;
         self
     }
 
@@ -321,7 +304,7 @@ impl WindowBuilder {
     /// See [`Window::set_title`] for details.
     #[inline]
     pub fn with_title<T: Into<String>>(mut self, title: T) -> Self {
-        self.window.title = title.into();
+        self.title = title.into();
         self
     }
 
@@ -332,7 +315,7 @@ impl WindowBuilder {
     /// See [`Window::set_fullscreen`] for details.
     #[inline]
     pub fn with_fullscreen(mut self, fullscreen: Option<Fullscreen>) -> Self {
-        self.window.fullscreen = fullscreen;
+        self.fullscreen = fullscreen;
         self
     }
 
@@ -343,7 +326,7 @@ impl WindowBuilder {
     /// See [`Window::set_maximized`] for details.
     #[inline]
     pub fn with_maximized(mut self, maximized: bool) -> Self {
-        self.window.maximized = maximized;
+        self.maximized = maximized;
         self
     }
 
@@ -354,7 +337,7 @@ impl WindowBuilder {
     /// See [`Window::set_visible`] for details.
     #[inline]
     pub fn with_visible(mut self, visible: bool) -> Self {
-        self.window.visible = visible;
+        self.visible = visible;
         self
     }
 
@@ -368,7 +351,7 @@ impl WindowBuilder {
     /// The default is `false`.
     #[inline]
     pub fn with_transparent(mut self, transparent: bool) -> Self {
-        self.window.transparent = transparent;
+        self.transparent = transparent;
         self
     }
 
@@ -379,14 +362,14 @@ impl WindowBuilder {
     /// See [`Window::set_blur`] for details.
     #[inline]
     pub fn with_blur(mut self, blur: bool) -> Self {
-        self.window.blur = blur;
+        self.blur = blur;
         self
     }
 
     /// Get whether the window will support transparency.
     #[inline]
     pub fn transparent(&self) -> bool {
-        self.window.transparent
+        self.transparent
     }
 
     /// Sets whether the window should have a border, a title bar, etc.
@@ -396,7 +379,7 @@ impl WindowBuilder {
     /// See [`Window::set_decorations`] for details.
     #[inline]
     pub fn with_decorations(mut self, decorations: bool) -> Self {
-        self.window.decorations = decorations;
+        self.decorations = decorations;
         self
     }
 
@@ -409,7 +392,7 @@ impl WindowBuilder {
     /// See [`WindowLevel`] for details.
     #[inline]
     pub fn with_window_level(mut self, level: WindowLevel) -> Self {
-        self.window.window_level = level;
+        self.window_level = level;
         self
     }
 
@@ -420,7 +403,7 @@ impl WindowBuilder {
     /// See [`Window::set_window_icon`] for details.
     #[inline]
     pub fn with_window_icon(mut self, window_icon: Option<Icon>) -> Self {
-        self.window.window_icon = window_icon;
+        self.window_icon = window_icon;
         self
     }
 
@@ -439,7 +422,7 @@ impl WindowBuilder {
     /// - **iOS / Android / Web / x11 / Orbital:** Ignored.
     #[inline]
     pub fn with_theme(mut self, theme: Option<Theme>) -> Self {
-        self.window.preferred_theme = theme;
+        self.preferred_theme = theme;
         self
     }
 
@@ -450,7 +433,7 @@ impl WindowBuilder {
     /// See [`Window::set_resize_increments`] for details.
     #[inline]
     pub fn with_resize_increments<S: Into<Size>>(mut self, resize_increments: S) -> Self {
-        self.window.resize_increments = Some(resize_increments.into());
+        self.resize_increments = Some(resize_increments.into());
         self
     }
 
@@ -467,7 +450,7 @@ impl WindowBuilder {
     /// [`NSWindowSharingNone`]: https://developer.apple.com/documentation/appkit/nswindowsharingtype/nswindowsharingnone
     #[inline]
     pub fn with_content_protected(mut self, protected: bool) -> Self {
-        self.window.content_protected = protected;
+        self.content_protected = protected;
         self
     }
 
@@ -483,7 +466,7 @@ impl WindowBuilder {
     /// [`WindowEvent::Focused`]: crate::event::WindowEvent::Focused.
     #[inline]
     pub fn with_active(mut self, active: bool) -> Self {
-        self.window.active = active;
+        self.active = active;
         self
     }
 
@@ -494,7 +477,7 @@ impl WindowBuilder {
     /// See [`Window::set_cursor()`] for more details.
     #[inline]
     pub fn with_cursor(mut self, cursor: impl Into<Cursor>) -> Self {
-        self.window.cursor = cursor.into();
+        self.cursor = cursor.into();
         self
     }
 
@@ -519,7 +502,7 @@ impl WindowBuilder {
         mut self,
         parent_window: Option<rwh_06::RawWindowHandle>,
     ) -> Self {
-        self.window.parent_window = parent_window.map(SendSyncRawWindowHandle);
+        self.parent_window = parent_window.map(SendSyncRawWindowHandle);
         self
     }
 
@@ -536,7 +519,7 @@ impl WindowBuilder {
         self,
         window_target: &EventLoopWindowTarget<T>,
     ) -> Result<Window, OsError> {
-        let window = platform_impl::Window::new(&window_target.p, self.window)?;
+        let window = platform_impl::Window::new(&window_target.p, self)?;
         window.maybe_queue_on_main(|w| w.request_redraw());
         Ok(Window { window })
     }
@@ -546,7 +529,7 @@ impl WindowBuilder {
 impl Window {
     /// Creates a new Window for platforms where this is appropriate.
     ///
-    /// This function is equivalent to [`WindowBuilder::new().build(event_loop)`].
+    /// This function is equivalent to [`WindowAttributes::new().build(event_loop)`].
     ///
     /// Error should be very rare and only occur in case of permission denied, incompatible system,
     ///  out of memory, etc.
@@ -556,10 +539,10 @@ impl Window {
     /// - **Web:** The window is created but not inserted into the web page automatically. Please
     ///   see the web platform module for more information.
     ///
-    /// [`WindowBuilder::new().build(event_loop)`]: WindowBuilder::build
+    /// [`WindowAttributes::new().build(event_loop)`]: WindowAttributes::build
     #[inline]
     pub fn new<T: 'static>(event_loop: &EventLoopWindowTarget<T>) -> Result<Window, OsError> {
-        let builder = WindowBuilder::new();
+        let builder = WindowAttributes::new();
         builder.build(event_loop)
     }
 
@@ -929,12 +912,12 @@ impl Window {
     /// the content of your window and this hint may result in
     /// visual artifacts.
     ///
-    /// The default value follows the [`WindowBuilder::with_transparent`].
+    /// The default value follows the [`WindowAttributes::with_transparent`].
     ///
     /// ## Platform-specific
     ///
     /// - **Web / iOS / Android / Orbital:** Unsupported.
-    /// - **X11:** Can only be set while building the window, with [`WindowBuilder::with_transparent`].
+    /// - **X11:** Can only be set while creating the window, with [`WindowAttributes::with_transparent`].
     #[inline]
     pub fn set_transparent(&self, transparent: bool) {
         self.window

--- a/tests/send_objects.rs
+++ b/tests/send_objects.rs
@@ -17,8 +17,8 @@ fn window_send() {
 }
 
 #[test]
-fn window_builder_send() {
-    needs_send::<winit::window::WindowBuilder>();
+fn window_attributes_send() {
+    needs_send::<winit::window::WindowAttributes>();
 }
 
 #[test]


### PR DESCRIPTION
Blocked on https://github.com/rust-windowing/winit/pull/3318.

Rough draft, the plan is to move towards:
```rust
let attrs = WindowAttributes::new().with_title("MyTitle");
let window = event_loop.create_window(attrs).unwrap();
```

I think in this case it makes sense to remove the builder, because it really _is_ just attributes; but in a case like `EventLoopBuilder`, I think it still makes sense to keep that as a builder.

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
