### PR TITLE
On Wayland, fix min/max inner size setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Unreleased` header.
 - On X11, reload dpi on `_XSETTINGS_SETTINGS` update.
 - On X11, fix deadlock when adjusting DPI and resizing at the same time.
 - On Wayland, fix `Focused(false)` being send when other seats still have window focused.
+- On Wayland, fix `Window::set_{min,max}_inner_size` not always applied.
 
 # 0.29.10
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -332,7 +332,9 @@ impl Window {
         self.window_state
             .lock()
             .unwrap()
-            .set_min_inner_size(min_size)
+            .set_min_inner_size(min_size);
+        // NOTE: Requires commit to be applied.
+        self.request_redraw();
     }
 
     /// Set the maximum inner size for the window.
@@ -343,7 +345,9 @@ impl Window {
         self.window_state
             .lock()
             .unwrap()
-            .set_max_inner_size(max_size)
+            .set_max_inner_size(max_size);
+        // NOTE: Requires commit to be applied.
+        self.request_redraw();
     }
 
     #[inline]
@@ -392,7 +396,10 @@ impl Window {
 
     #[inline]
     pub fn set_resizable(&self, resizable: bool) {
-        self.window_state.lock().unwrap().set_resizable(resizable);
+        if self.window_state.lock().unwrap().set_resizable(resizable) {
+            // NOTE: Requires commit to be applied.
+            self.request_redraw();
+        }
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -504,10 +504,12 @@ impl WindowState {
     }
 
     /// Set the resizable state on the window.
+    ///
+    /// Returns `true` when the state was applied.
     #[inline]
-    pub fn set_resizable(&mut self, resizable: bool) {
+    pub fn set_resizable(&mut self, resizable: bool) -> bool {
         if self.resizable == resizable {
-            return;
+            return false;
         }
 
         self.resizable = resizable;
@@ -523,6 +525,8 @@ impl WindowState {
         if let Some(frame) = self.frame.as_mut() {
             frame.set_resizable(resizable);
         }
+
+        true
     }
 
     /// Whether the window is focused by any seat.


### PR DESCRIPTION
The size is only applied on the next `wl_surface::commit` thus we must trigger the redraw.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

