### PR TITLE
Keep a reference to ApplicationDelegate in NSWindowDelegate and NSView

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -39,3 +39,7 @@ The migration guide could reference other migration examples in the current
 changelog entry.
 
 ## Unreleased
+
+### Fixed
+
+- On macOS, fix panic on exit when dropping windows outside the event loop.

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -52,6 +52,8 @@ pub(super) struct State {
     wait_timeout: Cell<Option<Instant>>,
     pending_events: RefCell<VecDeque<QueuedEvent>>,
     pending_redraw: RefCell<Vec<WindowId>>,
+    // NOTE: This is strongly referenced by our `NSWindowDelegate` and our `NSView` subclass, and
+    // as such should be careful to not add fields that, in turn, strongly reference those.
 }
 
 declare_class!(
@@ -71,7 +73,7 @@ declare_class!(
     unsafe impl NSObjectProtocol for ApplicationDelegate {}
 
     unsafe impl NSApplicationDelegate for ApplicationDelegate {
-        // Note: This will, globally, only be run once, no matter how many
+        // NOTE: This will, globally, only be run once, no matter how many
         // `EventLoop`s the user creates.
         #[method(applicationDidFinishLaunching:)]
         fn did_finish_launching(&self, _sender: Option<&AnyObject>) {
@@ -106,7 +108,7 @@ declare_class!(
             // In this case we still want to consider Winit's `EventLoop` to be "running",
             // so we call `start_running()` above.
             if self.ivars().stop_on_launch.get() {
-                // Note: the original idea had been to only stop the underlying `RunLoop`
+                // NOTE: the original idea had been to only stop the underlying `RunLoop`
                 // for the app but that didn't work as expected (`-[NSApplication run]`
                 // effectively ignored the attempt to stop the RunLoop and re-started it).
                 //
@@ -188,7 +190,7 @@ impl ApplicationDelegate {
 
     /// Clears the `running` state and resets the `control_flow` state when an `EventLoop` exits.
     ///
-    /// Note: that if the `NSApplication` has been launched then that state is preserved,
+    /// NOTE: that if the `NSApplication` has been launched then that state is preserved,
     /// and we won't need to re-launch the app if subsequent EventLoops are run.
     pub fn internal_exit(&self) {
         self.handle_event(Event::LoopExiting);

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -78,6 +78,10 @@ impl ActiveEventLoop {
         RootWindowTarget { p, _marker: PhantomData }
     }
 
+    pub(super) fn app_delegate(&self) -> &ApplicationDelegate {
+        &self.delegate
+    }
+
     pub fn create_custom_cursor(&self, source: CustomCursorSource) -> RootCustomCursor {
         RootCustomCursor { inner: CustomCursor::new(source.inner) }
     }
@@ -133,9 +137,7 @@ impl ActiveEventLoop {
     pub(crate) fn owned_display_handle(&self) -> OwnedDisplayHandle {
         OwnedDisplayHandle
     }
-}
 
-impl ActiveEventLoop {
     pub(crate) fn hide_application(&self) {
         NSApplication::sharedApplication(self.mtm).hide(None)
     }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -28,7 +28,9 @@ impl Window {
         attributes: WindowAttributes,
     ) -> Result<Self, RootOsError> {
         let mtm = window_target.mtm;
-        let delegate = autoreleasepool(|_| WindowDelegate::new(attributes, mtm))?;
+        let delegate = autoreleasepool(|_| {
+            WindowDelegate::new(window_target.app_delegate(), attributes, mtm)
+        })?;
         Ok(Window {
             window: MainThreadBound::new(delegate.window().retain(), mtm),
             delegate: MainThreadBound::new(delegate, mtm),


### PR DESCRIPTION
The delegate is only weakly referenced by NSApplication, so getting it from there may fail if the event loop has been dropped.

Fixes https://github.com/rust-windowing/winit/issues/3668.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
