### PR TITLE
Add Event::OpenFiles

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -1,5 +1,7 @@
 //! End user application handling.
 
+use std::path::PathBuf;
+
 use crate::event::{DeviceEvent, DeviceId, StartCause, WindowEvent};
 use crate::event_loop::ActiveEventLoop;
 use crate::window::WindowId;
@@ -221,5 +223,9 @@ pub trait ApplicationHandler<T: 'static = ()> {
     /// - **macOS / Orbital / Wayland / Web / Windows:** Unsupported.
     fn memory_warning(&mut self, event_loop: &ActiveEventLoop) {
         let _ = event_loop;
+    }
+
+    fn open_files(&mut self, files: Vec<PathBuf>) {
+        let _ = files;
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -67,12 +67,18 @@ pub enum Event<T: 'static> {
     /// See [`ApplicationHandler::window_event`] for details.
     ///
     /// [`ApplicationHandler::window_event`]: crate::application::ApplicationHandler::window_event
-    WindowEvent { window_id: WindowId, event: WindowEvent },
+    WindowEvent {
+        window_id: WindowId,
+        event: WindowEvent,
+    },
 
     /// See [`ApplicationHandler::device_event`] for details.
     ///
     /// [`ApplicationHandler::device_event`]: crate::application::ApplicationHandler::device_event
-    DeviceEvent { device_id: DeviceId, event: DeviceEvent },
+    DeviceEvent {
+        device_id: DeviceId,
+        event: DeviceEvent,
+    },
 
     /// See [`ApplicationHandler::user_event`] for details.
     ///
@@ -103,6 +109,8 @@ pub enum Event<T: 'static> {
     ///
     /// [`ApplicationHandler::memory_warning`]: crate::application::ApplicationHandler::memory_warning
     MemoryWarning,
+
+    OpenFiles(Vec<PathBuf>),
 }
 
 impl<T> Event<T> {
@@ -119,6 +127,7 @@ impl<T> Event<T> {
             Suspended => Ok(Suspended),
             Resumed => Ok(Resumed),
             MemoryWarning => Ok(MemoryWarning),
+            OpenFiles(path) => Ok(OpenFiles(path)),
         }
     }
 }

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -178,6 +178,7 @@ fn map_user_event<T: 'static, A: ApplicationHandler<T>>(
         Event::AboutToWait => app.about_to_wait(window_target),
         Event::LoopExiting => app.exiting(window_target),
         Event::MemoryWarning => app.memory_warning(window_target),
+        Event::OpenFiles(files) => app.open_files(files),
     }
 }
 


### PR DESCRIPTION
Emit an event when the application is opened by clicking on files in Finder or by dropping files on the Dock icon. This is macOS specific, as other OSs usually communicate that information through `std::env::args()`.

I am not sure with the current implementation, i.e. maybe the `OpenFiles` event should be defined in a macOS specific event enum type?

This basically implements #1751.

To test the event, a application bundle is required:

```
Winit.App
- Contents
  - Info.plist
  - MacOS
    - <executable>
```

The `Info.plist` should look like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>CFBundleExecutable</key>
    <string>
        <!-- Name of executable -->
    </string>
</dict>
</plist>
```

Also, you need to implement `fn ApplicationHandler::open_files(&mut self, files: Vec<PathBuf>)`.


- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit
