### PR TITLE
windows: remove github URLs from binaries

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1245,7 +1245,7 @@ unsafe fn public_window_callback_inner(
 
                 let new_rect = if window_pos.flags & NOMOVE_OR_NOSIZE != 0 {
                     let cur_rect = util::WindowArea::Outer.get_rect(window)
-                        .expect("Unexpected GetWindowRect failure; please report this error to https://github.com/rust-windowing/winit");
+                        .expect("Unexpected GetWindowRect failure; please report this error to rust-windowing/winit");
 
                     match window_pos.flags & NOMOVE_OR_NOSIZE {
                         NOMOVE_OR_NOSIZE => None,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -180,14 +180,14 @@ impl Window {
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         util::WindowArea::Outer.get_rect(self.hwnd())
             .map(|rect| Ok(PhysicalPosition::new(rect.left, rect.top)))
-            .expect("Unexpected GetWindowRect failure; please report this error to https://github.com/rust-windowing/winit")
+            .expect("Unexpected GetWindowRect failure; please report this error to rust-windowing/winit")
     }
 
     #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let mut position: POINT = unsafe { mem::zeroed() };
         if unsafe { ClientToScreen(self.hwnd(), &mut position) } == false.into() {
-            panic!("Unexpected ClientToScreen failure: please report this error to https://github.com/rust-windowing/winit")
+            panic!("Unexpected ClientToScreen failure: please report this error to rust-windowing/winit")
         }
         Ok(PhysicalPosition::new(position.x, position.y))
     }
@@ -223,7 +223,7 @@ impl Window {
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         let mut rect: RECT = unsafe { mem::zeroed() };
         if unsafe { GetClientRect(self.hwnd(), &mut rect) } == false.into() {
-            panic!("Unexpected GetClientRect failure: please report this error to https://github.com/rust-windowing/winit")
+            panic!("Unexpected GetClientRect failure: please report this error to rust-windowing/winit")
         }
         PhysicalSize::new(
             (rect.right - rect.left) as u32,


### PR DESCRIPTION
There are really stupid AV rules out there which cause almost any program that contains github URLs to become marked as malware.

While those rules are spurious, they're years old, and AV vendors have a very poor reputation at appropriately following up with these problems. I've already mailed Defender about this weeks ago and they've yet to respond.

Removing these strings from the panic data present in the binary prevents binaries linking the dependency from being spuriously marked as Trojan:Win32/Wacatac.B!ml.

It might be better to use an URL shortener or similar, but I suspect that if someone actually hits these rare cases, googling the path will be more than sufficient to get someone where they need to be.

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

I have tested this change by producing a release build prior to this change, uploading it somewhere, downloading via firefox -> Defender fires. Apply patch, release build, upload, download, run -> only smart screen, no Defender.

I also have a version of this patch against the 0.29 branch here: https://github.com/raggi/winit/tree/raggi/remove-urls-0.29

I'm happy to update the patch to include changelog, but wanted to send it for feedback first, given the novelty of the change.