### PR TITLE
chore(wayland): don't reapply same cursor grab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- On Wayland, don't reapply cursor grab when unchanged.
 - Move `dpi` types to its own crate, and re-export it from the root crate.
 - Implement `Sync` for `EventLoopProxy<T: Send>`.
 - **Breaking:** Move `Window::new` to `ActiveEventLoop::create_window` and `EventLoop::create_window` (with the latter being deprecated).

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -826,9 +826,14 @@ impl WindowState {
 
     /// Set the cursor grabbing state on the top-level.
     pub fn set_cursor_grab(&mut self, mode: CursorGrabMode) -> Result<(), ExternalError> {
-        // Replace the user grabbing mode.
+        if self.cursor_grab_mode.user_grab_mode == mode {
+            return Ok(());
+        }
+
+        self.set_cursor_grab_inner(mode)?;
+        // Update user grab on success.
         self.cursor_grab_mode.user_grab_mode = mode;
-        self.set_cursor_grab_inner(mode)
+        Ok(())
     }
 
     /// Reload the hints for minimum and maximum sizes.


### PR DESCRIPTION
Some compositors break when re-taking the same grab.

Closes: https://github.com/rust-windowing/winit/issues/3566

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
