### PR TITLE
Add support for MacOS ARM64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,8 @@ jobs:
           - { name: 'Wayland',            target: x86_64-unknown-linux-gnu, os: ubuntu-latest, options: '--no-default-features --features=wayland,wayland-dlopen' }
           - { name: 'Android',            target: aarch64-linux-android,    os: ubuntu-latest, options: '--package=winit --features=android-native-activity', cmd: 'apk --' }
           - { name: 'Redox OS',           target: x86_64-unknown-redox,     os: ubuntu-latest,   }
-          - { name: 'macOS',              target: x86_64-apple-darwin,      os: macos-latest,    }
+          - { name: 'macOS x86_64',       target: x86_64-apple-darwin,      os: macos-latest,    }
+          - { name: 'macOS Aarch64',      target: aarch64-apple-darwin,     os: macos-latest,    }
           - { name: 'iOS x86_64',         target: x86_64-apple-ios,         os: macos-latest,    }
           - { name: 'iOS Aarch64',        target: aarch64-apple-ios,        os: macos-latest,    }
           - { name: 'Web',                target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
@@ -243,10 +244,11 @@ jobs:
           - { name: 'Android', target: aarch64-linux-android }
           - { name: 'iOS', target: aarch64-apple-ios }
           - { name: 'Linux', target: x86_64-unknown-linux-gnu }
-          - { name: 'macOS', target: x86_64-apple-darwin }
+          - { name: 'macOS', target: aarch64-apple-darwin }
           - { name: 'Redox OS', target: x86_64-unknown-redox }
           - { name: 'Web', target: wasm32-unknown-unknown }
-          - { name: 'Windows', target: x86_64-pc-windows-gnu }
+          - { name: 'Windows GNU', target: x86_64-pc-windows-gnu }
+          - { name: 'Windows MSVC', target: x86_64-pc-windows-msvc }
 
     steps:
     - uses: taiki-e/checkout-action@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,13 @@ targets = [
     "i686-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
     # macOS
+    "aarch64-apple-darwin",
     "x86_64-apple-darwin",
     # Unix (X11 & Wayland)
     "i686-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
     # iOS
-    "x86_64-apple-ios",
+    "aarch64-apple-ios",
     # Android
     "aarch64-linux-android",
     # Web

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@
 all-features = true
 exclude-dev = true
 targets = [
+    { triple = "aarch64-apple-darwin" },
     { triple = "aarch64-apple-ios" },
     { triple = "aarch64-linux-android" },
     { triple = "i686-pc-windows-gnu" },

--- a/dpi/Cargo.toml
+++ b/dpi/Cargo.toml
@@ -26,12 +26,13 @@ targets = [
     "i686-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
     # macOS
+    "aarch64-apple-darwin",
     "x86_64-apple-darwin",
     # Unix (X11 & Wayland)
     "i686-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
     # iOS
-    "x86_64-apple-ios",
+    "aarch64-apple-ios",
     # Android
     "aarch64-linux-android",
     # Web

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -365,11 +365,11 @@ pub trait EventLoopBuilderExtMacOS {
     /// Set the activation policy to "accessory".
     ///
     /// ```
-    /// use winit::event_loop::EventLoopBuilder;
+    /// use winit::event_loop::EventLoop;
     /// #[cfg(target_os = "macos")]
     /// use winit::platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS};
     ///
-    /// let mut builder = EventLoopBuilder::new();
+    /// let mut builder = EventLoop::builder();
     /// #[cfg(target_os = "macos")]
     /// builder.with_activation_policy(ActivationPolicy::Accessory);
     /// # if false { // We can't test this part
@@ -387,11 +387,11 @@ pub trait EventLoopBuilderExtMacOS {
     /// Disable creating a default menubar.
     ///
     /// ```
-    /// use winit::event_loop::EventLoopBuilder;
+    /// use winit::event_loop::EventLoop;
     /// #[cfg(target_os = "macos")]
     /// use winit::platform::macos::EventLoopBuilderExtMacOS;
     ///
-    /// let mut builder = EventLoopBuilder::new();
+    /// let mut builder = EventLoop::builder();
     /// #[cfg(target_os = "macos")]
     /// builder.with_default_menu(false);
     /// # if false { // We can't test this part


### PR DESCRIPTION
This adds support for `aarch64-apple-darwin`, which includes no code related changes, just updating the CI and our other configurations.