### PR TITLE
Web: fix crash with `ControlFlow::Wait|WaitUntil`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Unreleased` header.
 - **Breaking:** Removed `EventLoopBuilder::with_user_event`, the functionality is now available in `EventLoop::with_user_event`.
 - Add `Window::default_attributes` to get default `WindowAttributes`.
 - `log` has been replaced with `tracing`. The old behavior can be emulated by setting the `log` feature on the `tracing` crate.
+- On Web, fix possible crash with `ControlFlow::Wait` and `ControlFlow::WaitUntil`.
 
 # 0.29.12
 

--- a/src/platform_impl/web/web_sys/schedule.rs
+++ b/src/platform_impl/web/web_sys/schedule.rs
@@ -117,9 +117,7 @@ impl Schedule {
         let channel = MessageChannel::new().unwrap();
         let closure = Closure::new(f);
         let port_1 = channel.port1();
-        port_1
-            .add_event_listener_with_callback("message", closure.as_ref().unchecked_ref())
-            .expect("Failed to set message handler");
+        port_1.set_onmessage(Some(closure.as_ref().unchecked_ref()));
         port_1.start();
 
         let port_2 = channel.port2();
@@ -178,6 +176,7 @@ impl Drop for Schedule {
             } => {
                 window.clear_timeout_with_handle(*handle);
                 port.close();
+                port.set_onmessage(None);
             }
         }
     }


### PR DESCRIPTION
Apparently closing a `MessagePort` doesn't actually stop already delivered messages from triggering the message handler. So when we drop the message handler beforehand, it can cause a crash.