### PR TITLE
wayland: fix CSD decorations glitch when closing

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -253,3 +253,4 @@ changelog entry.
 - On Web, fix setting cursor icon overriding cursor visibility.
 - On Windows, fix cursor not confined to center of window when grabbed and hidden.
 - On macOS, fix sequence of mouse events being out of order when dragging on the trackpad.
+- On Wayland, fix decoration glitch on close with some compositors

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -57,9 +57,6 @@ pub struct WindowState {
     /// The connection to Wayland server.
     pub connection: Connection,
 
-    /// The window frame, which is created from the configure request.
-    frame: Option<WinitFrame>,
-
     /// The `Shm` to set cursor.
     pub shm: WlShm,
 
@@ -155,6 +152,13 @@ pub struct WindowState {
 
     /// The underlying SCTK window.
     pub window: Window,
+
+    // NOTE: The spec says that destroying parent(`window` in our case), will unmap the
+    // subsurfaces. Thus to achieve atomic unmap of the client, drop the decorations
+    // frame after the `window` is dropped. To achieve that we rely on rust's struct
+    // field drop order guarantees.
+    /// The window frame, which is created from the configure request.
+    frame: Option<WinitFrame>,
 }
 
 impl WindowState {


### PR DESCRIPTION
In rare cases destroying subsurfaces before the main surface could result in a frame where the window is still shown, but decorations got hidden, right before the window itself disappears.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented


--

cc @Yalter