### PR TITLE
Remove `dummy()` from `WindowId` and `DeviceId` and use `Option<DeviceId>`

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -522,7 +522,7 @@ impl ApplicationHandler for Application {
     fn device_event(
         &mut self,
         _event_loop: &dyn ActiveEventLoop,
-        device_id: DeviceId,
+        device_id: Option<DeviceId>,
         event: DeviceEvent,
     ) {
         info!("Device {device_id:?} event: {event:?}");

--- a/src/application.rs
+++ b/src/application.rs
@@ -196,7 +196,7 @@ pub trait ApplicationHandler {
     fn device_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
-        device_id: DeviceId,
+        device_id: Option<DeviceId>,
         event: DeviceEvent,
     ) {
         let _ = (event_loop, device_id, event);
@@ -363,7 +363,7 @@ impl<A: ?Sized + ApplicationHandler> ApplicationHandler for &mut A {
     fn device_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
-        device_id: DeviceId,
+        device_id: Option<DeviceId>,
         event: DeviceEvent,
     ) {
         (**self).device_event(event_loop, device_id, event);
@@ -431,7 +431,7 @@ impl<A: ?Sized + ApplicationHandler> ApplicationHandler for Box<A> {
     fn device_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
-        device_id: DeviceId,
+        device_id: Option<DeviceId>,
         event: DeviceEvent,
     ) {
         (**self).device_event(event_loop, device_id, event);

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -125,6 +125,8 @@ changelog entry.
   - `Window::set_max_inner_size` to `set_max_surface_size`.
 
   To migrate, you can probably just replace all instances of `inner_size` with `surface_size` in your codebase.
+- Every event carrying a `DeviceId` now uses `Option<DeviceId>` instead. A `None` value signifies that the
+  device can't be uniquely identified.
 
 ### Removed
 
@@ -153,6 +155,7 @@ changelog entry.
 - On Android, remove all `MonitorHandle` support instead of emitting false data.
 - Remove `impl From<u64> for WindowId` and `impl From<WindowId> for u64`. Replaced with
   `WindowId::into_raw()` and `from_raw()`.
+- Remove `dummy()` from `WindowId` and `DeviceId`.
 
 ### Fixed
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -316,7 +316,7 @@ impl EventLoop {
         match event {
             InputEvent::MotionEvent(motion_event) => {
                 let window_id = window::WindowId(WindowId);
-                let device_id = event::DeviceId(DeviceId(motion_event.device_id()));
+                let device_id = Some(event::DeviceId(DeviceId(motion_event.device_id())));
 
                 let phase = match motion_event.action() {
                     MotionAction::Down | MotionAction::PointerDown => {
@@ -388,7 +388,7 @@ impl EventLoop {
 
                         let window_id = window::WindowId(WindowId);
                         let event = event::WindowEvent::KeyboardInput {
-                            device_id: event::DeviceId(DeviceId(key.device_id())),
+                            device_id: Some(event::DeviceId(DeviceId(key.device_id()))),
                             event: event::KeyEvent {
                                 state,
                                 physical_key: keycodes::to_physical_key(keycode),
@@ -668,10 +668,6 @@ impl OwnedDisplayHandle {
 pub(crate) struct WindowId;
 
 impl WindowId {
-    pub const fn dummy() -> Self {
-        WindowId
-    }
-
     pub const fn into_raw(self) -> u64 {
         0
     }
@@ -684,16 +680,11 @@ impl WindowId {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DeviceId(i32);
 
-impl DeviceId {
-    pub const fn dummy() -> Self {
-        DeviceId(0)
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FingerId(i32);
 
 impl FingerId {
+    #[cfg(test)]
     pub const fn dummy() -> Self {
         FingerId(0)
     }

--- a/src/platform_impl/apple/appkit/app.rs
+++ b/src/platform_impl/apple/appkit/app.rs
@@ -7,7 +7,6 @@ use objc2_app_kit::{NSApplication, NSEvent, NSEventModifierFlags, NSEventType, N
 use objc2_foundation::{MainThreadMarker, NSObject};
 
 use super::app_state::AppState;
-use super::DEVICE_ID;
 use crate::event::{DeviceEvent, ElementState};
 
 declare_class!(
@@ -61,7 +60,7 @@ fn maybe_dispatch_device_event(app_state: &Rc<AppState>, event: &NSEvent) {
 
             if delta_x != 0.0 || delta_y != 0.0 {
                 app_state.maybe_queue_with_handler(move |app, event_loop| {
-                    app.device_event(event_loop, DEVICE_ID, DeviceEvent::MouseMotion {
+                    app.device_event(event_loop, None, DeviceEvent::MouseMotion {
                         delta: (delta_x, delta_y),
                     });
                 });
@@ -70,7 +69,7 @@ fn maybe_dispatch_device_event(app_state: &Rc<AppState>, event: &NSEvent) {
         NSEventType::LeftMouseDown | NSEventType::RightMouseDown | NSEventType::OtherMouseDown => {
             let button = unsafe { event.buttonNumber() } as u32;
             app_state.maybe_queue_with_handler(move |app, event_loop| {
-                app.device_event(event_loop, DEVICE_ID, DeviceEvent::Button {
+                app.device_event(event_loop, None, DeviceEvent::Button {
                     button,
                     state: ElementState::Pressed,
                 });
@@ -79,7 +78,7 @@ fn maybe_dispatch_device_event(app_state: &Rc<AppState>, event: &NSEvent) {
         NSEventType::LeftMouseUp | NSEventType::RightMouseUp | NSEventType::OtherMouseUp => {
             let button = unsafe { event.buttonNumber() } as u32;
             app_state.maybe_queue_with_handler(move |app, event_loop| {
-                app.device_event(event_loop, DEVICE_ID, DeviceEvent::Button {
+                app.device_event(event_loop, None, DeviceEvent::Button {
                     button,
                     state: ElementState::Released,
                 });

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -24,26 +24,17 @@ pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::{Window, WindowId};
 pub(crate) use self::window_delegate::PlatformSpecificWindowAttributes;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
-use crate::event::DeviceId as RootDeviceId;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
 
-impl DeviceId {
-    pub const fn dummy() -> Self {
-        DeviceId
-    }
-}
-
-// Constant device ID; to be removed when if backend is updated to report real device IDs.
-pub(crate) const DEVICE_ID: RootDeviceId = RootDeviceId(DeviceId);
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId;
 
 impl FingerId {
+    #[cfg(test)]
     pub const fn dummy() -> Self {
         FingerId
     }

--- a/src/platform_impl/apple/appkit/view.rs
+++ b/src/platform_impl/apple/appkit/view.rs
@@ -24,7 +24,6 @@ use super::event::{
     scancode_to_physicalkey,
 };
 use super::window::WinitWindow;
-use super::DEVICE_ID;
 use crate::dpi::{LogicalPosition, LogicalSize};
 use crate::event::{
     DeviceEvent, ElementState, Ime, Modifiers, MouseButton, MouseScrollDelta, TouchPhase,
@@ -486,7 +485,7 @@ declare_class!(
             if !had_ime_input || self.ivars().forward_key_to_app.get() {
                 let key_event = create_key_event(&event, true, unsafe { event.isARepeat() }, None);
                 self.queue_event(WindowEvent::KeyboardInput {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     event: key_event,
                     is_synthetic: false,
                 });
@@ -506,7 +505,7 @@ declare_class!(
                 ImeState::Ground | ImeState::Disabled
             ) {
                 self.queue_event(WindowEvent::KeyboardInput {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     event: create_key_event(&event, false, false, None),
                     is_synthetic: false,
                 });
@@ -557,7 +556,7 @@ declare_class!(
             let event = create_key_event(&event, true, unsafe { event.isARepeat() }, None);
 
             self.queue_event(WindowEvent::KeyboardInput {
-                device_id: DEVICE_ID,
+                device_id: None,
                 event,
                 is_synthetic: false,
             });
@@ -642,7 +641,7 @@ declare_class!(
         fn mouse_entered(&self, _event: &NSEvent) {
             trace_scope!("mouseEntered:");
             self.queue_event(WindowEvent::CursorEntered {
-                device_id: DEVICE_ID,
+                device_id: None,
             });
         }
 
@@ -651,7 +650,7 @@ declare_class!(
             trace_scope!("mouseExited:");
 
             self.queue_event(WindowEvent::CursorLeft {
-                device_id: DEVICE_ID,
+                device_id: None,
             });
         }
 
@@ -689,10 +688,10 @@ declare_class!(
             self.update_modifiers(event, false);
 
             self.ivars().app_state.maybe_queue_with_handler(move |app, event_loop|
-                app.device_event(event_loop, DEVICE_ID, DeviceEvent::MouseWheel { delta })
+                app.device_event(event_loop, None, DeviceEvent::MouseWheel { delta })
             );
             self.queue_event(WindowEvent::MouseWheel {
-                device_id: DEVICE_ID,
+                device_id: None,
                 delta,
                 phase,
             });
@@ -714,7 +713,7 @@ declare_class!(
             };
 
             self.queue_event(WindowEvent::PinchGesture {
-                device_id: DEVICE_ID,
+                device_id: None,
                 delta: unsafe { event.magnification() },
                 phase,
             });
@@ -727,7 +726,7 @@ declare_class!(
             self.mouse_motion(event);
 
             self.queue_event(WindowEvent::DoubleTapGesture {
-                device_id: DEVICE_ID,
+                device_id: None,
             });
         }
 
@@ -747,7 +746,7 @@ declare_class!(
             };
 
             self.queue_event(WindowEvent::RotationGesture {
-                device_id: DEVICE_ID,
+                device_id: None,
                 delta: unsafe { event.rotation() },
                 phase,
             });
@@ -758,7 +757,7 @@ declare_class!(
             trace_scope!("pressureChangeWithEvent:");
 
             self.queue_event(WindowEvent::TouchpadPressure {
-                device_id: DEVICE_ID,
+                device_id: None,
                 pressure: unsafe { event.pressure() },
                 stage: unsafe { event.stage() } as i64,
             });
@@ -972,7 +971,7 @@ impl WinitView {
                         event.location = KeyLocation::Left;
                         event.physical_key = get_left_modifier_code(&event.logical_key).into();
                         events.push_back(WindowEvent::KeyboardInput {
-                            device_id: DEVICE_ID,
+                            device_id: None,
                             event,
                             is_synthetic: false,
                         });
@@ -981,7 +980,7 @@ impl WinitView {
                         event.location = KeyLocation::Right;
                         event.physical_key = get_right_modifier_code(&event.logical_key).into();
                         events.push_back(WindowEvent::KeyboardInput {
-                            device_id: DEVICE_ID,
+                            device_id: None,
                             event,
                             is_synthetic: false,
                         });
@@ -1012,7 +1011,7 @@ impl WinitView {
                     }
 
                     events.push_back(WindowEvent::KeyboardInput {
-                        device_id: DEVICE_ID,
+                        device_id: None,
                         event,
                         is_synthetic: false,
                     });
@@ -1038,11 +1037,7 @@ impl WinitView {
 
         self.update_modifiers(event, false);
 
-        self.queue_event(WindowEvent::MouseInput {
-            device_id: DEVICE_ID,
-            state: button_state,
-            button,
-        });
+        self.queue_event(WindowEvent::MouseInput { device_id: None, state: button_state, button });
     }
 
     fn mouse_motion(&self, event: &NSEvent) {
@@ -1067,7 +1062,7 @@ impl WinitView {
         self.update_modifiers(event, false);
 
         self.queue_event(WindowEvent::CursorMoved {
-            device_id: DEVICE_ID,
+            device_id: None,
             position: view_point.to_physical(self.scale_factor()),
         });
     }

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -339,10 +339,6 @@ impl CoreWindow for Window {
 pub struct WindowId(pub usize);
 
 impl WindowId {
-    pub const fn dummy() -> Self {
-        Self(0)
-    }
-
     pub const fn into_raw(self) -> u64 {
         self.0 as u64
     }

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -18,7 +18,6 @@ pub(crate) use self::window::{PlatformSpecificWindowAttributes, Window, WindowId
 pub(crate) use crate::cursor::{
     NoCustomCursor as PlatformCustomCursor, NoCustomCursor as PlatformCustomCursorSource,
 };
-use crate::event::DeviceId as RootDeviceId;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
@@ -29,18 +28,11 @@ pub(crate) use crate::platform_impl::Fullscreen;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
 
-impl DeviceId {
-    pub const fn dummy() -> Self {
-        DeviceId
-    }
-}
-
-pub(crate) const DEVICE_ID: RootDeviceId = RootDeviceId(DeviceId);
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId(usize);
 
 impl FingerId {
+    #[cfg(test)]
     pub const fn dummy() -> Self {
         FingerId(0)
     }

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -14,7 +14,7 @@ use objc2_ui_kit::{
 
 use super::app_state::{self, EventWrapper};
 use super::window::WinitUIWindow;
-use super::{FingerId, DEVICE_ID};
+use super::FingerId;
 use crate::dpi::PhysicalPosition;
 use crate::event::{
     ElementState, Event, FingerId as RootFingerId, Force, KeyEvent, Touch, TouchPhase, WindowEvent,
@@ -198,7 +198,7 @@ declare_class!(
             let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
                 window_id: RootWindowId(window.id()),
                 event: WindowEvent::PinchGesture {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     delta: delta as f64,
                     phase,
                 },
@@ -216,7 +216,7 @@ declare_class!(
                 let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
                     window_id: RootWindowId(window.id()),
                     event: WindowEvent::DoubleTapGesture {
-                        device_id: DEVICE_ID,
+                        device_id: None,
                     },
                 });
 
@@ -258,7 +258,7 @@ declare_class!(
             let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
                 window_id: RootWindowId(window.id()),
                 event: WindowEvent::RotationGesture {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     delta: -delta.to_degrees() as _,
                     phase,
                 },
@@ -309,7 +309,7 @@ declare_class!(
             let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
                 window_id: RootWindowId(window.id()),
                 event: WindowEvent::PanGesture {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     delta: PhysicalPosition::new(dx as _, dy as _),
                     phase,
                 },
@@ -530,7 +530,7 @@ impl WinitView {
             touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
                 window_id: RootWindowId(window.id()),
                 event: WindowEvent::Touch(Touch {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     finger_id: RootFingerId(FingerId(touch_id)),
                     location: physical_location,
                     force,
@@ -572,7 +572,7 @@ impl WinitView {
                                 platform_specific: KeyEventExtra {},
                             },
                             is_synthetic: false,
-                            device_id: DEVICE_ID,
+                            device_id: None,
                         },
                     })
                 })
@@ -590,7 +590,7 @@ impl WinitView {
                 EventWrapper::StaticEvent(Event::WindowEvent {
                     window_id,
                     event: WindowEvent::KeyboardInput {
-                        device_id: DEVICE_ID,
+                        device_id: None,
                         event: KeyEvent {
                             state,
                             logical_key: Key::Named(NamedKey::Backspace),

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -944,10 +944,6 @@ impl Inner {
 pub struct WindowId(usize);
 
 impl WindowId {
-    pub const fn dummy() -> Self {
-        WindowId(0)
-    }
-
     pub const fn into_raw(self) -> u64 {
         self.0 as _
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -111,10 +111,6 @@ pub(crate) static X11_BACKEND: Lazy<Mutex<Result<Arc<XConnection>, XNotSupported
 pub struct WindowId(u64);
 
 impl WindowId {
-    pub const fn dummy() -> Self {
-        Self(0)
-    }
-
     pub const fn into_raw(self) -> u64 {
         self.0
     }
@@ -129,16 +125,8 @@ pub enum DeviceId {
     #[cfg(x11_platform)]
     X(x11::DeviceId),
     #[cfg(wayland_platform)]
+    #[allow(unused)]
     Wayland(wayland::DeviceId),
-}
-
-impl DeviceId {
-    pub const fn dummy() -> Self {
-        #[cfg(wayland_platform)]
-        return DeviceId::Wayland(wayland::DeviceId::dummy());
-        #[cfg(all(not(wayland_platform), x11_platform))]
-        return DeviceId::X(x11::DeviceId::dummy());
-    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -150,6 +138,7 @@ pub enum FingerId {
 }
 
 impl FingerId {
+    #[cfg(test)]
     pub const fn dummy() -> Self {
         #[cfg(wayland_platform)]
         return FingerId::Wayland(wayland::FingerId::dummy());

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -30,7 +30,7 @@ use sink::EventSink;
 
 use super::state::{WindowCompositorUpdate, WinitState};
 use super::window::state::FrameCallbackState;
-use super::{logical_to_physical_rounded, DeviceId, WindowId};
+use super::{logical_to_physical_rounded, WindowId};
 
 type WaylandDispatcher = calloop::Dispatcher<'static, WaylandSource<WinitState>, WinitState>;
 

--- a/src/platform_impl/linux/wayland/event_loop/sink.rs
+++ b/src/platform_impl/linux/wayland/event_loop/sink.rs
@@ -2,9 +2,8 @@
 
 use std::vec::Drain;
 
-use super::{DeviceId, WindowId};
-use crate::event::{DeviceEvent, DeviceId as RootDeviceId, Event, WindowEvent};
-use crate::platform_impl::platform::DeviceId as PlatformDeviceId;
+use super::WindowId;
+use crate::event::{DeviceEvent, Event, WindowEvent};
 use crate::window::WindowId as RootWindowId;
 
 /// An event loop's sink to deliver events from the Wayland event callbacks
@@ -27,11 +26,8 @@ impl EventSink {
 
     /// Add new device event to a queue.
     #[inline]
-    pub fn push_device_event(&mut self, event: DeviceEvent, device_id: DeviceId) {
-        self.window_events.push(Event::DeviceEvent {
-            event,
-            device_id: RootDeviceId(PlatformDeviceId::Wayland(device_id)),
-        });
+    pub fn push_device_event(&mut self, event: DeviceEvent) {
+        self.window_events.push(Event::DeviceEvent { event, device_id: None });
     }
 
     /// Add new window event to a queue.

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -21,16 +21,11 @@ mod window;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;
 
-impl DeviceId {
-    pub const fn dummy() -> Self {
-        DeviceId
-    }
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId(i32);
 
 impl FingerId {
+    #[cfg(test)]
     pub const fn dummy() -> Self {
         FingerId(0)
     }

--- a/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/keyboard/mod.rs
@@ -17,7 +17,7 @@ use crate::keyboard::ModifiersState;
 use crate::platform_impl::common::xkb::Context;
 use crate::platform_impl::wayland::event_loop::sink::EventSink;
 use crate::platform_impl::wayland::state::WinitState;
-use crate::platform_impl::wayland::{self, DeviceId, WindowId};
+use crate::platform_impl::wayland::{self, WindowId};
 
 impl Dispatch<WlKeyboard, KeyboardData, WinitState> for WinitState {
     fn event(
@@ -369,10 +369,9 @@ fn key_input(
         None => return,
     };
 
-    let device_id = crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(DeviceId));
     if let Some(mut key_context) = keyboard_state.xkb_context.key_context() {
         let event = key_context.process_key_event(keycode, state, repeat);
-        let event = WindowEvent::KeyboardInput { device_id, event, is_synthetic: false };
+        let event = WindowEvent::KeyboardInput { device_id: None, event, is_synthetic: false };
         event_sink.push_window_event(event, window_id);
     }
 }

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -30,7 +30,7 @@ use crate::dpi::{LogicalPosition, PhysicalPosition};
 use crate::event::{ElementState, MouseButton, MouseScrollDelta, TouchPhase, WindowEvent};
 
 use crate::platform_impl::wayland::state::WinitState;
-use crate::platform_impl::wayland::{self, DeviceId, WindowId};
+use crate::platform_impl::wayland::{self, WindowId};
 
 pub mod relative_pointer;
 
@@ -58,8 +58,6 @@ impl PointerHandler for WinitState {
                 return;
             },
         };
-
-        let device_id = crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(DeviceId));
 
         for event in events {
             let surface = &event.surface;
@@ -124,8 +122,10 @@ impl PointerHandler for WinitState {
                 },
                 // Regular events on the main surface.
                 PointerEventKind::Enter { .. } => {
-                    self.events_sink
-                        .push_window_event(WindowEvent::CursorEntered { device_id }, window_id);
+                    self.events_sink.push_window_event(
+                        WindowEvent::CursorEntered { device_id: None },
+                        window_id,
+                    );
 
                     window.pointer_entered(Arc::downgrade(themed_pointer));
 
@@ -133,7 +133,7 @@ impl PointerHandler for WinitState {
                     pointer.winit_data().inner.lock().unwrap().surface = Some(window_id);
 
                     self.events_sink.push_window_event(
-                        WindowEvent::CursorMoved { device_id, position },
+                        WindowEvent::CursorMoved { device_id: None, position },
                         window_id,
                     );
                 },
@@ -144,11 +144,11 @@ impl PointerHandler for WinitState {
                     pointer.winit_data().inner.lock().unwrap().surface = None;
 
                     self.events_sink
-                        .push_window_event(WindowEvent::CursorLeft { device_id }, window_id);
+                        .push_window_event(WindowEvent::CursorLeft { device_id: None }, window_id);
                 },
                 PointerEventKind::Motion { .. } => {
                     self.events_sink.push_window_event(
-                        WindowEvent::CursorMoved { device_id, position },
+                        WindowEvent::CursorMoved { device_id: None, position },
                         window_id,
                     );
                 },
@@ -164,7 +164,7 @@ impl PointerHandler for WinitState {
                         ElementState::Released
                     };
                     self.events_sink.push_window_event(
-                        WindowEvent::MouseInput { device_id, state, button },
+                        WindowEvent::MouseInput { device_id: None, state, button },
                         window_id,
                     );
                 },
@@ -209,7 +209,7 @@ impl PointerHandler for WinitState {
                     };
 
                     self.events_sink.push_window_event(
-                        WindowEvent::MouseWheel { device_id, delta, phase },
+                        WindowEvent::MouseWheel { device_id: None, delta, phase },
                         window_id,
                     )
                 },

--- a/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
@@ -66,10 +66,9 @@ impl Dispatch<ZwpRelativePointerV1, GlobalData, WinitState> for RelativePointerS
             },
             _ => return,
         };
-        state.events_sink.push_device_event(
-            DeviceEvent::MouseMotion { delta: (dx_unaccel, dy_unaccel) },
-            super::DeviceId,
-        );
+        state
+            .events_sink
+            .push_device_event(DeviceEvent::MouseMotion { delta: (dx_unaccel, dy_unaccel) });
     }
 }
 

--- a/src/platform_impl/linux/wayland/seat/touch/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/touch/mod.rs
@@ -10,7 +10,7 @@ use tracing::warn;
 use crate::dpi::LogicalPosition;
 use crate::event::{Touch, TouchPhase, WindowEvent};
 use crate::platform_impl::wayland::state::WinitState;
-use crate::platform_impl::wayland::{self, DeviceId, FingerId};
+use crate::platform_impl::wayland::{self, FingerId};
 
 impl TouchHandler for WinitState {
     fn down(
@@ -44,9 +44,7 @@ impl TouchHandler for WinitState {
 
         self.events_sink.push_window_event(
             WindowEvent::Touch(Touch {
-                device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
-                    DeviceId,
-                )),
+                device_id: None,
                 phase: TouchPhase::Started,
                 location: location.to_physical(scale_factor),
                 force: None,
@@ -89,9 +87,7 @@ impl TouchHandler for WinitState {
 
         self.events_sink.push_window_event(
             WindowEvent::Touch(Touch {
-                device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
-                    DeviceId,
-                )),
+                device_id: None,
                 phase: TouchPhase::Ended,
                 location: touch_point.location.to_physical(scale_factor),
                 force: None,
@@ -136,9 +132,7 @@ impl TouchHandler for WinitState {
 
         self.events_sink.push_window_event(
             WindowEvent::Touch(Touch {
-                device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
-                    DeviceId,
-                )),
+                device_id: None,
                 phase: TouchPhase::Moved,
                 location: touch_point.location.to_physical(scale_factor),
                 force: None,
@@ -170,9 +164,7 @@ impl TouchHandler for WinitState {
 
             self.events_sink.push_window_event(
                 WindowEvent::Touch(Touch {
-                    device_id: crate::event::DeviceId(crate::platform_impl::DeviceId::Wayland(
-                        DeviceId,
-                    )),
+                    device_id: None,
                     phase: TouchPhase::Cancelled,
                     location,
                     force: None,

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -811,17 +811,11 @@ impl<'a> Deref for DeviceInfo<'a> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId(xinput::DeviceId);
 
-impl DeviceId {
-    #[allow(unused)]
-    pub const fn dummy() -> Self {
-        DeviceId(0)
-    }
-}
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId(u32);
 
 impl FingerId {
+    #[cfg(test)]
     #[allow(unused)]
     pub const fn dummy() -> Self {
         FingerId(0)

--- a/src/platform_impl/linux/x11/util/input.rs
+++ b/src/platform_impl/linux/x11/util/input.rs
@@ -6,7 +6,6 @@ use x11rb::protocol::xkb;
 use super::*;
 
 pub const VIRTUAL_CORE_POINTER: u16 = 2;
-pub const VIRTUAL_CORE_KEYBOARD: u16 = 3;
 
 // A base buffer size of 1kB uses a negligible amount of RAM while preventing us from having to
 // re-allocate (and make another round-trip) in the *vast* majority of cases.

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -12,8 +12,8 @@ use orbclient::{
 use smol_str::SmolStr;
 
 use super::{
-    DeviceId, KeyEventExtra, MonitorHandle, PlatformSpecificEventLoopAttributes, RedoxSocket,
-    TimeSocket, WindowId, WindowProperties,
+    KeyEventExtra, MonitorHandle, PlatformSpecificEventLoopAttributes, RedoxSocket, TimeSocket,
+    WindowId, WindowProperties,
 };
 use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, NotSupportedError, RequestError};
@@ -364,7 +364,7 @@ impl EventLoop {
 
                 let window_id = RootWindowId(window_id);
                 let event = event::WindowEvent::KeyboardInput {
-                    device_id: event::DeviceId(DeviceId),
+                    device_id: None,
                     event: event::KeyEvent {
                         logical_key,
                         physical_key,
@@ -407,29 +407,20 @@ impl EventLoop {
                 app.window_event(
                     window_target,
                     RootWindowId(window_id),
-                    event::WindowEvent::CursorMoved {
-                        device_id: event::DeviceId(DeviceId),
-                        position: (x, y).into(),
-                    },
+                    event::WindowEvent::CursorMoved { device_id: None, position: (x, y).into() },
                 );
             },
             EventOption::MouseRelative(MouseRelativeEvent { dx, dy }) => {
-                app.device_event(
-                    window_target,
-                    event::DeviceId(DeviceId),
-                    event::DeviceEvent::MouseMotion { delta: (dx as f64, dy as f64) },
-                );
+                app.device_event(window_target, None, event::DeviceEvent::MouseMotion {
+                    delta: (dx as f64, dy as f64),
+                });
             },
             EventOption::Button(ButtonEvent { left, middle, right }) => {
                 while let Some((button, state)) = event_state.mouse(left, middle, right) {
                     app.window_event(
                         window_target,
                         RootWindowId(window_id),
-                        event::WindowEvent::MouseInput {
-                            device_id: event::DeviceId(DeviceId),
-                            state,
-                            button,
-                        },
+                        event::WindowEvent::MouseInput { device_id: None, state, button },
                     );
                 }
             },
@@ -438,7 +429,7 @@ impl EventLoop {
                     window_target,
                     RootWindowId(window_id),
                     event::WindowEvent::MouseWheel {
-                        device_id: event::DeviceId(DeviceId),
+                        device_id: None,
                         delta: event::MouseScrollDelta::LineDelta(x as f32, y as f32),
                         phase: event::TouchPhase::Moved,
                     },
@@ -478,9 +469,9 @@ impl EventLoop {
             // TODO: Screen, Clipboard, Drop
             EventOption::Hover(HoverEvent { entered }) => {
                 let event = if entered {
-                    event::WindowEvent::CursorEntered { device_id: event::DeviceId(DeviceId) }
+                    event::WindowEvent::CursorEntered { device_id: None }
                 } else {
-                    event::WindowEvent::CursorLeft { device_id: event::DeviceId(DeviceId) }
+                    event::WindowEvent::CursorLeft { device_id: None }
                 };
 
                 app.window_event(window_target, RootWindowId(window_id), event);

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -105,10 +105,6 @@ pub struct WindowId {
 }
 
 impl WindowId {
-    pub const fn dummy() -> Self {
-        WindowId { fd: u64::MAX }
-    }
-
     pub const fn into_raw(self) -> u64 {
         self.fd
     }
@@ -121,16 +117,11 @@ impl WindowId {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DeviceId;
 
-impl DeviceId {
-    pub const fn dummy() -> Self {
-        DeviceId
-    }
-}
-
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FingerId;
 
 impl FingerId {
+    #[cfg(test)]
     pub const fn dummy() -> Self {
         FingerId
     }

--- a/src/platform_impl/web/event.rs
+++ b/src/platform_impl/web/event.rs
@@ -1,13 +1,16 @@
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId(i32);
+#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct DeviceId(u32);
 
 impl DeviceId {
-    pub fn new(pointer_id: i32) -> Self {
-        Self(pointer_id)
-    }
-
-    pub const fn dummy() -> Self {
-        Self(-1)
+    pub fn new(pointer_id: i32) -> Option<Self> {
+        if let Ok(pointer_id) = u32::try_from(pointer_id) {
+            Some(Self(pointer_id))
+        } else if pointer_id == -1 {
+            None
+        } else {
+            tracing::error!("found unexpected negative `PointerEvent.pointerId`: {pointer_id}");
+            None
+        }
     }
 }
 
@@ -22,6 +25,7 @@ impl FingerId {
         Self { pointer_id, primary }
     }
 
+    #[cfg(test)]
     pub const fn dummy() -> Self {
         Self { pointer_id: -1, primary: false }
     }

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -1,4 +1,4 @@
-use super::{backend, event, window, HasMonitorPermissionFuture, MonitorPermissionFuture};
+use super::{backend, window, HasMonitorPermissionFuture, MonitorPermissionFuture};
 use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, NotSupportedError};
 use crate::event::Event;

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -286,7 +286,7 @@ impl Shared {
                 }
 
                 // chorded button event
-                let device_id = RootDeviceId(DeviceId::new(event.pointer_id()));
+                let device_id = DeviceId::new(event.pointer_id()).map(RootDeviceId);
 
                 if let Some(button) = backend::event::mouse_button(&event) {
                     let state = if backend::event::mouse_buttons(&event).contains(button.into()) {
@@ -327,7 +327,7 @@ impl Shared {
 
                 if let Some(delta) = backend::event::mouse_scroll_delta(&window, &event) {
                     runner.send_event(Event::DeviceEvent {
-                        device_id: RootDeviceId(DeviceId::dummy()),
+                        device_id: None,
                         event: DeviceEvent::MouseWheel { delta },
                     });
                 }
@@ -344,7 +344,7 @@ impl Shared {
 
                 let button = backend::event::mouse_button(&event).expect("no mouse button pressed");
                 runner.send_event(Event::DeviceEvent {
-                    device_id: RootDeviceId(DeviceId::new(event.pointer_id())),
+                    device_id: DeviceId::new(event.pointer_id()).map(RootDeviceId),
                     event: DeviceEvent::Button {
                         button: button.to_id(),
                         state: ElementState::Pressed,
@@ -363,7 +363,7 @@ impl Shared {
 
                 let button = backend::event::mouse_button(&event).expect("no mouse button pressed");
                 runner.send_event(Event::DeviceEvent {
-                    device_id: RootDeviceId(DeviceId::new(event.pointer_id())),
+                    device_id: DeviceId::new(event.pointer_id()).map(RootDeviceId),
                     event: DeviceEvent::Button {
                         button: button.to_id(),
                         state: ElementState::Released,
@@ -381,7 +381,7 @@ impl Shared {
                 }
 
                 runner.send_event(Event::DeviceEvent {
-                    device_id: RootDeviceId(DeviceId::dummy()),
+                    device_id: None,
                     event: DeviceEvent::Key(RawKeyEvent {
                         physical_key: backend::event::key_code(&event),
                         state: ElementState::Pressed,
@@ -399,7 +399,7 @@ impl Shared {
                 }
 
                 runner.send_event(Event::DeviceEvent {
-                    device_id: RootDeviceId(DeviceId::dummy()),
+                    device_id: None,
                     event: DeviceEvent::Key(RawKeyEvent {
                         physical_key: backend::event::key_code(&event),
                         state: ElementState::Released,

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -7,7 +7,6 @@ use web_sys::Element;
 
 use super::super::monitor::MonitorPermissionFuture;
 use super::super::{lock, KeyEventExtra};
-use super::event::DeviceId;
 use super::runner::{EventWrapper, WeakShared};
 use super::window::WindowId;
 use super::{backend, runner, EventLoopProxy};
@@ -144,13 +143,11 @@ impl ActiveEventLoop {
                     }
                 });
 
-                let device_id = RootDeviceId(DeviceId::dummy());
-
                 runner.send_events(
                     iter::once(Event::WindowEvent {
                         window_id: RootWindowId(id),
                         event: WindowEvent::KeyboardInput {
-                            device_id,
+                            device_id: None,
                             event: KeyEvent {
                                 physical_key,
                                 logical_key,
@@ -180,13 +177,11 @@ impl ActiveEventLoop {
                     }
                 });
 
-                let device_id = RootDeviceId(DeviceId::dummy());
-
                 runner.send_events(
                     iter::once(Event::WindowEvent {
                         window_id: RootWindowId(id),
                         event: WindowEvent::KeyboardInput {
-                            device_id,
+                            device_id: None,
                             event: KeyEvent {
                                 physical_key,
                                 logical_key,
@@ -221,7 +216,7 @@ impl ActiveEventLoop {
 
                 let pointer = pointer_id.map(|device_id| Event::WindowEvent {
                     window_id: RootWindowId(id),
-                    event: WindowEvent::CursorLeft { device_id: RootDeviceId(device_id) },
+                    event: WindowEvent::CursorLeft { device_id: device_id.map(RootDeviceId) },
                 });
 
                 if focus.is_some() || pointer.is_some() {
@@ -246,7 +241,7 @@ impl ActiveEventLoop {
 
                 let pointer = pointer_id.map(|device_id| Event::WindowEvent {
                     window_id: RootWindowId(id),
-                    event: WindowEvent::CursorEntered { device_id: RootDeviceId(device_id) },
+                    event: WindowEvent::CursorEntered { device_id: device_id.map(RootDeviceId) },
                 });
 
                 if focus.is_some() || pointer.is_some() {
@@ -272,7 +267,7 @@ impl ActiveEventLoop {
                         });
 
                     runner.send_events(modifiers.into_iter().chain(events.flat_map(|position| {
-                        let device_id = RootDeviceId(pointer_id);
+                        let device_id = pointer_id.map(RootDeviceId);
 
                         iter::once(Event::WindowEvent {
                             window_id: RootWindowId(id),
@@ -301,7 +296,7 @@ impl ActiveEventLoop {
                             window_id: RootWindowId(id),
                             event: WindowEvent::Touch(Touch {
                                 finger_id: RootFingerId(finger_id),
-                                device_id: RootDeviceId(device_id),
+                                device_id: device_id.map(RootDeviceId),
                                 phase: TouchPhase::Moved,
                                 force: Some(force),
                                 location,
@@ -329,7 +324,7 @@ impl ActiveEventLoop {
                             }
                         });
 
-                    let device_id = RootDeviceId(device_id);
+                    let device_id = device_id.map(RootDeviceId);
 
                     let state = if buttons.contains(button.into()) {
                         ElementState::Pressed
@@ -368,7 +363,7 @@ impl ActiveEventLoop {
                         }
                     });
 
-                    let device_id: RootDeviceId = RootDeviceId(pointer_id);
+                    let device_id = pointer_id.map(RootDeviceId);
 
                     // A mouse down event may come in without any prior CursorMoved events,
                     // therefore we should send a CursorMoved event to make sure that the
@@ -407,7 +402,7 @@ impl ActiveEventLoop {
                             window_id: RootWindowId(id),
                             event: WindowEvent::Touch(Touch {
                                 finger_id: RootFingerId(finger_id),
-                                device_id: RootDeviceId(device_id),
+                                device_id: device_id.map(RootDeviceId),
                                 phase: TouchPhase::Started,
                                 force: Some(force),
                                 location,
@@ -434,7 +429,7 @@ impl ActiveEventLoop {
                             }
                         });
 
-                    let device_id: RootDeviceId = RootDeviceId(pointer_id);
+                    let device_id = pointer_id.map(RootDeviceId);
 
                     // A mouse up event may come in without any prior CursorMoved events,
                     // therefore we should send a CursorMoved event to make sure that the
@@ -475,7 +470,7 @@ impl ActiveEventLoop {
                             window_id: RootWindowId(id),
                             event: WindowEvent::Touch(Touch {
                                 finger_id: RootFingerId(finger_id),
-                                device_id: RootDeviceId(device_id),
+                                device_id: device_id.map(RootDeviceId),
                                 phase: TouchPhase::Ended,
                                 force: Some(force),
                                 location,
@@ -502,7 +497,7 @@ impl ActiveEventLoop {
                 Event::WindowEvent {
                     window_id: RootWindowId(id),
                     event: WindowEvent::MouseWheel {
-                        device_id: RootDeviceId(DeviceId::dummy()),
+                        device_id: None,
                         delta,
                         phase: TouchPhase::Moved,
                     },
@@ -516,7 +511,7 @@ impl ActiveEventLoop {
                 window_id: RootWindowId(id),
                 event: WindowEvent::Touch(Touch {
                     finger_id: RootFingerId(finger_id),
-                    device_id: RootDeviceId(device_id),
+                    device_id: device_id.map(RootDeviceId),
                     phase: TouchPhase::Cancelled,
                     force: Some(force),
                     location,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -330,22 +330,23 @@ impl Canvas {
 
     pub fn on_cursor_leave<F>(&self, handler: F)
     where
-        F: 'static + FnMut(ModifiersState, Option<DeviceId>),
+        F: 'static + FnMut(ModifiersState, Option<Option<DeviceId>>),
     {
         self.handlers.borrow_mut().pointer_handler.on_cursor_leave(&self.common, handler)
     }
 
     pub fn on_cursor_enter<F>(&self, handler: F)
     where
-        F: 'static + FnMut(ModifiersState, Option<DeviceId>),
+        F: 'static + FnMut(ModifiersState, Option<Option<DeviceId>>),
     {
         self.handlers.borrow_mut().pointer_handler.on_cursor_enter(&self.common, handler)
     }
 
     pub fn on_mouse_release<M, T>(&self, mouse_handler: M, touch_handler: T)
     where
-        M: 'static + FnMut(ModifiersState, DeviceId, PhysicalPosition<f64>, MouseButton),
-        T: 'static + FnMut(ModifiersState, DeviceId, FingerId, PhysicalPosition<f64>, Force),
+        M: 'static + FnMut(ModifiersState, Option<DeviceId>, PhysicalPosition<f64>, MouseButton),
+        T: 'static
+            + FnMut(ModifiersState, Option<DeviceId>, FingerId, PhysicalPosition<f64>, Force),
     {
         self.handlers.borrow_mut().pointer_handler.on_mouse_release(
             &self.common,
@@ -356,8 +357,9 @@ impl Canvas {
 
     pub fn on_mouse_press<M, T>(&self, mouse_handler: M, touch_handler: T)
     where
-        M: 'static + FnMut(ModifiersState, DeviceId, PhysicalPosition<f64>, MouseButton),
-        T: 'static + FnMut(ModifiersState, DeviceId, FingerId, PhysicalPosition<f64>, Force),
+        M: 'static + FnMut(ModifiersState, Option<DeviceId>, PhysicalPosition<f64>, MouseButton),
+        T: 'static
+            + FnMut(ModifiersState, Option<DeviceId>, FingerId, PhysicalPosition<f64>, Force),
     {
         self.handlers.borrow_mut().pointer_handler.on_mouse_press(
             &self.common,
@@ -370,16 +372,22 @@ impl Canvas {
     pub fn on_cursor_move<M, T, B>(&self, mouse_handler: M, touch_handler: T, button_handler: B)
     where
         M: 'static
-            + FnMut(ModifiersState, DeviceId, &mut dyn Iterator<Item = PhysicalPosition<f64>>),
+            + FnMut(ModifiersState, Option<DeviceId>, &mut dyn Iterator<Item = PhysicalPosition<f64>>),
         T: 'static
             + FnMut(
                 ModifiersState,
-                DeviceId,
+                Option<DeviceId>,
                 FingerId,
                 &mut dyn Iterator<Item = (PhysicalPosition<f64>, Force)>,
             ),
         B: 'static
-            + FnMut(ModifiersState, DeviceId, PhysicalPosition<f64>, ButtonsState, MouseButton),
+            + FnMut(
+                ModifiersState,
+                Option<DeviceId>,
+                PhysicalPosition<f64>,
+                ButtonsState,
+                MouseButton,
+            ),
     {
         self.handlers.borrow_mut().pointer_handler.on_cursor_move(
             &self.common,
@@ -392,7 +400,7 @@ impl Canvas {
 
     pub fn on_touch_cancel<F>(&self, handler: F)
     where
-        F: 'static + FnMut(DeviceId, FingerId, PhysicalPosition<f64>, Force),
+        F: 'static + FnMut(Option<DeviceId>, FingerId, PhysicalPosition<f64>, Force),
     {
         self.handlers.borrow_mut().pointer_handler.on_touch_cancel(&self.common, handler)
     }

--- a/src/platform_impl/web/web_sys/pointer.rs
+++ b/src/platform_impl/web/web_sys/pointer.rs
@@ -36,7 +36,7 @@ impl PointerHandler {
 
     pub fn on_cursor_leave<F>(&mut self, canvas_common: &Common, mut handler: F)
     where
-        F: 'static + FnMut(ModifiersState, Option<DeviceId>),
+        F: 'static + FnMut(ModifiersState, Option<Option<DeviceId>>),
     {
         self.on_cursor_leave =
             Some(canvas_common.add_event("pointerout", move |event: PointerEvent| {
@@ -54,7 +54,7 @@ impl PointerHandler {
 
     pub fn on_cursor_enter<F>(&mut self, canvas_common: &Common, mut handler: F)
     where
-        F: 'static + FnMut(ModifiersState, Option<DeviceId>),
+        F: 'static + FnMut(ModifiersState, Option<Option<DeviceId>>),
     {
         self.on_cursor_enter =
             Some(canvas_common.add_event("pointerover", move |event: PointerEvent| {
@@ -76,8 +76,9 @@ impl PointerHandler {
         mut mouse_handler: M,
         mut touch_handler: T,
     ) where
-        M: 'static + FnMut(ModifiersState, DeviceId, PhysicalPosition<f64>, MouseButton),
-        T: 'static + FnMut(ModifiersState, DeviceId, FingerId, PhysicalPosition<f64>, Force),
+        M: 'static + FnMut(ModifiersState, Option<DeviceId>, PhysicalPosition<f64>, MouseButton),
+        T: 'static
+            + FnMut(ModifiersState, Option<DeviceId>, FingerId, PhysicalPosition<f64>, Force),
     {
         let window = canvas_common.window.clone();
         self.on_pointer_release =
@@ -112,8 +113,9 @@ impl PointerHandler {
         mut touch_handler: T,
         prevent_default: Rc<Cell<bool>>,
     ) where
-        M: 'static + FnMut(ModifiersState, DeviceId, PhysicalPosition<f64>, MouseButton),
-        T: 'static + FnMut(ModifiersState, DeviceId, FingerId, PhysicalPosition<f64>, Force),
+        M: 'static + FnMut(ModifiersState, Option<DeviceId>, PhysicalPosition<f64>, MouseButton),
+        T: 'static
+            + FnMut(ModifiersState, Option<DeviceId>, FingerId, PhysicalPosition<f64>, Force),
     {
         let window = canvas_common.window.clone();
         let canvas = canvas_common.raw().clone();
@@ -172,16 +174,22 @@ impl PointerHandler {
         prevent_default: Rc<Cell<bool>>,
     ) where
         M: 'static
-            + FnMut(ModifiersState, DeviceId, &mut dyn Iterator<Item = PhysicalPosition<f64>>),
+            + FnMut(ModifiersState, Option<DeviceId>, &mut dyn Iterator<Item = PhysicalPosition<f64>>),
         T: 'static
             + FnMut(
                 ModifiersState,
-                DeviceId,
+                Option<DeviceId>,
                 FingerId,
                 &mut dyn Iterator<Item = (PhysicalPosition<f64>, Force)>,
             ),
         B: 'static
-            + FnMut(ModifiersState, DeviceId, PhysicalPosition<f64>, ButtonsState, MouseButton),
+            + FnMut(
+                ModifiersState,
+                Option<DeviceId>,
+                PhysicalPosition<f64>,
+                ButtonsState,
+                MouseButton,
+            ),
     {
         let window = canvas_common.window.clone();
         let canvas = canvas_common.raw().clone();
@@ -237,7 +245,7 @@ impl PointerHandler {
 
     pub fn on_touch_cancel<F>(&mut self, canvas_common: &Common, mut handler: F)
     where
-        F: 'static + FnMut(DeviceId, FingerId, PhysicalPosition<f64>, Force),
+        F: 'static + FnMut(Option<DeviceId>, FingerId, PhysicalPosition<f64>, Force),
     {
         let window = canvas_common.window.clone();
         self.on_touch_cancel =

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -433,10 +433,6 @@ impl Drop for Inner {
 pub struct WindowId(pub(crate) u64);
 
 impl WindowId {
-    pub const fn dummy() -> Self {
-        Self(0)
-    }
-
     pub const fn into_raw(self) -> u64 {
         self.0
     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -81,7 +81,7 @@ use crate::platform_impl::platform::window_state::{
     CursorFlags, ImeState, WindowFlags, WindowState,
 };
 use crate::platform_impl::platform::{
-    raw_input, util, wrap_device_id, FingerId, Fullscreen, WindowId, DEVICE_ID,
+    raw_input, util, wrap_device_id, FingerId, Fullscreen, WindowId,
 };
 use crate::platform_impl::Window;
 use crate::utils::Lazy;
@@ -1047,7 +1047,7 @@ unsafe fn public_window_callback_inner(
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
                 event: KeyboardInput {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     event: event.event,
                     is_synthetic: event.is_synthetic,
                 },
@@ -1541,7 +1541,7 @@ unsafe fn public_window_callback_inner(
                         drop(w);
                         userdata.send_event(Event::WindowEvent {
                             window_id: CoreWindowId(WindowId(window)),
-                            event: CursorEntered { device_id: DEVICE_ID },
+                            event: CursorEntered { device_id: None },
                         });
 
                         // Calling TrackMouseEvent in order to receive mouse leave events.
@@ -1562,7 +1562,7 @@ unsafe fn public_window_callback_inner(
                         drop(w);
                         userdata.send_event(Event::WindowEvent {
                             window_id: CoreWindowId(WindowId(window)),
-                            event: CursorLeft { device_id: DEVICE_ID },
+                            event: CursorLeft { device_id: None },
                         });
                     },
                     PointerMoveKind::None => drop(w),
@@ -1581,7 +1581,7 @@ unsafe fn public_window_callback_inner(
 
                 userdata.send_event(Event::WindowEvent {
                     window_id: CoreWindowId(WindowId(window)),
-                    event: CursorMoved { device_id: DEVICE_ID, position },
+                    event: CursorMoved { device_id: None, position },
                 });
             }
 
@@ -1597,7 +1597,7 @@ unsafe fn public_window_callback_inner(
 
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
-                event: CursorLeft { device_id: DEVICE_ID },
+                event: CursorLeft { device_id: None },
             });
 
             result = ProcResult::Value(0);
@@ -1614,7 +1614,7 @@ unsafe fn public_window_callback_inner(
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
                 event: WindowEvent::MouseWheel {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     delta: LineDelta(0.0, value),
                     phase: TouchPhase::Moved,
                 },
@@ -1634,7 +1634,7 @@ unsafe fn public_window_callback_inner(
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
                 event: WindowEvent::MouseWheel {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     delta: LineDelta(value, 0.0),
                     phase: TouchPhase::Moved,
                 },
@@ -1668,7 +1668,7 @@ unsafe fn public_window_callback_inner(
 
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
-                event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Left },
+                event: MouseInput { device_id: None, state: Pressed, button: Left },
             });
             result = ProcResult::Value(0);
         },
@@ -1684,7 +1684,7 @@ unsafe fn public_window_callback_inner(
 
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
-                event: MouseInput { device_id: DEVICE_ID, state: Released, button: Left },
+                event: MouseInput { device_id: None, state: Released, button: Left },
             });
             result = ProcResult::Value(0);
         },
@@ -1700,7 +1700,7 @@ unsafe fn public_window_callback_inner(
 
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
-                event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Right },
+                event: MouseInput { device_id: None, state: Pressed, button: Right },
             });
             result = ProcResult::Value(0);
         },
@@ -1716,7 +1716,7 @@ unsafe fn public_window_callback_inner(
 
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
-                event: MouseInput { device_id: DEVICE_ID, state: Released, button: Right },
+                event: MouseInput { device_id: None, state: Released, button: Right },
             });
             result = ProcResult::Value(0);
         },
@@ -1732,7 +1732,7 @@ unsafe fn public_window_callback_inner(
 
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
-                event: MouseInput { device_id: DEVICE_ID, state: Pressed, button: Middle },
+                event: MouseInput { device_id: None, state: Pressed, button: Middle },
             });
             result = ProcResult::Value(0);
         },
@@ -1748,7 +1748,7 @@ unsafe fn public_window_callback_inner(
 
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
-                event: MouseInput { device_id: DEVICE_ID, state: Released, button: Middle },
+                event: MouseInput { device_id: None, state: Released, button: Middle },
             });
             result = ProcResult::Value(0);
         },
@@ -1766,7 +1766,7 @@ unsafe fn public_window_callback_inner(
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     state: Pressed,
                     button: match xbutton {
                         1 => Back,
@@ -1791,7 +1791,7 @@ unsafe fn public_window_callback_inner(
             userdata.send_event(Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
                 event: MouseInput {
-                    device_id: DEVICE_ID,
+                    device_id: None,
                     state: Released,
                     button: match xbutton {
                         1 => Back,
@@ -1855,7 +1855,7 @@ unsafe fn public_window_callback_inner(
                                 id: input.dwID,
                                 primary: util::has_flag(input.dwFlags, TOUCHEVENTF_PRIMARY),
                             }),
-                            device_id: DEVICE_ID,
+                            device_id: None,
                         }),
                     });
                 }
@@ -2007,7 +2007,7 @@ unsafe fn public_window_callback_inner(
                                     POINTER_FLAG_PRIMARY,
                                 ),
                             }),
-                            device_id: DEVICE_ID,
+                            device_id: None,
                         }),
                     });
                 }
@@ -2435,7 +2435,7 @@ unsafe fn handle_raw_input(userdata: &ThreadMsgTargetData, data: RAWINPUT) {
     use crate::event::ElementState::{Pressed, Released};
     use crate::event::MouseScrollDelta::LineDelta;
 
-    let device_id = wrap_device_id(data.header.hDevice as _);
+    let device_id = Some(wrap_device_id(data.header.hDevice as _));
 
     if data.header.dwType == RIM_TYPEMOUSE {
         let mouse = unsafe { data.data.mouse };

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -63,12 +63,6 @@ unsafe impl Sync for PlatformSpecificWindowAttributes {}
 pub struct DeviceId(u32);
 
 impl DeviceId {
-    pub const fn dummy() -> Self {
-        DeviceId(0)
-    }
-}
-
-impl DeviceId {
     pub fn persistent_identifier(&self) -> Option<String> {
         if self.0 != 0 {
             raw_input::get_raw_input_device_name(self.0 as HANDLE)
@@ -85,6 +79,7 @@ pub struct FingerId {
 }
 
 impl FingerId {
+    #[cfg(test)]
     pub const fn dummy() -> Self {
         FingerId { id: 0, primary: false }
     }
@@ -95,9 +90,6 @@ impl FingerId {
         self.primary
     }
 }
-
-// Constant device ID, to be removed when this backend is updated to report real device IDs.
-const DEVICE_ID: RootDeviceId = RootDeviceId(DeviceId(0));
 
 fn wrap_device_id(id: u32) -> RootDeviceId {
     RootDeviceId(DeviceId(id))
@@ -115,10 +107,6 @@ unsafe impl Send for WindowId {}
 unsafe impl Sync for WindowId {}
 
 impl WindowId {
-    pub const fn dummy() -> Self {
-        WindowId(0)
-    }
-
     pub const fn into_raw(self) -> u64 {
         self.0 as u64
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -24,17 +24,6 @@ use crate::utils::AsAny;
 pub struct WindowId(pub(crate) platform_impl::WindowId);
 
 impl WindowId {
-    /// Returns a dummy id, useful for unit testing.
-    ///
-    /// # Notes
-    ///
-    /// The only guarantee made about the return value of this function is that
-    /// it will always be equal to itself and to future values returned by this function.
-    /// No other guarantees are made. This may be equal to a real [`WindowId`].
-    pub const fn dummy() -> Self {
-        WindowId(platform_impl::WindowId::dummy())
-    }
-
     /// Convert the `WindowId` into the underlying integer.
     ///
     /// This is useful if you need to pass the ID across an FFI boundary, or store it in an atomic.


### PR DESCRIPTION
This was discussed in the last meeting but it was so late only @kchibisov and myself were around so I'm gonna re-iterate what we discussed here.

`WindowId`, `DeviceId` and the newly added `FingerId`, have only one purpose: making sure that users are able to differentiate between events coming from different devices.
`dummy()` however entirely circumvents this property, because it is *always equal itself*. Ideally `dummy()` would never be equal itself, but that's not possible while we want to implement `Hash` (unless we add a counter ...).
This is in a similar vein to #3795.

However, this assumption was made under the fact hat adding `Option<DeviceId>` was not necessary because only Web is using `dummy()` internally. Turned out this isn't exactly true: *every* backend has at least some events where it is unable to emit a unique `DeviceId` for a device. Some backends, like Wayland and Orbital, don't use any `DeviceId` at all, making all devices appear equal!

So with that in mind, I also replaced all `DeviceId`s with `Option<DeviceId>`.
Surprisingly enough this wasn't necessary for `FingerId` because *every* backend that implements touch emits a proper finger ID.

Based on #3795.