### PR TITLE
Add `MonitorHandle::current_video_mode()`

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -304,31 +304,30 @@ impl Application {
 
             if let Some(current_mode) = monitor.current_video_mode() {
                 let PhysicalSize { width, height } = current_mode.size();
-                info!(
-                    "  Current mode: {width}x{height}{}",
-                    if let Some(m_hz) = current_mode.refresh_rate_millihertz() {
-                        format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
-                    } else {
-                        String::new()
-                    }
-                );
+                let bits =
+                    current_mode.bit_depth().map(|bits| format!("x{bits}")).unwrap_or_default();
+                let m_hz = current_mode
+                    .refresh_rate_millihertz()
+                    .map(|m_hz| format!(" @ {}.{} Hz", m_hz.get() / 1000, m_hz.get() % 1000))
+                    .unwrap_or_default();
+                info!("  {width}x{height}{bits}{m_hz}");
             }
 
-            let PhysicalPosition { x, y } = monitor.position();
-            info!("  Position: {x},{y}");
+            if let Some(PhysicalPosition { x, y }) = monitor.position() {
+                info!("  Position: {x},{y}");
+            }
 
             info!("  Scale factor: {}", monitor.scale_factor());
 
             info!("  Available modes (width x height x bit-depth):");
             for mode in monitor.video_modes() {
                 let PhysicalSize { width, height } = mode.size();
-                let bits = mode.bit_depth();
-                let m_hz = if let Some(m_hz) = mode.refresh_rate_millihertz() {
-                    format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
-                } else {
-                    String::new()
-                };
-                info!("    {width}x{height}x{bits}{m_hz}");
+                let bits = mode.bit_depth().map(|bits| format!("x{bits}")).unwrap_or_default();
+                let m_hz = mode
+                    .refresh_rate_millihertz()
+                    .map(|m_hz| format!(" @ {}.{} Hz", m_hz.get() / 1000, m_hz.get() % 1000))
+                    .unwrap_or_default();
+                info!("    {width}x{height}{bits}{m_hz}");
             }
         }
     }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -302,15 +302,17 @@ impl Application {
                 info!("{intro}: [no name]");
             }
 
-            let PhysicalSize { width, height } = monitor.size();
-            info!(
-                "  Current mode: {width}x{height}{}",
-                if let Some(m_hz) = monitor.refresh_rate_millihertz() {
-                    format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
-                } else {
-                    String::new()
-                }
-            );
+            if let Some(current_mode) = monitor.current_video_mode() {
+                let PhysicalSize { width, height } = current_mode.size();
+                info!(
+                    "  Current mode: {width}x{height}{}",
+                    if let Some(m_hz) = current_mode.refresh_rate_millihertz() {
+                        format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
+                    } else {
+                        String::new()
+                    }
+                );
+            }
 
             let PhysicalPosition { x, y } = monitor.position();
             info!("  Position: {x},{y}");
@@ -321,8 +323,12 @@ impl Application {
             for mode in monitor.video_modes() {
                 let PhysicalSize { width, height } = mode.size();
                 let bits = mode.bit_depth();
-                let m_hz = mode.refresh_rate_millihertz();
-                info!("    {width}x{height}x{bits} @ {}.{} Hz", m_hz / 1000, m_hz % 1000);
+                let m_hz = if let Some(m_hz) = mode.refresh_rate_millihertz() {
+                    format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
+                } else {
+                    String::new()
+                };
+                info!("    {width}x{height}x{bits}{m_hz}");
             }
         }
     }

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -122,6 +122,7 @@ changelog entry.
 - Remove `Touch::id` in favor of `Touch::finger_id`.
 - Remove `MonitorHandle::size()` and `refresh_rate_millihertz()` in favor of
   `MonitorHandle::current_video_mode()`.
+- On Android, remove all `MonitorHandle` support instead of emitting false data.
 
 ### Fixed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -95,6 +95,7 @@ changelog entry.
   accelerated, if the browser supports it.
 - `(Active)EventLoop::create_custom_cursor()` now returns a `Result<CustomCursor, ExternalError>`.
 - Changed how `ModifiersState` is serialized by Serde.
+- `VideoModeHandle::refresh_rate_millihertz()` now returns an `Option`.
 
 ### Removed
 
@@ -118,6 +119,8 @@ changelog entry.
 - Remove `DeviceEvent::Added` and `DeviceEvent::Removed`.
 - Remove `DeviceEvent::Motion` and `WindowEvent::AxisMotion`.
 - Remove `Touch::id` in favor of `Touch::finger_id`.
+- Remove `MonitorHandle::size()` and `refresh_rate_millihertz()` in favor of
+  `MonitorHandle::current_video_mode()`.
 
 ### Fixed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -95,7 +95,8 @@ changelog entry.
   accelerated, if the browser supports it.
 - `(Active)EventLoop::create_custom_cursor()` now returns a `Result<CustomCursor, ExternalError>`.
 - Changed how `ModifiersState` is serialized by Serde.
-- `VideoModeHandle::refresh_rate_millihertz()` now returns an `Option`.
+- `VideoModeHandle::refresh_rate_millihertz()` and `bit_depth()` now return a `Option<NonZero*>`.
+- `MonitorHandle::position()` now returns an `Option`.
 
 ### Removed
 
@@ -127,3 +128,4 @@ changelog entry.
 - On Web, pen events are now routed through to `WindowEvent::Cursor*`.
 - On macOS, fix panic when releasing not available monitor.
 - On MacOS, return the system theme in `Window::theme()` if no theme override is set.
+- On Orbital, `MonitorHandle::name()` now returns `None` instead of a dummy name.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -61,6 +61,7 @@ changelog entry.
   the primary finger in a multi-touch interaction.
 - Implement `Clone`, `Copy`, `Debug`, `Deserialize`, `Eq`, `Hash`, `Ord`, `PartialEq`, `PartialOrd`
   and `Serialize` on many types.
+- Add `MonitorHandle::current_video_mode()`.
 
 ### Changed
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -64,12 +64,8 @@ impl VideoModeHandle {
     }
 
     /// Returns the refresh rate of this video mode in mHz.
-    ///
-    /// ## Platform-specific
-    ///
-    /// **Web:** Always returns `0`.
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> u32 {
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         self.video_mode.refresh_rate_millihertz()
     }
 
@@ -85,10 +81,10 @@ impl std::fmt::Display for VideoModeHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}x{} @ {} mHz ({} bpp)",
+            "{}x{} {}({} bpp)",
             self.size().width,
             self.size().height,
-            self.refresh_rate_millihertz(),
+            self.refresh_rate_millihertz().map(|rate| format!("@ {rate} mHz ")).unwrap_or_default(),
             self.bit_depth()
         )
     }
@@ -139,12 +135,6 @@ impl MonitorHandle {
         self.inner.name()
     }
 
-    /// Returns the monitor's resolution.
-    #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.inner.size()
-    }
-
     /// Returns the top-left corner position of the monitor relative to the larger full
     /// screen area.
     ///
@@ -159,22 +149,6 @@ impl MonitorHandle {
     #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         self.inner.position()
-    }
-
-    /// The monitor refresh rate used by the system.
-    ///
-    /// Return `Some` if succeed, or `None` if failed, which usually happens when the monitor
-    /// the window is on is removed.
-    ///
-    /// When using exclusive fullscreen, the refresh rate of the [`VideoModeHandle`] that was
-    /// used to enter fullscreen should be used instead.
-    ///
-    /// ## Platform-specific
-    ///
-    /// **Web:** Always returns [`None`].
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        self.inner.refresh_rate_millihertz()
     }
 
     /// Returns the scale factor of the underlying monitor. To map logical pixels to physical

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -201,6 +201,12 @@ impl MonitorHandle {
         self.inner.scale_factor()
     }
 
+    /// Returns the currently active video mode of this monitor.
+    #[inline]
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+        self.inner.current_video_mode().map(|video_mode| VideoModeHandle { video_mode })
+    }
+
     /// Returns all fullscreen video modes supported by this monitor.
     #[inline]
     pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -2,6 +2,7 @@ use std::any::Any;
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::hash::Hash;
+use std::num::{NonZeroU16, NonZeroU32};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -980,8 +981,8 @@ impl MonitorHandle {
         Some("Android Device".to_owned())
     }
 
