### PR TITLE
Replace log with tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Unreleased` header.
 - **Breaking:** Changed the signature of `EventLoop::with_user_event` to return a builder.
 - **Breaking:** Removed `EventLoopBuilder::with_user_event`, the functionality is now available in `EventLoop::with_user_event`.
 - Add `Window::default_attributes` to get default `WindowAttributes`.
+- `log` has been replaced with `tracing`. The old behavior can be emulated by setting the `log` feature on the `tracing` crate.
 
 # 0.29.12
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,17 +64,18 @@ cfg_aliases = "0.2.0"
 [dependencies]
 bitflags = "2"
 cursor-icon = "1.1.0"
-log = "0.4"
 rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
 rwh_05 = { package = "raw-window-handle", version = "0.5.2", features = ["std"], optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"], optional = true }
 serde = { workspace = true, optional = true }
 smol_str = "0.2.0"
 dpi = { path = "dpi" }
+tracing = { version = "0.1.40", default_features = false }
 
 [dev-dependencies]
 image = { version = "0.24.0", default-features = false, features = ["png"] }
-simple_logger = { version = "4.2.0", default_features = false }
+tracing = { version = "0.1.40", default_features = false, features = ["log"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 winit = { path = ".", features = ["rwh_05"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dev-dependencies]

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -6,7 +6,6 @@ use std::time;
 #[cfg(web_platform)]
 use web_time as time;
 
-use simple_logger::SimpleLogger;
 use winit::{
     event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
@@ -28,7 +27,7 @@ const WAIT_TIME: time::Duration = time::Duration::from_millis(100);
 const POLL_SLEEP_TIME: time::Duration = time::Duration::from_millis(100);
 
 fn main() -> Result<(), impl std::error::Error> {
-    SimpleLogger::new().init().unwrap();
+    tracing_subscriber::fmt::init();
 
     println!("Press '1' to switch to Wait mode.");
     println!("Press '2' to switch to WaitUntil mode.");

--- a/examples/pump_events.rs
+++ b/examples/pump_events.rs
@@ -11,7 +11,6 @@
 fn main() -> std::process::ExitCode {
     use std::{process::ExitCode, thread::sleep, time::Duration};
 
-    use simple_logger::SimpleLogger;
     use winit::{
         event::{Event, WindowEvent},
         event_loop::EventLoop,
@@ -24,7 +23,7 @@ fn main() -> std::process::ExitCode {
 
     let mut event_loop = EventLoop::new().unwrap();
 
-    SimpleLogger::new().init().unwrap();
+    tracing_subscriber::fmt::init();
 
     let mut window = None;
 

--- a/examples/run_on_demand.rs
+++ b/examples/run_on_demand.rs
@@ -5,8 +5,6 @@
 fn main() -> Result<(), impl std::error::Error> {
     use std::time::Duration;
 
-    use simple_logger::SimpleLogger;
-
     use winit::{
         error::EventLoopError,
         event::{Event, WindowEvent},
@@ -24,7 +22,7 @@ fn main() -> Result<(), impl std::error::Error> {
         window: Option<Window>,
     }
 
-    SimpleLogger::new().init().unwrap();
+    tracing_subscriber::fmt::init();
     let mut event_loop = EventLoop::new().unwrap();
 
     fn run_app(event_loop: &mut EventLoop<()>, idx: usize) -> Result<(), EventLoopError> {

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -3,8 +3,6 @@ use std::error::Error;
 
 #[cfg(x11_platform)]
 fn main() -> Result<(), Box<dyn Error>> {
-    use simple_logger::SimpleLogger;
-
     use winit::{
         event::{Event, WindowEvent},
         event_loop::EventLoop,
@@ -21,7 +19,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .ok_or("Expected a 32-bit X11 window ID as the first argument.")?
         .parse::<u32>()?;
 
-    SimpleLogger::new().init().unwrap();
+    tracing_subscriber::fmt::init();
     let event_loop = EventLoop::new()?;
 
     let mut window = None;

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -88,6 +88,15 @@ impl CustomCursor {
         hotspot_x: u16,
         hotspot_y: u16,
     ) -> Result<CustomCursorSource, BadImage> {
+        let _span = tracing::debug_span!(
+            "winit::Cursor::from_rgba",
+            width,
+            height,
+            hotspot_x,
+            hotspot_y
+        )
+        .entered();
+
         Ok(CustomCursorSource {
             inner: PlatformCustomCursorSource::from_rgba(
                 rgba.into(),

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -109,6 +109,8 @@ impl<T> EventLoopBuilder<T> {
     )]
     #[inline]
     pub fn build(&mut self) -> Result<EventLoop<T>, EventLoopError> {
+        let _span = tracing::debug_span!("winit::EventLoopBuilder::build").entered();
+
         if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
             return Err(EventLoopError::RecreationAttempt);
         }
@@ -248,6 +250,8 @@ impl<T> EventLoop<T> {
     where
         F: FnMut(Event<T>, &ActiveEventLoop),
     {
+        let _span = tracing::debug_span!("winit::EventLoop::run").entered();
+
         self.event_loop.run(event_handler)
     }
 
@@ -274,6 +278,12 @@ impl<T> EventLoop<T> {
     ///
     /// [`DeviceEvent`]: crate::event::DeviceEvent
     pub fn listen_device_events(&self, allowed: DeviceEvents) {
+        let _span = tracing::debug_span!(
+            "winit::EventLoop::listen_device_events",
+            allowed = ?allowed
+        )
+        .entered();
+
         self.event_loop
             .window_target()
             .p
@@ -295,6 +305,12 @@ impl<T> EventLoop<T> {
     #[deprecated = "use `ActiveEventLoop::create_window` instead"]
     #[inline]
     pub fn create_window(&self, window_attributes: WindowAttributes) -> Result<Window, OsError> {
+        let _span = tracing::debug_span!(
+            "winit::EventLoop::create_window",
+            window_attributes = ?window_attributes
+        )
+        .entered();
+
         let window =
             platform_impl::Window::new(&self.event_loop.window_target().p, window_attributes)?;
         Ok(Window { window })
@@ -363,18 +379,28 @@ impl ActiveEventLoop {
     ///   see the web platform module for more information.
     #[inline]
     pub fn create_window(&self, window_attributes: WindowAttributes) -> Result<Window, OsError> {
+        let _span = tracing::debug_span!(
+            "winit::ActiveEventLoop::create_window",
+            window_attributes = ?window_attributes
+        )
+        .entered();
+
         let window = platform_impl::Window::new(&self.p, window_attributes)?;
         Ok(Window { window })
     }
 
     /// Create custom cursor.
     pub fn create_custom_cursor(&self, custom_cursor: CustomCursorSource) -> CustomCursor {
+        let _span = tracing::debug_span!("winit::ActiveEventLoop::create_custom_cursor",).entered();
+
         self.p.create_custom_cursor(custom_cursor)
     }
 
     /// Returns the list of all the monitors available on the system.
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
+        let _span = tracing::debug_span!("winit::ActiveEventLoop::available_monitors",).entered();
+
         #[allow(clippy::useless_conversion)] // false positive on some platforms
         self.p
             .available_monitors()
@@ -391,6 +417,8 @@ impl ActiveEventLoop {
     /// **Wayland / Web:** Always returns `None`.
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        let _span = tracing::debug_span!("winit::ActiveEventLoop::primary_monitor",).entered();
+
         self.p
             .primary_monitor()
             .map(|inner| MonitorHandle { inner })
@@ -408,6 +436,12 @@ impl ActiveEventLoop {
     ///
     /// [`DeviceEvent`]: crate::event::DeviceEvent
     pub fn listen_device_events(&self, allowed: DeviceEvents) {
+        let _span = tracing::debug_span!(
+            "winit::ActiveEventLoop::listen_device_events",
+            allowed = ?allowed
+        )
+        .entered();
+
         self.p.listen_device_events(allowed);
     }
 
@@ -425,6 +459,8 @@ impl ActiveEventLoop {
     ///
     /// See [`LoopExiting`](Event::LoopExiting).
     pub fn exit(&self) {
+        let _span = tracing::debug_span!("winit::ActiveEventLoop::exit",).entered();
+
         self.p.exit()
     }
 
@@ -530,6 +566,8 @@ impl<T: 'static> EventLoopProxy<T> {
     ///
     /// [`UserEvent(event)`]: Event::UserEvent
     pub fn send_event(&self, event: T) -> Result<(), EventLoopClosed<T>> {
+        let _span = tracing::debug_span!("winit::EventLoopProxy::send_event",).entered();
+
         self.event_loop_proxy.send_event(event)
     }
 }

--- a/src/icon.rs
+++ b/src/icon.rs
@@ -118,6 +118,8 @@ impl Icon {
     /// The length of `rgba` must be divisible by 4, and `width * height` must equal
     /// `rgba.len() / 4`. Otherwise, this will return a `BadIcon` error.
     pub fn from_rgba(rgba: Vec<u8>, width: u32, height: u32) -> Result<Self, BadIcon> {
+        let _span = tracing::debug_span!("winit::Icon::from_rgba", width, height).entered();
+
         Ok(Icon {
             inner: PlatformIcon::from_rgba(rgba, width, height)?,
         })

--- a/src/platform_impl/android/keycodes.rs
+++ b/src/platform_impl/android/keycodes.rs
@@ -174,7 +174,7 @@ pub fn character_map_and_combine_key(
     let key_map = match app.device_key_character_map(device_id) {
         Ok(key_map) => key_map,
         Err(err) => {
-            log::warn!("Failed to look up `KeyCharacterMap` for device {device_id}: {err:?}");
+            tracing::warn!("Failed to look up `KeyCharacterMap` for device {device_id}: {err:?}");
             return None;
         }
     };
@@ -188,7 +188,7 @@ pub fn character_map_and_combine_key(
                         Ok(Some(key)) => Some(key),
                         Ok(None) => None,
                         Err(err) => {
-                            log::warn!("KeyEvent: Failed to combine 'dead key' accent '{accent}' with '{unicode}': {err:?}");
+                            tracing::warn!("KeyEvent: Failed to combine 'dead key' accent '{accent}' with '{unicode}': {err:?}");
                             None
                         }
                     }
@@ -213,7 +213,7 @@ pub fn character_map_and_combine_key(
             None
         }
         Err(err) => {
-            log::warn!("KeyEvent: Failed to get key map character: {err:?}");
+            tracing::warn!("KeyEvent: Failed to get key map character: {err:?}");
             *combining_accent = None;
             None
         }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -16,7 +16,7 @@ use android_activity::input::{InputEvent, KeyAction, Keycode, MotionAction};
 use android_activity::{
     AndroidApp, AndroidAppWaker, ConfigurationRef, InputStatus, MainEvent, Rect,
 };
-use log::{debug, trace, warn};
+use tracing::{debug, trace, warn};
 
 use crate::{
     cursor::Cursor,
@@ -330,7 +330,7 @@ impl<T: 'static> EventLoop<T> {
                 }
             },
             Err(err) => {
-                log::warn!("Failed to get input events iterator: {err:?}");
+                tracing::warn!("Failed to get input events iterator: {err:?}");
             }
         }
 
@@ -1014,7 +1014,7 @@ impl Window {
         if let Some(native_window) = self.app.native_window().as_ref() {
             native_window.raw_window_handle()
         } else {
-            log::error!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
+            tracing::error!("Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.");
             Err(rwh_06::HandleError::Unavailable)
         }
     }

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -622,9 +622,9 @@ pub(crate) fn handle_nonuser_events<I: IntoIterator<Item = EventWrapper>>(
         match wrapper {
             EventWrapper::StaticEvent(event) => {
                 if !processing_redraws && event.is_redraw() {
-                    log::info!("processing `RedrawRequested` during the main event loop");
+                    tracing::info!("processing `RedrawRequested` during the main event loop");
                 } else if processing_redraws && !event.is_redraw() {
-                    log::warn!(
+                    tracing::warn!(
                         "processing non `RedrawRequested` event after the main event loop: {:#?}",
                         event
                     );
@@ -676,9 +676,9 @@ pub(crate) fn handle_nonuser_events<I: IntoIterator<Item = EventWrapper>>(
             match wrapper {
                 EventWrapper::StaticEvent(event) => {
                     if !processing_redraws && event.is_redraw() {
-                        log::info!("processing `RedrawRequested` during the main event loop");
+                        tracing::info!("processing `RedrawRequested` during the main event loop");
                     } else if processing_redraws && !event.is_redraw() {
-                        log::warn!(
+                        tracing::warn!(
                             "processing non-`RedrawRequested` event after the main event loop: {:#?}",
                             event
                         );
@@ -911,7 +911,7 @@ macro_rules! os_capabilities {
         impl OSCapabilities {$(
             $(#[$attr])*
             pub fn $error_name(&self, extra_msg: &str) {
-                log::warn!(
+                tracing::warn!(
                     concat!("`", $objc_call, "` requires iOS {}.{}+. This device is running iOS {}.{}.{}. {}"),
                     $major, $minor, self.os_version.majorVersion, self.os_version.minorVersion, self.os_version.patchVersion,
                     extra_msg

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -85,7 +85,7 @@ impl ActiveEventLoop {
     pub(crate) fn exit(&self) {
         // https://developer.apple.com/library/archive/qa/qa1561/_index.html
         // it is not possible to quit an iOS app gracefully and programmatically
-        log::warn!("`ControlFlow::Exit` ignored on iOS");
+        tracing::warn!("`ControlFlow::Exit` ignored on iOS");
     }
 
     pub(crate) fn exiting(&self) -> bool {

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -3,10 +3,10 @@
 use std::collections::VecDeque;
 
 use icrate::Foundation::{CGFloat, CGPoint, CGRect, CGSize, MainThreadBound, MainThreadMarker};
-use log::{debug, warn};
 use objc2::rc::Id;
 use objc2::runtime::{AnyObject, NSObject};
 use objc2::{class, declare_class, msg_send, msg_send_id, mutability, ClassType, DeclaredClass};
+use tracing::{debug, warn};
 
 use super::app_state::EventWrapper;
 use super::uikit::{

--- a/src/platform_impl/linux/common/xkb/mod.rs
+++ b/src/platform_impl/linux/common/xkb/mod.rs
@@ -4,10 +4,10 @@ use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use crate::utils::Lazy;
-use log::warn;
 use smol_str::SmolStr;
 #[cfg(wayland_platform)]
 use std::os::unix::io::OwnedFd;
+use tracing::warn;
 use xkbcommon_dl::{
     self as xkb, xkb_compose_status, xkb_context, xkb_context_flags, xkbcommon_compose_handle,
     xkbcommon_handle, XkbCommon, XkbCommonCompose,
@@ -451,7 +451,7 @@ fn byte_slice_to_smol_str(bytes: &[u8]) -> Option<SmolStr> {
     std::str::from_utf8(bytes)
         .map(SmolStr::new)
         .map_err(|e| {
-            log::warn!(
+            tracing::warn!(
                 "UTF-8 received from libxkbcommon ({:?}) was invalid: {e}",
                 bytes
             )

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -687,7 +687,7 @@ unsafe extern "C" fn x_error_callback(
 
         // Don't log error.
         if !error_handled {
-            log::error!("X11 error: {:#?}", error);
+            tracing::error!("X11 error: {:#?}", error);
             // XXX only update the error, if it wasn't handled by any of the hooks.
             *xconn.latest_error.lock().unwrap() = Some(error);
         }

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -584,7 +584,7 @@ impl<T: 'static> EventLoop<T> {
         };
 
         self.event_loop.dispatch(timeout, state).map_err(|error| {
-            log::error!("Error dispatching event loop: {}", error);
+            tracing::error!("Error dispatching event loop: {}", error);
             error.into()
         })
     }

--- a/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use calloop::timer::{TimeoutAction, Timer};
 use calloop::{LoopHandle, RegistrationToken};
-use log::warn;
+use tracing::warn;
 
 use sctk::reexports::client::protocol::wl_keyboard::WlKeyboard;
 use sctk::reexports::client::protocol::wl_keyboard::{

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -133,7 +133,7 @@ impl WinitState {
         ) {
             Ok(c) => Some(c),
             Err(e) => {
-                log::warn!("Subcompositor protocol not available, ignoring CSD: {e:?}");
+                tracing::warn!("Subcompositor protocol not available, ignoring CSD: {e:?}");
                 None
             }
         };

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -14,7 +14,7 @@ use sctk::shell::xdg::window::Window as SctkWindow;
 use sctk::shell::xdg::window::WindowDecorations;
 use sctk::shell::WaylandSurface;
 
-use log::warn;
+use tracing::warn;
 
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -5,7 +5,7 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
 use ahash::HashSet;
-use log::{info, warn};
+use tracing::{info, warn};
 
 use sctk::reexports::client::backend::ObjectId;
 use sctk::reexports::client::protocol::wl_seat::WlSeat;
@@ -727,7 +727,7 @@ impl WindowState {
             RootCustomCursor {
                 inner: PlatformCustomCursor::X(_),
             } => {
-                log::error!("passed a X11 cursor to Wayland backend");
+                tracing::error!("passed a X11 cursor to Wayland backend");
                 return;
             }
         };

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -86,7 +86,7 @@ extern "C" fn preedit_draw_callback(
     let chg_range =
         call_data.chg_first as usize..(call_data.chg_first + call_data.chg_length) as usize;
     if chg_range.start > client_data.text.len() || chg_range.end > client_data.text.len() {
-        log::warn!(
+        tracing::warn!(
             "invalid chg range: buffer length={}, but chg_first={} chg_lengthg={}",
             client_data.text.len(),
             call_data.chg_first,

--- a/src/platform_impl/linux/x11/ime/mod.rs
+++ b/src/platform_impl/linux/x11/ime/mod.rs
@@ -10,9 +10,9 @@ use std::sync::{
     Arc,
 };
 
-use log::debug;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use super::{ffi, util, XConnection, XError};
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -18,7 +18,7 @@ use calloop::generic::Generic;
 use calloop::EventLoop as Loop;
 use calloop::{ping::Ping, Readiness};
 use libc::{setlocale, LC_CTYPE};
-use log::warn;
+use tracing::warn;
 
 use x11rb::connection::RequestConnection;
 use x11rb::errors::{ConnectError, ConnectionError, IdsExhausted, ReplyError};
@@ -483,7 +483,7 @@ impl<T: 'static> EventLoop<T> {
             .dispatch(timeout, &mut self.state)
             .map_err(std::io::Error::from)
         {
-            log::error!("Failed to poll for events: {error:?}");
+            tracing::error!("Failed to poll for events: {error:?}");
             let exit_code = error.raw_os_error().unwrap_or(1);
             self.set_exit_code(exit_code);
             return;
@@ -567,7 +567,7 @@ impl<T: 'static> EventLoop<T> {
                     callback(event, &self.event_processor.target)
                 }
                 Some(Err(e)) => {
-                    log::error!("Failed to get activation token: {}", e);
+                    tracing::error!("Failed to get activation token: {}", e);
                 }
                 None => {}
             }

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -45,7 +45,7 @@ impl XConnection {
             self.flush_requests()?;
             Ok(true)
         } else {
-            log::error!("Could not select XKB events: The XKB extension is not initialized!");
+            tracing::error!("Could not select XKB events: The XKB extension is not initialized!");
             Ok(false)
         }
     }

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -4,7 +4,7 @@ use super::*;
 use crate::platform_impl::platform::x11::monitor;
 use crate::{dpi::validate_scale_factor, platform_impl::platform::x11::VideoModeHandle};
 
-use log::warn;
+use tracing::warn;
 use x11rb::protocol::randr::{self, ConnectionExt as _};
 
 /// Represents values of `WINIT_HIDPI_FACTOR`.
@@ -44,7 +44,7 @@ impl XConnection {
                 Ok(Some(dpi)) => return Some(dpi),
                 Ok(None) => {}
                 Err(err) => {
-                    log::warn!("failed to fetch XSettings: {err}");
+                    tracing::warn!("failed to fetch XSettings: {err}");
                 }
             }
         }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -7,7 +7,7 @@ use std::{
     sync::{Arc, Mutex, MutexGuard},
 };
 
-use log::{debug, info, warn};
+use tracing::{debug, info, warn};
 use x11rb::{
     connection::Connection,
     properties::{WmHints, WmSizeHints, WmSizeHintsSpecification},
@@ -1573,7 +1573,7 @@ impl UnownedWindow {
             #[cfg(wayland_platform)]
             Cursor::Custom(RootCustomCursor {
                 inner: PlatformCustomCursor::Wayland(_),
-            }) => log::error!("passed a Wayland cursor to X11 backend"),
+            }) => tracing::error!("passed a Wayland cursor to X11 backend"),
         }
     }
 
@@ -1857,7 +1857,7 @@ impl UnownedWindow {
                 )
                 .expect_then_ignore_error("Failed to send client message");
             if let Err(e) = self.xconn.flush_requests() {
-                log::error!(
+                tracing::error!(
                     "`flush` returned an error when focusing the window. Error was: {}",
                     e
                 );

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -121,7 +121,7 @@ impl XConnection {
 
         let xsettings_screen = Self::new_xsettings_screen(&xcb, default_screen);
         if xsettings_screen.is_none() {
-            log::warn!("error setting XSETTINGS; Xft options won't reload automatically")
+            tracing::warn!("error setting XSETTINGS; Xft options won't reload automatically")
         }
 
         // Fetch atoms.

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -471,10 +471,10 @@ fn window_activation_hack(app: &NSApplication) {
         // This way we preserve the user's desired initial visibility status
         // TODO: Also filter on the type/"level" of the window, and maybe other things?
         if window.isVisible() {
-            log::trace!("Activating visible window");
+            tracing::trace!("Activating visible window");
             window.makeKeyAndOrderFront(None);
         } else {
-            log::trace!("Skipping activating invisible window");
+            tracing::trace!("Skipping activating invisible window");
         }
     })
 }

--- a/src/platform_impl/macos/cursor.rs
+++ b/src/platform_impl/macos/cursor.rs
@@ -71,7 +71,7 @@ unsafe fn try_cursor_from_selector(sel: Sel) -> Option<Id<NSCursor>> {
         let cursor: Id<NSCursor> = unsafe { msg_send_id![cls, performSelector: sel] };
         Some(cursor)
     } else {
-        log::warn!("cursor `{sel}` appears to be invalid");
+        tracing::warn!("cursor `{sel}` appears to be invalid");
         None
     }
 }

--- a/src/platform_impl/macos/event.rs
+++ b/src/platform_impl/macos/event.rs
@@ -36,14 +36,14 @@ pub fn get_modifierless_char(scancode: u16) -> Key {
     unsafe {
         input_source = ffi::TISCopyCurrentKeyboardLayoutInputSource();
         if input_source.is_null() {
-            log::error!("`TISCopyCurrentKeyboardLayoutInputSource` returned null ptr");
+            tracing::error!("`TISCopyCurrentKeyboardLayoutInputSource` returned null ptr");
             return Key::Unidentified(NativeKey::MacOS(scancode));
         }
         let layout_data =
             ffi::TISGetInputSourceProperty(input_source, ffi::kTISPropertyUnicodeKeyLayoutData);
         if layout_data.is_null() {
             CFRelease(input_source as *mut c_void);
-            log::error!("`TISGetInputSourceProperty` returned null ptr");
+            tracing::error!("`TISGetInputSourceProperty` returned null ptr");
             return Key::Unidentified(NativeKey::MacOS(scancode));
         }
         layout = CFDataGetBytePtr(layout_data as CFDataRef) as *const ffi::UCKeyboardLayout;
@@ -71,7 +71,7 @@ pub fn get_modifierless_char(scancode: u16) -> Key {
         CFRelease(input_source as *mut c_void);
     }
     if translate_result != 0 {
-        log::error!(
+        tracing::error!(
             "`UCKeyTranslate` returned with the non-zero value: {}",
             translate_result
         );

--- a/src/platform_impl/macos/event_handler.rs
+++ b/src/platform_impl/macos/event_handler.rs
@@ -71,7 +71,7 @@ impl EventHandler {
                         *data = None;
                     }
                     Ok(None) => {
-                        log::error!("tried to clear handler, but no handler was set");
+                        tracing::error!("tried to clear handler, but no handler was set");
                     }
                     Err(_) => {
                         // Note: This is not expected to ever happen, this
@@ -125,7 +125,7 @@ impl EventHandler {
                 // `NSApplication`, our app delegate and this handler are all
                 // global state and so it's not impossible that we could get
                 // an event after the application has exited the `EventLoop`.
-                log::error!("tried to run event handler, but no handler was set");
+                tracing::error!("tried to run event handler, but no handler was set");
             }
             Err(_) => {
                 // Prevent re-entrancy.

--- a/src/platform_impl/macos/util.rs
+++ b/src/platform_impl/macos/util.rs
@@ -1,5 +1,5 @@
 use icrate::Foundation::{NSNotFound, NSRange, NSUInteger};
-use log::trace;
+use tracing::trace;
 
 pub const EMPTY_RANGE: NSRange = NSRange {
     location: NSNotFound as NSUInteger,
@@ -20,7 +20,7 @@ pub(crate) struct TraceGuard {
 impl TraceGuard {
     #[inline]
     pub(crate) fn new(module_path: &'static str, called_from_fn: &'static str) -> Self {
-        trace!(target: module_path, "Triggered `{}`", called_from_fn);
+        trace!(target = module_path, "Triggered `{}`", called_from_fn);
         Self {
             module_path,
             called_from_fn,
@@ -31,6 +31,10 @@ impl TraceGuard {
 impl Drop for TraceGuard {
     #[inline]
     fn drop(&mut self) {
-        trace!(target: self.module_path, "Completed `{}`", self.called_from_fn);
+        trace!(
+            target = self.module_path,
+            "Completed `{}`",
+            self.called_from_fn
+        );
     }
 }

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -338,7 +338,7 @@ declare_class!(
                 // Leave the Preedit self.ivars()
                 self.ivars().ime_state.set(ImeState::Ground);
             } else {
-                log::warn!("Expected to have IME enabled when receiving unmarkText");
+                tracing::warn!("Expected to have IME enabled when receiving unmarkText");
             }
         }
 

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -537,7 +537,7 @@ impl<T: 'static> EventLoop<T> {
                 }
             }
             other => {
-                log::warn!("unhandled event: {:?}", other);
+                tracing::warn!("unhandled event: {:?}", other);
             }
         }
     }

--- a/src/platform_impl/web/cursor.rs
+++ b/src/platform_impl/web/cursor.rs
@@ -301,7 +301,9 @@ impl CursorHandler {
                         };
                     }
                     ImageState::Failed(error) => {
-                        log::error!("trying to load custom cursor that has failed to load: {error}")
+                        tracing::error!(
+                            "trying to load custom cursor that has failed to load: {error}"
+                        )
                     }
                     ImageState::Image(_) => {
                         drop(state);
@@ -413,7 +415,7 @@ impl Inner {
                 self.set_style();
             }
             ImageState::Failed(error) => {
-                log::error!("custom cursor failed to load: {error}");
+                tracing::error!("custom cursor failed to load: {error}");
                 self.cursor = previous.into()
             }
             ImageState::Loading { .. } => unreachable!("notified without being ready"),

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -190,7 +190,7 @@ pub fn key_location(event: &KeyboardEvent) -> KeyLocation {
         KeyboardEvent::DOM_KEY_LOCATION_NUMPAD => KeyLocation::Numpad,
         KeyboardEvent::DOM_KEY_LOCATION_STANDARD => KeyLocation::Standard,
         location => {
-            log::warn!("Unexpected key location: {location}");
+            tracing::warn!("Unexpected key location: {location}");
             KeyLocation::Standard
         }
     }

--- a/src/platform_impl/web/web_sys/resize_scaling.rs
+++ b/src/platform_impl/web/web_sys/resize_scaling.rs
@@ -1,5 +1,5 @@
 use js_sys::{Array, Object};
-use log::warn;
+use tracing::warn;
 use wasm_bindgen::prelude::{wasm_bindgen, Closure};
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -18,7 +18,7 @@ use windows_sys::{
     },
 };
 
-use log::debug;
+use tracing::debug;
 
 use crate::platform_impl::platform::{
     definitions::{IDataObjectVtbl, IDropTarget, IDropTargetVtbl, IUnknownVtbl},

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -536,7 +536,7 @@ impl ActiveEventLoop {
         let inner = match WinCursor::new(&source.inner.0) {
             Ok(cursor) => cursor,
             Err(err) => {
-                log::warn!("Failed to create custom cursor: {err}");
+                tracing::warn!("Failed to create custom cursor: {err}");
                 WinCursor::Failed
             }
         };

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -32,8 +32,8 @@ use windows_sys::Win32::{
     },
 };
 
-use log::{trace, warn};
 use smol_str::SmolStr;
+use tracing::{trace, warn};
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -236,7 +236,7 @@ impl MonitorHandle {
         let monitor_info = match get_monitor_info(self.0) {
             Ok(monitor_info) => monitor_info,
             Err(error) => {
-                log::warn!("Error from get_monitor_info: {error}");
+                tracing::warn!("Error from get_monitor_info: {error}");
                 return modes.into_iter().map(mod_map);
             }
         };

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -59,7 +59,7 @@ use windows_sys::Win32::{
     },
 };
 
-use log::warn;
+use tracing::warn;
 
 use crate::{
     cursor::Cursor,

--- a/src/window.rs
+++ b/src/window.rs
@@ -528,6 +528,8 @@ impl Window {
     /// Returns an identifier unique to the window.
     #[inline]
     pub fn id(&self) -> WindowId {
+        let _span = tracing::debug_span!("winit::Window::id",).entered();
+
         self.window.maybe_wait_on_main(|w| WindowId(w.id()))
     }
 
@@ -591,6 +593,8 @@ impl Window {
     /// [`contentScaleFactor`]: https://developer.apple.com/documentation/uikit/uiview/1622657-contentscalefactor?language=objc
     #[inline]
     pub fn scale_factor(&self) -> f64 {
+        let _span = tracing::debug_span!("winit::Window::scale_factor",).entered();
+
         self.window.maybe_wait_on_main(|w| w.scale_factor())
     }
 
@@ -622,6 +626,8 @@ impl Window {
     /// [`WindowEvent::RedrawRequested`]: crate::event::WindowEvent::RedrawRequested
     #[inline]
     pub fn request_redraw(&self) {
+        let _span = tracing::debug_span!("winit::Window::request_redraw",).entered();
+
         self.window.maybe_queue_on_main(|w| w.request_redraw())
     }
 
@@ -658,6 +664,8 @@ impl Window {
     /// [`WindowEvent::RedrawRequested`]: crate::event::WindowEvent::RedrawRequested
     #[inline]
     pub fn pre_present_notify(&self) {
+        let _span = tracing::debug_span!("winit::Window::pre_present_notify",).entered();
+
         self.window.maybe_queue_on_main(|w| w.pre_present_notify());
     }
 
@@ -674,6 +682,8 @@ impl Window {
     // at least, then this function should be provided through a platform specific
     // extension trait
     pub fn reset_dead_keys(&self) {
+        let _span = tracing::debug_span!("winit::Window::reset_dead_keys",).entered();
+
         self.window.maybe_queue_on_main(|w| w.reset_dead_keys())
     }
 }
@@ -696,6 +706,8 @@ impl Window {
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+        let _span = tracing::debug_span!("winit::Window::inner_position",).entered();
+
         self.window.maybe_wait_on_main(|w| w.inner_position())
     }
 
@@ -717,6 +729,8 @@ impl Window {
     /// - **Android / Wayland:** Always returns [`NotSupportedError`].
     #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+        let _span = tracing::debug_span!("winit::Window::outer_position",).entered();
+
         self.window.maybe_wait_on_main(|w| w.outer_position())
     }
 
@@ -749,6 +763,12 @@ impl Window {
     #[inline]
     pub fn set_outer_position<P: Into<Position>>(&self, position: P) {
         let position = position.into();
+        let _span = tracing::debug_span!(
+            "winit::Window::set_outer_position",
+            position = ?position
+        )
+        .entered();
+
         self.window
             .maybe_queue_on_main(move |w| w.set_outer_position(position))
     }
@@ -767,6 +787,8 @@ impl Window {
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
+        let _span = tracing::debug_span!("winit::Window::inner_size",).entered();
+
         self.window.maybe_wait_on_main(|w| w.inner_size())
     }
 
@@ -808,6 +830,11 @@ impl Window {
     #[must_use]
     pub fn request_inner_size<S: Into<Size>>(&self, size: S) -> Option<PhysicalSize<u32>> {
         let size = size.into();
+        let _span = tracing::debug_span!(
+            "winit::Window::request_inner_size",
+            size = ?size
+        )
+        .entered();
         self.window
             .maybe_wait_on_main(|w| w.request_inner_size(size))
     }
@@ -825,6 +852,7 @@ impl Window {
     ///   [`Window::inner_size`]._
     #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
+        let _span = tracing::debug_span!("winit::Window::outer_size",).entered();
         self.window.maybe_wait_on_main(|w| w.outer_size())
     }
 
@@ -848,6 +876,11 @@ impl Window {
     #[inline]
     pub fn set_min_inner_size<S: Into<Size>>(&self, min_size: Option<S>) {
         let min_size = min_size.map(|s| s.into());
+        let _span = tracing::debug_span!(
+            "winit::Window::set_min_inner_size",
+            min_size = ?min_size
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_min_inner_size(min_size))
     }
@@ -872,6 +905,11 @@ impl Window {
     #[inline]
     pub fn set_max_inner_size<S: Into<Size>>(&self, max_size: Option<S>) {
         let max_size = max_size.map(|s| s.into());
+        let _span = tracing::debug_span!(
+            "winit::Window::max_size",
+            max_size = ?max_size
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_max_inner_size(max_size))
     }
@@ -883,6 +921,7 @@ impl Window {
     /// - **iOS / Android / Web / Wayland / Windows / Orbital:** Always returns [`None`].
     #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+        let _span = tracing::debug_span!("winit::Window::resize_increments",).entered();
         self.window.maybe_wait_on_main(|w| w.resize_increments())
     }
 
@@ -899,6 +938,11 @@ impl Window {
     #[inline]
     pub fn set_resize_increments<S: Into<Size>>(&self, increments: Option<S>) {
         let increments = increments.map(Into::into);
+        let _span = tracing::debug_span!(
+            "winit::Window::set_resize_increments",
+            increments = ?increments
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_resize_increments(increments))
     }
@@ -913,6 +957,7 @@ impl Window {
     /// - **iOS / Android:** Unsupported.
     #[inline]
     pub fn set_title(&self, title: &str) {
+        let _span = tracing::debug_span!("winit::Window::set_title", title).entered();
         self.window.maybe_wait_on_main(|w| w.set_title(title))
     }
 
@@ -931,6 +976,7 @@ impl Window {
     /// - **X11:** Can only be set while building the window, with [`WindowAttributes::with_transparent`].
     #[inline]
     pub fn set_transparent(&self, transparent: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_transparent", transparent).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_transparent(transparent))
     }
@@ -945,6 +991,7 @@ impl Window {
     /// - **Wayland:** Only works with org_kde_kwin_blur_manager protocol.
     #[inline]
     pub fn set_blur(&self, blur: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_blur", blur).entered();
         self.window.maybe_queue_on_main(move |w| w.set_blur(blur))
     }
 
@@ -958,6 +1005,7 @@ impl Window {
     /// - **iOS:** Can only be called on the main thread.
     #[inline]
     pub fn set_visible(&self, visible: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_visible", visible).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_visible(visible))
     }
@@ -972,6 +1020,7 @@ impl Window {
     /// - **Wayland / iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn is_visible(&self) -> Option<bool> {
+        let _span = tracing::debug_span!("winit::Window::is_visible",).entered();
         self.window.maybe_wait_on_main(|w| w.is_visible())
     }
 
@@ -991,6 +1040,7 @@ impl Window {
     /// [`WindowEvent::Resized`]: crate::event::WindowEvent::Resized
     #[inline]
     pub fn set_resizable(&self, resizable: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_resizable", resizable).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_resizable(resizable))
     }
@@ -1003,6 +1053,7 @@ impl Window {
     /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn is_resizable(&self) -> bool {
+        let _span = tracing::debug_span!("winit::Window::is_resizable",).entered();
         self.window.maybe_wait_on_main(|w| w.is_resizable())
     }
 
@@ -1013,6 +1064,11 @@ impl Window {
     /// - **Wayland / X11 / Orbital:** Not implemented.
     /// - **Web / iOS / Android:** Unsupported.
     pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
+        let _span = tracing::debug_span!(
+            "winit::Window::set_enabled_buttons",
+            buttons = ?buttons
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_enabled_buttons(buttons))
     }
@@ -1024,6 +1080,7 @@ impl Window {
     /// - **Wayland / X11 / Orbital:** Not implemented. Always returns [`WindowButtons::all`].
     /// - **Web / iOS / Android:** Unsupported. Always returns [`WindowButtons::all`].
     pub fn enabled_buttons(&self) -> WindowButtons {
+        let _span = tracing::debug_span!("winit::Window::enabled_buttons",).entered();
         self.window.maybe_wait_on_main(|w| w.enabled_buttons())
     }
 
@@ -1035,6 +1092,7 @@ impl Window {
     /// - **Wayland:** Un-minimize is unsupported.
     #[inline]
     pub fn set_minimized(&self, minimized: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_minimized", minimized).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_minimized(minimized))
     }
@@ -1053,6 +1111,7 @@ impl Window {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
+        let _span = tracing::debug_span!("winit::Window::is_minimized",).entered();
         self.window.maybe_wait_on_main(|w| w.is_minimized())
     }
 
@@ -1063,6 +1122,7 @@ impl Window {
     /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_maximized", maximized).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_maximized(maximized))
     }
@@ -1074,6 +1134,7 @@ impl Window {
     /// - **iOS / Android / Web:** Unsupported.
     #[inline]
     pub fn is_maximized(&self) -> bool {
+        let _span = tracing::debug_span!("winit::Window::is_maximized",).entered();
         self.window.maybe_wait_on_main(|w| w.is_maximized())
     }
 
@@ -1102,6 +1163,11 @@ impl Window {
     /// [transient activation]: https://developer.mozilla.org/en-US/docs/Glossary/Transient_activation
     #[inline]
     pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
+        let _span = tracing::debug_span!(
+            "winit::Window::set_fullscreen",
+            fullscreen = ?fullscreen
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_fullscreen(fullscreen.map(|f| f.into())))
     }
@@ -1116,6 +1182,7 @@ impl Window {
     /// - **Web:** Can only return `None` or `Borderless(None)`.
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
+        let _span = tracing::debug_span!("winit::Window::fullscreen",).entered();
         self.window
             .maybe_wait_on_main(|w| w.fullscreen().map(|f| f.into()))
     }
@@ -1131,6 +1198,7 @@ impl Window {
     /// - **iOS / Android / Web:** No effect.
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_decorations", decorations).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_decorations(decorations))
     }
@@ -1145,6 +1213,7 @@ impl Window {
     /// - **iOS / Android / Web:** Always returns `true`.
     #[inline]
     pub fn is_decorated(&self) -> bool {
+        let _span = tracing::debug_span!("winit::Window::is_decorated",).entered();
         self.window.maybe_wait_on_main(|w| w.is_decorated())
     }
 
@@ -1154,6 +1223,11 @@ impl Window {
     ///
     /// See [`WindowLevel`] for details.
     pub fn set_window_level(&self, level: WindowLevel) {
+        let _span = tracing::debug_span!(
+            "winit::Window::set_window_level",
+            level = ?level
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_window_level(level))
     }
@@ -1174,6 +1248,7 @@ impl Window {
     ///   said, it's usually in the same ballpark as on Windows.
     #[inline]
     pub fn set_window_icon(&self, window_icon: Option<Icon>) {
+        let _span = tracing::debug_span!("winit::Window::set_window_icon",).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_window_icon(window_icon))
     }
@@ -1216,6 +1291,12 @@ impl Window {
     pub fn set_ime_cursor_area<P: Into<Position>, S: Into<Size>>(&self, position: P, size: S) {
         let position = position.into();
         let size = size.into();
+        let _span = tracing::debug_span!(
+            "winit::Window::set_ime_cursor_area",
+            position = ?position,
+            size = ?size,
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_ime_cursor_area(position, size))
     }
@@ -1242,6 +1323,7 @@ impl Window {
     /// [`KeyboardInput`]: crate::event::WindowEvent::KeyboardInput
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_ime_allowed", allowed).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_ime_allowed(allowed))
     }
@@ -1253,6 +1335,11 @@ impl Window {
     /// - **iOS / Android / Web / Windows / X11 / macOS / Orbital:** Unsupported.
     #[inline]
     pub fn set_ime_purpose(&self, purpose: ImePurpose) {
+        let _span = tracing::debug_span!(
+            "winit::Window::set_ime_purpose",
+            purpose = ?purpose
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_ime_purpose(purpose))
     }
@@ -1269,6 +1356,7 @@ impl Window {
     /// - **iOS / Android / Wayland / Orbital:** Unsupported.
     #[inline]
     pub fn focus_window(&self) {
+        let _span = tracing::debug_span!("winit::Window::focus_window",).entered();
         self.window.maybe_queue_on_main(|w| w.focus_window())
     }
 
@@ -1279,6 +1367,7 @@ impl Window {
     /// [`WindowEvent::Focused`]: crate::event::WindowEvent::Focused
     #[inline]
     pub fn has_focus(&self) -> bool {
+        let _span = tracing::debug_span!("winit::Window::has_focus",).entered();
         self.window.maybe_wait_on_main(|w| w.has_focus())
     }
 
@@ -1297,6 +1386,11 @@ impl Window {
     /// - **Wayland:** Requires `xdg_activation_v1` protocol, `None` has no effect.
     #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
+        let _span = tracing::debug_span!(
+            "winit::Window::request_user_attention",
+            request_type = ?request_type
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.request_user_attention(request_type))
     }
@@ -1312,6 +1406,11 @@ impl Window {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     #[inline]
     pub fn set_theme(&self, theme: Option<Theme>) {
+        let _span = tracing::debug_span!(
+            "winit::Window::set_theme",
+            theme = ?theme
+        )
+        .entered();
         self.window.maybe_queue_on_main(move |w| w.set_theme(theme))
     }
 
@@ -1323,6 +1422,7 @@ impl Window {
     /// - **iOS / Android / Wayland / x11 / Orbital:** Unsupported.
     #[inline]
     pub fn theme(&self) -> Option<Theme> {
+        let _span = tracing::debug_span!("winit::Window::theme",).entered();
         self.window.maybe_wait_on_main(|w| w.theme())
     }
 
@@ -1336,6 +1436,8 @@ impl Window {
     ///
     /// [`NSWindowSharingNone`]: https://developer.apple.com/documentation/appkit/nswindowsharingtype/nswindowsharingnone
     pub fn set_content_protected(&self, protected: bool) {
+        let _span =
+            tracing::debug_span!("winit::Window::set_content_protected", protected).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_content_protected(protected))
     }
@@ -1347,6 +1449,7 @@ impl Window {
     /// - **iOS / Android / x11 / Wayland / Web:** Unsupported. Always returns an empty string.
     #[inline]
     pub fn title(&self) -> String {
+        let _span = tracing::debug_span!("winit::Window::title",).entered();
         self.window.maybe_wait_on_main(|w| w.title())
     }
 }
@@ -1363,6 +1466,7 @@ impl Window {
     #[inline]
     pub fn set_cursor(&self, cursor: impl Into<Cursor>) {
         let cursor = cursor.into();
+        let _span = tracing::debug_span!("winit::Window::set_cursor",).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_cursor(cursor))
     }
@@ -1395,6 +1499,11 @@ impl Window {
     #[inline]
     pub fn set_cursor_position<P: Into<Position>>(&self, position: P) -> Result<(), ExternalError> {
         let position = position.into();
+        let _span = tracing::debug_span!(
+            "winit::Window::set_cursor_position",
+            position = ?position
+        )
+        .entered();
         self.window
             .maybe_wait_on_main(|w| w.set_cursor_position(position))
     }
@@ -1415,6 +1524,11 @@ impl Window {
     /// ```
     #[inline]
     pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
