### PR TITLE
On Android, bump to `ndk 0.9.0` and `android-activity 0.6.0`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,9 +102,8 @@ softbuffer = { version = "0.4.0", default-features = false, features = [
 ] }
 
 [target.'cfg(target_os = "android")'.dependencies]
-android-activity = "0.5.0"
-ndk = { version = "0.8.0", default-features = false }
-ndk-sys = "0.5.0"
+android-activity = "0.6.0"
+ndk = { version = "0.9.0", default-features = false }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 core-foundation = "0.9.3"

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -91,6 +91,8 @@ changelog entry.
 - On macOS, return `HandleError::Unavailable` when a window handle is not available.
 - On Windows, remove `WS_CAPTION`, `WS_BORDER`, and `WS_EX_WINDOWEDGE` styles
   for child windows without decorations.
+- On Android, bump `ndk` to `0.9.0` and `android-activity` to `0.6.0`,
+  and remove unused direct dependency on `ndk-sys`.
 
 ### Deprecated
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