-    pub fn position(&self) -> PhysicalPosition<i32> {
-        (0, 0).into()
+    pub fn position(&self) -> Option<PhysicalPosition<i32>> {
+        None
     }
 
     pub fn scale_factor(&self) -> f64 {
@@ -989,12 +990,7 @@ impl MonitorHandle {
     }
 
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
-        Some(VideoModeHandle {
-            size: screen_size(&self.app),
-            // FIXME: it is guaranteed to support 32 bit color though
-            bit_depth: 32,
-            monitor: self.clone(),
-        })
+        Some(VideoModeHandle { size: screen_size(&self.app), monitor: self.clone() })
     }
 
     pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
@@ -1005,7 +1001,6 @@ impl MonitorHandle {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct VideoModeHandle {
     size: PhysicalSize<u32>,
-    bit_depth: u16,
     monitor: MonitorHandle,
 }
 
@@ -1014,11 +1009,11 @@ impl VideoModeHandle {
         self.size
     }
 
-    pub fn bit_depth(&self) -> u16 {
-        self.bit_depth
+    pub fn bit_depth(&self) -> Option<NonZeroU16> {
+        None
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
         None
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -1003,16 +1003,20 @@ impl MonitorHandle {
         None
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(VideoModeHandle {
+        Some(VideoModeHandle {
             size,
             bit_depth: 32,
             refresh_rate_millihertz: 60000,
             monitor: self.clone(),
         })
+    }
+
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+        self.current_video_mode().into_iter()
     }
 }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -204,9 +204,7 @@ impl EventLoop {
                     let old_scale_factor = monitor.scale_factor();
                     let scale_factor = monitor.scale_factor();
                     if (scale_factor - old_scale_factor).abs() < f64::EPSILON {
-                        let new_inner_size = Arc::new(Mutex::new(
-                            MonitorHandle::new(self.android_app.clone()).size(),
-                        ));
+                        let new_inner_size = Arc::new(Mutex::new(screen_size(&self.android_app)));
                         let window_id = window::WindowId(WindowId);
                         let event = event::WindowEvent::ScaleFactorChanged {
                             inner_size_writer: InnerSizeWriter::new(Arc::downgrade(
@@ -789,7 +787,7 @@ impl Window {
     }
 
     pub fn outer_size(&self) -> PhysicalSize<u32> {
-        MonitorHandle::new(self.app.clone()).size()
+        screen_size(&self.app)
     }
 
     pub fn set_min_inner_size(&self, _: Option<Size>) {}
@@ -982,14 +980,6 @@ impl MonitorHandle {
         Some("Android Device".to_owned())
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        if let Some(native_window) = self.app.native_window() {
-            PhysicalSize::new(native_window.width() as _, native_window.height() as _)
-        } else {
-            PhysicalSize::new(0, 0)
-        }
-    }
-
     pub fn position(&self) -> PhysicalPosition<i32> {
         (0, 0).into()
     }
@@ -998,19 +988,11 @@ impl MonitorHandle {
         self.app.config().density().map(|dpi| dpi as f64 / 160.0).unwrap_or(1.0)
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        // FIXME no way to get real refresh rate for now.
-        None
-    }
-
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
-        let size = self.size().into();
-        // FIXME this is not the real refresh rate
-        // (it is guaranteed to support 32 bit color though)
         Some(VideoModeHandle {
-            size,
+            size: screen_size(&self.app),
+            // FIXME: it is guaranteed to support 32 bit color though
             bit_depth: 32,
-            refresh_rate_millihertz: 60000,
             monitor: self.clone(),
         })
     }
@@ -1022,26 +1004,33 @@ impl MonitorHandle {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct VideoModeHandle {
-    size: (u32, u32),
+    size: PhysicalSize<u32>,
     bit_depth: u16,
-    refresh_rate_millihertz: u32,
     monitor: MonitorHandle,
 }
 
 impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
-        self.size.into()
+        self.size
     }
 
     pub fn bit_depth(&self) -> u16 {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        None
     }
 
     pub fn monitor(&self) -> MonitorHandle {
         self.monitor.clone()
+    }
+}
+
+fn screen_size(app: &AndroidApp) -> PhysicalSize<u32> {
+    if let Some(native_window) = app.native_window() {
+        PhysicalSize::new(native_window.width() as _, native_window.height() as _)
+    } else {
+        PhysicalSize::new(0, 0)
     }
 }

--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -21,7 +21,7 @@ use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 pub struct VideoModeHandle {
     size: PhysicalSize<u32>,
     bit_depth: u16,
-    refresh_rate_millihertz: u32,
+    refresh_rate_millihertz: Option<u32>,
     pub(crate) monitor: MonitorHandle,
     pub(crate) native_mode: NativeDisplayMode,
 }
@@ -80,7 +80,11 @@ impl Clone for NativeDisplayMode {
 }
 
 impl VideoModeHandle {
-    fn new(monitor: MonitorHandle, mode: NativeDisplayMode, refresh_rate_millihertz: u32) -> Self {
+    fn new(
+        monitor: MonitorHandle,
+        mode: NativeDisplayMode,
+        refresh_rate_millihertz: Option<u32>,
+    ) -> Self {
         unsafe {
             let pixel_encoding =
                 CFString::wrap_under_create_rule(ffi::CGDisplayModeCopyPixelEncoding(mode.0))
@@ -116,7 +120,7 @@ impl VideoModeHandle {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         self.refresh_rate_millihertz
     }
 
@@ -186,7 +190,6 @@ impl fmt::Debug for MonitorHandle {
         f.debug_struct("MonitorHandle")
             .field("name", &self.name())
             .field("native_identifier", &self.native_identifier())
-            .field("size", &self.size())
             .field("position", &self.position())
             .field("scale_factor", &self.scale_factor())
             .field("refresh_rate_millihertz", &self.refresh_rate_millihertz())
@@ -212,14 +215,6 @@ impl MonitorHandle {
         self.0
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        let MonitorHandle(display_id) = *self;
-        let display = CGDisplay::new(display_id);
-        let height = display.pixels_high();
-        let width = display.pixels_wide();
-        PhysicalSize::from_logical::<_, f64>((width as f64, height as f64), self.scale_factor())
-    }
-
     #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         // This is already in screen coordinates. If we were using `NSScreen`,
@@ -239,7 +234,7 @@ impl MonitorHandle {
         })
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    fn refresh_rate_millihertz(&self) -> Option<u32> {
         let current_display_mode =
             NativeDisplayMode(unsafe { CGDisplayCopyDisplayMode(self.0) } as _);
         refresh_rate_millihertz(self.0, &current_display_mode)
@@ -247,12 +242,12 @@ impl MonitorHandle {
 
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         let mode = NativeDisplayMode(unsafe { CGDisplayCopyDisplayMode(self.0) } as _);
-        let refresh_rate_millihertz = refresh_rate_millihertz(self.0, &mode).unwrap_or(0);
+        let refresh_rate_millihertz = refresh_rate_millihertz(self.0, &mode);
         Some(VideoModeHandle::new(self.clone(), mode, refresh_rate_millihertz))
     }
 
     pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
-        let refresh_rate_millihertz = self.refresh_rate_millihertz().unwrap_or(0);
+        let refresh_rate_millihertz = self.refresh_rate_millihertz();
         let monitor = self.clone();
 
         unsafe {
@@ -277,7 +272,7 @@ impl MonitorHandle {
                 // CGDisplayModeGetRefreshRate returns 0.0 for any display that
                 // isn't a CRT
                 let refresh_rate_millihertz = if cg_refresh_rate_hertz > 0 {
-                    (cg_refresh_rate_hertz * 1000) as u32
+                    Some((cg_refresh_rate_hertz * 1000) as u32)
                 } else {
                     refresh_rate_millihertz
                 };

--- a/src/platform_impl/apple/uikit/monitor.rs
+++ b/src/platform_impl/apple/uikit/monitor.rs
@@ -75,8 +75,8 @@ impl VideoModeHandle {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        Some(self.refresh_rate_millihertz)
     }
 
     pub fn monitor(&self) -> MonitorHandle {
@@ -131,10 +131,8 @@ impl fmt::Debug for MonitorHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MonitorHandle")
             .field("name", &self.name())
-            .field("size", &self.size())
             .field("position", &self.position())
             .field("scale_factor", &self.scale_factor())
-            .field("refresh_rate_millihertz", &self.refresh_rate_millihertz())
             .finish_non_exhaustive()
     }
 }
@@ -164,11 +162,6 @@ impl MonitorHandle {
         })
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        let bounds = self.ui_screen.get_on_main(|ui_screen| ui_screen.nativeBounds());
-        PhysicalSize::new(bounds.size.width as u32, bounds.size.height as u32)
-    }
-
     pub fn position(&self) -> PhysicalPosition<i32> {
         let bounds = self.ui_screen.get_on_main(|ui_screen| ui_screen.nativeBounds());
         (bounds.origin.x as f64, bounds.origin.y as f64).into()
@@ -176,10 +169,6 @@ impl MonitorHandle {
 
     pub fn scale_factor(&self) -> f64 {
         self.ui_screen.get_on_main(|ui_screen| ui_screen.nativeScale()) as f64
-    }
-
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        Some(self.ui_screen.get_on_main(|ui_screen| refresh_rate_millihertz(ui_screen)))
     }
 
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {

--- a/src/platform_impl/apple/uikit/monitor.rs
+++ b/src/platform_impl/apple/uikit/monitor.rs
@@ -182,6 +182,16 @@ impl MonitorHandle {
         Some(self.ui_screen.get_on_main(|ui_screen| refresh_rate_millihertz(ui_screen)))
     }
 
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+        Some(run_on_main(|mtm| {
+            VideoModeHandle::new(
+                self.ui_screen(mtm).clone(),
+                self.ui_screen(mtm).currentMode().unwrap(),
+                mtm,
+            )
+        }))
+    }
+
     pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
         run_on_main(|mtm| {
             let ui_screen = self.ui_screen(mtm);

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -4,6 +4,7 @@
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
 use std::collections::VecDeque;
+use std::num::{NonZeroU16, NonZeroU32};
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::sync::Arc;
 use std::time::Duration;
@@ -242,7 +243,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn position(&self) -> PhysicalPosition<i32> {
+    pub fn position(&self) -> Option<PhysicalPosition<i32>> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.position())
     }
 
@@ -277,12 +278,12 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn bit_depth(&self) -> u16 {
+    pub fn bit_depth(&self) -> Option<NonZeroU16> {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.bit_depth())
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.refresh_rate_millihertz())
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -262,6 +262,11 @@ impl MonitorHandle {
     }
 
     #[inline]
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+        x11_or_wayland!(match self; MonitorHandle(m) => m.current_video_mode())
+    }
+
+    #[inline]
     pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoModeHandle>> {
         x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -242,18 +242,8 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        x11_or_wayland!(match self; MonitorHandle(m) => m.size())
-    }
-
-    #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.position())
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        x11_or_wayland!(match self; MonitorHandle(m) => m.refresh_rate_millihertz())
     }
 
     #[inline]
@@ -292,7 +282,7 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> u32 {
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.refresh_rate_millihertz())
     }
 

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -1,4 +1,4 @@
-use sctk::output::OutputData;
+use sctk::output::{Mode, OutputData};
 use sctk::reexports::client::protocol::wl_output::WlOutput;
 use sctk::reexports::client::Proxy;
 
@@ -74,6 +74,18 @@ impl MonitorHandle {
     }
 
     #[inline]
+    pub fn current_video_mode(&self) -> Option<PlatformVideoModeHandle> {
+        let output_data = self.proxy.data::<OutputData>().unwrap();
+        output_data.with_output_info(|info| {
+            let mode = info.modes.iter().find(|mode| mode.current).cloned();
+
+            mode.map(|mode| {
+                PlatformVideoModeHandle::Wayland(VideoModeHandle::new(self.clone(), mode))
+            })
+        })
+    }
+
+    #[inline]
     pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoModeHandle> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         let modes = output_data.with_output_info(|info| info.modes.clone());
@@ -81,12 +93,7 @@ impl MonitorHandle {
         let monitor = self.clone();
 
         modes.into_iter().map(move |mode| {
-            PlatformVideoModeHandle::Wayland(VideoModeHandle {
-                size: (mode.dimensions.0 as u32, mode.dimensions.1 as u32).into(),
-                refresh_rate_millihertz: mode.refresh_rate as u32,
-                bit_depth: 32,
-                monitor: monitor.clone(),
-            })
+            PlatformVideoModeHandle::Wayland(VideoModeHandle::new(monitor.clone(), mode))
         })
     }
 }
@@ -126,6 +133,15 @@ pub struct VideoModeHandle {
 }
 
 impl VideoModeHandle {
+    fn new(monitor: MonitorHandle, mode: Mode) -> Self {
+        VideoModeHandle {
+            size: (mode.dimensions.0 as u32, mode.dimensions.1 as u32).into(),
+            refresh_rate_millihertz: mode.refresh_rate as u32,
+            bit_depth: 32,
+            monitor: monitor.clone(),
+        }
+    }
+
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         self.size

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -29,20 +29,6 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        let output_data = self.proxy.data::<OutputData>().unwrap();
-        let dimensions = output_data.with_output_info(|info| {
-            info.modes.iter().find_map(|mode| mode.current.then_some(mode.dimensions))
-        });
-
-        match dimensions {
-            Some((width, height)) => (width as u32, height as u32),
-            _ => (0, 0),
-        }
-        .into()
-    }
-
-    #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         output_data.with_output_info(|info| {
@@ -56,14 +42,6 @@ impl MonitorHandle {
                         .to_physical(info.scale_factor as f64)
                 },
             )
-        })
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        let output_data = self.proxy.data::<OutputData>().unwrap();
-        output_data.with_output_info(|info| {
-            info.modes.iter().find_map(|mode| mode.current.then_some(mode.refresh_rate as u32))
         })
     }
 
@@ -153,8 +131,8 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        Some(self.refresh_rate_millihertz)
     }
 
     pub fn monitor(&self) -> MonitorHandle {

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -21,7 +21,7 @@ pub struct VideoModeHandle {
     pub(crate) current: bool,
     pub(crate) size: (u32, u32),
     pub(crate) bit_depth: u16,
-    pub(crate) refresh_rate_millihertz: u32,
+    pub(crate) refresh_rate_millihertz: Option<u32>,
     pub(crate) native_mode: randr::Mode,
     pub(crate) monitor: Option<MonitorHandle>,
 }
@@ -38,7 +38,7 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> u32 {
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         self.refresh_rate_millihertz
     }
 
@@ -54,8 +54,6 @@ pub struct MonitorHandle {
     pub(crate) id: randr::Crtc,
     /// The name of the monitor
     pub(crate) name: String,
-    /// The size of the monitor
-    dimensions: (u32, u32),
     /// The position of the monitor in the X screen
     position: (i32, i32),
     /// If the monitor is the primary one
@@ -118,16 +116,7 @@ impl MonitorHandle {
 
         let rect = util::AaRect::new(position, dimensions);
 
-        Some(MonitorHandle {
-            id,
-            name,
-            scale_factor,
-            dimensions,
-            position,
-            primary,
-            rect,
-            video_modes,
-        })
+        Some(MonitorHandle { id, name, scale_factor, position, primary, rect, video_modes })
     }
 
     pub fn dummy() -> Self {
@@ -135,7 +124,6 @@ impl MonitorHandle {
             id: 0,
             name: "<dummy monitor>".into(),
             scale_factor: 1.0,
-            dimensions: (1, 1),
             position: (0, 0),
             primary: true,
             rect: util::AaRect::new((0, 0), (1, 1)),
@@ -157,18 +145,8 @@ impl MonitorHandle {
         self.id as _
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.dimensions.into()
-    }
-
     pub fn position(&self) -> PhysicalPosition<i32> {
         self.position.into()
-    }
-
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        self.video_modes
-            .iter()
-            .find_map(|mode| mode.current.then_some(mode.refresh_rate_millihertz))
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroU16;
 use std::str::FromStr;
 use std::{env, str};
 
@@ -86,7 +87,7 @@ impl XConnection {
                     current: mode.id == current_mode,
                     size: (mode.width.into(), mode.height.into()),
                     refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode),
-                    bit_depth: bit_depth as u16,
+                    bit_depth: NonZeroU16::new(bit_depth as u16),
                     native_mode: mode.id,
                     // This is populated in `MonitorHandle::video_modes` as the
                     // video mode is returned to the user

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -74,6 +74,7 @@ impl XConnection {
         let bit_depth = self.default_root().root_depth;
         let output_modes = &output_info.modes;
         let resource_modes = resources.modes();
+        let current_mode = crtc.mode;
 
         let modes = resource_modes
             .iter()
@@ -82,6 +83,7 @@ impl XConnection {
             .filter(|x| output_modes.iter().any(|id| x.id == *id))
             .map(|mode| {
                 VideoModeHandle {
+                    current: mode.id == current_mode,
                     size: (mode.width.into(), mode.height.into()),
                     refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode)
                         .unwrap_or(0),

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -85,8 +85,7 @@ impl XConnection {
                 VideoModeHandle {
                     current: mode.id == current_mode,
                     size: (mode.width.into(), mode.height.into()),
-                    refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode)
-                        .unwrap_or(0),
+                    refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode),
                     bit_depth: bit_depth as u16,
                     native_mode: mode.id,
                     // This is populated in `MonitorHandle::video_modes` as the

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -822,7 +822,7 @@ impl UnownedWindow {
 
                 let window_position = self.outer_position_physical();
                 self.shared_state_lock().restore_position = Some(window_position);
-                let monitor_origin: (i32, i32) = monitor.position().into();
+                let monitor_origin: (i32, i32) = monitor.position;
                 self.set_position_inner(monitor_origin.0, monitor_origin.1)
                     .expect_then_ignore_error("Failed to set window position");
                 self.set_fullscreen_hint(true).map(Some)

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -217,16 +217,20 @@ impl MonitorHandle {
         None
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(VideoModeHandle {
+        Some(VideoModeHandle {
             size,
             bit_depth: 32,
             refresh_rate_millihertz: 60000,
             monitor: self.clone(),
         })
+    }
+
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+        self.current_video_mode().into_iter()
     }
 }
 

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -200,10 +200,6 @@ impl MonitorHandle {
         Some("Redox Device".to_owned())
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        PhysicalSize::new(0, 0) // TODO
-    }
-
     pub fn position(&self) -> PhysicalPosition<i32> {
         (0, 0).into()
     }
@@ -212,19 +208,11 @@ impl MonitorHandle {
         1.0 // TODO
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        // FIXME no way to get real refresh rate for now.
-        None
-    }
-
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
-        let size = self.size().into();
-        // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
         Some(VideoModeHandle {
-            size,
+            size: PhysicalSize::default(), // TODO
             bit_depth: 32,
-            refresh_rate_millihertz: 60000,
             monitor: self.clone(),
         })
     }
@@ -236,23 +224,23 @@ impl MonitorHandle {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct VideoModeHandle {
-    size: (u32, u32),
+    size: PhysicalSize<u32>,
     bit_depth: u16,
-    refresh_rate_millihertz: u32,
     monitor: MonitorHandle,
 }
 
 impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
-        self.size.into()
+        self.size
     }
 
     pub fn bit_depth(&self) -> u16 {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        // TODO
+        None
     }
 
     pub fn monitor(&self) -> MonitorHandle {

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -1,6 +1,7 @@
 #![cfg(target_os = "redox")]
 
 use std::fmt::{self, Display, Formatter};
+use std::num::{NonZeroU16, NonZeroU32};
 use std::str;
 use std::sync::Arc;
 
@@ -197,11 +198,11 @@ pub struct MonitorHandle;
 
 impl MonitorHandle {
     pub fn name(&self) -> Option<String> {
-        Some("Redox Device".to_owned())
+        None
     }
 
-    pub fn position(&self) -> PhysicalPosition<i32> {
-        (0, 0).into()
+    pub fn position(&self) -> Option<PhysicalPosition<i32>> {
+        None
     }
 
     pub fn scale_factor(&self) -> f64 {
@@ -210,11 +211,7 @@ impl MonitorHandle {
 
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         // (it is guaranteed to support 32 bit color though)
-        Some(VideoModeHandle {
-            size: PhysicalSize::default(), // TODO
-            bit_depth: 32,
-            monitor: self.clone(),
-        })
+        Some(VideoModeHandle { monitor: self.clone() })
     }
 
     pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
@@ -224,21 +221,20 @@ impl MonitorHandle {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct VideoModeHandle {
-    size: PhysicalSize<u32>,
-    bit_depth: u16,
     monitor: MonitorHandle,
 }
 
 impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
-        self.size
+        // TODO
+        PhysicalSize::default()
     }
 
-    pub fn bit_depth(&self) -> u16 {
-        self.bit_depth
+    pub fn bit_depth(&self) -> Option<NonZeroU16> {
+        None
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
         // TODO
         None
     }

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -71,24 +71,6 @@ impl MonitorHandle {
         })
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        None
-    }
-
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.inner.queue(|inner| {
-            let width = inner.screen.width().unwrap();
-            let height = inner.screen.height().unwrap();
-
-            if let Some(Engine::Chromium) = inner.engine {
-                PhysicalSize::new(width, height).cast()
-            } else {
-                LogicalSize::new(width, height)
-                    .to_physical(super::web_sys::scale_factor(&inner.window))
-            }
-        })
-    }
-
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         Some(VideoModeHandle(self.clone()))
     }
@@ -291,15 +273,25 @@ pub struct VideoModeHandle(pub(super) MonitorHandle);
 
 impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
-        self.0.size()
+        self.0.inner.queue(|inner| {
+            let width = inner.screen.width().unwrap();
+            let height = inner.screen.height().unwrap();
+
+            if let Some(Engine::Chromium) = inner.engine {
+                PhysicalSize::new(width, height).cast()
+            } else {
+                LogicalSize::new(width, height)
+                    .to_physical(super::web_sys::scale_factor(&inner.window))
+            }
+        })
     }
 
     pub fn bit_depth(&self) -> u16 {
         self.0.inner.queue(|inner| inner.screen.color_depth().unwrap()).try_into().unwrap()
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        0
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        None
     }
 
     pub fn monitor(&self) -> MonitorHandle {

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -89,6 +89,10 @@ impl MonitorHandle {
         })
     }
 
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+        Some(VideoModeHandle(self.clone()))
+    }
+
     pub fn video_modes(&self) -> Once<VideoModeHandle> {
         iter::once(VideoModeHandle(self.clone()))
     }

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -81,8 +81,8 @@ impl VideoModeHandle {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        Some(self.refresh_rate_millihertz)
     }
 
     pub fn monitor(&self) -> MonitorHandle {
@@ -180,29 +180,11 @@ impl MonitorHandle {
         self.0
     }
 
-    #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
+    pub(crate) fn size(&self) -> PhysicalSize<u32> {
         let rc_monitor = get_monitor_info(self.0).unwrap().monitorInfo.rcMonitor;
         PhysicalSize {
             width: (rc_monitor.right - rc_monitor.left) as u32,
             height: (rc_monitor.bottom - rc_monitor.top) as u32,
-        }
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        let monitor_info = get_monitor_info(self.0).ok()?;
-        let device_name = monitor_info.szDevice.as_ptr();
-        unsafe {
-            let mut mode: DEVMODEW = mem::zeroed();
-            mode.dmSize = mem::size_of_val(&mode) as u16;
-            if EnumDisplaySettingsExW(device_name, ENUM_CURRENT_SETTINGS, &mut mode, 0)
-                == false.into()
-            {
-                None
-            } else {
-                Some(mode.dmDisplayFrequency * 1000)
-            }
         }
     }
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -786,7 +786,7 @@ impl Window {
                         Fullscreen::Borderless(None) => monitor::current_monitor(window),
                     };
 
-                    let position: (i32, i32) = monitor.position().into();
+                    let position: (i32, i32) = monitor.position().unwrap_or_default().into();
                     let size: (u32, u32) = monitor.size().into();
 
                     unsafe {


### PR DESCRIPTION
After some discussion we decided its more useful to encode current monitor information into `VideoModeHandle` then move more information to `MonitorHandle`. To this end this PR implements `MonitorHandle::current_video_mode()`.

Additionally `MonitorHandle::size()` and `refresh_rate_millihertz()` were removed, because it logically fits into video modes and not the monitor itself.

To improve the output, this PR also changes `VideoModeHandle::refresh_rate_millihertz()` to return a `Option<NonZeroU32>` and `size()` and `bit_depth()` an `Option`.

Follow up to #3801.