### PR TITLE
Make `ActiveEventLoop` conditionally subtrait `HasDisplayHandle`

### DIFF
--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -643,11 +643,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn as_any(&self) -> &dyn Any {
         self
     }
-
-    #[cfg(feature = "rwh_06")]
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
-        self
-    }
 }
 
 #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -162,11 +162,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn as_any(&self) -> &dyn Any {
         self
     }
-
-    #[cfg(feature = "rwh_06")]
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
-        self
-    }
 }
 
 #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -97,11 +97,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn as_any(&self) -> &dyn Any {
         self
     }
-
-    #[cfg(feature = "rwh_06")]
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
-        self
-    }
 }
 
 #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -662,11 +662,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn as_any(&self) -> &dyn Any {
         self
     }
-
-    #[cfg(feature = "rwh_06")]
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
-        self
-    }
 }
 
 impl ActiveEventLoop {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -754,11 +754,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn as_any(&self) -> &dyn Any {
         self
     }
-
-    #[cfg(feature = "rwh_06")]
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
-        self
-    }
 }
 
 #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -781,11 +781,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn as_any(&self) -> &dyn Any {
         self
     }
-
-    #[cfg(feature = "rwh_06")]
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
-        self
-    }
 }
 
 #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -696,11 +696,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn as_any(&self) -> &dyn Any {
         self
     }
-
-    #[cfg(feature = "rwh_06")]
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
-        self
-    }
 }
 
 #[cfg(feature = "rwh_06")]

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -573,10 +573,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn as_any(&self) -> &dyn std::any::Any {
         self
     }
-
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
-        self
-    }
 }
 
 #[cfg(feature = "rwh_06")]


### PR DESCRIPTION
Using a hacky macro that wraps the definition of `ActiveEventLoop`.

This allows getting rid of the `rwh_06_handle` method.

In the future, once a new version of `raw-window-handle` is released that we want to support, the macro could be extended (though it'll require 4 macros to support all 4 feature combinations, and 8 if there's 3 `raw-window-handle` versions).