### PR TITLE
Add typos - Source code spell checker 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,24 @@ jobs:
     - name: Check Formatting
       run: cargo fmt -- --check
 
+  typos:
+    name: Check for typos
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: typos-cli
+      - name: run typos
+        run: typos
+      - name: Typos info
+        if: failure()
+        run: |
+          echo 'To fix typos, please run `typos -w`'
+          echo 'To check for a diff, run `typos`'
+          echo 'You can find typos here: https://crates.io/crates/typos'
+
   tests:
     name: Test ${{ matrix.toolchain }} ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.os }}

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -392,7 +392,7 @@ impl ApplicationHandler<UserEvent> for Application {
                     println!("Preedit: {}, with caret at {:?}", text, caret_pos);
                 }
                 Ime::Commit(text) => {
-                    println!("Commited: {}", text);
+                    println!("Committed: {}", text);
                 }
                 Ime::Disabled => println!("IME disabled for Window={window_id:?}"),
             },

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -981,7 +981,7 @@ impl EventProcessor {
 
         // Always update the modifiers when we're not replaying.
         if !replay {
-            self.udpate_mods_from_core_event(window_id, xev.state as u16, &mut callback);
+            self.update_mods_from_core_event(window_id, xev.state as u16, &mut callback);
         }
 
         if keycode != 0 && !self.is_composing {
@@ -1778,7 +1778,7 @@ impl EventProcessor {
         self.send_modifiers(window_id, mods.into(), true, &mut callback)
     }
 
-    pub fn udpate_mods_from_core_event<T: 'static, F>(
+    pub fn update_mods_from_core_event<T: 'static, F>(
         &mut self,
         window_id: crate::window::WindowId,
         state: u16,

--- a/src/platform_impl/linux/x11/util/xmodmap.rs
+++ b/src/platform_impl/linux/x11/util/xmodmap.rs
@@ -16,7 +16,7 @@ const NUM_MODS: usize = 8;
 #[derive(Debug, Default)]
 pub struct ModifierKeymap {
     // Maps keycodes to modifiers
-    modifers: HashSet<XKeyCode>,
+    modifiers: HashSet<XKeyCode>,
 }
 
 impl ModifierKeymap {
@@ -25,7 +25,7 @@ impl ModifierKeymap {
     }
 
     pub fn is_modifier(&self, keycode: XKeyCode) -> bool {
-        self.modifers.contains(&keycode)
+        self.modifiers.contains(&keycode)
     }
 
     pub fn reload_from_x_connection(&mut self, xconn: &super::XConnection) {
@@ -48,9 +48,9 @@ impl ModifierKeymap {
         let keys = unsafe {
             slice::from_raw_parts(keymap.modifiermap as *const _, keys_per_mod * NUM_MODS)
         };
-        self.modifers.clear();
+        self.modifiers.clear();
         for key in keys {
-            self.modifers.insert(*key);
+            self.modifiers.insert(*key);
         }
     }
 }

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -159,7 +159,7 @@ impl XConnection {
 
         // Get PropertyNotify events from the XSETTINGS window.
         // TODO: The XSETTINGS window here can change. In the future, listen for DestroyNotify on this window
-        // in order to accomodate for a changed window here.
+        // in order to accommodate for a changed window here.
         let selector_window = xcb
             .get_selection_owner(xsettings_screen)
             .ok()?

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -45,12 +45,12 @@ impl ImeContext {
         let mut boundary_before_char = 0;
 
         for (attr, chr) in attrs.into_iter().zip(text.chars()) {
-            let char_is_targetted =
+            let char_is_targeted =
                 attr as u32 == ATTR_TARGET_CONVERTED || attr as u32 == ATTR_TARGET_NOTCONVERTED;
 
-            if first.is_none() && char_is_targetted {
+            if first.is_none() && char_is_targeted {
                 first = Some(boundary_before_char);
-            } else if first.is_some() && last.is_none() && !char_is_targetted {
+            } else if first.is_some() && last.is_none() && !char_is_targeted {
                 last = Some(boundary_before_char);
             }
 

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,6 @@
+# documentation: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default.extend-identifiers]
+ptd = "ptd"                         # From winwows_sys::Win32::System::Com::FORMATETC { ptd, ..}
+requestor = "requestor"             # From x11_dl::xlib::XSelectionEvent { requestor ..}
+XF86_Calculater = "XF86_Calculater" # From xkbcommon_dl::keysyms::XF86_Calculater


### PR DESCRIPTION
Same as https://github.com/rust-windowing/winit/pull/3557 but with [typos](https://github.com/crate-ci/typos)

Advantages:

 -  Fast to run on monorepos
 -  Low false positives so you can run on PRs

For reference typos is used in:
Bevy - https://github.com/bevyengine/bevy/pull/12036
Wgpu - https://github.com/gfx-rs/wgpu/pull/5191