### PR TITLE
wayland: bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,7 @@ windows-sys = { version = "0.52.0", features = [
 [target.'cfg(all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_vendor = "apple"))))'.dependencies]
 ahash = { version = "0.8.7", features = ["no-rng"], optional = true }
 bytemuck = { version = "1.13.1", default-features = false, optional = true }
-calloop = "0.12.3"
+calloop = "0.13.0"
 libc = "0.2.64"
 memmap2 = { version = "0.9.0", optional = true }
 percent-encoding = { version = "2.0", optional = true }
@@ -242,18 +242,18 @@ rustix = { version = "0.38.4", default-features = false, features = [
     "thread",
     "process",
 ] }
-sctk = { package = "smithay-client-toolkit", version = "0.18.0", default-features = false, features = [
+sctk = { package = "smithay-client-toolkit", version = "0.19.2", default-features = false, features = [
     "calloop",
 ], optional = true }
-sctk-adwaita = { version = "0.9.0", default-features = false, optional = true }
-wayland-backend = { version = "0.3.0", default-features = false, features = [
+sctk-adwaita = { version = "0.10.1", default-features = false, optional = true }
+wayland-backend = { version = "0.3.5", default-features = false, features = [
     "client_system",
 ], optional = true }
-wayland-client = { version = "0.31.1", optional = true }
-wayland-protocols = { version = "0.31.0", features = [
+wayland-client = { version = "0.31.4", optional = true }
+wayland-protocols = { version = "0.32.2", features = [
     "staging",
 ], optional = true }
-wayland-protocols-plasma = { version = "0.2.0", features = [
+wayland-protocols-plasma = { version = "0.3.2", features = [
     "client",
 ], optional = true }
 x11-dl = { version = "2.19.1", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -33,7 +33,6 @@ deny = []
 skip = [
     { name = "raw-window-handle" },    # we intentionally have multiple versions of this
     { name = "bitflags" },             # the ecosystem is in the process of migrating.
-    { name = "libloading" },           # x11rb uses a different version until the next update
 ]
 skip-tree = []
 

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -341,10 +341,28 @@ impl CompositorHandler for WinitState {
         &mut self,
         _: &Connection,
         _: &QueueHandle<Self>,
-        _: &wayland_client::protocol::wl_surface::WlSurface,
+        _: &WlSurface,
         _: wayland_client::protocol::wl_output::Transform,
     ) {
         // TODO(kchibisov) we need to expose it somehow in winit.
+    }
+
+    fn surface_enter(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlSurface,
+        _: &WlOutput,
+    ) {
+    }
+
+    fn surface_leave(
+        &mut self,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+        _: &WlSurface,
+        _: &WlOutput,
+    ) {
     }
 
     fn scale_factor_changed(


### PR DESCRIPTION
Update SCTK as a follow-up to 1170554dbdb (ignore events to dead objects) fixing it for wl_output.