### PR TITLE
Fix feature = "cargo-clippy" deprecation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(clippy::all)]
 #![deny(unsafe_op_in_unsafe_fn)]
-#![cfg_attr(feature = "cargo-clippy", deny(warnings))]
+#![cfg_attr(clippy, deny(warnings))]
 // Doc feature labels can be tested locally by running RUSTDOCFLAGS="--cfg=docsrs" cargo +nightly doc
 #![cfg_attr(
     docsrs,


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html