### PR TITLE
Handle URLs on  macOS

### DIFF
--- a/src/application.rs
+++ b/src/application.rs
@@ -325,6 +325,15 @@ pub trait ApplicationHandler {
     fn memory_warning(&mut self, event_loop: &ActiveEventLoop) {
         let _ = event_loop;
     }
+
+    /// Emitted when the application has received a URL, through a
+    /// custom URL handler.
+    ///
+    /// Only supported on macOS.
+    fn received_url(&mut self, event_loop: &ActiveEventLoop, url: String) {
+        let _ = event_loop;
+        let _ = url;
+    }
 }
 
 #[deny(clippy::missing_trait_methods)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -112,6 +112,21 @@ pub(crate) enum Event {
 
     /// User requested a wake up.
     UserWakeUp,
+
+    /// Emitted when the event loop receives an event that only occurs on some specific platform.
+    PlatformSpecific(PlatformSpecific),
+}
+
+/// Describes an event from some specific platform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PlatformSpecific {
+    MacOS(MacOS),
+}
+
+/// Describes an event that only happens in `MacOS`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MacOS {
+    ReceivedUrl(String),
 }
 
 /// Describes the reason the event loop is resuming.


### PR DESCRIPTION
This allows macOS apps to access the URL when they are opened "as a browser / url handler". This is adapted from Iced's fork of Winit and I believe it is the main things preventing Iced from using upstream Winit.

Fixes #2190

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
