### PR TITLE
Consistently emit extra mouse motion events

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -41,3 +41,4 @@
 - Add `Window::default_attributes` to get default `WindowAttributes`.
 - `log` has been replaced with `tracing`. The old behavior can be emulated by setting the `log` feature on the `tracing` crate.
 - On Windows, confine cursor to center of window when grabbed and hidden.
+- On macOS, fix sequence of mouse events being out of order when dragging on the trackpad.


### PR DESCRIPTION
In particular, we don't want to emit those events inside of `pressureChangeWithEvent:`, since the mouse motion value is sometimes outdated.

Additionally, we want to ensure the events have been emitted during other gestures.

Fixes https://github.com/rust-windowing/winit/issues/3516.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
