### PR TITLE
Fix clippy::legacy_numeric_consts lints.

### DIFF
--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -753,7 +753,7 @@ impl EventLoopWaker {
             // future, but that gets changed to fire immediately in did_finish_launching
             let timer = CFRunLoopTimerCreate(
                 ptr::null_mut(),
-                std::f64::MAX,
+                f64::MAX,
                 0.000_000_1,
                 0,
                 0,
@@ -767,11 +767,11 @@ impl EventLoopWaker {
     }
 
     fn stop(&mut self) {
-        unsafe { CFRunLoopTimerSetNextFireDate(self.timer, std::f64::MAX) }
+        unsafe { CFRunLoopTimerSetNextFireDate(self.timer, f64::MAX) }
     }
 
     fn start(&mut self) {
-        unsafe { CFRunLoopTimerSetNextFireDate(self.timer, std::f64::MIN) }
+        unsafe { CFRunLoopTimerSetNextFireDate(self.timer, f64::MIN) }
     }
 
     fn start_at(&mut self, instant: Instant) {

--- a/src/platform_impl/ios/event_loop.rs
+++ b/src/platform_impl/ios/event_loop.rs
@@ -260,8 +260,7 @@ impl<T> EventLoopProxy<T> {
                 cancel: None,
                 perform: event_loop_proxy_handler,
             };
-            let source =
-                CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::max_value() - 1, &mut context);
+            let source = CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::MAX - 1, &mut context);
             CFRunLoopAddSource(rl, source, kCFRunLoopCommonModes);
             CFRunLoopWakeUp(rl);
 
@@ -344,7 +343,7 @@ fn setup_control_flow_observers() {
             ptr::null_mut(),
             kCFRunLoopAfterWaiting,
             1, // repeat = true
-            CFIndex::min_value(),
+            CFIndex::MIN,
             control_flow_begin_handler,
             ptr::null_mut(),
         );
@@ -364,7 +363,7 @@ fn setup_control_flow_observers() {
             ptr::null_mut(),
             kCFRunLoopExit | kCFRunLoopBeforeWaiting,
             1, // repeat = true
-            CFIndex::max_value(),
+            CFIndex::MAX,
             control_flow_end_handler,
             ptr::null_mut(),
         );

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -434,7 +434,7 @@ impl EventProcessor {
             let flags = xev.data.get_long(1);
             let version = flags >> 24;
             self.dnd.version = Some(version);
-            let has_more_types = flags - (flags & (c_long::max_value() - 1)) == 1;
+            let has_more_types = flags - (flags & (c_long::MAX - 1)) == 1;
             if !has_more_types {
                 let type_list = vec![
                     xev.data.get_long(2) as xproto::Atom,

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -480,8 +480,7 @@ impl<T> EventLoopProxy<T> {
                 cancel: None,
                 perform: event_loop_proxy_handler,
             };
-            let source =
-                CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::max_value() - 1, &mut context);
+            let source = CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::MAX - 1, &mut context);
             CFRunLoopAddSource(rl, source, kCFRunLoopCommonModes);
             CFRunLoopWakeUp(rl);
 

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -128,13 +128,13 @@ pub fn setup_control_flow_observers(panic_info: Weak<PanicInfo>) {
         let run_loop = RunLoop::get();
         run_loop.add_observer(
             kCFRunLoopAfterWaiting,
-            CFIndex::min_value(),
+            CFIndex::MIN,
             control_flow_begin_handler,
             &mut context as *mut _,
         );
         run_loop.add_observer(
             kCFRunLoopExit | kCFRunLoopBeforeWaiting,
-            CFIndex::max_value(),
+            CFIndex::MAX,
             control_flow_end_handler,
             &mut context as *mut _,
         );
@@ -174,7 +174,7 @@ impl Default for EventLoopWaker {
             // future, but that gets changed to fire immediately in did_finish_launching
             let timer = CFRunLoopTimerCreate(
                 ptr::null_mut(),
-                std::f64::MAX,
+                f64::MAX,
                 0.000_000_1,
                 0,
                 0,
@@ -191,14 +191,14 @@ impl EventLoopWaker {
     pub fn stop(&mut self) {
         if self.next_fire_date.is_some() {
             self.next_fire_date = None;
-            unsafe { CFRunLoopTimerSetNextFireDate(self.timer, std::f64::MAX) }
+            unsafe { CFRunLoopTimerSetNextFireDate(self.timer, f64::MAX) }
         }
     }
 
     pub fn start(&mut self) {
         if self.next_fire_date != Some(self.start_instant) {
             self.next_fire_date = Some(self.start_instant);
-            unsafe { CFRunLoopTimerSetNextFireDate(self.timer, std::f64::MIN) }
+            unsafe { CFRunLoopTimerSetNextFireDate(self.timer, f64::MIN) }
         }
     }
 

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -904,8 +904,8 @@ impl WindowDelegate {
 
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
         let dimensions = dimensions.unwrap_or(Size::Logical(LogicalSize {
-            width: std::f32::MAX as f64,
-            height: std::f32::MAX as f64,
+            width: f32::MAX as f64,
+            height: f32::MAX as f64,
         }));
         let scale_factor = self.scale_factor();
         let max_size = dimensions.to_logical::<CGFloat>(scale_factor);

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -103,7 +103,7 @@ pub struct WindowId {
 
 impl WindowId {
     pub const fn dummy() -> Self {
-        WindowId { fd: u64::max_value() }
+        WindowId { fd: u64::MAX }
     }
 }
 


### PR DESCRIPTION
Prefer to use the associated constants on the types rather than the legacy items like `std::<type>::MAX` or functions like `max_value`. These legacy items are marked to indicate that they will be deprecated in a future version of Rust.

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
