### PR TITLE
Web: queue `EventLoopProxy::send_event()` to microtask when triggered from outside the event loop

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -40,6 +40,11 @@ changelog entry.
 
 ## Unreleased
 
+### Fixed
+
+- On Web, fix `EventLoopProxy::send_event()` triggering event loop immediately
+  when not called from inside the event loop. Now queues a microtask instead.
+
 ### Removed
 
 - Remove `EventLoop::run`.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -40,6 +40,11 @@ changelog entry.
 
 ## Unreleased
 
+### Changed
+
+- On Web, let events wake up event loop immediately when using
+  `ControlFlow::Poll`.
+
 ### Fixed
 
 - On Web, fix `EventLoopProxy::send_event()` triggering event loop immediately

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -476,33 +476,30 @@ impl Shared {
 
         if local {
             // If the loop is not running and triggered locally, queue on next microtick.
-            if let Ok(RunnerEnum::Running(ref runner)) =
+            if let Ok(RunnerEnum::Running(_)) =
                 self.0.runner.try_borrow().as_ref().map(Deref::deref)
             {
-                // If we're currently polling let `send_events` do its job.
-                if !matches!(runner.state, State::Poll { .. }) {
-                    #[wasm_bindgen]
-                    extern "C" {
-                        #[wasm_bindgen(js_name = queueMicrotask)]
-                        fn queue_microtask(task: Function);
-                    }
-
-                    queue_microtask(
-                        Closure::once_into_js({
-                            let this = Rc::downgrade(&self.0);
-                            move || {
-                                if let Some(shared) = this.upgrade() {
-                                    Shared(shared).send_events(
-                                        iter::repeat(Event::UserEvent(())).take(count.get()),
-                                    )
-                                }
-                            }
-                        })
-                        .unchecked_into(),
-                    );
-
-                    return;
+                #[wasm_bindgen]
+                extern "C" {
+                    #[wasm_bindgen(js_name = queueMicrotask)]
+                    fn queue_microtask(task: Function);
                 }
+
+                queue_microtask(
+                    Closure::once_into_js({
+                        let this = Rc::downgrade(&self.0);
+                        move || {
+                            if let Some(shared) = this.upgrade() {
+                                Shared(shared).send_events(
+                                    iter::repeat(Event::UserEvent(())).take(count.get()),
+                                )
+                            }
+                        }
+                    })
+                    .unchecked_into(),
+                );
+
+                return;
             }
         }
 
@@ -520,13 +517,8 @@ impl Shared {
         // If we can run the event processing right now, or need to queue this and wait for later
         let mut process_immediately = true;
         match self.0.runner.try_borrow().as_ref().map(Deref::deref) {
-            Ok(RunnerEnum::Running(ref runner)) => {
-                // If we're currently polling, queue this and wait for the poll() method to be
-                // called
-                if let State::Poll { .. } = runner.state {
-                    process_immediately = false;
-                }
-            },
+            // If the runner is attached but not running, we always wake it up.
+            Ok(RunnerEnum::Running(_)) => (),
             Ok(RunnerEnum::Pending) => {
                 // The runner still hasn't been attached: queue this event and wait for it to be
                 process_immediately = false;


### PR DESCRIPTION
This also checks if its coming from a thread or not, in which case it doesn't queue it.

I also noticed some legacy code that deferred to `ControlFlow::Poll` when receiving events instead of waking up the event loop immediately, which I removed, so now events should come in faster regardless of `PollStrategy`.

Fixes #3715.