### PR TITLE
fix: set current size in Canvas::create based on inner_size attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- Set current size when creating canvas with inner size
 - On X11, don't require XIM to run.
 - On X11, fix xkb state not being updated correctly sometimes leading to wrong input.
 - Fix compatibility with 32-bit platforms without 64-bit atomics.

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -120,6 +120,10 @@ impl Canvas {
         };
 
         if let Some(size) = attr.inner_size {
+            common
+                .current_size
+                .set(size.to_physical(super::scale_factor(&common.window)));
+
             let size = size.to_logical(super::scale_factor(&common.window));
             super::set_canvas_size(&common.document, &common.raw, &common.style, size);
         }


### PR DESCRIPTION
This PR updates `Canvas::create` to set the `current_size` based on `attr.inner_size` if present. This allows the window size to be used immediately on web.

- [ ] Tested on all platforms changed
- [x ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
