### PR TITLE
More concise `Debug` output for `WindowId`.

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -249,3 +249,4 @@ changelog entry.
 - On Web, fix setting cursor icon overriding cursor visibility.
 - On Windows, fix cursor not confined to center of window when grabbed and hidden.
 - On macOS, fix sequence of mouse events being out of order when dragging on the trackpad.
+- Debug formatting of `WindowId` is more concise.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -77,6 +77,7 @@ changelog entry.
 - Rename `platform::x11::XWindowType` to `platform::x11::WindowType`.
 - Rename `VideoMode` to `VideoModeHandle` to represent that it doesn't hold
   static data.
+- Make `Debug` formatting of `WindowId` more concise.
 - Move `dpi` types to its own crate, and re-export it from the root crate.
 - Replace `log` with `tracing`, use `log` feature on `tracing` to restore old
   behavior.
@@ -252,4 +253,3 @@ changelog entry.
 - On Web, fix setting cursor icon overriding cursor visibility.
 - On Windows, fix cursor not confined to center of window when grabbed and hidden.
 - On macOS, fix sequence of mouse events being out of order when dragging on the trackpad.
-- Debug formatting of `WindowId` is more concise.

--- a/src/window.rs
+++ b/src/window.rs
@@ -67,7 +67,7 @@ impl Drop for Window {
 ///
 /// Whenever you receive an event specific to a window, this event contains a `WindowId` which you
 /// can then compare to the ids of your windows.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(pub(crate) platform_impl::WindowId);
 
 impl WindowId {
@@ -83,6 +83,12 @@ impl WindowId {
     pub const unsafe fn dummy() -> Self {
         #[allow(unused_unsafe)]
         WindowId(unsafe { platform_impl::WindowId::dummy() })
+    }
+}
+
+impl fmt::Debug for WindowId {
+    fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(fmtr)
     }
 }
 


### PR DESCRIPTION
Since this is a nested struct, it was printing
`"WindowId(WindowId(2834882))"` when just printing `"WindowId(2834882)"` would be sufficient.

- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
