### PR TITLE
wayland: Add support for PinchGesture and RotationGesture

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -39,3 +39,7 @@ The migration guide could reference other migration examples in the current
 changelog entry.
 
 ## Unreleased
+
+### Added
+
+- On Wayland, add `PinchGesture` and `RotationGesture`

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -42,4 +42,4 @@ changelog entry.
 
 ### Added
 
-- On Wayland, add `PinchGesture` and `RotationGesture`
+- On Wayland, add `PinchGesture`, `PanGesture` and `RotationGesture`.

--- a/src/event.rs
+++ b/src/event.rs
@@ -297,7 +297,7 @@ pub enum WindowEvent {
     ///
     /// ## Platform-specific
     ///
-    /// - Only available on **iOS**.
+    /// - Only available on **iOS** and **Wayland**.
     /// - On iOS, not recognized by default. It must be enabled when needed.
     PanGesture {
         device_id: DeviceId,

--- a/src/event.rs
+++ b/src/event.rs
@@ -281,7 +281,7 @@ pub enum WindowEvent {
     ///
     /// ## Platform-specific
     ///
-    /// - Only available on **macOS** and **iOS**.
+    /// - Only available on **macOS**, **iOS** and **Wayland**.
     /// - On iOS, not recognized by default. It must be enabled when needed.
     PinchGesture {
         device_id: DeviceId,
@@ -333,7 +333,7 @@ pub enum WindowEvent {
     ///
     /// ## Platform-specific
     ///
-    /// - Only available on **macOS** and **iOS**.
+    /// - Only available on **macOS**, **iOS** and **Wayland**.
     /// - On iOS, not recognized by default. It must be enabled when needed.
     RotationGesture {
         device_id: DeviceId,

--- a/src/platform_impl/linux/wayland/seat/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/mod.rs
@@ -8,6 +8,7 @@ use sctk::reexports::client::backend::ObjectId;
 use sctk::reexports::client::protocol::wl_seat::WlSeat;
 use sctk::reexports::client::protocol::wl_touch::WlTouch;
 use sctk::reexports::client::{Connection, Proxy, QueueHandle};
+use sctk::reexports::protocols::wp::pointer_gestures::zv1::client::zwp_pointer_gesture_pinch_v1::ZwpPointerGesturePinchV1;
 use sctk::reexports::protocols::wp::relative_pointer::zv1::client::zwp_relative_pointer_v1::ZwpRelativePointerV1;
 use sctk::reexports::protocols::wp::text_input::zv3::client::zwp_text_input_v3::ZwpTextInputV3;
 
@@ -24,7 +25,9 @@ mod text_input;
 mod touch;
 
 pub use pointer::relative_pointer::RelativePointerState;
-pub use pointer::{PointerConstraintsState, WinitPointerData, WinitPointerDataExt};
+pub use pointer::{
+    PointerConstraintsState, PointerGesturesState, WinitPointerData, WinitPointerDataExt,
+};
 pub use text_input::{TextInputState, ZwpTextInputV3Ext};
 
 use keyboard::{KeyboardData, KeyboardState};
@@ -47,6 +50,9 @@ pub struct WinitSeatState {
 
     /// The relative pointer bound on the seat.
     relative_pointer: Option<ZwpRelativePointerV1>,
+
+    /// The pinch gesture of the pointer bound on the seat.
+    pinch_gesture: Option<ZwpPointerGesturePinchV1>,
 
     /// The keyboard bound on the seat.
     keyboard_state: Option<KeyboardState>,
@@ -105,6 +111,14 @@ impl SeatHandler for WinitState {
 
                 seat_state.relative_pointer = self.relative_pointer.as_ref().map(|manager| {
                     manager.get_relative_pointer(
+                        themed_pointer.pointer(),
+                        queue_handle,
+                        sctk::globals::GlobalData,
+                    )
+                });
+
+                seat_state.pinch_gesture = self.pointer_gestures.as_ref().map(|gestures| {
+                    gestures.get_pinch_gesture(
                         themed_pointer.pointer(),
                         queue_handle,
                         sctk::globals::GlobalData,

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -26,8 +26,8 @@ use sctk::subcompositor::SubcompositorState;
 use crate::platform_impl::wayland::event_loop::sink::EventSink;
 use crate::platform_impl::wayland::output::MonitorHandle;
 use crate::platform_impl::wayland::seat::{
-    PointerConstraintsState, RelativePointerState, TextInputState, WinitPointerData,
-    WinitPointerDataExt, WinitSeatState,
+    PointerConstraintsState, PointerGesturesState, RelativePointerState, TextInputState,
+    WinitPointerData, WinitPointerDataExt, WinitSeatState,
 };
 use crate::platform_impl::wayland::types::kwin_blur::KWinBlurManager;
 use crate::platform_impl::wayland::types::wp_fractional_scaling::FractionalScalingManager;
@@ -99,6 +99,15 @@ pub struct WinitState {
 
     /// Pointer constraints to handle pointer locking and confining.
     pub pointer_constraints: Option<Arc<PointerConstraintsState>>,
+
+    /// Pointer gestures to handle swipe, pinch and hold.
+    pub pointer_gestures: Option<PointerGesturesState>,
+
+    /// XXX: Is this really meant to stay here?
+    pub window_id: WindowId,
+
+    /// XXX: Is this really meant to stay here?
+    pub previous_scale: f64,
 
     /// Viewporter state on the given window.
     pub viewporter_state: Option<ViewporterState>,
@@ -185,7 +194,11 @@ impl WinitState {
             pointer_constraints: PointerConstraintsState::new(globals, queue_handle)
                 .map(Arc::new)
                 .ok(),
+            pointer_gestures: PointerGesturesState::new(globals, queue_handle).ok(),
             pointer_surfaces: Default::default(),
+
+            window_id: WindowId(0),
+            previous_scale: 1.,
 
             monitors: Arc::new(Mutex::new(monitors)),
             events_sink: EventSink::new(),


### PR DESCRIPTION
These two events are synthesized from the same event from the same protocol, [zwp_pointer_gestures_v1](https://wayland.app/protocols/pointer-gestures-unstable-v1), and will always come together.

I’ve left over the third value, which is a `dx`/`dy` from the center of the gesture, it could be exposed as a 2D scroll but I feel like this should be a different event than the normal `AxisMotion`.

The documentation doesn’t indicate the unit of the rotation, so I’ve left it as degrees.  I don’t have any Apple OS where I could test whether that event is also in degrees or in radians there.

The other two gestures supported by this protocol, a multi-finger swipe, and a multi-finger hold, aren’t currently matched with any event in winit, would it make sense to expose them?

I’ve only tested on GNOME, but I expect other compositors to expose the same protocol eventually.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

The last two items aren’t needed, as they were already added for the other two platforms which support this feature.