### PR TITLE
api: convert `Window` to `dyn Window`

### DIFF
--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), impl std::error::Error> {
     use winit::event::{ElementState, KeyEvent, WindowEvent};
     use winit::event_loop::{ActiveEventLoop, EventLoop};
     use winit::raw_window_handle::HasRawWindowHandle;
-    use winit::window::{Window, WindowId};
+    use winit::window::{Window, WindowAttributes, WindowId};
 
     #[path = "util/fill.rs"]
     mod fill;
@@ -16,12 +16,12 @@ fn main() -> Result<(), impl std::error::Error> {
     #[derive(Default)]
     struct Application {
         parent_window_id: Option<WindowId>,
-        windows: HashMap<WindowId, Window>,
+        windows: HashMap<WindowId, Box<dyn Window>>,
     }
 
     impl ApplicationHandler for Application {
         fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-            let attributes = Window::default_attributes()
+            let attributes = WindowAttributes::default()
                 .with_title("parent window")
                 .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
                 .with_inner_size(LogicalSize::new(640.0f32, 480.0f32));
@@ -57,14 +57,14 @@ fn main() -> Result<(), impl std::error::Error> {
                     ..
                 } => {
                     let parent_window = self.windows.get(&self.parent_window_id.unwrap()).unwrap();
-                    let child_window = spawn_child_window(parent_window, event_loop);
+                    let child_window = spawn_child_window(parent_window.as_ref(), event_loop);
                     let child_id = child_window.id();
                     println!("Child window created with id: {child_id:?}");
                     self.windows.insert(child_id, child_window);
                 },
                 WindowEvent::RedrawRequested => {
                     if let Some(window) = self.windows.get(&window_id) {
-                        fill::fill_window(window);
+                        fill::fill_window(window.as_ref());
                     }
                 },
                 _ => (),
@@ -72,9 +72,12 @@ fn main() -> Result<(), impl std::error::Error> {
         }
     }
 
-    fn spawn_child_window(parent: &Window, event_loop: &dyn ActiveEventLoop) -> Window {
+    fn spawn_child_window(
+        parent: &dyn Window,
+        event_loop: &dyn ActiveEventLoop,
+    ) -> Box<dyn Window> {
         let parent = parent.raw_window_handle().unwrap();
-        let mut window_attributes = Window::default_attributes()
+        let mut window_attributes = WindowAttributes::default()
             .with_title("child window")
             .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
             .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))

--- a/examples/control_flow.rs
+++ b/examples/control_flow.rs
@@ -11,7 +11,7 @@ use winit::application::ApplicationHandler;
 use winit::event::{ElementState, KeyEvent, StartCause, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
 use winit::keyboard::{Key, NamedKey};
-use winit::window::{Window, WindowId};
+use winit::window::{Window, WindowAttributes, WindowId};
 
 #[path = "util/fill.rs"]
 mod fill;
@@ -52,7 +52,7 @@ struct ControlFlowDemo {
     request_redraw: bool,
     wait_cancelled: bool,
     close_requested: bool,
-    window: Option<Window>,
+    window: Option<Box<dyn Window>>,
 }
 
 impl ApplicationHandler for ControlFlowDemo {
@@ -66,7 +66,7 @@ impl ApplicationHandler for ControlFlowDemo {
     }
 
     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-        let window_attributes = Window::default_attributes().with_title(
+        let window_attributes = WindowAttributes::default().with_title(
             "Press 1, 2, 3 to change control flow mode. Press R to toggle redraw requests.",
         );
         self.window = Some(event_loop.create_window(window_attributes).unwrap());
@@ -114,7 +114,7 @@ impl ApplicationHandler for ControlFlowDemo {
             WindowEvent::RedrawRequested => {
                 let window = self.window.as_ref().unwrap();
                 window.pre_present_notify();
-                fill::fill_window(window);
+                fill::fill_window(window.as_ref());
             },
             _ => (),
         }

--- a/examples/pump_events.rs
+++ b/examples/pump_events.rs
@@ -11,19 +11,19 @@ fn main() -> std::process::ExitCode {
     use winit::event::WindowEvent;
     use winit::event_loop::{ActiveEventLoop, EventLoop};
     use winit::platform::pump_events::{EventLoopExtPumpEvents, PumpStatus};
-    use winit::window::{Window, WindowId};
+    use winit::window::{Window, WindowAttributes, WindowId};
 
     #[path = "util/fill.rs"]
     mod fill;
 
     #[derive(Default)]
     struct PumpDemo {
-        window: Option<Window>,
+        window: Option<Box<dyn Window>>,
     }
 
     impl ApplicationHandler for PumpDemo {
         fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-            let window_attributes = Window::default_attributes().with_title("A fantastic window!");
+            let window_attributes = WindowAttributes::default().with_title("A fantastic window!");
             self.window = Some(event_loop.create_window(window_attributes).unwrap());
         }
 
@@ -43,7 +43,7 @@ fn main() -> std::process::ExitCode {
             match event {
                 WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
-                    fill::fill_window(window);
+                    fill::fill_window(window.as_ref());
                     window.request_redraw();
                 },
                 _ => (),

--- a/examples/run_on_demand.rs
+++ b/examples/run_on_demand.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     use winit::event::WindowEvent;
     use winit::event_loop::{ActiveEventLoop, EventLoop};
     use winit::platform::run_on_demand::EventLoopExtRunOnDemand;
-    use winit::window::{Window, WindowId};
+    use winit::window::{Window, WindowAttributes, WindowId};
 
     #[path = "util/fill.rs"]
     mod fill;
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     struct App {
         idx: usize,
         window_id: Option<WindowId>,
-        window: Option<Window>,
+        window: Option<Box<dyn Window>>,
     }
 
     impl ApplicationHandler for App {
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-            let window_attributes = Window::default_attributes()
+            let window_attributes = WindowAttributes::default()
                 .with_title("Fantastic window number one!")
                 .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0));
             let window = event_loop.create_window(window_attributes).unwrap();
@@ -65,11 +65,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                          CloseRequested",
                         self.idx
                     );
-                    fill::cleanup_window(window);
+                    fill::cleanup_window(window.as_ref());
                     self.window = None;
                 },
                 WindowEvent::RedrawRequested => {
-                    fill::fill_window(window);
+                    fill::fill_window(window.as_ref());
                 },
                 _ => (),
             }

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -34,18 +34,20 @@ mod platform {
     /// The graphics context used to draw to a window.
     struct GraphicsContext {
         /// The global softbuffer context.
-        context: RefCell<Context<&'static Window>>,
+        context: RefCell<Context<&'static dyn Window>>,
 
         /// The hash map of window IDs to surfaces.
-        surfaces: HashMap<WindowId, Surface<&'static Window, &'static Window>>,
+        surfaces: HashMap<WindowId, Surface<&'static dyn Window, &'static dyn Window>>,
     }
 
     impl GraphicsContext {
-        fn new(w: &Window) -> Self {
+        fn new(w: &dyn Window) -> Self {
             Self {
                 context: RefCell::new(
-                    Context::new(unsafe { mem::transmute::<&'_ Window, &'static Window>(w) })
-                        .expect("Failed to create a softbuffer context"),
+                    Context::new(unsafe {
+                        mem::transmute::<&'_ dyn Window, &'static dyn Window>(w)
+                    })
+                    .expect("Failed to create a softbuffer context"),
                 ),
                 surfaces: HashMap::new(),
             }
@@ -53,22 +55,22 @@ mod platform {
 
         fn create_surface(
             &mut self,
-            window: &Window,
-        ) -> &mut Surface<&'static Window, &'static Window> {
+            window: &dyn Window,
+        ) -> &mut Surface<&'static dyn Window, &'static dyn Window> {
             self.surfaces.entry(window.id()).or_insert_with(|| {
                 Surface::new(&self.context.borrow(), unsafe {
-                    mem::transmute::<&'_ Window, &'static Window>(window)
+                    mem::transmute::<&'_ dyn Window, &'static dyn Window>(window)
                 })
                 .expect("Failed to create a softbuffer surface")
             })
         }
 
-        fn destroy_surface(&mut self, window: &Window) {
+        fn destroy_surface(&mut self, window: &dyn Window) {
             self.surfaces.remove(&window.id());
         }
     }
 
-    pub fn fill_window(window: &Window) {
+    pub fn fill_window(window: &dyn Window) {
         GC.with(|gc| {
             let size = window.inner_size();
             let (Some(width), Some(height)) =
@@ -94,7 +96,7 @@ mod platform {
     }
 
     #[allow(dead_code)]
-    pub fn cleanup_window(window: &Window) {
+    pub fn cleanup_window(window: &dyn Window) {
         GC.with(|gc| {
             let mut gc = gc.borrow_mut();
             if let Some(context) = gc.as_mut() {
@@ -106,12 +108,12 @@ mod platform {
 
 #[cfg(not(all(feature = "rwh_06", not(any(target_os = "android", target_os = "ios")))))]
 mod platform {
-    pub fn fill_window(_window: &winit::window::Window) {
+    pub fn fill_window(_window: &dyn winit::window::Window) {
         // No-op on mobile platforms.
     }
 
     #[allow(dead_code)]
-    pub fn cleanup_window(_window: &winit::window::Window) {
+    pub fn cleanup_window(_window: &dyn winit::window::Window) {
         // No-op on mobile platforms.
     }
 }

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -7,19 +7,19 @@ fn main() -> Result<(), Box<dyn Error>> {
     use winit::event::WindowEvent;
     use winit::event_loop::{ActiveEventLoop, EventLoop};
     use winit::platform::x11::WindowAttributesExtX11;
-    use winit::window::{Window, WindowId};
+    use winit::window::{Window, WindowAttributes, WindowId};
 
     #[path = "util/fill.rs"]
     mod fill;
 
     pub struct XEmbedDemo {
         parent_window_id: u32,
-        window: Option<Window>,
+        window: Option<Box<dyn Window>>,
     }
 
     impl ApplicationHandler for XEmbedDemo {
         fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-            let window_attributes = Window::default_attributes()
+            let window_attributes = WindowAttributes::default()
                 .with_title("An embedded window!")
                 .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
                 .with_embed_parent_window(self.parent_window_id);
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 WindowEvent::CloseRequested => event_loop.exit(),
                 WindowEvent::RedrawRequested => {
                     window.pre_present_notify();
-                    fill::fill_window(window);
+                    fill::fill_window(window.as_ref());
                 },
                 _ => (),
             }

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -67,6 +67,8 @@ changelog entry.
 ### Changed
 
 - Change `ActiveEventLoop` to be a trait.
+- Change `Window` to be a trait.
+- `ActiveEventLoop::create_window` now returns `Box<dyn Window>`.
 - `ApplicationHandler` now uses `dyn ActiveEventLoop`.
 - On Web, let events wake up event loop immediately when using `ControlFlow::Poll`.
 - Bump MSRV from `1.70` to `1.73`.

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -50,7 +50,7 @@ impl From<CustomCursor> for Cursor {
 /// ```no_run
 /// # use winit::event_loop::ActiveEventLoop;
 /// # use winit::window::Window;
-/// # fn scope(event_loop: &dyn ActiveEventLoop, window: &Window) {
+/// # fn scope(event_loop: &dyn ActiveEventLoop, window: &dyn Window) {
 /// use winit::window::CustomCursor;
 ///
 /// let w = 10;
@@ -67,7 +67,7 @@ impl From<CustomCursor> for Cursor {
 /// };
 ///
 /// if let Ok(custom_cursor) = event_loop.create_custom_cursor(source) {
-///     window.set_cursor(custom_cursor.clone());
+///     window.set_cursor(custom_cursor.clone().into());
 /// }
 /// # }
 /// ```

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -321,7 +321,10 @@ pub trait ActiveEventLoop: AsAny {
     ///
     /// - **Web:** The window is created but not inserted into the Web page automatically. Please
     ///   see the Web platform module for more information.
-    fn create_window(&self, window_attributes: WindowAttributes) -> Result<Window, OsError>;
+    fn create_window(
+        &self,
+        window_attributes: WindowAttributes,
+    ) -> Result<Box<dyn Window>, OsError>;
 
     /// Create custom cursor.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,16 +44,16 @@
 //! use winit::application::ApplicationHandler;
 //! use winit::event::WindowEvent;
 //! use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
-//! use winit::window::{Window, WindowId};
+//! use winit::window::{Window, WindowId, WindowAttributes};
 //!
 //! #[derive(Default)]
 //! struct App {
-//!     window: Option<Window>,
+//!     window: Option<Box<dyn Window>>,
 //! }
 //!
 //! impl ApplicationHandler for App {
 //!     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-//!         self.window = Some(event_loop.create_window(Window::default_attributes()).unwrap());
+//!         self.window = Some(event_loop.create_window(WindowAttributes::default()).unwrap());
 //!     }
 //!
 //!     fn window_event(&mut self, event_loop: &dyn ActiveEventLoop, id: WindowId, event: WindowEvent) {

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -99,13 +99,15 @@ pub trait WindowExtAndroid {
     fn config(&self) -> ConfigurationRef;
 }
 
-impl WindowExtAndroid for Window {
+impl WindowExtAndroid for dyn Window + '_ {
     fn content_rect(&self) -> Rect {
-        self.window.content_rect()
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.content_rect()
     }
 
     fn config(&self) -> ConfigurationRef {
-        self.window.config()
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.config()
     }
 }
 

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -209,42 +209,49 @@ pub trait WindowExtIOS {
     fn recognize_rotation_gesture(&self, should_recognize: bool);
 }
 
-impl WindowExtIOS for Window {
+impl WindowExtIOS for dyn Window + '_ {
     #[inline]
     fn set_scale_factor(&self, scale_factor: f64) {
-        self.window.maybe_queue_on_main(move |w| w.set_scale_factor(scale_factor))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_scale_factor(scale_factor));
     }
 
     #[inline]
     fn set_valid_orientations(&self, valid_orientations: ValidOrientations) {
-        self.window.maybe_queue_on_main(move |w| w.set_valid_orientations(valid_orientations))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_valid_orientations(valid_orientations));
     }
 
     #[inline]
     fn set_prefers_home_indicator_hidden(&self, hidden: bool) {
-        self.window.maybe_queue_on_main(move |w| w.set_prefers_home_indicator_hidden(hidden))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_prefers_home_indicator_hidden(hidden));
     }
 
     #[inline]
     fn set_preferred_screen_edges_deferring_system_gestures(&self, edges: ScreenEdge) {
-        self.window.maybe_queue_on_main(move |w| {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| {
             w.set_preferred_screen_edges_deferring_system_gestures(edges)
-        })
+        });
     }
 
     #[inline]
     fn set_prefers_status_bar_hidden(&self, hidden: bool) {
-        self.window.maybe_queue_on_main(move |w| w.set_prefers_status_bar_hidden(hidden))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_prefers_status_bar_hidden(hidden));
     }
 
     #[inline]
     fn set_preferred_status_bar_style(&self, status_bar_style: StatusBarStyle) {
-        self.window.maybe_queue_on_main(move |w| w.set_preferred_status_bar_style(status_bar_style))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_preferred_status_bar_style(status_bar_style))
     }
 
     #[inline]
     fn recognize_pinch_gesture(&self, should_recognize: bool) {
-        self.window.maybe_queue_on_main(move |w| w.recognize_pinch_gesture(should_recognize));
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.recognize_pinch_gesture(should_recognize));
     }
 
     #[inline]
@@ -254,7 +261,8 @@ impl WindowExtIOS for Window {
         minimum_number_of_touches: u8,
         maximum_number_of_touches: u8,
     ) {
-        self.window.maybe_queue_on_main(move |w| {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| {
             w.recognize_pan_gesture(
                 should_recognize,
                 minimum_number_of_touches,
@@ -265,12 +273,14 @@ impl WindowExtIOS for Window {
 
     #[inline]
     fn recognize_doubletap_gesture(&self, should_recognize: bool) {
-        self.window.maybe_queue_on_main(move |w| w.recognize_doubletap_gesture(should_recognize));
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.recognize_doubletap_gesture(should_recognize));
     }
 
     #[inline]
     fn recognize_rotation_gesture(&self, should_recognize: bool) {
-        self.window.maybe_queue_on_main(move |w| w.recognize_rotation_gesture(should_recognize));
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.recognize_rotation_gesture(should_recognize));
     }
 }
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -152,75 +152,89 @@ pub trait WindowExtMacOS {
     fn option_as_alt(&self) -> OptionAsAlt;
 }
 
-impl WindowExtMacOS for Window {
+impl WindowExtMacOS for dyn Window + '_ {
     #[inline]
     fn simple_fullscreen(&self) -> bool {
-        self.window.maybe_wait_on_main(|w| w.simple_fullscreen())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.simple_fullscreen())
     }
 
     #[inline]
     fn set_simple_fullscreen(&self, fullscreen: bool) -> bool {
-        self.window.maybe_wait_on_main(move |w| w.set_simple_fullscreen(fullscreen))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_simple_fullscreen(fullscreen))
     }
 
     #[inline]
     fn has_shadow(&self) -> bool {
-        self.window.maybe_wait_on_main(|w| w.has_shadow())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.has_shadow())
     }
 
     #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
-        self.window.maybe_queue_on_main(move |w| w.set_has_shadow(has_shadow))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_has_shadow(has_shadow));
     }
 
     #[inline]
     fn set_tabbing_identifier(&self, identifier: &str) {
-        self.window.maybe_wait_on_main(|w| w.set_tabbing_identifier(identifier))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.set_tabbing_identifier(identifier))
     }
 
     #[inline]
     fn tabbing_identifier(&self) -> String {
-        self.window.maybe_wait_on_main(|w| w.tabbing_identifier())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.tabbing_identifier())
     }
 
     #[inline]
     fn select_next_tab(&self) {
-        self.window.maybe_queue_on_main(|w| w.select_next_tab())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.select_next_tab());
     }
 
     #[inline]
     fn select_previous_tab(&self) {
-        self.window.maybe_queue_on_main(|w| w.select_previous_tab())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.select_previous_tab());
     }
 
     #[inline]
     fn select_tab_at_index(&self, index: usize) {
-        self.window.maybe_queue_on_main(move |w| w.select_tab_at_index(index))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.select_tab_at_index(index));
     }
 
     #[inline]
     fn num_tabs(&self) -> usize {
-        self.window.maybe_wait_on_main(|w| w.num_tabs())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.num_tabs())
     }
 
     #[inline]
     fn is_document_edited(&self) -> bool {
-        self.window.maybe_wait_on_main(|w| w.is_document_edited())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.is_document_edited())
     }
 
     #[inline]
     fn set_document_edited(&self, edited: bool) {
-        self.window.maybe_queue_on_main(move |w| w.set_document_edited(edited))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_document_edited(edited));
     }
 
     #[inline]
     fn set_option_as_alt(&self, option_as_alt: OptionAsAlt) {
-        self.window.maybe_queue_on_main(move |w| w.set_option_as_alt(option_as_alt))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_option_as_alt(option_as_alt));
     }
 
     #[inline]
     fn option_as_alt(&self) -> OptionAsAlt {
-        self.window.maybe_wait_on_main(|w| w.option_as_alt())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.option_as_alt())
     }
 }
 

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -16,7 +16,7 @@
 use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
 use crate::monitor::MonitorHandle;
 pub use crate::window::Theme;
-use crate::window::{Window, WindowAttributes};
+use crate::window::{Window as CoreWindow, WindowAttributes};
 
 /// Additional methods on [`ActiveEventLoop`] that are specific to Wayland.
 pub trait ActiveEventLoopExtWayland {
@@ -71,9 +71,11 @@ impl EventLoopBuilderExtWayland for EventLoopBuilder {
 }
 
 /// Additional methods on [`Window`] that are specific to Wayland.
+///
+/// [`Window`]: crate::window::Window
 pub trait WindowExtWayland {}
 
-impl WindowExtWayland for Window {}
+impl WindowExtWayland for dyn CoreWindow + '_ {}
 
 /// Additional methods on [`WindowAttributes`] that are specific to Wayland.
 pub trait WindowAttributesExtWayland {

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -82,7 +82,7 @@ pub trait WindowExtWeb {
 
     /// Returns [`true`] if calling `event.preventDefault()` is enabled.
     ///
-    /// See [`Window::set_prevent_default()`] for more details.
+    /// See [`WindowExtWeb::set_prevent_default()`] for more details.
     fn prevent_default(&self) -> bool;
 
     /// Sets whether `event.preventDefault()` should be called on events on the
@@ -104,22 +104,34 @@ pub trait WindowExtWeb {
     fn is_cursor_lock_raw(&self) -> bool;
 }
 
-impl WindowExtWeb for Window {
+impl WindowExtWeb for dyn Window + '_ {
     #[inline]
     fn canvas(&self) -> Option<Ref<'_, HtmlCanvasElement>> {
-        self.window.canvas()
+        self.as_any()
+            .downcast_ref::<crate::platform_impl::Window>()
+            .expect("non Web window on Web")
+            .canvas()
     }
 
     fn prevent_default(&self) -> bool {
-        self.window.prevent_default()
+        self.as_any()
+            .downcast_ref::<crate::platform_impl::Window>()
+            .expect("non Web window on Web")
+            .prevent_default()
     }
 
     fn set_prevent_default(&self, prevent_default: bool) {
-        self.window.set_prevent_default(prevent_default)
+        self.as_any()
+            .downcast_ref::<crate::platform_impl::Window>()
+            .expect("non Web window on Web")
+            .set_prevent_default(prevent_default)
     }
 
     fn is_cursor_lock_raw(&self) -> bool {
-        self.window.is_cursor_lock_raw()
+        self.as_any()
+            .downcast_ref::<crate::platform_impl::Window>()
+            .expect("non Web window on Web")
+            .is_cursor_lock_raw()
     }
 }
 
@@ -136,7 +148,7 @@ pub trait WindowAttributesExtWeb {
     /// Sets whether `event.preventDefault()` should be called on events on the
     /// canvas that have side effects.
     ///
-    /// See [`Window::set_prevent_default()`] for more details.
+    /// See [`WindowExtWeb::set_prevent_default()`] for more details.
     ///
     /// Enabled by default.
     fn with_prevent_default(self, prevent_default: bool) -> Self;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -4,6 +4,7 @@
 //! tested regularly.
 use std::borrow::Borrow;
 use std::ffi::c_void;
+use std::ops::Deref;
 use std::path::Path;
 
 #[cfg(feature = "serde")]
@@ -115,50 +116,25 @@ pub enum CornerPreference {
 ///
 /// See [`WindowBorrowExtWindows::any_thread`] for more information.
 #[derive(Clone, Debug)]
-pub struct AnyThread<W>(W);
+pub struct AnyThread<W: Window>(W);
 
-impl<W: Borrow<Window>> AnyThread<W> {
+impl<W: Window> AnyThread<W> {
     /// Get a reference to the inner window.
     #[inline]
-    pub fn get_ref(&self) -> &Window {
-        self.0.borrow()
-    }
-
-    /// Get a reference to the inner object.
-    #[inline]
-    pub fn inner(&self) -> &W {
+    pub fn get_ref(&self) -> &dyn Window {
         &self.0
     }
-
-    /// Unwrap and get the inner window.
-    #[inline]
-    pub fn into_inner(self) -> W {
-        self.0
-    }
 }
 
-impl<W: Borrow<Window>> AsRef<Window> for AnyThread<W> {
-    fn as_ref(&self) -> &Window {
-        self.get_ref()
-    }
-}
-
-impl<W: Borrow<Window>> Borrow<Window> for AnyThread<W> {
-    fn borrow(&self) -> &Window {
-        self.get_ref()
-    }
-}
-
-impl<W: Borrow<Window>> std::ops::Deref for AnyThread<W> {
-    type Target = Window;
-
+impl<W: Window> Deref for AnyThread<W> {
+    type Target = W;
     fn deref(&self) -> &Self::Target {
-        self.get_ref()
+        &self.0
     }
 }
 
 #[cfg(feature = "rwh_06")]
-impl<W: Borrow<Window>> rwh_06::HasWindowHandle for AnyThread<W> {
+impl<W: Window> rwh_06::HasWindowHandle for AnyThread<W> {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         // SAFETY: The top level user has asserted this is only used safely.
         unsafe { self.get_ref().window_handle_any_thread() }
@@ -341,7 +317,7 @@ pub trait WindowExtWindows {
     ///
     /// ```no_run
     /// # use winit::window::Window;
-    /// # fn scope(window: Window) {
+    /// # fn scope(window: Box<dyn Window>) {
     /// use std::thread;
     ///
     /// use winit::platform::windows::WindowExtWindows;
@@ -365,35 +341,41 @@ pub trait WindowExtWindows {
     ) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError>;
 }
 
-impl WindowExtWindows for Window {
+impl WindowExtWindows for dyn Window + '_ {
     #[inline]
     fn set_enable(&self, enabled: bool) {
-        self.window.set_enable(enabled)
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_enable(enabled)
     }
 
     #[inline]
     fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {
-        self.window.set_taskbar_icon(taskbar_icon)
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_taskbar_icon(taskbar_icon)
     }
 
     #[inline]
     fn set_skip_taskbar(&self, skip: bool) {
-        self.window.set_skip_taskbar(skip)
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_skip_taskbar(skip)
     }
 
     #[inline]
     fn set_undecorated_shadow(&self, shadow: bool) {
-        self.window.set_undecorated_shadow(shadow)
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_undecorated_shadow(shadow)
     }
 
     #[inline]
     fn set_system_backdrop(&self, backdrop_type: BackdropType) {
-        self.window.set_system_backdrop(backdrop_type)
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_system_backdrop(backdrop_type)
     }
 
     #[inline]
     fn set_border_color(&self, color: Option<Color>) {
-        self.window.set_border_color(color.unwrap_or(Color::NONE))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_border_color(color.unwrap_or(Color::NONE))
     }
 
     #[inline]
@@ -401,25 +383,29 @@ impl WindowExtWindows for Window {
         // The windows docs don't mention NONE as a valid options but it works in practice and is
         // useful to circumvent the Windows option "Show accent color on title bars and
         // window borders"
-        self.window.set_title_background_color(color.unwrap_or(Color::NONE))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_title_background_color(color.unwrap_or(Color::NONE))
     }
 
     #[inline]
     fn set_title_text_color(&self, color: Color) {
-        self.window.set_title_text_color(color)
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_title_text_color(color)
     }
 
     #[inline]
     fn set_corner_preference(&self, preference: CornerPreference) {
-        self.window.set_corner_preference(preference)
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_corner_preference(preference)
     }
 
     #[cfg(feature = "rwh_06")]
     unsafe fn window_handle_any_thread(
         &self,
     ) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
         unsafe {
-            let handle = self.window.rwh_06_no_thread_check()?;
+            let handle = window.rwh_06_no_thread_check()?;
 
             // SAFETY: The handle is valid in this context.
             Ok(rwh_06::WindowHandle::borrow_raw(handle))
@@ -430,7 +416,7 @@ impl WindowExtWindows for Window {
 /// Additional methods for anything that dereference to [`Window`].
 ///
 /// [`Window`]: crate::window::Window
-pub trait WindowBorrowExtWindows: Borrow<Window> + Sized {
+pub trait WindowBorrowExtWindows: Borrow<dyn Window> + Sized {
     /// Create an object that allows accessing the inner window handle in a thread-unsafe way.
     ///
     /// It is possible to call [`window_handle_any_thread`] to get around Windows's thread
@@ -457,12 +443,15 @@ pub trait WindowBorrowExtWindows: Borrow<Window> + Sized {
         doc = "[`HasWindowHandle`]: #only-available-with-rwh_06",
         doc = "[`window_handle_any_thread`]: #only-available-with-rwh_06"
     )]
-    unsafe fn any_thread(self) -> AnyThread<Self> {
+    unsafe fn any_thread(self) -> AnyThread<Self>
+    where
+        Self: Window,
+    {
         AnyThread(self)
     }
 }
 
-impl<W: Borrow<Window> + Sized> WindowBorrowExtWindows for W {}
+impl<W: Borrow<dyn Window> + Sized> WindowBorrowExtWindows for W {}
 
 /// Additional methods on `WindowAttributes` that are specific to Windows.
 #[allow(rustdoc::broken_intra_doc_links)]

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::dpi::Size;
 use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
 use crate::monitor::MonitorHandle;
-use crate::window::{Window, WindowAttributes};
+use crate::window::{Window as CoreWindow, WindowAttributes};
 
 /// X window type. Maps directly to
 /// [`_NET_WM_WINDOW_TYPE`](https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html).
@@ -138,9 +138,11 @@ impl EventLoopBuilderExtX11 for EventLoopBuilder {
 }
 
 /// Additional methods on [`Window`] that are specific to X11.
+///
+/// [`Window`]: crate::window::Window
 pub trait WindowExtX11 {}
 
-impl WindowExtX11 for Window {}
+impl WindowExtX11 for dyn CoreWindow {}
 
 /// Additional methods on [`WindowAttributes`] that are specific to X11.
 pub trait WindowAttributesExtX11 {
@@ -169,13 +171,13 @@ pub trait WindowAttributesExtX11 {
     ///
     /// ```
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
-    /// # use winit::window::Window;
+    /// # use winit::window::{Window, WindowAttributes};
     /// # use winit::platform::x11::WindowAttributesExtX11;
     /// // Specify the size in logical dimensions like this:
-    /// Window::default_attributes().with_base_size(LogicalSize::new(400.0, 200.0));
+    /// WindowAttributes::default().with_base_size(LogicalSize::new(400.0, 200.0));
     ///
     /// // Or specify the size in physical dimensions like this:
-    /// Window::default_attributes().with_base_size(PhysicalSize::new(400, 200));
+    /// WindowAttributes::default().with_base_size(PhysicalSize::new(400, 200));
     /// ```
     fn with_base_size<S: Into<Size>>(self, base_size: S) -> Self;
 
@@ -184,12 +186,12 @@ pub trait WindowAttributesExtX11 {
     /// # Example
     ///
     /// ```no_run
-    /// use winit::window::Window;
+    /// use winit::window::{Window, WindowAttributes};
     /// use winit::event_loop::ActiveEventLoop;
     /// use winit::platform::x11::{XWindow, WindowAttributesExtX11};
     /// # fn create_window(event_loop: &dyn ActiveEventLoop) -> Result<(), Box<dyn std::error::Error>> {
     /// let parent_window_id = std::env::args().nth(1).unwrap().parse::<XWindow>()?;
-    /// let window_attributes = Window::default_attributes().with_embed_parent_window(parent_window_id);
+    /// let window_attributes = WindowAttributes::default().with_embed_parent_window(parent_window_id);
     /// let window = event_loop.create_window(window_attributes)?;
     /// # Ok(()) }
     /// ```

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -38,9 +38,7 @@ use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform::macos::ActivationPolicy;
 use crate::platform::pump_events::PumpStatus;
 use crate::platform_impl::Window;
-use crate::window::{
-    CustomCursor as RootCustomCursor, CustomCursorSource, Theme, Window as RootWindow,
-};
+use crate::window::{CustomCursor as RootCustomCursor, CustomCursorSource, Theme};
 
 #[derive(Default)]
 pub struct PanicInfo {
@@ -105,9 +103,8 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: crate::window::WindowAttributes,
-    ) -> Result<crate::window::Window, crate::error::OsError> {
-        let window = Window::new(self, window_attributes)?;
-        Ok(RootWindow { window })
+    ) -> Result<Box<dyn crate::window::Window>, crate::error::OsError> {
+        Ok(Box::new(Window::new(self, window_attributes)?))
     }
 
     fn create_custom_cursor(

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::unnecessary_cast)]
 
+use dpi::{Position, Size};
 use objc2::rc::{autoreleasepool, Retained};
 use objc2::{declare_class, mutability, ClassType, DeclaredClass};
 use objc2_app_kit::{NSResponder, NSWindow};
@@ -8,18 +9,16 @@ use objc2_foundation::{MainThreadBound, MainThreadMarker, NSObject};
 use super::event_loop::ActiveEventLoop;
 use super::window_delegate::WindowDelegate;
 use crate::error::OsError as RootOsError;
-use crate::window::WindowAttributes;
+use crate::monitor::MonitorHandle as CoreMonitorHandle;
+use crate::window::{
+    Cursor, Fullscreen, Icon, ImePurpose, Theme, UserAttentionType, Window as CoreWindow,
+    WindowAttributes, WindowButtons, WindowLevel,
+};
 
 pub(crate) struct Window {
     window: MainThreadBound<Retained<WinitWindow>>,
     /// The window only keeps a weak reference to this, so we must keep it around here.
     delegate: MainThreadBound<Retained<WindowDelegate>>,
-}
-
-impl Drop for Window {
-    fn drop(&mut self) {
-        self.window.get_on_main(|window| autoreleasepool(|_| window.close()))
-    }
 }
 
 impl Window {
@@ -34,11 +33,6 @@ impl Window {
             window: MainThreadBound::new(delegate.window().retain(), mtm),
             delegate: MainThreadBound::new(delegate, mtm),
         })
-    }
-
-    pub(crate) fn maybe_queue_on_main(&self, f: impl FnOnce(&WindowDelegate) + Send + 'static) {
-        // For now, don't actually do queuing, since it may be less predictable
-        self.maybe_wait_on_main(f)
     }
 
     pub(crate) fn maybe_wait_on_main<R: Send>(
@@ -66,6 +60,283 @@ impl Window {
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
         Ok(rwh_06::RawDisplayHandle::AppKit(rwh_06::AppKitDisplayHandle::new()))
+    }
+}
+
+impl Drop for Window {
+    fn drop(&mut self) {
+        // Restore the video mode.
+        if matches!(self.fullscreen(), Some(Fullscreen::Exclusive(_))) {
+            self.set_fullscreen(None);
+        }
+
+        self.window.get_on_main(|window| autoreleasepool(|_| window.close()))
+    }
+}
+
+#[cfg(feature = "rwh_06")]
+impl rwh_06::HasDisplayHandle for Window {
+    fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
+        let raw = self.raw_display_handle_rwh_06()?;
+        unsafe { Ok(rwh_06::DisplayHandle::borrow_raw(raw)) }
+    }
+}
+
+#[cfg(feature = "rwh_06")]
+impl rwh_06::HasWindowHandle for Window {
+    fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
+        let raw = self.raw_window_handle_rwh_06()?;
+        unsafe { Ok(rwh_06::WindowHandle::borrow_raw(raw)) }
+    }
+}
+
+impl CoreWindow for Window {
+    fn id(&self) -> crate::window::WindowId {
+        self.maybe_wait_on_main(|delegate| crate::window::WindowId(delegate.id()))
+    }
+
+    fn scale_factor(&self) -> f64 {
+        self.maybe_wait_on_main(|delegate| delegate.scale_factor())
+    }
+
+    fn request_redraw(&self) {
+        self.maybe_wait_on_main(|delegate| delegate.request_redraw());
+    }
+
+    fn pre_present_notify(&self) {
+        self.maybe_wait_on_main(|delegate| delegate.pre_present_notify());
+    }
+
+    fn reset_dead_keys(&self) {
+        self.maybe_wait_on_main(|delegate| delegate.reset_dead_keys());
+    }
+
+    fn inner_position(
+        &self,
+    ) -> Result<dpi::PhysicalPosition<i32>, crate::error::NotSupportedError> {
+        self.maybe_wait_on_main(|delegate| delegate.inner_position())
+    }
+
+    fn outer_position(
+        &self,
+    ) -> Result<dpi::PhysicalPosition<i32>, crate::error::NotSupportedError> {
+        self.maybe_wait_on_main(|delegate| delegate.outer_position())
+    }
+
+    fn set_outer_position(&self, position: Position) {
+        self.maybe_wait_on_main(|delegate| delegate.set_outer_position(position));
+    }
+
+    fn inner_size(&self) -> dpi::PhysicalSize<u32> {
+        self.maybe_wait_on_main(|delegate| delegate.inner_size())
+    }
+
+    fn request_inner_size(&self, size: Size) -> Option<dpi::PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.request_inner_size(size))
+    }
+
+    fn outer_size(&self) -> dpi::PhysicalSize<u32> {
+        self.maybe_wait_on_main(|delegate| delegate.outer_size())
+    }
+
+    fn set_min_inner_size(&self, min_size: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_min_inner_size(min_size))
+    }
+
+    fn set_max_inner_size(&self, max_size: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_max_inner_size(max_size));
+    }
+
+    fn resize_increments(&self) -> Option<dpi::PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.resize_increments())
+    }
+
+    fn set_resize_increments(&self, increments: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_resize_increments(increments));
+    }
+
+    fn set_title(&self, title: &str) {
+        self.maybe_wait_on_main(|delegate| delegate.set_title(title));
+    }
+
+    fn set_transparent(&self, transparent: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_transparent(transparent));
+    }
+
+    fn set_blur(&self, blur: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_blur(blur));
+    }
+
+    fn set_visible(&self, visible: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_visible(visible));
+    }
+
+    fn is_visible(&self) -> Option<bool> {
+        self.maybe_wait_on_main(|delegate| delegate.is_visible())
+    }
+
+    fn set_resizable(&self, resizable: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_resizable(resizable))
+    }
+
+    fn is_resizable(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_resizable())
+    }
+
+    fn set_enabled_buttons(&self, buttons: WindowButtons) {
+        self.maybe_wait_on_main(|delegate| delegate.set_enabled_buttons(buttons))
+    }
+
+    fn enabled_buttons(&self) -> WindowButtons {
+        self.maybe_wait_on_main(|delegate| delegate.enabled_buttons())
+    }
+
+    fn set_minimized(&self, minimized: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_minimized(minimized));
+    }
+
+    fn is_minimized(&self) -> Option<bool> {
+        self.maybe_wait_on_main(|delegate| delegate.is_minimized())
+    }
+
+    fn set_maximized(&self, maximized: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_maximized(maximized));
+    }
+
+    fn is_maximized(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_maximized())
+    }
+
+    fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_fullscreen(fullscreen.map(Into::into)))
+    }
+
+    fn fullscreen(&self) -> Option<Fullscreen> {
+        self.maybe_wait_on_main(|delegate| delegate.fullscreen().map(Into::into))
+    }
+
+    fn set_decorations(&self, decorations: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_decorations(decorations));
+    }
+
+    fn is_decorated(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_decorated())
+    }
+
+    fn set_window_level(&self, level: WindowLevel) {
+        self.maybe_wait_on_main(|delegate| delegate.set_window_level(level));
+    }
+
+    fn set_window_icon(&self, window_icon: Option<Icon>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_window_icon(window_icon));
+    }
+
+    fn set_ime_cursor_area(&self, position: Position, size: Size) {
+        self.maybe_wait_on_main(|delegate| delegate.set_ime_cursor_area(position, size));
+    }
+
+    fn set_ime_allowed(&self, allowed: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_ime_allowed(allowed));
+    }
+
+    fn set_ime_purpose(&self, purpose: ImePurpose) {
+        self.maybe_wait_on_main(|delegate| delegate.set_ime_purpose(purpose));
+    }
+
+    fn focus_window(&self) {
+        self.maybe_wait_on_main(|delegate| delegate.focus_window());
+    }
+
+    fn has_focus(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.has_focus())
+    }
+
+    fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
+        self.maybe_wait_on_main(|delegate| delegate.request_user_attention(request_type));
+    }
+
+    fn set_theme(&self, theme: Option<Theme>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_theme(theme));
+    }
+
+    fn theme(&self) -> Option<Theme> {
+        self.maybe_wait_on_main(|delegate| delegate.theme())
+    }
+
+    fn set_content_protected(&self, protected: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_content_protected(protected));
+    }
+
+    fn title(&self) -> String {
+        self.maybe_wait_on_main(|delegate| delegate.title())
+    }
+
+    fn set_cursor(&self, cursor: Cursor) {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor(cursor));
+    }
+
+    fn set_cursor_position(&self, position: Position) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor_position(position))
+    }
+
+    fn set_cursor_grab(
+        &self,
+        mode: crate::window::CursorGrabMode,
+    ) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor_grab(mode))
+    }
+
+    fn set_cursor_visible(&self, visible: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor_visible(visible))
+    }
+
+    fn drag_window(&self) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.drag_window())
+    }
+
+    fn drag_resize_window(
+        &self,
+        direction: crate::window::ResizeDirection,
+    ) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.drag_resize_window(direction))
+    }
+
+    fn show_window_menu(&self, position: Position) {
+        self.maybe_wait_on_main(|delegate| delegate.show_window_menu(position))
+    }
+
+    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor_hittest(hittest))
+    }
+
+    fn current_monitor(&self) -> Option<CoreMonitorHandle> {
+        self.maybe_wait_on_main(|delegate| {
+            delegate.current_monitor().map(|inner| CoreMonitorHandle { inner })
+        })
+    }
+
+    fn available_monitors(&self) -> Box<dyn Iterator<Item = CoreMonitorHandle>> {
+        self.maybe_wait_on_main(|delegate| {
+            Box::new(
+                delegate.available_monitors().into_iter().map(|inner| CoreMonitorHandle { inner }),
+            )
+        })
+    }
+
+    fn primary_monitor(&self) -> Option<CoreMonitorHandle> {
+        self.maybe_wait_on_main(|delegate| {
+            delegate.primary_monitor().map(|inner| CoreMonitorHandle { inner })
+        })
+    }
+
+    #[cfg(feature = "rwh_06")]
+    fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
+        self
+    }
+
+    #[cfg(feature = "rwh_06")]
+    fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
+        self
     }
 }
 

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -33,7 +33,7 @@ use crate::event_loop::{
 };
 use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform_impl::Window;
