### PR TITLE
Remove drm/kms features from softbuffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ simple_logger = { version = "4.2.0", default_features = false }
 winit = { path = ".", features = ["rwh_05"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dev-dependencies]
-softbuffer = { version = "0.3.0", default-features = false, features = ["x11", "wayland"] }
+softbuffer = { version = "0.3.0", default-features = false, features = ["x11", "x11-dlopen", "wayland", "wayland-dlopen"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ simple_logger = { version = "4.2.0", default_features = false }
 winit = { path = ".", features = ["rwh_05"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dev-dependencies]
-softbuffer = "0.3.0"
+softbuffer = { version = "0.3.0", default-features = false, features = ["x11", "wayland"] }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = "0.5.0"


### PR DESCRIPTION
We use softbuffer as a dev-dependency for rendering into our windows in examples. However, we do not support a DRM/KMS backend yet, while softbuffer comes with a DRM/KMS backend by default. This commit removes the DRM/KMS feature from softbuffer to save some build time during testing

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
