### PR TITLE
Add warning to ignore synthetic keyboard presses

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -215,6 +215,11 @@ pub enum WindowEvent {
         ///   Windows***
         ///
         /// Otherwise, this value is always `false`.
+        ///
+        /// # Warning
+        ///
+        /// Synthetic key presses (but not releases) should be ignored by default in your application.
+        /// These are produced by the OS, and do not reflect real user inputs.
         is_synthetic: bool,
     },
 


### PR DESCRIPTION
This PR adds a more prominent warning about synthetic keyboard events, as a simple stopgap for https://github.com/rust-windowing/winit/issues/3543.

I encountered this when reviewing https://github.com/bevyengine/bevy/pull/13696: the existing docs alone were not clear enough for me to determine that synthetic presses should be ignored.

While I suspect that removing them on the winit end is likely better, this is a simple non-breaking improvement.