### PR TITLE
macOS: Call `ApplicationHandler` directly instead of using `Event `

### DIFF
--- a/src/platform_impl/macos/app.rs
+++ b/src/platform_impl/macos/app.rs
@@ -5,6 +5,7 @@ use objc2_app_kit::{NSApplication, NSEvent, NSEventModifierFlags, NSEventType, N
 use objc2_foundation::{MainThreadMarker, NSObject};
 
 use super::app_state::ApplicationDelegate;
+use super::DEVICE_ID;
 use crate::event::{DeviceEvent, ElementState};
 
 declare_class!(
@@ -57,29 +58,47 @@ fn maybe_dispatch_device_event(delegate: &ApplicationDelegate, event: &NSEvent) 
             let delta_y = unsafe { event.deltaY() } as f64;
 
             if delta_x != 0.0 {
-                delegate.maybe_queue_device_event(DeviceEvent::Motion { axis: 0, value: delta_x });
+                delegate.maybe_queue_with_handler(move |app, event_loop| {
+                    app.device_event(event_loop, DEVICE_ID, DeviceEvent::Motion {
+                        axis: 0,
+                        value: delta_x,
+                    });
+                });
             }
 
             if delta_y != 0.0 {
-                delegate.maybe_queue_device_event(DeviceEvent::Motion { axis: 1, value: delta_y })
+                delegate.maybe_queue_with_handler(move |app, event_loop| {
+                    app.device_event(event_loop, DEVICE_ID, DeviceEvent::Motion {
+                        axis: 1,
+                        value: delta_y,
+                    });
+                })
             }
 
             if delta_x != 0.0 || delta_y != 0.0 {
-                delegate.maybe_queue_device_event(DeviceEvent::MouseMotion {
-                    delta: (delta_x, delta_y),
+                delegate.maybe_queue_with_handler(move |app, event_loop| {
+                    app.device_event(event_loop, DEVICE_ID, DeviceEvent::MouseMotion {
+                        delta: (delta_x, delta_y),
+                    });
                 });
             }
         },
         NSEventType::LeftMouseDown | NSEventType::RightMouseDown | NSEventType::OtherMouseDown => {
-            delegate.maybe_queue_device_event(DeviceEvent::Button {
-                button: unsafe { event.buttonNumber() } as u32,
-                state: ElementState::Pressed,
+            let button = unsafe { event.buttonNumber() } as u32;
+            delegate.maybe_queue_with_handler(move |app, event_loop| {
+                app.device_event(event_loop, DEVICE_ID, DeviceEvent::Button {
+                    button,
+                    state: ElementState::Pressed,
+                });
             });
         },
         NSEventType::LeftMouseUp | NSEventType::RightMouseUp | NSEventType::OtherMouseUp => {
-            delegate.maybe_queue_device_event(DeviceEvent::Button {
-                button: unsafe { event.buttonNumber() } as u32,
-                state: ElementState::Released,
+            let button = unsafe { event.buttonNumber() } as u32;
+            delegate.maybe_queue_with_handler(move |app, event_loop| {
+                app.device_event(event_loop, DEVICE_ID, DeviceEvent::Button {
+                    button,
+                    state: ElementState::Released,
+                });
             });
         },
         _ => (),

--- a/src/platform_impl/macos/event_handler.rs
+++ b/src/platform_impl/macos/event_handler.rs
@@ -2,31 +2,31 @@ use std::cell::RefCell;
 use std::{fmt, mem};
 
 use super::app_state::HandlePendingUserEvents;
-use crate::event::Event;
+use crate::application::ApplicationHandler;
 use crate::event_loop::ActiveEventLoop as RootActiveEventLoop;
 
-struct EventHandlerData {
-    #[allow(clippy::type_complexity)]
-    handler: Box<dyn FnMut(Event<HandlePendingUserEvents>, &RootActiveEventLoop) + 'static>,
-}
-
-impl fmt::Debug for EventHandlerData {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("EventHandlerData").finish_non_exhaustive()
-    }
-}
-
-#[derive(Debug)]
+#[derive(Default)]
 pub(crate) struct EventHandler {
     /// This can be in the following states:
     /// - Not registered by the event loop (None).
     /// - Present (Some(handler)).
     /// - Currently executing the handler / in use (RefCell borrowed).
-    inner: RefCell<Option<EventHandlerData>>,
+    inner: RefCell<Option<&'static mut dyn ApplicationHandler<HandlePendingUserEvents>>>,
+}
+
+impl fmt::Debug for EventHandler {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = match self.inner.try_borrow().as_deref() {
+            Ok(Some(_)) => "<available>",
+            Ok(None) => "<not set>",
+            Err(_) => "<in use>",
+        };
+        f.debug_struct("EventHandler").field("state", &state).finish_non_exhaustive()
+    }
 }
 
 impl EventHandler {
-    pub(crate) const fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self { inner: RefCell::new(None) }
     }
 
@@ -37,7 +37,7 @@ impl EventHandler {
     /// from within the closure.
     pub(crate) fn set<'handler, R>(
         &self,
-        handler: impl FnMut(Event<HandlePendingUserEvents>, &RootActiveEventLoop) + 'handler,
+        app: &'handler mut dyn ApplicationHandler<HandlePendingUserEvents>,
         closure: impl FnOnce() -> R,
     ) -> R {
         // SAFETY: We extend the lifetime of the handler here so that we can
@@ -48,9 +48,9 @@ impl EventHandler {
         // extended beyond `'handler`.
         let handler = unsafe {
             mem::transmute::<
-                Box<dyn FnMut(Event<HandlePendingUserEvents>, &RootActiveEventLoop) + 'handler>,
-                Box<dyn FnMut(Event<HandlePendingUserEvents>, &RootActiveEventLoop) + 'static>,
-            >(Box::new(handler))
+                &'handler mut dyn ApplicationHandler<HandlePendingUserEvents>,
+                &'static mut dyn ApplicationHandler<HandlePendingUserEvents>,
+            >(app)
         };
 
         match self.inner.try_borrow_mut().as_deref_mut() {
@@ -58,7 +58,7 @@ impl EventHandler {
                 unreachable!("tried to set handler while another was already set");
             },
             Ok(data @ None) => {
-                *data = Some(EventHandlerData { handler });
+                *data = Some(handler);
             },
             Err(_) => {
                 unreachable!("tried to set handler that is currently in use");
@@ -109,20 +109,22 @@ impl EventHandler {
         matches!(self.inner.try_borrow().as_deref(), Ok(Some(_)))
     }
 
-    pub(crate) fn handle_event(
+    pub(crate) fn handle<
+        F: FnOnce(&mut dyn ApplicationHandler<HandlePendingUserEvents>, &RootActiveEventLoop),
+    >(
         &self,
-        event: Event<HandlePendingUserEvents>,
+        callback: F,
         event_loop: &RootActiveEventLoop,
     ) {
         match self.inner.try_borrow_mut().as_deref_mut() {
-            Ok(Some(EventHandlerData { handler })) => {
+            Ok(Some(user_app)) => {
                 // It is important that we keep the reference borrowed here,
                 // so that `in_use` can properly detect that the handler is
                 // still in use.
                 //
                 // If the handler unwinds, the `RefMut` will ensure that the
                 // handler is no longer borrowed.
-                (handler)(event, event_loop);
+                callback(*user_app, event_loop);
             },
             Ok(None) => {
                 // `NSApplication`, our app delegate and this handler are all

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -31,6 +31,7 @@ use crate::event::{
 };
 use crate::keyboard::{Key, KeyCode, KeyLocation, ModifiersState, NamedKey};
 use crate::platform::macos::OptionAsAlt;
+use crate::window::WindowId as RootWindowId;
 
 #[derive(Debug)]
 struct CursorState {
@@ -686,7 +687,9 @@ declare_class!(
 
             self.update_modifiers(event, false);
 
-            self.ivars().app_delegate.maybe_queue_device_event(DeviceEvent::MouseWheel { delta });
+            self.ivars().app_delegate.maybe_queue_with_handler(move |app, event_loop|
+                app.device_event(event_loop, DEVICE_ID, DeviceEvent::MouseWheel { delta })
+            );
             self.queue_event(WindowEvent::MouseWheel {
                 device_id: DEVICE_ID,
                 delta,
@@ -830,7 +833,10 @@ impl WinitView {
     }
 
     fn queue_event(&self, event: WindowEvent) {
-        self.ivars().app_delegate.maybe_queue_window_event(self.window().id(), event);
+        let window_id = RootWindowId(self.window().id());
+        self.ivars().app_delegate.maybe_queue_with_handler(move |app, event_loop| {
+            app.window_event(event_loop, window_id, event);
+        });
     }
 
     fn scale_factor(&self) -> f64 {

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -811,7 +811,6 @@ impl WindowDelegate {
     }
 
     fn handle_scale_factor_changed(&self, scale_factor: CGFloat) {
-        let app_delegate = &self.ivars().app_delegate;
         let window = self.window();
 
         let content_size = window.contentRectForFrameRect(window.frame()).size;
@@ -819,7 +818,7 @@ impl WindowDelegate {
 
         let suggested_size = content_size.to_physical(scale_factor);
         let new_inner_size = Arc::new(Mutex::new(suggested_size));
-        app_delegate.handle_window_event(window.id(), WindowEvent::ScaleFactorChanged {
+        self.queue_event(WindowEvent::ScaleFactorChanged {
             scale_factor,
             inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
         });
@@ -831,7 +830,7 @@ impl WindowDelegate {
             let size = NSSize::new(logical_size.width, logical_size.height);
             window.setContentSize(size);
         }
-        app_delegate.handle_window_event(window.id(), WindowEvent::Resized(physical_size));
+        self.queue_event(WindowEvent::Resized(physical_size));
     }
 
     fn emit_move_event(&self) {

--- a/src/platform_impl/macos/window_delegate.rs
+++ b/src/platform_impl/macos/window_delegate.rs
@@ -39,7 +39,7 @@ use crate::event::{InnerSizeWriter, WindowEvent};
 use crate::platform::macos::{OptionAsAlt, WindowExtMacOS};
 use crate::window::{
     Cursor, CursorGrabMode, Icon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
-    WindowAttributes, WindowButtons, WindowLevel,
+    WindowAttributes, WindowButtons, WindowId as RootWindowId, WindowLevel,
 };
 
 #[derive(Clone, Debug)]
@@ -807,7 +807,10 @@ impl WindowDelegate {
     }
 
     pub(crate) fn queue_event(&self, event: WindowEvent) {
-        self.ivars().app_delegate.maybe_queue_window_event(self.window().id(), event);
+        let window_id = RootWindowId(self.window().id());
+        self.ivars().app_delegate.maybe_queue_with_handler(move |app, event_loop| {
+            app.window_event(event_loop, window_id, event);
+        });
     }
 
     fn handle_scale_factor_changed(&self, scale_factor: CGFloat) {


### PR DESCRIPTION
When we added `ApplicationHandler`, the intention was always to slowly phase out `Event` - this does that in the macOS backend.

Extracted from https://github.com/rust-windowing/winit/pull/3694 to reduce the diff in that.

- [x] Tested on all platforms changed
