### PR TITLE
wayland: bump sctk-adwaita to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,7 @@ memmap2 = { version = "0.9.0", optional = true }
 percent-encoding = { version = "2.0", optional = true }
 rustix = { version = "0.38.4", default-features = false, features = ["std", "system", "thread", "process"] }
 sctk = { package = "smithay-client-toolkit", version = "0.18.0", default-features = false, features = ["calloop"], optional = true }
-sctk-adwaita = { version = "0.8.0", default_features = false, optional = true }
+sctk-adwaita = { version = "0.9.0", default_features = false, optional = true }
 wayland-backend = { version = "0.3.0", default_features = false, features = ["client_system"], optional = true }
 wayland-client = { version = "0.31.1", optional = true }
 wayland-protocols = { version = "0.31.0", features = [ "staging"], optional = true }

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -67,6 +67,9 @@ changelog entry.
 ### Changed
 
 - Bump MSRV from `1.65` to `1.70`.
+- On Wayland, bump `sctk-adwaita` to `0.9.0`, which changed system library
+  crates. This change is a **cascading breaking change**, you must do breaking
+  change as well, even if you don't expose winit.
 - Rename `TouchpadMagnify` to `PinchGesture`.
 - Rename `SmartMagnify` to `DoubleTapGesture`.
 - Rename `TouchpadRotate` to `RotationGesture`.


### PR DESCRIPTION
This is a breaking change, because the system versions of the libraries used by sctk-adwaita were changed. Such changes cascade through all the deps, so all libraries using winit MUST do a breaking change.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

--

Suggestions for how to handle such cascade breaking changes are much appreciated. For now I can only _warn_ in the changelog that you **must** do a breaking change as well to not break builds. 