### PR TITLE
Only run observers in the default run loop mode

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -12,4 +12,6 @@ disallowed-methods = [
     { path = "web_sys::Document::fullscreen_element", reason = "Doesn't account for compatibility with Safari" },
     { path = "objc2_app_kit::NSView::visibleRect", reason = "We expose a render target to the user, and visibility is not really relevant to that (and can break if you don't use the rectangle position as well). Use `frame` instead." },
     { path = "objc2_app_kit::NSWindow::setFrameTopLeftPoint", reason = "Not sufficient when working with Winit's coordinate system, use `flip_window_screen_coordinates` instead" },
+    { path = "core_foundation::runloop::kCFRunLoopCommonModes", reason = "Using the common modes includes the modal panel mode, which we usually want to avoid" },
+    { path = "objc2_foundation::NSRunLoopCommonModes", reason = "Using the common modes includes the modal panel mode, which we usually want to avoid" }
 ]

--- a/src/platform_impl/apple/appkit/app_state.rs
+++ b/src/platform_impl/apple/appkit/app_state.rs
@@ -323,8 +323,7 @@ impl ApplicationDelegate {
             .upgrade()
             .expect("The panic info must exist here. This failure indicates a developer error.");
 
-        // Return when in event handler due to https://github.com/rust-windowing/winit/issues/1779
-        if panic_info.is_panicking() || !self.ivars().event_handler.ready() || !self.is_running() {
+        if panic_info.is_panicking() || !self.is_running() {
             return;
         }
 
@@ -356,10 +355,7 @@ impl ApplicationDelegate {
             .upgrade()
             .expect("The panic info must exist here. This failure indicates a developer error.");
 
-        // Return when in event handler due to https://github.com/rust-windowing/winit/issues/1779
-        // XXX: how does it make sense that `event_handler.ready()` can ever return `false` here if
-        // we're about to return to the `CFRunLoop` to poll for new events?
-        if panic_info.is_panicking() || !self.ivars().event_handler.ready() || !self.is_running() {
+        if panic_info.is_panicking() || !self.is_running() {
             return;
         }
 

--- a/src/platform_impl/apple/appkit/event_handler.rs
+++ b/src/platform_impl/apple/appkit/event_handler.rs
@@ -104,10 +104,6 @@ impl EventHandler {
         self.inner.try_borrow().is_err()
     }
 
-    pub(crate) fn ready(&self) -> bool {
-        matches!(self.inner.try_borrow().as_deref(), Ok(Some(_)))
-    }
-
     pub(crate) fn handle(
         &self,
         callback: impl FnOnce(&mut dyn ApplicationHandler, &RootActiveEventLoop),

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 
 use core_foundation::base::{CFIndex, CFRelease};
 use core_foundation::runloop::{
-    kCFRunLoopCommonModes, CFRunLoopAddSource, CFRunLoopGetMain, CFRunLoopSourceContext,
+    kCFRunLoopDefaultMode, CFRunLoopAddSource, CFRunLoopGetMain, CFRunLoopSourceContext,
     CFRunLoopSourceCreate, CFRunLoopSourceRef, CFRunLoopSourceSignal, CFRunLoopWakeUp,
 };
 use objc2::rc::{autoreleasepool, Retained};
@@ -462,7 +462,7 @@ impl EventLoopProxy {
                 perform: event_loop_proxy_handler,
             };
             let source = CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::MAX - 1, &mut context);
-            CFRunLoopAddSource(rl, source, kCFRunLoopCommonModes);
+            CFRunLoopAddSource(rl, source, kCFRunLoopDefaultMode);
             CFRunLoopWakeUp(rl);
 
             EventLoopProxy { proxy_wake_up, source }

--- a/src/platform_impl/apple/appkit/observer.rs
+++ b/src/platform_impl/apple/appkit/observer.rs
@@ -13,8 +13,8 @@ use block2::Block;
 use core_foundation::base::{CFIndex, CFOptionFlags, CFRelease, CFTypeRef};
 use core_foundation::date::CFAbsoluteTimeGetCurrent;
 use core_foundation::runloop::{
-    kCFRunLoopAfterWaiting, kCFRunLoopBeforeWaiting, kCFRunLoopCommonModes, kCFRunLoopDefaultMode,
-    kCFRunLoopExit, CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddTimer, CFRunLoopGetMain,
+    kCFRunLoopAfterWaiting, kCFRunLoopBeforeWaiting, kCFRunLoopDefaultMode, kCFRunLoopExit,
+    CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddTimer, CFRunLoopGetMain,
     CFRunLoopObserverCallBack, CFRunLoopObserverContext, CFRunLoopObserverCreate,
     CFRunLoopObserverRef, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
     CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CFRunLoopWakeUp,
@@ -129,7 +129,7 @@ impl RunLoop {
                 context,
             )
         };
-        unsafe { CFRunLoopAddObserver(self.0, observer, kCFRunLoopCommonModes) };
+        unsafe { CFRunLoopAddObserver(self.0, observer, kCFRunLoopDefaultMode) };
     }
 
     /// Submit a closure to run on the main thread as the next step in the run loop, before other
@@ -267,7 +267,7 @@ impl EventLoopWaker {
                 wakeup_main_loop,
                 ptr::null_mut(),
             );
-            CFRunLoopAddTimer(CFRunLoopGetMain(), timer, kCFRunLoopCommonModes);
+            CFRunLoopAddTimer(CFRunLoopGetMain(), timer, kCFRunLoopDefaultMode);
             Self { timer, start_instant: Instant::now(), next_fire_date: None }
         }
     }

--- a/src/platform_impl/apple/uikit/app_state.rs
+++ b/src/platform_impl/apple/uikit/app_state.rs
@@ -10,7 +10,7 @@ use std::{fmt, mem, ptr};
 use core_foundation::base::CFRelease;
 use core_foundation::date::CFAbsoluteTimeGetCurrent;
 use core_foundation::runloop::{
-    kCFRunLoopCommonModes, CFRunLoopAddTimer, CFRunLoopGetMain, CFRunLoopRef, CFRunLoopTimerCreate,
+    kCFRunLoopDefaultMode, CFRunLoopAddTimer, CFRunLoopGetMain, CFRunLoopRef, CFRunLoopTimerCreate,
     CFRunLoopTimerInvalidate, CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate,
 };
 use objc2::rc::Retained;
@@ -802,7 +802,7 @@ impl EventLoopWaker {
                 wakeup_main_loop,
                 ptr::null_mut(),
             );
-            CFRunLoopAddTimer(rl, timer, kCFRunLoopCommonModes);
+            CFRunLoopAddTimer(rl, timer, kCFRunLoopDefaultMode);
 
             EventLoopWaker { timer }
         }

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 
 use core_foundation::base::{CFIndex, CFRelease};
 use core_foundation::runloop::{
-    kCFRunLoopAfterWaiting, kCFRunLoopBeforeWaiting, kCFRunLoopCommonModes, kCFRunLoopDefaultMode,
-    kCFRunLoopExit, CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddSource, CFRunLoopGetMain,
+    kCFRunLoopAfterWaiting, kCFRunLoopBeforeWaiting, kCFRunLoopDefaultMode, kCFRunLoopExit,
+    CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddSource, CFRunLoopGetMain,
     CFRunLoopObserverCreate, CFRunLoopObserverRef, CFRunLoopSourceContext, CFRunLoopSourceCreate,
     CFRunLoopSourceInvalidate, CFRunLoopSourceRef, CFRunLoopSourceSignal, CFRunLoopWakeUp,
 };
