### PR TITLE
On Wayland, disable Occluded handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Unreleased` header.
 - On Windows, Remove `WS_CAPTION`, `WS_BORDER` and `WS_EX_WINDOWEDGE` styles for child windows without decorations.
 - On Windows, fixed a race condition when sending an event through the loop proxy.
 - **Breaking:** Removed `EventLoopError::AlreadyRunning`, which can't happen as it is already prevented by the type system.
+- On Wayland, disable `Occluded` event handling.
 
 # 0.29.10
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -580,7 +580,7 @@ pub enum WindowEvent {
     /// ### Others
     ///
     /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
-    /// - **Android / Windows / Orbital:** Unsupported.
+    /// - **Android / Wayland / Windows / Orbital:** Unsupported.
     ///
     /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
     /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -296,12 +296,19 @@ impl WindowHandler for WinitState {
             .expect("got configure for dead window.")
             .lock()
             .unwrap()
-            .configure(
-                configure,
-                &self.shm,
-                &self.subcompositor_state,
-                &mut self.events_sink,
-            );
+            .configure(configure, &self.shm, &self.subcompositor_state);
+
+        // NOTE: configure demands wl_surface::commit, however winit doesn't commit on behalf of the
+        // users, since it can break a lot of things, thus it'll ask users to redraw instead.
+        self.window_requests
+            .get_mut()
+            .get(&window_id)
+            .unwrap()
+            .redraw_requested
+            .store(true, Ordering::Relaxed);
+
+        // Manually mark that we've got an event, since configure may not generate a resize.
+        self.dispatched_events = true;
     }
 }
 

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -31,11 +31,9 @@ use wayland_protocols_plasma::blur::client::org_kde_kwin_blur::OrgKdeKwinBlur;
 use crate::cursor::CustomCursor as RootCustomCursor;
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalSize, Size};
 use crate::error::{ExternalError, NotSupportedError};
-use crate::event::WindowEvent;
-use crate::platform_impl::wayland::event_loop::sink::EventSink;
+use crate::platform_impl::wayland::logical_to_physical_rounded;
 use crate::platform_impl::wayland::types::cursor::{CustomCursor, SelectedCursor};
 use crate::platform_impl::wayland::types::kwin_blur::KWinBlurManager;
-use crate::platform_impl::wayland::{logical_to_physical_rounded, make_wid};
 use crate::platform_impl::{PlatformCustomCursor, WindowId};
 use crate::window::{CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme};
 
@@ -261,7 +259,6 @@ impl WindowState {
         configure: WindowConfigure,
         shm: &Shm,
         subcompositor: &Option<Arc<SubcompositorState>>,
-        event_sink: &mut EventSink,
     ) -> bool {
         // NOTE: when using fractional scaling or wl_compositor@v6 the scaling
         // should be delivered before the first configure, thus apply it to
@@ -304,19 +301,6 @@ impl WindowState {
         }
 
         let stateless = Self::is_stateless(&configure);
-
-        // Emit `Occluded` event on suspension change.
-        let occluded = configure.state.contains(XdgWindowState::SUSPENDED);
-        if self
-            .last_configure
-            .as_ref()
-            .map(|c| c.state.contains(XdgWindowState::SUSPENDED))
-            .unwrap_or(false)
-            != occluded
-        {
-            let window_id = make_wid(self.window.wl_surface());
-            event_sink.push_window_event(WindowEvent::Occluded(occluded), window_id);
-        }
 
         let (mut new_size, constrain) = if let Some(frame) = self.frame.as_mut() {
             // Configure the window states.


### PR DESCRIPTION
Change in state requires a redraw, however drawing when getting `Occluded` with vsync will block indefinitely, thus the event in it's current state is rather useless.

To solve this issue winit needs a way to determine whether the user paused/continued their render loop, so it can commit on their behalf.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
