### PR TITLE
On Windows, Remove `WS_CAPTION`, `WS_BORDER` and `WS_EX_WINDOWEDGE` styles for child windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Unreleased` header.
 - Add the `OwnedDisplayHandle` type for allowing safe display handle usage outside of trivial cases.
 - **Breaking:** Rename `TouchpadMagnify` to `PinchGesture`, `SmartMagnify` to `DoubleTapGesture` and `TouchpadRotate` to `RotationGesture` to represent the action rather than the intent.
 - on iOS, add detection support for `PinchGesture`, `DoubleTapGesture` and `RotationGesture`.
+- On Windows, Remove `WS_CAPTION`, `WS_BORDER` and `WS_EX_WINDOWEDGE` styles for child windows
 
 # 0.29.10
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -253,9 +253,15 @@ impl WindowFlags {
 
     pub fn to_window_styles(self) -> (WINDOW_STYLE, WINDOW_EX_STYLE) {
         // Required styles to properly support common window functionality like aero snap.
-        let mut style = WS_CAPTION | WS_BORDER | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
-        let mut style_ex = WS_EX_WINDOWEDGE | WS_EX_ACCEPTFILES;
+        let mut style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
+        let mut style_ex = WS_EX_ACCEPTFILES;
 
+        if self.contains(WindowFlags::CHILD) {
+            style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
+        } else {
+            style |= WS_CAPTION | WS_BORDER;
+            style_ex |= WS_EX_WINDOWEDGE;
+        }
         if self.contains(WindowFlags::RESIZABLE) {
             style |= WS_SIZEBOX;
         }
@@ -276,9 +282,6 @@ impl WindowFlags {
         }
         if self.contains(WindowFlags::NO_BACK_BUFFER) {
             style_ex |= WS_EX_NOREDIRECTIONBITMAP;
-        }
-        if self.contains(WindowFlags::CHILD) {
-            style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
         }
         if self.contains(WindowFlags::POPUP) {
             style |= WS_POPUP;

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -253,15 +253,9 @@ impl WindowFlags {
 
     pub fn to_window_styles(self) -> (WINDOW_STYLE, WINDOW_EX_STYLE) {
         // Required styles to properly support common window functionality like aero snap.
-        let mut style = WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
-        let mut style_ex = WS_EX_ACCEPTFILES;
+        let mut style = WS_CAPTION | WS_BORDER | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_SYSMENU;
+        let mut style_ex = WS_EX_WINDOWEDGE | WS_EX_ACCEPTFILES;
 
-        if self.contains(WindowFlags::CHILD) {
-            style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
-        } else {
-            style |= WS_CAPTION | WS_BORDER;
-            style_ex |= WS_EX_WINDOWEDGE;
-        }
         if self.contains(WindowFlags::RESIZABLE) {
             style |= WS_SIZEBOX;
         }
@@ -282,6 +276,15 @@ impl WindowFlags {
         }
         if self.contains(WindowFlags::NO_BACK_BUFFER) {
             style_ex |= WS_EX_NOREDIRECTIONBITMAP;
+        }
+        if self.contains(WindowFlags::CHILD) {
+            style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
+
+            // Remove decorations window styles for child
+            if !self.contains(WindowFlags::MARKER_DECORATIONS) {
+                style &= !(WS_CAPTION | WS_BORDER);
+                style_ex &= !WS_EX_WINDOWEDGE;
+            }
         }
         if self.contains(WindowFlags::POPUP) {
             style |= WS_POPUP;


### PR DESCRIPTION
closes #2754

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
