### PR TITLE
add `available_monitors` method to `EventLoop`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -43,6 +43,7 @@ changelog entry.
 ### Added
 
 - Add `ActiveEventLoop::create_proxy()`.
+- Add `EventLoop::available_monitors()`.
 
 ### Changed
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -299,6 +299,11 @@ impl EventLoop {
     pub fn create_custom_cursor(&self, custom_cursor: CustomCursorSource) -> CustomCursor {
         self.event_loop.window_target().p.create_custom_cursor(custom_cursor)
     }
+
+    /// Returns the list of all the monitors available on the system.
+    pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
+        self.event_loop.window_target().available_monitors()
+    }
 }
 
 #[cfg(feature = "rwh_06")]


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

Hi, I need to access the list of monitors, to set up some state, before the app runs. Also, I'm in a Bevy project, so Bevy defines the app, and I cannot alter its behavior. As a result, I cannot easily get a handle to `ActiveEventLoop`, hence I cannot get the list of monitors.

With this change, list of available monitors is accessible directly in the event loop, and I can easily get the list of monitors before the app is run.