### PR TITLE
Fix Clippy CI after Rust 1.77

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -117,9 +117,8 @@ impl error::Error for NotSupportedError {}
 impl error::Error for EventLoopError {}
 
 #[cfg(test)]
+#[allow(clippy::redundant_clone)]
 mod tests {
-    #![allow(clippy::redundant_clone)]
-
     use super::*;
 
     // Eat attributes for testing

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1494,8 +1494,8 @@ thread_local! {
         }
     };
 
-    static TASKBAR_LIST: Cell<*mut ITaskbarList> = Cell::new(ptr::null_mut());
-    static TASKBAR_LIST2: Cell<*mut ITaskbarList2> = Cell::new(ptr::null_mut());
+    static TASKBAR_LIST: Cell<*mut ITaskbarList> = const { Cell::new(ptr::null_mut()) };
+    static TASKBAR_LIST2: Cell<*mut ITaskbarList2> = const { Cell::new(ptr::null_mut()) };
 }
 
 pub fn com_initialized() {


### PR DESCRIPTION
Failed job: https://github.com/rust-windowing/winit/actions/runs/8379455401/job/22946414148