### PR TITLE
Add DWMWA_CLOAK support on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Unreleased` header.
 - Add the `OwnedDisplayHandle` type for allowing safe display handle usage outside of trivial cases.
 - **Breaking:** Rename `TouchpadMagnify` to `PinchGesture`, `SmartMagnify` to `DoubleTapGesture` and `TouchpadRotate` to `RotationGesture` to represent the action rather than the intent.
 - on iOS, add detection support for `PinchGesture`, `DoubleTapGesture` and `RotationGesture`.
-- on Windows: add `with_system_backdrop`, `with_border_color`, `with_title_background_color`, `with_title_text_color` and `with_corner_preference`
+- on Windows: add `with_cloaked`, `with_system_backdrop`, `with_border_color`, `with_title_background_color`, `with_title_text_color` and `with_corner_preference`
 - On Windows, Remove `WS_CAPTION`, `WS_BORDER` and `WS_EX_WINDOWEDGE` styles for child windows without decorations.
 - **Breaking:** Removed `EventLoopError::AlreadyRunning`, which can't happen as it is already prevented by the type system.
 - Added `EventLoop::builder`, which is intended to replace the (now deprecated) `EventLoopBuilder::new`.

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -20,6 +20,7 @@ use winit::event::{DeviceEvent, DeviceId, Ime, WindowEvent};
 use winit::event::{MouseButton, MouseScrollDelta};
 use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::keyboard::{Key, ModifiersState};
+use winit::platform::windows::WindowAttributesExtWindows;
 use winit::window::{
     Cursor, CursorGrabMode, CustomCursor, CustomCursorSource, Fullscreen, Icon, ResizeDirection,
     Theme,

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -248,6 +248,11 @@ pub trait WindowExtWindows {
     ///
     /// Supported starting with Windows 11 Build 22000.
     fn set_corner_preference(&self, preference: CornerPreference);
+
+    /// Cloaks the window such that it is not visible to the user. The window is still composed by DWM.
+    ///
+    /// Not supported on Windows 7 and earlier.
+    fn set_cloaked(&self, cloaked: bool);
 }
 
 impl WindowExtWindows for Window {
@@ -297,6 +302,11 @@ impl WindowExtWindows for Window {
     #[inline]
     fn set_corner_preference(&self, preference: CornerPreference) {
         self.window.set_corner_preference(preference)
+    }
+
+    #[inline]
+    fn set_cloaked(&self, cloaked: bool) {
+        self.window.set_cloaked(cloaked)
     }
 }
 
@@ -388,6 +398,11 @@ pub trait WindowAttributesExtWindows {
     ///
     /// Supported starting with Windows 11 Build 22000.
     fn with_corner_preference(self, corners: CornerPreference) -> Self;
+
+    /// Cloaks the window such that it is not visible to the user. The window is still composed by DWM.
+    ///
+    /// Not supported on Windows 7 and earlier.
+    fn with_cloaked(self, cloaked: bool) -> Self;
 }
 
 impl WindowAttributesExtWindows for WindowAttributes {
@@ -472,6 +487,12 @@ impl WindowAttributesExtWindows for WindowAttributes {
     #[inline]
     fn with_corner_preference(mut self, corners: CornerPreference) -> Self {
         self.platform_specific.corner_preference = Some(corners);
+        self
+    }
+
+    #[inline]
+    fn with_cloaked(mut self, cloaked: bool) -> Self {
+        self.platform_specific.cloaked = cloaked;
         self
     }
 }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -43,6 +43,7 @@ pub struct PlatformSpecificWindowAttributes {
     pub title_background_color: Option<Color>,
     pub title_text_color: Option<Color>,
     pub corner_preference: Option<CornerPreference>,
+    pub cloaked: bool,
 }
 
 impl Default for PlatformSpecificWindowAttributes {
@@ -62,6 +63,7 @@ impl Default for PlatformSpecificWindowAttributes {
             title_background_color: None,
             title_text_color: None,
             corner_preference: None,
+            cloaked: false,
         }
     }
 }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -11,12 +11,13 @@ use std::{
 
 use windows_sys::Win32::{
     Foundation::{
-        HWND, LPARAM, OLE_E_WRONGCOMPOBJ, POINT, POINTS, RECT, RPC_E_CHANGED_MODE, S_OK, WPARAM,
+        BOOL, FALSE, HWND, LPARAM, OLE_E_WRONGCOMPOBJ, POINT, POINTS, RECT, RPC_E_CHANGED_MODE,
+        S_OK, TRUE, WPARAM,
     },
     Graphics::{
         Dwm::{
             DwmEnableBlurBehindWindow, DwmSetWindowAttribute, DWMWA_BORDER_COLOR,
-            DWMWA_CAPTION_COLOR, DWMWA_SYSTEMBACKDROP_TYPE, DWMWA_TEXT_COLOR,
+            DWMWA_CAPTION_COLOR, DWMWA_CLOAK, DWMWA_SYSTEMBACKDROP_TYPE, DWMWA_TEXT_COLOR,
             DWMWA_WINDOW_CORNER_PREFERENCE, DWM_BB_BLURREGION, DWM_BB_ENABLE, DWM_BLURBEHIND,
             DWM_SYSTEMBACKDROP_TYPE, DWM_WINDOW_CORNER_PREFERENCE,
         },
@@ -1126,6 +1127,19 @@ impl Window {
             );
         }
     }
+
+    #[inline]
+    pub fn set_cloaked(&self, cloaked: bool) {
+        let cloaked = if cloaked { TRUE } else { FALSE };
+        unsafe {
+            DwmSetWindowAttribute(
+                self.hwnd(),
+                DWMWA_CLOAK,
+                &cloaked as *const BOOL as *const _,
+                mem::size_of::<BOOL>() as u32,
+            );
+        }
+    }
 }
 
 impl Drop for Window {
@@ -1335,6 +1349,7 @@ impl<'a> InitData<'a> {
         if let Some(corner) = self.attributes.platform_specific.corner_preference {
             win.set_corner_preference(corner);
         }
+        win.set_cloaked(self.attributes.platform_specific.cloaked);
     }
 }
 unsafe fn init(


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Tested on Windows 11 build 22621.3155