### PR TITLE
Fix Documentation for `ScaleFactorChanged` in `WindowEvent`.

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -536,9 +536,8 @@ pub enum WindowEvent {
     /// * Changing the display's scale factor (e.g. in Control Panel on Windows).
     /// * Moving the window to a display with a different scale factor.
     ///
-    /// After this event callback has been processed, the window will be resized to whatever value
-    /// is pointed to by the `new_inner_size` reference. By default, this will contain the size suggested
-    /// by the OS, but it can be changed to any value.
+    /// To update the window size, use the provided [`InnerSizeWriter`] handle. By default, the window is
+    /// resized to the value suggested by the OS, but it can be changed to any value.
     ///
     /// For more information about DPI in general, see the [`dpi`](crate::dpi) module.
     ScaleFactorChanged {


### PR DESCRIPTION
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

Updating documentation for `ScaleFactorChanged` since it now has a `InnerSizeWriter` instead of a reference.

Relevant commit:
https://github.com/rust-windowing/winit/commit/9ac3259a79f996da63d91d5ee4b7233d14687b85#diff-14da7c350de5742eaa248de110fefeae9b4b639c0358e26024d6040ccf174a41R530
