### PR TITLE
iOS: Refactor event handling to share code with macOS

### DIFF
--- a/src/platform_impl/apple/appkit/app_state.rs
+++ b/src/platform_impl/apple/appkit/app_state.rs
@@ -8,7 +8,7 @@ use std::time::Instant;
 use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy};
 use objc2_foundation::{MainThreadMarker, NSNotification};
 
-use super::event_handler::EventHandler;
+use super::super::event_handler::EventHandler;
 use super::event_loop::{stop_app_immediately, ActiveEventLoop, PanicInfo};
 use super::observer::{EventLoopWaker, RunLoop};
 use super::{menu, WindowId};
@@ -291,7 +291,7 @@ impl AppState {
         callback: impl FnOnce(&mut dyn ApplicationHandler, &ActiveEventLoop),
     ) {
         let event_loop = ActiveEventLoop { app_state: Rc::clone(self), mtm: self.mtm };
-        self.event_handler.handle(callback, &event_loop);
+        self.event_handler.handle(|app| callback(app, &event_loop));
     }
 
     /// dispatch `NewEvents(Init)` + `Resumed`

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -5,7 +5,6 @@ mod app;
 mod app_state;
 mod cursor;
 mod event;
-mod event_handler;
 mod event_loop;
 mod ffi;
 mod menu;

--- a/src/platform_impl/apple/event_handler.rs
+++ b/src/platform_impl/apple/event_handler.rs
@@ -2,8 +2,9 @@ use std::cell::RefCell;
 use std::{fmt, mem};
 
 use crate::application::ApplicationHandler;
-use crate::platform_impl::ActiveEventLoop;
 
+/// A helper type for storing a reference to `ApplicationHandler`, allowing interior mutable access
+/// to it within the execution of a closure.
 #[derive(Default)]
 pub(crate) struct EventHandler {
     /// This can be in the following states:
@@ -100,19 +101,17 @@ impl EventHandler {
         // soundness.
     }
 
+    #[cfg(target_os = "macos")]
     pub(crate) fn in_use(&self) -> bool {
         self.inner.try_borrow().is_err()
     }
 
+    #[cfg(target_os = "macos")]
     pub(crate) fn ready(&self) -> bool {
         matches!(self.inner.try_borrow().as_deref(), Ok(Some(_)))
     }
 
-    pub(crate) fn handle(
-        &self,
-        callback: impl FnOnce(&mut dyn ApplicationHandler, &ActiveEventLoop),
-        event_loop: &ActiveEventLoop,
-    ) {
+    pub(crate) fn handle(&self, callback: impl FnOnce(&mut dyn ApplicationHandler)) {
         match self.inner.try_borrow_mut().as_deref_mut() {
             Ok(Some(user_app)) => {
                 // It is important that we keep the reference borrowed here,
@@ -121,7 +120,7 @@ impl EventHandler {
                 //
                 // If the handler unwinds, the `RefMut` will ensure that the
                 // handler is no longer borrowed.
-                callback(*user_app, event_loop);
+                callback(*user_app);
             },
             Ok(None) => {
                 // `NSApplication`, our app state and this handler are all

--- a/src/platform_impl/apple/mod.rs
+++ b/src/platform_impl/apple/mod.rs
@@ -2,6 +2,7 @@
 
 #[cfg(target_os = "macos")]
 mod appkit;
+mod event_handler;
 mod notification_center;
 #[cfg(not(target_os = "macos"))]
 mod uikit;


### PR DESCRIPTION
Instead of storing the event handler within the AppState, and extracting it our every time we need it, we now use the same event handling implementation as for macOS that ensures we don't re-entrantly call the event handler, and that we un-register the handler again after we're done using it (`UIApplicationMain` won't return, but may still unwind, so this is very important for panic safety).

This is the first step of me trying to untangle the inscrutable mess that is the current event handling on iOS.

- [x] Tested on all platforms changed
