### PR TITLE
add remote notification registration app delegates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,8 @@ features = [
     "dispatch",
     "Foundation",
     "Foundation_NSArray",
+    "Foundation_NSData",
+    "Foundation_NSError",
     "Foundation_NSString",
     "Foundation_NSProcessInfo",
     "Foundation_NSThread",

--- a/src/event.rs
+++ b/src/event.rs
@@ -52,6 +52,16 @@ use crate::{
     window::{ActivationToken, Theme, WindowId},
 };
 
+/// iOS specific event sent when UIApplication delegate receives the response upon registering for remote notifications
+#[derive(Debug, Clone, PartialEq)]
+pub enum IosRemoteRegistration {
+    Failed {
+        code: isize,
+        localized_description: String,
+    },
+    DeviceToken(Vec<u8>),
+}
+
 /// Describes a generic event.
 ///
 /// See the module-level docs for more information on the event loop manages each event.
@@ -251,6 +261,9 @@ pub enum Event<T: 'static> {
     ///
     /// - **macOS / Wayland / Windows / Orbital:** Unsupported.
     MemoryWarning,
+
+    /// TODO
+    IosRemoteRegistration(IosRemoteRegistration),
 }
 
 impl<T> Event<T> {
@@ -267,6 +280,7 @@ impl<T> Event<T> {
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
             MemoryWarning => Ok(MemoryWarning),
+            IosRemoteRegistration(v) => Ok(IosRemoteRegistration(v)),
         }
     }
 }


### PR DESCRIPTION
I need some input here :)

I am not sure about the way to bubble up the events. For now i added a new one entirely but that feels wrong. do you think it should rather be a DeviceEvent cause it is for sure not a window event, right?

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
