### PR TITLE
Rename refresh rate

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -236,15 +236,17 @@ impl Application {
                 info!("{intro}: [no name]");
             }
 
-            let PhysicalSize { width, height } = monitor.size();
-            info!(
-                "  Current mode: {width}x{height}{}",
-                if let Some(m_hz) = monitor.refresh_rate_millihertz() {
-                    format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
-                } else {
-                    String::new()
-                }
-            );
+            if let Some(current_mode) = monitor.current_video_mode() {
+                let PhysicalSize { width, height } = current_mode.size();
+                info!(
+                    "  Current mode: {width}x{height}{}",
+                    if let Some(m_hz) = current_mode.refresh_rate_millihertz() {
+                        format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
+                    } else {
+                        String::new()
+                    }
+                );
+            }
 
             let PhysicalPosition { x, y } = monitor.position();
             info!("  Position: {x},{y}");
@@ -255,8 +257,12 @@ impl Application {
             for mode in monitor.video_modes() {
                 let PhysicalSize { width, height } = mode.size();
                 let bits = mode.bit_depth();
-                let m_hz = mode.refresh_rate_millihertz();
-                info!("    {width}x{height}x{bits} @ {}.{} Hz", m_hz / 1000, m_hz % 1000);
+                let m_hz = if let Some(m_hz) = mode.refresh_rate_millihertz() {
+                    format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
+                } else {
+                    String::new()
+                };
+                info!("    {width}x{height}x{bits}{m_hz}");
             }
         }
     }

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -240,7 +240,7 @@ impl Application {
                 let PhysicalSize { width, height } = current_mode.size();
                 info!(
                     "  Current mode: {width}x{height}{}",
-                    if let Some(m_hz) = current_mode.refresh_rate_millihertz() {
+                    if let Some(m_hz) = current_mode.refresh_rate() {
                         format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
                     } else {
                         String::new()
@@ -257,7 +257,7 @@ impl Application {
             for mode in monitor.video_modes() {
                 let PhysicalSize { width, height } = mode.size();
                 let bits = mode.bit_depth();
-                let m_hz = if let Some(m_hz) = mode.refresh_rate_millihertz() {
+                let m_hz = if let Some(m_hz) = mode.refresh_rate() {
                     format!(" @ {}.{} Hz", m_hz / 1000, m_hz % 1000)
                 } else {
                     String::new()

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -44,6 +44,7 @@ changelog entry.
 
 - Add `ActiveEventLoop::create_proxy()`.
 - On Web, implement `Error` for `platform::web::CustomCursorError`.
+- Add `MonitorHandle::current_video_mode()`.
 
 ### Changed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -70,7 +70,8 @@ changelog entry.
 - Change signature of `EventLoop::run_app`, `EventLoopExtPumpEvents::pump_app_events` and
   `EventLoopExtRunOnDemand::run_app_on_demand` to accept a `impl ApplicationHandler` directly,
   instead of requiring a `&mut` reference to it.
-- `VideoModeHandle::refresh_rate_millihertz()` now returns an `Option`.
+- Rename `VideoModeHandle::refresh_rate_millihertz()` to `refresh_rate()`.
+- `VideoModeHandle::refresh_rate()` now returns an `Option`.
 
 ### Removed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -70,6 +70,7 @@ changelog entry.
 - Change signature of `EventLoop::run_app`, `EventLoopExtPumpEvents::pump_app_events` and
   `EventLoopExtRunOnDemand::run_app_on_demand` to accept a `impl ApplicationHandler` directly,
   instead of requiring a `&mut` reference to it.
+- `VideoModeHandle::refresh_rate_millihertz()` now returns an `Option`.
 
 ### Removed
 
@@ -82,3 +83,5 @@ changelog entry.
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside
   of `winit` using `objc2-ui-kit` and calling `UIDevice::currentDevice().userInterfaceIdiom()`.
 - On Web, remove unused `platform::web::CustomCursorError::Animation`.
+- Remove `MonitorHandle::size()` and `refresh_rate_millihertz()` in favor of
+  `MonitorHandle::current_video_mode()`.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -38,8 +38,8 @@ impl Ord for VideoModeHandle {
             self.size()
                 .cmp(&other.size())
                 .then(
-                    self.refresh_rate_millihertz()
-                        .cmp(&other.refresh_rate_millihertz())
+                    self.refresh_rate()
+                        .cmp(&other.refresh_rate())
                         .then(self.bit_depth().cmp(&other.bit_depth())),
                 )
                 .reverse(),
@@ -73,8 +73,8 @@ impl VideoModeHandle {
     ///
     /// - **Android / Orbital:** Always returns [`None`].
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        self.video_mode.refresh_rate_millihertz()
+    pub fn refresh_rate(&self) -> Option<u32> {
+        self.video_mode.refresh_rate()
     }
 
     /// Returns the monitor that this video mode is valid for. Each monitor has
@@ -92,7 +92,7 @@ impl std::fmt::Display for VideoModeHandle {
             "{}x{} {}({} bpp)",
             self.size().width,
             self.size().height,
-            self.refresh_rate_millihertz().map(|rate| format!("@ {rate} mHz ")).unwrap_or_default(),
+            self.refresh_rate().map(|rate| format!("@ {rate} mHz ")).unwrap_or_default(),
             self.bit_depth()
         )
     }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -155,6 +155,12 @@ impl MonitorHandle {
         self.inner.scale_factor()
     }
 
+    /// Returns the currently active video mode of this monitor.
+    #[inline]
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+        self.inner.current_video_mode().map(|video_mode| VideoModeHandle { video_mode })
+    }
+
     /// Returns all fullscreen video modes supported by this monitor.
     ///
     /// ## Platform-specific

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -68,8 +68,12 @@ impl VideoModeHandle {
     }
 
     /// Returns the refresh rate of this video mode in mHz.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Android / Orbital:** Always returns [`None`].
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> u32 {
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         self.video_mode.refresh_rate_millihertz()
     }
 
@@ -85,10 +89,10 @@ impl std::fmt::Display for VideoModeHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{}x{} @ {} mHz ({} bpp)",
+            "{}x{} {}({} bpp)",
             self.size().width,
             self.size().height,
-            self.refresh_rate_millihertz(),
+            self.refresh_rate_millihertz().map(|rate| format!("@ {rate} mHz ")).unwrap_or_default(),
             self.bit_depth()
         )
     }
@@ -113,29 +117,11 @@ impl MonitorHandle {
         self.inner.name()
     }
 
-    /// Returns the monitor's resolution.
-    #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.inner.size()
-    }
-
     /// Returns the top-left corner position of the monitor relative to the larger full
     /// screen area.
     #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         self.inner.position()
-    }
-
-    /// The monitor refresh rate used by the system.
-    ///
-    /// Return `Some` if succeed, or `None` if failed, which usually happens when the monitor
-    /// the window is on is removed.
-    ///
-    /// When using exclusive fullscreen, the refresh rate of the [`VideoModeHandle`] that was
-    /// used to enter fullscreen should be used instead.
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        self.inner.refresh_rate_millihertz()
     }
 
     /// Returns the scale factor of the underlying monitor. To map logical pixels to physical

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -1032,7 +1032,7 @@ impl VideoModeHandle {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn refresh_rate(&self) -> Option<u32> {
         None
     }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -1017,16 +1017,20 @@ impl MonitorHandle {
         None
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(VideoModeHandle {
+        Some(VideoModeHandle {
             size,
             bit_depth: 32,
             refresh_rate_millihertz: 60000,
             monitor: self.clone(),
         })
+    }
+
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+        self.current_video_mode().into_iter()
     }
 }
 

--- a/src/platform_impl/apple/uikit/monitor.rs
+++ b/src/platform_impl/apple/uikit/monitor.rs
@@ -182,6 +182,16 @@ impl MonitorHandle {
         Some(self.ui_screen.get_on_main(|ui_screen| refresh_rate_millihertz(ui_screen)))
     }
 
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+        Some(run_on_main(|mtm| {
+            VideoModeHandle::new(
+                self.ui_screen(mtm).clone(),
+                self.ui_screen(mtm).currentMode().unwrap(),
+                mtm,
+            )
+        }))
+    }
+
     pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
         run_on_main(|mtm| {
             let ui_screen = self.ui_screen(mtm);

--- a/src/platform_impl/apple/uikit/monitor.rs
+++ b/src/platform_impl/apple/uikit/monitor.rs
@@ -75,8 +75,8 @@ impl VideoModeHandle {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        Some(self.refresh_rate_millihertz)
     }
 
     pub fn monitor(&self) -> MonitorHandle {
@@ -131,7 +131,6 @@ impl fmt::Debug for MonitorHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MonitorHandle")
             .field("name", &self.name())
-            .field("size", &self.size())
             .field("position", &self.position())
             .field("scale_factor", &self.scale_factor())
             .field("refresh_rate_millihertz", &self.refresh_rate_millihertz())
@@ -162,11 +161,6 @@ impl MonitorHandle {
                     .map(|idx| idx.to_string())
             }
         })
-    }
-
-    pub fn size(&self) -> PhysicalSize<u32> {
-        let bounds = self.ui_screen.get_on_main(|ui_screen| ui_screen.nativeBounds());
-        PhysicalSize::new(bounds.size.width as u32, bounds.size.height as u32)
     }
 
     pub fn position(&self) -> PhysicalPosition<i32> {

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -225,18 +225,8 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        x11_or_wayland!(match self; MonitorHandle(m) => m.size())
-    }
-
-    #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.position())
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        x11_or_wayland!(match self; MonitorHandle(m) => m.refresh_rate_millihertz())
     }
 
     #[inline]
@@ -275,7 +265,7 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> u32 {
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.refresh_rate_millihertz())
     }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -265,8 +265,8 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        x11_or_wayland!(match self; VideoModeHandle(m) => m.refresh_rate_millihertz())
+    pub fn refresh_rate(&self) -> Option<u32> {
+        x11_or_wayland!(match self; VideoModeHandle(m) => m.refresh_rate())
     }
 
     #[inline]

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -245,6 +245,11 @@ impl MonitorHandle {
     }
 
     #[inline]
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+        x11_or_wayland!(match self; MonitorHandle(m) => m.current_video_mode())
+    }
+
+    #[inline]
     pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoModeHandle>> {
         x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
     }

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -43,20 +43,6 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        let output_data = self.proxy.data::<OutputData>().unwrap();
-        let dimensions = output_data.with_output_info(|info| {
-            info.modes.iter().find_map(|mode| mode.current.then_some(mode.dimensions))
-        });
-
-        match dimensions {
-            Some((width, height)) => (width as u32, height as u32),
-            _ => (0, 0),
-        }
-        .into()
-    }
-
-    #[inline]
     pub fn position(&self) -> PhysicalPosition<i32> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         output_data.with_output_info(|info| {
@@ -70,14 +56,6 @@ impl MonitorHandle {
                         .to_physical(info.scale_factor as f64)
                 },
             )
-        })
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        let output_data = self.proxy.data::<OutputData>().unwrap();
-        output_data.with_output_info(|info| {
-            info.modes.iter().find_map(|mode| mode.current.then_some(mode.refresh_rate as u32))
         })
     }
 
