### PR TITLE
Add atypical targets to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,130 @@ jobs:
           ~/.cargo/git/db/
         key: cargo-${{ matrix.toolchain }}-${{ matrix.platform.name }}-${{ hashFiles('Cargo.lock') }}
 
+  tier2:
+    name: Check winit for Tier 2 Targets
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly, '1.73']
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
+
+    - name: Use specific dependency versions for Rust 1.63 compatibility.
+      if: matrix.rust == '1.63'
+      run: |
+        cargo update --package=dashmap --precise 5.4.0
+        cargo update --package=regex --precise=1.9.0
+        cargo update --package=half --precise=2.2.1
+
+    - run: >
+        rustup target add
+        x86_64-unknown-linux-musl
+        x86_64-unknown-linux-gnux32
+        x86_64-linux-android
+        i686-linux-android
+        x86_64-unknown-freebsd
+        x86_64-unknown-netbsd
+        x86_64-unknown-illumos
+        i686-unknown-linux-musl
+        riscv64gc-unknown-linux-gnu
+        aarch64-unknown-linux-gnu
+        aarch64-unknown-linux-musl
+        powerpc64le-unknown-linux-gnu
+        armv5te-unknown-linux-gnueabi
+        s390x-unknown-linux-gnu
+        arm-linux-androideabi
+        sparc64-unknown-linux-gnu
+        sparcv9-sun-solaris
+
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-linux-musl
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-linux-musl --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-linux-musl --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-linux-gnux32
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-linux-gnux32 --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-linux-gnux32 --no-default-features --features wayland
+    # TODO: Figure out best way to check Android targets.
+    # - run: cargo check --release -vv --all-targets --target=x86_64-linux-android --features android-native-activity
+    # - run: cargo check --release -vv --all-targets --target=x86_64-linux-android --features android-game-activity
+    # - run: cargo check --release -vv --all-targets --target=i686-linux-android --features android-native-activity
+    # - run: cargo check --release -vv --all-targets --target=i686-linux-android --features android-game-activity
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-freebsd
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-freebsd --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-freebsd --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-netbsd
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-netbsd --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-netbsd --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-illumos
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-illumos --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-illumos --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=i686-unknown-linux-musl
+    - run: cargo check --release -vv --all-targets --target=i686-unknown-linux-musl --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=i686-unknown-linux-musl --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=riscv64gc-unknown-linux-gnu
+    - run: cargo check --release -vv --all-targets --target=riscv64gc-unknown-linux-gnu --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=riscv64gc-unknown-linux-gnu --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=aarch64-unknown-linux-gnu
+    - run: cargo check --release -vv --all-targets --target=aarch64-unknown-linux-gnu --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=aarch64-unknown-linux-gnu --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=aarch64-unknown-linux-musl
+    - run: cargo check --release -vv --all-targets --target=aarch64-unknown-linux-musl --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=aarch64-unknown-linux-musl --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=powerpc64le-unknown-linux-gnu
+    - run: cargo check --release -vv --all-targets --target=powerpc64le-unknown-linux-gnu --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=powerpc64le-unknown-linux-gnu --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=armv5te-unknown-linux-gnueabi
+    - run: cargo check --release -vv --all-targets --target=armv5te-unknown-linux-gnueabi --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=armv5te-unknown-linux-gnueabi --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=s390x-unknown-linux-gnu
+    - run: cargo check --release -vv --all-targets --target=s390x-unknown-linux-gnu --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=s390x-unknown-linux-gnu --no-default-features --features wayland
+    # - run: cargo check --release -vv --all-targets --target=arm-linux-androideabi --features android-native-activity
+    # - run: cargo check --release -vv --all-targets --target=arm-linux-androideabi --features android-game-activity
+    - run: cargo check --release -vv --all-targets --target=sparc64-unknown-linux-gnu
+    - run: cargo check --release -vv --all-targets --target=sparc64-unknown-linux-gnu --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=sparc64-unknown-linux-gnu --no-default-features --features wayland
+    - run: cargo check --release -vv --all-targets --target=sparcv9-sun-solaris
+    - run: cargo check --release -vv --all-targets --target=sparcv9-sun-solaris --no-default-features --features x11
+    - run: cargo check --release -vv --all-targets --target=sparcv9-sun-solaris --no-default-features --features wayland
+
+  tier3:
+    name: Check winit for Tier 3 Targets
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [nightly]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
+
+    - run: rustup component add rust-src
+    - run: cargo check -Z build-std -vv --target x86_64-unknown-openbsd --all-targets
+    - run: cargo check -Z build-std -vv --target x86_64-unknown-openbsd --all-targets --no-default-features --features x11
+    - run: cargo check -Z build-std -vv --target x86_64-unknown-openbsd --all-targets --no-default-features --features wayland
+    - run: cargo check -Z build-std -vv --target mips64-openwrt-linux-musl --all-targets
+    - run: cargo check -Z build-std -vv --target mips64-openwrt-linux-musl --all-targets --no-default-features --features x11
+    - run: cargo check -Z build-std -vv --target mips64-openwrt-linux-musl --all-targets --no-default-features --features wayland
+    - run: cargo check -Z build-std -vv --target sparc-unknown-linux-gnu --all-targets
+    - run: cargo check -Z build-std -vv --target sparc-unknown-linux-gnu --all-targets --no-default-features --features x11
+    - run: cargo check -Z build-std -vv --target sparc-unknown-linux-gnu --all-targets --no-default-features --features wayland
+    - run: cargo check -Z build-std -vv --target aarch64-unknown-linux-gnu_ilp32 --all-targets
+    - run: cargo check -Z build-std -vv --target aarch64-unknown-linux-gnu_ilp32 --all-targets --no-default-features --features x11
+    - run: cargo check -Z build-std -vv --target aarch64-unknown-linux-gnu_ilp32 --all-targets --no-default-features --features wayland
+    - run: cargo check -Z build-std -vv --target x86_64-uwp-windows-msvc --all-targets
+
   cargo-deny:
     name: Run cargo-deny on ${{ matrix.platform.name }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
         toolchain: [stable, nightly, '1.73']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: taiki-e/checkout-action@v1
 
     - uses: dtolnay/rust-toolchain@master
       with:
@@ -262,9 +262,6 @@ jobs:
     - run: cargo check --release -vv --all-targets --target=x86_64-unknown-netbsd
     - run: cargo check --release -vv --all-targets --target=x86_64-unknown-netbsd --no-default-features --features x11
     - run: cargo check --release -vv --all-targets --target=x86_64-unknown-netbsd --no-default-features --features wayland
-    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-illumos
-    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-illumos --no-default-features --features x11
-    - run: cargo check --release -vv --all-targets --target=x86_64-unknown-illumos --no-default-features --features wayland
     - run: cargo check --release -vv --all-targets --target=i686-unknown-linux-musl
     - run: cargo check --release -vv --all-targets --target=i686-unknown-linux-musl --no-default-features --features x11
     - run: cargo check --release -vv --all-targets --target=i686-unknown-linux-musl --no-default-features --features wayland
@@ -291,9 +288,6 @@ jobs:
     - run: cargo check --release -vv --all-targets --target=sparc64-unknown-linux-gnu
     - run: cargo check --release -vv --all-targets --target=sparc64-unknown-linux-gnu --no-default-features --features x11
     - run: cargo check --release -vv --all-targets --target=sparc64-unknown-linux-gnu --no-default-features --features wayland
-    - run: cargo check --release -vv --all-targets --target=sparcv9-sun-solaris
-    - run: cargo check --release -vv --all-targets --target=sparcv9-sun-solaris --no-default-features --features x11
-    - run: cargo check --release -vv --all-targets --target=sparcv9-sun-solaris --no-default-features --features wayland
 
   tier3:
     name: Check winit for Tier 3 Targets
@@ -305,7 +299,7 @@ jobs:
         toolchain: [nightly]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: taiki-e/checkout-action@v1
 
     - uses: dtolnay/rust-toolchain@master
       with:

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -3,6 +3,11 @@
 #[cfg(all(not(x11_platform), not(wayland_platform)))]
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
+#[cfg(any(target_os = "solaris", target_os = "illumos"))]
+compile_error! {
+    "winit does not support Solarish operating systems."
+}
+
 use std::collections::VecDeque;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::sync::Arc;


### PR DESCRIPTION
This adds some Tier-2 and Tier-3 targets to CI, so we can detect
breakage in these platforms early.

cc #3735

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
