### PR TITLE
On Windows, only return the window handle if it is on the correct thread

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -64,6 +64,7 @@ changelog entry.
 - On Windows, add `with_title_text_color`, and `with_corner_preference` on
   `WindowAttributesExtWindows`.
 - On Windows, implement resize increments.
+- On Windows, add `AnyThread` API to access window handle off the main thread.
 
 ### Changed
 
@@ -256,3 +257,4 @@ changelog entry.
 - On macOS, fix sequence of mouse events being out of order when dragging on the trackpad.
 - On Wayland, fix decoration glitch on close with some compositors.
 - On Android, fix a regression introduced in #2748 to allow volume key events to be received again.
+- On Windows, don't return a valid window handle outside of the GUI thread.


### PR DESCRIPTION
On Windows, it is generally unsafe to use the HWND outside of the thread
that it originates from. In reality, the HWND is an index into a
thread-local table, so using it outside of the GUI thread can result in
another window being used instead, following by code unsoundness. This
is why the WindowHandle type is !Send. However, Window is Send and Sync,
which means we have to account for this.

Thus far the best solution seems to be to check if we are not in the GUI
thread. If we aren't, refuse the return the window handle.

----

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
