### PR TITLE
Implement smooth resizing on X11 with _NET_WM_SYNC_REQUEST

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -262,6 +262,7 @@ x11rb = { version = "0.13.0", default-features = false, features = [
     "dl-libxcb",
     "randr",
     "resource_manager",
+    "sync",
     "xinput",
     "xkb",
 ], optional = true }

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -57,6 +57,7 @@ changelog entry.
   to send specific data to be processed on the main thread.
 - Changed `EventLoopProxy::send_event` to `EventLoopProxy::wake_up`, it now
   only wakes up the loop.
+- On X11, implement smooth resizing through the sync extension API.
 - `ApplicationHandler::create|destroy_surfaces()` was split off from
   `ApplicationHandler::resumed/suspended()`.
 

--- a/src/platform_impl/linux/x11/atoms.rs
+++ b/src/platform_impl/linux/x11/atoms.rs
@@ -48,6 +48,8 @@ atom_manager! {
     _NET_WM_NAME,
     _NET_WM_PID,
     _NET_WM_PING,
+    _NET_WM_SYNC_REQUEST,
+    _NET_WM_SYNC_REQUEST_COUNTER,
     _NET_WM_STATE,
     _NET_WM_STATE_ABOVE,
     _NET_WM_STATE_BELOW,

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -438,8 +438,11 @@ impl EventProcessor {
                 None => return,
             };
 
-            let lo = (xev.data.get_long(2) & 0xffffffff) as u32;
-            let hi = (xev.data.get_long(3) & 0x0fffffff) as i32;
+            #[allow(clippy::identity_op)]
+            let lo = (bytemuck::cast::<c_long, c_ulong>(xev.data.get_long(2)) & 0xffffffff) as u32;
+            #[allow(clippy::identity_op)]
+            let hi = (bytemuck::cast::<c_long, c_ulong>(xev.data.get_long(3)) & 0xffffffff) as u32;
+            let hi = bytemuck::cast::<u32, i32>(hi);
 
             wt.xconn
                 .xcb_connection()

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -434,16 +434,13 @@ impl EventProcessor {
             let sync_counter_id = match self
                 .with_window(xev.window as xproto::Window, |window| window.sync_counter_id())
             {
-                Some(sync_counter_id) => sync_counter_id,
-                None => return,
+                Some(Some(sync_counter_id)) => sync_counter_id.get(),
+                _ => return,
             };
 
-
             #[cfg(target_pointer_width = "32")]
-            let (lo, hi) = (
-                bytemuck::cast::<c_long, u32>(xev.data.get_long(2)),
-                xev.data.get_long(3),
-            );
+            let (lo, hi) =
+                (bytemuck::cast::<c_long, u32>(xev.data.get_long(2)), xev.data.get_long(3));
 
             #[cfg(not(target_pointer_width = "32"))]
             let (lo, hi) = (

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -13,6 +13,7 @@ use x11_dl::xlib::{
     XDestroyWindowEvent, XEvent, XExposeEvent, XKeyEvent, XMapEvent, XPropertyEvent,
     XReparentEvent, XSelectionEvent, XVisibilityEvent, XkbAnyEvent, XkbStateRec,
 };
+use x11rb::protocol::sync::{ConnectionExt, Int64};
 use x11rb::protocol::xinput;
 use x11rb::protocol::xkb::ID as XkbId;
 use x11rb::protocol::xproto::{self, ConnectionExt as _, ModMask};
@@ -426,6 +427,24 @@ impl EventProcessor {
                     client_msg.serialize(),
                 )
                 .expect_then_ignore_error("Failed to send `ClientMessage` event.");
+            return;
+        }
+
+        if xev.data.get_long(0) as xproto::Atom == wt.net_wm_sync_request {
+            let sync_counter_id = match self
+                .with_window(xev.window as xproto::Window, |window| window.sync_counter_id())
+            {
+                Some(sync_counter_id) => sync_counter_id,
+                None => return,
+            };
+
+            let lo = (xev.data.get_long(2) & 0xffffffff) as u32;
+            let hi = (xev.data.get_long(3) & 0x0fffffff) as i32;
+
+            wt.xconn
+                .xcb_connection()
+                .sync_set_counter(sync_counter_id, Int64 { lo, hi })
+                .expect_then_ignore_error("Failed to set XSync counter.");
             return;
         }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -127,6 +127,7 @@ pub struct ActiveEventLoop {
     xconn: Arc<XConnection>,
     wm_delete_window: xproto::Atom,
     net_wm_ping: xproto::Atom,
+    net_wm_sync_request: xproto::Atom,
     ime_sender: ImeSender,
     control_flow: Cell<ControlFlow>,
     exit: Cell<Option<i32>>,
@@ -167,6 +168,7 @@ impl EventLoop {
 
         let wm_delete_window = atoms[WM_DELETE_WINDOW];
         let net_wm_ping = atoms[_NET_WM_PING];
+        let net_wm_sync_request = atoms[_NET_WM_SYNC_REQUEST];
 
         let dnd = Dnd::new(Arc::clone(&xconn))
             .expect("Failed to call XInternAtoms when initializing drag and drop");
@@ -292,6 +294,7 @@ impl EventLoop {
             xconn,
             wm_delete_window,
             net_wm_ping,
+            net_wm_sync_request,
             redraw_sender: WakeSender {
                 sender: redraw_sender, // not used again so no clone
                 waker: waker.clone(),

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -489,8 +489,10 @@ impl UnownedWindow {
 
             // Create a sync request counter
             window.sync_counter_id = leap!(xconn.xcb_connection().generate_id());
-            leap!(xconn.xcb_connection().sync_create_counter(window.sync_counter_id, Int64::default()))
-                .ignore_error();
+            leap!(xconn
+                .xcb_connection()
+                .sync_create_counter(window.sync_counter_id, Int64::default()))
+            .ignore_error();
 
             let result = xconn.xcb_connection().change_property(
                 xproto::PropMode::REPLACE,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users

Resolves #2153.

I only tested this on KDE so far, this probably needs more tests on other DEs and WMs.

~~One thing I'm unsure about is whether all the widely used DEs and WMs support the sync API. I know KDE and Gnome definitely do, and it seems that awesomewm also does, but I don't know if some other important ones don't. Searching around, I saw that [Qt preemptively checks if the sync extension is supported](https://github.com/qt/qtbase/blob/bcfa0102e5910d99263ebb73515cc9d35b818b5c/src/plugins/platforms/xcb/qxcbwindow.cpp#L420) through a `hasXSync` call, but I couldn't find a way to do that with `x11rb` so right now there's just no checks...~~ Done through suggestion.

~~On KDE, there's also the subtly weird behavior of the window when resizing a certain way that I mentioned in [this C gist](https://gist.github.com/Speykious/58911fb1c029e17f982b6f76ff8003f5) that I shared in #2153, but it looks more like a KDE bug to me than a misuse of the API.~~ ok it actually definitely is a KDE bug because it happens to all windows of all applications regardless of whether they support `_NET_WM_SYNC_REQUEST`.