@@ -167,8 +145,8 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        Some(self.refresh_rate_millihertz)
     }
 
     pub fn monitor(&self) -> MonitorHandle {

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -120,7 +120,7 @@ impl std::hash::Hash for MonitorHandle {
 pub struct VideoModeHandle {
     pub(crate) size: PhysicalSize<u32>,
     pub(crate) bit_depth: u16,
-    pub(crate) refresh_rate_millihertz: u32,
+    pub(crate) refresh_rate: u32,
     pub(crate) monitor: MonitorHandle,
 }
 
@@ -128,7 +128,7 @@ impl VideoModeHandle {
     fn new(monitor: MonitorHandle, mode: Mode) -> Self {
         VideoModeHandle {
             size: (mode.dimensions.0 as u32, mode.dimensions.1 as u32).into(),
-            refresh_rate_millihertz: mode.refresh_rate as u32,
+            refresh_rate: mode.refresh_rate as u32,
             bit_depth: 32,
             monitor: monitor.clone(),
         }
@@ -145,8 +145,8 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        Some(self.refresh_rate_millihertz)
+    pub fn refresh_rate(&self) -> Option<u32> {
+        Some(self.refresh_rate)
     }
 
     pub fn monitor(&self) -> MonitorHandle {

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -21,7 +21,7 @@ pub struct VideoModeHandle {
     pub(crate) current: bool,
     pub(crate) size: (u32, u32),
     pub(crate) bit_depth: u16,
-    pub(crate) refresh_rate_millihertz: u32,
+    pub(crate) refresh_rate_millihertz: Option<u32>,
     pub(crate) native_mode: randr::Mode,
     pub(crate) monitor: Option<MonitorHandle>,
 }
@@ -38,7 +38,7 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> u32 {
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         self.refresh_rate_millihertz
     }
 
@@ -54,8 +54,6 @@ pub struct MonitorHandle {
     pub(crate) id: randr::Crtc,
     /// The name of the monitor
     pub(crate) name: String,
-    /// The size of the monitor
-    dimensions: (u32, u32),
     /// The position of the monitor in the X screen
     position: (i32, i32),
     /// If the monitor is the primary one
@@ -118,16 +116,7 @@ impl MonitorHandle {
 
         let rect = util::AaRect::new(position, dimensions);
 
-        Some(MonitorHandle {
-            id,
-            name,
-            scale_factor,
-            dimensions,
-            position,
-            primary,
-            rect,
-            video_modes,
-        })
+        Some(MonitorHandle { id, name, scale_factor, position, primary, rect, video_modes })
     }
 
     pub fn dummy() -> Self {
@@ -135,7 +124,6 @@ impl MonitorHandle {
             id: 0,
             name: "<dummy monitor>".into(),
             scale_factor: 1.0,
-            dimensions: (1, 1),
             position: (0, 0),
             primary: true,
             rect: util::AaRect::new((0, 0), (1, 1)),
@@ -157,18 +145,8 @@ impl MonitorHandle {
         self.id as _
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.dimensions.into()
-    }
-
     pub fn position(&self) -> PhysicalPosition<i32> {
         self.position.into()
-    }
-
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        self.video_modes
-            .iter()
-            .find_map(|mode| mode.current.then_some(mode.refresh_rate_millihertz))
     }
 
     #[inline]

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -21,7 +21,7 @@ pub struct VideoModeHandle {
     pub(crate) current: bool,
     pub(crate) size: (u32, u32),
     pub(crate) bit_depth: u16,
-    pub(crate) refresh_rate_millihertz: Option<u32>,
+    pub(crate) refresh_rate: Option<u32>,
     pub(crate) native_mode: randr::Mode,
     pub(crate) monitor: Option<MonitorHandle>,
 }
@@ -38,8 +38,8 @@ impl VideoModeHandle {
     }
 
     #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate(&self) -> Option<u32> {
+        self.refresh_rate
     }
 
     #[inline]
@@ -93,7 +93,7 @@ impl std::hash::Hash for MonitorHandle {
 }
 
 #[inline]
-pub fn mode_refresh_rate_millihertz(mode: &randr::ModeInfo) -> Option<u32> {
+pub fn mode_refresh_rate(mode: &randr::ModeInfo) -> Option<u32> {
     if mode.dot_clock > 0 && mode.htotal > 0 && mode.vtotal > 0 {
         #[allow(clippy::unnecessary_cast)]
         Some((mode.dot_clock as u64 * 1000 / (mode.htotal as u64 * mode.vtotal as u64)) as u32)

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -85,7 +85,7 @@ impl XConnection {
                 VideoModeHandle {
                     current: mode.id == current_mode,
                     size: (mode.width.into(), mode.height.into()),
-                    refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode),
+                    refresh_rate: monitor::mode_refresh_rate(mode),
                     bit_depth: bit_depth as u16,
                     native_mode: mode.id,
                     // This is populated in `MonitorHandle::video_modes` as the

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -74,6 +74,7 @@ impl XConnection {
         let bit_depth = self.default_root().root_depth;
         let output_modes = &output_info.modes;
         let resource_modes = resources.modes();
+        let current_mode = crtc.mode;
 
         let modes = resource_modes
             .iter()
@@ -82,6 +83,7 @@ impl XConnection {
             .filter(|x| output_modes.iter().any(|id| x.id == *id))
             .map(|mode| {
                 VideoModeHandle {
+                    current: mode.id == current_mode,
                     size: (mode.width.into(), mode.height.into()),
                     refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode)
                         .unwrap_or(0),

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -85,8 +85,7 @@ impl XConnection {
                 VideoModeHandle {
                     current: mode.id == current_mode,
                     size: (mode.width.into(), mode.height.into()),
-                    refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode)
-                        .unwrap_or(0),
+                    refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode),
                     bit_depth: bit_depth as u16,
                     native_mode: mode.id,
                     // This is populated in `MonitorHandle::video_modes` as the

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -191,10 +191,6 @@ impl MonitorHandle {
         Some("Redox Device".to_owned())
     }
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        PhysicalSize::new(0, 0) // TODO
-    }
-
     pub fn position(&self) -> PhysicalPosition<i32> {
         (0, 0).into()
     }
@@ -203,19 +199,11 @@ impl MonitorHandle {
         1.0 // TODO
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        // FIXME no way to get real refresh rate for now.
-        None
-    }
-
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
-        let size = self.size().into();
-        // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
         Some(VideoModeHandle {
-            size,
+            size: PhysicalSize::default(), // TODO
             bit_depth: 32,
-            refresh_rate_millihertz: 60000,
             monitor: self.clone(),
         })
     }
@@ -227,23 +215,23 @@ impl MonitorHandle {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct VideoModeHandle {
-    size: (u32, u32),
+    size: PhysicalSize<u32>,
     bit_depth: u16,
-    refresh_rate_millihertz: u32,
     monitor: MonitorHandle,
 }
 
 impl VideoModeHandle {
     pub fn size(&self) -> PhysicalSize<u32> {
-        self.size.into()
+        self.size
     }
 
     pub fn bit_depth(&self) -> u16 {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        // TODO
+        None
     }
 
     pub fn monitor(&self) -> MonitorHandle {

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -208,16 +208,20 @@ impl MonitorHandle {
         None
     }
 
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         let size = self.size().into();
         // FIXME this is not the real refresh rate
         // (it is guaranteed to support 32 bit color though)
-        std::iter::once(VideoModeHandle {
+        Some(VideoModeHandle {
             size,
             bit_depth: 32,
             refresh_rate_millihertz: 60000,
             monitor: self.clone(),
         })
+    }
+
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+        self.current_video_mode().into_iter()
     }
 }
 

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -229,7 +229,7 @@ impl VideoModeHandle {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn refresh_rate(&self) -> Option<u32> {
         // TODO
         None
     }

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -26,6 +26,10 @@ impl MonitorHandle {
         unreachable!()
     }
 
+    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+        unreachable!()
+    }
+
     pub fn video_modes(&self) -> Empty<VideoModeHandle> {
         unreachable!()
     }

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -18,14 +18,6 @@ impl MonitorHandle {
         unreachable!()
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        unreachable!()
-    }
-
-    pub fn size(&self) -> PhysicalSize<u32> {
-        unreachable!()
-    }
-
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         unreachable!()
     }
@@ -47,7 +39,7 @@ impl VideoModeHandle {
         unreachable!();
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
         unreachable!();
     }
 

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -39,7 +39,7 @@ impl VideoModeHandle {
         unreachable!();
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+    pub fn refresh_rate(&self) -> Option<u32> {
         unreachable!();
     }
 

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -21,7 +21,7 @@ use crate::platform_impl::platform::window::Window;
 pub struct VideoModeHandle {
     pub(crate) size: (u32, u32),
     pub(crate) bit_depth: u16,
-    pub(crate) refresh_rate_millihertz: u32,
+    pub(crate) refresh_rate: u32,
     pub(crate) monitor: MonitorHandle,
     // DEVMODEW is huge so we box it to avoid blowing up the size of winit::window::Fullscreen
     pub(crate) native_video_mode: Box<DEVMODEW>,
@@ -31,7 +31,7 @@ impl PartialEq for VideoModeHandle {
     fn eq(&self, other: &Self) -> bool {
         self.size == other.size
             && self.bit_depth == other.bit_depth
-            && self.refresh_rate_millihertz == other.refresh_rate_millihertz
+            && self.refresh_rate == other.refresh_rate
             && self.monitor == other.monitor
     }
 }
@@ -42,7 +42,7 @@ impl std::hash::Hash for VideoModeHandle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.size.hash(state);
         self.bit_depth.hash(state);
-        self.refresh_rate_millihertz.hash(state);
+        self.refresh_rate.hash(state);
         self.monitor.hash(state);
     }
 }
@@ -52,7 +52,7 @@ impl std::fmt::Debug for VideoModeHandle {
         f.debug_struct("VideoModeHandle")
             .field("size", &self.size)
             .field("bit_depth", &self.bit_depth)
-            .field("refresh_rate_millihertz", &self.refresh_rate_millihertz)
+            .field("refresh_rate", &self.refresh_rate)
             .field("monitor", &self.monitor)
             .finish()
     }
@@ -67,7 +67,7 @@ impl VideoModeHandle {
         VideoModeHandle {
             size: (mode.dmPelsWidth, mode.dmPelsHeight),
             bit_depth: mode.dmBitsPerPel as u16,
-            refresh_rate_millihertz: mode.dmDisplayFrequency * 1000,
+            refresh_rate: mode.dmDisplayFrequency * 1000,
             monitor,
             native_video_mode: Box::new(mode),
         }
@@ -81,8 +81,8 @@ impl VideoModeHandle {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        Some(self.refresh_rate_millihertz)
+    pub fn refresh_rate(&self) -> Option<u32> {
+        Some(self.refresh_rate)
     }
 
     pub fn monitor(&self) -> MonitorHandle {

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -81,8 +81,8 @@ impl VideoModeHandle {
         self.bit_depth
     }
 
-    pub fn refresh_rate_millihertz(&self) -> u32 {
-        self.refresh_rate_millihertz
+    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
+        Some(self.refresh_rate_millihertz)
     }
 
     pub fn monitor(&self) -> MonitorHandle {
@@ -180,29 +180,11 @@ impl MonitorHandle {
         self.0
     }
 
-    #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
+    pub(crate) fn size(&self) -> PhysicalSize<u32> {
         let rc_monitor = get_monitor_info(self.0).unwrap().monitorInfo.rcMonitor;
         PhysicalSize {
             width: (rc_monitor.right - rc_monitor.left) as u32,
             height: (rc_monitor.bottom - rc_monitor.top) as u32,
-        }
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<u32> {
-        let monitor_info = get_monitor_info(self.0).ok()?;
-        let device_name = monitor_info.szDevice.as_ptr();
-        unsafe {
-            let mut mode: DEVMODEW = mem::zeroed();
-            mode.dmSize = mem::size_of_val(&mode) as u16;
-            if EnumDisplaySettingsExW(device_name, ENUM_CURRENT_SETTINGS, &mut mode, 0)
-                == false.into()
-            {
-                None
-            } else {
-                Some(mode.dmDisplayFrequency * 1000)
-            }
         }
     }
 


### PR DESCRIPTION
While working on #3802 I wondered about `VideoModeHandle::refresh_rate_millihertz()`s really long name.
WDYT about renaming it to `refresh_rate()`?
Alternatively `refresh_rate_mh()`?

Requires #3802.