### PR TITLE
Don't set the background color when initializing with transparency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ features = [
     "NSApplication",
     "NSBitmapImageRep",
     "NSButton",
-    "NSColor",
     "NSControl",
     "NSCursor",
     "NSDragging",

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -260,3 +260,4 @@ changelog entry.
 - On Wayland, fix decoration glitch on close with some compositors.
 - On Android, fix a regression introduced in #2748 to allow volume key events to be received again.
 - On Windows, don't return a valid window handle outside of the GUI thread.
+- On macOS, don't set the background color when initializing a window with transparency.

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -12,7 +12,7 @@ use objc2::{
 };
 use objc2_app_kit::{
     NSAppKitVersionNumber, NSAppKitVersionNumber10_12, NSAppearance, NSApplication,
-    NSApplicationPresentationOptions, NSBackingStoreType, NSColor, NSDraggingDestination,
+    NSApplicationPresentationOptions, NSBackingStoreType, NSDraggingDestination,
     NSFilenamesPboardType, NSPasteboard, NSRequestUserAttentionType, NSScreen, NSView,
     NSWindowButton, NSWindowDelegate, NSWindowFullScreenButton, NSWindowLevel,
     NSWindowOcclusionState, NSWindowOrderingMode, NSWindowSharingType, NSWindowStyleMask,
@@ -605,7 +605,6 @@ fn new_window(attrs: &WindowAttributes, mtm: MainThreadMarker) -> Option<Id<Wini
 
         if attrs.transparent {
             window.setOpaque(false);
-            window.setBackgroundColor(Some(unsafe { &NSColor::clearColor() }));
         }
 
         // register for drag and drop operations.

--- a/src/window.rs
+++ b/src/window.rs
@@ -941,6 +941,8 @@ impl Window {
     ///
     /// ## Platform-specific
     ///
+    /// - **macOS:** If you're not drawing to the window yourself, you might have to set the
+    ///   background color of the window to enable transparency.
     /// - **Web / iOS / Android:** Unsupported.
     /// - **X11:** Can only be set while building the window, with
     ///   [`WindowAttributes::with_transparent`].


### PR DESCRIPTION
Setting the background color changes how the window title bar appears, which is something that the application should customize itself if it wants this behaviour (and also, it wasn't set when calling `set_transparent`, so the behaviour wasn't consistent).

This was introduced all the way back in https://github.com/rust-windowing/winit/pull/853, so I can't really tell what the reasoning behind it was, but I assume it was for the examples to show better (i.e. setting the window as transparent worked even when not rendering into it).

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users

Related: https://github.com/alacritty/alacritty/pull/7928
