### PR TITLE
bugfix(x11): crash when querying xsettings prop fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Unreleased` header.
 - **Breaking:** Removed `EventLoopBuilder::with_user_event`, the functionality is now available in `EventLoop::with_user_event`.
 - Add `Window::default_attributes` to get default `WindowAttributes`.
 - `log` has been replaced with `tracing`. The old behavior can be emulated by setting the `log` feature on the `tracing` crate.
+- On X11, fix crash due to xsettings query on systems with incomplete xsettings.
 
 # 0.29.14
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -887,6 +887,9 @@ pub enum X11Error {
 
     /// Unable to parse xsettings.
     XsettingsParse(xsettings::ParserError),
+
+    /// Failed to get property.
+    GetProperty(util::GetPropertyError),
 }
 
 impl fmt::Display for X11Error {
@@ -896,6 +899,7 @@ impl fmt::Display for X11Error {
             X11Error::Connect(e) => write!(f, "X11 connection error: {}", e),
             X11Error::Connection(e) => write!(f, "X11 connection error: {}", e),
             X11Error::XidsExhausted(e) => write!(f, "XID range exhausted: {}", e),
+            X11Error::GetProperty(e) => write!(f, "Failed to get X property {}", e),
             X11Error::X11(e) => write!(f, "X11 error: {:?}", e),
             X11Error::UnexpectedNull(s) => write!(f, "Xlib function returned null: {}", s),
             X11Error::InvalidActivationToken(s) => write!(
@@ -985,6 +989,12 @@ impl From<ReplyOrIdError> for X11Error {
 impl From<xsettings::ParserError> for X11Error {
     fn from(value: xsettings::ParserError) -> Self {
         Self::XsettingsParse(value)
+    }
+}
+
+impl From<util::GetPropertyError> for X11Error {
+    fn from(value: util::GetPropertyError) -> Self {
+        Self::GetProperty(value)
     }
 }
 

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -53,6 +53,7 @@ impl XConnection {
             .get_string("Xft.dpi", "")
             .and_then(|s| f64::from_str(s).ok())
     }
+
     pub fn get_output_info(
         &self,
         resources: &monitor::ScreenResources,

--- a/src/platform_impl/linux/x11/util/window_property.rs
+++ b/src/platform_impl/linux/x11/util/window_property.rs
@@ -1,24 +1,23 @@
-use super::*;
-use bytemuck::{NoUninit, Pod};
+use std::error::Error;
+use std::fmt;
 use std::sync::Arc;
+
+use bytemuck::{NoUninit, Pod};
 
 use x11rb::connection::Connection;
 use x11rb::errors::ReplyError;
 
-pub type Cardinal = u32;
+use super::*;
+
 pub const CARDINAL_SIZE: usize = mem::size_of::<u32>();
+
+pub type Cardinal = u32;
 
 #[derive(Debug, Clone)]
 pub enum GetPropertyError {
     X11rbError(Arc<ReplyError>),
     TypeMismatch(xproto::Atom),
     FormatMismatch(c_int),
-}
-
-impl<T: Into<ReplyError>> From<T> for GetPropertyError {
-    fn from(e: T) -> Self {
-        Self::X11rbError(Arc::new(e.into()))
-    }
 }
 
 impl GetPropertyError {
@@ -30,6 +29,24 @@ impl GetPropertyError {
         }
     }
 }
+
+impl<T: Into<ReplyError>> From<T> for GetPropertyError {
+    fn from(e: T) -> Self {
+        Self::X11rbError(Arc::new(e.into()))
+    }
+}
+
+impl fmt::Display for GetPropertyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GetPropertyError::X11rbError(err) => err.fmt(f),
+            GetPropertyError::TypeMismatch(err) => write!(f, "type mismatch: {err}"),
+            GetPropertyError::FormatMismatch(err) => write!(f, "format mismatch: {err}"),
+        }
+    }
+}
+
+impl Error for GetPropertyError {}
 
 // Number of 32-bit chunks to retrieve per iteration of get_property's inner loop.
 // To test if `get_property` works correctly, set this to 1.

--- a/src/platform_impl/linux/x11/xsettings.rs
+++ b/src/platform_impl/linux/x11/xsettings.rs
@@ -33,13 +33,11 @@ impl XConnection {
             .reply()?;
 
         // Read the _XSETTINGS_SETTINGS property.
-        let data: Vec<u8> = self
-            .get_property(
-                owner.owner,
-                atoms[_XSETTINGS_SETTINGS],
-                atoms[_XSETTINGS_SETTINGS],
-            )
-            .unwrap();
+        let data: Vec<u8> = self.get_property(
+            owner.owner,
+            atoms[_XSETTINGS_SETTINGS],
+            atoms[_XSETTINGS_SETTINGS],
+        )?;
 
         // Parse the property.
         let dpi_setting = read_settings(&data)?


### PR DESCRIPTION
Don't crash when xsettings query fails with _present_ xsettings.

Closes: https://github.com/rust-windowing/winit/issues/3573

- [ ] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