@@ -266,7 +266,7 @@ impl EventLoopProxy {
                 perform: event_loop_proxy_handler,
             };
             let source = CFRunLoopSourceCreate(ptr::null_mut(), CFIndex::MAX - 1, &mut context);
-            CFRunLoopAddSource(rl, source, kCFRunLoopCommonModes);
+            CFRunLoopAddSource(rl, source, kCFRunLoopDefaultMode);
             CFRunLoopWakeUp(rl);
 
             EventLoopProxy { proxy_wake_up, source }


### PR DESCRIPTION
AppKit/UIKit has a concept of "run loops", which are effectively a queue of events that are repeatedly consumed from, and when empty, the consuming thread is `std::thread::park`ed until new events appear.

Apple has locked the exact details of these down quite tightly, especially on iOS, which is part of the reason why everything must be in a callback there instead of the original `pump_events` API, but effectively this is the basis of our event loop.

We are still given the option to listen to certain events, however! And this is how we implement the `new_events`/`about_to_wait` events, as well as the `proxy_wake_up` event.

One somewhat odd thing about run loops is that they support being run re-entrantly / in a nested fashion! In this way, the system takes events out of the queue that the nested caller requests, and keeps the rest of the events queued up until the nested caller returns and the outer caller can now process the queued events. Internally, it looks roughly like the following:

```rust
'outer loop {
    match run_loop.get_event_matching(_) {
        ClickOnCornerOfWindow => {
            'inner loop {
                match run_loop.get_event_matching(ReleaseClick | MouseMoved) {
                    ReleaseClick => break 'inner,
                    MouseMoved => window.resized(),
                    _ => unreachable!(),
                }
            }
        }
        ClickOnCloseButton => {
            break 'outer;
        }
        _ => {} // Other events
    }
}
```

Notably, both calls to the fictional "get_event_matching" can end up parking the thread when there is no more work to be done. Now, what this means for us is that we're given basically two options for how to emit `new_events`/`about_to_wait`/`proxy_wake_up`:

1. Emit it from inside each "get_event_matching" (`kCFRunLoopCommonModes`).
2. Emit it only from the outer event loop's "get_event_matching" (`kCFRunLoopDefaultMode`).

Nested run loops like these are used notably in the following instances:
A. When opening e.g. a file dialog with the `rfd` crate.
B. When clicking the corner of the window and dragging to live-resize it.

I am unsure what the desired behaviour is for `new_events`/`about_to_wait`/`proxy_wake_up`? In case A, the file dialog is spawned from inside the event loop itself, and as such we _cannot_ emit the event (since that would be re-entrant). But in case B, we might want to emit the `new_events`/`about_to_wait`/`proxy_wake_up`, even though that is not technically what is happening with our outer event loop.

I felt like the most consistent answer would be that we always use `kCFRunLoopDefaultMode` when originally writing the PR, though then again, maybe resizing should be considered an implementation detail here, and we should just paper over it (like we somewhat currently do)? CC @daxpedda @kchibisov, I'd like input on this! Would the user still expect `new_events`/`about_to_wait` to be emitted when live-resizing a window, even though the application is still somewhat "alive" at this stage?

(In any case, I will first have to [fix calling `request_redraw` inside of `RedrawRequested`](https://github.com/rust-windowing/winit/issues/3406), since the approach of calling it inside `about_to_wait` would break resizing with this PR in its current form).

TODO:
- [ ] Figure out what is actually the desired behaviour here.
- [ ] Test.
- [ ] Add entry to the changelog.
- [ ] Update internal documentation.
- [ ] Update public documentation (esp. also `pump_events`) with my learnings.
- [ ] Write a proper commit message.
