### PR TITLE
Make DeviceId simpler on iOS

### DIFF
--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -68,6 +68,8 @@ mod window;
 
 use std::fmt;
 
+use crate::event::DeviceId as RootDeviceId;
+
 pub(crate) use self::{
     event_loop::{
         EventLoop, EventLoopProxy, EventLoopWindowTarget, OwnedDisplayHandle,
@@ -76,28 +78,25 @@ pub(crate) use self::{
     monitor::{MonitorHandle, VideoModeHandle},
     window::{PlatformSpecificWindowBuilderAttributes, Window, WindowId},
 };
-
-use self::uikit::UIScreen;
 pub(crate) use crate::cursor::NoCustomCursor as PlatformCustomCursor;
 pub(crate) use crate::cursor::NoCustomCursor as PlatformCustomCursorBuilder;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
+/// There is no way to detect which device that performed a certain event in
+/// UIKit (i.e. you can't differentiate between different external keyboards,
+/// or wether it was the main touchscreen, assistive technologies, or some
+/// other pointer device that caused a touch event).
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId {
-    uiscreen: *const UIScreen,
-}
+pub struct DeviceId;
 
 impl DeviceId {
     pub const unsafe fn dummy() -> Self {
-        DeviceId {
-            uiscreen: std::ptr::null(),
-        }
+        DeviceId
     }
 }
 
-unsafe impl Send for DeviceId {}
-unsafe impl Sync for DeviceId {}
+pub(crate) const DEVICE_ID: RootDeviceId = RootDeviceId(DeviceId);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeyEventExtra {}

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -17,12 +17,12 @@ use super::uikit::{
 use super::window::WindowId;
 use crate::{
     dpi::PhysicalPosition,
-    event::{DeviceId as RootDeviceId, Event, Force, Touch, TouchPhase, WindowEvent},
+    event::{Event, Force, Touch, TouchPhase, WindowEvent},
     platform::ios::ValidOrientations,
     platform_impl::platform::{
         ffi::{UIRectEdge, UIUserInterfaceIdiom},
         window::PlatformSpecificWindowBuilderAttributes,
-        DeviceId, Fullscreen,
+        Fullscreen, DEVICE_ID,
     },
     window::{WindowAttributes, WindowId as RootWindowId},
 };
@@ -199,7 +199,6 @@ impl WinitView {
 
     fn handle_touches(&self, touches: &NSSet<UITouch>) {
         let window = self.window().unwrap();
-        let uiscreen = window.screen();
         let mut touch_events = Vec::new();
         let os_supports_force = app_state::os_capabilities().force_touch;
         for touch in touches {
@@ -252,9 +251,7 @@ impl WinitView {
             touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
                 window_id: RootWindowId(window.id()),
                 event: WindowEvent::Touch(Touch {
-                    device_id: RootDeviceId(DeviceId {
-                        uiscreen: Id::as_ptr(&uiscreen),
-                    }),
+                    device_id: DEVICE_ID,
                     id: touch_id,
                     location: physical_location,
                     force,


### PR DESCRIPTION
This previously contained a UIScreen for some weird reason; perhaps because `DeviceId` was confused for `UIDevice`? In any case, it doesn't need to contain that.