### PR TITLE
macOS/iOS: Various refactorings in application state

### DIFF
--- a/src/platform_impl/ios/app_delegate.rs
+++ b/src/platform_impl/ios/app_delegate.rs
@@ -1,11 +1,9 @@
 use objc2::{declare_class, mutability, ClassType, DeclaredClass};
-use objc2_foundation::{MainThreadMarker, NSObject, NSObjectProtocol};
-use objc2_ui_kit::{UIApplication, UIWindow};
+use objc2_foundation::{MainThreadMarker, NSObject};
+use objc2_ui_kit::UIApplication;
 
-use super::app_state::{self, EventWrapper};
-use super::window::WinitUIWindow;
-use crate::event::{Event, WindowEvent};
-use crate::window::WindowId as RootWindowId;
+use super::app_state::{self, send_occluded_event_for_all_windows, EventWrapper};
+use crate::event::Event;
 
 declare_class!(
     pub struct AppDelegate;
@@ -40,35 +38,17 @@ declare_class!(
 
         #[method(applicationWillEnterForeground:)]
         fn will_enter_foreground(&self, application: &UIApplication) {
-            self.send_occluded_event_for_all_windows(application, false);
+            send_occluded_event_for_all_windows(application, false);
         }
 
         #[method(applicationDidEnterBackground:)]
         fn did_enter_background(&self, application: &UIApplication) {
-            self.send_occluded_event_for_all_windows(application, true);
+            send_occluded_event_for_all_windows(application, true);
         }
 
         #[method(applicationWillTerminate:)]
         fn will_terminate(&self, application: &UIApplication) {
-            let mut events = Vec::new();
-            #[allow(deprecated)]
-            for window in application.windows().iter() {
-                if window.is_kind_of::<WinitUIWindow>() {
-                    // SAFETY: We just checked that the window is a `winit` window
-                    let window = unsafe {
-                        let ptr: *const UIWindow = window;
-                        let ptr: *const WinitUIWindow = ptr.cast();
-                        &*ptr
-                    };
-                    events.push(EventWrapper::StaticEvent(Event::WindowEvent {
-                        window_id: RootWindowId(window.id()),
-                        event: WindowEvent::Destroyed,
-                    }));
-                }
-            }
-            let mtm = MainThreadMarker::new().unwrap();
-            app_state::handle_nonuser_events(mtm, events);
-            app_state::terminated(mtm);
+            app_state::terminated(application);
         }
 
         #[method(applicationDidReceiveMemoryWarning:)]
@@ -78,26 +58,3 @@ declare_class!(
         }
     }
 );
-
-impl AppDelegate {
-    fn send_occluded_event_for_all_windows(&self, application: &UIApplication, occluded: bool) {
-        let mut events = Vec::new();
-        #[allow(deprecated)]
-        for window in application.windows().iter() {
-            if window.is_kind_of::<WinitUIWindow>() {
-                // SAFETY: We just checked that the window is a `winit` window
-                let window = unsafe {
-                    let ptr: *const UIWindow = window;
-                    let ptr: *const WinitUIWindow = ptr.cast();
-                    &*ptr
-                };
-                events.push(EventWrapper::StaticEvent(Event::WindowEvent {
-                    window_id: RootWindowId(window.id()),
-                    event: WindowEvent::Occluded(occluded),
-                }));
-            }
-        }
-        let mtm = MainThreadMarker::new().unwrap();
-        app_state::handle_nonuser_events(mtm, events);
-    }
-}

--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -20,7 +20,7 @@ use objc2_foundation::{
     CGRect, CGSize, MainThreadMarker, NSInteger, NSObjectProtocol, NSOperatingSystemVersion,
     NSProcessInfo,
 };
-use objc2_ui_kit::{UICoordinateSpace, UIView};
+use objc2_ui_kit::{UIApplication, UICoordinateSpace, UIView, UIWindow};
 
 use super::window::WinitUIWindow;
 use crate::dpi::PhysicalSize;
@@ -662,6 +662,28 @@ fn handle_user_events(mtm: MainThreadMarker) {
     }
 }
 
