### PR TITLE
Replace pointer dereference with read_unaligned()

### DIFF
--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1424,7 +1424,7 @@ impl EventProcessor {
             if !xinput2::XIMaskIsSet(mask, i) {
                 continue;
             }
-            let x = unsafe { *value };
+            let x = unsafe { value.read_unaligned() };
 
             // We assume that every XInput2 device with analog axes is a pointing device emitting
             // relative coordinates.


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

**Reason for Pull Request:** On Raspberry Pi, using the Rust crate eframe caused the program to crash on mouse movement. The Backtrace lead to this specific line of code, and the exact error was a "misaligned pointer dereference: address must be a multiple of 0x8 but is xxxx"

The edit has been tested with the Raspberry Pi, which works now.

Technical information:

- Raspberry Pi 3 B+
- Raspbian OS Bullseye 32-Bit
- Using the Waveshare 3.5 (A) display connected via GPIO
- Using <https://github.com/goodtft/LCD-show> as display drivers