### PR TITLE
Add `EventLoopProxy::waker(self) -> Waker`

### DIFF
--- a/winit-core/src/event_loop/mod.rs
+++ b/winit-core/src/event_loop/mod.rs
@@ -4,6 +4,7 @@ pub mod run_on_demand;
 use std::fmt::{self, Debug};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::task::Waker;
 use std::time::Duration;
 
 use rwh_06::{DisplayHandle, HandleError, HasDisplayHandle};
@@ -150,6 +151,13 @@ impl EventLoopProxy {
         self.proxy.wake_up();
     }
 
+    /// Get a [`Waker`] that calls [`wake_up`] on the proxy when awoken.
+    ///
+    /// This may be useful to `async` code or otherwise interoperating with `std`.
+    pub fn waker(&self) -> Waker {
+        self.proxy.waker()
+    }
+
     pub fn new(proxy: Arc<dyn EventLoopProxyProvider>) -> Self {
         Self { proxy }
     }
@@ -158,6 +166,9 @@ impl EventLoopProxy {
 pub trait EventLoopProxyProvider: Send + Sync + Debug {
     /// See [`EventLoopProxy::wake_up`] for details.
     fn wake_up(&self);
+
+    /// See [`EventLoopProxy::waker`] for details.
+    fn waker(&self) -> Waker;
 }
 
 /// A proxy for the underlying display handle.


### PR DESCRIPTION
As part of https://github.com/rust-windowing/winit/issues/3367, we're considering removing the generic on `Event<T>`, `EventLoop<T>`, `EventLoopProxy<T>` and the callback. By extension, we'd be getting rid of `Event::UserEvent(T)`.

One approach to doing so would be to allow converting `EventLoopProxy` to the standard library's [`Waker`](https://doc.rust-lang.org/std/task/struct.Waker.html) type, which allows the user to wake a task (in this case the event loop) from any thread; then they can implement what they need themselves on top of that, using the standard library's [`mpsc::channel`](https://doc.rust-lang.org/std/sync/mpsc/fn.channel.html), [`mpsc::sync_channel`](https://doc.rust-lang.org/std/sync/mpsc/fn.sync_channel.html) or likewise, depending on their needs.

This is likely not a perfect solution for wakeups, we still need to properly figure out how to do timers; but this can get us some of the way there.

Blocked on https://github.com/rust-windowing/winit/pull/3449, we need to ensure that `Sync` is actually sound.

CC @notgull, I think this may be slightly useful for `async`?

Questions:
- [ ] Do we need a `UserWoken` event, or is `NewEvents` is enough?
- [x] Should we hide the `Waker` behind a custom type like `EventLoopWaker`, in case we want to expose further functionality in the future?
  - We keep `EventLoopProxy`, and allow that to be converted to `Waker`.
- [ ] Is `Waker` too heavy-weight for this? Can we just use a function `wake(&self)` on `EventLoopProxy`? Or maybe both?
- [ ] Does the user need the ability to handle the case where the event loop has been destroyed? Or is that handled fine enough through other means, like in `mpsc`?

TODO:
- [ ] Finish implementation on all platforms.
- [ ] Properly test `Waker` implementations with updated example.
- [ ] Add an entry to `CHANGELOG.md`.
- [ ] Update documentation.
