### PR TITLE
bugfix(dpi): `PhysicalUnit::to_logical` computation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,13 @@ jobs:
     - name: Build crate
       run: cargo $CMD build $OPTIONS
 
+    # Test only on Linux x86_64, so we avoid spending unnecessary CI hours.
+    - name: Test dpi crate
+      if: >
+        contains(matrix.platform.name, 'Linux 64bit') &&
+        matrix.toolchain != '1.70.0'
+      run: cargo test -p dpi
+
     - name: Build tests
       if: >
         !contains(matrix.platform.target, 'redox') &&

--- a/dpi/src/lib.rs
+++ b/dpi/src/lib.rs
@@ -250,7 +250,7 @@ impl<P: Pixel> PhysicalUnit<P> {
     #[inline]
     pub fn to_logical<X: Pixel>(&self, scale_factor: f64) -> LogicalUnit<X> {
         assert!(validate_scale_factor(scale_factor));
-        LogicalUnit::new(self.0.into() * scale_factor).cast()
+        LogicalUnit::new(self.0.into() / scale_factor).cast()
     }
 
     #[inline]

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -195,6 +195,7 @@ impl OnlyCursorImageSource {
 }
 
 /// Platforms export this directly as `PlatformCustomCursor` if they don't implement caching.
+#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub(crate) struct OnlyCursorImage(pub(crate) Arc<CursorImage>);
 


### PR DESCRIPTION
The conversion of PhysicalUnit was wrongly computed and the tests were not running on the CI for the dpi crate, thus it was missed, even though the test was correctly failing.
