### PR TITLE
Remove `DeviceEvent::Motion` and `WindowEvent::AxisMotion`

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -488,7 +488,6 @@ impl ApplicationHandler for Application {
             | WindowEvent::HoveredFileCancelled
             | WindowEvent::KeyboardInput { .. }
             | WindowEvent::CursorEntered { .. }
-            | WindowEvent::AxisMotion { .. }
             | WindowEvent::DroppedFile(_)
             | WindowEvent::HoveredFile(_)
             | WindowEvent::Destroyed

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -105,6 +105,7 @@ changelog entry.
 - Remove the `rwh_04` and `rwh_05` cargo feature and the corresponding `raw-window-handle` v0.4 and
   v0.5 support. v0.6 remains in place and is enabled by default.
 - Remove `DeviceEvent::Added` and `DeviceEvent::Removed`.
+- Remove `DeviceEvent::Motion` and `WindowEvent::AxisMotion`.
 
 ### Fixed
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -340,9 +340,6 @@ pub enum WindowEvent {
     /// touchpad is being pressed) and stage (integer representing the click level).
     TouchpadPressure { device_id: DeviceId, pressure: f32, stage: i64 },
 
-    /// Motion on some analog axis. May report data redundant to other, more specific events.
-    AxisMotion { device_id: DeviceId, axis: AxisId, value: f64 },
-
     /// Touch event has been received
     ///
     /// ## Platform-specific
@@ -490,14 +487,6 @@ pub enum DeviceEvent {
     /// Physical scroll event
     MouseWheel {
         delta: MouseScrollDelta,
-    },
-
-    /// Motion on some analog axis. This event will be reported for all arbitrary input devices
-    /// that winit supports on this platform, including mouse devices.  If the device is a mouse
-    /// device then this will be reported alongside the MouseMotion event.
-    Motion {
-        axis: AxisId,
-        value: f64,
     },
 
     Button {
@@ -1082,7 +1071,6 @@ mod tests {
                     phase: event::TouchPhase::Started,
                 });
                 with_window_event(TouchpadPressure { device_id: did, pressure: 0.0, stage: 0 });
-                with_window_event(AxisMotion { device_id: did, axis: 0, value: 0.0 });
                 with_window_event(Touch(event::Touch {
                     device_id: did,
                     phase: event::TouchPhase::Started,
@@ -1105,7 +1093,6 @@ mod tests {
                 with_device_event(MouseWheel {
                     delta: event::MouseScrollDelta::LineDelta(0.0, 0.0),
                 });
-                with_device_event(Motion { axis: 0, value: 0.0 });
                 with_device_event(Button { button: 0, state: event::ElementState::Pressed });
             }
         }};

--- a/src/platform_impl/apple/appkit/app.rs
+++ b/src/platform_impl/apple/appkit/app.rs
@@ -57,24 +57,6 @@ fn maybe_dispatch_device_event(delegate: &ApplicationDelegate, event: &NSEvent) 
             let delta_x = unsafe { event.deltaX() } as f64;
             let delta_y = unsafe { event.deltaY() } as f64;
 
-            if delta_x != 0.0 {
-                delegate.maybe_queue_with_handler(move |app, event_loop| {
-                    app.device_event(event_loop, DEVICE_ID, DeviceEvent::Motion {
-                        axis: 0,
-                        value: delta_x,
-                    });
-                });
-            }
-
-            if delta_y != 0.0 {
-                delegate.maybe_queue_with_handler(move |app, event_loop| {
-                    app.device_event(event_loop, DEVICE_ID, DeviceEvent::Motion {
-                        axis: 1,
-                        value: delta_y,
-                    });
-                })
-            }
-
             if delta_x != 0.0 || delta_y != 0.0 {
                 delegate.maybe_queue_with_handler(move |app, event_loop| {
                     app.device_event(event_loop, DEVICE_ID, DeviceEvent::MouseMotion {

--- a/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
@@ -66,12 +66,6 @@ impl Dispatch<ZwpRelativePointerV1, GlobalData, WinitState> for RelativePointerS
             },
             _ => return,
         };
-        state
-            .events_sink
-            .push_device_event(DeviceEvent::Motion { axis: 0, value: dx_unaccel }, super::DeviceId);
-        state
-            .events_sink
-            .push_device_event(DeviceEvent::Motion { axis: 1, value: dy_unaccel }, super::DeviceId);
         state.events_sink.push_device_event(
             DeviceEvent::MouseMotion { delta: (dx_unaccel, dy_unaccel) },
             super::DeviceId,

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1147,7 +1147,7 @@ impl EventProcessor {
 
             let x = unsafe { *value };
 
-            let event = if let Some(&mut (_, ref mut info)) =
+            if let Some(&mut (_, ref mut info)) =
                 physical_device.scroll_axes.iter_mut().find(|&&mut (axis, _)| axis == i as _)
             {
                 let delta = (x - info.position) / info.increment;
@@ -1160,12 +1160,9 @@ impl EventProcessor {
                     ScrollOrientation::Vertical => MouseScrollDelta::LineDelta(0.0, -delta as f32),
                 };
 
-                WindowEvent::MouseWheel { device_id, delta, phase: TouchPhase::Moved }
-            } else {
-                WindowEvent::AxisMotion { device_id, axis: i as u32, value: unsafe { *value } }
-            };
-
-            events.push(Event::WindowEvent { window_id, event });
+                let event = WindowEvent::MouseWheel { device_id, delta, phase: TouchPhase::Moved };
+                events.push(Event::WindowEvent { window_id, event });
+            }
 
             value = unsafe { value.offset(1) };
         }
@@ -1445,12 +1442,6 @@ impl EventProcessor {
                 3 => scroll_delta.set_y(x as f32),
                 _ => {},
             }
-
-            let event = Event::DeviceEvent {
-                device_id: did,
-                event: DeviceEvent::Motion { axis: i as u32, value: x },
-            };
-            callback(&self.target, event);
 
             value = unsafe { value.offset(1) };
         }

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -306,23 +306,13 @@ impl Shared {
 
                 // pointer move event
                 let mut delta = backend::event::MouseDelta::init(&navigator, &event);
-                runner.send_events(backend::event::pointer_move_event(event).flat_map(|event| {
+                runner.send_events(backend::event::pointer_move_event(event).map(|event| {
                     let delta = delta.delta(&event).to_physical(backend::scale_factor(&window));
 
-                    let x_motion = (delta.x != 0.0).then_some(Event::DeviceEvent {
-                        device_id,
-                        event: DeviceEvent::Motion { axis: 0, value: delta.x },
-                    });
-
-                    let y_motion = (delta.y != 0.0).then_some(Event::DeviceEvent {
-                        device_id,
-                        event: DeviceEvent::Motion { axis: 1, value: delta.y },
-                    });
-
-                    x_motion.into_iter().chain(y_motion).chain(iter::once(Event::DeviceEvent {
+                    Event::DeviceEvent {
                         device_id,
                         event: DeviceEvent::MouseMotion { delta: (delta.x, delta.y) },
-                    }))
+                    }
                 }));
             }),
         ));

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2382,7 +2382,7 @@ unsafe extern "system" fn thread_event_target_callback(
 }
 
 unsafe fn handle_raw_input(userdata: &ThreadMsgTargetData, data: RAWINPUT) {
-    use crate::event::DeviceEvent::{Button, Key, Motion, MouseMotion, MouseWheel};
+    use crate::event::DeviceEvent::{Button, Key, MouseMotion, MouseWheel};
     use crate::event::ElementState::{Pressed, Released};
     use crate::event::MouseScrollDelta::LineDelta;
 
@@ -2394,20 +2394,6 @@ unsafe fn handle_raw_input(userdata: &ThreadMsgTargetData, data: RAWINPUT) {
         if util::has_flag(mouse.usFlags as u32, MOUSE_MOVE_RELATIVE) {
             let x = mouse.lLastX as f64;
             let y = mouse.lLastY as f64;
-
-            if x != 0.0 {
-                userdata.send_event(Event::DeviceEvent {
-                    device_id,
-                    event: Motion { axis: 0, value: x },
-                });
-            }
-
-            if y != 0.0 {
-                userdata.send_event(Event::DeviceEvent {
-                    device_id,
-                    event: Motion { axis: 1, value: y },
-                });
-            }
 
             if x != 0.0 || y != 0.0 {
                 userdata.send_event(Event::DeviceEvent {


### PR DESCRIPTION
We decided to remove them because they contained too little information for the user to be useful. This was only implemented in X11, other backends were only using them to be more cross-platform consistent.

The assumption is that they were originally implemented to enable gamepad support, which we already decided we are not going to add directly to Winit, but only support events informing the user that an UUID was added or removed.

See https://github.com/rust-windowing/winit/issues/750#issuecomment-2245015159.