### PR TITLE
On X11, don't require XSETTINGS

### DIFF
--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -39,11 +39,13 @@ impl XConnection {
     // Retrieve DPI from Xft.dpi property
     pub fn get_xft_dpi(&self) -> Option<f64> {
         // Try to get it from XSETTINGS first.
-        match self.xsettings_dpi() {
-            Ok(Some(dpi)) => return Some(dpi),
-            Ok(None) => {}
-            Err(err) => {
-                log::warn!("failed to fetch XSettings: {err}");
+        if let Some(xsettings_screen) = self.xsettings_screen() {
+            match self.xsettings_dpi(xsettings_screen) {
+                Ok(Some(dpi)) => return Some(dpi),
+                Ok(None) => {}
+                Err(err) => {
+                    log::warn!("failed to fetch XSettings: {err}");
+                }
             }
         }
 

--- a/src/platform_impl/linux/x11/xsettings.rs
+++ b/src/platform_impl/linux/x11/xsettings.rs
@@ -4,12 +4,12 @@
 //!
 //! [here]: https://github.com/derat/xsettingsd
 
-use super::{atoms::*, XConnection};
-
-use x11rb::protocol::xproto::ConnectionExt;
-
 use std::iter;
 use std::num::NonZeroUsize;
+
+use x11rb::protocol::xproto::{self, ConnectionExt};
+
+use super::{atoms::*, XConnection};
 
 type Result<T> = core::result::Result<T, ParserError>;
 
@@ -20,13 +20,16 @@ const BIG_ENDIAN: u8 = b'B';
 
 impl XConnection {
     /// Get the DPI from XSettings.
-    pub(crate) fn xsettings_dpi(&self) -> core::result::Result<Option<f64>, super::X11Error> {
+    pub(crate) fn xsettings_dpi(
+        &self,
+        xsettings_screen: xproto::Atom,
+    ) -> core::result::Result<Option<f64>, super::X11Error> {
         let atoms = self.atoms();
 
         // Get the current owner of the screen's settings.
         let owner = self
             .xcb_connection()
-            .get_selection_owner(self.xsettings_screen())?
+            .get_selection_owner(xsettings_screen)?
             .reply()?;
 
         // Read the _XSETTINGS_SETTINGS property.


### PR DESCRIPTION
We could fail to setup property watcher and fail to start, thus don't require XSETTINGS to work.

Fixes: df8805c0 (On X11, reload DPI on _XSETTINGS_SETTINGS)

- [x] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
