### PR TITLE
Remove `EventLoopError::AlreadyRunning`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Unreleased` header.
 - on Windows: add `with_border_color`, `with_title_background_color`, `with_title_text_color` and `with_corner_preference`
 - On Windows, Remove `WS_CAPTION`, `WS_BORDER` and `WS_EX_WINDOWEDGE` styles for child windows without decorations.
 - On Windows, fixed a race condition when sending an event through the loop proxy.
+- **Breaking:** Removed `EventLoopError::AlreadyRunning`, which can't happen as it is already prevented by the type system.
 
 # 0.29.10
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,8 +35,6 @@ pub enum EventLoopError {
     NotSupported(NotSupportedError),
     /// The OS cannot perform the operation.
     Os(OsError),
-    /// The event loop can't be re-run while it's already running
-    AlreadyRunning,
     /// The event loop can't be re-created.
     RecreationAttempt,
     /// Application has exit with an error status.
@@ -105,7 +103,6 @@ impl fmt::Display for NotSupportedError {
 impl fmt::Display for EventLoopError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            EventLoopError::AlreadyRunning => write!(f, "EventLoop is already running"),
             EventLoopError::RecreationAttempt => write!(f, "EventLoop can't be recreated"),
             EventLoopError::NotSupported(e) => e.fmt(f),
             EventLoopError::Os(e) => e.fmt(f),

--- a/src/platform/run_on_demand.rs
+++ b/src/platform/run_on_demand.rs
@@ -55,7 +55,7 @@ pub trait EventLoopExtRunOnDemand {
     ///   loop that would block the browser and there is nothing that can be
     ///   polled to ask for new events. Events are delivered via callbacks based
     ///   on an event loop that is internal to the browser itself.
-    /// - **iOS:** It's not possible to stop and start an `NSApplication` repeatedly on iOS.
+    /// - **iOS:** It's not possible to stop and start an `UIApplication` repeatedly on iOS.
     ///
     #[cfg_attr(
         not(web_platform),
@@ -87,3 +87,16 @@ impl EventLoopWindowTarget {
         self.p.clear_exit()
     }
 }
+
+/// ```compile_fail
+/// use winit::event_loop::EventLoop;
+/// use winit::platform::run_on_demand::EventLoopExtRunOnDemand;
+///
+/// let mut event_loop = EventLoop::new().unwrap();
+/// event_loop.run_on_demand(|_, _| {
+///     // Attempt to run the event loop re-entrantly; this must fail.
+///     event_loop.run_on_demand(|_, _| {});
+/// });
+/// ```
+#[allow(dead_code)]
+fn test_run_on_demand_cannot_access_event_loop() {}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -491,10 +491,6 @@ impl<T: 'static> EventLoop<T> {
     where
         F: FnMut(event::Event<T>, &event_loop::EventLoopWindowTarget),
     {
-        if self.loop_running {
-            return Err(EventLoopError::AlreadyRunning);
-        }
-
         loop {
             match self.pump_events(None, &mut event_handler) {
                 PumpStatus::Exit(0) => {

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -192,10 +192,6 @@ impl<T: 'static> EventLoop<T> {
     where
         F: FnMut(Event<T>, &RootEventLoopWindowTarget),
     {
-        if self.loop_running {
-            return Err(EventLoopError::AlreadyRunning);
-        }
-
         let exit = loop {
             match self.pump_events(None, &mut event_handler) {
                 PumpStatus::Exit(0) => {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -402,10 +402,6 @@ impl<T: 'static> EventLoop<T> {
     where
         F: FnMut(Event<T>, &RootELW),
     {
-        if self.loop_running {
-            return Err(EventLoopError::AlreadyRunning);
-        }
-
         let exit = loop {
             match self.pump_events(None, &mut event_handler) {
                 PumpStatus::Exit(0) => {

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -279,10 +279,6 @@ impl<T> EventLoop<T> {
     where
         F: FnMut(Event<T>, &RootWindowTarget),
     {
-        if self.delegate.is_running() {
-            return Err(EventLoopError::AlreadyRunning);
-        }
-
         let callback = map_user_event(callback, self.receiver.clone());
 
         // # Safety

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -94,8 +94,6 @@ use crate::{
 };
 use runner::{EventLoopRunner, EventLoopRunnerShared};
 
-use self::runner::RunnerState;
-
 use super::{window::set_skip_taskbar, SelectedCursor};
 
 /// some backends like macos uses an uninhabited `Never` type,
@@ -246,9 +244,6 @@ impl<T: 'static> EventLoop<T> {
     {
         {
             let runner = &self.window_target.p.runner_shared;
-            if runner.state() != RunnerState::Uninitialized {
-                return Err(EventLoopError::AlreadyRunning);
-            }
 
             let event_loop_windows_ref = &self.window_target;
             let user_event_receiver = &self.user_event_receiver;

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -143,10 +143,6 @@ impl<T> EventLoopRunner<T> {
         }
     }
 
-    pub fn state(&self) -> RunnerState {
-        self.runner_state.get()
-    }
-
     pub fn set_control_flow(&self, control_flow: ControlFlow) {
         self.control_flow.set(control_flow)
     }


### PR DESCRIPTION
This is already prevented by the type-system, and as such it doesn't make sense to have an error case for this.

This was added by @rib in https://github.com/rust-windowing/winit/pull/2767, maybe you can shed some light on if this was an oversight added out of an abundance of caution, or if you think my reasoning is wrong here, and the error actually can happen?

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
