### PR TITLE
Update minimum version of `wasm-bindgen`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,12 +270,12 @@ redox_syscall = "0.4.1"
 
 # Web
 [target.'cfg(target_family = "wasm")'.dependencies]
-js-sys = "0.3.64"
+js-sys = "0.3.70"
 pin-project = "1"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
+wasm-bindgen = "0.2.93"
+wasm-bindgen-futures = "0.4.43"
 web-time = "1"
-web_sys = { package = "web-sys", version = "0.3.64", features = [
+web_sys = { package = "web-sys", version = "0.3.70", features = [
     "AbortController",
     "AbortSignal",
     "Blob",

--- a/deny.toml
+++ b/deny.toml
@@ -55,19 +55,6 @@ allow-globs = ["freetype2/*"]
 crate = "freetype-sys"
 
 [[bans.build.bypass]]
-allow = [
-    { path = "releases/friends.sh", checksum = "f896ccdcb8445d29ed6dd0d9a360f94d4f33af2f1cc9965e7bb38b156c45949d" },
-]
-crate = "wasm-bindgen"
-
-[[bans.build.bypass]]
-allow = [
-    { path = "ui-tests/update-all-references.sh", checksum = "8b8dbf31e7ada1314956db7a20ab14b13af3ae246a6295afdc7dc96af8ec3773" },
-    { path = "ui-tests/update-references.sh", checksum = "65375c25981646e08e8589449a06be4505b1a2c9e10d35f650be4b1b495dff22" },
-]
-crate = "wasm-bindgen-macro"
-
-[[bans.build.bypass]]
 allow-globs = ["lib/*.a"]
 crate = "windows_i686_gnu"
 

--- a/src/platform_impl/web/cursor.rs
+++ b/src/platform_impl/web/cursor.rs
@@ -542,8 +542,8 @@ fn from_rgba(
     //
     // We call `createImageBitmap()` before spawning the future,
     // to not have to clone the image buffer.
-    let mut options = ImageBitmapOptions::new();
-    options.premultiply_alpha(PremultiplyAlpha::None);
+    let options = ImageBitmapOptions::new();
+    options.set_premultiply_alpha(PremultiplyAlpha::None);
     let bitmap = JsFuture::from(
         window
             .create_image_bitmap_with_image_data_and_image_bitmap_options(&image_data, &options)

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -4,8 +4,7 @@ use std::iter;
 use std::ops::Deref;
 use std::rc::{Rc, Weak};
 
-use js_sys::Function;
-use wasm_bindgen::prelude::{wasm_bindgen, Closure};
+use wasm_bindgen::prelude::Closure;
 use wasm_bindgen::JsCast;
 use web_sys::{Document, KeyboardEvent, Navigator, PageTransitionEvent, PointerEvent, WheelEvent};
 use web_time::{Duration, Instant};
@@ -495,14 +494,8 @@ impl Shared {
             if let Ok(RunnerEnum::Running(_)) =
                 self.0.runner.try_borrow().as_ref().map(Deref::deref)
             {
-                #[wasm_bindgen]
-                extern "C" {
-                    #[wasm_bindgen(js_name = queueMicrotask)]
-                    fn queue_microtask(task: Function);
-                }
-
-                queue_microtask(
-                    Closure::once_into_js({
+                self.window().queue_microtask(
+                    &Closure::once_into_js({
                         let this = Rc::downgrade(&self.0);
                         move || {
                             if let Some(shared) = this.upgrade() {

--- a/src/platform_impl/web/web_sys/resize_scaling.rs
+++ b/src/platform_impl/web/web_sys/resize_scaling.rs
@@ -138,10 +138,9 @@ impl ResizeScaleInternal {
 
         // Safari doesn't support `devicePixelContentBoxSize`
         if has_device_pixel_support() {
-            observer.observe_with_options(
-                canvas,
-                ResizeObserverOptions::new().box_(ResizeObserverBoxOptions::DevicePixelContentBox),
-            );
+            let options = ResizeObserverOptions::new();
+            options.set_box(ResizeObserverBoxOptions::DevicePixelContentBox);
+            observer.observe_with_options(canvas, &options);
         } else {
             observer.observe(canvas);
         }

--- a/src/platform_impl/web/web_sys/schedule.rs
+++ b/src/platform_impl/web/web_sys/schedule.rs
@@ -275,8 +275,8 @@ struct ScriptUrl(String);
 impl ScriptUrl {
     fn new(script: &str) -> Self {
         let sequence = Array::of1(&script.into());
-        let mut property = BlobPropertyBag::new();
-        property.type_("text/javascript");
+        let property = BlobPropertyBag::new();
+        property.set_type("text/javascript");
         let blob = Blob::new_with_str_sequence_and_options(&sequence, &property)
             .expect("`new Blob()` should never throw");
 


### PR DESCRIPTION
This gets rid of:
- The shell file exceptions we accounted for in `cargo-deny`.
- The custom binding to [`queueMicrotrask()`](https://developer.mozilla.org/en-US/docs/Web/API/queueMicrotask).
- The deprecated setter methods.