### PR TITLE
Add `ApplicationHandler` and matching run APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Unreleased` header.
 # Unreleased
 
 - On Wayland, don't reapply cursor grab when unchanged.
+- Deprecate `EventLoop::run` in favor of `EventLoop::run_app`.
+- Deprecate `EventLoopExtRunOnDemand::run_on_demand` in favor of `EventLoop::run_app_on_demand`.
+- Deprecate `EventLoopExtPumpEvents::pump_events` in favor of `EventLoopExtPumpEvents::pump_app_events`.
+- Add `ApplicationHandler<T>` trait which mimics `Event<T>`.
 - Move `dpi` types to its own crate, and re-export it from the root crate.
 - Implement `Sync` for `EventLoopProxy<T: Send>`.
 - **Breaking:** Move `Window::new` to `ActiveEventLoop::create_window` and `EventLoop::create_window` (with the latter being deprecated).

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -3,28 +3,29 @@
 use std::thread;
 #[cfg(not(web_platform))]
 use std::time;
+
 #[cfg(web_platform)]
 use web_time as time;
 
-use winit::{
-    event::{ElementState, Event, KeyEvent, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
-    keyboard::{Key, NamedKey},
-    window::Window,
-};
+use winit::application::ApplicationHandler;
+use winit::event::{ElementState, KeyEvent, StartCause, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::keyboard::{Key, NamedKey};
+use winit::window::{Window, WindowId};
 
 #[path = "util/fill.rs"]
 mod fill;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+const WAIT_TIME: time::Duration = time::Duration::from_millis(100);
+const POLL_SLEEP_TIME: time::Duration = time::Duration::from_millis(100);
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 enum Mode {
+    #[default]
     Wait,
     WaitUntil,
     Poll,
 }
-
-const WAIT_TIME: time::Duration = time::Duration::from_millis(100);
-const POLL_SLEEP_TIME: time::Duration = time::Duration::from_millis(100);
 
 fn main() -> Result<(), impl std::error::Error> {
     tracing_subscriber::fmt::init();
@@ -37,96 +38,110 @@ fn main() -> Result<(), impl std::error::Error> {
 
     let event_loop = EventLoop::new().unwrap();
 
-    let mut mode = Mode::Wait;
-    let mut request_redraw = false;
-    let mut wait_cancelled = false;
-    let mut close_requested = false;
+    let mut app = ControlFlowDemo::default();
+    event_loop.run_app(&mut app)
+}
 
-    let mut window = None;
-    event_loop.run(move |event, event_loop| {
-        use winit::event::StartCause;
+#[derive(Default)]
+struct ControlFlowDemo {
+    mode: Mode,
+    request_redraw: bool,
+    wait_cancelled: bool,
+    close_requested: bool,
+    window: Option<Window>,
+}
+
+impl ApplicationHandler for ControlFlowDemo {
+    fn new_events(&mut self, _event_loop: &ActiveEventLoop, cause: StartCause) {
+        println!("new_events: {cause:?}");
+
+        self.wait_cancelled = match cause {
+            StartCause::WaitCancelled { .. } => self.mode == Mode::WaitUntil,
+            _ => false,
+        }
+    }
+
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        let window_attributes = Window::default_attributes().with_title(
+            "Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.",
+        );
+        self.window = Some(event_loop.create_window(window_attributes).unwrap());
+    }
+
+    fn window_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
         println!("{event:?}");
+
         match event {
-            Event::NewEvents(start_cause) => {
-                wait_cancelled = match start_cause {
-                    StartCause::WaitCancelled { .. } => mode == Mode::WaitUntil,
-                    _ => false,
-                }
+            WindowEvent::CloseRequested => {
+                self.close_requested = true;
             }
-            Event::Resumed => {
-                let window_attributes = Window::default_attributes().with_title(
-                    "Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.",
-                );
-                window = Some(event_loop.create_window(window_attributes).unwrap());
-            }
-            Event::WindowEvent { event, .. } => match event {
-                WindowEvent::CloseRequested => {
-                    close_requested = true;
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        logical_key: key,
+                        state: ElementState::Pressed,
+                        ..
+                    },
+                ..
+            } => match key.as_ref() {
+                // WARNING: Consider using `key_without_modifiers()` if available on your platform.
+                // See the `key_binding` example
+                Key::Character("1") => {
+                    self.mode = Mode::Wait;
+                    println!("\nmode: {:?}\n", self.mode);
                 }
-                WindowEvent::KeyboardInput {
-                    event:
-                        KeyEvent {
-                            logical_key: key,
-                            state: ElementState::Pressed,
-                            ..
-                        },
-                    ..
-                } => match key.as_ref() {
-                    // WARNING: Consider using `key_without_modifiers()` if available on your platform.
-                    // See the `key_binding` example
-                    Key::Character("1") => {
-                        mode = Mode::Wait;
-                        println!("\nmode: {mode:?}\n");
-                    }
-                    Key::Character("2") => {
-                        mode = Mode::WaitUntil;
-                        println!("\nmode: {mode:?}\n");
-                    }
-                    Key::Character("3") => {
-                        mode = Mode::Poll;
-                        println!("\nmode: {mode:?}\n");
-                    }
-                    Key::Character("r") => {
-                        request_redraw = !request_redraw;
-                        println!("\nrequest_redraw: {request_redraw}\n");
-                    }
-                    Key::Named(NamedKey::Escape) => {
-                        close_requested = true;
-                    }
-                    _ => (),
-                },
-                WindowEvent::RedrawRequested => {
-                    let window = window.as_ref().unwrap();
-                    window.pre_present_notify();
-                    fill::fill_window(window);
+                Key::Character("2") => {
+                    self.mode = Mode::WaitUntil;
+                    println!("\nmode: {:?}\n", self.mode);
+                }
+                Key::Character("3") => {
+                    self.mode = Mode::Poll;
+                    println!("\nmode: {:?}\n", self.mode);
+                }
+                Key::Character("r") => {
+                    self.request_redraw = !self.request_redraw;
+                    println!("\nrequest_redraw: {}\n", self.request_redraw);
+                }
+                Key::Named(NamedKey::Escape) => {
+                    self.close_requested = true;
                 }
                 _ => (),
             },
-            Event::AboutToWait => {
-                if request_redraw && !wait_cancelled && !close_requested {
-                    window.as_ref().unwrap().request_redraw();
-                }
-
-                match mode {
-                    Mode::Wait => event_loop.set_control_flow(ControlFlow::Wait),
-                    Mode::WaitUntil => {
-                        if !wait_cancelled {
-                            event_loop.set_control_flow(ControlFlow::WaitUntil(
-                                time::Instant::now() + WAIT_TIME,
-                            ));
-                        }
-                    }
-                    Mode::Poll => {
-                        thread::sleep(POLL_SLEEP_TIME);
-                        event_loop.set_control_flow(ControlFlow::Poll);
-                    }
-                };
-
-                if close_requested {
-                    event_loop.exit();
-                }
+            WindowEvent::RedrawRequested => {
+                let window = self.window.as_ref().unwrap();
+                window.pre_present_notify();
+                fill::fill_window(window);
             }
             _ => (),
         }
-    })
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        if self.request_redraw && !self.wait_cancelled && !self.close_requested {
+            self.window.as_ref().unwrap().request_redraw();
+        }
+
+        match self.mode {
+            Mode::Wait => event_loop.set_control_flow(ControlFlow::Wait),
+            Mode::WaitUntil => {
+                if !self.wait_cancelled {
+                    event_loop
+                        .set_control_flow(ControlFlow::WaitUntil(time::Instant::now() + WAIT_TIME));
+                }
+            }
+            Mode::Poll => {
+                thread::sleep(POLL_SLEEP_TIME);
+                event_loop.set_control_flow(ControlFlow::Poll);
+            }
+        };
+
+        if self.close_requested {
+            event_loop.exit();
+        }
+    }
 }

--- a/examples/run_on_demand.rs
+++ b/examples/run_on_demand.rs
@@ -2,86 +2,94 @@
 
 // Limit this example to only compatible platforms.
 #[cfg(any(windows_platform, macos_platform, x11_platform, wayland_platform,))]
-fn main() -> Result<(), impl std::error::Error> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     use std::time::Duration;
 
-    use winit::{
-        error::EventLoopError,
-        event::{Event, WindowEvent},
-        event_loop::EventLoop,
-        platform::run_on_demand::EventLoopExtRunOnDemand,
-        window::{Window, WindowId},
-    };
+    use winit::application::ApplicationHandler;
+    use winit::event::WindowEvent;
+    use winit::event_loop::{ActiveEventLoop, EventLoop};
+    use winit::platform::run_on_demand::EventLoopExtRunOnDemand;
+    use winit::window::{Window, WindowId};
 
     #[path = "util/fill.rs"]
     mod fill;
 
     #[derive(Default)]
     struct App {
+        idx: usize,
         window_id: Option<WindowId>,
         window: Option<Window>,
     }
 
-    tracing_subscriber::fmt::init();
-    let mut event_loop = EventLoop::new().unwrap();
-
-    fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), EventLoopError> {
-        let mut app = App::default();
-
-        event_loop.run_on_demand(move |event, event_loop| {
-            println!("Run {idx}: {:?}", event);
-
-            if let Some(window) = &app.window {
-                match event {
-                    Event::WindowEvent {
-                        event: WindowEvent::CloseRequested,
-                        window_id,
-                    } if window.id() == window_id => {
-                        println!("--------------------------------------------------------- Window {idx} CloseRequested");
-                        fill::cleanup_window(window);
-                        app.window = None;
-                    }
-                    Event::AboutToWait => window.request_redraw(),
-                    Event::WindowEvent {
-                        event: WindowEvent::RedrawRequested,
-                        ..
-                    }  => {
-                        fill::fill_window(window);
-                    }
-                    _ => (),
-                }
-            } else if let Some(id) = app.window_id {
-                match event {
-                    Event::WindowEvent {
-                        event: WindowEvent::Destroyed,
-                        window_id,
-                    } if id == window_id => {
-                        println!("--------------------------------------------------------- Window {idx} Destroyed");
-                        app.window_id = None;
-                        event_loop.exit();
-                    }
-                    _ => (),
-                }
-            } else if let Event::Resumed = event {
-                let window_attributes = Window::default_attributes()
-                        .with_title("Fantastic window number one!")
-                        .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0));
-                let window = event_loop.create_window(window_attributes).unwrap();
-                app.window_id = Some(window.id());
-                app.window = Some(window);
+    impl ApplicationHandler for App {
+        fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+            if let Some(window) = self.window.as_ref() {
+                window.request_redraw();
             }
-        })
+        }
+
+        fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+            let window_attributes = Window::default_attributes()
+                .with_title("Fantastic window number one!")
+                .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0));
+            let window = event_loop.create_window(window_attributes).unwrap();
+            self.window_id = Some(window.id());
+            self.window = Some(window);
+        }
+
+        fn window_event(
+            &mut self,
+            event_loop: &ActiveEventLoop,
+            window_id: WindowId,
+            event: WindowEvent,
+        ) {
+            if event == WindowEvent::Destroyed && self.window_id == Some(window_id) {
+                println!(
+                    "--------------------------------------------------------- Window {} Destroyed",
+                    self.idx
+                );
+                self.window_id = None;
+                event_loop.exit();
+                return;
+            }
+
+            let window = match self.window.as_mut() {
+                Some(window) => window,
+                None => return,
+            };
+
+            match event {
+                WindowEvent::CloseRequested => {
+                    println!("--------------------------------------------------------- Window {} CloseRequested", self.idx);
+                    fill::cleanup_window(window);
+                    self.window = None;
+                }
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(window);
+                }
+                _ => (),
+            }
+        }
     }
 
-    run_app(&mut event_loop, 1)?;
+    tracing_subscriber::fmt::init();
+
+    let mut event_loop = EventLoop::new().unwrap();
+
+    let mut app = App {
+        idx: 1,
+        ..Default::default()
+    };
+    event_loop.run_app_on_demand(&mut app)?;
 
     println!("--------------------------------------------------------- Finished first loop");
     println!("--------------------------------------------------------- Waiting 5 seconds");
     std::thread::sleep(Duration::from_secs(5));
 
-    let ret = run_app(&mut event_loop, 2);
+    app.idx += 1;
+    event_loop.run_app_on_demand(&mut app)?;
     println!("--------------------------------------------------------- Finished second loop");
-    ret
+    Ok(())
 }
 
 #[cfg(not(any(windows_platform, macos_platform, x11_platform, wayland_platform,)))]

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -3,15 +3,51 @@ use std::error::Error;
 
 #[cfg(x11_platform)]
 fn main() -> Result<(), Box<dyn Error>> {
-    use winit::{
-        event::{Event, WindowEvent},
-        event_loop::EventLoop,
-        platform::x11::WindowAttributesExtX11,
-        window::Window,
-    };
+    use winit::application::ApplicationHandler;
+    use winit::event::WindowEvent;
+    use winit::event_loop::{ActiveEventLoop, EventLoop};
+    use winit::platform::x11::WindowAttributesExtX11;
+    use winit::window::{Window, WindowId};
 
     #[path = "util/fill.rs"]
     mod fill;
+
+    pub struct XEmbedDemo {
+        parent_window_id: u32,
+        window: Option<Window>,
+    }
+
+    impl ApplicationHandler for XEmbedDemo {
+        fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+            let window_attributes = Window::default_attributes()
+                .with_title("An embedded window!")
+                .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
+                .with_embed_parent_window(self.parent_window_id);
+
+            self.window = Some(event_loop.create_window(window_attributes).unwrap());
+        }
+
+        fn window_event(
+            &mut self,
+            event_loop: &ActiveEventLoop,
+            _window_id: WindowId,
+            event: WindowEvent,
+        ) {
+            let window = self.window.as_ref().unwrap();
+            match event {
+                WindowEvent::CloseRequested => event_loop.exit(),
+                WindowEvent::RedrawRequested => {
+                    window.pre_present_notify();
+                    fill::fill_window(window);
+                }
+                _ => (),
+            }
+        }
+
+        fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+            self.window.as_ref().unwrap().request_redraw();
+        }
+    }
 
     // First argument should be a 32-bit X11 window ID.
     let parent_window_id = std::env::args()
@@ -22,35 +58,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     tracing_subscriber::fmt::init();
     let event_loop = EventLoop::new()?;
 
-    let mut window = None;
-    event_loop.run(move |event, event_loop| match event {
-        Event::Resumed => {
-            let window_attributes = Window::default_attributes()
-                .with_title("An embedded window!")
-                .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
-                .with_embed_parent_window(parent_window_id);
-
-            window = Some(event_loop.create_window(window_attributes).unwrap());
-        }
-        Event::WindowEvent { event, .. } => {
-            let window = window.as_ref().unwrap();
-
-            match event {
-                WindowEvent::CloseRequested => event_loop.exit(),
-                WindowEvent::RedrawRequested => {
-                    window.pre_present_notify();
-                    fill::fill_window(window);
-                }
-                _ => (),
-            }
-        }
-        Event::AboutToWait => {
-            window.as_ref().unwrap().request_redraw();
-        }
-        _ => (),
-    })?;
-
-    Ok(())
+    let mut app = XEmbedDemo {
+        parent_window_id,
+        window: None,
+    };
+    event_loop.run_app(&mut app).map_err(Into::into)
 }
 
 #[cfg(not(x11_platform))]

--- a/src/application.rs
+++ b/src/application.rs
@@ -1,0 +1,221 @@
+//! End user application handling.
+
+use crate::event::{DeviceEvent, DeviceId, StartCause, WindowEvent};
+use crate::event_loop::ActiveEventLoop;
+use crate::window::WindowId;
+
+/// The handler of the application events.
+pub trait ApplicationHandler<T: 'static = ()> {
+    /// Emitted when new events arrive from the OS to be processed.
+    ///
+    /// This is a useful place to put code that should be done before you start processing
+    /// events, such as updating frame timing information for benchmarking or checking the
+    /// [`StartCause`] to see if a timer set by
+    /// [`ControlFlow::WaitUntil`](crate::event_loop::ControlFlow::WaitUntil) has elapsed.
+    fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
+        let _ = (event_loop, cause);
+    }
+
+    /// Emitted when the application has been resumed.
+    ///
+    /// For consistency, all platforms emit a `Resumed` event even if they don't themselves have a
+    /// formal suspend/resume lifecycle. For systems without a formal suspend/resume lifecycle
+    /// the `Resumed` event is always emitted after the [`NewEvents(StartCause::Init)`][StartCause::Init]
+    /// event.
+    ///
+    /// # Portability
+    ///
+    /// It's recommended that applications should only initialize their graphics context and create
+    /// a window after they have received their first `Resumed` event. Some systems
+    /// (specifically Android) won't allow applications to create a render surface until they are
+    /// resumed.
+    ///
+    /// Considering that the implementation of [`Suspended`] and `Resumed` events may be internally
+    /// driven by multiple platform-specific events, and that there may be subtle differences across
+    /// platforms with how these internal events are delivered, it's recommended that applications
+    /// be able to gracefully handle redundant (i.e. back-to-back) [`Suspended`] or `Resumed` events.
+    ///
+    /// Also see [`Suspended`] notes.
+    ///
+    /// ## Android
+    ///
+    /// On Android, the `Resumed` event is sent when a new [`SurfaceView`] has been created. This is
+    /// expected to closely correlate with the [`onResume`] lifecycle event but there may technically
+    /// be a discrepancy.
+    ///
+    /// [`onResume`]: https://developer.android.com/reference/android/app/Activity#onResume()
+    ///
+    /// Applications that need to run on Android must wait until they have been `Resumed`
+    /// before they will be able to create a render surface (such as an `EGLSurface`,
+    /// [`VkSurfaceKHR`] or [`wgpu::Surface`]) which depend on having a
+    /// [`SurfaceView`]. Applications must also assume that if they are [`Suspended`], then their
+    /// render surfaces are invalid and should be dropped.
+    ///
+    /// Also see [`Suspended`] notes.
+    ///
+    /// [`SurfaceView`]: https://developer.android.com/reference/android/view/SurfaceView
+    /// [Activity lifecycle]: https://developer.android.com/guide/components/activities/activity-lifecycle
+    /// [`VkSurfaceKHR`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSurfaceKHR.html
+    /// [`wgpu::Surface`]: https://docs.rs/wgpu/latest/wgpu/struct.Surface.html
+    ///
+    /// ## iOS
+    ///
+    /// On iOS, the `Resumed` event is emitted in response to an [`applicationDidBecomeActive`]
+    /// callback which means the application is "active" (according to the
+    /// [iOS application lifecycle]).
+    ///
+    /// [`applicationDidBecomeActive`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622956-applicationdidbecomeactive
+    /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
+    ///
+    /// ## Web
+    ///
+    /// On Web, the `Resumed` event is emitted in response to a [`pageshow`] event
+    /// with the property [`persisted`] being true, which means that the page is being
+    /// restored from the [`bfcache`] (back/forward cache) - an in-memory cache that
+    /// stores a complete snapshot of a page (including the JavaScript heap) as the
+    /// user is navigating away.
+    ///
+    /// [`pageshow`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/pageshow_event
+    /// [`persisted`]: https://developer.mozilla.org/en-US/docs/Web/API/PageTransitionEvent/persisted
+    /// [`bfcache`]: https://web.dev/bfcache/
+    /// [`Suspended`]: Self::suspended
+    fn resumed(&mut self, event_loop: &ActiveEventLoop);
+
+    /// Emitted when an event is sent from [`EventLoopProxy::send_event`].
+    ///
+    /// [`EventLoopProxy::send_event`]: crate::event_loop::EventLoopProxy::send_event
+    fn user_event(&mut self, event_loop: &ActiveEventLoop, event: T) {
+        let _ = (event_loop, event);
+    }
+
+    /// Emitted when the OS sends an event to a winit window.
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    );
+
+    /// Emitted when the OS sends an event to a device.
+    fn device_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        device_id: DeviceId,
+        event: DeviceEvent,
+    ) {
+        let _ = (event_loop, device_id, event);
+    }
+
+    /// Emitted when the event loop is about to block and wait for new events.
+    ///
+    /// Most applications shouldn't need to hook into this event since there is no real relationship
+    /// between how often the event loop needs to wake up and the dispatching of any specific events.
+    ///
+    /// High frequency event sources, such as input devices could potentially lead to lots of wake
+    /// ups and also lots of corresponding `AboutToWait` events.
+    ///
+    /// This is not an ideal event to drive application rendering from and instead applications
+    /// should render in response to [`WindowEvent::RedrawRequested`] events.
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        let _ = event_loop;
+    }
+
+    /// Emitted when the application has been suspended.
+    ///
+    /// # Portability
+    ///
+    /// Not all platforms support the notion of suspending applications, and there may be no
+    /// technical way to guarantee being able to emit a `Suspended` event if the OS has
+    /// no formal application lifecycle (currently only Android, iOS, and Web do). For this reason,
+    /// Winit does not currently try to emit pseudo `Suspended` events before the application
+    /// quits on platforms without an application lifecycle.
+    ///
+    /// Considering that the implementation of `Suspended` and [`Resumed`] events may be internally
+    /// driven by multiple platform-specific events, and that there may be subtle differences across
+    /// platforms with how these internal events are delivered, it's recommended that applications
+    /// be able to gracefully handle redundant (i.e. back-to-back) `Suspended` or [`Resumed`] events.
+    ///
+    /// Also see [`Resumed`] notes.
+    ///
+    /// ## Android
+    ///
+    /// On Android, the `Suspended` event is only sent when the application's associated
+    /// [`SurfaceView`] is destroyed. This is expected to closely correlate with the [`onPause`]
+    /// lifecycle event but there may technically be a discrepancy.
+    ///
+    /// [`onPause`]: https://developer.android.com/reference/android/app/Activity#onPause()
+    ///
+    /// Applications that need to run on Android should assume their [`SurfaceView`] has been
+    /// destroyed, which indirectly invalidates any existing render surfaces that may have been
+    /// created outside of Winit (such as an `EGLSurface`, [`VkSurfaceKHR`] or [`wgpu::Surface`]).
+    ///
+    /// After being `Suspended` on Android applications must drop all render surfaces before
+    /// the event callback completes, which may be re-created when the application is next [`Resumed`].
+    ///
+    /// [`SurfaceView`]: https://developer.android.com/reference/android/view/SurfaceView
+    /// [Activity lifecycle]: https://developer.android.com/guide/components/activities/activity-lifecycle
+    /// [`VkSurfaceKHR`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSurfaceKHR.html
+    /// [`wgpu::Surface`]: https://docs.rs/wgpu/latest/wgpu/struct.Surface.html
+    ///
+    /// ## iOS
+    ///
+    /// On iOS, the `Suspended` event is currently emitted in response to an
+    /// [`applicationWillResignActive`] callback which means that the application is
+    /// about to transition from the active to inactive state (according to the
+    /// [iOS application lifecycle]).
+    ///
+    /// [`applicationWillResignActive`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1622950-applicationwillresignactive
+    /// [iOS application lifecycle]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle
+    ///
+    /// ## Web
+    ///
+    /// On Web, the `Suspended` event is emitted in response to a [`pagehide`] event
+    /// with the property [`persisted`] being true, which means that the page is being
+    /// put in the [`bfcache`] (back/forward cache) - an in-memory cache that stores a
+    /// complete snapshot of a page (including the JavaScript heap) as the user is
+    /// navigating away.
+    ///
+    /// [`pagehide`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/pagehide_event
+    /// [`persisted`]: https://developer.mozilla.org/en-US/docs/Web/API/PageTransitionEvent/persisted
+    /// [`bfcache`]: https://web.dev/bfcache/
+    /// [`Resumed`]: Self::resumed
+    fn suspended(&mut self, event_loop: &ActiveEventLoop) {
+        let _ = event_loop;
+    }
+
+    /// Emitted when the event loop is being shut down.
+    ///
+    /// This is irreversible - if this method is called, it is guaranteed that the event loop
+    /// will exist right after.
+    fn exiting(&mut self, event_loop: &ActiveEventLoop) {
+        let _ = event_loop;
+    }
+
+    /// Emitted when the application has received a memory warning.
+    ///
+    /// ## Platform-specific
+    ///
+    /// ### Android
+    ///
+    /// On Android, the `MemoryWarning` event is sent when [`onLowMemory`] was called. The application
+    /// must [release memory] or risk being killed.
+    ///
+    /// [`onLowMemory`]: https://developer.android.com/reference/android/app/Application.html#onLowMemory()
+    /// [release memory]: https://developer.android.com/topic/performance/memory#release
+    ///
+    /// ### iOS
+    ///
+    /// On iOS, the `MemoryWarning` event is emitted in response to an [`applicationDidReceiveMemoryWarning`]
+    /// callback. The application must free as much memory as possible or risk being terminated, see
+    /// [how to respond to memory warnings].
+    ///
+    /// [`applicationDidReceiveMemoryWarning`]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623063-applicationdidreceivememorywarni
+    /// [how to respond to memory warnings]: https://developer.apple.com/documentation/uikit/app_and_environment/managing_your_app_s_life_cycle/responding_to_memory_warnings
+    ///
+    /// ### Others
+    ///
+    /// - **macOS / Orbital / Wayland / Web / Windows:** Unsupported.
+    fn memory_warning(&mut self, event_loop: &ActiveEventLoop) {
+        let _ = event_loop;
+    }
+}

--- a/src/platform/run_on_demand.rs
+++ b/src/platform/run_on_demand.rs
@@ -1,8 +1,7 @@
-use crate::{
-    error::EventLoopError,
-    event::Event,
-    event_loop::{ActiveEventLoop, EventLoop},
-};
+use crate::application::ApplicationHandler;
+use crate::error::EventLoopError;
+use crate::event::Event;
+use crate::event_loop::{self, ActiveEventLoop, EventLoop};
 
 #[cfg(doc)]
 use crate::{platform::pump_events::EventLoopExtPumpEvents, window::Window};
@@ -10,12 +9,19 @@ use crate::{platform::pump_events::EventLoopExtPumpEvents, window::Window};
 /// Additional methods on [`EventLoop`] to return control flow to the caller.
 pub trait EventLoopExtRunOnDemand {
     /// A type provided by the user that can be passed through [`Event::UserEvent`].
-    type UserEvent;
+    type UserEvent: 'static;
 
-    /// Runs the event loop in the calling thread and calls the given `event_handler` closure
-    /// to dispatch any window system events.
+    /// See [`run_app_on_demand`].
     ///
-    /// Unlike [`EventLoop::run`], this function accepts non-`'static` (i.e. non-`move`) closures
+    /// [`run_app_on_demand`]: Self::run_app_on_demand
+    #[deprecated = "use EventLoopExtRunOnDemand::run_app_on_demand"]
+    fn run_on_demand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
+    where
+        F: FnMut(Event<Self::UserEvent>, &ActiveEventLoop);
+
+    /// Run the application with the event loop on the calling thread.
+    ///
+    /// Unlike [`EventLoop::run_app`], this function accepts non-`'static` (i.e. non-`move`) closures
     /// and it is possible to return control back to the caller without
     /// consuming the `EventLoop` (by using [`exit()`]) and
     /// so the event loop can be re-run after it has exit.
