### PR TITLE
Web: Remove some unnecessary compatibility code

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -52,6 +52,7 @@ changelog entry.
   to send specific data to be processed on the main thread.
 - Changed `EventLoopProxy::send_event` to `EventLoopProxy::wake_up`, it now
   only wakes up the loop.
+- On Web, slightly improve accuracy of `DeviceEvent::MouseMotion`.
 
 ### Removed
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -234,7 +234,7 @@ impl Shared {
         ));
 
         let runner = self.clone();
-        let window = self.window().clone();
+        let mut delta = backend::event::MouseDelta::new();
         *self.0.on_mouse_move.borrow_mut() = Some(EventListenerHandle::new(
             self.window().clone(),
             "pointermove",
@@ -273,23 +273,26 @@ impl Shared {
                 }
 
                 // pointer move event
-                let mut delta = backend::event::MouseDelta::init(&window, &event);
                 runner.send_events(backend::event::pointer_move_event(event).flat_map(|event| {
-                    let delta = delta.delta(&event).to_physical(backend::scale_factor(&window));
+                    let delta = delta.delta(&event);
 
-                    let x_motion = (delta.x != 0.0).then_some(Event::DeviceEvent {
+                    if delta.x == 0 && delta.y == 0 {
+                        return None.into_iter().chain(None).chain(None);
+                    }
+
+                    let x_motion = (delta.x != 0).then_some(Event::DeviceEvent {
                         device_id,
-                        event: DeviceEvent::Motion { axis: 0, value: delta.x },
+                        event: DeviceEvent::Motion { axis: 0, value: delta.x.into() },
                     });
 
-                    let y_motion = (delta.y != 0.0).then_some(Event::DeviceEvent {
+                    let y_motion = (delta.y != 0).then_some(Event::DeviceEvent {
                         device_id,
-                        event: DeviceEvent::Motion { axis: 1, value: delta.y },
+                        event: DeviceEvent::Motion { axis: 1, value: delta.y.into() },
                     });
 
-                    x_motion.into_iter().chain(y_motion).chain(iter::once(Event::DeviceEvent {
+                    x_motion.into_iter().chain(y_motion).chain(Some(Event::DeviceEvent {
                         device_id,
-                        event: DeviceEvent::MouseMotion { delta: (delta.x, delta.y) },
+                        event: DeviceEvent::MouseMotion { delta: (delta.x.into(), delta.y.into()) },
                     }))
                 }));
             }),


### PR DESCRIPTION
Apparently `MouseEvent.movementX/Y` should not be used anymore.
Replacing it with `screenX/Y` simplifies the code, removes unnecessary conversion and increases accuracy.

Addresses https://github.com/rust-windowing/winit/issues/2875.