### PR TITLE
Fixes unnecessary initial resize on Windows

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -299,6 +299,7 @@ impl ApplicationHandler<UserEvent> for Application {
 
         match event {
             WindowEvent::Resized(size) => {
+                println!("Window={window_id:?} resized to {size:?}");
                 window.resize(size);
             }
             WindowEvent::Focused(focused) => {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -60,6 +60,7 @@ use windows_sys::Win32::{
 };
 
 use tracing::warn;
+use windows_sys::Win32::UI::WindowsAndMessaging::AdjustWindowRectEx;
 
 use crate::{
     cursor::Cursor,
@@ -1284,6 +1285,7 @@ impl<'a> InitData<'a> {
         win.set_taskbar_icon(self.attributes.platform_specific.taskbar_icon.clone());
 
         let attributes = self.attributes.clone();
+        let clamped_size = calculate_clamped_window_size(&attributes, win.scale_factor());
 
         if attributes.content_protected {
             win.set_content_protected(true);
@@ -1297,16 +1299,6 @@ impl<'a> InitData<'a> {
 
         win.set_enabled_buttons(attributes.enabled_buttons);
 
-        let size = attributes
-            .inner_size
-            .unwrap_or_else(|| PhysicalSize::new(800, 600).into());
-        let max_size = attributes
-            .max_inner_size
-            .unwrap_or_else(|| PhysicalSize::new(f64::MAX, f64::MAX).into());
-        let min_size = attributes
-            .min_inner_size
-            .unwrap_or_else(|| PhysicalSize::new(0, 0).into());
-        let clamped_size = Size::clamp(size, min_size, max_size, win.scale_factor());
         win.request_inner_size(clamped_size);
 
         // let margins = MARGINS {
@@ -1406,6 +1398,13 @@ unsafe fn init(
     let menu = attributes.platform_specific.menu;
     let fullscreen = attributes.fullscreen.clone();
     let maximized = attributes.maximized;
+
+    let default_scale_factor = event_loop
+        .primary_monitor()
+        .map(|monitor| monitor.scale_factor())
+        .unwrap_or(1.0);
+    let clamped_size = calculate_clamped_window_size(&attributes, default_scale_factor);
+
     let mut initdata = InitData {
         event_loop,
         attributes,
@@ -1414,6 +1413,22 @@ unsafe fn init(
     };
 
     let (style, ex_style) = window_flags.to_window_styles();
+
+    // Best effort: try to create the window with the requested inner size
+    let adjusted_size = {
+        let [w, h] = clamped_size.to_physical::<u32>(default_scale_factor).into();
+        let mut rect = RECT {
+            left: 0,
+            top: 0,
+            right: w,
+            bottom: h,
+        };
+        unsafe {
+            AdjustWindowRectEx(&mut rect, style, menu.is_some().into(), ex_style);
+        }
+        (rect.right - rect.left, rect.bottom - rect.top)
+    };
+
     let handle = unsafe {
         CreateWindowExW(
             ex_style,
@@ -1422,8 +1437,8 @@ unsafe fn init(
             style,
             CW_USEDEFAULT,
             CW_USEDEFAULT,
-            CW_USEDEFAULT,
-            CW_USEDEFAULT,
+            adjusted_size.0,
+            adjusted_size.1,
             parent.unwrap_or(0),
             menu.unwrap_or(0),
             util::get_instance_handle(),
@@ -1477,6 +1492,19 @@ unsafe fn register_window_class(class_name: &[u16]) {
     // Also since there is no weird element in the struct, there is no reason for this
     //  call to fail.
     unsafe { RegisterClassExW(&class) };
+}
+
+fn calculate_clamped_window_size(attributes: &WindowAttributes, scale_factor: f64) -> Size {
+    let size = attributes
+        .inner_size
+        .unwrap_or_else(|| PhysicalSize::new(800, 600).into());
+    let max_size = attributes
+        .max_inner_size
+        .unwrap_or_else(|| PhysicalSize::new(f64::MAX, f64::MAX).into());
+    let min_size = attributes
+        .min_inner_size
+        .unwrap_or_else(|| PhysicalSize::new(0, 0).into());
+    Size::clamp(size, min_size, max_size, scale_factor)
 }
 
 struct ComInitialized(#[allow(dead_code)] *mut ());


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

On Windows, this code calculates the size of the window before creating it instead of using `CW_USEDEFAULT`.

Tested using `WindowBuilder::new().with_inner_size()` with both `PhysicalSize` and `LogicalSize` on multiple scale factors.

Closes #2094 

