### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+---

--- a/.github/ISSUE_TEMPLATE/bug_android.yml
+++ b/.github/ISSUE_TEMPLATE/bug_android.yml
@@ -1,0 +1,36 @@
+name: Android bug
+description: Create an Android-specific bug report
+labels:
+  - B - bug
+  - DS - android
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the problem you're having
+    validations:
+      required: true
+  - type: textarea
+    id: device
+    attributes:
+      label: Device and Android version
+      description: Which devices and Android versions are you seeing the problem on?
+      placeholder: |
+        Samsung Galaxy Z running Android Pie (API level 28),
+        Samsung Galaxy Z running Android 14 (API level 34),
+        Pixel 8 running Android 14 (API level 34)
+    validations:
+      required: true
+  - type: textarea
+    id: winit-version
+    attributes:
+      label: Winit version
+      description: What version of Winit are you using?
+      placeholder: 0.29.11
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_ios.yml
+++ b/.github/ISSUE_TEMPLATE/bug_ios.yml
@@ -1,0 +1,37 @@
+name: iOS bug
+description: Create an iOS-specific bug report
+labels:
+  - B - bug
+  - DS - ios
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the problem you're having
+    validations:
+      required: true
+  - type: textarea
+    id: device
+    attributes:
+      label: Device and iOS version
+      description: Which devices and iOS versions are you seeing the problem on?
+      placeholder: |
+        iPhone 15 running iOS 14.0,
+        iPhone 15 running iOS 17.0,
+        MacBook Pro M2 Mac Catalyst running macOS 14.2,
+        iPhone simulator running iOS 17.0
+    validations:
+      required: true
+  - type: textarea
+    id: winit-version
+    attributes:
+      label: Winit version
+      description: What version of Winit are you using?
+      placeholder: 0.29.11
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_macos.yml
+++ b/.github/ISSUE_TEMPLATE/bug_macos.yml
@@ -1,0 +1,37 @@
+name: MacOS bug
+description: Create a macOS-specific bug report
+labels:
+  - B - bug
+  - DS - macos
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the problem you're having
+    validations:
+      required: true
+  - type: textarea
+    id: os-version
+    attributes:
+      label: macOS version
+      description: What version of macOS are you using? Please paste in the output of `sw_vers`.
+      placeholder: |
+        ProductName:            macOS
+        ProductVersion:         14.2.1
+        BuildVersion:           23C71
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: winit-version
+    attributes:
+      label: Winit version
+      description: What version of Winit are you using?
+      placeholder: 0.29.11
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_wayland.yml
+++ b/.github/ISSUE_TEMPLATE/bug_wayland.yml
@@ -1,0 +1,41 @@
+name: Wayland bug
+description: Create a Wayland-specific bug report
+labels:
+  - B - bug
+  - DS - wayland
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the problem you're having
+    validations:
+      required: true
+  - type: textarea
+    id: debug
+    attributes:
+      label: Debugging output
+      description: Output of a binary run with `WAYLAND_DEBUG=1`
+      placeholder: |
+        [1234.5678]  -> wl_display@1.get_registry(new id wl_registry@2)
+        [1234.5678]  -> wl_display@1.sync(new id wl_callback@3)
+        ...
+      render: shell
+  - type: checkboxes
+    attributes:
+      label: Window isn't shown unless you draw
+      options:
+        - label: I understand that windows aren't shown on Wayland unless I draw and present to them.
+          required: true
+  - type: textarea
+    id: winit-version
+    attributes:
+      label: Winit version
+      description: What version of Winit are you using?
+      placeholder: 0.29.11
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_web.yml
+++ b/.github/ISSUE_TEMPLATE/bug_web.yml
@@ -1,0 +1,51 @@
+name: Web bug
+description: Create a web-specific bug report
+labels:
+  - B - bug
+  - DS - web
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the problem you're having
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: Tested browsers
+      description: What browsers are you seeing the problem on?
+      options:
+        - Firefox
+        - Chrome
+        - Microsoft Edge
+        - Safari 13
+        - Safari 14
+        - Safari 15
+        - Safari 16
+        - Safari 17
+        - Safari (newer than listed)
+      multiple: true
+    validations:
+      required: true
+  - type: textarea
+    id: device
+    attributes:
+      label: Tested devices
+      description: Which device(s) are you using?
+      placeholder: 'iPhone 15, Lenovo ThinkPad X1, MacBook Pro M2, Samsung Galaxy Z, ...'
+    validations:
+      required: true
+  - type: textarea
+    id: winit-version
+    attributes:
+      label: Winit version
+      description: What version of Winit are you using?
+      placeholder: 0.29.11
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_windows.yml
+++ b/.github/ISSUE_TEMPLATE/bug_windows.yml
@@ -1,0 +1,35 @@
+name: Windows bug
+description: Create a Windows-specific bug report
+labels:
+  - B - bug
+  - DS - windows
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the problem you're having
+    validations:
+      required: true
+  - type: textarea
+    id: os-version
+    attributes:
+      label: Windows version
+      description: What version of Windows are you using? Please paste in the output of the `ver` command.
+      placeholder: |
+        Microsoft Windows [Version 10.0.19042.2251]
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: winit-version
+    attributes:
+      label: Winit version
+      description: What version of Winit are you using?
+      placeholder: 0.29.11
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_x11.yml
+++ b/.github/ISSUE_TEMPLATE/bug_x11.yml
@@ -1,0 +1,32 @@
+name: X11 bug
+description: Create a X11-specific bug report
+labels:
+  - B - bug
+  - DS - x11
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the problem you're having
+    validations:
+      required: true
+  - type: textarea
+    id: os-info
+    attributes:
+      label: OS and window mananger
+      description: Which operating system and window manager are you using?
+    validations:
+      required: true
+  - type: textarea
+    id: winit-version
+    attributes:
+      label: Winit version
+      description: What version of Winit are you using?
+      placeholder: 0.29.11
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question
+    url: https://matrix.to/#/#rust-windowing:matrix.org
+    about: Please ask questions on the Matrix channel.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,26 @@
+name: Feature request
+description: Propose a new feature
+labels:
+  - S - enhancement
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Description of the problem does this solve or what need does it fill? Please be mindful of the [scope](https://github.com/rust-windowing/winit/blob/master/FEATURES.md) of Winit.
+    validations:
+      required: true
+  - type: dropdown
+    id: platforms
+    attributes:
+      label: Relevant platforms
+      description: On which platforms is this feature relevant?
+      options:
+        - Windows
+        - macOS
+        - Wayland
+        - X11
+        - Web
+        - iOS
+        - Android
+      multiple: true


### PR DESCRIPTION
Add issue templates, in particular issue templates for each platform, such that we don't have to request the same information each time a new issue is opened.

You can see how it currently looks [over at my fork](https://github.com/madsmtm/winit/issues/new/choose).

I would like feedback on what each platform would like to request from the user. Feel free to edit this PR description.
- [x] macOS: `sw_vers`.
- [x] Wayland: `WAYLAND_DEBUG=1`, a checkbox to ensure that users know that wayland doesn't show windows unless you present to them.
- [x] X11: Window manager, operating system.
- [x] Windows: Output of `ver`.
- [x] Web: Tested browsers, device info.
- [x] iOS: iOS version, device name.
- [x] Android: Android version and device info.
