### PR TITLE
Web: fix `MouseMotion` coordinate space

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -302,6 +302,7 @@ web_sys = { package = "web-sys", version = "0.3.64", features = [
     'MediaQueryList',
     'MessageChannel',
     'MessagePort',
+    'Navigator',
     'Node',
     'PageTransitionEvent',
     'PointerEvent',

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -56,7 +56,6 @@ changelog entry.
   to send specific data to be processed on the main thread.
 - Changed `EventLoopProxy::send_event` to `EventLoopProxy::wake_up`, it now
   only wakes up the loop.
-- On Web, slightly improve accuracy of `DeviceEvent::MouseMotion`.
 - `ApplicationHandler::create|destroy_surfaces()` was split off from
   `ApplicationHandler::resumed/suspended()`.
 
@@ -80,3 +79,4 @@ changelog entry.
 ### Fixed
 
 - On Wayland, avoid crashing when compositor is misbehaving.
+- Account for different browser engine implementations of pointer movement coordinate space.


### PR DESCRIPTION
This basically reverts #3766.

Reason being that `screenX/Y` doesn't work when locking the pointer. Its also not ideal because when you move the pointer out of the frame and enter it again, it pretends like the mouse moved a lot, which is quite different then what `movementX/Y` reports and probably not what we want.

Seeing that its unclear in the spec how browsers should implement `movementX/Y` I also opened https://github.com/w3c/pointerlock/issues/100.

Now that we don't have a choice but use `movementX/Y` we have to account for the following:
1. Pretend like https://github.com/w3c/pointerlock/issues/100 has been resolved and all browsers actually set values there instead of zero. Which they currently do.
2. Account for browsers not actually following the spec which coordinate system to use. See https://github.com/w3c/pointerlock/issues/42.
3. Account for Firefox actually being buggy when un-coalescing events. See [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1753724).

To account for all these issues, I added some browser engine detection code, which I might expose to the user in a follow-up PR.

Also have to update #2875 after this is merged.