### PR TITLE
Fix incorrect delta filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Unreleased` header.
 - **Breaking:** Removed `EventLoopBuilder::with_user_event`, the functionality is now available in `EventLoop::with_user_event`.
 - Add `Window::default_attributes` to get default `WindowAttributes`.
 - `log` has been replaced with `tracing`. The old behavior can be emulated by setting the `log` feature on the `tracing` crate.
+- On X11, fix a bug where some mouse events would be unexpectedly filtered out.
 
 # 0.29.13
 

--- a/src/platform_impl/linux/x11/util/mouse.rs
+++ b/src/platform_impl/linux/x11/util/mouse.rs
@@ -30,8 +30,8 @@ macro_rules! consume {
         let this = $this;
         let (x, y) = match (this.x.abs() < <$ty>::EPSILON, this.y.abs() < <$ty>::EPSILON) {
             (true, true) => return None,
-            (true, false) => (this.x, 0.0),
-            (false, true) => (0.0, this.y),
+            (false, true) => (this.x, 0.0),
+            (true, false) => (0.0, this.y),
             (false, false) => (this.x, this.y),
         };
 


### PR DESCRIPTION
This fixes the incorrect delta filtering. Due to a bug in the filtering
code, it would incorrectly filter out the correct mouse delta rather
than the one below zero. This fixes the order of events.

----

Closes #3558

- [ ] Tested on all platforms changed
- [ ] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
