### PR TITLE
Skip releasing displays that are unavailable

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -110,3 +110,4 @@ changelog entry.
 ### Fixed
 
 - On Web, pen events are now routed through to `WindowEvent::Cursor*`.
+- On macOS, fix panic when releasing not available monitor.


### PR DESCRIPTION
Prevent assertion error when trying to close a fullscreen window that was on a display that got disconnected.

---

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