@@ -26,11 +32,10 @@ pub trait EventLoopExtRunOnDemand {
     ///
     /// This API is not designed to run an event loop in bursts that you can exit from and return
     /// to while maintaining the full state of your application. (If you need something like this
-    /// you can look at the [`EventLoopExtPumpEvents::pump_events()`] API)
+    /// you can look at the [`EventLoopExtPumpEvents::pump_app_events()`] API)
     ///
-    /// Each time `run_on_demand` is called the `event_handler` can expect to receive a
-    /// `NewEvents(Init)` and `Resumed` event (even on platforms that have no suspend/resume
-    /// lifecycle) - which can be used to consistently initialize application state.
+    /// Each time `run_app_on_demand` is called the startup sequence of `init`, followed by
+    /// `resume` is being preserved.
     ///
     /// See the [`set_control_flow()`] docs on how to change the event loop's behavior.
     ///
@@ -40,8 +45,8 @@ pub trait EventLoopExtRunOnDemand {
     ///   backend it is possible to use `EventLoopExtWebSys::spawn()`[^1] more than once instead).
     /// - No [`Window`] state can be carried between separate runs of the event loop.
     ///
-    /// You are strongly encouraged to use [`EventLoop::run()`] for portability, unless you specifically need
-    /// the ability to re-run a single event loop more than once
+    /// You are strongly encouraged to use [`EventLoop::run_app()`] for portability, unless you
+    /// specifically need the ability to re-run a single event loop more than once
     ///
     /// # Supported Platforms
     /// - Windows
@@ -64,9 +69,15 @@ pub trait EventLoopExtRunOnDemand {
     ///
     /// [`exit()`]: ActiveEventLoop::exit()
     /// [`set_control_flow()`]: ActiveEventLoop::set_control_flow()
-    fn run_on_demand<F>(&mut self, event_handler: F) -> Result<(), EventLoopError>
-    where
-        F: FnMut(Event<Self::UserEvent>, &ActiveEventLoop);
+    fn run_app_on_demand<A: ApplicationHandler<Self::UserEvent>>(
+        &mut self,
+        app: &mut A,
+    ) -> Result<(), EventLoopError> {
+        #[allow(deprecated)]
+        self.run_on_demand(|event, event_loop| {
+            event_loop::dispatch_event_for_app(app, event_loop, event)
+        })
+    }
 }
 
 impl<T> EventLoopExtRunOnDemand for EventLoop<T> {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -182,7 +182,7 @@ impl<T: 'static> EventLoop<T> {
             application.is_none(),
             "\
                 `EventLoop` cannot be `run` after a call to `UIApplicationMain` on iOS\n\
-                 Note: `EventLoop::run` calls `UIApplicationMain` on iOS",
+                 Note: `EventLoop::run_app` calls `UIApplicationMain` on iOS",
         );
 
         let handler = map_user_event(handler, self.receiver);

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -689,7 +689,7 @@ impl Inner {
             let screen_frame = self.rect_to_screen_space(bounds);
             let status_bar_frame = {
                 let app = UIApplication::shared(MainThreadMarker::new().unwrap()).expect(
-                    "`Window::get_inner_position` cannot be called before `EventLoop::run` on iOS",
+                    "`Window::get_inner_position` cannot be called before `EventLoop::run_app` on iOS",
                 );
                 app.statusBarFrame()
             };

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -91,7 +91,7 @@ declare_class!(
             self.set_is_running(true);
             self.dispatch_init_events();
 
-            // If the application is being launched via `EventLoop::pump_events()` then we'll
+            // If the application is being launched via `EventLoop::pump_app_events()` then we'll
             // want to stop the app once it is launched (and return to the external loop)
             //
             // In this case we still want to consider Winit's `EventLoop` to be "running",

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -75,8 +75,8 @@ enum RunnerEnum {
     Pending,
     /// The `EventLoop` is being run.
     Running(Runner),
-    /// The `EventLoop` is exited after being started with `EventLoop::run`. Since
-    /// `EventLoop::run` takes ownership of the `EventLoop`, we can be certain
+    /// The `EventLoop` is exited after being started with `EventLoop::run_app`. Since
+    /// `EventLoop::run_app` takes ownership of the `EventLoop`, we can be certain
     /// that this event loop will never be run again.
     Destroyed,
 }
@@ -735,7 +735,7 @@ impl Shared {
         // * `self`, i.e. the item which triggered this event loop wakeup, which
         //   is usually a `wasm-bindgen` `Closure`, which will be dropped after
         //   returning to the JS glue code.
-        // * The `ActiveEventLoop` leaked inside `EventLoop::run` due to the
+        // * The `ActiveEventLoop` leaked inside `EventLoop::run_app` due to the
         //   JS exception thrown at the end.
         // * For each undropped `Window`:
         //     * The `register_redraw_request` closure.

--- a/src/window.rs
+++ b/src/window.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 ///
 /// The window is closed when dropped.
 ///
-/// # Threading
+/// ## Threading
 ///
 /// This is `Send + Sync`, meaning that it can be freely used from other
 /// threads.
@@ -29,37 +29,6 @@ use serde::{Deserialize, Serialize};
 /// interactions on the main thread, so on those platforms, if you use the
 /// window from a thread other than the main, the code is scheduled to run on
 /// the main thread, and your thread may be blocked until that completes.
-///
-/// # Example
-///
-/// ```no_run
-/// use winit::{
-///     event::{Event, WindowEvent},
-///     event_loop::{ControlFlow, EventLoop},
-///     window::Window,
-/// };
-///
-/// let mut event_loop = EventLoop::new().unwrap();
-/// event_loop.set_control_flow(ControlFlow::Wait);
-/// let mut windows = Vec::new();
-///
-/// event_loop.run(move |event, event_loop| {
-///     match event {
-///         Event::Resumed => {
-///             let window = event_loop.create_window(Window::default_attributes()).unwrap();
-///             windows.push(window);
-///         }
-///         Event::WindowEvent {
-///             event: WindowEvent::CloseRequested,
-///             ..
-///         } => {
-///             windows.clear();
-///             event_loop.exit();
-///         }
-///         _ => (),
-///     }
-/// });
-/// ```
 ///
 /// ## Platform-specific
 ///


### PR DESCRIPTION
Winit is moving towards trait based end user application structure, thus add a simple `ApplicationHandler` trait which follows the `Event<T>`. To make use of this trait the new `run_app` group of APIs were added with the old `run` APIs being deprecated.

Part-of: #3432. Replaces https://github.com/rust-windowing/winit/pull/3386.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
