### PR TITLE
Add more specific error messages for X11 failed initialization

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -43,6 +43,8 @@ changelog entry.
 ### Added
 
 - Reexport `raw-window-handle` versions 0.4 and 0.5 as `raw_window_handle_04` and `raw_window_handle_05`.
+- On X11, a log message will be emitted to describe why the display failed to
+  initialize if it did.
 
 ### Fixed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -43,8 +43,8 @@ changelog entry.
 ### Added
 
 - Reexport `raw-window-handle` versions 0.4 and 0.5 as `raw_window_handle_04` and `raw_window_handle_05`.
-- On X11, a log message will be emitted to describe why the display failed to
-  initialize if it did.
+- On X11, the "NotSupportedError" type now has extra information if the display
+  failed to initialize. 
 
 ### Fixed
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -779,7 +779,9 @@ impl<T: 'static> EventLoop<T> {
     fn new_x11_any_thread() -> Result<EventLoop<T>, EventLoopError> {
         let xconn = match X11_BACKEND.lock().unwrap().as_ref() {
             Ok(xconn) => xconn.clone(),
-            Err(_) => return Err(EventLoopError::NotSupported(NotSupportedError::new())),
+            Err(x) => {
+                return Err(EventLoopError::NotSupported(NotSupportedError::from_x11(x.clone())))
+            },
         };
 
         Ok(EventLoop::X(x11::EventLoop::new(xconn)))

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -434,7 +434,7 @@ impl EventProcessor {
             let flags = xev.data.get_long(1);
             let version = flags >> 24;
             self.dnd.version = Some(version);
-            let has_more_types = flags - (flags & (c_long::max_value() - 1)) == 1;
+            let has_more_types = flags - (flags & (c_long::MAX - 1)) == 1;
             if !has_more_types {
                 let type_list = vec![
                     xev.data.get_long(2) as xproto::Atom,

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -112,7 +112,8 @@ impl XConnection {
             let conn =
                 unsafe { XCBConnection::from_raw_xcb_connection(xcb_connection.cast(), false) };
 
-            conn.context("failed to initialize XCB connection").map_err(|e| XNotSupported::XcbConversionError(Arc::new(WrapConnectError(e))))?
+            conn.context("failed to initialize XCB connection")
+                .map_err(|e| XNotSupported::XcbConversionError(Arc::new(WrapConnectError(e))))?
         };
 
         // Get the default screen.

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -9,6 +9,7 @@ use crate::window::CursorIcon;
 use super::atoms::Atoms;
 use super::ffi;
 use super::monitor::MonitorHandle;
+use tracing::{error, warn};
 use x11rb::connection::Connection;
 use x11rb::protocol::randr::ConnectionExt as _;
 use x11rb::protocol::xproto::{self, ConnectionExt};
@@ -74,7 +75,7 @@ trait ResultExt {
 impl<T, E: core::fmt::Debug> ResultExt for Result<T, E> {
     fn context(self, msg: &str) -> Self {
         self.map_err(|err| {
-            tracing::error!("{}: {:?}", msg, err);
+            error!("{}: {:?}", msg, err);
             err
         })
     }
@@ -95,7 +96,7 @@ impl XConnection {
         let display = unsafe {
             let display = (xlib.XOpenDisplay)(ptr::null());
             if display.is_null() {
-                tracing::error!("failed to open dsplay: XOpenDisplay returned a null pointer");
+                error!("failed to open dsplay: XOpenDisplay returned a null pointer");
                 return Err(XNotSupported::XOpenDisplayFailed);
             }
             display
@@ -133,7 +134,7 @@ impl XConnection {
 
         let xsettings_screen = Self::new_xsettings_screen(&xcb, default_screen);
         if xsettings_screen.is_none() {
-            tracing::warn!("error setting XSETTINGS; Xft options won't reload automatically")
+            warn!("error setting XSETTINGS; Xft options won't reload automatically")
         }
 
         // Fetch atoms.


### PR DESCRIPTION
This ensures that, when X11 initialization fails, we know exactly why.

cc #3671

Signed-off-by: John Nunley <dev@notgull.net>

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