-use crate::window::{CustomCursor, CustomCursorSource, Theme, Window as RootWindow};
+use crate::window::{CustomCursor, CustomCursorSource, Theme, Window as CoreWindow};
 
 #[derive(Debug)]
 pub(crate) struct ActiveEventLoop {
@@ -49,9 +49,8 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: crate::window::WindowAttributes,
-    ) -> Result<RootWindow, OsError> {
-        let window = Window::new(self, window_attributes)?;
-        Ok(RootWindow { window })
+    ) -> Result<Box<dyn CoreWindow>, OsError> {
+        Ok(Box::new(Window::new(self, window_attributes)?))
     }
 
     fn create_custom_cursor(

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -23,10 +23,11 @@ use crate::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, P
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
 use crate::event::{Event, WindowEvent};
 use crate::icon::Icon;
+use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::platform::ios::{ScreenEdge, StatusBarStyle, ValidOrientations};
 use crate::window::{
-    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, WindowAttributes,
-    WindowButtons, WindowId as RootWindowId, WindowLevel,
+    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
+    WindowAttributes, WindowButtons, WindowId as CoreWindowId, WindowLevel,
 };
 
 declare_class!(
@@ -49,7 +50,7 @@ declare_class!(
             app_state::handle_nonuser_event(
                 mtm,
                 EventWrapper::StaticEvent(Event::WindowEvent {
-                    window_id: RootWindowId(self.id()),
+                    window_id: CoreWindowId(self.id()),
                     event: WindowEvent::Focused(true),
                 }),
             );
@@ -62,7 +63,7 @@ declare_class!(
             app_state::handle_nonuser_event(
                 mtm,
                 EventWrapper::StaticEvent(Event::WindowEvent {
-                    window_id: RootWindowId(self.id()),
+                    window_id: CoreWindowId(self.id()),
                     event: WindowEvent::Focused(false),
                 }),
             );
@@ -522,7 +523,7 @@ impl Window {
                 width: screen_frame.size.width as f64,
                 height: screen_frame.size.height as f64,
             };
-            let window_id = RootWindowId(window.id());
+            let window_id = CoreWindowId(window.id());
             app_state::handle_nonuser_events(
                 mtm,
                 std::iter::once(EventWrapper::ScaleFactorChanged(app_state::ScaleFactorChanged {
@@ -541,11 +542,6 @@ impl Window {
 
         let inner = Inner { window, view_controller, view, gl_or_metal_backed };
         Ok(Window { inner: MainThreadBound::new(inner, mtm) })
-    }
-
-    pub(crate) fn maybe_queue_on_main(&self, f: impl FnOnce(&Inner) + Send + 'static) {
-        // For now, don't actually do queuing, since it may be less predictable
-        self.maybe_wait_on_main(f)
     }
 
     pub(crate) fn maybe_wait_on_main<R: Send>(&self, f: impl FnOnce(&Inner) -> R + Send) -> R {
@@ -570,6 +566,272 @@ impl Window {
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
         Ok(rwh_06::RawDisplayHandle::UiKit(rwh_06::UiKitDisplayHandle::new()))
+    }
+}
+
+#[cfg(feature = "rwh_06")]
+impl rwh_06::HasDisplayHandle for Window {
+    fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
+        let raw = self.raw_display_handle_rwh_06()?;
+        unsafe { Ok(rwh_06::DisplayHandle::borrow_raw(raw)) }
+    }
+}
+
+#[cfg(feature = "rwh_06")]
+impl rwh_06::HasWindowHandle for Window {
+    fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
+        let raw = self.raw_window_handle_rwh_06()?;
+        unsafe { Ok(rwh_06::WindowHandle::borrow_raw(raw)) }
+    }
+}
+
+impl CoreWindow for Window {
+    fn id(&self) -> crate::window::WindowId {
+        self.maybe_wait_on_main(|delegate| crate::window::WindowId(delegate.id()))
+    }
+
+    fn scale_factor(&self) -> f64 {
+        self.maybe_wait_on_main(|delegate| delegate.scale_factor())
+    }
+
+    fn request_redraw(&self) {
+        self.maybe_wait_on_main(|delegate| delegate.request_redraw());
+    }
+
+    fn pre_present_notify(&self) {
+        self.maybe_wait_on_main(|delegate| delegate.pre_present_notify());
+    }
+
+    fn reset_dead_keys(&self) {
+        self.maybe_wait_on_main(|delegate| delegate.reset_dead_keys());
+    }
+
+    fn inner_position(
+        &self,
+    ) -> Result<dpi::PhysicalPosition<i32>, crate::error::NotSupportedError> {
+        self.maybe_wait_on_main(|delegate| delegate.inner_position())
+    }
+
+    fn outer_position(
+        &self,
+    ) -> Result<dpi::PhysicalPosition<i32>, crate::error::NotSupportedError> {
+        self.maybe_wait_on_main(|delegate| delegate.outer_position())
+    }
+
+    fn set_outer_position(&self, position: Position) {
+        self.maybe_wait_on_main(|delegate| delegate.set_outer_position(position));
+    }
+
+    fn inner_size(&self) -> dpi::PhysicalSize<u32> {
+        self.maybe_wait_on_main(|delegate| delegate.inner_size())
+    }
+
+    fn request_inner_size(&self, size: Size) -> Option<dpi::PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.request_inner_size(size))
+    }
+
+    fn outer_size(&self) -> dpi::PhysicalSize<u32> {
+        self.maybe_wait_on_main(|delegate| delegate.outer_size())
+    }
+
+    fn set_min_inner_size(&self, min_size: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_min_inner_size(min_size))
+    }
+
+    fn set_max_inner_size(&self, max_size: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_max_inner_size(max_size));
+    }
+
+    fn resize_increments(&self) -> Option<dpi::PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.resize_increments())
+    }
+
+    fn set_resize_increments(&self, increments: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_resize_increments(increments));
+    }
+
+    fn set_title(&self, title: &str) {
+        self.maybe_wait_on_main(|delegate| delegate.set_title(title));
+    }
+
+    fn set_transparent(&self, transparent: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_transparent(transparent));
+    }
+
+    fn set_blur(&self, blur: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_blur(blur));
+    }
+
+    fn set_visible(&self, visible: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_visible(visible));
+    }
+
+    fn is_visible(&self) -> Option<bool> {
+        self.maybe_wait_on_main(|delegate| delegate.is_visible())
+    }
+
+    fn set_resizable(&self, resizable: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_resizable(resizable))
+    }
+
+    fn is_resizable(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_resizable())
+    }
+
+    fn set_enabled_buttons(&self, buttons: WindowButtons) {
+        self.maybe_wait_on_main(|delegate| delegate.set_enabled_buttons(buttons))
+    }
+
+    fn enabled_buttons(&self) -> WindowButtons {
+        self.maybe_wait_on_main(|delegate| delegate.enabled_buttons())
+    }
+
+    fn set_minimized(&self, minimized: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_minimized(minimized));
+    }
+
+    fn is_minimized(&self) -> Option<bool> {
+        self.maybe_wait_on_main(|delegate| delegate.is_minimized())
+    }
+
+    fn set_maximized(&self, maximized: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_maximized(maximized));
+    }
+
+    fn is_maximized(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_maximized())
+    }
+
+    fn set_fullscreen(&self, fullscreen: Option<crate::window::Fullscreen>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_fullscreen(fullscreen.map(Into::into)))
+    }
+
+    fn fullscreen(&self) -> Option<crate::window::Fullscreen> {
+        self.maybe_wait_on_main(|delegate| delegate.fullscreen().map(Into::into))
+    }
+
+    fn set_decorations(&self, decorations: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_decorations(decorations));
+    }
+
+    fn is_decorated(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_decorated())
+    }
+
+    fn set_window_level(&self, level: WindowLevel) {
+        self.maybe_wait_on_main(|delegate| delegate.set_window_level(level));
+    }
+
+    fn set_window_icon(&self, window_icon: Option<Icon>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_window_icon(window_icon));
+    }
+
+    fn set_ime_cursor_area(&self, position: Position, size: Size) {
+        self.maybe_wait_on_main(|delegate| delegate.set_ime_cursor_area(position, size));
+    }
+
+    fn set_ime_allowed(&self, allowed: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_ime_allowed(allowed));
+    }
+
+    fn set_ime_purpose(&self, purpose: ImePurpose) {
+        self.maybe_wait_on_main(|delegate| delegate.set_ime_purpose(purpose));
+    }
+
+    fn focus_window(&self) {
+        self.maybe_wait_on_main(|delegate| delegate.focus_window());
+    }
+
+    fn has_focus(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.has_focus())
+    }
+
+    fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
+        self.maybe_wait_on_main(|delegate| delegate.request_user_attention(request_type));
+    }
+
+    fn set_theme(&self, theme: Option<Theme>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_theme(theme));
+    }
+
+    fn theme(&self) -> Option<Theme> {
+        self.maybe_wait_on_main(|delegate| delegate.theme())
+    }
+
+    fn set_content_protected(&self, protected: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_content_protected(protected));
+    }
+
+    fn title(&self) -> String {
+        self.maybe_wait_on_main(|delegate| delegate.title())
+    }
+
+    fn set_cursor(&self, cursor: Cursor) {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor(cursor));
+    }
+
+    fn set_cursor_position(&self, position: Position) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor_position(position))
+    }
+
+    fn set_cursor_grab(
+        &self,
+        mode: crate::window::CursorGrabMode,
+    ) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor_grab(mode))
+    }
+
+    fn set_cursor_visible(&self, visible: bool) {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor_visible(visible))
+    }
+
+    fn drag_window(&self) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.drag_window())
+    }
+
+    fn drag_resize_window(
+        &self,
+        direction: crate::window::ResizeDirection,
+    ) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.drag_resize_window(direction))
+    }
+
+    fn show_window_menu(&self, position: Position) {
+        self.maybe_wait_on_main(|delegate| delegate.show_window_menu(position))
+    }
+
+    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), crate::error::ExternalError> {
+        self.maybe_wait_on_main(|delegate| delegate.set_cursor_hittest(hittest))
+    }
+
+    fn current_monitor(&self) -> Option<CoreMonitorHandle> {
+        self.maybe_wait_on_main(|delegate| {
+            delegate.current_monitor().map(|inner| CoreMonitorHandle { inner })
+        })
+    }
+
+    fn available_monitors(&self) -> Box<dyn Iterator<Item = CoreMonitorHandle>> {
+        self.maybe_wait_on_main(|delegate| {
+            Box::new(
+                delegate.available_monitors().into_iter().map(|inner| CoreMonitorHandle { inner }),
+            )
+        })
+    }
+
+    fn primary_monitor(&self) -> Option<CoreMonitorHandle> {
+        self.maybe_wait_on_main(|delegate| {
+            delegate.primary_monitor().map(|inner| CoreMonitorHandle { inner })
+        })
+    }
+
+    #[cfg(feature = "rwh_06")]
+    fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
+        self
+    }
+
+    #[cfg(feature = "rwh_06")]
+    fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
+        self
     }
 }
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -3,7 +3,6 @@
 #[cfg(all(not(x11_platform), not(wayland_platform)))]
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
-use std::collections::VecDeque;
 use std::num::{NonZeroU16, NonZeroU32};
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::sync::Arc;
@@ -19,22 +18,19 @@ pub(crate) use self::common::xkb::{physicalkey_to_scancode, scancode_to_physical
 use self::x11::{X11Error, XConnection, XError, XNotSupported};
 use crate::application::ApplicationHandler;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
-use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
-use crate::error::{EventLoopError, ExternalError, NotSupportedError};
-use crate::event_loop::{ActiveEventLoop, AsyncRequestSerial};
-use crate::icon::Icon;
+#[cfg(x11_platform)]
+use crate::dpi::Size;
+use crate::dpi::{PhysicalPosition, PhysicalSize};
+use crate::error::EventLoopError;
+use crate::event_loop::ActiveEventLoop;
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 use crate::keyboard::Key;
 use crate::platform::pump_events::PumpStatus;
 #[cfg(x11_platform)]
 use crate::platform::x11::{WindowType as XWindowType, XlibErrorHook};
-pub(crate) use crate::platform_impl::Fullscreen;
 #[cfg(x11_platform)]
 use crate::utils::Lazy;
-use crate::window::{
-    ActivationToken, Cursor, CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType,
-    WindowButtons, WindowLevel,
-};
+use crate::window::ActivationToken;
 
 pub(crate) mod common;
 #[cfg(wayland_platform)]
@@ -135,13 +131,6 @@ impl fmt::Display for OsError {
             OsError::WaylandError(ref e) => fmt::Display::fmt(e, _f),
         }
     }
