### PR TITLE
Replace `WindowId` `From/Into` `u64` with `WindowId::into_raw()` and `from_raw()`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -62,6 +62,7 @@ changelog entry.
 - Implement `Clone`, `Copy`, `Debug`, `Deserialize`, `Eq`, `Hash`, `Ord`, `PartialEq`, `PartialOrd`
   and `Serialize` on many types.
 - Add `MonitorHandle::current_video_mode()`.
+- Add `WindowId::into_raw()` and `from_raw()`.
 
 ### Changed
 
@@ -127,6 +128,8 @@ changelog entry.
 - Remove `MonitorHandle::size()` and `refresh_rate_millihertz()` in favor of
   `MonitorHandle::current_video_mode()`.
 - On Android, remove all `MonitorHandle` support instead of emitting false data.
+- Remove `impl From<u64> for WindowId` and `impl From<WindowId> for u64`. Replaced with
+  `WindowId::into_raw()` and `from_raw()`.
 
 ### Fixed
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -673,16 +673,12 @@ impl WindowId {
     pub const fn dummy() -> Self {
         WindowId
     }
-}
 
-impl From<WindowId> for u64 {
-    fn from(_: WindowId) -> Self {
+    pub const fn into_raw(self) -> u64 {
         0
     }
-}
 
-impl From<u64> for WindowId {
-    fn from(_: u64) -> Self {
+    pub const fn from_raw(_id: u64) -> Self {
         Self
     }
 }

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -76,17 +76,13 @@ impl WindowId {
     pub const fn dummy() -> Self {
         Self(0)
     }
-}
 
-impl From<WindowId> for u64 {
-    fn from(window_id: WindowId) -> Self {
-        window_id.0 as u64
+    pub const fn into_raw(self) -> u64 {
+        self.0 as u64
     }
-}
 
-impl From<u64> for WindowId {
-    fn from(raw_id: u64) -> Self {
-        Self(raw_id as usize)
+    pub const fn from_raw(id: u64) -> Self {
+        Self(id as usize)
     }
 }
 

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -100,7 +100,7 @@ impl WinitUIWindow {
     }
 
     pub(crate) fn id(&self) -> WindowId {
-        (self as *const Self as usize as u64).into()
+        WindowId { window: (self as *const Self as usize) as _ }
     }
 }
 
@@ -679,17 +679,13 @@ impl WindowId {
     pub const fn dummy() -> Self {
         WindowId { window: std::ptr::null_mut() }
     }
-}
 
-impl From<WindowId> for u64 {
-    fn from(window_id: WindowId) -> Self {
-        window_id.window as u64
+    pub fn into_raw(self) -> u64 {
+        self.window as u64
     }
-}
 
-impl From<u64> for WindowId {
-    fn from(raw_id: u64) -> Self {
-        Self { window: raw_id as _ }
+    pub const fn from_raw(id: u64) -> Self {
+        Self { window: id as *mut WinitUIWindow }
     }
 }
 

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -3,10 +3,9 @@
 use std::collections::VecDeque;
 
 use objc2::rc::Retained;
-use objc2::runtime::{AnyObject, NSObject};
 use objc2::{class, declare_class, msg_send, msg_send_id, mutability, ClassType, DeclaredClass};
 use objc2_foundation::{
-    CGFloat, CGPoint, CGRect, CGSize, MainThreadBound, MainThreadMarker, NSObjectProtocol,
+    CGFloat, CGPoint, CGRect, CGSize, MainThreadBound, MainThreadMarker, NSObject, NSObjectProtocol,
 };
 use objc2_ui_kit::{
     UIApplication, UICoordinateSpace, UIResponder, UIScreen, UIScreenOverscanCompensation,
@@ -100,7 +99,7 @@ impl WinitUIWindow {
     }
 
     pub(crate) fn id(&self) -> WindowId {
-        WindowId { window: (self as *const Self as usize) as _ }
+        WindowId::from_window(self)
     }
 }
 
@@ -671,30 +670,23 @@ impl Inner {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId {
-    window: *mut WinitUIWindow,
-}
+pub struct WindowId(usize);
 
 impl WindowId {
     pub const fn dummy() -> Self {
-        WindowId { window: std::ptr::null_mut() }
+        WindowId(0)
     }
 
-    pub fn into_raw(self) -> u64 {
-        self.window as u64
+    pub const fn into_raw(self) -> u64 {
+        self.0 as _
     }
 
     pub const fn from_raw(id: u64) -> Self {
-        Self { window: id as *mut WinitUIWindow }
+        Self(id as _)
     }
-}
 
-unsafe impl Send for WindowId {}
-unsafe impl Sync for WindowId {}
-
-impl From<&AnyObject> for WindowId {
-    fn from(window: &AnyObject) -> WindowId {
-        WindowId { window: window as *const _ as _ }
+    fn from_window(window: &UIWindow) -> Self {
+        Self(window as *const UIWindow as usize)
     }
 }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -143,21 +143,17 @@ pub(crate) enum Window {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WindowId(u64);
 
-impl From<WindowId> for u64 {
-    fn from(window_id: WindowId) -> Self {
-        window_id.0
-    }
-}
-
-impl From<u64> for WindowId {
-    fn from(raw_id: u64) -> Self {
-        Self(raw_id)
-    }
-}
-
 impl WindowId {
     pub const fn dummy() -> Self {
         Self(0)
+    }
+
+    pub const fn into_raw(self) -> u64 {
+        self.0
+    }
+
+    pub const fn from_raw(id: u64) -> Self {
+        Self(id)
     }
 }
 

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -105,17 +105,13 @@ impl WindowId {
     pub const fn dummy() -> Self {
         WindowId { fd: u64::MAX }
     }
-}
 
-impl From<WindowId> for u64 {
-    fn from(id: WindowId) -> Self {
-        id.fd
+    pub const fn into_raw(self) -> u64 {
+        self.fd
     }
-}
 
-impl From<u64> for WindowId {
-    fn from(fd: u64) -> Self {
-        Self { fd }
+    pub const fn from_raw(id: u64) -> Self {
+        Self { fd: id }
     }
 }
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -49,7 +49,7 @@ struct Execution {
     suspended: Cell<bool>,
     event_loop_recreation: Cell<bool>,
     events: RefCell<VecDeque<EventWrapper>>,
-    id: RefCell<u32>,
+    id: Cell<u64>,
     window: web_sys::Window,
     navigator: Navigator,
     document: Document,
@@ -171,7 +171,7 @@ impl Shared {
                 window,
                 navigator,
                 document,
-                id: RefCell::new(0),
+                id: Cell::new(0),
                 all_canvases: RefCell::new(Vec::new()),
                 redraw_pending: RefCell::new(HashSet::new()),
                 destroy_pending: RefCell::new(VecDeque::new()),
@@ -438,11 +438,11 @@ impl Shared {
 
     // Generate a strictly increasing ID
     // This is used to differentiate windows when handling events
-    pub fn generate_id(&self) -> u32 {
-        let mut id = self.0.id.borrow_mut();
-        *id += 1;
+    pub fn generate_id(&self) -> u64 {
+        let id = self.0.id.get();
+        self.0.id.set(id.checked_add(1).expect("exhausted `WindowId`"));
 
-        *id
+        id
     }
 
     pub fn request_redraw(&self, id: WindowId) {

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -429,23 +429,19 @@ impl Drop for Inner {
     }
 }
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(pub(crate) u32);
+pub struct WindowId(pub(crate) u64);
 
 impl WindowId {
     pub const fn dummy() -> Self {
         Self(0)
     }
-}
 
-impl From<WindowId> for u64 {
-    fn from(window_id: WindowId) -> Self {
-        window_id.0 as u64
+    pub const fn into_raw(self) -> u64 {
+        self.0
     }
-}
 
-impl From<u64> for WindowId {
-    fn from(raw_id: u64) -> Self {
-        Self(raw_id as u32)
+    pub const fn from_raw(id: u64) -> Self {
+        Self(id)
     }
 }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -120,23 +120,19 @@ impl WindowId {
     pub const fn dummy() -> Self {
         WindowId(0)
     }
-}
 
-impl From<WindowId> for u64 {
-    fn from(window_id: WindowId) -> Self {
-        window_id.0 as u64
+    pub const fn into_raw(self) -> u64 {
+        self.0 as u64
+    }
+
+    pub const fn from_raw(id: u64) -> Self {
+        Self(id as HWND)
     }
 }
 
 impl From<WindowId> for HWND {
     fn from(window_id: WindowId) -> Self {
         window_id.0
-    }
-}
-
-impl From<u64> for WindowId {
-    fn from(raw_id: u64) -> Self {
-        Self(raw_id as HWND)
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -93,10 +93,16 @@ impl WindowId {
         WindowId(platform_impl::WindowId::dummy())
     }
 
+    /// Convert the `WindowId` into the underlying integer.
+    ///
+    /// This is useful if you need to pass the ID across an FFI boundary, or store it in an atomic.
     pub const fn into_raw(self) -> u64 {
         self.0.into_raw()
     }
 
+    /// Construct a `WindowId` from the underlying integer.
+    ///
+    /// This should only be called with integers returned from [`WindowId::into_raw`].
     pub const fn from_raw(id: u64) -> Self {
         Self(platform_impl::WindowId::from_raw(id))
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -92,23 +92,19 @@ impl WindowId {
     pub const fn dummy() -> Self {
         WindowId(platform_impl::WindowId::dummy())
     }
+
+    pub fn into_raw(self) -> u64 {
+        self.0.into_raw()
+    }
+
+    pub const fn from_raw(id: u64) -> Self {
+        Self(platform_impl::WindowId::from_raw(id))
+    }
 }
 
 impl fmt::Debug for WindowId {
     fn fmt(&self, fmtr: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(fmtr)
-    }
-}
-
-impl From<WindowId> for u64 {
-    fn from(window_id: WindowId) -> Self {
-        window_id.0.into()
-    }
-}
-
-impl From<u64> for WindowId {
-    fn from(raw_id: u64) -> Self {
-        Self(raw_id.into())
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -93,7 +93,7 @@ impl WindowId {
         WindowId(platform_impl::WindowId::dummy())
     }
 
-    pub fn into_raw(self) -> u64 {
+    pub const fn into_raw(self) -> u64 {
         self.0.into_raw()
     }
 


### PR DESCRIPTION
As there shouldn't really be a need for a user-constructible `WindowId`, I assume this was used previously because `WindowId` was passed as a parameter?

~~I introduced `WindowId::to_u64()` as a replacement, but I'm not sure if this has any use case.~~
After the last meeting we decided to add conversion methods called `from_raw()` and `into_raw()`.
