### PR TITLE
Web: don't block pen input

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -86,3 +86,4 @@ changelog entry.
 ### Fixed
 
 - On MacOS, fix building with `feature = "rwh_04"`.
+- On Web, pen events are now routed through to `WindowEvent::Cursor*`.

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -244,21 +244,10 @@ impl Shared {
                     return;
                 }
 
-                let pointer_type = event.pointer_type();
-
-                if pointer_type != "mouse" {
-                    return;
-                }
-
                 // chorded button event
                 let device_id = RootDeviceId(DeviceId(event.pointer_id()));
 
                 if let Some(button) = backend::event::mouse_button(&event) {
-                    debug_assert_eq!(
-                        pointer_type, "mouse",
-                        "expect pointer type of a chorded button event to be a mouse"
-                    );
-
                     let state = if backend::event::mouse_buttons(&event).contains(button.into()) {
                         ElementState::Pressed
                     } else {
@@ -322,10 +311,6 @@ impl Shared {
                     return;
                 }
 
-                if event.pointer_type() != "mouse" {
-                    return;
-                }
-
                 let button = backend::event::mouse_button(&event).expect("no mouse button pressed");
                 runner.send_event(Event::DeviceEvent {
                     device_id: RootDeviceId(DeviceId(event.pointer_id())),
@@ -342,10 +327,6 @@ impl Shared {
             "pointerup",
             Closure::new(move |event: PointerEvent| {
                 if !runner.device_events() {
-                    return;
-                }
-
-                if event.pointer_type() != "mouse" {
                     return;
                 }
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -271,21 +271,6 @@ impl ActiveEventLoop {
                 let has_focus = has_focus.clone();
                 let modifiers = self.modifiers.clone();
 
-                move |active_modifiers| {
-                    if has_focus.get() && modifiers.get() != active_modifiers {
-                        modifiers.set(active_modifiers);
-                        runner.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(id),
-                            event: WindowEvent::ModifiersChanged(active_modifiers.into()),
-                        })
-                    }
-                }
-            },
-            {
-                let runner = self.runner.clone();
-                let has_focus = has_focus.clone();
-                let modifiers = self.modifiers.clone();
-
                 move |active_modifiers, pointer_id, events| {
                     let modifiers =
                         (has_focus.get() && modifiers.get() != active_modifiers).then(|| {
@@ -384,20 +369,6 @@ impl ActiveEventLoop {
                 let runner = self.runner.clone();
                 let modifiers = self.modifiers.clone();
 
-                move |active_modifiers| {
-                    if modifiers.get() != active_modifiers {
-                        modifiers.set(active_modifiers);
-                        runner.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(id),
-                            event: WindowEvent::ModifiersChanged(active_modifiers.into()),
-                        })
-                    }
-                }
-            },
-            {
-                let runner = self.runner.clone();
-                let modifiers = self.modifiers.clone();
-
                 move |active_modifiers, pointer_id, position, button| {
                     let modifiers = (modifiers.get() != active_modifiers).then(|| {
                         modifiers.set(active_modifiers);
@@ -458,21 +429,6 @@ impl ActiveEventLoop {
         );
 
         canvas.on_mouse_release(
-            {
-                let runner = self.runner.clone();
-                let has_focus = has_focus.clone();
-                let modifiers = self.modifiers.clone();
-
-                move |active_modifiers| {
-                    if has_focus.get() && modifiers.get() != active_modifiers {
-                        modifiers.set(active_modifiers);
-                        runner.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(id),
-                            event: WindowEvent::ModifiersChanged(active_modifiers.into()),
-                        });
-                    }
-                }
-            },
             {
                 let runner = self.runner.clone();
                 let has_focus = has_focus.clone();

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -328,51 +328,29 @@ impl Canvas {
         self.pointer_handler.on_cursor_enter(&self.common, handler)
     }
 
-    pub fn on_mouse_release<MOD, M, T>(
-        &mut self,
-        modifier_handler: MOD,
-        mouse_handler: M,
-        touch_handler: T,
-    ) where
-        MOD: 'static + FnMut(ModifiersState),
+    pub fn on_mouse_release<M, T>(&mut self, mouse_handler: M, touch_handler: T)
+    where
         M: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, MouseButton),
         T: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, Force),
     {
-        self.pointer_handler.on_mouse_release(
-            &self.common,
-            modifier_handler,
-            mouse_handler,
-            touch_handler,
-        )
+        self.pointer_handler.on_mouse_release(&self.common, mouse_handler, touch_handler)
     }
 
-    pub fn on_mouse_press<MOD, M, T>(
-        &mut self,
-        modifier_handler: MOD,
-        mouse_handler: M,
-        touch_handler: T,
-    ) where
-        MOD: 'static + FnMut(ModifiersState),
+    pub fn on_mouse_press<M, T>(&mut self, mouse_handler: M, touch_handler: T)
+    where
         M: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, MouseButton),
         T: 'static + FnMut(ModifiersState, i32, PhysicalPosition<f64>, Force),
     {
         self.pointer_handler.on_mouse_press(
             &self.common,
-            modifier_handler,
             mouse_handler,
             touch_handler,
             Rc::clone(&self.prevent_default),
         )
     }
 
-    pub fn on_cursor_move<MOD, M, T, B>(
-        &mut self,
-        modifier_handler: MOD,
-        mouse_handler: M,
-        touch_handler: T,
-        button_handler: B,
-    ) where
-        MOD: 'static + FnMut(ModifiersState),
+    pub fn on_cursor_move<M, T, B>(&mut self, mouse_handler: M, touch_handler: T, button_handler: B)
+    where
         M: 'static + FnMut(ModifiersState, i32, &mut dyn Iterator<Item = PhysicalPosition<f64>>),
         T: 'static
             + FnMut(ModifiersState, i32, &mut dyn Iterator<Item = (PhysicalPosition<f64>, Force)>),
@@ -380,7 +358,6 @@ impl Canvas {
     {
         self.pointer_handler.on_cursor_move(
             &self.common,
-            modifier_handler,
             mouse_handler,
             touch_handler,
             button_handler,


### PR DESCRIPTION
After some discussion with @kchibisov on Matrix, I came to the realization that pen input should not be blocked and instead be routed to `WindowEvent::Cursor*` as usual.

Related #3810.