### PR TITLE
Web: don't overwrite cursor with `CursorIcon::Default`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -49,6 +49,7 @@ changelog entry.
 
 - On Web, fix `EventLoopProxy::send_event()` triggering event loop immediately
   when not called from inside the event loop. Now queues a microtask instead.
+- On Web, stop overwriting default cursor with `CursorIcon::Default`.
 
 ### Removed
 

--- a/src/platform_impl/web/cursor.rs
+++ b/src/platform_impl/web/cursor.rs
@@ -324,7 +324,11 @@ impl Inner {
             match &self.cursor {
                 SelectedCursor::Icon(icon)
                 | SelectedCursor::Loading { previous: Previous::Icon(icon), .. } => {
-                    self.style.set("cursor", icon.name())
+                    if let CursorIcon::Default = icon {
+                        self.style.remove("cursor")
+                    } else {
+                        self.style.set("cursor", icon.name())
+                    }
                 },
                 SelectedCursor::Loading { previous: Previous::Image(cursor), .. }
                 | SelectedCursor::Image(cursor) => {


### PR DESCRIPTION
When setting `CursorIcon::Default` on Web, it now simply removes the `cursor` style, this prevents overwriting any user set default cursor.

Fixes #3661.