### PR TITLE
Wayland: Fixed DeviceEvent::Motion behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- On Wayland, fixed DeviceEvent::Motion behaviour
 - On X11, don't require XIM to run.
 - On X11, fix xkb state not being updated correctly sometimes leading to wrong input.
 - Fix compatibility with 32-bit platforms without 64-bit atomics.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
-- On Wayland, fixed DeviceEvent::Motion behaviour
+- On Wayland, fix DeviceEvent::Motion not being sent
 - On X11, don't require XIM to run.
 - On X11, fix xkb state not being updated correctly sometimes leading to wrong input.
 - Fix compatibility with 32-bit platforms without 64-bit atomics.

--- a/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
@@ -72,6 +72,20 @@ impl Dispatch<ZwpRelativePointerV1, GlobalData, WinitState> for RelativePointerS
                 },
                 super::DeviceId,
             );
+            state.events_sink.push_device_event(
+                DeviceEvent::Motion {
+                    axis: 0,
+                    value: dx_unaccel,
+                },
+                super::DeviceId,
+            );
+            state.events_sink.push_device_event(
+                DeviceEvent::Motion {
+                    axis: 1,
+                    value: dy_unaccel,
+                },
+                super::DeviceId,
+            );
         }
     }
 }

--- a/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
@@ -60,33 +60,34 @@ impl Dispatch<ZwpRelativePointerV1, GlobalData, WinitState> for RelativePointerS
         _conn: &Connection,
         _qhandle: &QueueHandle<WinitState>,
     ) {
-        if let zwp_relative_pointer_v1::Event::RelativeMotion {
-            dx_unaccel,
-            dy_unaccel,
-            ..
-        } = event
-        {
-            state.events_sink.push_device_event(
-                DeviceEvent::MouseMotion {
-                    delta: (dx_unaccel, dy_unaccel),
-                },
-                super::DeviceId,
-            );
-            state.events_sink.push_device_event(
-                DeviceEvent::Motion {
-                    axis: 0,
-                    value: dx_unaccel,
-                },
-                super::DeviceId,
-            );
-            state.events_sink.push_device_event(
-                DeviceEvent::Motion {
-                    axis: 1,
-                    value: dy_unaccel,
-                },
-                super::DeviceId,
-            );
-        }
+        let (dx_unaccel, dy_unaccel) = match event {
+            zwp_relative_pointer_v1::Event::RelativeMotion {
+                dx_unaccel,
+                dy_unaccel,
+                ..
+            } => (dx_unaccel, dy_unaccel),
+            _ => return,
+        };
+        state.events_sink.push_device_event(
+            DeviceEvent::Motion {
+                axis: 0,
+                value: dx_unaccel,
+            },
+            super::DeviceId,
+        );
+        state.events_sink.push_device_event(
+            DeviceEvent::Motion {
+                axis: 1,
+                value: dy_unaccel,
+            },
+            super::DeviceId,
+        );
+        state.events_sink.push_device_event(
+            DeviceEvent::MouseMotion {
+                delta: (dx_unaccel, dy_unaccel),
+            },
+            super::DeviceId,
+        );
     }
 }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users

# Description
`DeviceEvent::Motion` is supposed to be triggered on every analog device input, including mouse input
which was not the case in Wayland before. I found this bug, when launching an example from nannou wgpu_teapot_camera example, which shows the importance of this feature

# Disclamer
This is (I think) my first PR ever, so if I missed something, please tell me
