### PR TITLE
Improve error when the discovered Linux platform is not enabled

### DIFF
--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -765,10 +765,15 @@ impl<T: 'static> EventLoop<T> {
             #[cfg(x11_platform)]
             (None, _, true) => Backend::X,
             // No backend is present.
-            _ => {
-                return Err(EventLoopError::Os(os_error!(OsError::Misc(
+            (_, wayland_display, x11_display) => {
+                let msg = if wayland_display && !cfg!(wayland_platform) {
+                    "DISPLAY is not set; note: enable the `winit/wayland` feature to support Wayland"
+                } else if x11_display && !cfg!(x11_platform) {
+                    "WAYLAND_DISPLAY is not set; note: enable the `winit/x11` feature to support X11"
+                } else {
                     "neither WAYLAND_DISPLAY nor DISPLAY is set."
-                ))));
+                };
+                return Err(EventLoopError::Os(os_error!(OsError::Misc(msg))));
             }
         };
 


### PR DESCRIPTION
Previously, misleading error messages were shown when the current platform (Wayland/X11) is not enabled.

Case: X11 (`DISPLAY=:0`) but only the `wayland` feature is enabled:
```
Error: EventLoop(Os(OsError { line: 776, file: "/home/dhardy/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.10/src/platform_impl/linux/mod.rs", error: Misc("neither WAYLAND_DISPLAY nor DISPLAY is set.") }))
```

This PR improves the error. For the above case the message is now: "WAYLAND_DISPLAY is not set; note: enable the `winit/x11` feature to support X11".

- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
