### PR TITLE
On Windows, confine cursor to center of window when grabbed and hidden

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -40,3 +40,4 @@
 - **Breaking:** Removed `EventLoopBuilder::with_user_event`, the functionality is now available in `EventLoop::with_user_event`.
 - Add `Window::default_attributes` to get default `WindowAttributes`.
 - `log` has been replaced with `tracing`. The old behavior can be emulated by setting the `log` feature on the `tracing` crate.
+- On Windows, confine cursor to center of window when grabbed and hidden.

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -510,7 +510,22 @@ impl CursorFlags {
 
         if util::is_focused(window) {
             let cursor_clip = match self.contains(CursorFlags::GRABBED) {
-                true => Some(client_rect),
+                true => {
+                    if self.contains(CursorFlags::HIDDEN) {
+                        // Confine the cursor to the center of the window if the cursor is hidden. This avoids
+                        // problems with the cursor activating the taskbar if the window borders or overlaps that.
+                        let cx = (client_rect.left + client_rect.right) / 2;
+                        let cy = (client_rect.top + client_rect.bottom) / 2;
+                        Some(RECT {
+                            left: cx,
+                            right: cx + 1,
+                            top: cy,
+                            bottom: cy + 1,
+                        })
+                    } else {
+                        Some(client_rect)
+                    }
+                }
                 false => None,
             };
 


### PR DESCRIPTION
This fixes issues where a hidden and grabbed cursor could leave the window and become visible on top of the windows taskbar (and potentially leave the window altogether if the taskbar is clicked) under at least two occasions:

- When a window is overlapping the taskbar.
- When a window is maximized and `Automatically hide the taskbar` has been enabled.

This approach of confining the cursor to the center of the window is used in SDL.

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
