### PR TITLE
Add GitHub Actions to Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,15 @@
 version: 2
 
 updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+        interval: daily
+    groups:
+        github-actions:
+            patterns:
+                - "*"
+
   - package-ecosystem: npm
     directory: src/platform_impl/web/script
     schedule:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,3 +18,5 @@ updates:
         github-actions:
             patterns:
                 - '*'
+    labels:
+        - "DS - web"


### PR DESCRIPTION
While we are at it, add GitHub Actions to Dependabot.
I didn't add Cargo because we didn't reach consensus on that in the past.