-}
-
-pub(crate) enum Window {
-    #[cfg(x11_platform)]
-    X(x11::Window),
-    #[cfg(wayland_platform)]
-    Wayland(wayland::Window),
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -294,316 +283,6 @@ impl VideoModeHandle {
     #[inline]
     pub fn monitor(&self) -> MonitorHandle {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.monitor(); as MonitorHandle)
-    }
-}
-
-impl Window {
-    pub(crate) fn maybe_queue_on_main(&self, f: impl FnOnce(&Self) + Send + 'static) {
-        f(self)
-    }
-
-    pub(crate) fn maybe_wait_on_main<R: Send>(&self, f: impl FnOnce(&Self) -> R + Send) -> R {
-        f(self)
-    }
-
-    #[inline]
-    pub fn id(&self) -> WindowId {
-        x11_or_wayland!(match self; Window(w) => w.id())
-    }
-
-    #[inline]
-    pub fn set_title(&self, title: &str) {
-        x11_or_wayland!(match self; Window(w) => w.set_title(title));
-    }
-
-    #[inline]
-    pub fn set_transparent(&self, transparent: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_transparent(transparent));
-    }
-
-    #[inline]
-    pub fn set_blur(&self, blur: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_blur(blur));
-    }
-
-    #[inline]
-    pub fn set_visible(&self, visible: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_visible(visible))
-    }
-
-    #[inline]
-    pub fn is_visible(&self) -> Option<bool> {
-        x11_or_wayland!(match self; Window(w) => w.is_visible())
-    }
-
-    #[inline]
-    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-        x11_or_wayland!(match self; Window(w) => w.outer_position())
-    }
-
-    #[inline]
-    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-        x11_or_wayland!(match self; Window(w) => w.inner_position())
-    }
-
-    #[inline]
-    pub fn set_outer_position(&self, position: Position) {
-        x11_or_wayland!(match self; Window(w) => w.set_outer_position(position))
-    }
-
-    #[inline]
-    pub fn inner_size(&self) -> PhysicalSize<u32> {
-        x11_or_wayland!(match self; Window(w) => w.inner_size())
-    }
-
-    #[inline]
-    pub fn outer_size(&self) -> PhysicalSize<u32> {
-        x11_or_wayland!(match self; Window(w) => w.outer_size())
-    }
-
-    #[inline]
-    pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
-        x11_or_wayland!(match self; Window(w) => w.request_inner_size(size))
-    }
-
-    #[inline]
-    pub(crate) fn request_activation_token(&self) -> Result<AsyncRequestSerial, NotSupportedError> {
-        x11_or_wayland!(match self; Window(w) => w.request_activation_token())
-    }
-
-    #[inline]
-    pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
-        x11_or_wayland!(match self; Window(w) => w.set_min_inner_size(dimensions))
-    }
-
-    #[inline]
-    pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
-        x11_or_wayland!(match self; Window(w) => w.set_max_inner_size(dimensions))
-    }
-
-    #[inline]
-    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
-        x11_or_wayland!(match self; Window(w) => w.resize_increments())
-    }
-
-    #[inline]
-    pub fn set_resize_increments(&self, increments: Option<Size>) {
-        x11_or_wayland!(match self; Window(w) => w.set_resize_increments(increments))
-    }
-
-    #[inline]
-    pub fn set_resizable(&self, resizable: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_resizable(resizable))
-    }
-
-    #[inline]
-    pub fn is_resizable(&self) -> bool {
-        x11_or_wayland!(match self; Window(w) => w.is_resizable())
-    }
-
-    #[inline]
-    pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
-        x11_or_wayland!(match self; Window(w) => w.set_enabled_buttons(buttons))
-    }
-
-    #[inline]
-    pub fn enabled_buttons(&self) -> WindowButtons {
-        x11_or_wayland!(match self; Window(w) => w.enabled_buttons())
-    }
-
-    #[inline]
-    pub fn set_cursor(&self, cursor: Cursor) {
-        x11_or_wayland!(match self; Window(w) => w.set_cursor(cursor))
-    }
-
-    #[inline]
-    pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
-        x11_or_wayland!(match self; Window(window) => window.set_cursor_grab(mode))
-    }
-
-    #[inline]
-    pub fn set_cursor_visible(&self, visible: bool) {
-        x11_or_wayland!(match self; Window(window) => window.set_cursor_visible(visible))
-    }
-
-    #[inline]
-    pub fn drag_window(&self) -> Result<(), ExternalError> {
-        x11_or_wayland!(match self; Window(window) => window.drag_window())
-    }
-
-    #[inline]
-    pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
-        x11_or_wayland!(match self; Window(window) => window.drag_resize_window(direction))
-    }
-
-    #[inline]
-    pub fn show_window_menu(&self, position: Position) {
-        x11_or_wayland!(match self; Window(w) => w.show_window_menu(position))
-    }
-
-    #[inline]
-    pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
-        x11_or_wayland!(match self; Window(w) => w.set_cursor_hittest(hittest))
-    }
-
-    #[inline]
-    pub fn scale_factor(&self) -> f64 {
-        x11_or_wayland!(match self; Window(w) => w.scale_factor())
-    }
-
-    #[inline]
-    pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
-        x11_or_wayland!(match self; Window(w) => w.set_cursor_position(position))
-    }
-
-    #[inline]
-    pub fn set_maximized(&self, maximized: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_maximized(maximized))
-    }
-
-    #[inline]
-    pub fn is_maximized(&self) -> bool {
-        x11_or_wayland!(match self; Window(w) => w.is_maximized())
-    }
-
-    #[inline]
-    pub fn set_minimized(&self, minimized: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_minimized(minimized))
-    }
-
-    #[inline]
-    pub fn is_minimized(&self) -> Option<bool> {
-        x11_or_wayland!(match self; Window(w) => w.is_minimized())
-    }
-
-    #[inline]
-    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
-        x11_or_wayland!(match self; Window(w) => w.fullscreen())
-    }
-
-    #[inline]
-    pub(crate) fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
-        x11_or_wayland!(match self; Window(w) => w.set_fullscreen(monitor))
-    }
-
-    #[inline]
-    pub fn set_decorations(&self, decorations: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_decorations(decorations))
-    }
-
-    #[inline]
-    pub fn is_decorated(&self) -> bool {
-        x11_or_wayland!(match self; Window(w) => w.is_decorated())
-    }
-
-    #[inline]
-    pub fn set_window_level(&self, level: WindowLevel) {
-        x11_or_wayland!(match self; Window(w) => w.set_window_level(level))
-    }
-
-    #[inline]
-    pub fn set_window_icon(&self, window_icon: Option<Icon>) {
-        x11_or_wayland!(match self; Window(w) => w.set_window_icon(window_icon.map(|icon| icon.inner)))
-    }
-
-    #[inline]
-    pub fn set_ime_cursor_area(&self, position: Position, size: Size) {
-        x11_or_wayland!(match self; Window(w) => w.set_ime_cursor_area(position, size))
-    }
-
-    #[inline]
-    pub fn reset_dead_keys(&self) {
-        common::xkb::reset_dead_keys()
-    }
-
-    #[inline]
-    pub fn set_ime_allowed(&self, allowed: bool) {
-        x11_or_wayland!(match self; Window(w) => w.set_ime_allowed(allowed))
-    }
-
-    #[inline]
-    pub fn set_ime_purpose(&self, purpose: ImePurpose) {
-        x11_or_wayland!(match self; Window(w) => w.set_ime_purpose(purpose))
-    }
-
-    #[inline]
-    pub fn focus_window(&self) {
-        x11_or_wayland!(match self; Window(w) => w.focus_window())
-    }
-
-    pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
-        x11_or_wayland!(match self; Window(w) => w.request_user_attention(request_type))
-    }
-
-    #[inline]
-    pub fn request_redraw(&self) {
-        x11_or_wayland!(match self; Window(w) => w.request_redraw())
-    }
-
-    #[inline]
-    pub fn pre_present_notify(&self) {
-        x11_or_wayland!(match self; Window(w) => w.pre_present_notify())
-    }
-
-    #[inline]
-    pub fn current_monitor(&self) -> Option<MonitorHandle> {
-        Some(x11_or_wayland!(match self; Window(w) => w.current_monitor()?; as MonitorHandle))
-    }
-
-    #[inline]
-    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        match self {
-            #[cfg(x11_platform)]
-            Window::X(ref window) => {
-                window.available_monitors().into_iter().map(MonitorHandle::X).collect()
-            },
-            #[cfg(wayland_platform)]
-            Window::Wayland(ref window) => {
-                window.available_monitors().into_iter().map(MonitorHandle::Wayland).collect()
-            },
-        }
-    }
-
-    #[inline]
-    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        Some(x11_or_wayland!(match self; Window(w) => w.primary_monitor()?; as MonitorHandle))
-    }
-
-    #[cfg(feature = "rwh_06")]
-    #[inline]
-    pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
-        x11_or_wayland!(match self; Window(window) => window.raw_window_handle_rwh_06())
-    }
-
-    #[cfg(feature = "rwh_06")]
-    #[inline]
-    pub fn raw_display_handle_rwh_06(
-        &self,
-    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
-        x11_or_wayland!(match self; Window(window) => window.raw_display_handle_rwh_06())
-    }
-
-    #[inline]
-    pub fn set_theme(&self, theme: Option<Theme>) {
-        x11_or_wayland!(match self; Window(window) => window.set_theme(theme))
-    }
-
-    #[inline]
-    pub fn theme(&self) -> Option<Theme> {
-        x11_or_wayland!(match self; Window(window) => window.theme())
-    }
-
-    pub fn set_content_protected(&self, protected: bool) {
-        x11_or_wayland!(match self; Window(window) => window.set_content_protected(protected))
-    }
-
-    #[inline]
-    pub fn has_focus(&self) -> bool {
-        x11_or_wayland!(match self; Window(window) => window.has_focus())
-    }
-
-    pub fn title(&self) -> String {
-        x11_or_wayland!(match self; Window(window) => window.title())
     }
 }
 

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -628,10 +628,9 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: crate::window::WindowAttributes,
-    ) -> Result<crate::window::Window, RootOsError> {
+    ) -> Result<Box<dyn crate::window::Window>, RootOsError> {
         let window = crate::platform_impl::wayland::Window::new(self, window_attributes)?;
-        let window = crate::platform_impl::Window::Wayland(window);
-        Ok(crate::window::Window { window })
+        Ok(Box::new(window))
     }
 
     fn available_monitors(&self) -> Box<dyn Iterator<Item = crate::monitor::MonitorHandle>> {

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -23,8 +23,10 @@ use crate::keyboard::{
     Key, KeyCode, KeyLocation, ModifiersKeys, ModifiersState, NamedKey, NativeKey, NativeKeyCode,
     PhysicalKey,
 };
+use crate::platform_impl::Window;
 use crate::window::{
-    CustomCursor as RootCustomCursor, CustomCursorSource, Theme, WindowId as RootWindowId,
+    CustomCursor as RootCustomCursor, CustomCursorSource, Theme, Window as CoreWindow,
+    WindowId as RootWindowId,
 };
 
 fn convert_scancode(scancode: u8) -> (PhysicalKey, Option<NamedKey>) {
@@ -729,9 +731,8 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: crate::window::WindowAttributes,
-    ) -> Result<crate::window::Window, crate::error::OsError> {
-        let window = crate::platform_impl::Window::new(self, window_attributes)?;
-        Ok(crate::window::Window { window })
+    ) -> Result<Box<dyn CoreWindow>, crate::error::OsError> {
+        Ok(Box::new(Window::new(self, window_attributes)?))
     }
 
     fn create_custom_cursor(

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -6,9 +6,9 @@ use super::{
 };
 use crate::cursor::Cursor;
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
-use crate::platform_impl::Fullscreen;
-use crate::window::ImePurpose;
-use crate::{error, window};
+use crate::error;
+use crate::monitor::MonitorHandle as CoreMonitorHandle;
+use crate::window::{self, Fullscreen, ImePurpose, Window as CoreWindow, WindowId as CoreWindowId};
 
 // These values match the values uses in the `window_new` function in orbital:
 // https://gitlab.redox-os.org/redox-os/orbital/-/blob/master/src/scheme.rs
@@ -125,14 +125,6 @@ impl Window {
         })
     }
 
