### PR TITLE
chore: drop v0.30 deprecated APIs

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -86,10 +86,16 @@ changelog entry.
 
 ### Removed
 
-- Remove `EventLoop::run`.
-- Remove `EventLoopExtRunOnDemand::run_on_demand`.
-- Remove `EventLoopExtPumpEvents::pump_events`.
 - Remove `Event`.
+- Remove already deprecated APIs:
+  - `EventLoop::create_window()`
+  - `EventLoop::run`.
+  - `EventLoopBuilder::new()`
+  - `EventLoopExtPumpEvents::pump_events`.
+  - `EventLoopExtRunOnDemand::run_on_demand`.
+  - `VideoMode`
+  - `WindowAttributes::new()`
+  - `Window::set_cursor_icon()`
 - On iOS, remove `platform::ios::EventLoopExtIOS` and related `platform::ios::Idiom` type.
 
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -68,15 +68,6 @@ pub struct EventLoopBuilder {
 static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
 
 impl EventLoopBuilder {
-    /// Start building a new event loop.
-    #[inline]
-    #[deprecated = "use `EventLoop::builder` instead"]
-    pub fn new() -> Self {
-        EventLoop::builder()
-    }
-}
-
-impl EventLoopBuilder {
     /// Builds a new event loop.
     ///
     /// ***For cross-platform compatibility, the [`EventLoop`] must be created on the main thread,
@@ -276,24 +267,6 @@ impl EventLoop {
     /// Sets the [`ControlFlow`].
     pub fn set_control_flow(&self, control_flow: ControlFlow) {
         self.event_loop.window_target().p.set_control_flow(control_flow)
-    }
-
-    /// Create a window.
-    ///
-    /// Creating window without event loop running often leads to improper window creation;
-    /// use [`ActiveEventLoop::create_window`] instead.
-    #[deprecated = "use `ActiveEventLoop::create_window` instead"]
-    #[inline]
-    pub fn create_window(&self, window_attributes: WindowAttributes) -> Result<Window, OsError> {
-        let _span = tracing::debug_span!(
-            "winit::EventLoop::create_window",
-            window_attributes = ?window_attributes
-        )
-        .entered();
-
-        let window =
-            platform_impl::Window::new(&self.event_loop.window_target().p, window_attributes)?;
-        Ok(Window { window })
     }
 
     /// Create custom cursor.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -8,10 +8,6 @@
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::platform_impl;
 
-/// Deprecated! Use `VideoModeHandle` instead.
-#[deprecated = "Renamed to `VideoModeHandle`"]
-pub type VideoMode = VideoModeHandle;
-
 /// Describes a fullscreen video mode of a monitor.
 ///
 /// Can be acquired with [`MonitorHandle::video_modes`].

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -183,11 +183,11 @@ pub trait EventLoopBuilderExtWindows {
     /// Disable process-wide DPI awareness.
     ///
     /// ```
-    /// use winit::event_loop::EventLoopBuilder;
+    /// use winit::event_loop::EventLoop;
     /// #[cfg(target_os = "windows")]
     /// use winit::platform::windows::EventLoopBuilderExtWindows;
     ///
-    /// let mut builder = EventLoopBuilder::new();
+    /// let mut builder = EventLoop::builder();
     /// #[cfg(target_os = "windows")]
     /// builder.with_dpi_aware(false);
     /// # if false { // We can't test this part
@@ -203,11 +203,11 @@ pub trait EventLoopBuilderExtWindows {
     ///
     /// ```
     /// # use windows_sys::Win32::UI::WindowsAndMessaging::{ACCEL, CreateAcceleratorTableW, TranslateAcceleratorW, DispatchMessageW, TranslateMessage, MSG};
-    /// use winit::event_loop::EventLoopBuilder;
+    /// use winit::event_loop::EventLoop;
     /// #[cfg(target_os = "windows")]
     /// use winit::platform::windows::EventLoopBuilderExtWindows;
     ///
-    /// let mut builder = EventLoopBuilder::new();
+    /// let mut builder = EventLoop::builder();
     /// #[cfg(target_os = "windows")]
     /// builder.with_msg_hook(|msg|{
     ///     let msg = msg as *const MSG;

--- a/src/window.rs
+++ b/src/window.rs
@@ -175,15 +175,6 @@ unsafe impl Send for SendSyncRawWindowHandle {}
 unsafe impl Sync for SendSyncRawWindowHandle {}
 
 impl WindowAttributes {
-    /// Initializes new attributes with default values.
-    #[inline]
-    #[deprecated = "use `Window::default_attributes` instead"]
-    pub fn new() -> Self {
-        Default::default()
-    }
-}
-
-impl WindowAttributes {
     /// Get the parent window stored on the attributes.
     #[cfg(feature = "rwh_06")]
     pub fn parent_window(&self) -> Option<&rwh_06::RawWindowHandle> {
@@ -1431,13 +1422,6 @@ impl Window {
         let cursor = cursor.into();
         let _span = tracing::debug_span!("winit::Window::set_cursor",).entered();
         self.window.maybe_queue_on_main(move |w| w.set_cursor(cursor))
-    }
-
-    /// Deprecated! Use [`Window::set_cursor()`] instead.
-    #[deprecated = "Renamed to `set_cursor`"]
-    #[inline]
-    pub fn set_cursor_icon(&self, icon: CursorIcon) {
-        self.set_cursor(icon)
     }
 
     /// Changes the position of the cursor in window coordinates.


### PR DESCRIPTION
--

I think there's no reason to keep them around for the 0.31.