### PR TITLE
Web: fix Clippy v1.78 FPs

### DIFF
--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -17,8 +17,8 @@
 // incoming events (from the registered handlers) and ensuring they are passed to the user in a
 // compliant way.
 
-// TODO: FP, remove when <https://github.com/rust-lang/rust/issues/121621> is fixed.
-#![allow(unknown_lints, non_local_definitions)]
+// TODO: FP, remove when <https://github.com/rust-lang/rust-clippy/issues/12377> is fixed.
+#![allow(clippy::empty_docs)]
 
 mod r#async;
 mod cursor;


### PR DESCRIPTION
See https://github.com/rust-lang/rust-clippy/issues/12377, which I think should be in v1.79 again?