-    pub(crate) fn maybe_queue_on_main(&self, f: impl FnOnce(&Self) + Send + 'static) {
-        f(self)
-    }
-
-    pub(crate) fn maybe_wait_on_main<R: Send>(&self, f: impl FnOnce(&Self) -> R + Send) -> R {
-        f(self)
-    }
-
     fn get_flag(&self, flag: char) -> Result<bool, error::ExternalError> {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self
@@ -150,36 +142,51 @@ impl Window {
         Ok(())
     }
 
+    #[cfg(feature = "rwh_06")]
     #[inline]
-    pub fn id(&self) -> WindowId {
-        WindowId { fd: self.window_socket.fd as u64 }
+    fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
+        let handle = rwh_06::OrbitalWindowHandle::new({
+            let window = self.window_socket.fd as *mut _;
+            std::ptr::NonNull::new(window).expect("orbital fd should never be null")
+        });
+        Ok(rwh_06::RawWindowHandle::Orbital(handle))
+    }
+
+    #[cfg(feature = "rwh_06")]
+    #[inline]
+    fn raw_display_handle_rwh_06(&self) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
+        Ok(rwh_06::RawDisplayHandle::Orbital(rwh_06::OrbitalDisplayHandle::new()))
+    }
+}
+
+impl CoreWindow for Window {
+    fn id(&self) -> CoreWindowId {
+        CoreWindowId(WindowId { fd: self.window_socket.fd as u64 })
     }
 
     #[inline]
-    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        Some(MonitorHandle)
+    fn primary_monitor(&self) -> Option<CoreMonitorHandle> {
+        Some(CoreMonitorHandle { inner: MonitorHandle })
     }
 
     #[inline]
-    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        let mut v = VecDeque::with_capacity(1);
-        v.push_back(MonitorHandle);
-        v
+    fn available_monitors(&self) -> Box<dyn Iterator<Item = CoreMonitorHandle>> {
+        Box::new(vec![CoreMonitorHandle { inner: MonitorHandle }].into_iter())
     }
 
     #[inline]
-    pub fn current_monitor(&self) -> Option<MonitorHandle> {
-        Some(MonitorHandle)
+    fn current_monitor(&self) -> Option<CoreMonitorHandle> {
+        Some(CoreMonitorHandle { inner: MonitorHandle })
     }
 
     #[inline]
-    pub fn scale_factor(&self) -> f64 {
+    fn scale_factor(&self) -> f64 {
         MonitorHandle.scale_factor()
     }
 
     #[inline]
-    pub fn request_redraw(&self) {
-        let window_id = self.id();
+    fn request_redraw(&self) {
+        let window_id = self.id().0;
         let mut redraws = self.redraws.lock().unwrap();
         if !redraws.contains(&window_id) {
             redraws.push_back(window_id);
@@ -189,15 +196,15 @@ impl Window {
     }
 
     #[inline]
-    pub fn pre_present_notify(&self) {}
+    fn pre_present_notify(&self) {}
 
     #[inline]
-    pub fn reset_dead_keys(&self) {
+    fn reset_dead_keys(&self) {
         // TODO?
     }
 
     #[inline]
-    pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
+    fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self.window_socket.fpath(&mut buf).expect("failed to read properties");
         let properties = WindowProperties::new(path);
@@ -205,20 +212,20 @@ impl Window {
     }
 
     #[inline]
-    pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
+    fn outer_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
         // TODO: adjust for window decorations
         self.inner_position()
     }
 
     #[inline]
-    pub fn set_outer_position(&self, position: Position) {
+    fn set_outer_position(&self, position: Position) {
         // TODO: adjust for window decorations
         let (x, y): (i32, i32) = position.to_physical::<i32>(self.scale_factor()).into();
         self.window_socket.write(format!("P,{x},{y}").as_bytes()).expect("failed to set position");
     }
 
     #[inline]
-    pub fn inner_size(&self) -> PhysicalSize<u32> {
+    fn inner_size(&self) -> PhysicalSize<u32> {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self.window_socket.fpath(&mut buf).expect("failed to read properties");
         let properties = WindowProperties::new(path);
@@ -226,26 +233,26 @@ impl Window {
     }
 
     #[inline]
-    pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
+    fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let (w, h): (u32, u32) = size.to_physical::<u32>(self.scale_factor()).into();
         self.window_socket.write(format!("S,{w},{h}").as_bytes()).expect("failed to set size");
         None
     }
 
     #[inline]
-    pub fn outer_size(&self) -> PhysicalSize<u32> {
+    fn outer_size(&self) -> PhysicalSize<u32> {
         // TODO: adjust for window decorations
         self.inner_size()
     }
 
     #[inline]
-    pub fn set_min_inner_size(&self, _: Option<Size>) {}
+    fn set_min_inner_size(&self, _: Option<Size>) {}
 
     #[inline]
-    pub fn set_max_inner_size(&self, _: Option<Size>) {}
+    fn set_max_inner_size(&self, _: Option<Size>) {}
 
     #[inline]
-    pub fn title(&self) -> String {
+    fn title(&self) -> String {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self.window_socket.fpath(&mut buf).expect("failed to read properties");
         let properties = WindowProperties::new(path);
@@ -253,84 +260,82 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_title(&self, title: &str) {
+    fn set_title(&self, title: &str) {
         self.window_socket.write(format!("T,{title}").as_bytes()).expect("failed to set title");
     }
 
     #[inline]
-    pub fn set_transparent(&self, transparent: bool) {
+    fn set_transparent(&self, transparent: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_TRANSPARENT, transparent);
     }
 
     #[inline]
-    pub fn set_blur(&self, _blur: bool) {}
+    fn set_blur(&self, _blur: bool) {}
 
     #[inline]
-    pub fn set_visible(&self, visible: bool) {
+    fn set_visible(&self, visible: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_HIDDEN, !visible);
     }
 
     #[inline]
-    pub fn is_visible(&self) -> Option<bool> {
+    fn is_visible(&self) -> Option<bool> {
         Some(!self.get_flag(ORBITAL_FLAG_HIDDEN).unwrap_or(false))
     }
 
     #[inline]
-    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+    fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
     #[inline]
-    pub fn set_resize_increments(&self, _increments: Option<Size>) {}
+    fn set_resize_increments(&self, _increments: Option<Size>) {}
 
     #[inline]
-    pub fn set_resizable(&self, resizeable: bool) {
+    fn set_resizable(&self, resizeable: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_RESIZABLE, resizeable);
     }
 
     #[inline]
-    pub fn is_resizable(&self) -> bool {
+    fn is_resizable(&self) -> bool {
         self.get_flag(ORBITAL_FLAG_RESIZABLE).unwrap_or(false)
     }
 
     #[inline]
-    pub fn set_minimized(&self, _minimized: bool) {}
+    fn set_minimized(&self, _minimized: bool) {}
 
     #[inline]
-    pub fn is_minimized(&self) -> Option<bool> {
+    fn is_minimized(&self) -> Option<bool> {
         None
     }
 
     #[inline]
-    pub fn set_maximized(&self, maximized: bool) {
+    fn set_maximized(&self, maximized: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_MAXIMIZED, maximized);
     }
 
     #[inline]
-    pub fn is_maximized(&self) -> bool {
+    fn is_maximized(&self) -> bool {
         self.get_flag(ORBITAL_FLAG_MAXIMIZED).unwrap_or(false)
     }
 
-    #[inline]
-    pub(crate) fn set_fullscreen(&self, _monitor: Option<Fullscreen>) {}
+    fn set_fullscreen(&self, _monitor: Option<Fullscreen>) {}
 
-    #[inline]
-    pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
+    fn fullscreen(&self) -> Option<Fullscreen> {
         None
     }
 
     #[inline]
-    pub fn set_decorations(&self, decorations: bool) {
+    fn set_decorations(&self, decorations: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_BORDERLESS, !decorations);
     }
 
     #[inline]
-    pub fn is_decorated(&self) -> bool {
+    fn is_decorated(&self) -> bool {
         !self.get_flag(ORBITAL_FLAG_BORDERLESS).unwrap_or(false)
     }
 
     #[inline]
-    pub fn set_window_level(&self, level: window::WindowLevel) {
+    fn set_window_level(&self, level: window::WindowLevel) {
         match level {
             window::WindowLevel::AlwaysOnBottom => {
                 let _ = self.set_flag(ORBITAL_FLAG_BACK, true);
@@ -346,36 +351,33 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_window_icon(&self, _window_icon: Option<crate::icon::Icon>) {}
+    fn set_window_icon(&self, _window_icon: Option<crate::icon::Icon>) {}
 
     #[inline]
-    pub fn set_ime_cursor_area(&self, _position: Position, _size: Size) {}
+    fn set_ime_cursor_area(&self, _position: Position, _size: Size) {}
 
     #[inline]
-    pub fn set_ime_allowed(&self, _allowed: bool) {}
+    fn set_ime_allowed(&self, _allowed: bool) {}
 
     #[inline]
-    pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
+    fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     #[inline]
-    pub fn focus_window(&self) {}
+    fn focus_window(&self) {}
 
     #[inline]
-    pub fn request_user_attention(&self, _request_type: Option<window::UserAttentionType>) {}
+    fn request_user_attention(&self, _request_type: Option<window::UserAttentionType>) {}
 
     #[inline]
-    pub fn set_cursor(&self, _: Cursor) {}
+    fn set_cursor(&self, _: Cursor) {}
 
     #[inline]
-    pub fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {
+    fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
     }
 
     #[inline]
-    pub fn set_cursor_grab(
-        &self,
-        mode: window::CursorGrabMode,
-    ) -> Result<(), error::ExternalError> {
+    fn set_cursor_grab(&self, mode: window::CursorGrabMode) -> Result<(), error::ExternalError> {
         let (grab, relative) = match mode {
             window::CursorGrabMode::None => (false, false),
             window::CursorGrabMode::Confined => (true, false),
@@ -391,12 +393,12 @@ impl Window {
     }
 
     #[inline]
-    pub fn set_cursor_visible(&self, visible: bool) {
+    fn set_cursor_visible(&self, visible: bool) {
         let _ = self.window_socket.write(format!("M,C,{}", if visible { 1 } else { 0 }).as_bytes());
     }
 
     #[inline]
-    pub fn drag_window(&self) -> Result<(), error::ExternalError> {
+    fn drag_window(&self) -> Result<(), error::ExternalError> {
         self.window_socket
             .write(b"D")
             .map_err(|err| error::ExternalError::Os(os_error!(OsError::new(err))))?;
@@ -404,7 +406,7 @@ impl Window {
     }
 
     #[inline]
-    pub fn drag_resize_window(
+    fn drag_resize_window(
         &self,
         direction: window::ResizeDirection,
     ) -> Result<(), error::ExternalError> {
@@ -425,60 +427,68 @@ impl Window {
     }
 
     #[inline]
-    pub fn show_window_menu(&self, _position: Position) {}
+    fn show_window_menu(&self, _position: Position) {}
 
     #[inline]
-    pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
+    fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
-    pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
-        let handle = rwh_06::OrbitalWindowHandle::new({
-            let window = self.window_socket.fd as *mut _;
-            std::ptr::NonNull::new(window).expect("orbital fd should never be null")
-        });
-        Ok(rwh_06::RawWindowHandle::Orbital(handle))
-    }
-
-    #[cfg(feature = "rwh_06")]
-    #[inline]
-    pub fn raw_display_handle_rwh_06(
-        &self,
-    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
-        Ok(rwh_06::RawDisplayHandle::Orbital(rwh_06::OrbitalDisplayHandle::new()))
-    }
+    fn set_enabled_buttons(&self, _buttons: window::WindowButtons) {}
 
     #[inline]
-    pub fn set_enabled_buttons(&self, _buttons: window::WindowButtons) {}
-
-    #[inline]
-    pub fn enabled_buttons(&self) -> window::WindowButtons {
+    fn enabled_buttons(&self) -> window::WindowButtons {
         window::WindowButtons::all()
     }
 
     #[inline]
-    pub fn theme(&self) -> Option<window::Theme> {
+    fn theme(&self) -> Option<window::Theme> {
         None
     }
 
     #[inline]
-    pub fn has_focus(&self) -> bool {
+    fn has_focus(&self) -> bool {
         false
     }
 
     #[inline]
-    pub fn set_theme(&self, _theme: Option<window::Theme>) {}
+    fn set_theme(&self, _theme: Option<window::Theme>) {}
 
-    pub fn set_content_protected(&self, _protected: bool) {}
+    fn set_content_protected(&self, _protected: bool) {}
+
+    #[cfg(feature = "rwh_06")]
+    fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
+        self
+    }
+
+    #[cfg(feature = "rwh_06")]
+    fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
+        self
+    }
+}
+
+#[cfg(feature = "rwh_06")]
+impl rwh_06::HasWindowHandle for Window {
+    fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
+        let raw = self.raw_window_handle_rwh_06()?;
+        unsafe { Ok(rwh_06::WindowHandle::borrow_raw(raw)) }
+    }
+}
+
+#[cfg(feature = "rwh_06")]
+impl rwh_06::HasDisplayHandle for Window {
+    fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
+        let raw = self.raw_display_handle_rwh_06()?;
+        unsafe { Ok(rwh_06::DisplayHandle::borrow_raw(raw)) }
+    }
 }
 
 impl Drop for Window {
     fn drop(&mut self) {
         {
             let mut destroys = self.destroys.lock().unwrap();
-            destroys.push_back(self.id());
+            destroys.push_back(self.id().0);
         }
 
         self.wake_socket.wake().unwrap();

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -27,8 +27,7 @@ use crate::platform_impl::platform::cursor::CustomCursor;
 use crate::platform_impl::platform::r#async::Waker;
 use crate::platform_impl::Window;
 use crate::window::{
-    CustomCursor as RootCustomCursor, CustomCursorSource, Theme, Window as RootWindow,
-    WindowId as RootWindowId,
+    CustomCursor as RootCustomCursor, CustomCursorSource, Theme, WindowId as RootWindowId,
 };
 
 #[derive(Default)]
@@ -632,9 +631,9 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: crate::window::WindowAttributes,
-    ) -> Result<crate::window::Window, crate::error::OsError> {
+    ) -> Result<Box<dyn crate::window::Window>, crate::error::OsError> {
         let window = Window::new(self, window_attributes)?;
-        Ok(RootWindow { window })
+        Ok(Box::new(window))
     }
 
     fn create_custom_cursor(

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -51,4 +51,3 @@ pub(crate) use self::monitor::{
 use self::web_sys as backend;
 pub use self::window::{PlatformSpecificWindowAttributes, Window, WindowId};
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
-pub(crate) use crate::platform_impl::Fullscreen;

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -29,6 +29,7 @@ use super::main_thread::MainThreadMarker;
 use super::r#async::{Dispatcher, Notified, Notifier};
 use super::web_sys::{Engine, EventListenerHandle};
 use crate::dpi::{PhysicalPosition, PhysicalSize};
+use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform::web::{
     MonitorPermissionError, Orientation, OrientationData, OrientationLock, OrientationLockError,
 };
@@ -185,6 +186,12 @@ impl PartialEq for MonitorHandle {
 impl PartialOrd for MonitorHandle {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl From<MonitorHandle> for RootMonitorHandle {
+    fn from(inner: MonitorHandle) -> Self {
+        RootMonitorHandle { inner }
     }
 }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -86,8 +86,8 @@ use crate::platform_impl::platform::{
 use crate::platform_impl::Window;
 use crate::utils::Lazy;
 use crate::window::{
-    CustomCursor as RootCustomCursor, CustomCursorSource, Theme, Window as RootWindow,
-    WindowAttributes, WindowId as RootWindowId,
+    CustomCursor as RootCustomCursor, CustomCursorSource, Theme, Window as CoreWindow,
+    WindowAttributes, WindowId as CoreWindowId,
 };
 
 pub(crate) struct WindowData {
@@ -518,9 +518,11 @@ impl RootActiveEventLoop for ActiveEventLoop {
         RootEventLoopProxy { event_loop_proxy }
     }
 
-    fn create_window(&self, window_attributes: WindowAttributes) -> Result<RootWindow, OsError> {
-        let window = Window::new(self, window_attributes)?;
-        Ok(RootWindow { window })
+    fn create_window(
+        &self,
+        window_attributes: WindowAttributes,
+    ) -> Result<Box<dyn CoreWindow>, OsError> {
+        Ok(Box::new(Window::new(self, window_attributes)?))
     }
 
     fn create_custom_cursor(
@@ -918,7 +920,7 @@ fn update_modifiers(window: HWND, userdata: &WindowData) {
         drop(window_state);
 
         userdata.send_event(Event::WindowEvent {
-            window_id: RootWindowId(WindowId(window)),
+            window_id: CoreWindowId(WindowId(window)),
             event: ModifiersChanged(modifiers.into()),
         });
     }
@@ -930,7 +932,7 @@ unsafe fn gain_active_focus(window: HWND, userdata: &WindowData) {
     update_modifiers(window, userdata);
 
     userdata.send_event(Event::WindowEvent {
-        window_id: RootWindowId(WindowId(window)),
+        window_id: CoreWindowId(WindowId(window)),
         event: Focused(true),
     });
 }
@@ -940,12 +942,12 @@ unsafe fn lose_active_focus(window: HWND, userdata: &WindowData) {
 
     userdata.window_state_lock().modifiers_state = ModifiersState::empty();
     userdata.send_event(Event::WindowEvent {
-        window_id: RootWindowId(WindowId(window)),
+        window_id: CoreWindowId(WindowId(window)),
         event: ModifiersChanged(ModifiersState::empty().into()),
     });
 
     userdata.send_event(Event::WindowEvent {
-        window_id: RootWindowId(WindowId(window)),
+        window_id: CoreWindowId(WindowId(window)),
         event: Focused(false),
     });
 }
@@ -1043,7 +1045,7 @@ unsafe fn public_window_callback_inner(
             userdata.key_event_builder.process_message(window, msg, wparam, lparam, &mut result);
         for event in events {
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: KeyboardInput {
                     device_id: DEVICE_ID,
                     event: event.event,
@@ -1128,7 +1130,7 @@ unsafe fn public_window_callback_inner(
         WM_CLOSE => {
             use crate::event::WindowEvent::CloseRequested;
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: CloseRequested,
             });
             result = ProcResult::Value(0);
@@ -1138,7 +1140,7 @@ unsafe fn public_window_callback_inner(
             use crate::event::WindowEvent::Destroyed;
             unsafe { RevokeDragDrop(window) };
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: Destroyed,
             });
             result = ProcResult::Value(0);
@@ -1159,7 +1161,7 @@ unsafe fn public_window_callback_inner(
             // and request a normal redraw with `RedrawWindow`.
             if !userdata.event_loop_runner.should_buffer() {
                 userdata.send_event(Event::WindowEvent {
-                    window_id: RootWindowId(WindowId(window)),
+                    window_id: CoreWindowId(WindowId(window)),
                     event: WindowEvent::RedrawRequested,
                 });
             }
@@ -1262,7 +1264,7 @@ unsafe fn public_window_callback_inner(
                 let physical_position =
                     unsafe { PhysicalPosition::new((*windowpos).x, (*windowpos).y) };
                 userdata.send_event(Event::WindowEvent {
-                    window_id: RootWindowId(WindowId(window)),
+                    window_id: CoreWindowId(WindowId(window)),
                     event: Moved(physical_position),
                 });
             }
@@ -1278,7 +1280,7 @@ unsafe fn public_window_callback_inner(
 
             let physical_size = PhysicalSize::new(w, h);
             let event = Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: Resized(physical_size),
             };
 
@@ -1393,7 +1395,7 @@ unsafe fn public_window_callback_inner(
                 userdata.window_state_lock().ime_state = ImeState::Enabled;
 
                 userdata.send_event(Event::WindowEvent {
-                    window_id: RootWindowId(WindowId(window)),
+                    window_id: CoreWindowId(WindowId(window)),
                     event: WindowEvent::Ime(Ime::Enabled),
                 });
             }
@@ -1413,7 +1415,7 @@ unsafe fn public_window_callback_inner(
 
                 if lparam == 0 {
                     userdata.send_event(Event::WindowEvent {
-                        window_id: RootWindowId(WindowId(window)),
+                        window_id: CoreWindowId(WindowId(window)),
                         event: WindowEvent::Ime(Ime::Preedit(String::new(), None)),
                     });
                 }
@@ -1425,11 +1427,11 @@ unsafe fn public_window_callback_inner(
                         userdata.window_state_lock().ime_state = ImeState::Enabled;
 
                         userdata.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(WindowId(window)),
+                            window_id: CoreWindowId(WindowId(window)),
                             event: WindowEvent::Ime(Ime::Preedit(String::new(), None)),
                         });
                         userdata.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(WindowId(window)),
+                            window_id: CoreWindowId(WindowId(window)),
                             event: WindowEvent::Ime(Ime::Commit(text)),
                         });
                     }
@@ -1444,7 +1446,7 @@ unsafe fn public_window_callback_inner(
                         let cursor_range = first.map(|f| (f, last.unwrap_or(f)));
 
                         userdata.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(WindowId(window)),
+                            window_id: CoreWindowId(WindowId(window)),
                             event: WindowEvent::Ime(Ime::Preedit(text, cursor_range)),
                         });
                     }
@@ -1467,11 +1469,11 @@ unsafe fn public_window_callback_inner(
                     let ime_context = unsafe { ImeContext::current(window) };
                     if let Some(text) = unsafe { ime_context.get_composed_text() } {
                         userdata.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(WindowId(window)),
+                            window_id: CoreWindowId(WindowId(window)),
                             event: WindowEvent::Ime(Ime::Preedit(String::new(), None)),
                         });
                         userdata.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(WindowId(window)),
+                            window_id: CoreWindowId(WindowId(window)),
                             event: WindowEvent::Ime(Ime::Commit(text)),
                         });
                     }
@@ -1480,7 +1482,7 @@ unsafe fn public_window_callback_inner(
                 userdata.window_state_lock().ime_state = ImeState::Disabled;
 
                 userdata.send_event(Event::WindowEvent {
-                    window_id: RootWindowId(WindowId(window)),
+                    window_id: CoreWindowId(WindowId(window)),
                     event: WindowEvent::Ime(Ime::Disabled),
                 });
             }
@@ -1538,7 +1540,7 @@ unsafe fn public_window_callback_inner(
 
                         drop(w);
                         userdata.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(WindowId(window)),
+                            window_id: CoreWindowId(WindowId(window)),
                             event: CursorEntered { device_id: DEVICE_ID },
                         });
 
@@ -1559,7 +1561,7 @@ unsafe fn public_window_callback_inner(
 
                         drop(w);
                         userdata.send_event(Event::WindowEvent {
-                            window_id: RootWindowId(WindowId(window)),
+                            window_id: CoreWindowId(WindowId(window)),
                             event: CursorLeft { device_id: DEVICE_ID },
                         });
                     },
@@ -1578,7 +1580,7 @@ unsafe fn public_window_callback_inner(
                 update_modifiers(window, userdata);
 
                 userdata.send_event(Event::WindowEvent {
-                    window_id: RootWindowId(WindowId(window)),
+                    window_id: CoreWindowId(WindowId(window)),
                     event: CursorMoved { device_id: DEVICE_ID, position },
                 });
             }
@@ -1594,7 +1596,7 @@ unsafe fn public_window_callback_inner(
             }
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: CursorLeft { device_id: DEVICE_ID },
             });
 
@@ -1610,7 +1612,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: WindowEvent::MouseWheel {
                     device_id: DEVICE_ID,
                     delta: LineDelta(0.0, value),
@@ -1630,7 +1632,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: WindowEvent::MouseWheel {
                     device_id: DEVICE_ID,
                     delta: LineDelta(value, 0.0),
@@ -1665,7 +1667,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Left },
             });
             result = ProcResult::Value(0);
@@ -1681,7 +1683,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Released, button: Left },
             });
             result = ProcResult::Value(0);
@@ -1697,7 +1699,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Right },
             });
             result = ProcResult::Value(0);
@@ -1713,7 +1715,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Released, button: Right },
             });
             result = ProcResult::Value(0);
@@ -1729,7 +1731,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Middle },
             });
             result = ProcResult::Value(0);
@@ -1745,7 +1747,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput { device_id: DEVICE_ID, state: Released, button: Middle },
             });
             result = ProcResult::Value(0);
@@ -1762,7 +1764,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
                     state: Pressed,
@@ -1787,7 +1789,7 @@ unsafe fn public_window_callback_inner(
             update_modifiers(window, userdata);
 
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput {
                     device_id: DEVICE_ID,
                     state: Released,
@@ -1836,7 +1838,7 @@ unsafe fn public_window_callback_inner(
                     let y = location.y as f64 + (input.y % 100) as f64 / 100f64;
                     let location = PhysicalPosition::new(x, y);
                     userdata.send_event(Event::WindowEvent {
-                        window_id: RootWindowId(WindowId(window)),
+                        window_id: CoreWindowId(WindowId(window)),
                         event: WindowEvent::Touch(Touch {
                             phase: if util::has_flag(input.dwFlags, TOUCHEVENTF_DOWN) {
                                 TouchPhase::Started
@@ -1984,7 +1986,7 @@ unsafe fn public_window_callback_inner(
                     let y = location.y as f64 + y.fract();
                     let location = PhysicalPosition::new(x, y);
                     userdata.send_event(Event::WindowEvent {
-                        window_id: RootWindowId(WindowId(window)),
+                        window_id: CoreWindowId(WindowId(window)),
                         event: WindowEvent::Touch(Touch {
                             phase: if util::has_flag(pointer_info.pointerFlags, POINTER_FLAG_DOWN) {
                                 TouchPhase::Started
@@ -2167,7 +2169,7 @@ unsafe fn public_window_callback_inner(
 
             let new_inner_size = Arc::new(Mutex::new(new_physical_inner_size));
             userdata.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(window)),
+                window_id: CoreWindowId(WindowId(window)),
                 event: ScaleFactorChanged {
                     scale_factor: new_scale_factor,
                     inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
@@ -2319,7 +2321,7 @@ unsafe fn public_window_callback_inner(
                     window_state.current_theme = new_theme;
                     drop(window_state);
                     userdata.send_event(Event::WindowEvent {
-                        window_id: RootWindowId(WindowId(window)),
+                        window_id: CoreWindowId(WindowId(window)),
                         event: ThemeChanged(new_theme),
                     });
                 }

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -16,7 +16,6 @@ use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::monitor::VideoModeHandle as RootVideoModeHandle;
 use crate::platform_impl::platform::dpi::{dpi_to_scale_factor, get_monitor_dpi};
 use crate::platform_impl::platform::util::has_flag;
-use crate::platform_impl::platform::window::Window;
 
 #[derive(Clone)]
 pub struct VideoModeHandle {
@@ -134,17 +133,6 @@ pub fn primary_monitor() -> MonitorHandle {
 pub fn current_monitor(hwnd: HWND) -> MonitorHandle {
     let hmonitor = unsafe { MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST) };
     MonitorHandle::new(hmonitor)
-}
-
-impl Window {
-    pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
-        available_monitors()
-    }
-
-    pub fn primary_monitor(&self) -> Option<MonitorHandle> {
-        let monitor = primary_monitor();
-        Some(monitor)
-    }
 }
 
 pub(crate) fn get_monitor_info(hmonitor: HMONITOR) -> Result<MONITORINFOEXW, io::Error> {

--- a/tests/send_objects.rs
+++ b/tests/send_objects.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-fn needs_send<T: Send>() {}
+fn needs_send<T: Send + ?Sized>() {}
 
 #[test]
 fn event_loop_proxy_send() {
@@ -8,7 +8,7 @@ fn event_loop_proxy_send() {
 
 #[test]
 fn window_send() {
-    needs_send::<winit::window::Window>();
+    needs_send::<dyn winit::window::Window>();
 }
 
 #[test]

--- a/tests/sync_object.rs
+++ b/tests/sync_object.rs
@@ -1,5 +1,5 @@
 #[allow(dead_code)]
-fn needs_sync<T: Sync>() {}
+fn needs_sync<T: Sync + ?Sized>() {}
 
 #[test]
 fn event_loop_proxy_send() {
@@ -8,7 +8,7 @@ fn event_loop_proxy_send() {
 
 #[test]
 fn window_sync() {
-    needs_sync::<winit::window::Window>();
+    needs_sync::<dyn winit::window::Window>();
 }
 
 #[test]


### PR DESCRIPTION
--

The only issue right now is how to deal with `maybe_queue_on_main` and `maybe_block_on_main`. From what I can say the backends should do that themselves for the time being, since it's a _temporary_ peace unless we remove the `Send` and `Sync` from the window.

I've only did the Wayland backend and `examples/window.rs` to show how it may look.

I'd assume @daxpedda will do for `MonitorHandle` (trait is not really needed since data is used) and after that it should be pretty much ready to split backends.

The only issue I see is that we can not use generics, since they prevent object safety.

The `Drop` impl we had should also be done for backends, since it's a _backend specific_ behavior and clearly not needed on most of the backends. Though, I've kept it to simple not forget about it.