### PR TITLE
fix(xkb): text not being None when composing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Unreleased` header.
 
 # Unreleased
 
+- On X11/Wayland, fix `text` and `text_with_all_modifiers` not being `None` during compose.
 - On Wayland, don't reapply cursor grab when unchanged.
 - Deprecate `EventLoop::run` in favor of `EventLoop::run_app`.
 - Deprecate `EventLoopExtRunOnDemand::run_on_demand` in favor of `EventLoop::run_app_on_demand`.

--- a/src/platform_impl/linux/common/xkb/mod.rs
+++ b/src/platform_impl/linux/common/xkb/mod.rs
@@ -373,10 +373,15 @@ impl<'a, 'b> KeyEventResults<'a, 'b> {
 
     fn composed_text(&mut self) -> Result<Option<SmolStr>, ()> {
         match self.compose {
-            ComposeStatus::Accepted(xkb_compose_status::XKB_COMPOSE_COMPOSED) => {
-                let state = self.context.compose_state1.as_mut().unwrap();
-                Ok(state.get_string(self.context.scratch_buffer))
-            }
+            ComposeStatus::Accepted(status) => match status {
+                xkb_compose_status::XKB_COMPOSE_COMPOSED => {
+                    let state = self.context.compose_state1.as_mut().unwrap();
+                    Ok(state.get_string(self.context.scratch_buffer))
+                }
+                xkb_compose_status::XKB_COMPOSE_COMPOSING
+                | xkb_compose_status::XKB_COMPOSE_CANCELLED => Ok(None),
+                xkb_compose_status::XKB_COMPOSE_NOTHING => Err(()),
+            },
             _ => Err(()),
         }
     }


### PR DESCRIPTION
When composing the text was not reset to `None` leading to input in some applications e.g. alacritty.

Links: https://github.com/alacritty/alacritty/issues/7806

- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
