### PR TITLE
Web: remove unused `CustomCursorError::Animation`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -80,3 +80,4 @@ changelog entry.
 
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside
   of `winit` using `objc2-ui-kit` and calling `UIDevice::currentDevice().userInterfaceIdiom()`.
+- On Web, remove unused `platform::web::CustomCursorError::Animation`.

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -423,7 +423,6 @@ impl Future for CustomCursorFuture {
 pub enum CustomCursorError {
     Blob,
     Decode(String),
-    Animation,
 }
 
 impl Display for CustomCursorError {
@@ -431,9 +430,6 @@ impl Display for CustomCursorError {
         match self {
             Self::Blob => write!(f, "failed to create `Blob`"),
             Self::Decode(error) => write!(f, "failed to decode image: {error}"),
-            Self::Animation => {
-                write!(f, "found `CustomCursor` that is an animation when building an animation")
-            },
         }
     }
 }


### PR DESCRIPTION
This was initially there before refactoring these errors into `BadAnimation`.

Separated from #3793 because this is a breaking change.
Missed in #3384.