### PR TITLE
Web: implement `Error` for `CustomCursorError`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -43,6 +43,7 @@ changelog entry.
 ### Added
 
 - Add `ActiveEventLoop::create_proxy()`.
+- On Web, implement `Error` for `platform::web::CustomCursorError`.
 
 ### Changed
 

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -437,3 +437,5 @@ impl Display for CustomCursorError {
         }
     }
 }
+
+impl Error for CustomCursorError {}


### PR DESCRIPTION
Missed in #3384.