### PR TITLE
On Wayland, send `Focused(false)` once seats left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Unreleased` header.
 - Add `Window::builder`, which is intended to replace the (now deprecated) `WindowBuilder::new`.
 - On X11, reload dpi on `_XSETTINGS_SETTINGS` update.
 - On X11, fix deadlock when adjusting DPI and resizing at the same time.
+- On Wayland, fix `Focused(false)` being send when other seats still have window focused.
 
 # 0.29.10
 

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -4,8 +4,10 @@ use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
+use ahash::HashSet;
 use log::{info, warn};
 
+use sctk::reexports::client::backend::ObjectId;
 use sctk::reexports::client::protocol::wl_seat::WlSeat;
 use sctk::reexports::client::protocol::wl_shm::WlShm;
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
@@ -90,8 +92,10 @@ pub struct WindowState {
     /// Whether the frame is resizable.
     resizable: bool,
 
-    /// Whether the window has focus.
-    has_focus: bool,
+    // NOTE: we can't use simple counter, since it's racy when seat getting destroyed and new
+    // is created, since add/removed stuff could be delivered a bit out of order.
+    /// Seats that has keyboard focus on that window.
+    seat_focus: HashSet<ObjectId>,
 
     /// The scale factor of the window.
     scale_factor: f64,
@@ -187,7 +191,7 @@ impl WindowState {
             fractional_scale,
             frame: None,
             frame_callback_state: FrameCallbackState::None,
-            has_focus: false,
+            seat_focus: Default::default(),
             has_pending_move: None,
             ime_allowed: false,
             ime_purpose: ImePurpose::Normal,
@@ -521,10 +525,10 @@ impl WindowState {
         }
     }
 
-    /// Whether the window is focused.
+    /// Whether the window is focused by any seat.
     #[inline]
     pub fn has_focus(&self) -> bool {
-        self.has_focus
+        !self.seat_focus.is_empty()
     }
 
     /// Whether the IME is allowed.
@@ -951,12 +955,16 @@ impl WindowState {
         }
     }
 
-    /// Mark that the window has focus.
-    ///
-    /// Should be used from routine that sends focused event.
+    /// Add seat focus for the window.
     #[inline]
-    pub fn set_has_focus(&mut self, has_focus: bool) {
-        self.has_focus = has_focus;
+    pub fn add_seat_focus(&mut self, seat: ObjectId) {
+        self.seat_focus.insert(seat);
+    }
+
+    /// Remove seat focus from the window.
+    #[inline]
+    pub fn remove_seat_focus(&mut self, seat: &ObjectId) {
+        self.seat_focus.remove(seat);
     }
 
     /// Returns `true` if the requested state was applied.


### PR DESCRIPTION
Given that we merge all the seats, we should consider that window is not focused once all seats wl_keyboards are no longer present.

We use seats instead of keyboards to track focus to protect against wl_keyboard::leave not being delivered when removing the seat (usually it's not the case though).

Fixes: #3376

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