+pub(crate) fn send_occluded_event_for_all_windows(application: &UIApplication, occluded: bool) {
+    let mtm = MainThreadMarker::from(application);
+
+    let mut events = Vec::new();
+    #[allow(deprecated)]
+    for window in application.windows().iter() {
+        if window.is_kind_of::<WinitUIWindow>() {
+            // SAFETY: We just checked that the window is a `winit` window
+            let window = unsafe {
+                let ptr: *const UIWindow = window;
+                let ptr: *const WinitUIWindow = ptr.cast();
+                &*ptr
+            };
+            events.push(EventWrapper::StaticEvent(Event::WindowEvent {
+                window_id: RootWindowId(window.id()),
+                event: WindowEvent::Occluded(occluded),
+            }));
+        }
+    }
+    handle_nonuser_events(mtm, events);
+}
+
 pub fn handle_main_events_cleared(mtm: MainThreadMarker) {
     let mut this = AppState::get_mut(mtm);
     if !this.has_launched() || this.has_terminated() {
@@ -696,7 +718,27 @@ pub fn handle_events_cleared(mtm: MainThreadMarker) {
     AppState::get_mut(mtm).events_cleared_transition();
 }
 
-pub fn terminated(mtm: MainThreadMarker) {
+pub(crate) fn terminated(application: &UIApplication) {
+    let mtm = MainThreadMarker::from(application);
+
+    let mut events = Vec::new();
+    #[allow(deprecated)]
+    for window in application.windows().iter() {
+        if window.is_kind_of::<WinitUIWindow>() {
+            // SAFETY: We just checked that the window is a `winit` window
+            let window = unsafe {
+                let ptr: *const UIWindow = window;
+                let ptr: *const WinitUIWindow = ptr.cast();
+                &*ptr
+            };
+            events.push(EventWrapper::StaticEvent(Event::WindowEvent {
+                window_id: RootWindowId(window.id()),
+                event: WindowEvent::Destroyed,
+            }));
+        }
+    }
+    handle_nonuser_events(mtm, events);
+
     let mut this = AppState::get_mut(mtm);
     let mut handler = this.terminated_transition();
     drop(this);

--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -4,7 +4,7 @@ use objc2::{declare_class, msg_send, mutability, ClassType, DeclaredClass};
 use objc2_app_kit::{NSApplication, NSEvent, NSEventModifierFlags, NSEventType, NSResponder};
 use objc2_foundation::{MainThreadMarker, NSObject};
 
-use super::app_delegate::ApplicationDelegate;
+use super::app_state::ApplicationDelegate;
 use crate::event::{DeviceEvent, ElementState};
 
 declare_class!(

--- a/src/platform_impl/macos/app_state.rs
+++ b/src/platform_impl/macos/app_state.rs
@@ -27,7 +27,7 @@ impl Default for Policy {
 }
 
 #[derive(Debug, Default)]
-pub(super) struct State {
+pub(super) struct AppState {
     activation_policy: Policy,
     default_menu: bool,
     activate_ignoring_other_apps: bool,
@@ -63,7 +63,7 @@ declare_class!(
     }
 
     impl DeclaredClass for ApplicationDelegate {
-        type Ivars = State;
+        type Ivars = AppState;
     }
 
     unsafe impl NSObjectProtocol for ApplicationDelegate {}
@@ -130,7 +130,7 @@ impl ApplicationDelegate {
         default_menu: bool,
         activate_ignoring_other_apps: bool,
     ) -> Retained<Self> {
-        let this = mtm.alloc().set_ivars(State {
+        let this = mtm.alloc().set_ivars(AppState {
             activation_policy: Policy(activation_policy),
             default_menu,
             activate_ignoring_other_apps,

--- a/src/platform_impl/macos/event_handler.rs
+++ b/src/platform_impl/macos/event_handler.rs
@@ -16,7 +16,7 @@ impl fmt::Debug for EventHandlerData {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct EventHandler {
     /// This can be in the following states:
     /// - Not registered by the event loop (None).
@@ -26,6 +26,10 @@ pub(crate) struct EventHandler {
 }
 
 impl EventHandler {
+    pub(crate) const fn new() -> Self {
+        Self { inner: RefCell::new(None) }
+    }
+
     /// Set the event loop handler for the duration of the given closure.
     ///
     /// This is similar to using the `scoped-tls` or `scoped-tls-hkt` crates

--- a/src/platform_impl/macos/event_handler.rs
+++ b/src/platform_impl/macos/event_handler.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::{fmt, mem};
 
-use super::app_delegate::HandlePendingUserEvents;
+use super::app_state::HandlePendingUserEvents;
 use crate::event::Event;
 use crate::event_loop::ActiveEventLoop as RootActiveEventLoop;
 

--- a/src/platform_impl/macos/event_loop.rs
+++ b/src/platform_impl/macos/event_loop.rs
@@ -21,7 +21,7 @@ use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSWindow};
 use objc2_foundation::{MainThreadMarker, NSObjectProtocol};
 
 use super::app::WinitApplication;
-use super::app_delegate::{ApplicationDelegate, HandlePendingUserEvents};
+use super::app_state::{ApplicationDelegate, HandlePendingUserEvents};
 use super::event::dummy_event;
 use super::monitor::{self, MonitorHandle};
 use super::observer::setup_control_flow_observers;

--- a/src/platform_impl/macos/mod.rs
+++ b/src/platform_impl/macos/mod.rs
@@ -2,7 +2,7 @@
 mod util;
 
 mod app;
-mod app_delegate;
+mod app_state;
 mod cursor;
 mod event;
 mod event_handler;

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -22,7 +22,7 @@ use core_foundation::runloop::{
 use objc2_foundation::MainThreadMarker;
 use tracing::error;
 
-use super::app_delegate::ApplicationDelegate;
+use super::app_state::ApplicationDelegate;
 use super::event_loop::{stop_app_on_panic, PanicInfo};
 use super::ffi;
 

--- a/src/platform_impl/macos/observer.rs
+++ b/src/platform_impl/macos/observer.rs
@@ -251,8 +251,8 @@ impl Drop for EventLoopWaker {
     }
 }
 
-impl Default for EventLoopWaker {
-    fn default() -> EventLoopWaker {
+impl EventLoopWaker {
+    pub(crate) fn new() -> Self {
         extern "C" fn wakeup_main_loop(_timer: CFRunLoopTimerRef, _info: *mut c_void) {}
         unsafe {
             // Create a timer with a 0.1µs interval (1ns does not work) to mimic polling.
@@ -268,12 +268,10 @@ impl Default for EventLoopWaker {
                 ptr::null_mut(),
             );
             CFRunLoopAddTimer(CFRunLoopGetMain(), timer, kCFRunLoopCommonModes);
-            EventLoopWaker { timer, start_instant: Instant::now(), next_fire_date: None }
+            Self { timer, start_instant: Instant::now(), next_fire_date: None }
         }
     }
-}
 
-impl EventLoopWaker {
     pub fn stop(&mut self) {
         if self.next_fire_date.is_some() {
             self.next_fire_date = None;

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -16,7 +16,7 @@ use objc2_foundation::{
     NSPoint, NSRange, NSRect, NSSize, NSString, NSUInteger,
 };
 
-use super::app_delegate::ApplicationDelegate;
+use super::app_state::ApplicationDelegate;
 use super::cursor::{default_cursor, invisible_cursor};
 use super::event::{
     code_to_key, code_to_location, create_key_event, event_mods, lalt_pressed, ralt_pressed,

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -22,7 +22,7 @@ use objc2_foundation::{
     NSPoint, NSRect, NSSize, NSString,
 };
 
-use super::app_delegate::ApplicationDelegate;
+use super::app_state::ApplicationDelegate;
 use super::cursor::cursor_from_icon;
 use super::monitor::{self, flip_window_screen_coordinates, get_display_id};
 use super::observer::RunLoop;


### PR DESCRIPTION
I'm preparing to get rid of our application delegate in favour of registering notification observers, to do so I'm renaming `app_delegate.rs` to `app_state.rs`, and moving the functionality out of the Objective-C method into a normal method.

Additionally, `AppState` previously implemented `Default`, but really, this was a hack done because someone (probably myself) was too lazy to write out the full initialization in `AppDelegate::new`.

This is (deliberately) a non-functional change.

- [x] Tested on all platforms changed
