### PR TITLE
Fix nightly CI

### DIFF
--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -28,7 +28,7 @@ mod platform {
         // ManuallyDrop to prevent destructors from running.
         //
         // A static, thread-local map of graphics contexts to open windows.
-        static GC: ManuallyDrop<RefCell<Option<GraphicsContext>>> = ManuallyDrop::new(RefCell::new(None));
+        static GC: ManuallyDrop<RefCell<Option<GraphicsContext>>> = const { ManuallyDrop::new(RefCell::new(None)) };
     }
 
     /// The graphics context used to draw to a window.

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -17,6 +17,9 @@
 // incoming events (from the registered handlers) and ensuring they are passed to the user in a
 // compliant way.
 
+// TODO: FP, remove when <https://github.com/rust-lang/rust/issues/121621> is fixed.
+#![allow(unknown_lints, non_local_definitions)]
+
 mod r#async;
 mod cursor;
 mod device;

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -256,7 +256,7 @@ pub fn pointer_move_event(event: PointerEvent) -> impl Iterator<Item = PointerEv
 // See <https://github.com/rust-windowing/winit/issues/2875>.
 pub fn has_pointer_raw_support(window: &web_sys::Window) -> bool {
     thread_local! {
-        static POINTER_RAW_SUPPORT: OnceCell<bool> = OnceCell::new();
+        static POINTER_RAW_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
     }
 
     POINTER_RAW_SUPPORT.with(|support| {
@@ -279,7 +279,7 @@ pub fn has_pointer_raw_support(window: &web_sys::Window) -> bool {
 // See <https://bugs.webkit.org/show_bug.cgi?id=210454>.
 pub fn has_coalesced_events_support(event: &PointerEvent) -> bool {
     thread_local! {
-        static COALESCED_EVENTS_SUPPORT: OnceCell<bool> = OnceCell::new();
+        static COALESCED_EVENTS_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
     }
 
     COALESCED_EVENTS_SUPPORT.with(|support| {

--- a/src/platform_impl/web/web_sys/fullscreen.rs
+++ b/src/platform_impl/web/web_sys/fullscreen.rs
@@ -83,7 +83,7 @@ pub fn exit_fullscreen(document: &Document, canvas: &HtmlCanvasElement) {
 
 fn has_fullscreen_api_support(canvas: &HtmlCanvasElement) -> bool {
     thread_local! {
-        static FULLSCREEN_API_SUPPORT: OnceCell<bool> = OnceCell::new();
+        static FULLSCREEN_API_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
     }
 
     FULLSCREEN_API_SUPPORT.with(|support| {

--- a/src/platform_impl/web/web_sys/schedule.rs
+++ b/src/platform_impl/web/web_sys/schedule.rs
@@ -199,7 +199,7 @@ fn duration_millis_ceil(duration: Duration) -> u32 {
 
 fn has_scheduler_support(window: &web_sys::Window) -> bool {
     thread_local! {
-        static SCHEDULER_SUPPORT: OnceCell<bool> = OnceCell::new();
+        static SCHEDULER_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
     }
 
     SCHEDULER_SUPPORT.with(|support| {
@@ -221,7 +221,7 @@ fn has_scheduler_support(window: &web_sys::Window) -> bool {
 
 fn has_idle_callback_support(window: &web_sys::Window) -> bool {
     thread_local! {
-        static IDLE_CALLBACK_SUPPORT: OnceCell<bool> = OnceCell::new();
+        static IDLE_CALLBACK_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
     }
 
     IDLE_CALLBACK_SUPPORT.with(|support| {


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/3525.

Currently nightly fails because of FPs introduced by the new `non_local_definitions` lint.
FPs are tracked in https://github.com/rust-lang/rust/issues/121621.