### PR TITLE
Remove once_cell dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,6 @@ bitflags = "2"
 cursor-icon = "1.1.0"
 log = "0.4"
 mint = { version = "0.5.6", optional = true }
-once_cell = "1.12"
 rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
 rwh_05 = { package = "raw-window-handle", version = "0.5.2", features = ["std"], optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,6 +187,7 @@ mod icon;
 pub mod keyboard;
 pub mod monitor;
 mod platform_impl;
+mod utils;
 pub mod window;
 
 pub mod platform;

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -12,12 +12,12 @@ use std::{
     time::{Duration, Instant},
 };
 
+use crate::utils::Lazy;
 use android_activity::input::{InputEvent, KeyAction, Keycode, MotionAction};
 use android_activity::{
     AndroidApp, AndroidAppWaker, ConfigurationRef, InputStatus, MainEvent, Rect,
 };
 use log::{debug, trace, warn};
-use once_cell::sync::Lazy;
 
 use crate::{
     cursor::Cursor,

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -10,6 +10,7 @@ use std::{
     time::Instant,
 };
 
+use crate::utils::Lazy;
 use core_foundation::base::CFRelease;
 use core_foundation::date::CFAbsoluteTimeGetCurrent;
 use core_foundation::runloop::{
@@ -22,7 +23,6 @@ use icrate::Foundation::{
 use objc2::rc::Id;
 use objc2::runtime::AnyObject;
 use objc2::{msg_send, sel};
-use once_cell::sync::Lazy;
 
 use super::uikit::UIView;
 use super::window::WinitUIWindow;

--- a/src/platform_impl/linux/common/xkb/mod.rs
+++ b/src/platform_impl/linux/common/xkb/mod.rs
@@ -4,10 +4,10 @@ use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use log::warn;
-use once_cell::sync::Lazy;
 use smol_str::SmolStr;
 #[cfg(wayland_platform)]
 use std::os::unix::io::OwnedFd;
+use utils::Lazy;
 use xkbcommon_dl::{
     self as xkb, xkb_compose_status, xkb_context, xkb_context_flags, xkbcommon_compose_handle,
     xkbcommon_handle, XkbCommon, XkbCommonCompose,

--- a/src/platform_impl/linux/common/xkb/mod.rs
+++ b/src/platform_impl/linux/common/xkb/mod.rs
@@ -7,7 +7,7 @@ use log::warn;
 use smol_str::SmolStr;
 #[cfg(wayland_platform)]
 use std::os::unix::io::OwnedFd;
-use utils::Lazy;
+use crate::utils::Lazy;
 use xkbcommon_dl::{
     self as xkb, xkb_compose_status, xkb_context, xkb_context_flags, xkbcommon_compose_handle,
     xkbcommon_handle, XkbCommon, XkbCommonCompose,

--- a/src/platform_impl/linux/common/xkb/mod.rs
+++ b/src/platform_impl/linux/common/xkb/mod.rs
@@ -3,11 +3,11 @@ use std::os::raw::c_char;
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use crate::utils::Lazy;
 use log::warn;
 use smol_str::SmolStr;
 #[cfg(wayland_platform)]
 use std::os::unix::io::OwnedFd;
-use crate::utils::Lazy;
 use xkbcommon_dl::{
     self as xkb, xkb_compose_status, xkb_context, xkb_context_flags, xkbcommon_compose_handle,
     xkbcommon_handle, XkbCommon, XkbCommonCompose,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -11,7 +11,7 @@ use std::{collections::VecDeque, env, fmt};
 use std::{ffi::CStr, mem::MaybeUninit, os::raw::*, sync::Mutex};
 
 #[cfg(x11_platform)]
-use once_cell::sync::Lazy;
+use crate::utils::Lazy;
 use smol_str::SmolStr;
 
 #[cfg(x11_platform)]

--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use super::{super::atoms::*, ffi, util, XConnection, XError};
-use once_cell::sync::Lazy;
+use crate::utils::Lazy;
 use x11rb::protocol::xproto;
 
 static GLOBAL_LOCK: Lazy<Mutex<()>> = Lazy::new(Default::default);

--- a/src/platform_impl/linux/x11/util/wm.rs
+++ b/src/platform_impl/linux/x11/util/wm.rs
@@ -1,6 +1,6 @@
 use std::sync::Mutex;
 
-use once_cell::sync::Lazy;
+use crate::utils::Lazy;
 
 use super::*;
 

--- a/src/platform_impl/macos/cursor.rs
+++ b/src/platform_impl/macos/cursor.rs
@@ -1,3 +1,4 @@
+use crate::utils::Lazy;
 use icrate::AppKit::{NSBitmapImageRep, NSCursor, NSDeviceRGBColorSpace, NSImage};
 use icrate::Foundation::{
     ns_string, NSData, NSDictionary, NSNumber, NSObject, NSObjectProtocol, NSPoint, NSSize,
@@ -6,7 +7,6 @@ use icrate::Foundation::{
 use objc2::rc::Id;
 use objc2::runtime::Sel;
 use objc2::{msg_send_id, sel, ClassType};
-use once_cell::sync::Lazy;
 use std::ffi::c_uchar;
 use std::slice;
 

--- a/src/platform_impl/windows/dark_mode.rs
+++ b/src/platform_impl/windows/dark_mode.rs
@@ -2,7 +2,7 @@
 /// which is inspired by the solution in https://github.com/ysc3839/win32-darkmode
 use std::{ffi::c_void, ptr};
 
-use once_cell::sync::Lazy;
+use crate::utils::Lazy;
 use windows_sys::{
     core::PCSTR,
     Win32::{

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -848,16 +848,16 @@ static USER_EVENT_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::WakeupMsg\0
 static EXEC_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::ExecMsg\0");
 // Message sent by a `Window` when it wants to be destroyed by the main thread.
 // WPARAM and LPARAM are unused.
-pub static DESTROY_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::DestroyMsg\0");
+pub(crate) static DESTROY_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::DestroyMsg\0");
 // WPARAM is a bool specifying the `WindowFlags::MARKER_RETAIN_STATE_ON_SIZE` flag. See the
 // documentation in the `window_state` module for more information.
-pub static SET_RETAIN_STATE_ON_SIZE_MSG_ID: LazyMessageId =
+pub (crate) static SET_RETAIN_STATE_ON_SIZE_MSG_ID: LazyMessageId =
     LazyMessageId::new("Winit::SetRetainMaximized\0");
 static THREAD_EVENT_TARGET_WINDOW_CLASS: Lazy<Vec<u16>> =
     Lazy::new(|| util::encode_wide("Winit Thread Event Target"));
 /// When the taskbar is created, it registers a message with the "TaskbarCreated" string and then broadcasts this message to all top-level windows
 /// <https://docs.microsoft.com/en-us/windows/win32/shell/taskbar#taskbar-creation-notification>
-pub static TASKBAR_CREATED: LazyMessageId = LazyMessageId::new("TaskbarCreated\0");
+pub (crate) static TASKBAR_CREATED: LazyMessageId = LazyMessageId::new("TaskbarCreated\0");
 
 fn create_event_target_window() -> HWND {
     use windows_sys::Win32::UI::WindowsAndMessaging::CS_HREDRAW;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -17,7 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use once_cell::sync::Lazy;
+use crate::utils::Lazy;
 
 use windows_sys::Win32::{
     Devices::HumanInterfaceDevice::MOUSE_MOVE_RELATIVE,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -851,13 +851,13 @@ static EXEC_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::ExecMsg\0");
 pub(crate) static DESTROY_MSG_ID: LazyMessageId = LazyMessageId::new("Winit::DestroyMsg\0");
 // WPARAM is a bool specifying the `WindowFlags::MARKER_RETAIN_STATE_ON_SIZE` flag. See the
 // documentation in the `window_state` module for more information.
-pub (crate) static SET_RETAIN_STATE_ON_SIZE_MSG_ID: LazyMessageId =
+pub(crate) static SET_RETAIN_STATE_ON_SIZE_MSG_ID: LazyMessageId =
     LazyMessageId::new("Winit::SetRetainMaximized\0");
 static THREAD_EVENT_TARGET_WINDOW_CLASS: Lazy<Vec<u16>> =
     Lazy::new(|| util::encode_wide("Winit Thread Event Target"));
 /// When the taskbar is created, it registers a message with the "TaskbarCreated" string and then broadcasts this message to all top-level windows
 /// <https://docs.microsoft.com/en-us/windows/win32/shell/taskbar#taskbar-creation-notification>
-pub (crate) static TASKBAR_CREATED: LazyMessageId = LazyMessageId::new("TaskbarCreated\0");
+pub(crate) static TASKBAR_CREATED: LazyMessageId = LazyMessageId::new("TaskbarCreated\0");
 
 fn create_event_target_window() -> HWND {
     use windows_sys::Win32::UI::WindowsAndMessaging::CS_HREDRAW;

--- a/src/platform_impl/windows/keyboard_layout.rs
+++ b/src/platform_impl/windows/keyboard_layout.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Mutex,
 };
 
-use once_cell::sync::Lazy;
+use crate::utils::Lazy;
 use smol_str::SmolStr;
 use windows_sys::Win32::{
     System::SystemServices::{LANG_JAPANESE, LANG_KOREAN},

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -262,27 +262,27 @@ pub type GetPointerTouchInfo =
 pub type GetPointerPenInfo =
     unsafe extern "system" fn(pointId: u32, penInfo: *mut POINTER_PEN_INFO) -> BOOL;
 
-pub static GET_DPI_FOR_WINDOW: Lazy<Option<GetDpiForWindow>> =
+pub(crate)static GET_DPI_FOR_WINDOW: Lazy<Option<GetDpiForWindow>> =
     Lazy::new(|| get_function!("user32.dll", GetDpiForWindow));
-pub static ADJUST_WINDOW_RECT_EX_FOR_DPI: Lazy<Option<AdjustWindowRectExForDpi>> =
+pub(crate)static ADJUST_WINDOW_RECT_EX_FOR_DPI: Lazy<Option<AdjustWindowRectExForDpi>> =
     Lazy::new(|| get_function!("user32.dll", AdjustWindowRectExForDpi));
-pub static GET_DPI_FOR_MONITOR: Lazy<Option<GetDpiForMonitor>> =
+pub(crate)static GET_DPI_FOR_MONITOR: Lazy<Option<GetDpiForMonitor>> =
     Lazy::new(|| get_function!("shcore.dll", GetDpiForMonitor));
-pub static ENABLE_NON_CLIENT_DPI_SCALING: Lazy<Option<EnableNonClientDpiScaling>> =
+pub(crate)static ENABLE_NON_CLIENT_DPI_SCALING: Lazy<Option<EnableNonClientDpiScaling>> =
     Lazy::new(|| get_function!("user32.dll", EnableNonClientDpiScaling));
-pub static SET_PROCESS_DPI_AWARENESS_CONTEXT: Lazy<Option<SetProcessDpiAwarenessContext>> =
+pub(crate)static SET_PROCESS_DPI_AWARENESS_CONTEXT: Lazy<Option<SetProcessDpiAwarenessContext>> =
     Lazy::new(|| get_function!("user32.dll", SetProcessDpiAwarenessContext));
-pub static SET_PROCESS_DPI_AWARENESS: Lazy<Option<SetProcessDpiAwareness>> =
+pub(crate)static SET_PROCESS_DPI_AWARENESS: Lazy<Option<SetProcessDpiAwareness>> =
     Lazy::new(|| get_function!("shcore.dll", SetProcessDpiAwareness));
-pub static SET_PROCESS_DPI_AWARE: Lazy<Option<SetProcessDPIAware>> =
+pub(crate)static SET_PROCESS_DPI_AWARE: Lazy<Option<SetProcessDPIAware>> =
     Lazy::new(|| get_function!("user32.dll", SetProcessDPIAware));
-pub static GET_POINTER_FRAME_INFO_HISTORY: Lazy<Option<GetPointerFrameInfoHistory>> =
+pub(crate)static GET_POINTER_FRAME_INFO_HISTORY: Lazy<Option<GetPointerFrameInfoHistory>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerFrameInfoHistory));
-pub static SKIP_POINTER_FRAME_MESSAGES: Lazy<Option<SkipPointerFrameMessages>> =
+pub(crate)static SKIP_POINTER_FRAME_MESSAGES: Lazy<Option<SkipPointerFrameMessages>> =
     Lazy::new(|| get_function!("user32.dll", SkipPointerFrameMessages));
-pub static GET_POINTER_DEVICE_RECTS: Lazy<Option<GetPointerDeviceRects>> =
+pub(crate)static GET_POINTER_DEVICE_RECTS: Lazy<Option<GetPointerDeviceRects>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerDeviceRects));
-pub static GET_POINTER_TOUCH_INFO: Lazy<Option<GetPointerTouchInfo>> =
+pub(crate)static GET_POINTER_TOUCH_INFO: Lazy<Option<GetPointerTouchInfo>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerTouchInfo));
-pub static GET_POINTER_PEN_INFO: Lazy<Option<GetPointerPenInfo>> =
+pub(crate)static GET_POINTER_PEN_INFO: Lazy<Option<GetPointerPenInfo>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerPenInfo));

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -9,7 +9,7 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use once_cell::sync::Lazy;
+use crate::utils::Lazy;
 use windows_sys::{
     core::{HRESULT, PCWSTR},
     Win32::{

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -262,27 +262,27 @@ pub type GetPointerTouchInfo =
 pub type GetPointerPenInfo =
     unsafe extern "system" fn(pointId: u32, penInfo: *mut POINTER_PEN_INFO) -> BOOL;
 
-pub(crate)static GET_DPI_FOR_WINDOW: Lazy<Option<GetDpiForWindow>> =
+pub(crate) static GET_DPI_FOR_WINDOW: Lazy<Option<GetDpiForWindow>> =
     Lazy::new(|| get_function!("user32.dll", GetDpiForWindow));
-pub(crate)static ADJUST_WINDOW_RECT_EX_FOR_DPI: Lazy<Option<AdjustWindowRectExForDpi>> =
+pub(crate) static ADJUST_WINDOW_RECT_EX_FOR_DPI: Lazy<Option<AdjustWindowRectExForDpi>> =
     Lazy::new(|| get_function!("user32.dll", AdjustWindowRectExForDpi));
-pub(crate)static GET_DPI_FOR_MONITOR: Lazy<Option<GetDpiForMonitor>> =
+pub(crate) static GET_DPI_FOR_MONITOR: Lazy<Option<GetDpiForMonitor>> =
     Lazy::new(|| get_function!("shcore.dll", GetDpiForMonitor));
-pub(crate)static ENABLE_NON_CLIENT_DPI_SCALING: Lazy<Option<EnableNonClientDpiScaling>> =
+pub(crate) static ENABLE_NON_CLIENT_DPI_SCALING: Lazy<Option<EnableNonClientDpiScaling>> =
     Lazy::new(|| get_function!("user32.dll", EnableNonClientDpiScaling));
-pub(crate)static SET_PROCESS_DPI_AWARENESS_CONTEXT: Lazy<Option<SetProcessDpiAwarenessContext>> =
+pub(crate) static SET_PROCESS_DPI_AWARENESS_CONTEXT: Lazy<Option<SetProcessDpiAwarenessContext>> =
     Lazy::new(|| get_function!("user32.dll", SetProcessDpiAwarenessContext));
-pub(crate)static SET_PROCESS_DPI_AWARENESS: Lazy<Option<SetProcessDpiAwareness>> =
+pub(crate) static SET_PROCESS_DPI_AWARENESS: Lazy<Option<SetProcessDpiAwareness>> =
     Lazy::new(|| get_function!("shcore.dll", SetProcessDpiAwareness));
-pub(crate)static SET_PROCESS_DPI_AWARE: Lazy<Option<SetProcessDPIAware>> =
+pub(crate) static SET_PROCESS_DPI_AWARE: Lazy<Option<SetProcessDPIAware>> =
     Lazy::new(|| get_function!("user32.dll", SetProcessDPIAware));
-pub(crate)static GET_POINTER_FRAME_INFO_HISTORY: Lazy<Option<GetPointerFrameInfoHistory>> =
+pub(crate) static GET_POINTER_FRAME_INFO_HISTORY: Lazy<Option<GetPointerFrameInfoHistory>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerFrameInfoHistory));
-pub(crate)static SKIP_POINTER_FRAME_MESSAGES: Lazy<Option<SkipPointerFrameMessages>> =
+pub(crate) static SKIP_POINTER_FRAME_MESSAGES: Lazy<Option<SkipPointerFrameMessages>> =
     Lazy::new(|| get_function!("user32.dll", SkipPointerFrameMessages));
-pub(crate)static GET_POINTER_DEVICE_RECTS: Lazy<Option<GetPointerDeviceRects>> =
+pub(crate) static GET_POINTER_DEVICE_RECTS: Lazy<Option<GetPointerDeviceRects>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerDeviceRects));
-pub(crate)static GET_POINTER_TOUCH_INFO: Lazy<Option<GetPointerTouchInfo>> =
+pub(crate) static GET_POINTER_TOUCH_INFO: Lazy<Option<GetPointerTouchInfo>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerTouchInfo));
-pub(crate)static GET_POINTER_PEN_INFO: Lazy<Option<GetPointerPenInfo>> =
+pub(crate) static GET_POINTER_PEN_INFO: Lazy<Option<GetPointerPenInfo>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerPenInfo));

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,31 +2,26 @@
 // Replace with std::sync::LazyLock when https://github.com/rust-lang/rust/issues/109736 is stablized.
 
 use std::ops::Deref;
