### PR TITLE
Bump MSRV to v1.73

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, nightly, '1.70.0']
+        toolchain: [stable, nightly, '1.73']
         platform:
           # Note: Make sure that we test all the `docs.rs` targets defined in Cargo.toml!
           - { name: 'Windows 64bit MSVC', target: x86_64-pc-windows-msvc,   os: windows-latest,  }
@@ -61,10 +61,10 @@ jobs:
           - { name: 'web',                target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
         exclude:
           # Android is tested on stable-3
-          - toolchain: '1.70.0'
+          - toolchain: '1.73'
             platform: { name: 'Android', target: aarch64-linux-android, os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
         include:
-          - toolchain: '1.70.0'
+          - toolchain: '1.73'
             platform: { name: 'Android', target: aarch64-linux-android, os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
           - toolchain: 'nightly'
             platform: {
@@ -149,13 +149,13 @@ jobs:
     - name: Test dpi crate
       if: >
         contains(matrix.platform.name, 'Linux 64bit') &&
-        matrix.toolchain != '1.70.0'
+        matrix.toolchain != '1.73'
       run: cargo test -p dpi
 
     - name: Build tests
       if: >
         !contains(matrix.platform.target, 'redox') &&
-        matrix.toolchain != '1.70.0'
+        matrix.toolchain != '1.73'
       run: cargo $CMD test --no-run $OPTIONS
 
     - name: Run tests
@@ -164,7 +164,7 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
-        matrix.toolchain != '1.70.0'
+        matrix.toolchain != '1.73'
       run: cargo $CMD test $OPTIONS
 
     - name: Lint with clippy
@@ -174,7 +174,7 @@ jobs:
     - name: Build tests with serde enabled
       if: >
         !contains(matrix.platform.target, 'redox') &&
-        matrix.toolchain != '1.70.0'
+        matrix.toolchain != '1.73'
       run: cargo $CMD test --no-run $OPTIONS --features serde
 
     - name: Run tests with serde enabled
@@ -183,7 +183,7 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         !contains(matrix.platform.target, 'wasm32') &&
         !contains(matrix.platform.target, 'redox') &&
-        matrix.toolchain != '1.70.0'
+        matrix.toolchain != '1.73'
       run: cargo $CMD test $OPTIONS --features serde
 
     - name: Check docs.rs documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -346,7 +346,7 @@ resolver = "2"
 members = ["dpi"]
 
 [workspace.package]
-rust-version = "1.70.0"
+rust-version = "1.73"
 repository = "https://github.com/rust-windowing/winit"
 license = "Apache-2.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ another library.
 
 ## MSRV Policy
 
-This crate's Minimum Supported Rust Version (MSRV) is **1.70**. Changes to
+This crate's Minimum Supported Rust Version (MSRV) is **1.73**. Changes to
 the MSRV will be accompanied by a minor version bump.
 
 As a **tentative** policy, the upper bound of the MSRV is given by the following

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -44,6 +44,7 @@ changelog entry.
 
 - On Web, let events wake up event loop immediately when using
   `ControlFlow::Poll`.
+- Bump MSRV from `1.70` to `1.73`.
 
 ### Removed
 

--- a/src/platform_impl/web/web_sys/schedule.rs
+++ b/src/platform_impl/web/web_sys/schedule.rs
@@ -74,7 +74,7 @@ impl Schedule {
             let duration = duration
                 .as_secs()
                 .checked_mul(1000)
-                .and_then(|secs| secs.checked_add(duration_millis_ceil(duration).into()))
+                .and_then(|secs| secs.checked_add(duration.subsec_micros().div_ceil(1000).into()))
                 .unwrap_or(u64::MAX);
 
             options.delay(duration as f64);
@@ -127,7 +127,9 @@ impl Schedule {
                 .ok()
                 .and_then(|secs: i32| secs.checked_mul(1000))
                 .and_then(|secs: i32| {
-                    let millis: i32 = duration_millis_ceil(duration)
+                    let millis: i32 = duration
+                        .subsec_micros()
+                        .div_ceil(1000)
                         .try_into()
                         .expect("millis are somehow bigger then 1K");
                     secs.checked_add(millis)
@@ -166,20 +168,6 @@ impl Drop for Schedule {
                 port.set_onmessage(None);
             },
         }
-    }
-}
-
-// TODO: Replace with `u32::div_ceil()` when we hit Rust v1.73.
-fn duration_millis_ceil(duration: Duration) -> u32 {
-    let micros = duration.subsec_micros();
-
-    // From <https://doc.rust-lang.org/1.73.0/src/core/num/uint_macros.rs.html#2086-2094>.
-    let d = micros / 1000;
-    let r = micros % 1000;
-    if r > 0 && 1000 > 0 {
-        d + 1
-    } else {
-        d
     }
 }
 


### PR DESCRIPTION
Facilitates some improvements in the Web code.
Specifically the stabilization of [`u32::div_ceil()`](https://doc.rust-lang.org/1.73.0/std/primitive.u32.html#method.div_ceil) and [`mpsc::Sender` becoming `Sync`](https://doc.rust-lang.org/1.73.0/std/sync/mpsc/struct.Sender.html#impl-Sync-for-Sender%3CT%3E).

[Debian Sid](https://packages.debian.org/sid/rustc) has reached v1.76, but I didn't need more then v1.73.