### PR TITLE
event_loop: remove deprecated `run` APIs

### DIFF
--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -3,50 +3,45 @@
 fn main() -> Result<(), impl std::error::Error> {
     use std::collections::HashMap;
 
+    use winit::application::ApplicationHandler;
     use winit::dpi::{LogicalPosition, LogicalSize, Position};
-    use winit::event::{ElementState, Event, KeyEvent, WindowEvent};
+    use winit::event::{ElementState, KeyEvent, WindowEvent};
     use winit::event_loop::{ActiveEventLoop, EventLoop};
     use winit::raw_window_handle::HasRawWindowHandle;
-    use winit::window::Window;
+    use winit::window::{Window, WindowId};
 
     #[path = "util/fill.rs"]
     mod fill;
 
-    fn spawn_child_window(parent: &Window, event_loop: &ActiveEventLoop) -> Window {
-        let parent = parent.raw_window_handle().unwrap();
-        let mut window_attributes = Window::default_attributes()
-            .with_title("child window")
-            .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
-            .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
-            .with_visible(true);
-        // `with_parent_window` is unsafe. Parent window must be a valid window.
-        window_attributes = unsafe { window_attributes.with_parent_window(Some(parent)) };
-
-        event_loop.create_window(window_attributes).unwrap()
+    #[derive(Default)]
+    struct Application {
+        parent_window_id: Option<WindowId>,
+        windows: HashMap<WindowId, Window>,
     }
 
-    let mut windows = HashMap::new();
+    impl ApplicationHandler for Application {
+        fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+            let attributes = Window::default_attributes()
+                .with_title("parent window")
+                .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+                .with_inner_size(LogicalSize::new(640.0f32, 480.0f32));
+            let window = event_loop.create_window(attributes).unwrap();
 
-    let event_loop: EventLoop<()> = EventLoop::new().unwrap();
-    let mut parent_window_id = None;
+            println!("Parent window id: {:?})", window.id());
+            self.parent_window_id = Some(window.id());
 
-    event_loop.run(move |event: Event<()>, event_loop| {
-        match event {
-            Event::Resumed => {
-                let attributes = Window::default_attributes()
-                    .with_title("parent window")
-                    .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
-                    .with_inner_size(LogicalSize::new(640.0f32, 480.0f32));
-                let window = event_loop.create_window(attributes).unwrap();
+            self.windows.insert(window.id(), window);
+        }
 
-                parent_window_id = Some(window.id());
-
-                println!("Parent window id: {parent_window_id:?})");
-                windows.insert(window.id(), window);
-            },
-            Event::WindowEvent { window_id, event } => match event {
+        fn window_event(
+            &mut self,
+            event_loop: &ActiveEventLoop,
+            window_id: winit::window::WindowId,
+            event: WindowEvent,
+        ) {
+            match event {
                 WindowEvent::CloseRequested => {
-                    windows.clear();
+                    self.windows.clear();
                     event_loop.exit();
                 },
                 WindowEvent::CursorEntered { device_id: _ } => {
@@ -61,22 +56,38 @@ fn main() -> Result<(), impl std::error::Error> {
                     event: KeyEvent { state: ElementState::Pressed, .. },
                     ..
                 } => {
-                    let parent_window = windows.get(&parent_window_id.unwrap()).unwrap();
+                    let parent_window = self.windows.get(&self.parent_window_id.unwrap()).unwrap();
                     let child_window = spawn_child_window(parent_window, event_loop);
                     let child_id = child_window.id();
                     println!("Child window created with id: {child_id:?}");
-                    windows.insert(child_id, child_window);
+                    self.windows.insert(child_id, child_window);
                 },
                 WindowEvent::RedrawRequested => {
-                    if let Some(window) = windows.get(&window_id) {
+                    if let Some(window) = self.windows.get(&window_id) {
                         fill::fill_window(window);
                     }
                 },
                 _ => (),
-            },
-            _ => (),
+            }
         }
-    })
+    }
+
+    fn spawn_child_window(parent: &Window, event_loop: &ActiveEventLoop) -> Window {
+        let parent = parent.raw_window_handle().unwrap();
+        let mut window_attributes = Window::default_attributes()
+            .with_title("child window")
+            .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
+            .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
+            .with_visible(true);
+        // `with_parent_window` is unsafe. Parent window must be a valid window.
+        window_attributes = unsafe { window_attributes.with_parent_window(Some(parent)) };
+
+        event_loop.create_window(window_attributes).unwrap()
+    }
+
+    let event_loop: EventLoop<()> = EventLoop::new().unwrap();
+    let mut app = Application::default();
+    event_loop.run_app(&mut app)
 }
 
 #[cfg(all(feature = "rwh_06", not(any(x11_platform, macos_platform, windows_platform))))]

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -44,6 +44,12 @@ changelog entry.
 
 - Reexport `raw-window-handle` versions 0.4 and 0.5 as `raw_window_handle_04` and `raw_window_handle_05`.
 
+### Removed
+
+- Remove `EventLoop::run`.
+- Remove `EventLoopExtRunOnDemand::run_on_demand`.
+- Remove `EventLoopExtPumpEvents::pump_events`.
+
 ### Fixed
 
 - On macOS, fix panic on exit when dropping windows outside the event loop.

--- a/src/changelog/v0.30.md
+++ b/src/changelog/v0.30.md
@@ -65,7 +65,7 @@
   `Fn`. The semantics are mostly the same, given that the capture list of the
   closure is your new `State`. Consider the following code:
 
-  ```rust,no_run
+  ```rust,no_run,ignore
   use winit::event::Event;
   use winit::event_loop::EventLoop;
   use winit::window::Window;

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -1,12 +1,13 @@
 use std::time::Duration;
 
 use crate::application::ApplicationHandler;
-use crate::event::Event;
-use crate::event_loop::{self, ActiveEventLoop, EventLoop};
+use crate::event_loop::EventLoop;
 
 /// Additional methods on [`EventLoop`] for pumping events within an external event loop
 pub trait EventLoopExtPumpEvents {
     /// A type provided by the user that can be passed through [`Event::UserEvent`].
+    ///
+    /// [`Event::UserEvent`]: crate::event::Event::UserEvent
     type UserEvent: 'static;
 
     /// Pump the `EventLoop` to check for and dispatch pending events.
@@ -107,30 +108,18 @@ pub trait EventLoopExtPumpEvents {
         &mut self,
         timeout: Option<Duration>,
         app: &mut A,
-    ) -> PumpStatus {
-        #[allow(deprecated)]
-        self.pump_events(timeout, |event, event_loop| {
-            event_loop::dispatch_event_for_app(app, event_loop, event)
-        })
-    }
-
-    /// See [`pump_app_events`].
-    ///
-    /// [`pump_app_events`]: Self::pump_app_events
-    #[deprecated = "use EventLoopExtPumpEvents::pump_app_events"]
-    fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
-    where
-        F: FnMut(Event<Self::UserEvent>, &ActiveEventLoop);
+    ) -> PumpStatus;
 }
 
 impl<T> EventLoopExtPumpEvents for EventLoop<T> {
     type UserEvent = T;
 
-    fn pump_events<F>(&mut self, timeout: Option<Duration>, event_handler: F) -> PumpStatus
-    where
-        F: FnMut(Event<Self::UserEvent>, &ActiveEventLoop),
-    {
-        self.event_loop.pump_events(timeout, event_handler)
+    fn pump_app_events<A: ApplicationHandler<Self::UserEvent>>(
+        &mut self,
+        timeout: Option<Duration>,
+        app: &mut A,
+    ) -> PumpStatus {
+        self.event_loop.pump_app_events(timeout, app)
     }
 }
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -25,6 +25,7 @@ use super::app_delegate::{ApplicationDelegate, HandlePendingUserEvents};
 use super::event::dummy_event;
 use super::monitor::{self, MonitorHandle};
 use super::observer::setup_control_flow_observers;
+use crate::application::ApplicationHandler;
 use crate::error::EventLoopError;
 use crate::event::Event;
 use crate::event_loop::{
@@ -155,17 +156,28 @@ impl ActiveEventLoop {
     }
 }
 
-fn map_user_event<T: 'static>(
-    mut handler: impl FnMut(Event<T>, &RootWindowTarget),
+fn map_user_event<T: 'static, A: ApplicationHandler<T>>(
+    app: &mut A,
     receiver: Rc<mpsc::Receiver<T>>,
-) -> impl FnMut(Event<HandlePendingUserEvents>, &RootWindowTarget) {
-    move |event, window_target| match event.map_nonuser_event() {
-        Ok(event) => (handler)(event, window_target),
-        Err(_) => {
+) -> impl FnMut(Event<HandlePendingUserEvents>, &RootWindowTarget) + '_ {
+    move |event, window_target| match event {
+        Event::NewEvents(cause) => app.new_events(window_target, cause),
+        Event::WindowEvent { window_id, event } => {
+            app.window_event(window_target, window_id, event)
+        },
+        Event::DeviceEvent { device_id, event } => {
+            app.device_event(window_target, device_id, event)
+        },
+        Event::UserEvent(_) => {
             for event in receiver.try_iter() {
-                (handler)(Event::UserEvent(event), window_target);
+                app.user_event(window_target, event);
             }
         },
+        Event::Suspended => app.suspended(window_target),
+        Event::Resumed => app.resumed(window_target),
+        Event::AboutToWait => app.about_to_wait(window_target),
+        Event::LoopExiting => app.exiting(window_target),
+        Event::MemoryWarning => app.memory_warning(window_target),
     }
 }
 
@@ -260,22 +272,19 @@ impl<T> EventLoop<T> {
         &self.window_target
     }
 
-    pub fn run<F>(mut self, handler: F) -> Result<(), EventLoopError>
-    where
-        F: FnMut(Event<T>, &RootWindowTarget),
-    {
-        self.run_on_demand(handler)
+    pub fn run_app<A: ApplicationHandler<T>>(mut self, app: &mut A) -> Result<(), EventLoopError> {
+        self.run_app_on_demand(app)
     }
 
     // NB: we don't base this on `pump_events` because for `MacOs` we can't support
     // `pump_events` elegantly (we just ask to run the loop for a "short" amount of
     // time and so a layered implementation would end up using a lot of CPU due to
     // redundant wake ups.
-    pub fn run_on_demand<F>(&mut self, handler: F) -> Result<(), EventLoopError>
-    where
-        F: FnMut(Event<T>, &RootWindowTarget),
-    {
-        let handler = map_user_event(handler, self.receiver.clone());
+    pub fn run_app_on_demand<A: ApplicationHandler<T>>(
+        &mut self,
+        app: &mut A,
+    ) -> Result<(), EventLoopError> {
+        let handler = map_user_event(app, self.receiver.clone());
 
         self.delegate.set_event_handler(handler, || {
             autoreleasepool(|_| {
@@ -310,11 +319,12 @@ impl<T> EventLoop<T> {
         Ok(())
     }
 
-    pub fn pump_events<F>(&mut self, timeout: Option<Duration>, handler: F) -> PumpStatus
-    where
-        F: FnMut(Event<T>, &RootWindowTarget),
-    {
-        let handler = map_user_event(handler, self.receiver.clone());
+    pub fn pump_app_events<A: ApplicationHandler<T>>(
+        &mut self,
+        timeout: Option<Duration>,
+        app: &mut A,
+    ) -> PumpStatus {
+        let handler = map_user_event(app, self.receiver.clone());
 
         self.delegate.set_event_handler(handler, || {
             autoreleasepool(|_| {


### PR DESCRIPTION
The APIs are not well suited for the `&dyn ApplicationHandler` model and
`Box<dyn EventLoop>` structure, thus remove them.

- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
