### PR TITLE
Add `ActiveEventLoop::create_proxy()`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -40,6 +40,10 @@ changelog entry.
 
 ## Unreleased
 
+### Added
+
+- Add `ActiveEventLoop::create_proxy()`.
+
 ### Changed
 
 - On Web, let events wake up event loop immediately when using `ControlFlow::Poll`.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -247,7 +247,7 @@ impl EventLoop {
     /// Creates an [`EventLoopProxy`] that can be used to dispatch user events
     /// to the main event loop, possibly from another thread.
     pub fn create_proxy(&self) -> EventLoopProxy {
-        EventLoopProxy { event_loop_proxy: self.event_loop.create_proxy() }
+        EventLoopProxy { event_loop_proxy: self.event_loop.window_target().p.create_proxy() }
     }
 
     /// Gets a persistent reference to the underlying platform display.
@@ -345,6 +345,12 @@ impl AsRawFd for EventLoop {
 }
 
 impl ActiveEventLoop {
+    /// Creates an [`EventLoopProxy`] that can be used to dispatch user events
+    /// to the main event loop, possibly from another thread.
+    pub fn create_proxy(&self) -> EventLoopProxy {
+        EventLoopProxy { event_loop_proxy: self.p.create_proxy() }
+    }
+
     /// Create the window.
     ///
     /// Possible causes of error include denied permission, incompatible system, and lack of memory.

--- a/src/platform_impl/apple/appkit/app_state.rs
+++ b/src/platform_impl/apple/appkit/app_state.rs
@@ -80,13 +80,12 @@ impl ApplicationDelegate {
     pub(super) fn new(
         mtm: MainThreadMarker,
         activation_policy: NSApplicationActivationPolicy,
-        proxy_wake_up: Arc<AtomicBool>,
         default_menu: bool,
         activate_ignoring_other_apps: bool,
     ) -> Retained<Self> {
         let this = mtm.alloc().set_ivars(AppState {
             activation_policy,
-            proxy_wake_up,
+            proxy_wake_up: Arc::new(AtomicBool::new(false)),
             default_menu,
             activate_ignoring_other_apps,
             run_loop: RunLoop::main(mtm),
@@ -177,6 +176,10 @@ impl ApplicationDelegate {
         closure: impl FnOnce() -> R,
     ) -> R {
         self.ivars().event_handler.set(handler, closure)
+    }
+
+    pub fn proxy_wake_up(&self) -> Arc<AtomicBool> {
+        self.ivars().proxy_wake_up.clone()
     }
 
     /// If `pump_events` is called to progress the event loop then we

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -789,10 +789,6 @@ impl EventLoop {
         }
     }
 
-    pub fn create_proxy(&self) -> EventLoopProxy {
-        x11_or_wayland!(match self; EventLoop(evlp) => evlp.create_proxy(); as EventLoopProxy)
-    }
-
     pub fn run_app<A: ApplicationHandler>(self, app: &mut A) -> Result<(), EventLoopError> {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.run_app(app))
     }
@@ -843,6 +839,10 @@ pub enum ActiveEventLoop {
 }
 
 impl ActiveEventLoop {
+    pub fn create_proxy(&self) -> EventLoopProxy {
+        x11_or_wayland!(match self; ActiveEventLoop(evlp) => evlp.create_proxy(); as EventLoopProxy)
+    }
+
     #[inline]
     pub fn is_wayland(&self) -> bool {
         match *self {

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -47,9 +47,6 @@ pub struct EventLoop {
     compositor_updates: Vec<WindowCompositorUpdate>,
     window_ids: Vec<WindowId>,
 
-    /// Event loop proxy
-    event_loop_proxy: EventLoopProxy,
-
     /// The Wayland dispatcher to has raw access to the queue when needed, such as
     /// when creating a new window.
     wayland_dispatcher: WaylandDispatcher,
@@ -139,6 +136,7 @@ impl EventLoop {
             connection: connection.clone(),
             wayland_dispatcher: wayland_dispatcher.clone(),
             event_loop_awakener,
+            event_loop_proxy: EventLoopProxy::new(ping),
             queue_handle,
             control_flow: Cell::new(ControlFlow::default()),
             exit: Cell::new(None),
@@ -152,7 +150,6 @@ impl EventLoop {
             window_ids: Vec::new(),
             connection,
             wayland_dispatcher,
-            event_loop_proxy: EventLoopProxy::new(ping),
             event_loop,
             window_target: RootActiveEventLoop {
                 p: PlatformActiveEventLoop::Wayland(window_target),
@@ -513,11 +510,6 @@ impl EventLoop {
     }
 
     #[inline]
-    pub fn create_proxy(&self) -> EventLoopProxy {
-        self.event_loop_proxy.clone()
-    }
-
-    #[inline]
     pub fn window_target(&self) -> &RootActiveEventLoop {
         &self.window_target
     }
@@ -589,6 +581,9 @@ impl AsRawFd for EventLoop {
 }
 
 pub struct ActiveEventLoop {
+    /// Event loop proxy
+    event_loop_proxy: EventLoopProxy,
+
     /// The event loop wakeup source.
     pub event_loop_awakener: calloop::ping::Ping,
 
@@ -613,6 +608,10 @@ pub struct ActiveEventLoop {
 }
 
 impl ActiveEventLoop {
+    pub(crate) fn create_proxy(&self) -> EventLoopProxy {
+        self.event_loop_proxy.clone()
+    }
+
     pub(crate) fn set_control_flow(&self, control_flow: ControlFlow) {
         self.control_flow.set(control_flow)
     }

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -58,10 +58,6 @@ impl EventLoop {
         self.elw.p.run(Box::new(move |event| handle_event(&mut app, &target, event)), true);
     }
 
-    pub fn create_proxy(&self) -> EventLoopProxy {
-        EventLoopProxy::new(self.elw.p.waker())
-    }
-
     pub fn window_target(&self) -> &RootActiveEventLoop {
         &self.elw
     }

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -12,7 +12,7 @@ use super::super::KeyEventExtra;
 use super::device::DeviceId;
 use super::runner::{EventWrapper, Execution};
 use super::window::WindowId;
-use super::{backend, runner};
+use super::{backend, runner, EventLoopProxy};
 use crate::event::{
     DeviceId as RootDeviceId, ElementState, Event, KeyEvent, Touch, TouchPhase, WindowEvent,
 };
@@ -66,6 +66,10 @@ impl ActiveEventLoop {
 
     pub fn generate_id(&self) -> WindowId {
         WindowId(self.runner.generate_id())
+    }
+
+    pub fn create_proxy(&self) -> EventLoopProxy {
+        EventLoopProxy::new(self.waker())
     }
 
     pub fn create_custom_cursor(&self, source: CustomCursorSource) -> RootCustomCursor {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -468,16 +468,16 @@ impl EventLoop {
         }
     }
 
-    pub fn create_proxy(&self) -> EventLoopProxy {
-        EventLoopProxy { target_window: self.window_target.p.thread_msg_target }
-    }
-
     fn exit_code(&self) -> Option<i32> {
         self.window_target.p.exit_code()
     }
 }
 
 impl ActiveEventLoop {
+    pub fn create_proxy(&self) -> EventLoopProxy {
+        EventLoopProxy { target_window: self.thread_msg_target }
+    }
+
     #[inline(always)]
     pub(crate) fn create_thread_executor(&self) -> EventLoopThreadExecutor {
         EventLoopThreadExecutor { thread_id: self.thread_id, target_window: self.thread_msg_target }


### PR DESCRIPTION
This PR adds `ActiveEventLoop::create_proxy()`, letting users create `EventLoopProxy` from inside the event loop.
Internally I basically just moved `backend::EventLoop::create_proxy()` to `backend::ActiveEventLoop::create_proxy()`.

Fixes #3741.