+        let _span = tracing::debug_span!(
+            "winit::Window::set_cursor_grab",
+            mode = ?mode
+        )
+        .entered();
         self.window.maybe_wait_on_main(|w| w.set_cursor_grab(mode))
     }
 
@@ -1432,6 +1546,7 @@ impl Window {
     /// - **iOS / Android:** Unsupported.
     #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
+        let _span = tracing::debug_span!("winit::Window::set_cursor_visible", visible).entered();
         self.window
             .maybe_queue_on_main(move |w| w.set_cursor_visible(visible))
     }
@@ -1449,6 +1564,7 @@ impl Window {
     /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
     #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
+        let _span = tracing::debug_span!("winit::Window::drag_window",).entered();
         self.window.maybe_wait_on_main(|w| w.drag_window())
     }
 
@@ -1463,6 +1579,11 @@ impl Window {
     /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
     #[inline]
     pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+        let _span = tracing::debug_span!(
+            "winit::Window::drag_resize_window",
+            direction = ?direction
+        )
+        .entered();
         self.window
             .maybe_wait_on_main(|w| w.drag_resize_window(direction))
     }
@@ -1478,6 +1599,11 @@ impl Window {
     /// [window menu]: https://en.wikipedia.org/wiki/Common_menus_in_Microsoft_Windows#System_menu
     pub fn show_window_menu(&self, position: impl Into<Position>) {
         let position = position.into();
+        let _span = tracing::debug_span!(
+            "winit::Window::show_window_menu",
+            position = ?position
+        )
+        .entered();
         self.window
             .maybe_queue_on_main(move |w| w.show_window_menu(position))
     }
@@ -1492,6 +1618,7 @@ impl Window {
     /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
     #[inline]
     pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
+        let _span = tracing::debug_span!("winit::Window::set_cursor_hittest", hittest).entered();
         self.window
             .maybe_wait_on_main(|w| w.set_cursor_hittest(hittest))
     }
@@ -1504,6 +1631,7 @@ impl Window {
     /// Returns `None` if current monitor can't be detected.
     #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
+        let _span = tracing::debug_span!("winit::Window::current_monitor",).entered();
         self.window
             .maybe_wait_on_main(|w| w.current_monitor().map(|inner| MonitorHandle { inner }))
     }
@@ -1515,6 +1643,7 @@ impl Window {
     /// [`ActiveEventLoop::available_monitors`]: crate::event_loop::ActiveEventLoop::available_monitors
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
+        let _span = tracing::debug_span!("winit::Window::available_monitors",).entered();
         self.window.maybe_wait_on_main(|w| {
             w.available_monitors()
                 .into_iter()
@@ -1535,6 +1664,7 @@ impl Window {
     /// [`ActiveEventLoop::primary_monitor`]: crate::event_loop::ActiveEventLoop::primary_monitor
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
+        let _span = tracing::debug_span!("winit::Window::primary_monitor",).entered();
         self.window
             .maybe_wait_on_main(|w| w.primary_monitor().map(|inner| MonitorHandle { inner }))
     }


### PR DESCRIPTION
Tracing is a modern replacement for the log crate that allows 
for annotating log messages with the function that they come from.

Closes #3482

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
