### PR TITLE
Fix CI

### DIFF
--- a/src/platform/run_on_demand.rs
+++ b/src/platform/run_on_demand.rs
@@ -30,7 +30,9 @@ pub trait EventLoopExtRunOnDemand {
     /// # Caveats
     /// - This extension isn't available on all platforms, since it's not always possible to return
     ///   to the caller (specifically this is impossible on iOS and Web - though with the Web
-    ///   backend it is possible to use `EventLoopExtWebSys::spawn()`[^1] more than once instead).
+    ///   backend it is possible to use `EventLoopExtWebSys::spawn()`
+    #[cfg_attr(not(web_platform), doc = "[^1]")]
+    ///   more than once instead).
     /// - No [`Window`] state can be carried between separate runs of the event loop.
     ///
     /// You are strongly encouraged to use [`EventLoop::run_app()`] for portability, unless you

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -556,7 +556,7 @@ impl PartialKeyEventInfo {
                 // We convert dead keys into their character.
                 // The reason for this is that `key_without_modifiers` is designed for key-bindings,
                 // but the US International layout treats `'` (apostrophe) as a dead key and the
-                // reguar US layout treats it a character. In order for a single binding
+                // regular US layout treats it a character. In order for a single binding
                 // configuration to work with both layouts, we forward each dead key as a character.
                 Key::Dead(k) => {
                     if let Some(ch) = k {


### PR DESCRIPTION
New and improved Rustdoc lint behavior caught a mistake.
Typos did also.