### PR TITLE
Fix CI failing when updating `typos` to 1.20.3

### DIFF
--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -170,7 +170,7 @@ impl From<util::GetPropertyError> for GetXimServersError {
 }
 
 // The root window has a property named XIM_SERVERS, which contains a list of atoms representing
-// the availabile XIM servers. For instance, if you're using ibus, it would contain an atom named
+// the available XIM servers. For instance, if you're using ibus, it would contain an atom named
 // "@server=ibus". It's possible for this property to contain multiple atoms, though presumably
 // rare. Note that we replace "@server=" with "@im=" in order to match the format of locale
 // modifiers, since we don't want a user who's looking at logs to ask "am I supposed to set

--- a/typos.toml
+++ b/typos.toml
@@ -1,6 +1,7 @@
 # documentation: https://github.com/crate-ci/typos/blob/master/docs/reference.md
 
 [default.extend-identifiers]
-ptd = "ptd"                         # From winwows_sys::Win32::System::Com::FORMATETC { ptd, ..}
+ptd = "ptd"                         # From windows_sys::Win32::System::Com::FORMATETC { ptd, ..}
+TME_LEAVE = "TME_LEAVE"             # From windows_sys::Win32::UI::Input::KeyboardAndMouse::TME_LEAVE
 requestor = "requestor"             # From x11_dl::xlib::XSelectionEvent { requestor ..}
 XF86_Calculater = "XF86_Calculater" # From xkbcommon_dl::keysyms::XF86_Calculater


### PR DESCRIPTION
[Example of failing workflow](https://github.com/rust-windowing/winit/actions/runs/8530045110/job/23367094972).