### PR TITLE
Android: set `KeyEvent::text` if possible

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -83,6 +83,7 @@ changelog entry.
   instead of requiring a `&mut` reference to it.
 - On Web, `Window::canvas()` now returns a reference.
 - On Web, `CursorGrabMode::Locked` now lets `DeviceEvent::MouseMotion` return raw data, not OS
+  accelerated, if the browser supports it.
 - On Android, when `keycode` can be represented as character, it is used as `KeyEvent::text`.
 
 ### Removed

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -83,7 +83,8 @@ changelog entry.
   instead of requiring a `&mut` reference to it.
 - On Web, `Window::canvas()` now returns a reference.
 - On Web, `CursorGrabMode::Locked` now lets `DeviceEvent::MouseMotion` return raw data, not OS
-  accelerated, if the browser supports it.
+- On Android, when `keycode` can be represented as character, it is used as
+  `KeyboardInput::text`.
 
 ### Removed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -83,8 +83,7 @@ changelog entry.
   instead of requiring a `&mut` reference to it.
 - On Web, `Window::canvas()` now returns a reference.
 - On Web, `CursorGrabMode::Locked` now lets `DeviceEvent::MouseMotion` return raw data, not OS
-- On Android, when `keycode` can be represented as character, it is used as
-  `KeyboardInput::text`.
+- On Android, when `keycode` can be represented as character, it is used as `KeyEvent::text`.
 
 ### Removed
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -390,6 +390,13 @@ impl EventLoop {
                             &mut self.combining_accent,
                         );
 
+                        let logical_key = keycodes::to_logical(key_char, keycode);
+                        let text = if let Key::Character(ref c) = logical_key {
+                            Some(c.to_owned())
+                        } else {
+                            None
+                        };
+
                         let window_id = window::WindowId(WindowId);
                         let event = event::WindowEvent::KeyboardInput {
                             device_id: event::DeviceId(DeviceId(key.device_id())),
@@ -399,7 +406,7 @@ impl EventLoop {
                                 logical_key: keycodes::to_logical(key_char, keycode),
                                 location: keycodes::to_location(keycode),
                                 repeat: key.repeat_count() > 0,
-                                text: None,
+                                text,
                                 platform_specific: KeyEventExtra {},
                             },
                             is_synthetic: false,


### PR DESCRIPTION
Related discussion: https://github.com/rust-windowing/winit/pull/3787#issuecomment-2229058082

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
