### PR TITLE
add: Hacky `cfg` `winit_ignore_noisy_logs_unstable`

### DIFF
--- a/src/platform_impl/ios/app_state.rs
+++ b/src/platform_impl/ios/app_state.rs
@@ -591,9 +591,15 @@ pub(crate) fn handle_nonuser_events<I: IntoIterator<Item = EventWrapper>>(
             match wrapper {
                 EventWrapper::StaticEvent(event) => {
                     if !processing_redraws && event.is_redraw() {
-                        tracing::info!("processing `RedrawRequested` during the main event loop");
+                        #[cfg(not(winit_ignore_noisy_logs_unstable))]
+                        tracing::info!(
+                            note = "See <https://github.com/rust-windowing/winit/issues/3714>",
+                            "processing `RedrawRequested` during the main event loop"
+                        );
                     } else if processing_redraws && !event.is_redraw() {
+                        #[cfg(not(winit_ignore_noisy_logs_unstable))]
                         tracing::warn!(
+                            note = "See <https://github.com/rust-windowing/winit/issues/3714>",
                             "processing non-`RedrawRequested` event after the main event loop: \
                              {:#?}",
                             event


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Helps address #3714.
Preferably the underlying issue could be fixed, but this is enough to satisfy my use case
