### PR TITLE
Introduce ignore_size_suggestions() for Wayland

### DIFF
--- a/examples/programmatical_resize.rs
+++ b/examples/programmatical_resize.rs
@@ -1,0 +1,56 @@
+#![allow(clippy::single_match)]
+
+use simple_logger::SimpleLogger;
+use winit::{
+    dpi::LogicalSize,
+    event::{ElementState, Event, KeyEvent, WindowEvent},
+    event_loop::EventLoop,
+    keyboard::{KeyCode, PhysicalKey},
+    window::Window,
+};
+
+#[path = "util/fill.rs"]
+mod fill;
+
+fn main() -> Result<(), impl std::error::Error> {
+    SimpleLogger::new().init().unwrap();
+    let event_loop = EventLoop::new().unwrap();
+
+    let min_size = LogicalSize::new(400.0, 200.0);
+    let max_size = LogicalSize::new(800.0, 400.0);
+    let mut size = min_size;
+
+    let window = Window::builder()
+        .with_title("Hit space to toggle size.")
+        .with_inner_size(size)
+        .with_min_inner_size(min_size)
+        .with_max_inner_size(max_size)
+        .without_size_suggestions(true)
+        .build(&event_loop)
+        .unwrap();
+
+    event_loop.run(move |event, elwt| {
+        if let Event::WindowEvent { event, .. } = event {
+            match event {
+                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::KeyboardInput {
+                    event:
+                        KeyEvent {
+                            physical_key: PhysicalKey::Code(KeyCode::Space),
+                            state: ElementState::Released,
+                            ..
+                        },
+                    ..
+                } => {
+                    size = if size == min_size { max_size } else { min_size };
+                    println!("New size: {:?}", size);
+                    let _ = window.request_inner_size(size);
+                }
+                WindowEvent::RedrawRequested => {
+                    fill::fill_window(&window);
+                }
+                _ => (),
+            }
+        };
+    })
+}

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -41,3 +41,4 @@
 - Add `Window::default_attributes` to get default `WindowAttributes`.
 - `log` has been replaced with `tracing`. The old behavior can be emulated by setting the `log` feature on the `tracing` crate.
 - On Windows, confine cursor to center of window when grabbed and hidden.
+- On Wayland, introduce `window.without_size_suggestions()` to ignore size suggested by window manager

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -405,6 +405,16 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_ignore_size_suggestions(&self, ignore: bool) {
+        x11_or_wayland!(match self; Window(w) => w.set_ignore_size_suggestions(ignore))
+    }
+
+    #[inline]
+    pub fn ignore_size_suggestions(&self) -> bool {
+        x11_or_wayland!(match self; Window(w) => w.ignore_size_suggestions())
+    }
+
+    #[inline]
     pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
         x11_or_wayland!(match self; Window(w) => w.set_enabled_buttons(buttons))
     }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -148,6 +148,10 @@ impl Window {
         // Non-resizable implies that the min and max sizes are set to the same value.
         window_state.set_resizable(attributes.resizable);
 
+        // Ignore size suggestions from window managers such as Sway. This allows programmatically
+        // resize window
+        window_state.set_ignore_size_suggestions(attributes.ignore_size_suggestions);
+
         // Set startup mode.
         match attributes.fullscreen.map(Into::into) {
             Some(Fullscreen::Exclusive(_)) => {
@@ -404,6 +408,16 @@ impl Window {
     #[inline]
     pub fn is_resizable(&self) -> bool {
         self.window_state.lock().unwrap().resizable()
+    }
+
+    #[inline]
+    pub fn set_ignore_size_suggestions(&self, ignore: bool) {
+        self.window_state.lock().unwrap().set_ignore_size_suggestions(ignore);
+    }
+
+    #[inline]
+    pub fn ignore_size_suggestions(&self) -> bool {
+        self.window_state.lock().unwrap().ignore_size_suggestions()
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -55,6 +55,7 @@ pub struct SharedState {
     pub inner_position: Option<(i32, i32)>,
     pub inner_position_rel_parent: Option<(i32, i32)>,
     pub is_resizable: bool,
+    pub ignore_size_suggestions: bool,
     pub is_decorated: bool,
     pub last_monitor: X11MonitorHandle,
     pub dpi_adjusted: Option<(u32, u32)>,
@@ -97,6 +98,7 @@ impl SharedState {
             visibility,
 
             is_resizable: window_attributes.resizable,
+            ignore_size_suggestions: window_attributes.ignore_size_suggestions,
             is_decorated: window_attributes.decorations,
             cursor_pos: None,
             size: None,
@@ -1523,6 +1525,15 @@ impl UnownedWindow {
     #[inline]
     pub fn is_resizable(&self) -> bool {
         self.shared_state_lock().is_resizable
+    }
+
+    pub fn set_ignore_size_suggestions(&self, _ignore: bool) {
+        unimplemented!();
+    }
+
+    #[inline]
+    pub fn ignore_size_suggestions(&self) -> bool {
+        unimplemented!();
     }
 
     #[inline]

--- a/src/window.rs
+++ b/src/window.rs
@@ -106,6 +106,7 @@ pub struct WindowAttributes {
     pub max_inner_size: Option<Size>,
     pub position: Option<Position>,
     pub resizable: bool,
+    pub ignore_size_suggestions: bool,
     pub enabled_buttons: WindowButtons,
     pub title: String,
     pub maximized: bool,
@@ -137,6 +138,7 @@ impl Default for WindowAttributes {
             max_inner_size: None,
             position: None,
             resizable: true,
+            ignore_size_suggestions: false,
             enabled_buttons: WindowButtons::all(),
             title: "winit window".to_owned(),
             maximized: false,
@@ -261,6 +263,17 @@ impl WindowAttributes {
     #[inline]
     pub fn with_resizable(mut self, resizable: bool) -> Self {
         self.resizable = resizable;
+        self
+    }
+
+    /// Sets whether the window ignore size suggestions from window manager or not.
+    ///
+    /// The default is `false`.
+    ///
+    /// See [`Window::set_ignore_size_suggestions`] for details.
+    #[inline]
+    pub fn without_size_suggestions(mut self, ignore: bool) -> Self {
+        self.window.ignore_size_suggestions = ignore;
         self
     }
 
@@ -1024,6 +1037,29 @@ impl Window {
     pub fn is_resizable(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::is_resizable",).entered();
         self.window.maybe_wait_on_main(|w| w.is_resizable())
+    }
+
+    /// Whether window ignores size suggestions from window manager or not
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **X11 / Windows:** Not implemented.
+    /// - **iOS / Android / Web:** Unsupported.
+    #[inline]
+    pub fn ignore_size_suggestions(&self) -> bool {
+        self.window.maybe_wait_on_main(|w| w.ignore_size_suggestions())
+    }
+
+    /// Sets whether the window ignores size suggested by window manager or not.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **X11 / Windows:** Not implemented
+    /// - **iOS / Android / Web:** Unsupported.
+    #[inline]
+    pub fn set_ignore_size_suggestions(&self, ignore: bool) {
+        self.window
+            .maybe_queue_on_main(move |w| w.set_ignore_size_suggestions(ignore))
     }
 
     /// Sets the enabled window buttons.


### PR DESCRIPTION
On Wayland, size is entirely controlled by the user, however winit obeys to the resizes window manager gives us. On tiling window managers, such as Sway, this make it impossible to control window size programmatically with request_inner_size() as they don't always care about windows original size.

This patch introduces window.without_size_suggestions(bool) which tells window to ignore sizes suggested by window managers. Exceptions are when window is switched to fullscreen, maximized or tiled mode.

This is currently implemented only for Wayland.

More on roots of this https://github.com/rust-windowing/winit/issues/3485

- [x] Tested on all platforms changed (Wayland only)
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
