### PR TITLE
macOS: fix building with `feature = "rwh_04"`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -82,3 +82,7 @@ changelog entry.
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside
   of `winit` using `objc2-ui-kit` and calling `UIDevice::currentDevice().userInterfaceIdiom()`.
 - On Web, remove unused `platform::web::CustomCursorError::Animation`.
+
+### Fixed
+
+- On MacOS, fix building with `feature = "rwh_04"`.

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1615,7 +1615,7 @@ impl WindowDelegate {
     pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
         let mut window_handle = rwh_04::AppKitHandle::empty();
         window_handle.ns_window = self.window() as *const WinitWindow as *mut _;
-        window_handle.ns_view = Retained::as_ptr(&self.contentView().unwrap()) as *mut _;
+        window_handle.ns_view = Retained::as_ptr(&self.view()) as *mut _;
         rwh_04::RawWindowHandle::AppKit(window_handle)
     }
 


### PR DESCRIPTION
I noticed while working on MacOS that I had some build error in `rwh_04::HasRawWindowHandle`, but always thought there was just something wrong with my cross-compile setup. I believe the issue was caused in https://github.com/rust-windowing/winit/pull/3391, where all calls to `contentView()` were renamed while this one was forgotten.

This should have been caught by the CI, but we don't check these features in CI. Luckily we may not want to actually fix the CI and instead remove this compatibility layer?

If this patch is correct, it should also be broken in [v0.30](https://github.com/rust-windowing/winit/blob/v0.30.4/src/platform_impl/macos/window_delegate.rs#L1611-L1618).

Cc @madsmtm.