### PR TITLE
bugfix(android): Allow `Volume*` keys to be passed to the user

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -255,3 +255,4 @@ changelog entry.
 - On Windows, fix cursor not confined to center of window when grabbed and hidden.
 - On macOS, fix sequence of mouse events being out of order when dragging on the trackpad.
 - On Wayland, fix decoration glitch on close with some compositors.
+- On Android, fix a regression introduced in #2748 to allow volume key events to be received again.

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -438,10 +438,10 @@ impl<T: 'static> EventLoop<T> {
                     // Flag keys related to volume as unhandled. While winit does not have a way for applications
                     // to configure what keys to flag as handled, this appears to be a good default until winit
                     // can be configured.
-                    Keycode::VolumeUp | Keycode::VolumeDown | Keycode::VolumeMute => {
-                        if self.ignore_volume_keys {
-                            input_status = InputStatus::Unhandled
-                        }
+                    Keycode::VolumeUp | Keycode::VolumeDown | Keycode::VolumeMute
+                        if self.ignore_volume_keys =>
+                    {
+                        input_status = InputStatus::Unhandled
                     }
                     keycode => {
                         let state = match key.action() {


### PR DESCRIPTION
It seems that discussions around #2748 (cc @Hoodad) being a poor workaround that should rather be implemented properly/differently drowned out the fact that the workaround was implemented incorrectly to begin with.  By having the `if` inside the match arm, rather than /on/ the match arm the `keycode =>` path is /never/ used for `Volume*` keys and this event is thus never passed on to the user, defeating the purpose of calling `handle_volume_keys()`.  Only the `Handled`/`Unhandled` state is affected by the `ignore_volume_keys` workaround, as set by `EventLoopBuilderExtAndroid::handle_volume_keys()`.

Fix this by moving the `if` workaround on the match arm, so that disabling it via `EventLoopBuilderExtAndroid::handle_volume_keys()` causes `Volume*` events to be delivered to user code once again.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
