### PR TITLE
chore: ensure that `.cargo` config is not published

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 repository.workspace = true
 license.workspace = true
 edition.workspace = true
+exclude = ["/.cargo"]
 
 [package.metadata.docs.rs]
 features = [


### PR DESCRIPTION
Just in case, so the correct changelog will be rendered when pulling the crate from the crates.io as archive and trying to build it.

