### PR TITLE
Support is_x11 and is_wayland on EventLoop

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -12,7 +12,7 @@ on how to add them:
 ### Added
 
 - Add `Window::turbo()`, implemented on X11, Wayland, and Web.
-- Implement `ActiveEventLoopExtWayland` and `ActiveEventLoopExtX11` for `EventLoop`.
+- Add traits `EventLoopExtWayland` and `EventLoopExtX11`, providing methods `is_wayland` and `is_x11` on `EventLoop`.
 - On X11, add `Window::some_rare_api`.
 - On X11, add `Window::even_more_rare_api`.
 - On Wayland, add `Window::common_api`.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -12,6 +12,7 @@ on how to add them:
 ### Added
 
 - Add `Window::turbo()`, implemented on X11, Wayland, and Web.
+- Implement `ActiveEventLoopExtWayland` and `ActiveEventLoopExtX11` for `EventLoop`.
 - On X11, add `Window::some_rare_api`.
 - On X11, add `Window::even_more_rare_api`.
 - On Wayland, add `Window::common_api`.

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -32,7 +32,13 @@ impl ActiveEventLoopExtWayland for ActiveEventLoop {
     }
 }
 
-impl<T: 'static> ActiveEventLoopExtWayland for EventLoop<T> {
+/// Additional methods on [`EventLoop`] that are specific to Wayland.
+pub trait EventLoopExtWayland {
+    /// True if the [`EventLoop`] uses Wayland.
+    fn is_wayland(&self) -> bool;
+}
+
+impl<T: 'static> EventLoopExtWayland for EventLoop<T> {
     #[inline]
     fn is_wayland(&self) -> bool {
         self.event_loop.is_wayland()

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -13,7 +13,7 @@
 //! * `wayland-csd-adwaita` (default).
 //! * `wayland-csd-adwaita-crossfont`.
 //! * `wayland-csd-adwaita-notitle`.
-use crate::event_loop::{ActiveEventLoop, EventLoopBuilder};
+use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
 use crate::monitor::MonitorHandle;
 use crate::window::{Window, WindowAttributes};
 
@@ -29,6 +29,13 @@ impl ActiveEventLoopExtWayland for ActiveEventLoop {
     #[inline]
     fn is_wayland(&self) -> bool {
         self.p.is_wayland()
+    }
+}
+
+impl<T: 'static> ActiveEventLoopExtWayland for EventLoop<T> {
+    #[inline]
+    fn is_wayland(&self) -> bool {
+        self.event_loop.is_wayland()
     }
 }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -2,7 +2,7 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::event_loop::{ActiveEventLoop, EventLoopBuilder};
+use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
 use crate::monitor::MonitorHandle;
 use crate::window::{Window, WindowAttributes};
 
@@ -96,6 +96,13 @@ impl ActiveEventLoopExtX11 for ActiveEventLoop {
     #[inline]
     fn is_x11(&self) -> bool {
         !self.p.is_wayland()
+    }
+}
+
+impl<T: 'static> ActiveEventLoopExtX11 for EventLoop<T> {
+    #[inline]
+    fn is_x11(&self) -> bool {
+        !self.event_loop.is_wayland()
     }
 }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -99,7 +99,13 @@ impl ActiveEventLoopExtX11 for ActiveEventLoop {
     }
 }
 
-impl<T: 'static> ActiveEventLoopExtX11 for EventLoop<T> {
+/// Additional methods on [`EventLoop`] that are specific to X11.
+pub trait EventLoopExtX11 {
+    /// True if the [`EventLoop`] uses X11.
+    fn is_x11(&self) -> bool;
+}
+
+impl<T: 'static> EventLoopExtX11 for EventLoop<T> {
     #[inline]
     fn is_x11(&self) -> bool {
         !self.event_loop.is_wayland()

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -785,6 +785,16 @@ impl<T: 'static> EventLoop<T> {
         Ok(EventLoop::X(x11::EventLoop::new(xconn)))
     }
 
+    #[inline]
+    pub fn is_wayland(&self) -> bool {
+        match *self {
+            #[cfg(wayland_platform)]
+            EventLoop::Wayland(_) => true,
+            #[cfg(x11_platform)]
+            _ => false,
+        }
+    }
+
     pub fn create_proxy(&self) -> EventLoopProxy<T> {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.create_proxy(); as EventLoopProxy)
     }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

---

Winit v0.30 does not allow testing `is_wayland` on an `EventLoop` (but only on an `ActiveEventLoop`), though this appears to be possible. This is an issue for me.

The trait names `ActiveEventLoopExtWayland` and `ActiveEventLoopExtX11` are now inaccurate (may cause issues with future additional functionality?), but this is the most straightforward solution.

Fixes https://github.com/rust-windowing/winit/issues/3670