### PR TITLE
Silence clippy

### DIFF
--- a/src/platform_impl/linux/common/xkb/keymap.rs
+++ b/src/platform_impl/linux/common/xkb/keymap.rs
@@ -1026,6 +1026,7 @@ impl Deref for XkbKeymap {
 }
 
 /// Modifier index in the keymap.
+#[cfg_attr(not(x11_platform), allow(dead_code))]
 #[derive(Default, Debug, Clone, Copy)]
 pub struct ModsIndices {
     pub shift: Option<xkb_mod_index_t>,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -92,6 +92,7 @@ pub struct X11WindowAttributes {
     pub embed_window: Option<x11rb::protocol::xproto::Window>,
 }
 
+#[cfg_attr(not(x11_platform), allow(clippy::derivable_impls))]
 impl Default for PlatformSpecificWindowAttributes {
     fn default() -> Self {
         Self {

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -153,6 +153,7 @@ impl Window {
             Some(Fullscreen::Exclusive(_)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland");
             }
+            #[cfg_attr(not(x11_platform), allow(clippy::bind_instead_of_map))]
             Some(Fullscreen::Borderless(monitor)) => {
                 let output = monitor.and_then(|monitor| match monitor {
                     PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),
@@ -499,6 +500,7 @@ impl Window {
             Some(Fullscreen::Exclusive(_)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland");
             }
+            #[cfg_attr(not(x11_platform), allow(clippy::bind_instead_of_map))]
             Some(Fullscreen::Borderless(monitor)) => {
                 let output = monitor.and_then(|monitor| match monitor {
                     PlatformMonitorHandle::Wayland(monitor) => Some(monitor.proxy),

--- a/src/platform_impl/linux/x11/dnd.rs
+++ b/src/platform_impl/linux/x11/dnd.rs
@@ -23,10 +23,10 @@ pub enum DndState {
 #[derive(Debug)]
 pub enum DndDataParseError {
     EmptyData,
-    InvalidUtf8(Utf8Error),
-    HostnameSpecified(String),
-    UnexpectedProtocol(String),
-    UnresolvablePath(io::Error),
+    InvalidUtf8(#[allow(dead_code)] Utf8Error),
+    HostnameSpecified(#[allow(dead_code)] String),
+    UnexpectedProtocol(#[allow(dead_code)] String),
+    UnresolvablePath(#[allow(dead_code)] io::Error),
 }
 
 impl From<Utf8Error> for DndDataParseError {

--- a/src/platform_impl/linux/x11/util/geometry.rs
+++ b/src/platform_impl/linux/x11/util/geometry.rs
@@ -40,26 +40,6 @@ impl AaRect {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct Geometry {
-    pub root: xproto::Window,
-    // If you want positions relative to the root window, use translate_coords.
-    // Note that the overwhelming majority of window managers are reparenting WMs, thus the window
-    // ID we get from window creation is for a nested window used as the window's client area. If
-    // you call get_geometry with that window ID, then you'll get the position of that client area
-    // window relative to the parent it's nested in (the frame), which isn't helpful if you want
-    // to know the frame position.
-    pub x_rel_parent: c_int,
-    pub y_rel_parent: c_int,
-    // In that same case, this will give you client area size.
-    pub width: c_uint,
-    pub height: c_uint,
-    // xmonad and dwm were the only WMs tested that use the border return at all.
-    // The majority of WMs seem to simply fill it with 0 unconditionally.
-    pub border: c_uint,
-    pub depth: c_uint,
-}
-
 #[derive(Debug, Clone)]
 pub struct FrameExtents {
     pub left: u32,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -753,7 +753,7 @@ impl UnownedWindow {
         if old_fullscreen == fullscreen {
             return Ok(None);
         }
-        shared_state_lock.fullscreen = fullscreen.clone();
+        shared_state_lock.fullscreen.clone_from(&fullscreen);
 
         match (&old_fullscreen, &fullscreen) {
             // Store the desktop video mode before entering exclusive

--- a/src/platform_impl/linux/x11/xsettings.rs
+++ b/src/platform_impl/linux/x11/xsettings.rs
@@ -251,6 +251,7 @@ impl Endianness {
 }
 
 /// Parser errors.
+#[allow(dead_code)]
 #[derive(Debug)]
 pub enum ParserError {
     /// Ran out of bytes.
@@ -274,9 +275,8 @@ impl ParserError {
 }
 
 #[cfg(test)]
+/// Tests for the XSETTINGS parser.
 mod tests {
-    //! Tests for the XSETTINGS parser.
-
     use super::*;
 
     const XSETTINGS: &str = include_str!("tests/xsettings.dat");

--- a/src/platform_impl/web/cursor.rs
+++ b/src/platform_impl/web/cursor.rs
@@ -711,7 +711,7 @@ async fn from_url(
 async fn from_animation(
     main_thread: MainThreadMarker,
     duration: Duration,
-    cursors: impl Iterator<Item = CustomCursor> + ExactSizeIterator,
+    cursors: impl ExactSizeIterator<Item = CustomCursor>,
 ) -> Result<Animation, CustomCursorError> {
     let keyframes = Array::new();
     let mut images = Vec::with_capacity(cursors.len());

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -669,7 +669,7 @@ impl Shared {
                 ControlFlow::Poll => {
                     let cloned = self.clone();
                     State::Poll {
-                        request: backend::Schedule::new(
+                        _request: backend::Schedule::new(
                             self.poll_strategy(),
                             self.window(),
                             move || cloned.poll(),
@@ -693,7 +693,7 @@ impl Shared {
                     State::WaitUntil {
                         start,
                         end,
-                        timeout: backend::Schedule::new_with_duration(
+                        _timeout: backend::Schedule::new_with_duration(
                             self.window(),
                             move || cloned.resume_time_reached(start, end),
                             delay,

--- a/src/platform_impl/web/event_loop/state.rs
+++ b/src/platform_impl/web/event_loop/state.rs
@@ -6,7 +6,7 @@ use web_time::Instant;
 pub enum State {
     Init,
     WaitUntil {
-        timeout: backend::Schedule,
+        _timeout: backend::Schedule,
         start: Instant,
         end: Instant,
     },
@@ -14,7 +14,7 @@ pub enum State {
         start: Instant,
     },
     Poll {
-        request: backend::Schedule,
+        _request: backend::Schedule,
     },
     Exit,
 }

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -724,7 +724,7 @@ impl Window {
             _ => {}
         }
 
-        window_state_lock.fullscreen = fullscreen.clone();
+        window_state_lock.fullscreen.clone_from(&fullscreen);
         drop(window_state_lock);
 
         self.thread_executor.execute_in_thread(move || {


### PR DESCRIPTION
It appears that clippy's dead code detection has gotten better. This
commit fixes winit's code to match.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
