### PR TITLE
Properly implement event loop extension traits

### DIFF
--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -109,7 +109,7 @@ impl WindowExtAndroid for Window {
     }
 }
 
-impl ActiveEventLoopExtAndroid for &dyn ActiveEventLoop {
+impl ActiveEventLoopExtAndroid for dyn ActiveEventLoop + '_ {
     fn android_app(&self) -> &AndroidApp {
         let event_loop =
             self.as_any().downcast_ref::<crate::platform_impl::ActiveEventLoop>().unwrap();

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -396,7 +396,7 @@ pub trait ActiveEventLoopExtMacOS {
     fn allows_automatic_window_tabbing(&self) -> bool;
 }
 
-impl ActiveEventLoopExtMacOS for &dyn ActiveEventLoop {
+impl ActiveEventLoopExtMacOS for dyn ActiveEventLoop + '_ {
     fn hide_application(&self) {
         let event_loop = self
             .as_any()

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -57,7 +57,7 @@ pub trait WindowAttributesExtStartupNotify {
     fn with_activation_token(self, token: ActivationToken) -> Self;
 }
 
-impl EventLoopExtStartupNotify for &dyn ActiveEventLoop {
+impl EventLoopExtStartupNotify for dyn ActiveEventLoop + '_ {
     fn read_token_from_env(&self) -> Option<ActivationToken> {
         #[cfg(x11_platform)]
         let _is_wayland = false;

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -24,7 +24,7 @@ pub trait ActiveEventLoopExtWayland {
     fn is_wayland(&self) -> bool;
 }
 
-impl ActiveEventLoopExtWayland for &dyn ActiveEventLoop {
+impl ActiveEventLoopExtWayland for dyn ActiveEventLoop + '_ {
     #[inline]
     fn is_wayland(&self) -> bool {
         self.as_any().downcast_ref::<crate::platform_impl::wayland::ActiveEventLoop>().is_some()

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -347,7 +347,7 @@ pub trait ActiveEventLoopExtWeb {
     fn has_detailed_monitor_permission(&self) -> bool;
 }
 
-impl ActiveEventLoopExtWeb for &dyn ActiveEventLoop {
+impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn create_custom_cursor_async(&self, source: CustomCursorSource) -> CustomCursorFuture {
         let event_loop = self

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -91,7 +91,7 @@ pub trait ActiveEventLoopExtX11 {
     fn is_x11(&self) -> bool;
 }
 
-impl ActiveEventLoopExtX11 for &dyn ActiveEventLoop {
+impl ActiveEventLoopExtX11 for dyn ActiveEventLoop + '_ {
     #[inline]
     fn is_x11(&self) -> bool {
         self.as_any().downcast_ref::<crate::platform_impl::x11::ActiveEventLoop>().is_some()


### PR DESCRIPTION
This was implemented for `&dyn ActiveEventLoop` in https://github.com/rust-windowing/winit/pull/3827, but that's less general than implementing it directly for `dyn ActiveEventLoop`.

The `+ '_` is required to tell the compiler that we want to implement this for all `dyn ActiveEventLoop`s, not just `'static` ones (even though they're all going to be `'static`).

This is especially confusing because the requirement to add `+ '_` on `dyn Trait` types differs depending on the place where `dyn Trait` is used, see [the reference](https://doc.rust-lang.org/reference/lifetime-elision.html#default-trait-object-lifetimes).

- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
  - No entry added, as this isn't yet released
