### PR TITLE
Orbital buildout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ Unreleased` header.
 - On Orbital, implement `set_decorations`.
 - On Orbital, implement `is_decorated`.
 - On Orbital, implement `set_window_level`.
+- On Orbital, emit `DeviceEvent::MouseMotion`.
 
 # 0.29.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ Unreleased` header.
 - On Orbital, implement `KeyEventExtModifierSupplement`.
 - On Orbital, map keys to `NamedKey` when possible.
 
+- On Orbital, implement `set_cursor_grab`.
+- On Orbital, implement `set_cursor_visible`.
+- On Orbital, implement `drag_window`.
+- On Orbital, implement `drag_resize_window`.
+
 # 0.29.10
 
 - On Web, account for canvas being focused already before event loop starts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,11 +53,20 @@ Unreleased` header.
 - On Orbital, fix `logical_key` and `text` not reported in `KeyEvent`.
 - On Orbital, implement `KeyEventExtModifierSupplement`.
 - On Orbital, map keys to `NamedKey` when possible.
-
 - On Orbital, implement `set_cursor_grab`.
 - On Orbital, implement `set_cursor_visible`.
 - On Orbital, implement `drag_window`.
 - On Orbital, implement `drag_resize_window`.
+- On Orbital, implement `set_transparent`.
+- On Orbital, implement `set_visible`.
+- On Orbital, implement `is_visible`.
+- On Orbital, implement `set_resizable`.
+- On Orbital, implement `is_resizable`.
+- On Orbital, implement `set_maximized`.
+- On Orbital, implement `is_maximized`.
+- On Orbital, implement `set_decorations`.
+- On Orbital, implement `is_decorated`.
+- On Orbital, implement `set_window_level`.
 
 # 0.29.10
 

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -9,8 +9,8 @@ use std::{
 
 use bitflags::bitflags;
 use orbclient::{
-    ButtonEvent, EventOption, FocusEvent, HoverEvent, KeyEvent, MouseEvent, MoveEvent, QuitEvent,
-    ResizeEvent, ScrollEvent, TextInputEvent,
+    ButtonEvent, EventOption, FocusEvent, HoverEvent, KeyEvent, MouseEvent, MouseRelativeEvent,
+    MoveEvent, QuitEvent, ResizeEvent, ScrollEvent, TextInputEvent,
 };
 use smol_str::SmolStr;
 
@@ -457,6 +457,14 @@ impl<T: 'static> EventLoop<T> {
                     },
                 });
             }
+            EventOption::MouseRelative(MouseRelativeEvent { dx, dy }) => {
+                event_handler(event::Event::DeviceEvent {
+                    device_id: event::DeviceId(DeviceId),
+                    event: event::DeviceEvent::MouseMotion {
+                        delta: (dx as f64, dy as f64),
+                    },
+                });
+            }
             EventOption::Button(ButtonEvent {
                 left,
                 middle,
@@ -510,7 +518,7 @@ impl<T: 'static> EventLoop<T> {
                 // Acknowledge resize after event loop.
                 event_state.resize_opt = Some((width, height));
             }
-            //TODO: Clipboard
+            //TODO: Screen, Clipboard, Drop
             EventOption::Hover(HoverEvent { entered }) => {
                 if entered {
                     event_handler(event::Event::WindowEvent {

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -299,7 +299,8 @@ impl Window {
     #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         Some(
-            !self.get_flag(ORBITAL_FLAG_HIDDEN)
+            !self
+                .get_flag(ORBITAL_FLAG_HIDDEN)
                 .expect("failed to get hidden"),
         )
     }

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -283,8 +283,7 @@ impl Window {
 
     #[inline]
     pub fn set_transparent(&self, transparent: bool) {
-        self.set_flag(ORBITAL_FLAG_TRANSPARENT, transparent)
-            .expect("failed to set transparent")
+        let _ = self.set_flag(ORBITAL_FLAG_TRANSPARENT, transparent);
     }
 
     #[inline]
@@ -292,17 +291,12 @@ impl Window {
 
     #[inline]
     pub fn set_visible(&self, visible: bool) {
-        self.set_flag(ORBITAL_FLAG_HIDDEN, !visible)
-            .expect("failed to set hidden")
+        let _ = self.set_flag(ORBITAL_FLAG_HIDDEN, !visible);
     }
 
     #[inline]
     pub fn is_visible(&self) -> Option<bool> {
-        Some(
-            !self
-                .get_flag(ORBITAL_FLAG_HIDDEN)
-                .expect("failed to get hidden"),
-        )
+        Some(!self.get_flag(ORBITAL_FLAG_HIDDEN).unwrap_or(false))
     }
 
     #[inline]
@@ -315,14 +309,12 @@ impl Window {
 
     #[inline]
     pub fn set_resizable(&self, resizeable: bool) {
-        self.set_flag(ORBITAL_FLAG_RESIZABLE, resizeable)
-            .expect("failed to set resizable")
+        let _ = self.set_flag(ORBITAL_FLAG_RESIZABLE, resizeable);
     }
 
     #[inline]
     pub fn is_resizable(&self) -> bool {
-        self.get_flag(ORBITAL_FLAG_RESIZABLE)
-            .expect("failed to get resizable")
+        self.get_flag(ORBITAL_FLAG_RESIZABLE).unwrap_or(false)
     }
 
     #[inline]
@@ -335,14 +327,12 @@ impl Window {
 
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
-        self.set_flag(ORBITAL_FLAG_MAXIMIZED, maximized)
-            .expect("failed to set maximized")
+        let _ = self.set_flag(ORBITAL_FLAG_MAXIMIZED, maximized);
     }
 
     #[inline]
     pub fn is_maximized(&self) -> bool {
-        self.get_flag(ORBITAL_FLAG_MAXIMIZED)
-            .expect("failed to get maximized")
+        self.get_flag(ORBITAL_FLAG_MAXIMIZED).unwrap_or(false)
     }
 
     #[inline]
@@ -355,33 +345,26 @@ impl Window {
 
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
-        self.set_flag(ORBITAL_FLAG_BORDERLESS, !decorations)
-            .expect("failed to set borderless")
+        let _ = self.set_flag(ORBITAL_FLAG_BORDERLESS, !decorations);
     }
 
     #[inline]
     pub fn is_decorated(&self) -> bool {
-        !self
-            .get_flag(ORBITAL_FLAG_BORDERLESS)
-            .expect("failed to get borderless")
+        !self.get_flag(ORBITAL_FLAG_BORDERLESS).unwrap_or(false)
     }
 
     #[inline]
     pub fn set_window_level(&self, level: window::WindowLevel) {
         match level {
             window::WindowLevel::AlwaysOnBottom => {
-                self.set_flag(ORBITAL_FLAG_BACK, true)
-                    .expect("failed to set back");
+                let _ = self.set_flag(ORBITAL_FLAG_BACK, true);
             }
             window::WindowLevel::Normal => {
-                self.set_flag(ORBITAL_FLAG_BACK, false)
-                    .expect("failed to set back");
-                self.set_flag(ORBITAL_FLAG_FRONT, false)
-                    .expect("failed to set front");
+                let _ = self.set_flag(ORBITAL_FLAG_BACK, false);
+                let _ = self.set_flag(ORBITAL_FLAG_FRONT, false);
             }
             window::WindowLevel::AlwaysOnTop => {
-                self.set_flag(ORBITAL_FLAG_FRONT, true)
-                    .expect("failed to set front");
+                let _ = self.set_flag(ORBITAL_FLAG_FRONT, true);
             }
         }
     }
@@ -435,9 +418,9 @@ impl Window {
 
     #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
-        self.window_socket
-            .write(format!("M,C,{}", if visible { 1 } else { 0 }).as_bytes())
-            .expect("failed to set cursor visible")
+        let _ = self
+            .window_socket
+            .write(format!("M,C,{}", if visible { 1 } else { 0 }).as_bytes());
     }
 
     #[inline]

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -22,11 +22,11 @@ use super::{
 const ORBITAL_FLAG_ASYNC: char = 'a';
 const ORBITAL_FLAG_BACK: char = 'b';
 const ORBITAL_FLAG_FRONT: char = 'f';
+const ORBITAL_FLAG_HIDDEN: char = 'h';
 const ORBITAL_FLAG_BORDERLESS: char = 'l';
 const ORBITAL_FLAG_MAXIMIZED: char = 'm';
 const ORBITAL_FLAG_RESIZABLE: char = 'r';
 const ORBITAL_FLAG_TRANSPARENT: char = 't';
-const ORBITAL_FLAG_VISIBLE: char = 'v';
 
 pub struct Window {
     window_socket: Arc<RedoxSocket>,
@@ -74,12 +74,12 @@ impl Window {
             flag_str.push(ORBITAL_FLAG_TRANSPARENT);
         }
 
-        if attrs.visible {
-            flag_str.push(ORBITAL_FLAG_VISIBLE);
-        }
-
         if !attrs.decorations {
             flag_str.push(ORBITAL_FLAG_BORDERLESS);
+        }
+
+        if !attrs.visible {
+            flag_str.push(ORBITAL_FLAG_HIDDEN);
         }
 
         match attrs.window_level {
@@ -292,15 +292,15 @@ impl Window {
 
     #[inline]
     pub fn set_visible(&self, visible: bool) {
-        self.set_flag(ORBITAL_FLAG_VISIBLE, visible)
-            .expect("failed to set visible")
+        self.set_flag(ORBITAL_FLAG_HIDDEN, !visible)
+            .expect("failed to set hidden")
     }
 
     #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         Some(
-            self.get_flag(ORBITAL_FLAG_VISIBLE)
-                .expect("failed to get visible"),
+            !self.get_flag(ORBITAL_FLAG_HIDDEN)
+                .expect("failed to get hidden"),
         )
     }
 
@@ -367,11 +367,8 @@ impl Window {
 
     #[inline]
     pub fn set_window_level(&self, level: window::WindowLevel) {
-        // The order here is important, always set false before setting true
         match level {
             window::WindowLevel::AlwaysOnBottom => {
-                self.set_flag(ORBITAL_FLAG_FRONT, false)
-                    .expect("failed to set front");
                 self.set_flag(ORBITAL_FLAG_BACK, true)
                     .expect("failed to set back");
             }
@@ -382,8 +379,6 @@ impl Window {
                     .expect("failed to set front");
             }
             window::WindowLevel::AlwaysOnTop => {
-                self.set_flag(ORBITAL_FLAG_BACK, false)
-                    .expect("failed to set back");
                 self.set_flag(ORBITAL_FLAG_FRONT, true)
                     .expect("failed to set front");
             }

--- a/src/window.rs
+++ b/src/window.rs
@@ -946,7 +946,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **Web / iOS / Android / Orbital:** Unsupported.
+    /// - **Web / iOS / Android:** Unsupported.
     /// - **X11:** Can only be set while building the window, with [`WindowBuilder::with_transparent`].
     #[inline]
     pub fn set_transparent(&self, transparent: bool) {
@@ -1079,7 +1079,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         self.window
@@ -1090,7 +1090,7 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn is_maximized(&self) -> bool {
         self.window.maybe_wait_on_main(|w| w.is_maximized())

--- a/src/window.rs
+++ b/src/window.rs
@@ -1450,7 +1450,7 @@ impl Window {
     /// - **Wayland:** The cursor is only hidden within the confines of the window.
     /// - **macOS:** The cursor is hidden as long as the window has input focus, even if the cursor is
     ///   outside of the window.
-    /// - **iOS / Android / Orbital:** Unsupported.
+    /// - **iOS / Android:** Unsupported.
     #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         self.window
@@ -1467,7 +1467,7 @@ impl Window {
     /// - **X11:** Un-grabs the cursor.
     /// - **Wayland:** Requires the cursor to be inside the window to be dragged.
     /// - **macOS:** May prevent the button release event to be triggered.
-    /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
     #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         self.window.maybe_wait_on_main(|w| w.drag_window())
@@ -1481,7 +1481,7 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **macOS:** Always returns an [`ExternalError::NotSupported`]
-    /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
     #[inline]
     pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
         self.window
@@ -1642,7 +1642,7 @@ pub enum CursorGrabMode {
     /// ## Platform-specific
     ///
     /// - **macOS:** Not implemented. Always returns [`ExternalError::NotSupported`] for now.
-    /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
     Confined,
 
     /// The cursor is locked inside the window area to the certain position.
@@ -1653,7 +1653,7 @@ pub enum CursorGrabMode {
     /// ## Platform-specific
     ///
     /// - **X11 / Windows:** Not implemented. Always returns [`ExternalError::NotSupported`] for now.
-    /// - **iOS / Android / Orbital:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android:** Always returns an [`ExternalError::NotSupported`].
     Locked,
 }
 


### PR DESCRIPTION
There are quite a few stubs on Orbital that can be implemented. These were tested in Redox alongside some additions to Orbital to support them.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
