### PR TITLE
Basic iOS IME support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,8 @@ objc2-ui-kit = { version = "0.2.2", features = [
     "UIEvent",
     "UIGeometry",
     "UIGestureRecognizer",
+    "UITextInput",
+    "UITextInputTraits",
     "UIOrientation",
     "UIPanGestureRecognizer",
     "UIPinchGestureRecognizer",

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -47,13 +47,13 @@ changelog entry.
   `DeviceEvent::MouseMotion` is returning raw data, not OS accelerated, when using
   `CursorGrabMode::Locked`.
 - On Web, implement `MonitorHandle` and `VideoModeHandle`.
-  
+
   Without prompting the user for permission, only the current monitor is returned. But when
   prompting and being granted permission through
   `ActiveEventLoop::request_detailed_monitor_permission()`, access to all monitors and their
   details is available. Handles created with "detailed monitor permissions" can be used in
   `Window::set_fullscreen()` as well.
-  
+
   Keep in mind that handles do not auto-upgrade after permissions are granted and have to be
   re-created to make full use of this feature.
 - Add `Touch::finger_id` with a new type `FingerId`.
@@ -62,6 +62,7 @@ changelog entry.
 - Implement `Clone`, `Copy`, `Debug`, `Deserialize`, `Eq`, `Hash`, `Ord`, `PartialEq`, `PartialOrd`
   and `Serialize` on many types.
 - Add `MonitorHandle::current_video_mode()`.
+- Add basic iOS IME support. The soft keyboard can now be shown using `Window::set_ime_allowed`.
 
 ### Changed
 
@@ -106,14 +107,14 @@ changelog entry.
 
 - Remove `Event`.
 - Remove already deprecated APIs:
-  - `EventLoop::create_window()`
-  - `EventLoop::run`.
-  - `EventLoopBuilder::new()`
-  - `EventLoopExtPumpEvents::pump_events`.
-  - `EventLoopExtRunOnDemand::run_on_demand`.
-  - `VideoMode`
-  - `WindowAttributes::new()`
-  - `Window::set_cursor_icon()`
+    - `EventLoop::create_window()`
+    - `EventLoop::run`.
+    - `EventLoopBuilder::new()`
+    - `EventLoopExtPumpEvents::pump_events`.
+    - `EventLoopExtRunOnDemand::run_on_demand`.
+    - `VideoMode`
+    - `WindowAttributes::new()`
+    - `Window::set_cursor_icon()`
 - On iOS, remove `platform::ios::EventLoopExtIOS` and related `platform::ios::Idiom` type.
 
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -107,14 +107,14 @@ changelog entry.
 
 - Remove `Event`.
 - Remove already deprecated APIs:
-    - `EventLoop::create_window()`
-    - `EventLoop::run`.
-    - `EventLoopBuilder::new()`
-    - `EventLoopExtPumpEvents::pump_events`.
-    - `EventLoopExtRunOnDemand::run_on_demand`.
-    - `VideoMode`
-    - `WindowAttributes::new()`
-    - `Window::set_cursor_icon()`
+  - `EventLoop::create_window()`
+  - `EventLoop::run`.
+  - `EventLoopBuilder::new()`
+  - `EventLoopExtPumpEvents::pump_events`.
+  - `EventLoopExtRunOnDemand::run_on_demand`.
+  - `VideoMode`
+  - `WindowAttributes::new()`
+  - `Window::set_cursor_icon()`
 - On iOS, remove `platform::ios::EventLoopExtIOS` and related `platform::ios::Idiom` type.
 
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -551,6 +551,7 @@ impl WinitView {
             mtm,
             text.to_string().chars().flat_map(|c| {
                 let text = smol_str::SmolStr::from_iter([c]);
+                // Emit both press and release events
                 [ElementState::Pressed, ElementState::Released].map(|state| {
                     EventWrapper::StaticEvent(Event::WindowEvent {
                         window_id,
@@ -561,7 +562,7 @@ impl WinitView {
                                 } else {
                                     None
                                 },
-                                state: ElementState::Pressed,
+                                state,
                                 location: KeyLocation::Standard,
                                 repeat: false,
                                 logical_key: Key::Character(text.clone()),

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -4,19 +4,21 @@ use std::cell::{Cell, RefCell};
 use objc2::rc::Retained;
 use objc2::runtime::{NSObjectProtocol, ProtocolObject};
 use objc2::{declare_class, msg_send, msg_send_id, mutability, sel, ClassType, DeclaredClass};
-use objc2_foundation::{CGFloat, CGPoint, CGRect, MainThreadMarker, NSObject, NSSet};
+use objc2_foundation::{CGFloat, CGPoint, CGRect, MainThreadMarker, NSObject, NSSet, NSString};
 use objc2_ui_kit::{
     UICoordinateSpace, UIEvent, UIForceTouchCapability, UIGestureRecognizer,
-    UIGestureRecognizerDelegate, UIGestureRecognizerState, UIPanGestureRecognizer,
+    UIGestureRecognizerDelegate, UIGestureRecognizerState, UIKeyInput, UIPanGestureRecognizer,
     UIPinchGestureRecognizer, UIResponder, UIRotationGestureRecognizer, UITapGestureRecognizer,
-    UITouch, UITouchPhase, UITouchType, UITraitEnvironment, UIView,
+    UITextInputTraits, UITouch, UITouchPhase, UITouchType, UITraitEnvironment, UIView,
 };
 
 use super::app_state::{self, EventWrapper};
 use super::window::WinitUIWindow;
 use super::{FingerId, DEVICE_ID};
 use crate::dpi::PhysicalPosition;
-use crate::event::{Event, FingerId as RootFingerId, Force, Touch, TouchPhase, WindowEvent};
+use crate::event::{ElementState, Event, FingerId as RootFingerId, Force, KeyEvent, Touch, TouchPhase, WindowEvent};
+use crate::keyboard::{Key, KeyCode, KeyLocation, NamedKey, NativeKeyCode, PhysicalKey};
+use crate::platform_impl::KeyEventExtra;
 use crate::window::{WindowAttributes, WindowId as RootWindowId};
 
 pub struct WinitViewState {
@@ -314,6 +316,11 @@ declare_class!(
             let mtm = MainThreadMarker::new().unwrap();
             app_state::handle_nonuser_event(mtm, gesture_event);
         }
+
+        #[method(canBecomeFirstResponder)]
+        fn can_become_first_responder(&self) -> bool {
+            true
+        }
     }
 
     unsafe impl NSObjectProtocol for WinitView {}
@@ -322,6 +329,26 @@ declare_class!(
         #[method(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)]
         fn should_recognize_simultaneously(&self, _gesture_recognizer: &UIGestureRecognizer, _other_gesture_recognizer: &UIGestureRecognizer) -> bool {
             true
+        }
+    }
+
+    unsafe impl UITextInputTraits for WinitView {
+    }
+
+    unsafe impl UIKeyInput for WinitView {
+        #[method(hasText)]
+        fn has_text(&self) -> bool {
+            true
+        }
+
+        #[method(insertText:)]
+        fn insert_text(&self, text: &NSString) {
+            self.handle_insert_text(text)
+        }
+
+        #[method(deleteBackward)]
+        fn delete_backward(&self) {
+            self.handle_delete_backward()
         }
     }
 );
@@ -511,5 +538,58 @@ impl WinitView {
         }
         let mtm = MainThreadMarker::new().unwrap();
         app_state::handle_nonuser_events(mtm, touch_events);
+    }
+
+    fn handle_insert_text(&self, text: &NSString) {
+        let window = self.window().unwrap();
+        let window_id = RootWindowId(window.id());
+        let mtm = MainThreadMarker::new().unwrap();
+        // send individual events for each character
+        app_state::handle_nonuser_events(
+            mtm,
+            text.to_string().chars().map(|c| {
+                EventWrapper::StaticEvent(Event::WindowEvent {
+                    window_id,
+                    event: WindowEvent::KeyboardInput {
+                        event: KeyEvent {
+                            text: Some(smol_str::SmolStr::from_iter([c])),
+                            state: ElementState::Pressed,
+                            location: KeyLocation::Standard,
+                            repeat: false,
+                            logical_key: Key::Character(smol_str::SmolStr::from_iter([c])),
+                            physical_key: PhysicalKey::Unidentified(NativeKeyCode::Unidentified),
+                            platform_specific: KeyEventExtra {},
+                        },
+                        is_synthetic: false,
+                        device_id: DEVICE_ID,
+                    },
+                })
+            }),
+        );
+    }
+
+    fn handle_delete_backward(&self) {
+        let window = self.window().unwrap();
+        let window_id = RootWindowId(window.id());
+        let mtm = MainThreadMarker::new().unwrap();
+        app_state::handle_nonuser_events(
+            mtm,
+            std::iter::once(EventWrapper::StaticEvent(Event::WindowEvent {
+                window_id,
+                event: WindowEvent::KeyboardInput {
+                    device_id: DEVICE_ID,
+                    event: KeyEvent {
+                        state: ElementState::Pressed,
+                        logical_key: Key::Named(NamedKey::Backspace),
+                        physical_key: PhysicalKey::Code(KeyCode::Backspace),
+                        platform_specific: KeyEventExtra {},
+                        repeat: false,
+                        location: KeyLocation::Standard,
+                        text: None,
+                    },
+                    is_synthetic: false,
+                },
+            })),
+        );
     }
 }

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -585,22 +585,24 @@ impl WinitView {
         let mtm = MainThreadMarker::new().unwrap();
         app_state::handle_nonuser_events(
             mtm,
-            std::iter::once(EventWrapper::StaticEvent(Event::WindowEvent {
-                window_id,
-                event: WindowEvent::KeyboardInput {
-                    device_id: DEVICE_ID,
-                    event: KeyEvent {
-                        state: ElementState::Pressed,
-                        logical_key: Key::Named(NamedKey::Backspace),
-                        physical_key: PhysicalKey::Code(KeyCode::Backspace),
-                        platform_specific: KeyEventExtra {},
-                        repeat: false,
-                        location: KeyLocation::Standard,
-                        text: None,
+            [ElementState::Pressed, ElementState::Released].map(|state| {
+                EventWrapper::StaticEvent(Event::WindowEvent {
+                    window_id,
+                    event: WindowEvent::KeyboardInput {
+                        device_id: DEVICE_ID,
+                        event: KeyEvent {
+                            state,
+                            logical_key: Key::Named(NamedKey::Backspace),
+                            physical_key: PhysicalKey::Code(KeyCode::Backspace),
+                            platform_specific: KeyEventExtra {},
+                            repeat: false,
+                            location: KeyLocation::Standard,
+                            text: None,
+                        },
+                        is_synthetic: false,
                     },
-                    is_synthetic: false,
-                },
-            })),
+                })
+            }),
         );
     }
 }

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -370,6 +370,9 @@ impl Inner {
         warn!("`Window::set_ime_cursor_area` is ignored on iOS")
     }
 
+    /// Show / hide the keyboard. To show the keyboard, we call `becomeFirstResponder`,
+    /// requesting focus for the [WinitView]. Since [WinitView] implements [objc2_ui_kit::UIKeyInput],
+    /// the keyboard will be shown. (As explained here: https://developer.apple.com/documentation/uikit/uiresponder/1621113-becomefirstresponder)
     pub fn set_ime_allowed(&self, allowed: bool) {
         if allowed {
             unsafe {

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -371,8 +371,9 @@ impl Inner {
     }
 
     /// Show / hide the keyboard. To show the keyboard, we call `becomeFirstResponder`,
-    /// requesting focus for the [WinitView]. Since [WinitView] implements [objc2_ui_kit::UIKeyInput],
-    /// the keyboard will be shown. (As explained here: https://developer.apple.com/documentation/uikit/uiresponder/1621113-becomefirstresponder)
+    /// requesting focus for the [WinitView]. Since [WinitView] implements
+    /// [objc2_ui_kit::UIKeyInput], the keyboard will be shown.
+    /// <https://developer.apple.com/documentation/uikit/uiresponder/1621113-becomefirstresponder>
     pub fn set_ime_allowed(&self, allowed: bool) {
         if allowed {
             unsafe {

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -370,12 +370,20 @@ impl Inner {
         warn!("`Window::set_ime_cursor_area` is ignored on iOS")
     }
 
-    pub fn set_ime_allowed(&self, _allowed: bool) {
-        warn!("`Window::set_ime_allowed` is ignored on iOS")
+    pub fn set_ime_allowed(&self, allowed: bool) {
+        if allowed {
+            unsafe {
+                self.view.becomeFirstResponder();
+            }
+        } else {
+            unsafe {
+                self.view.resignFirstResponder();
+            }
+        }
     }
 
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {
-        warn!("`Window::set_ime_allowed` is ignored on iOS")
+        warn!("`Window::set_ime_purpose` is ignored on iOS")
     }
 
     pub fn focus_window(&self) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1279,7 +1279,8 @@ impl Window {
     ///
     /// - **macOS:** IME must be enabled to receive text-input where dead-key sequences are
     ///   combined.
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS:** This will show / hide the soft keyboard.
+    /// - **Android / Web / Orbital:** Unsupported.
     /// - **X11**: Enabling IME will disable dead keys reporting during compose.
     ///
     /// [`Ime`]: crate::event::WindowEvent::Ime


### PR DESCRIPTION
This implements basic iOS IME support (typing, backspace, support for emojis etc but no autocomplete or copy / paste menu).
I've tested this with egui on winit 0.29 but unfortunately I wasn't able to test this yet with winit 0.30 since egui isn't updated yet.

This is an alternative implementation of #3571, implementing UIKeyInput for the WinitView instead of creating a extra text_field.

I'll leave this in draft until I was able to test this with egui and winit 0.30


- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