-use std::sync::Mutex;
 use std::sync::OnceLock;
 
-pub(crate) struct Lazy<T, F = fn() -> T> {
+pub(crate) struct Lazy<T> {
     cell: OnceLock<T>,
-    init: Mutex<Option<F>>,
+    init: fn() -> T,
 }
 
-impl<T, F: FnOnce() -> T> Lazy<T, F> {
-    pub const fn new(f: F) -> Self {
+impl<T> Lazy<T> {
+    pub const fn new(f: fn() -> T) -> Self {
         Self {
             cell: OnceLock::new(),
-            init: Mutex::new(Some(f)),
+            init: f,
         }
     }
 }
 
-impl<T, F: FnOnce() -> T> Deref for Lazy<T, F> {
+impl<T> Deref for Lazy<T> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &'_ T {
-        self.cell
-            .get_or_init(|| match self.init.lock().unwrap().take() {
-                Some(f) => f(),
-                None => unreachable!(),
-            })
+        self.cell.get_or_init(self.init)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,19 +19,15 @@ impl<T, F: FnOnce() -> T> Lazy<T, F> {
             init: Cell::new(Some(f)),
         }
     }
-
-    pub fn get(&self) -> &'_ T {
-        self.cell.get_or_init(|| match self.init.take() {
-            Some(f) => f(),
-            None => unreachable!(),
-        })
-    }
 }
 
 impl<T, F: FnOnce() -> T> Deref for Lazy<T, F> {
     type Target = T;
     #[inline]
     fn deref(&self) -> &'_ T {
-        self.get()
+        self.cell.get_or_init(|| match self.init.take() {
+            Some(f) => f(),
+            None => unreachable!(),
+        })
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ pub(crate) struct Lazy<T, F = fn() -> T> {
     init: Cell<Option<F>>,
 }
 
-unsafe impl<T, F> Sync for Lazy<T, F> {}
+unsafe impl<T: Send, F: Send> Sync for Lazy<T, F> {}
 
 impl<T, F: FnOnce() -> T> Lazy<T, F> {
     pub const fn new(f: F) -> Self {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,6 +1,9 @@
 // A poly-fill for `lazy_cell`
 // Replace with std::sync::LazyLock when https://github.com/rust-lang/rust/issues/109736 is stablized.
 
+// This isn't used on every platform, which can come up as dead code warnings.
+#![allow(dead_code)]
+
 use std::ops::Deref;
 use std::sync::OnceLock;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,37 @@
+// A poly-fill for `lazy_cell`
+// Replace with std::sync::LazyLock when https://github.com/rust-lang/rust/issues/109736 is stablized.
+
+use std::cell::Cell;
+use std::ops::Deref;
+use std::sync::OnceLock;
+
+pub(crate) struct Lazy<T, F = fn() -> T> {
+    cell: OnceLock<T>,
+    init: Cell<Option<F>>,
+}
+
+unsafe impl<T, F> Sync for Lazy<T, F> {}
+
+impl<T, F: FnOnce() -> T> Lazy<T, F> {
+    pub const fn new(f: F) -> Self {
+        Self {
+            cell: OnceLock::new(),
+            init: Cell::new(Some(f)),
+        }
+    }
+
+    pub fn get(&self) -> &'_ T {
+        self.cell.get_or_init(|| match self.init.take() {
+            Some(f) => f(),
+            None => unreachable!(),
+        })
+    }
+}
+
+impl<T, F: FnOnce() -> T> Deref for Lazy<T, F> {
+    type Target = T;
+    #[inline]
+    fn deref(&self) -> &'_ T {
+        self.get()
+    }
+}


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

A follow up to #2313. Removes the `once_cell` dependency, instead using `std::sync::OnceLock` and a minimal polyfill for `std::sync::LazyLock`, which may be stablized soon (see https://github.com/rust-lang/rust/pull/121377).

Should it be named `LazyLock` to match up with the proposed API? I kept it as `Lazy` for now.

This should not require a bump in MSRV, as `OnceLock` was stabilized in 1.70, which this crate is using.