### PR TITLE
Fix typo: Rename `ImeState::Commited` to `ImeState::Committed`

### DIFF
--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -65,8 +65,8 @@ enum ImeState {
     /// The IME is in preedit.
     Preedit,
 
-    /// The text was just commited, so the next input from the keyboard must be ignored.
-    Commited,
+    /// The text was just committed, so the next input from the keyboard must be ignored.
+    Committed,
 }
 
 bitflags::bitflags! {
@@ -397,7 +397,7 @@ declare_class!(
             if unsafe { self.hasMarkedText() } && self.is_ime_enabled() && !is_control {
                 self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
-                self.ivars().ime_state.set(ImeState::Commited);
+                self.ivars().ime_state.set(ImeState::Committed);
             }
         }
 
@@ -406,10 +406,10 @@ declare_class!(
         #[method(doCommandBySelector:)]
         fn do_command_by_selector(&self, _command: Sel) {
             trace_scope!("doCommandBySelector:");
-            // We shouldn't forward any character from just commited text, since we'll end up sending
+            // We shouldn't forward any character from just committed text, since we'll end up sending
             // it twice with some IMEs like Korean one. We'll also always send `Enter` in that case,
             // which is not desired given it was used to confirm IME input.
-            if self.ivars().ime_state.get() == ImeState::Commited {
+            if self.ivars().ime_state.get() == ImeState::Committed {
                 return;
             }
 
@@ -452,8 +452,8 @@ declare_class!(
                 let events_for_nsview = NSArray::from_slice(&[&*event]);
                 unsafe { self.interpretKeyEvents(&events_for_nsview) };
 
-                // If the text was commited we must treat the next keyboard event as IME related.
-                if self.ivars().ime_state.get() == ImeState::Commited {
+                // If the text was committed we must treat the next keyboard event as IME related.
+                if self.ivars().ime_state.get() == ImeState::Committed {
                     // Remove any marked text, so normal input can continue.
                     *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
                 }
@@ -462,7 +462,7 @@ declare_class!(
             self.update_modifiers(&event, false);
 
             let had_ime_input = match self.ivars().ime_state.get() {
-                ImeState::Commited => {
+                ImeState::Committed => {
                     // Allow normal input after the commit.
                     self.ivars().ime_state.set(ImeState::Ground);
                     true


### PR DESCRIPTION
This is only used within the macOS backend and isn't public.

- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
