### PR TITLE
fix drag glitch when dragging across monitor boundary

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -47,3 +47,4 @@ changelog entry.
 ### Fixed
 
 - On macOS, fix panic on exit when dropping windows outside the event loop.
+- On macOS, fix window dragging glitch when dragging across the monitor boundary with different scale factor.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -47,4 +47,4 @@ changelog entry.
 ### Fixed
 
 - On macOS, fix panic on exit when dropping windows outside the event loop.
-- On macOS, fix window dragging glitch when dragging across the monitor boundary with different scale factor.
+- On macOS, fix window dragging glitches when dragging across a monitor boundary with different scale factor.

--- a/src/platform_impl/macos/app_delegate.rs
+++ b/src/platform_impl/macos/app_delegate.rs
@@ -375,9 +375,11 @@ impl ApplicationDelegate {
 
                     let physical_size = *new_inner_size.lock().unwrap();
                     drop(new_inner_size);
-                    let logical_size = physical_size.to_logical(scale_factor);
-                    let size = NSSize::new(logical_size.width, logical_size.height);
-                    window.setContentSize(size);
+                    if physical_size != suggested_size {
+                        let logical_size = physical_size.to_logical(scale_factor);
+                        let size = NSSize::new(logical_size.width, logical_size.height);
+                        window.setContentSize(size);
+                    }
 
                     let resized_event = Event::WindowEvent {
                         window_id: RootWindowId(window.id()),


### PR DESCRIPTION
On macOS, when dragging across monitor boundary with a different scale factor, the `QueuedEvent::ScaleFactorChanged` event will be emit.

When process this event, will [unconditionally set the content size](https://github.com/rust-windowing/winit/blob/ab33fb8eda45f9a23587465d787a70a309c67ec4/src/platform_impl/macos/app_delegate.rs#L380), which would cause some glitch.

---

Because the event is emitted with `suggested_size` set to [current frame size](https://github.com/rust-windowing/winit/blob/ab33fb8eda45f9a23587465d787a70a309c67ec4/src/platform_impl/macos/window_delegate.rs#L774).

So, if the user hasn't requested a size change, the call to `setContentSize` wouldn't actually change the size.

So, change to only call `setContentSize` if the user has requested a size change.

---

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
