### PR TITLE
Exclude Redox OS from the MSRV policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
           # Android is tested on stable-3
           - toolchain: '1.73'
             platform: { name: 'Android', target: aarch64-linux-android, os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
+          # Redox OS doesn't follow MSRV
+          - toolchain: '1.73'
+            platform: { name: 'Redox OS', target: x86_64-unknown-redox, os: ubuntu-latest }
         include:
           - toolchain: '1.73'
             platform: { name: 'Android', target: aarch64-linux-android, os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }

--- a/README.md
+++ b/README.md
@@ -50,11 +50,14 @@ Where `sid` is the current version of `rustc` provided by [Debian Sid], and
 
 [Debian Sid]: https://packages.debian.org/sid/rustc
 
-The exception is for the Android platform, where a higher Rust version
+An exception is made for the Android platform, where a higher Rust version
 must be used for certain Android features. In this case, the MSRV will be
 capped at the latest stable version of Rust minus three. This inconsistency is
 not reflected in Cargo metadata, as it is not powerful enough to expose this
 restriction.
+
+Redox OS is also not covered by this MSRV policy, as it requires a Rust nightly
+toolchain to compile.
 
 All crates in the [`rust-windowing`] organizations have the
 same MSRV policy.


### PR DESCRIPTION
It makes no sense to have an MSRV policy for Redox OS and test it in CI if it requires nightly to begin with.

As discussed in https://github.com/rust-windowing/softbuffer/pull/228#discussion_r1686692401.