### PR TITLE
Web: fix `WindowEvent::Resized` not using rAF

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -85,3 +85,6 @@ changelog entry.
 
 - On Wayland, avoid crashing when compositor is misbehaving.
 - Account for different browser engine implementations of pointer movement coordinate space.
+- On Web, fix `WindowEvent::Resized` not using `requestAnimationFrame` when sending
+  `WindowEvent::RedrawRequested` and also potentially causing `WindowEvent::RedrawRequested`
+  to not be de-duplicated.

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -613,7 +613,7 @@ impl ActiveEventLoop {
                             window_id: RootWindowId(id),
                             event: WindowEvent::Resized(new_size),
                         });
-                        runner.request_redraw(RootWindowId(id));
+                        canvas.request_animation_frame();
                     }
                 }
             },


### PR DESCRIPTION
This caused two issues:
- `WindowEvent::RedrawRequested` send after an `WindowEvent::Resized` would not be throttled.
- Using `Window::request_redraw()` after an `WindowEvent::Resized` will cause two `WindowEvent::RedrawRequested` events. The first one not throttled and the second one throttled by rAF.

Probably a leftover from #2896.