### PR TITLE
Remove `PartialOrd` and `Ord` implementations from `WindowId`, `DeviceId`, `MonitorHandle` and   `VideoModeHandle`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -127,6 +127,8 @@ changelog entry.
 - Remove `MonitorHandle::size()` and `refresh_rate_millihertz()` in favor of
   `MonitorHandle::current_video_mode()`.
 - On Android, remove all `MonitorHandle` support instead of emitting false data.
+- Remove `PartialOrd` and `Ord` implementations from `WindowId`, `DeviceId`, `MonitorHandle` and
+  `VideoModeHandle`.
 
 ### Fixed
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -431,7 +431,7 @@ pub enum WindowEvent {
 /// `DeviceId` which identifies its origin. Note that devices may be virtual (representing an
 /// on-screen cursor and keyboard focus) or physical. Virtual devices typically aggregate inputs
 /// from multiple physical devices.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DeviceId(pub(crate) platform_impl::DeviceId);
 
 impl Default for DeviceId {
@@ -457,7 +457,7 @@ impl DeviceId {
 ///
 /// Whenever a touch event is received it contains a `FingerId` which uniquely identifies the finger
 /// used for the current interaction.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FingerId(pub(crate) platform_impl::FingerId);
 
 impl FingerId {
@@ -1032,7 +1032,7 @@ impl Eq for InnerSizeWriter {}
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeSet, HashSet};
+    use std::collections::HashSet;
 
     use crate::dpi::PhysicalPosition;
     use crate::event;
@@ -1166,11 +1166,6 @@ mod tests {
         let did = crate::event::DeviceId::dummy().clone();
         let fid = crate::event::FingerId::dummy().clone();
         HashSet::new().insert(did);
-        let mut set = [did, did, did];
-        set.sort_unstable();
-        let mut set2 = BTreeSet::new();
-        set2.insert(did);
-        set2.insert(did);
 
         HashSet::new().insert(event::TouchPhase::Started.clone());
         HashSet::new().insert(event::MouseButton::Left.clone());

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -24,27 +24,6 @@ impl std::fmt::Debug for VideoModeHandle {
     }
 }
 
-impl PartialOrd for VideoModeHandle {
-    fn partial_cmp(&self, other: &VideoModeHandle) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for VideoModeHandle {
-    fn cmp(&self, other: &VideoModeHandle) -> std::cmp::Ordering {
-        self.monitor().cmp(&other.monitor()).then(
-            self.size()
-                .cmp(&other.size())
-                .then(
-                    self.refresh_rate_millihertz()
-                        .cmp(&other.refresh_rate_millihertz())
-                        .then(self.bit_depth().cmp(&other.bit_depth())),
-                )
-                .reverse(),
-        )
-    }
-}
-
 impl VideoModeHandle {
     /// Returns the resolution of this video mode. This **must not** be used to create your
     /// rendering surface. Use [`Window::inner_size()`] instead.
@@ -112,7 +91,7 @@ impl std::fmt::Display for VideoModeHandle {
 /// to check.
 ///
 /// [`Window`]: crate::window::Window
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct MonitorHandle {
     pub(crate) inner: platform_impl::MonitorHandle,
 }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -666,7 +666,7 @@ impl OwnedDisplayHandle {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct WindowId;
 
 impl WindowId {
@@ -687,7 +687,7 @@ impl From<u64> for WindowId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct DeviceId(i32);
 
 impl DeviceId {
@@ -696,7 +696,7 @@ impl DeviceId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct FingerId(i32);
 
 impl FingerId {
@@ -947,7 +947,7 @@ impl Display for OsError {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct MonitorHandle;
 
 impl MonitorHandle {

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -31,7 +31,7 @@ use crate::event::DeviceId as RootDeviceId;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DeviceId;
 
 impl DeviceId {
@@ -43,7 +43,7 @@ impl DeviceId {
 // Constant device ID; to be removed when if backend is updated to report real device IDs.
 pub(crate) const DEVICE_ID: RootDeviceId = RootDeviceId(DeviceId);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FingerId;
 
 impl FingerId {

--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -147,21 +147,6 @@ impl PartialEq for MonitorHandle {
 
 impl Eq for MonitorHandle {}
 
-impl PartialOrd for MonitorHandle {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for MonitorHandle {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        unsafe {
-            ffi::CGDisplayCreateUUIDFromDisplayID(self.0)
-                .cmp(&ffi::CGDisplayCreateUUIDFromDisplayID(other.0))
-        }
-    }
-}
-
 impl std::hash::Hash for MonitorHandle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         unsafe {

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -69,7 +69,7 @@ impl Window {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WindowId(pub usize);
 
 impl WindowId {

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -26,7 +26,7 @@ pub(crate) use crate::platform_impl::Fullscreen;
 /// UIKit (i.e. you can't differentiate between different external keyboards,
 /// or whether it was the main touchscreen, assistive technologies, or some
 /// other pointer device that caused a touch event).
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DeviceId;
 
 impl DeviceId {
@@ -37,7 +37,7 @@ impl DeviceId {
 
 pub(crate) const DEVICE_ID: RootDeviceId = RootDeviceId(DeviceId);
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FingerId(usize);
 
 impl FingerId {

--- a/src/platform_impl/apple/uikit/monitor.rs
+++ b/src/platform_impl/apple/uikit/monitor.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unnecessary_cast)]
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::VecDeque;
 use std::num::{NonZeroU16, NonZeroU32};
 use std::{fmt, hash, ptr};
 
@@ -113,19 +113,6 @@ impl PartialEq for MonitorHandle {
 
 impl Eq for MonitorHandle {}
 
-impl PartialOrd for MonitorHandle {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for MonitorHandle {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // TODO: Make a better ordering
-        (self as *const Self).cmp(&(other as *const Self))
-    }
-}
-
 impl fmt::Debug for MonitorHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("MonitorHandle")
@@ -185,7 +172,7 @@ impl MonitorHandle {
             let ui_screen = self.ui_screen(mtm);
             // Use Ord impl of RootVideoModeHandle
 
-            let modes: BTreeSet<_> = ui_screen
+            let modes: Vec<_> = ui_screen
                 .availableModes()
                 .into_iter()
                 .map(|mode| RootVideoModeHandle {

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -670,7 +670,7 @@ impl Inner {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WindowId {
     window: *mut WinitUIWindow,
 }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -140,7 +140,7 @@ pub(crate) enum Window {
     Wayland(wayland::Window),
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WindowId(u64);
 
 impl From<WindowId> for u64 {
@@ -161,7 +161,7 @@ impl WindowId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DeviceId {
     #[cfg(x11_platform)]
     X(x11::DeviceId),
@@ -178,7 +178,7 @@ impl DeviceId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum FingerId {
     #[cfg(x11_platform)]
     X(x11::FingerId),
@@ -195,7 +195,7 @@ impl FingerId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum MonitorHandle {
     #[cfg(x11_platform)]
     X(x11::MonitorHandle),

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -62,7 +62,7 @@ impl From<WaylandError> for OsError {
 }
 
 /// Dummy device id, since Wayland doesn't have device events.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DeviceId;
 
 impl DeviceId {
@@ -71,7 +71,7 @@ impl DeviceId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FingerId(i32);
 
 impl FingerId {

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -86,18 +86,6 @@ impl PartialEq for MonitorHandle {
 
 impl Eq for MonitorHandle {}
 
-impl PartialOrd for MonitorHandle {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for MonitorHandle {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.native_identifier().cmp(&other.native_identifier())
-    }
-}
-
 impl std::hash::Hash for MonitorHandle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.native_identifier().hash(state);

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -807,7 +807,7 @@ impl<'a> Deref for DeviceInfo<'a> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DeviceId(xinput::DeviceId);
 
 impl DeviceId {
@@ -817,7 +817,7 @@ impl DeviceId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FingerId(u32);
 
 impl FingerId {

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -76,18 +76,6 @@ impl PartialEq for MonitorHandle {
 
 impl Eq for MonitorHandle {}
 
-impl PartialOrd for MonitorHandle {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for MonitorHandle {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.id.cmp(&other.id)
-    }
-}
-
 impl std::hash::Hash for MonitorHandle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.id.hash(state);

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -96,7 +96,7 @@ impl TimeSocket {
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct WindowId {
     fd: u64,
 }
@@ -119,7 +119,7 @@ impl From<u64> for WindowId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct DeviceId;
 
 impl DeviceId {
@@ -128,7 +128,7 @@ impl DeviceId {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct FingerId;
 
 impl FingerId {
@@ -193,7 +193,7 @@ pub(crate) use crate::cursor::{
 };
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
-#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct MonitorHandle;
 
 impl MonitorHandle {

--- a/src/platform_impl/web/async/dispatcher.rs
+++ b/src/platform_impl/web/async/dispatcher.rs
@@ -1,5 +1,4 @@
 use std::cell::Ref;
-use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
@@ -32,21 +31,9 @@ impl<T> Hash for Dispatcher<T> {
     }
 }
 
-impl<T> Ord for Dispatcher<T> {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.cmp(&other.0)
-    }
-}
-
 impl<T> PartialEq for Dispatcher<T> {
     fn eq(&self, other: &Self) -> bool {
         self.0.eq(&other.0)
-    }
-}
-
-impl<T> PartialOrd for Dispatcher<T> {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/src/platform_impl/web/async/wrapper.rs
+++ b/src/platform_impl/web/async/wrapper.rs
@@ -1,5 +1,4 @@
 use std::cell::{Ref, RefCell};
-use std::cmp;
 use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
@@ -89,18 +88,6 @@ impl<V, S: Clone + Send, E> Eq for Wrapper<V, S, E> {}
 impl<V, S: Clone + Send, E> Hash for Wrapper<V, S, E> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         Arc::as_ptr(&self.value.value).hash(state)
-    }
-}
-
-impl<V, S: Clone + Send, E> Ord for Wrapper<V, S, E> {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        Arc::as_ptr(&self.value.value).cmp(&Arc::as_ptr(&other.value.value))
-    }
-}
-
-impl<V, S: Clone + Send, E> PartialOrd for Wrapper<V, S, E> {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/src/platform_impl/web/event.rs
+++ b/src/platform_impl/web/event.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DeviceId(i32);
 
 impl DeviceId {
@@ -11,7 +11,7 @@ impl DeviceId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FingerId {
     pointer_id: i32,
     primary: bool,

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -1,5 +1,4 @@
 use std::cell::{OnceCell, Ref, RefCell};
-use std::cmp::Ordering;
 use std::fmt::{self, Debug, Formatter};
 use std::future::Future;
 use std::hash::{Hash, Hasher};
@@ -170,21 +169,9 @@ impl Hash for MonitorHandle {
     }
 }
 
-impl Ord for MonitorHandle {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.id.cmp(&other.id)
-    }
-}
-
 impl PartialEq for MonitorHandle {
     fn eq(&self, other: &Self) -> bool {
         self.id.eq(&other.id)
-    }
-}
-
-impl PartialOrd for MonitorHandle {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
     }
 }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -428,7 +428,7 @@ impl Drop for Inner {
         }
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WindowId(pub(crate) u32);
 
 impl WindowId {

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -59,7 +59,7 @@ impl Default for PlatformSpecificWindowAttributes {
 unsafe impl Send for PlatformSpecificWindowAttributes {}
 unsafe impl Sync for PlatformSpecificWindowAttributes {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct DeviceId(u32);
 
 impl DeviceId {
@@ -78,7 +78,7 @@ impl DeviceId {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct FingerId {
     id: u32,
     primary: bool,
@@ -111,7 +111,7 @@ pub struct KeyEventExtra {
     pub key_without_modifiers: Key,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WindowId(HWND);
 unsafe impl Send for WindowId {}
 unsafe impl Sync for WindowId {}

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::VecDeque;
 use std::hash::Hash;
 use std::num::{NonZeroU16, NonZeroU32};
 use std::{io, mem, ptr};
@@ -91,7 +91,7 @@ impl VideoModeHandle {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct MonitorHandle(HMONITOR);
 
 // Send is not implemented for HMONITOR, we have to wrap it and implement it manually.
@@ -226,7 +226,7 @@ impl MonitorHandle {
         // EnumDisplaySettingsExW can return duplicate values (or some of the
         // fields are probably changing, but we aren't looking at those fields
         // anyway), so we're using a BTreeSet deduplicate
-        let mut modes = BTreeSet::<RootVideoModeHandle>::new();
+        let mut modes = Vec::new();
         let mod_map = |mode: RootVideoModeHandle| mode.video_mode;
 
         let monitor_info = match get_monitor_info(self.0) {
@@ -247,10 +247,8 @@ impl MonitorHandle {
                 break;
             }
 
-            // Use Ord impl of RootVideoModeHandle
-            modes.insert(RootVideoModeHandle {
-                video_mode: VideoModeHandle::new(self.clone(), mode),
-            });
+            modes
+                .push(RootVideoModeHandle { video_mode: VideoModeHandle::new(self.clone(), mode) });
 
             i += 1;
         }

--- a/src/window.rs
+++ b/src/window.rs
@@ -78,7 +78,7 @@ impl std::hash::Hash for Window {
 ///
 /// Whenever you receive an event specific to a window, this event contains a `WindowId` which you
 /// can then compare to the ids of your windows.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WindowId(pub(crate) platform_impl::WindowId);
 
 impl WindowId {


### PR DESCRIPTION
As discussed in the last meeting, this PR removes `PartialOrd`/`Ord` from:
- `WindowId`
- `DeviceId`
- `FingerId`
- `MonitorHandle`
- `VideoModeHandle`

The reason being that `Ord` is supposed to tell users something meaningful, which it doesn't in this case. E.g. what does comparing the order of two `DeviceId`s mean?

On `VideoModeHandle` there was actually some useful implementation, but it wasn't documented and I don't actually believe it makes sense to compare them like this. We might want to consider implementing `Ord` again on `VideoModeData`.

`FingerId` would have been useful to compare with `Ord` *if* the ID actually signifies the finger used in order, in which case we should expose that information directly to the user as well. It isn't clear yet if every backend functions this way, something to ponder about when we overhaul touch events.