### PR TITLE
Fix typo in `cfg_attr`: `wayland_platfrom` -> `wayland_platform`.

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -309,7 +309,7 @@ pub enum WindowEvent {
     /// The activation token was delivered back and now could be used.
     ///
     #[cfg_attr(
-        not(any(x11_platform, wayland_platfrom)),
+        not(any(x11_platform, wayland_platform)),
         allow(rustdoc::broken_intra_doc_links)
     )]
     /// Delivered in response to [`request_activation_token`].


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
