### PR TITLE
Remove internal `ActiveEventLoop::clear_exit`

### DIFF
--- a/src/platform/run_on_demand.rs
+++ b/src/platform/run_on_demand.rs
@@ -1,8 +1,10 @@
 use crate::application::ApplicationHandler;
 use crate::error::EventLoopError;
-use crate::event_loop::{ActiveEventLoop, EventLoop};
+use crate::event_loop::EventLoop;
 #[cfg(doc)]
-use crate::{platform::pump_events::EventLoopExtPumpEvents, window::Window};
+use crate::{
+    event_loop::ActiveEventLoop, platform::pump_events::EventLoopExtPumpEvents, window::Window,
+};
 
 /// Additional methods on [`EventLoop`] to return control flow to the caller.
 pub trait EventLoopExtRunOnDemand {
@@ -63,15 +65,7 @@ pub trait EventLoopExtRunOnDemand {
 
 impl EventLoopExtRunOnDemand for EventLoop {
     fn run_app_on_demand<A: ApplicationHandler>(&mut self, app: A) -> Result<(), EventLoopError> {
-        self.event_loop.window_target().clear_exit();
         self.event_loop.run_app_on_demand(app)
-    }
-}
-
-impl ActiveEventLoop {
-    /// Clear exit status.
-    pub(crate) fn clear_exit(&self) {
-        self.p.clear_exit()
     }
 }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -425,6 +425,7 @@ impl EventLoop {
         &mut self,
         mut app: A,
     ) -> Result<(), EventLoopError> {
+        self.window_target.p.clear_exit();
         loop {
             match self.pump_app_events(None, &mut app) {
                 PumpStatus::Exit(0) => {

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -129,10 +129,6 @@ impl ActiveEventLoop {
         self.delegate.exit()
     }
 
-    pub(crate) fn clear_exit(&self) {
-        self.delegate.clear_exit()
-    }
-
     pub(crate) fn exiting(&self) -> bool {
         self.delegate.exiting()
     }
@@ -255,6 +251,7 @@ impl EventLoop {
         &mut self,
         mut app: A,
     ) -> Result<(), EventLoopError> {
+        self.delegate.clear_exit();
         self.delegate.set_event_handler(&mut app, || {
             autoreleasepool(|_| {
                 // clear / normalize pump_events state

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -904,7 +904,7 @@ impl ActiveEventLoop {
         x11_or_wayland!(match self; Self(evlp) => evlp.control_flow())
     }
 
-    pub(crate) fn clear_exit(&self) {
+    fn clear_exit(&self) {
         x11_or_wayland!(match self; Self(evlp) => evlp.clear_exit())
     }
 
@@ -925,12 +925,10 @@ impl ActiveEventLoop {
         }
     }
 
-    #[allow(dead_code)]
     fn set_exit_code(&self, code: i32) {
         x11_or_wayland!(match self; Self(evlp) => evlp.set_exit_code(code))
     }
 
-    #[allow(dead_code)]
     fn exit_code(&self) -> Option<i32> {
         x11_or_wayland!(match self; Self(evlp) => evlp.exit_code())
     }

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -168,6 +168,7 @@ impl EventLoop {
         &mut self,
         mut app: A,
     ) -> Result<(), EventLoopError> {
+        self.window_target.p.clear_exit();
         let exit = loop {
             match self.pump_app_events(None, &mut app) {
                 PumpStatus::Exit(0) => {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -375,6 +375,7 @@ impl EventLoop {
         &mut self,
         mut app: A,
     ) -> Result<(), EventLoopError> {
+        self.event_processor.target.p.clear_exit();
         let exit = loop {
             match self.pump_app_events(None, &mut app) {
                 PumpStatus::Exit(0) => {
@@ -600,13 +601,11 @@ impl EventLoop {
     }
 
     fn set_exit_code(&self, code: i32) {
-        let window_target = EventProcessor::window_target(&self.event_processor.target);
-        window_target.set_exit_code(code);
+        self.window_target().p.set_exit_code(code);
     }
 
     fn exit_code(&self) -> Option<i32> {
-        let window_target = EventProcessor::window_target(&self.event_processor.target);
-        window_target.exit_code()
+        self.window_target().p.exit_code()
     }
 }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -195,6 +195,7 @@ impl EventLoop {
         &mut self,
         mut app: A,
     ) -> Result<(), EventLoopError> {
+        self.window_target.p.clear_exit();
         {
             let runner = &self.window_target.p.runner_shared;
 


### PR DESCRIPTION
How to store and clear the internal state should be internal to the implementation on each backend.

I'm doing this because I want to refactor the macOS backend to not need to track this state manually in the future, which I so far _think_ should be possible: `NSApplication` itself already (roughly) tracks this in [`-[NSApplication isRunning]`](https://developer.apple.com/documentation/appkit/nsapplication/1428759-running?language=objc).