### PR TITLE
Send the event before waking up the message pump.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Unreleased` header.
 - on iOS, add detection support for `PinchGesture`, `DoubleTapGesture` and `RotationGesture`.
 - on Windows: add `with_border_color`, `with_title_background_color`, `with_title_text_color` and `with_corner_preference`
 - On Windows, Remove `WS_CAPTION`, `WS_BORDER` and `WS_EX_WINDOWEDGE` styles for child windows without decorations.
+- On Windows, fixed a race condition when sending an event through the loop proxy.
 
 # 0.29.10
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -769,14 +769,13 @@ impl<T: 'static> Clone for EventLoopProxy<T> {
 
 impl<T: 'static> EventLoopProxy<T> {
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
-        unsafe {
-            if PostMessageW(self.target_window, USER_EVENT_MSG_ID.get(), 0, 0) != false.into() {
-                self.event_send.send(event).ok();
-                Ok(())
-            } else {
-                Err(EventLoopClosed(event))
-            }
-        }
+        self.event_send
+            .send(event)
+            .map(|result| {
+                unsafe { PostMessageW(self.target_window, USER_EVENT_MSG_ID.get(), 0, 0) };
+                result
+            })
+            .map_err(|e| EventLoopClosed(e.0))
     }
 }
 


### PR DESCRIPTION
Fixes #3417.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
