### PR TITLE
Remove `raw-window-handle` v0.4 and v0.5 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
 
     - name: Check docs.rs documentation
       if: matrix.toolchain == 'nightly'
-      run: cargo doc --no-deps $OPTIONS --features=rwh_04,rwh_05,rwh_06,serde,mint,android-native-activity
+      run: cargo doc --no-deps $OPTIONS --features=serde,mint,android-native-activity
       env:
         RUSTDOCFLAGS: '--deny=warnings ${{ matrix.platform.rustflags }} --cfg=docsrs --cfg=unreleased_changelogs'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           RUSTDOCFLAGS: --crate-version master --cfg=docsrs --cfg=unreleased_changelogs
         run: |
-          cargo doc --no-deps -Z rustdoc-map -Z rustdoc-scrape-examples --features=rwh_04,rwh_05,rwh_06,serde,mint,android-native-activity
+          cargo doc --no-deps -Z rustdoc-map -Z rustdoc-scrape-examples --features=serde,mint,android-native-activity
 
       - name: Setup Pages
         uses: actions/configure-pages@v5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ version = "0.30.4"
 
 [package.metadata.docs.rs]
 features = [
-    "rwh_04",
-    "rwh_05",
     "rwh_06",
     "serde",
     "mint",
@@ -48,8 +46,6 @@ android-game-activity = ["android-activity/game-activity"]
 android-native-activity = ["android-activity/native-activity"]
 default = ["rwh_06", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 mint = ["dpi/mint"]
-rwh_04 = ["dep:rwh_04", "ndk/rwh_04"]
-rwh_05 = ["dep:rwh_05", "ndk/rwh_05"]
 rwh_06 = ["dep:rwh_06", "ndk/rwh_06"]
 serde = ["dep:serde", "cursor-icon/serde", "smol_str/serde", "dpi/serde"]
 wayland = [
@@ -74,8 +70,6 @@ cfg_aliases = "0.2.1"
 bitflags = "2"
 cursor-icon = "1.1.0"
 dpi = { version = "0.1.1", path = "dpi" }
-rwh_04 = { package = "raw-window-handle", version = "0.4", optional = true }
-rwh_05 = { package = "raw-window-handle", version = "0.5.2", features = ["std"], optional = true }
 rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"], optional = true }
 serde = { workspace = true, optional = true }
 smol_str = "0.2.0"
@@ -85,7 +79,7 @@ tracing = { version = "0.1.40", default-features = false }
 image = { version = "0.25.0", default-features = false, features = ["png"] }
 tracing = { version = "0.1.40", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-winit = { path = ".", features = ["rwh_05"] }
+winit = { path = "." }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dev-dependencies]
 softbuffer = { version = "0.4.0", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ tracing = { version = "0.1.40", default-features = false }
 image = { version = "0.25.0", default-features = false, features = ["png"] }
 tracing = { version = "0.1.40", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-winit = { path = "." }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dev-dependencies]
 softbuffer = { version = "0.4.0", default-features = false, features = [
@@ -327,6 +326,11 @@ wasm-bindgen-test = "0.3"
 [[example]]
 doc-scrape-examples = true
 name = "window"
+required-features = ["rwh_06"]
+
+[[example]]
+name = "child_window"
+required-features = ["rwh_06"]
 
 [workspace]
 members = ["dpi"]

--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "rwh_06", any(x11_platform, macos_platform, windows_platform)))]
+#[cfg(any(x11_platform, macos_platform, windows_platform))]
 #[allow(deprecated)]
 fn main() -> Result<(), impl std::error::Error> {
     use std::collections::HashMap;
@@ -89,7 +89,7 @@ fn main() -> Result<(), impl std::error::Error> {
     event_loop.run_app(Application::default())
 }
 
-#[cfg(all(feature = "rwh_06", not(any(x11_platform, macos_platform, windows_platform))))]
+#[cfg(not(any(x11_platform, macos_platform, windows_platform)))]
 fn main() {
     panic!(
         "This example is supported only on x11, macOS, and Windows, with the `rwh_06` feature \

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -11,7 +11,7 @@
 pub use platform::cleanup_window;
 pub use platform::fill_window;
 
-#[cfg(all(feature = "rwh_05", not(any(target_os = "android", target_os = "ios"))))]
+#[cfg(all(feature = "rwh_06", not(any(target_os = "android", target_os = "ios"))))]
 mod platform {
     use std::cell::RefCell;
     use std::collections::HashMap;
@@ -104,7 +104,7 @@ mod platform {
     }
 }
 
-#[cfg(not(all(feature = "rwh_05", not(any(target_os = "android", target_os = "ios")))))]
+#[cfg(not(all(feature = "rwh_06", not(any(target_os = "android", target_os = "ios")))))]
 mod platform {
     pub fn fill_window(_window: &winit::window::Window) {
         // No-op on mobile platforms.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -103,7 +103,7 @@ changelog entry.
   of `winit` using `objc2-ui-kit` and calling `UIDevice::currentDevice().userInterfaceIdiom()`.
 - On Web, remove unused `platform::web::CustomCursorError::Animation`.
 - Remove the `rwh_04` and `rwh_05` cargo feature and the corresponding `raw-window-handle` v0.4 and
-  v0.5 support.
+  v0.5 support. v0.6 remains in place and is enabled by default.
 
 ### Fixed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -102,8 +102,9 @@ changelog entry.
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside
   of `winit` using `objc2-ui-kit` and calling `UIDevice::currentDevice().userInterfaceIdiom()`.
 - On Web, remove unused `platform::web::CustomCursorError::Animation`.
+- Remove the `rwh_04` and `rwh_05` cargo feature and the corresponding `raw-window-handle` v0.4 and
+  v0.5 support.
 
 ### Fixed
 
-- On MacOS, fix building with `feature = "rwh_04"`.
 - On Web, pen events are now routed through to `WindowEvent::Cursor*`.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -282,14 +282,6 @@ impl rwh_06::HasDisplayHandle for EventLoop {
     }
 }
 
-#[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawDisplayHandle for EventLoop {
-    /// Returns a [`rwh_05::RawDisplayHandle`] for the event loop.
-    fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::HasRawDisplayHandle::raw_display_handle(self.event_loop.window_target())
-    }
-}
-
 #[cfg(any(x11_platform, wayland_platform))]
 impl AsFd for EventLoop {
     /// Get the underlying [EventLoop]'s `fd` which you can register
@@ -454,14 +446,6 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     }
 }
 
-#[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawDisplayHandle for ActiveEventLoop {
-    /// Returns a [`rwh_05::RawDisplayHandle`] for the event loop.
-    fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        self.p.raw_display_handle_rwh_05()
-    }
-}
-
 /// A proxy for the underlying display handle.
 ///
 /// The purpose of this type is to provide a cheaply clonable handle to the underlying
@@ -476,7 +460,7 @@ unsafe impl rwh_05::HasRawDisplayHandle for ActiveEventLoop {
 /// - A reference-counted pointer to the underlying type.
 #[derive(Clone)]
 pub struct OwnedDisplayHandle {
-    #[cfg_attr(not(any(feature = "rwh_05", feature = "rwh_06")), allow(dead_code))]
+    #[cfg_attr(not(feature = "rwh_06"), allow(dead_code))]
     platform: platform_impl::OwnedDisplayHandle,
 }
 
@@ -497,14 +481,6 @@ impl rwh_06::HasDisplayHandle for OwnedDisplayHandle {
         let handle = unsafe { rwh_06::DisplayHandle::borrow_raw(raw) };
 
         Ok(handle)
-    }
-}
-
-#[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawDisplayHandle for OwnedDisplayHandle {
-    #[inline]
-    fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        self.platform.raw_display_handle_rwh_05()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,8 +140,6 @@
 //!
 //! * `x11` (enabled by default): On Unix platforms, enables the X11 backend.
 //! * `wayland` (enabled by default): On Unix platforms, enables the Wayland backend.
-//! * `rwh_04`: Implement `raw-window-handle v0.4` traits.
-//! * `rwh_05`: Implement `raw-window-handle v0.5` traits.
 //! * `rwh_06`: Implement `raw-window-handle v0.6` traits.
 //! * `serde`: Enables serialization/deserialization of certain types with [Serde](https://crates.io/crates/serde).
 //! * `mint`: Enables mint (math interoperability standard types) conversions.
@@ -180,10 +178,6 @@
 // Re-export DPI types so that users don't have to put it in Cargo.toml.
 #[doc(inline)]
 pub use dpi;
-#[cfg(feature = "rwh_04")]
-pub use rwh_04 as raw_window_handle_04;
-#[cfg(feature = "rwh_05")]
-pub use rwh_05 as raw_window_handle_05;
 #[cfg(feature = "rwh_06")]
 pub use rwh_06 as raw_window_handle;
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -440,9 +440,17 @@ pub trait WindowBorrowExtWindows: Borrow<Window> + Sized {
     /// It is the responsibility of the user to only pass the window handle into thread-safe
     /// Win32 APIs.
     ///
-    /// [`window_handle_any_thread`]: WindowExtWindows::window_handle_any_thread
     /// [`Window`]: crate::window::Window
-    /// [`HasWindowHandle`]: rwh_06::HasWindowHandle
+    #[cfg_attr(
+        feature = "rwh_06",
+        doc = "[`HasWindowHandle`]: rwh_06::HasWindowHandle",
+        doc = "[`window_handle_any_thread`]: WindowExtWindows::window_handle_any_thread"
+    )]
+    #[cfg_attr(
+        not(feature = "rwh_06"),
+        doc = "[`HasWindowHandle`]: #only-available-with-rwh_06",
+        doc = "[`window_handle_any_thread`]: #only-available-with-rwh_06"
+    )]
     unsafe fn any_thread(self) -> AnyThread<Self> {
         AnyThread(self)
     }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -605,12 +605,6 @@ impl ActiveEventLoop {
     #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::Android(rwh_05::AndroidDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
@@ -648,12 +642,6 @@ impl ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::AndroidDisplayHandle::empty().into()
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
@@ -873,41 +861,6 @@ impl Window {
 
     pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
-    }
-
-    #[cfg(feature = "rwh_04")]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        use rwh_04::HasRawWindowHandle;
-
-        if let Some(native_window) = self.app.native_window().as_ref() {
-            native_window.raw_window_handle()
-        } else {
-            panic!(
-                "Cannot get the native window, it's null and will always be null before \
-                 Event::Resumed and after Event::Suspended. Make sure you only call this function \
-                 between those events."
-            );
-        }
-    }
-
-    #[cfg(feature = "rwh_05")]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        use rwh_05::HasRawWindowHandle;
-
-        if let Some(native_window) = self.app.native_window().as_ref() {
-            native_window.raw_window_handle()
-        } else {
-            panic!(
-                "Cannot get the native window, it's null and will always be null before \
-                 Event::Resumed and after Event::Suspended. Make sure you only call this function \
-                 between those events."
-            );
-        }
-    }
-
-    #[cfg(feature = "rwh_05")]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::Android(rwh_05::AndroidDisplayHandle::empty())
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -103,12 +103,6 @@ impl ActiveEventLoop {
     #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::AppKit(rwh_05::AppKitDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
@@ -359,12 +353,6 @@ impl EventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::AppKitDisplayHandle::empty().into()
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1610,30 +1610,6 @@ impl WindowDelegate {
         Some(monitor)
     }
 
-    #[cfg(feature = "rwh_04")]
-    #[inline]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        let mut window_handle = rwh_04::AppKitHandle::empty();
-        window_handle.ns_window = self.window() as *const WinitWindow as *mut _;
-        window_handle.ns_view = Retained::as_ptr(&self.view()) as *mut _;
-        rwh_04::RawWindowHandle::AppKit(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        let mut window_handle = rwh_05::AppKitWindowHandle::empty();
-        window_handle.ns_window = self.window() as *const WinitWindow as *mut _;
-        window_handle.ns_view = Retained::as_ptr(&self.view()) as *mut _;
-        rwh_05::RawWindowHandle::AppKit(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::AppKit(rwh_05::AppKitDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> rwh_06::RawWindowHandle {

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -53,12 +53,6 @@ impl ActiveEventLoop {
     #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::UiKit(rwh_05::UiKitDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
@@ -94,12 +88,6 @@ impl ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::UiKitDisplayHandle::empty().into()
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -403,29 +403,6 @@ impl Inner {
         self.window.id()
     }
 
-    #[cfg(feature = "rwh_04")]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        let mut window_handle = rwh_04::UiKitHandle::empty();
-        window_handle.ui_window = Retained::as_ptr(&self.window) as _;
-        window_handle.ui_view = Retained::as_ptr(&self.view) as _;
-        window_handle.ui_view_controller = Retained::as_ptr(&self.view_controller) as _;
-        rwh_04::RawWindowHandle::UiKit(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        let mut window_handle = rwh_05::UiKitWindowHandle::empty();
-        window_handle.ui_window = Retained::as_ptr(&self.window) as _;
-        window_handle.ui_view = Retained::as_ptr(&self.view) as _;
-        window_handle.ui_view_controller = Retained::as_ptr(&self.view_controller) as _;
-        rwh_05::RawWindowHandle::UiKit(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::UiKit(rwh_05::UiKitDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     pub fn raw_window_handle_rwh_06(&self) -> rwh_06::RawWindowHandle {
         let mut window_handle = rwh_06::UiKitWindowHandle::new({

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -569,24 +569,6 @@ impl Window {
         Some(x11_or_wayland!(match self; Window(w) => w.primary_monitor()?; as MonitorHandle))
     }
 
-    #[cfg(feature = "rwh_04")]
-    #[inline]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        x11_or_wayland!(match self; Window(window) => window.raw_window_handle_rwh_04())
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        x11_or_wayland!(match self; Window(window) => window.raw_window_handle_rwh_05())
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        x11_or_wayland!(match self; Window(window) => window.raw_display_handle_rwh_05())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
@@ -882,12 +864,6 @@ impl ActiveEventLoop {
         x11_or_wayland!(match self; Self(evlp) => evlp.listen_device_events(allowed))
     }
 
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        x11_or_wayland!(match self; Self(evlp) => evlp.raw_display_handle_rwh_05())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
@@ -944,29 +920,6 @@ pub(crate) enum OwnedDisplayHandle {
 }
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        match self {
-            #[cfg(x11_platform)]
-            Self::X(xconn) => {
-                let mut xlib_handle = rwh_05::XlibDisplayHandle::empty();
-                xlib_handle.display = xconn.display.cast();
-                xlib_handle.screen = xconn.default_screen_index() as _;
-                xlib_handle.into()
-            },
-
-            #[cfg(wayland_platform)]
-            Self::Wayland(conn) => {
-                use sctk::reexports::client::Proxy;
-
-                let mut wayland_handle = rwh_05::WaylandDisplayHandle::empty();
-                wayland_handle.display = conn.display().id().as_ptr() as *mut _;
-                wayland_handle.into()
-            },
-        }
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -650,16 +650,6 @@ impl ActiveEventLoop {
         }
     }
 
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        use sctk::reexports::client::Proxy;
-
-        let mut display_handle = rwh_05::WaylandDisplayHandle::empty();
-        display_handle.display = self.connection.display().id().as_ptr() as *mut _;
-        rwh_05::RawDisplayHandle::Wayland(display_handle)
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -628,31 +628,6 @@ impl Window {
         None
     }
 
-    #[cfg(feature = "rwh_04")]
-    #[inline]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        let mut window_handle = rwh_04::WaylandHandle::empty();
-        window_handle.surface = self.window.wl_surface().id().as_ptr() as *mut _;
-        window_handle.display = self.display.id().as_ptr() as *mut _;
-        rwh_04::RawWindowHandle::Wayland(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        let mut window_handle = rwh_05::WaylandWindowHandle::empty();
-        window_handle.surface = self.window.wl_surface().id().as_ptr() as *mut _;
-        rwh_05::RawWindowHandle::Wayland(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        let mut display_handle = rwh_05::WaylandDisplayHandle::empty();
-        display_handle.display = self.display.id().as_ptr() as *mut _;
-        rwh_05::RawDisplayHandle::Wayland(display_handle)
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -670,14 +670,6 @@ impl ActiveEventLoop {
             .expect_then_ignore_error("Failed to update device event filter");
     }
 
-    #[cfg(feature = "rwh_05")]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        let mut display_handle = rwh_05::XlibDisplayHandle::empty();
-        display_handle.display = self.xconn.display as *mut _;
-        display_handle.screen = self.xconn.default_screen_index() as c_int;
-        display_handle.into()
-    }
-
     #[cfg(feature = "rwh_06")]
     pub fn raw_display_handle_rwh_06(
         &self,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1854,34 +1854,6 @@ impl UnownedWindow {
         // TODO timer
     }
 
-    #[cfg(feature = "rwh_04")]
-    #[inline]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        let mut window_handle = rwh_04::XlibHandle::empty();
-        window_handle.display = self.xlib_display();
-        window_handle.window = self.xlib_window();
-        window_handle.visual_id = self.visual as c_ulong;
-        rwh_04::RawWindowHandle::Xlib(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        let mut window_handle = rwh_05::XlibWindowHandle::empty();
-        window_handle.window = self.xlib_window();
-        window_handle.visual_id = self.visual as c_ulong;
-        window_handle.into()
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        let mut display_handle = rwh_05::XlibDisplayHandle::empty();
-        display_handle.display = self.xlib_display();
-        display_handle.screen = self.screen_id;
-        display_handle.into()
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -747,12 +747,6 @@ impl ActiveEventLoop {
     #[inline]
     pub fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::Orbital(rwh_05::OrbitalDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
@@ -786,12 +780,6 @@ impl ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::OrbitalDisplayHandle::empty().into()
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -432,28 +432,6 @@ impl Window {
         Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
     }
 
-    #[cfg(feature = "rwh_04")]
-    #[inline]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        let mut handle = rwh_04::OrbitalHandle::empty();
-        handle.window = self.window_socket.fd as *mut _;
-        rwh_04::RawWindowHandle::Orbital(handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        let mut handle = rwh_05::OrbitalWindowHandle::empty();
-        handle.window = self.window_socket.fd as *mut _;
-        rwh_05::RawWindowHandle::Orbital(handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::Orbital(rwh_05::OrbitalDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -81,8 +81,6 @@ impl ActiveEventLoop {
 
     pub fn register(&self, canvas: &Rc<backend::Canvas>, id: WindowId) {
         let canvas_clone = canvas.clone();
-        #[cfg(any(feature = "rwh_04", feature = "rwh_05"))]
-        canvas.set_attribute("data-raw-handle", &id.0.to_string());
 
         canvas.on_touch_start();
 
@@ -601,12 +599,6 @@ impl ActiveEventLoop {
         self.runner.monitor().primary_monitor()
     }
 
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::Web(rwh_05::WebDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
@@ -680,12 +672,6 @@ impl ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::WebDisplayHandle::empty().into()
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -391,28 +391,6 @@ impl Inner {
         self.id
     }
 
-    #[cfg(feature = "rwh_04")]
-    #[inline]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        let mut window_handle = rwh_04::WebHandle::empty();
-        window_handle.id = self.id.0;
-        rwh_04::RawWindowHandle::Web(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        let mut window_handle = rwh_05::WebWindowHandle::empty();
-        window_handle.id = self.id.0;
-        rwh_05::RawWindowHandle::Web(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::Web(rwh_05::WebDisplayHandle::empty())
-    }
-
     #[inline]
     pub fn set_theme(&self, _theme: Option<Theme>) {}
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -506,11 +506,6 @@ impl ActiveEventLoop {
         Some(monitor)
     }
 
-    #[cfg(feature = "rwh_05")]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::Windows(rwh_05::WindowsDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     pub fn raw_display_handle_rwh_06(
         &self,
@@ -555,12 +550,6 @@ impl ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::WindowsDisplayHandle::empty().into()
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -336,32 +336,6 @@ impl Window {
         self.window
     }
 
-    #[cfg(feature = "rwh_04")]
-    #[inline]
-    pub fn raw_window_handle_rwh_04(&self) -> rwh_04::RawWindowHandle {
-        let mut window_handle = rwh_04::Win32Handle::empty();
-        window_handle.hwnd = self.window as *mut _;
-        let hinstance = unsafe { super::get_window_long(self.hwnd(), GWLP_HINSTANCE) };
-        window_handle.hinstance = hinstance as *mut _;
-        rwh_04::RawWindowHandle::Win32(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_window_handle_rwh_05(&self) -> rwh_05::RawWindowHandle {
-        let mut window_handle = rwh_05::Win32WindowHandle::empty();
-        window_handle.hwnd = self.window as *mut _;
-        let hinstance = unsafe { super::get_window_long(self.hwnd(), GWLP_HINSTANCE) };
-        window_handle.hinstance = hinstance as *mut _;
-        rwh_05::RawWindowHandle::Win32(window_handle)
-    }
-
-    #[cfg(feature = "rwh_05")]
-    #[inline]
-    pub fn raw_display_handle_rwh_05(&self) -> rwh_05::RawDisplayHandle {
-        rwh_05::RawDisplayHandle::Windows(rwh_05::WindowsDisplayHandle::empty())
-    }
-
     #[cfg(feature = "rwh_06")]
     #[inline]
     pub unsafe fn rwh_06_no_thread_check(

--- a/src/window.rs
+++ b/src/window.rs
@@ -1650,42 +1650,6 @@ impl rwh_06::HasDisplayHandle for Window {
     }
 }
 
-/// Wrapper to make objects `Send`.
-///
-/// # Safety
-///
-/// This is not safe! This is only used for `RawWindowHandle`, which only has unsafe getters.
-#[cfg(any(feature = "rwh_05", feature = "rwh_04"))]
-struct UnsafeSendWrapper<T>(T);
-
-#[cfg(any(feature = "rwh_05", feature = "rwh_04"))]
-unsafe impl<T> Send for UnsafeSendWrapper<T> {}
-
-#[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawWindowHandle for Window {
-    fn raw_window_handle(&self) -> rwh_05::RawWindowHandle {
-        self.window.maybe_wait_on_main(|w| UnsafeSendWrapper(w.raw_window_handle_rwh_05())).0
-    }
-}
-
-#[cfg(feature = "rwh_05")]
-unsafe impl rwh_05::HasRawDisplayHandle for Window {
-    /// Returns a [`rwh_05::RawDisplayHandle`] used by the [`EventLoop`] that
-    /// created a window.
-    ///
-    /// [`EventLoop`]: crate::event_loop::EventLoop
-    fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        self.window.maybe_wait_on_main(|w| UnsafeSendWrapper(w.raw_display_handle_rwh_05())).0
-    }
-}
-
-#[cfg(feature = "rwh_04")]
-unsafe impl rwh_04::HasRawWindowHandle for Window {
-    fn raw_window_handle(&self) -> rwh_04::RawWindowHandle {
-        self.window.maybe_wait_on_main(|w| UnsafeSendWrapper(w.raw_window_handle_rwh_04())).0
-    }
-}
-
 /// The behavior of cursor grabbing.
 ///
 /// Use this enum with [`Window::set_cursor_grab`] to grab the cursor.


### PR DESCRIPTION
As discussed before (somewhere), this PR removes `raw-window-handle` v0.4 and v0.5 support.
Also renames the `rwh_06` feature to `raw-window-handle`.

We could also remove the whole crate feature now that we support only one version?