### PR TITLE
android: add `ActiveEventLoopExtAndroid::android_app`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -54,6 +54,7 @@ changelog entry.
   `ActiveEventLoop::request_detailed_monitor_permission()`, access to all monitors and their
   information is available. This "detailed monitors" can be used in `Window::set_fullscreen()` as
   well.
+- On Android, add `{Active,}EventLoopExtAndroid::android_app()` to access the app used to create the loop.
 
 ### Changed
 

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -75,12 +75,22 @@ use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
 use crate::window::{Window, WindowAttributes};
 
 /// Additional methods on [`EventLoop`] that are specific to Android.
-pub trait EventLoopExtAndroid {}
+pub trait EventLoopExtAndroid {
+    /// Get the [`AndroidApp`] which was used to create this event loop.
+    fn android_app(&self) -> &AndroidApp;
+}
 
-impl EventLoopExtAndroid for EventLoop {}
+impl EventLoopExtAndroid for EventLoop {
+    fn android_app(&self) -> &AndroidApp {
+        &self.event_loop.android_app
+    }
+}
 
 /// Additional methods on [`ActiveEventLoop`] that are specific to Android.
-pub trait ActiveEventLoopExtAndroid {}
+pub trait ActiveEventLoopExtAndroid {
+    /// Get the [`AndroidApp`] which was used to create this event loop.
+    fn android_app(&self) -> &AndroidApp;
+}
 
 /// Additional methods on [`Window`] that are specific to Android.
 pub trait WindowExtAndroid {
@@ -99,7 +109,11 @@ impl WindowExtAndroid for Window {
     }
 }
 
-impl ActiveEventLoopExtAndroid for ActiveEventLoop {}
+impl ActiveEventLoopExtAndroid for ActiveEventLoop {
+    fn android_app(&self) -> &AndroidApp {
+        &self.p.app
+    }
+}
 
 /// Additional methods on [`WindowAttributes`] that are specific to Android.
 pub trait WindowAttributesExtAndroid {}
@@ -107,9 +121,9 @@ pub trait WindowAttributesExtAndroid {}
 impl WindowAttributesExtAndroid for WindowAttributes {}
 
 pub trait EventLoopBuilderExtAndroid {
-    /// Associates the `AndroidApp` that was passed to `android_main()` with the event loop
+    /// Associates the [`AndroidApp`] that was passed to `android_main()` with the event loop
     ///
-    /// This must be called on Android since the `AndroidApp` is not global state.
+    /// This must be called on Android since the [`AndroidApp`] is not global state.
     fn with_android_app(&mut self, app: AndroidApp) -> &mut Self;
 
     /// Calling this will mark the volume keys to be manually handled by the application
@@ -146,7 +160,7 @@ impl EventLoopBuilderExtAndroid for EventLoopBuilder {
 /// depending on the `android_activity` crate, and instead consume the API that
 /// is re-exported by Winit.
 ///
-/// For compatibility applications should then import the `AndroidApp` type for
+/// For compatibility applications should then import the [`AndroidApp`] type for
 /// their `android_main(app: AndroidApp)` function like:
 /// ```rust
 /// #[cfg(target_os = "android")]

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -98,7 +98,7 @@ impl RedrawRequester {
 pub struct KeyEventExtra {}
 
 pub struct EventLoop {
-    android_app: AndroidApp,
+    pub(crate) android_app: AndroidApp,
     window_target: event_loop::ActiveEventLoop,
     redraw_flag: SharedFlag,
     loop_running: bool, // Dispatched `NewEvents<Init>`
@@ -575,7 +575,7 @@ impl EventLoopProxy {
 }
 
 pub struct ActiveEventLoop {
-    app: AndroidApp,
+    pub(crate) app: AndroidApp,
     control_flow: Cell<ControlFlow>,
     exit: Cell<bool>,
     redraw_requester: RedrawRequester,


### PR DESCRIPTION
This type comes from the user and stored for the entire lifetime, so no need to hide it from them after they've passed it to winit.

Fixes #3818.

--

I can not really test it, but it's rather trivial and should just work, I guess.

@mwcampbell I guess you need something like that?