### PR TITLE
Reexport older versions of raw-window-handle

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -40,6 +40,10 @@ changelog entry.
 
 ## Unreleased
 
+### Added
+
+- Reexport `raw-window-handle` versions 0.4 and 0.5 as `raw_window_handle_04` and `raw_window_handle_05`.
+
 ### Fixed
 
 - On macOS, fix panic on exit when dropping windows outside the event loop.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,10 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide), doc(cfg_hide(doc, docsrs)))]
 #![allow(clippy::missing_safety_doc)]
 
+#[cfg(feature = "rwh_04")]
+pub use rwh_04 as raw_window_handle_04;
+#[cfg(feature = "rwh_05")]
+pub use rwh_05 as raw_window_handle_05;
 #[cfg(feature = "rwh_06")]
 pub use rwh_06 as raw_window_handle;
 


### PR DESCRIPTION
When the user decides to use an older version of raw-window-handle, through the `rwh_04` or `rwh_05` features, it makes sense to reexport the crate so they don’t have to depend on it manually and can instead use `winit::raw_window_handle`.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior