### PR TITLE
Windows: use `Box::leak()` instead of `Box::into_raw()`

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2391,7 +2391,7 @@ unsafe extern "system" fn thread_event_target_callback(
     if userdata_removed {
         drop(userdata);
     } else {
-        Box::into_raw(userdata);
+        Box::leak(userdata);
     }
     result
 }


### PR DESCRIPTION
`Box::into_raw()` was used to leak a value, but we have `Box::leak()` for that.
This was detected by a new change in Nightly Rust that applied `#[must_use]` to the return value of `Box::into_raw()`.

Unbreaks the Nightly CI.
