### PR TITLE
Derive `Debug, Copy, Clone, PartialEq, Serialize, Deserialize` for `PixelUnit`

### DIFF
--- a/dpi/CHANGELOG.md
+++ b/dpi/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased` header.
 
 # Unreleased
 
+- Derive `Debug`, `Copy`, `Clone`, `PartialEq`, `Serialize`, `Deserialize` traits for `PixelUnit`.
+
 # 0.1.0
 
 - Add `LogicalUnit`, `PhysicalUnit` and `PixelUnit` types and related functions.

--- a/dpi/src/lib.rs
+++ b/dpi/src/lib.rs
@@ -314,6 +314,8 @@ impl<P: Pixel> From<PhysicalUnit<P>> for f64 {
 }
 
 /// A pixel unit that's either physical or logical.
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum PixelUnit {
     Physical(PhysicalUnit<i32>),
     Logical(LogicalUnit<f64>),
@@ -1204,5 +1206,39 @@ mod tests {
 
         let _ = format!("{:?}", Size::Physical((1, 2).into()).clone());
         let _ = format!("{:?}", Position::Physical((1, 2).into()).clone());
+    }
+
+    #[test]
+    fn ensure_copy_trait() {
+        fn is_copy<T: Copy>() {}
+
+        is_copy::<LogicalUnit<i32>>();
+        is_copy::<PhysicalUnit<f64>>();
+        is_copy::<PixelUnit>();
+
+        is_copy::<LogicalSize<i32>>();
+        is_copy::<PhysicalSize<f64>>();
+        is_copy::<Size>();
+
+        is_copy::<LogicalPosition<i32>>();
+        is_copy::<PhysicalPosition<f64>>();
+        is_copy::<Position>();
+    }
+
+    #[test]
+    fn ensure_partial_eq_trait() {
+        fn is_partial_eq<T: PartialEq>() {}
+
+        is_partial_eq::<LogicalUnit<i32>>();
+        is_partial_eq::<PhysicalUnit<f64>>();
+        is_partial_eq::<PixelUnit>();
+
+        is_partial_eq::<LogicalSize<i32>>();
+        is_partial_eq::<PhysicalSize<f64>>();
+        is_partial_eq::<Size>();
+
+        is_partial_eq::<LogicalPosition<i32>>();
+        is_partial_eq::<PhysicalPosition<f64>>();
+        is_partial_eq::<Position>();
     }
 }


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality
- [X] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

---

Somehow I missed deriving those and didn't know until I tried replacing the `dpi` module in `tao` with this crate so I added a test to ensure these types will always be `Copy`.

If it is not too much to ask, could another release be made after merge?