### PR TITLE
chore: use our own AsAny<T> upcasting

### DIFF
--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::cell::Cell;
 use std::hash::Hash;
 use std::num::{NonZeroU16, NonZeroU32};
@@ -638,10 +637,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
 
     fn owned_display_handle(&self) -> RootOwnedDisplayHandle {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -159,10 +159,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
     }
 
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::ffi::{c_char, c_int, c_void};
 use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
@@ -92,10 +91,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
 
     fn owned_display_handle(&self) -> RootOwnedDisplayHandle {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -1,6 +1,5 @@
 //! The event-loop routines.
 
-use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::io::Result as IOResult;
 use std::mem;
@@ -656,11 +655,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
         crate::event_loop::OwnedDisplayHandle {
             platform: crate::platform_impl::OwnedDisplayHandle::Wayland(self.connection.clone()),
         }
-    }
-
-    #[inline(always)]
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::CStr;
@@ -749,10 +748,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn owned_display_handle(&self) -> RootOwnedDisplayHandle {
         let handle = OwnedDisplayHandle::X(self.x_connection().clone());
         RootOwnedDisplayHandle { platform: handle }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::sync::{mpsc, Arc, Mutex};
@@ -776,10 +775,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
 
     fn owned_display_handle(&self) -> event_loop::OwnedDisplayHandle {
         event_loop::OwnedDisplayHandle { platform: OwnedDisplayHandle }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::cell::Cell;
 use std::clone::Clone;
 use std::iter;
@@ -691,10 +690,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
 
     fn owned_display_handle(&self) -> RootOwnedDisplayHandle {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
     }
 
     #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -570,10 +570,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
     }
 
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,6 +4,7 @@
 // This isn't used on every platform, which can come up as dead code warnings.
 #![allow(dead_code)]
 
+use std::any::Any;
 use std::ops::Deref;
 use std::sync::OnceLock;
 
@@ -24,5 +25,22 @@ impl<T> Deref for Lazy<T> {
     #[inline]
     fn deref(&self) -> &'_ T {
         self.cell.get_or_init(self.init)
+    }
+}
+
+pub trait AsAny {
+    fn as_any(&self) -> &dyn Any;
+    fn as_any_mut(&mut self) -> &mut dyn Any;
+}
+
+impl<T: Any> AsAny for T {
+    #[inline(always)]
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    #[inline(always)]
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
     }
 }


### PR DESCRIPTION
This removes the direct requirement to implement `as_any` and it could be just derived.

Also implement HasDisplayHandle for dyn ActiveEventLoop + '_.

Suggested-by: @daxpedda
