### PR TITLE
Bump `x11-dl` to v2.19.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ wayland-backend = { version = "0.3.0", default_features = false, features = ["cl
 wayland-client = { version = "0.31.1", optional = true }
 wayland-protocols = { version = "0.31.0", features = [ "staging"], optional = true }
 wayland-protocols-plasma = { version = "0.2.0", features = [ "client" ], optional = true }
-x11-dl = { version = "2.18.5", optional = true }
+x11-dl = { version = "2.19.1", optional = true }
 x11rb = { version = "0.13.0", default-features = false, features = ["allow-unsafe-code", "dl-libxcb", "randr", "resource_manager", "xinput", "xkb"], optional = true }
 xkbcommon-dl = "0.4.2"
 


### PR DESCRIPTION
This bumps the minimal version of `x11-dl` required from v2.18.5 to v2.19.1, which is required by the changes made in #3507.
Thank you @paulcacheux for point this out.

Addresses https://github.com/rust-windowing/winit/pull/3507#issuecomment-1973316798.