### PR TITLE
Remove unnecessary `#[inline]` hints

### DIFF
--- a/dpi/src/lib.rs
+++ b/dpi/src/lib.rs
@@ -143,7 +143,6 @@ impl<P> LogicalUnit<P> {
 }
 
 impl<P: Pixel> LogicalUnit<P> {
-    #[inline]
     pub fn from_physical<T: Into<PhysicalUnit<X>>, X: Pixel>(
         physical: T,
         scale_factor: f64,
@@ -151,13 +150,11 @@ impl<P: Pixel> LogicalUnit<P> {
         physical.into().to_logical(scale_factor)
     }
 
-    #[inline]
     pub fn to_physical<X: Pixel>(&self, scale_factor: f64) -> PhysicalUnit<X> {
         assert!(validate_scale_factor(scale_factor));
         PhysicalUnit::new(self.0.into() * scale_factor).cast()
     }
 
-    #[inline]
     pub fn cast<X: Pixel>(&self) -> LogicalUnit<X> {
         LogicalUnit(self.0.cast())
     }
@@ -237,18 +234,15 @@ impl<P> PhysicalUnit<P> {
 }
 
 impl<P: Pixel> PhysicalUnit<P> {
-    #[inline]
     pub fn from_logical<T: Into<LogicalUnit<X>>, X: Pixel>(logical: T, scale_factor: f64) -> Self {
         logical.into().to_physical(scale_factor)
     }
 
-    #[inline]
     pub fn to_logical<X: Pixel>(&self, scale_factor: f64) -> LogicalUnit<X> {
         assert!(validate_scale_factor(scale_factor));
         LogicalUnit::new(self.0.into() / scale_factor).cast()
     }
 
-    #[inline]
     pub fn cast<X: Pixel>(&self) -> PhysicalUnit<X> {
         PhysicalUnit(self.0.cast())
     }
@@ -377,7 +371,6 @@ impl<P> LogicalPosition<P> {
 }
 
 impl<P: Pixel> LogicalPosition<P> {
-    #[inline]
     pub fn from_physical<T: Into<PhysicalPosition<X>>, X: Pixel>(
         physical: T,
         scale_factor: f64,
@@ -385,7 +378,6 @@ impl<P: Pixel> LogicalPosition<P> {
         physical.into().to_logical(scale_factor)
     }
 
-    #[inline]
     pub fn to_physical<X: Pixel>(&self, scale_factor: f64) -> PhysicalPosition<X> {
         assert!(validate_scale_factor(scale_factor));
         let x = self.x.into() * scale_factor;
@@ -393,7 +385,6 @@ impl<P: Pixel> LogicalPosition<P> {
         PhysicalPosition::new(x, y).cast()
     }
 
-    #[inline]
     pub fn cast<X: Pixel>(&self) -> LogicalPosition<X> {
         LogicalPosition { x: self.x.cast(), y: self.y.cast() }
     }
@@ -453,7 +444,6 @@ impl<P> PhysicalPosition<P> {
 }
 
 impl<P: Pixel> PhysicalPosition<P> {
-    #[inline]
     pub fn from_logical<T: Into<LogicalPosition<X>>, X: Pixel>(
         logical: T,
         scale_factor: f64,
@@ -461,7 +451,6 @@ impl<P: Pixel> PhysicalPosition<P> {
         logical.into().to_physical(scale_factor)
     }
 
-    #[inline]
     pub fn to_logical<X: Pixel>(&self, scale_factor: f64) -> LogicalPosition<X> {
         assert!(validate_scale_factor(scale_factor));
         let x = self.x.into() / scale_factor;
@@ -469,7 +458,6 @@ impl<P: Pixel> PhysicalPosition<P> {
         LogicalPosition::new(x, y).cast()
     }
 
-    #[inline]
     pub fn cast<X: Pixel>(&self) -> PhysicalPosition<X> {
         PhysicalPosition { x: self.x.cast(), y: self.y.cast() }
     }
@@ -529,7 +517,6 @@ impl<P> LogicalSize<P> {
 }
 
 impl<P: Pixel> LogicalSize<P> {
-    #[inline]
     pub fn from_physical<T: Into<PhysicalSize<X>>, X: Pixel>(
         physical: T,
         scale_factor: f64,
@@ -537,7 +524,6 @@ impl<P: Pixel> LogicalSize<P> {
         physical.into().to_logical(scale_factor)
     }
 
-    #[inline]
     pub fn to_physical<X: Pixel>(&self, scale_factor: f64) -> PhysicalSize<X> {
         assert!(validate_scale_factor(scale_factor));
         let width = self.width.into() * scale_factor;
@@ -545,7 +531,6 @@ impl<P: Pixel> LogicalSize<P> {
         PhysicalSize::new(width, height).cast()
     }
 
-    #[inline]
     pub fn cast<X: Pixel>(&self) -> LogicalSize<X> {
         LogicalSize { width: self.width.cast(), height: self.height.cast() }
     }
@@ -605,12 +590,10 @@ impl<P> PhysicalSize<P> {
 }
 
 impl<P: Pixel> PhysicalSize<P> {
-    #[inline]
     pub fn from_logical<T: Into<LogicalSize<X>>, X: Pixel>(logical: T, scale_factor: f64) -> Self {
         logical.into().to_physical(scale_factor)
     }
 
-    #[inline]
     pub fn to_logical<X: Pixel>(&self, scale_factor: f64) -> LogicalSize<X> {
         assert!(validate_scale_factor(scale_factor));
         let width = self.width.into() / scale_factor;
@@ -618,7 +601,6 @@ impl<P: Pixel> PhysicalSize<P> {
         LogicalSize::new(width, height).cast()
     }
 
-    #[inline]
     pub fn cast<X: Pixel>(&self) -> PhysicalSize<X> {
         PhysicalSize { width: self.width.cast(), height: self.height.cast() }
     }

--- a/src/application.rs
+++ b/src/application.rs
@@ -329,27 +329,22 @@ pub trait ApplicationHandler {
 
 #[deny(clippy::missing_trait_methods)]
 impl<A: ?Sized + ApplicationHandler> ApplicationHandler for &mut A {
-    #[inline]
     fn new_events(&mut self, event_loop: &dyn ActiveEventLoop, cause: StartCause) {
         (**self).new_events(event_loop, cause);
     }
 
-    #[inline]
     fn resumed(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).resumed(event_loop);
     }
 
-    #[inline]
     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).can_create_surfaces(event_loop);
     }
 
-    #[inline]
     fn proxy_wake_up(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).proxy_wake_up(event_loop);
     }
 
-    #[inline]
     fn window_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
@@ -359,7 +354,6 @@ impl<A: ?Sized + ApplicationHandler> ApplicationHandler for &mut A {
         (**self).window_event(event_loop, window_id, event);
     }
 
-    #[inline]
     fn device_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
@@ -369,27 +363,22 @@ impl<A: ?Sized + ApplicationHandler> ApplicationHandler for &mut A {
         (**self).device_event(event_loop, device_id, event);
     }
 
-    #[inline]
     fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).about_to_wait(event_loop);
     }
 
-    #[inline]
     fn suspended(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).suspended(event_loop);
     }
 
-    #[inline]
     fn destroy_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).destroy_surfaces(event_loop);
     }
 
-    #[inline]
     fn exiting(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).exiting(event_loop);
     }
 
-    #[inline]
     fn memory_warning(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).memory_warning(event_loop);
     }
@@ -397,27 +386,22 @@ impl<A: ?Sized + ApplicationHandler> ApplicationHandler for &mut A {
 
 #[deny(clippy::missing_trait_methods)]
 impl<A: ?Sized + ApplicationHandler> ApplicationHandler for Box<A> {
-    #[inline]
     fn new_events(&mut self, event_loop: &dyn ActiveEventLoop, cause: StartCause) {
         (**self).new_events(event_loop, cause);
     }
 
-    #[inline]
     fn resumed(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).resumed(event_loop);
     }
 
-    #[inline]
     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).can_create_surfaces(event_loop);
     }
 
-    #[inline]
     fn proxy_wake_up(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).proxy_wake_up(event_loop);
     }
 
-    #[inline]
     fn window_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
@@ -427,7 +411,6 @@ impl<A: ?Sized + ApplicationHandler> ApplicationHandler for Box<A> {
         (**self).window_event(event_loop, window_id, event);
     }
 
-    #[inline]
     fn device_event(
         &mut self,
         event_loop: &dyn ActiveEventLoop,
@@ -437,27 +420,22 @@ impl<A: ?Sized + ApplicationHandler> ApplicationHandler for Box<A> {
         (**self).device_event(event_loop, device_id, event);
     }
 
-    #[inline]
     fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).about_to_wait(event_loop);
     }
 
-    #[inline]
     fn suspended(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).suspended(event_loop);
     }
 
-    #[inline]
     fn destroy_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).destroy_surfaces(event_loop);
     }
 
-    #[inline]
     fn exiting(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).exiting(event_loop);
     }
 
-    #[inline]
     fn memory_warning(&mut self, event_loop: &dyn ActiveEventLoop) {
         (**self).memory_warning(event_loop);
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,6 @@ impl From<OsError> for EventLoopError {
 }
 
 impl NotSupportedError {
-    #[inline]
     #[allow(dead_code)]
     pub(crate) fn new() -> NotSupportedError {
         NotSupportedError { _marker: () }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -93,7 +93,6 @@ impl EventLoopBuilder {
         not(android_platform),
         doc = "[`.with_android_app(app)`]: #only-available-on-android"
     )]
-    #[inline]
     pub fn build(&mut self) -> Result<EventLoop, EventLoopError> {
         let _span = tracing::debug_span!("winit::EventLoopBuilder::build").entered();
 
@@ -176,7 +175,6 @@ impl EventLoop {
     /// Create the event loop.
     ///
     /// This is an alias of `EventLoop::builder().build()`.
-    #[inline]
     pub fn new() -> Result<EventLoop, EventLoopError> {
         Self::builder().build()
     }
@@ -186,7 +184,6 @@ impl EventLoop {
     /// This returns an [`EventLoopBuilder`], to allow configuring the event loop before creation.
     ///
     /// To get the actual event loop, call [`build`][EventLoopBuilder::build] on that.
-    #[inline]
     pub fn builder() -> EventLoopBuilder {
         EventLoopBuilder { platform_specific: Default::default() }
     }
@@ -222,7 +219,6 @@ impl EventLoop {
     ///
     /// [`set_control_flow()`]: ActiveEventLoop::set_control_flow()
     /// [`run_app()`]: Self::run_app()
-    #[inline]
     #[cfg(not(all(web_platform, target_feature = "exception-handling")))]
     pub fn run_app<A: ApplicationHandler>(self, app: A) -> Result<(), EventLoopError> {
         self.event_loop.run_app(app)
@@ -434,7 +430,6 @@ pub struct OwnedDisplayHandle {
 }
 
 impl fmt::Debug for OwnedDisplayHandle {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OwnedDisplayHandle").finish_non_exhaustive()
     }
@@ -442,7 +437,6 @@ impl fmt::Debug for OwnedDisplayHandle {
 
 #[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for OwnedDisplayHandle {
-    #[inline]
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.platform.raw_display_handle_rwh_06()?;
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -50,7 +50,6 @@ impl VideoModeHandle {
     /// rendering surface. Use [`Window::inner_size()`] instead.
     ///
     /// [`Window::inner_size()`]: crate::window::Window::inner_size
-    #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         self.video_mode.size()
     }
@@ -58,20 +57,17 @@ impl VideoModeHandle {
     /// Returns the bit depth of this video mode, as in how many bits you have
     /// available per color. This is generally 24 bits or 32 bits on modern
     /// systems, depending on whether the alpha channel is counted or not.
-    #[inline]
     pub fn bit_depth(&self) -> Option<NonZeroU16> {
         self.video_mode.bit_depth()
     }
 
     /// Returns the refresh rate of this video mode in mHz.
-    #[inline]
     pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
         self.video_mode.refresh_rate_millihertz()
     }
 
     /// Returns the monitor that this video mode is valid for. Each monitor has
     /// a separate set of valid video modes.
-    #[inline]
     pub fn monitor(&self) -> MonitorHandle {
         MonitorHandle { inner: self.video_mode.monitor() }
     }
@@ -136,7 +132,6 @@ impl MonitorHandle {
         doc = "[detailed monitor permissions][crate::platform::web::ActiveEventLoopExtWeb::request_detailed_monitor_permission]."
     )]
     #[cfg_attr(not(any(web_platform, docsrs)), doc = "detailed monitor permissions.")]
-    #[inline]
     pub fn name(&self) -> Option<String> {
         self.inner.name()
     }
@@ -152,7 +147,6 @@ impl MonitorHandle {
         doc = "[detailed monitor permissions][crate::platform::web::ActiveEventLoopExtWeb::request_detailed_monitor_permission]."
     )]
     #[cfg_attr(not(any(web_platform, docsrs)), doc = "detailed monitor permissions.")]
-    #[inline]
     pub fn position(&self) -> Option<PhysicalPosition<i32>> {
         self.inner.position()
     }
@@ -176,19 +170,16 @@ impl MonitorHandle {
     ///
     #[rustfmt::skip]
     /// [`Window::scale_factor`]: crate::window::Window::scale_factor
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         self.inner.scale_factor()
     }
 
     /// Returns the currently active video mode of this monitor.
-    #[inline]
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         self.inner.current_video_mode().map(|video_mode| VideoModeHandle { video_mode })
     }
 
     /// Returns all fullscreen video modes supported by this monitor.
-    #[inline]
     pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
         self.inner.video_modes().map(|video_mode| VideoModeHandle { video_mode })
     }

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -185,44 +185,36 @@ pub trait WindowExtIOS {
 }
 
 impl WindowExtIOS for Window {
-    #[inline]
     fn set_scale_factor(&self, scale_factor: f64) {
         self.window.maybe_queue_on_main(move |w| w.set_scale_factor(scale_factor))
     }
 
-    #[inline]
     fn set_valid_orientations(&self, valid_orientations: ValidOrientations) {
         self.window.maybe_queue_on_main(move |w| w.set_valid_orientations(valid_orientations))
     }
 
-    #[inline]
     fn set_prefers_home_indicator_hidden(&self, hidden: bool) {
         self.window.maybe_queue_on_main(move |w| w.set_prefers_home_indicator_hidden(hidden))
     }
 
-    #[inline]
     fn set_preferred_screen_edges_deferring_system_gestures(&self, edges: ScreenEdge) {
         self.window.maybe_queue_on_main(move |w| {
             w.set_preferred_screen_edges_deferring_system_gestures(edges)
         })
     }
 
-    #[inline]
     fn set_prefers_status_bar_hidden(&self, hidden: bool) {
         self.window.maybe_queue_on_main(move |w| w.set_prefers_status_bar_hidden(hidden))
     }
 
-    #[inline]
     fn set_preferred_status_bar_style(&self, status_bar_style: StatusBarStyle) {
         self.window.maybe_queue_on_main(move |w| w.set_preferred_status_bar_style(status_bar_style))
     }
 
-    #[inline]
     fn recognize_pinch_gesture(&self, should_recognize: bool) {
         self.window.maybe_queue_on_main(move |w| w.recognize_pinch_gesture(should_recognize));
     }
 
-    #[inline]
     fn recognize_pan_gesture(
         &self,
         should_recognize: bool,
@@ -238,12 +230,10 @@ impl WindowExtIOS for Window {
         });
     }
 
-    #[inline]
     fn recognize_doubletap_gesture(&self, should_recognize: bool) {
         self.window.maybe_queue_on_main(move |w| w.recognize_doubletap_gesture(should_recognize));
     }
 
-    #[inline]
     fn recognize_rotation_gesture(&self, should_recognize: bool) {
         self.window.maybe_queue_on_main(move |w| w.recognize_rotation_gesture(should_recognize));
     }
@@ -305,37 +295,31 @@ pub trait WindowAttributesExtIOS {
 }
 
 impl WindowAttributesExtIOS for WindowAttributes {
-    #[inline]
     fn with_scale_factor(mut self, scale_factor: f64) -> Self {
         self.platform_specific.scale_factor = Some(scale_factor);
         self
     }
 
-    #[inline]
     fn with_valid_orientations(mut self, valid_orientations: ValidOrientations) -> Self {
         self.platform_specific.valid_orientations = valid_orientations;
         self
     }
 
-    #[inline]
     fn with_prefers_home_indicator_hidden(mut self, hidden: bool) -> Self {
         self.platform_specific.prefers_home_indicator_hidden = hidden;
         self
     }
 
-    #[inline]
     fn with_preferred_screen_edges_deferring_system_gestures(mut self, edges: ScreenEdge) -> Self {
         self.platform_specific.preferred_screen_edges_deferring_system_gestures = edges;
         self
     }
 
-    #[inline]
     fn with_prefers_status_bar_hidden(mut self, hidden: bool) -> Self {
         self.platform_specific.prefers_status_bar_hidden = hidden;
         self
     }
 
-    #[inline]
     fn with_preferred_status_bar_style(mut self, status_bar_style: StatusBarStyle) -> Self {
         self.platform_specific.preferred_status_bar_style = status_bar_style;
         self
@@ -356,14 +340,12 @@ pub trait MonitorHandleExtIOS {
 }
 
 impl MonitorHandleExtIOS for MonitorHandle {
-    #[inline]
     fn ui_screen(&self) -> *mut c_void {
         // SAFETY: The marker is only used to get the pointer of the screen
         let mtm = unsafe { objc2_foundation::MainThreadMarker::new_unchecked() };
         objc2::rc::Retained::as_ptr(self.inner.ui_screen(mtm)) as *mut c_void
     }
 
-    #[inline]
     fn preferred_video_mode(&self) -> VideoModeHandle {
         VideoModeHandle { video_mode: self.inner.preferred_video_mode() }
     }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -165,72 +165,58 @@ pub trait WindowExtMacOS {
 }
 
 impl WindowExtMacOS for Window {
-    #[inline]
     fn simple_fullscreen(&self) -> bool {
         self.window.maybe_wait_on_main(|w| w.simple_fullscreen())
     }
 
-    #[inline]
     fn set_simple_fullscreen(&self, fullscreen: bool) -> bool {
         self.window.maybe_wait_on_main(move |w| w.set_simple_fullscreen(fullscreen))
     }
 
-    #[inline]
     fn has_shadow(&self) -> bool {
         self.window.maybe_wait_on_main(|w| w.has_shadow())
     }
 
-    #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
         self.window.maybe_queue_on_main(move |w| w.set_has_shadow(has_shadow))
     }
 
-    #[inline]
     fn set_tabbing_identifier(&self, identifier: &str) {
         self.window.maybe_wait_on_main(|w| w.set_tabbing_identifier(identifier))
     }
 
-    #[inline]
     fn tabbing_identifier(&self) -> String {
         self.window.maybe_wait_on_main(|w| w.tabbing_identifier())
     }
 
-    #[inline]
     fn select_next_tab(&self) {
         self.window.maybe_queue_on_main(|w| w.select_next_tab())
     }
 
-    #[inline]
     fn select_previous_tab(&self) {
         self.window.maybe_queue_on_main(|w| w.select_previous_tab())
     }
 
-    #[inline]
     fn select_tab_at_index(&self, index: usize) {
         self.window.maybe_queue_on_main(move |w| w.select_tab_at_index(index))
     }
 
-    #[inline]
     fn num_tabs(&self) -> usize {
         self.window.maybe_wait_on_main(|w| w.num_tabs())
     }
 
-    #[inline]
     fn is_document_edited(&self) -> bool {
         self.window.maybe_wait_on_main(|w| w.is_document_edited())
     }
 
-    #[inline]
     fn set_document_edited(&self, edited: bool) {
         self.window.maybe_queue_on_main(move |w| w.set_document_edited(edited))
     }
 
-    #[inline]
     fn set_option_as_alt(&self, option_as_alt: OptionAsAlt) {
         self.window.maybe_queue_on_main(move |w| w.set_option_as_alt(option_as_alt))
     }
 
-    #[inline]
     fn option_as_alt(&self) -> OptionAsAlt {
         self.window.maybe_wait_on_main(|w| w.option_as_alt())
     }
@@ -288,67 +274,56 @@ pub trait WindowAttributesExtMacOS {
 }
 
 impl WindowAttributesExtMacOS for WindowAttributes {
-    #[inline]
     fn with_movable_by_window_background(mut self, movable_by_window_background: bool) -> Self {
         self.platform_specific.movable_by_window_background = movable_by_window_background;
         self
     }
 
-    #[inline]
     fn with_titlebar_transparent(mut self, titlebar_transparent: bool) -> Self {
         self.platform_specific.titlebar_transparent = titlebar_transparent;
         self
     }
 
-    #[inline]
     fn with_titlebar_hidden(mut self, titlebar_hidden: bool) -> Self {
         self.platform_specific.titlebar_hidden = titlebar_hidden;
         self
     }
 
-    #[inline]
     fn with_titlebar_buttons_hidden(mut self, titlebar_buttons_hidden: bool) -> Self {
         self.platform_specific.titlebar_buttons_hidden = titlebar_buttons_hidden;
         self
     }
 
-    #[inline]
     fn with_title_hidden(mut self, title_hidden: bool) -> Self {
         self.platform_specific.title_hidden = title_hidden;
         self
     }
 
-    #[inline]
     fn with_fullsize_content_view(mut self, fullsize_content_view: bool) -> Self {
         self.platform_specific.fullsize_content_view = fullsize_content_view;
         self
     }
 
-    #[inline]
     fn with_disallow_hidpi(mut self, disallow_hidpi: bool) -> Self {
         self.platform_specific.disallow_hidpi = disallow_hidpi;
         self
     }
 
-    #[inline]
     fn with_has_shadow(mut self, has_shadow: bool) -> Self {
         self.platform_specific.has_shadow = has_shadow;
         self
     }
 
-    #[inline]
     fn with_accepts_first_mouse(mut self, accepts_first_mouse: bool) -> Self {
         self.platform_specific.accepts_first_mouse = accepts_first_mouse;
         self
     }
 
-    #[inline]
     fn with_tabbing_identifier(mut self, tabbing_identifier: &str) -> Self {
         self.platform_specific.tabbing_identifier.replace(tabbing_identifier.to_string());
         self
     }
 
-    #[inline]
     fn with_option_as_alt(mut self, option_as_alt: OptionAsAlt) -> Self {
         self.platform_specific.option_as_alt = option_as_alt;
         self
@@ -408,19 +383,16 @@ pub trait EventLoopBuilderExtMacOS {
 }
 
 impl EventLoopBuilderExtMacOS for EventLoopBuilder {
-    #[inline]
     fn with_activation_policy(&mut self, activation_policy: ActivationPolicy) -> &mut Self {
         self.platform_specific.activation_policy = activation_policy;
         self
     }
 
-    #[inline]
     fn with_default_menu(&mut self, enable: bool) -> &mut Self {
         self.platform_specific.default_menu = enable;
         self
     }
 
-    #[inline]
     fn with_activate_ignoring_other_apps(&mut self, ignore: bool) -> &mut Self {
         self.platform_specific.activate_ignoring_other_apps = ignore;
         self
@@ -436,7 +408,6 @@ pub trait MonitorHandleExtMacOS {
 }
 
 impl MonitorHandleExtMacOS for MonitorHandle {
-    #[inline]
     fn native_id(&self) -> u32 {
         self.inner.native_identifier()
     }

--- a/src/platform/modifier_supplement.rs
+++ b/src/platform/modifier_supplement.rs
@@ -23,12 +23,10 @@ pub trait KeyEventExtModifierSupplement {
 }
 
 impl KeyEventExtModifierSupplement for KeyEvent {
-    #[inline]
     fn text_with_all_modifiers(&self) -> Option<&str> {
         self.platform_specific.text_with_all_modifiers.as_ref().map(|s| s.as_str())
     }
 
-    #[inline]
     fn key_without_modifiers(&self) -> Key {
         self.platform_specific.key_without_modifiers.clone()
     }

--- a/src/platform/scancode.rs
+++ b/src/platform/scancode.rs
@@ -38,12 +38,10 @@ impl PhysicalKeyExtScancode for PhysicalKey {
 }
 
 impl PhysicalKeyExtScancode for KeyCode {
-    #[inline]
     fn to_scancode(self) -> Option<u32> {
         <PhysicalKey as PhysicalKeyExtScancode>::to_scancode(PhysicalKey::Code(self))
     }
 
-    #[inline]
     fn from_scancode(scancode: u32) -> PhysicalKey {
         <PhysicalKey as PhysicalKeyExtScancode>::from_scancode(scancode)
     }

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -25,7 +25,6 @@ pub trait ActiveEventLoopExtWayland {
 }
 
 impl ActiveEventLoopExtWayland for dyn ActiveEventLoop + '_ {
-    #[inline]
     fn is_wayland(&self) -> bool {
         self.as_any().downcast_ref::<crate::platform_impl::wayland::ActiveEventLoop>().is_some()
     }
@@ -38,7 +37,6 @@ pub trait EventLoopExtWayland {
 }
 
 impl EventLoopExtWayland for EventLoop {
-    #[inline]
     fn is_wayland(&self) -> bool {
         self.event_loop.is_wayland()
     }
@@ -57,13 +55,11 @@ pub trait EventLoopBuilderExtWayland {
 }
 
 impl EventLoopBuilderExtWayland for EventLoopBuilder {
-    #[inline]
     fn with_wayland(&mut self) -> &mut Self {
         self.platform_specific.forced_backend = Some(crate::platform_impl::Backend::Wayland);
         self
     }
 
-    #[inline]
     fn with_any_thread(&mut self, any_thread: bool) -> &mut Self {
         self.platform_specific.any_thread = any_thread;
         self
@@ -88,7 +84,6 @@ pub trait WindowAttributesExtWayland {
 }
 
 impl WindowAttributesExtWayland for WindowAttributes {
-    #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
         self.platform_specific.name =
             Some(crate::platform_impl::ApplicationName::new(general.into(), instance.into()));
@@ -103,7 +98,6 @@ pub trait MonitorHandleExtWayland {
 }
 
 impl MonitorHandleExtWayland for MonitorHandle {
-    #[inline]
     fn native_id(&self) -> u32 {
         self.inner.native_identifier()
     }

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -105,7 +105,6 @@ pub trait WindowExtWeb {
 }
 
 impl WindowExtWeb for Window {
-    #[inline]
     fn canvas(&self) -> Option<Ref<'_, HtmlCanvasElement>> {
         self.window.canvas()
     }
@@ -348,7 +347,6 @@ pub trait ActiveEventLoopExtWeb {
 }
 
 impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
-    #[inline]
     fn create_custom_cursor_async(&self, source: CustomCursorSource) -> CustomCursorFuture {
         let event_loop = self
             .as_any()
@@ -357,7 +355,6 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
         event_loop.create_custom_cursor_async(source)
     }
 
-    #[inline]
     fn set_poll_strategy(&self, strategy: PollStrategy) {
         let event_loop = self
             .as_any()
@@ -366,7 +363,6 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
         event_loop.set_poll_strategy(strategy);
     }
 
-    #[inline]
     fn poll_strategy(&self) -> PollStrategy {
         let event_loop = self
             .as_any()
@@ -375,7 +371,6 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
         event_loop.poll_strategy()
     }
 
-    #[inline]
     fn set_wait_until_strategy(&self, strategy: WaitUntilStrategy) {
         let event_loop = self
             .as_any()
@@ -384,7 +379,6 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
         event_loop.set_wait_until_strategy(strategy);
     }
 
-    #[inline]
     fn wait_until_strategy(&self) -> WaitUntilStrategy {
         let event_loop = self
             .as_any()
@@ -393,7 +387,6 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
         event_loop.wait_until_strategy()
     }
 
-    #[inline]
     fn is_cursor_lock_raw(&self) -> bool {
         let event_loop = self
             .as_any()
@@ -402,7 +395,6 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
         event_loop.is_cursor_lock_raw()
     }
 
-    #[inline]
     fn has_multiple_screens(&self) -> Result<bool, NotSupportedError> {
         let event_loop = self
             .as_any()
@@ -411,7 +403,6 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
         event_loop.has_multiple_screens()
     }
 
-    #[inline]
     fn request_detailed_monitor_permission(&self) -> MonitorPermissionFuture {
         let event_loop = self
             .as_any()
@@ -420,7 +411,6 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
         MonitorPermissionFuture(event_loop.request_detailed_monitor_permission())
     }
 
-    #[inline]
     fn has_detailed_monitor_permission(&self) -> bool {
         let event_loop = self
             .as_any()

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -119,19 +119,16 @@ pub struct AnyThread<W>(W);
 
 impl<W: Borrow<Window>> AnyThread<W> {
     /// Get a reference to the inner window.
-    #[inline]
     pub fn get_ref(&self) -> &Window {
         self.0.borrow()
     }
 
     /// Get a reference to the inner object.
-    #[inline]
     pub fn inner(&self) -> &W {
         &self.0
     }
 
     /// Unwrap and get the inner window.
-    #[inline]
     pub fn into_inner(self) -> W {
         self.0
     }
@@ -234,19 +231,16 @@ pub trait EventLoopBuilderExtWindows {
 }
 
 impl EventLoopBuilderExtWindows for EventLoopBuilder {
-    #[inline]
     fn with_any_thread(&mut self, any_thread: bool) -> &mut Self {
         self.platform_specific.any_thread = any_thread;
         self
     }
 
-    #[inline]
     fn with_dpi_aware(&mut self, dpi_aware: bool) -> &mut Self {
         self.platform_specific.dpi_aware = dpi_aware;
         self
     }
 
-    #[inline]
     fn with_msg_hook<F>(&mut self, callback: F) -> &mut Self
     where
         F: FnMut(*const c_void) -> bool + 'static,
@@ -366,37 +360,30 @@ pub trait WindowExtWindows {
 }
 
 impl WindowExtWindows for Window {
-    #[inline]
     fn set_enable(&self, enabled: bool) {
         self.window.set_enable(enabled)
     }
 
-    #[inline]
     fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {
         self.window.set_taskbar_icon(taskbar_icon)
     }
 
-    #[inline]
     fn set_skip_taskbar(&self, skip: bool) {
         self.window.set_skip_taskbar(skip)
     }
 
-    #[inline]
     fn set_undecorated_shadow(&self, shadow: bool) {
         self.window.set_undecorated_shadow(shadow)
     }
 
-    #[inline]
     fn set_system_backdrop(&self, backdrop_type: BackdropType) {
         self.window.set_system_backdrop(backdrop_type)
     }
 
-    #[inline]
     fn set_border_color(&self, color: Option<Color>) {
         self.window.set_border_color(color.unwrap_or(Color::NONE))
     }
 
-    #[inline]
     fn set_title_background_color(&self, color: Option<Color>) {
         // The windows docs don't mention NONE as a valid options but it works in practice and is
         // useful to circumvent the Windows option "Show accent color on title bars and
@@ -404,12 +391,10 @@ impl WindowExtWindows for Window {
         self.window.set_title_background_color(color.unwrap_or(Color::NONE))
     }
 
-    #[inline]
     fn set_title_text_color(&self, color: Color) {
         self.window.set_title_text_color(color)
     }
 
-    #[inline]
     fn set_corner_preference(&self, preference: CornerPreference) {
         self.window.set_corner_preference(preference)
     }
@@ -553,85 +538,71 @@ pub trait WindowAttributesExtWindows {
 }
 
 impl WindowAttributesExtWindows for WindowAttributes {
-    #[inline]
     fn with_owner_window(mut self, parent: HWND) -> Self {
         self.platform_specific.owner = Some(parent);
         self
     }
 
-    #[inline]
     fn with_menu(mut self, menu: HMENU) -> Self {
         self.platform_specific.menu = Some(menu);
         self
     }
 
-    #[inline]
     fn with_taskbar_icon(mut self, taskbar_icon: Option<Icon>) -> Self {
         self.platform_specific.taskbar_icon = taskbar_icon;
         self
     }
 
-    #[inline]
     fn with_no_redirection_bitmap(mut self, flag: bool) -> Self {
         self.platform_specific.no_redirection_bitmap = flag;
         self
     }
 
-    #[inline]
     fn with_drag_and_drop(mut self, flag: bool) -> Self {
         self.platform_specific.drag_and_drop = flag;
         self
     }
 
-    #[inline]
     fn with_skip_taskbar(mut self, skip: bool) -> Self {
         self.platform_specific.skip_taskbar = skip;
         self
     }
 
-    #[inline]
     fn with_class_name<S: Into<String>>(mut self, class_name: S) -> Self {
         self.platform_specific.class_name = class_name.into();
         self
     }
 
-    #[inline]
     fn with_undecorated_shadow(mut self, shadow: bool) -> Self {
         self.platform_specific.decoration_shadow = shadow;
         self
     }
 
-    #[inline]
     fn with_system_backdrop(mut self, backdrop_type: BackdropType) -> Self {
         self.platform_specific.backdrop_type = backdrop_type;
         self
     }
 
-    #[inline]
     fn with_clip_children(mut self, flag: bool) -> Self {
         self.platform_specific.clip_children = flag;
         self
     }
 
-    #[inline]
     fn with_border_color(mut self, color: Option<Color>) -> Self {
         self.platform_specific.border_color = Some(color.unwrap_or(Color::NONE));
         self
     }
 
-    #[inline]
     fn with_title_background_color(mut self, color: Option<Color>) -> Self {
         self.platform_specific.title_background_color = Some(color.unwrap_or(Color::NONE));
         self
     }
 
-    #[inline]
     fn with_title_text_color(mut self, color: Color) -> Self {
         self.platform_specific.title_text_color = Some(color);
         self
     }
 
-    #[inline]
     fn with_corner_preference(mut self, corners: CornerPreference) -> Self {
         self.platform_specific.corner_preference = Some(corners);
         self
@@ -648,12 +619,10 @@ pub trait MonitorHandleExtWindows {
 }
 
 impl MonitorHandleExtWindows for MonitorHandle {
-    #[inline]
     fn native_id(&self) -> String {
         self.inner.native_identifier()
     }
 
-    #[inline]
     fn hmonitor(&self) -> HMONITOR {
         self.inner.hmonitor()
     }
@@ -668,7 +637,6 @@ pub trait DeviceIdExtWindows {
 }
 
 impl DeviceIdExtWindows for DeviceId {
-    #[inline]
     fn persistent_identifier(&self) -> Option<String> {
         self.0.persistent_identifier()
     }
@@ -682,7 +650,6 @@ pub trait FingerIdExtWindows {
 }
 
 impl FingerIdExtWindows for FingerId {
-    #[inline]
     fn is_primary(self) -> bool {
         self.0.is_primary()
     }

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -77,7 +77,6 @@ pub type XWindow = u32;
 /// `false` if you're not initiated the `Sync`.**
 ///
 /// [`unsafe`]: https://www.remlab.net/op/xlib.shtml
-#[inline]
 pub fn register_xlib_error_hook(hook: XlibErrorHook) {
     // Append new hook.
     unsafe {
@@ -92,7 +91,6 @@ pub trait ActiveEventLoopExtX11 {
 }
 
 impl ActiveEventLoopExtX11 for dyn ActiveEventLoop + '_ {
-    #[inline]
     fn is_x11(&self) -> bool {
         self.as_any().downcast_ref::<crate::platform_impl::x11::ActiveEventLoop>().is_some()
     }
@@ -105,7 +103,6 @@ pub trait EventLoopExtX11 {
 }
 
 impl EventLoopExtX11 for EventLoop {
-    #[inline]
     fn is_x11(&self) -> bool {
         !self.event_loop.is_wayland()
     }
@@ -124,13 +121,11 @@ pub trait EventLoopBuilderExtX11 {
 }
 
 impl EventLoopBuilderExtX11 for EventLoopBuilder {
-    #[inline]
     fn with_x11(&mut self) -> &mut Self {
         self.platform_specific.forced_backend = Some(crate::platform_impl::Backend::X);
         self
     }
 
-    #[inline]
     fn with_any_thread(&mut self, any_thread: bool) -> &mut Self {
         self.platform_specific.any_thread = any_thread;
         self
@@ -197,44 +192,37 @@ pub trait WindowAttributesExtX11 {
 }
 
 impl WindowAttributesExtX11 for WindowAttributes {
-    #[inline]
     fn with_x11_visual(mut self, visual_id: XVisualID) -> Self {
         self.platform_specific.x11.visual_id = Some(visual_id);
         self
     }
 
-    #[inline]
     fn with_x11_screen(mut self, screen_id: i32) -> Self {
         self.platform_specific.x11.screen_id = Some(screen_id);
         self
     }
 
-    #[inline]
     fn with_name(mut self, general: impl Into<String>, instance: impl Into<String>) -> Self {
         self.platform_specific.name =
             Some(crate::platform_impl::ApplicationName::new(general.into(), instance.into()));
         self
     }
 
-    #[inline]
     fn with_override_redirect(mut self, override_redirect: bool) -> Self {
         self.platform_specific.x11.override_redirect = override_redirect;
         self
     }
 
-    #[inline]
     fn with_x11_window_type(mut self, x11_window_types: Vec<WindowType>) -> Self {
         self.platform_specific.x11.x11_window_types = x11_window_types;
         self
     }
 
-    #[inline]
     fn with_base_size<S: Into<Size>>(mut self, base_size: S) -> Self {
         self.platform_specific.x11.base_size = Some(base_size.into());
         self
     }
 
-    #[inline]
     fn with_embed_parent_window(mut self, parent_window_id: XWindow) -> Self {
         self.platform_specific.x11.embed_window = Some(parent_window_id);
         self
@@ -248,7 +236,6 @@ pub trait MonitorHandleExtX11 {
 }
 
 impl MonitorHandleExtX11 for MonitorHandle {
-    #[inline]
     fn native_id(&self) -> u32 {
         self.inner.native_identifier()
     }

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -658,7 +658,6 @@ pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
@@ -878,7 +877,6 @@ impl Window {
         Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
     }
 
-    #[inline]
     pub fn show_window_menu(&self, _position: Position) {}
 
     pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -402,7 +402,6 @@ pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
@@ -421,7 +420,6 @@ pub(super) fn stop_app_immediately(app: &NSApplication) {
 
 /// Catches panics that happen inside `f` and when a panic
 /// happens, stops the `sharedApplication`
-#[inline]
 pub fn stop_app_on_panic<F: FnOnce() -> R + UnwindSafe, R>(
     mtm: MainThreadMarker,
     panic_info: Weak<PanicInfo>,

--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -210,12 +210,10 @@ impl MonitorHandle {
         Some(format!("Monitor #{screen_num}"))
     }
 
-    #[inline]
     pub fn native_identifier(&self) -> u32 {
         self.0
     }
 
-    #[inline]
     pub fn position(&self) -> Option<PhysicalPosition<i32>> {
         // This is already in screen coordinates. If we were using `NSScreen`,
         // then a conversion would've been needed:

--- a/src/platform_impl/apple/appkit/util.rs
+++ b/src/platform_impl/apple/appkit/util.rs
@@ -13,7 +13,6 @@ pub(crate) struct TraceGuard {
 }
 
 impl TraceGuard {
-    #[inline]
     pub(crate) fn new(module_path: &'static str, called_from_fn: &'static str) -> Self {
         trace!(target = module_path, "Triggered `{}`", called_from_fn);
         Self { module_path, called_from_fn }
@@ -21,7 +20,6 @@ impl TraceGuard {
 }
 
 impl Drop for TraceGuard {
-    #[inline]
     fn drop(&mut self) {
         trace!(target = self.module_path, "Completed `{}`", self.called_from_fn);
     }

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -49,7 +49,6 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub(crate) fn raw_window_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
@@ -61,7 +60,6 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub(crate) fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -59,7 +59,6 @@ pub struct PlatformSpecificWindowAttributes {
 }
 
 impl Default for PlatformSpecificWindowAttributes {
-    #[inline]
     fn default() -> Self {
         Self {
             movable_by_window_background: false,
@@ -902,7 +901,6 @@ impl WindowDelegate {
         }
     }
 
-    #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         Some(self.window().isVisible())
     }
@@ -911,7 +909,6 @@ impl WindowDelegate {
         self.ivars().app_state.queue_redraw(self.window().id());
     }
 
-    #[inline]
     pub fn pre_present_notify(&self) {}
 
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
@@ -934,21 +931,18 @@ impl WindowDelegate {
         unsafe { self.window().setFrameOrigin(point) };
     }
 
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         let content_rect = self.window().contentRectForFrameRect(self.window().frame());
         let logical = LogicalSize::new(content_rect.size.width, content_rect.size.height);
         logical.to_physical(self.scale_factor())
     }
 
-    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         let frame = self.window().frame();
         let logical = LogicalSize::new(frame.size.width, frame.size.height);
         logical.to_physical(self.scale_factor())
     }
 
-    #[inline]
     pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let scale_factor = self.scale_factor();
         let size = size.to_logical(scale_factor);
@@ -1027,7 +1021,6 @@ impl WindowDelegate {
         self.window().setContentResizeIncrements(size);
     }
 
-    #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         self.ivars().resizable.set(resizable);
         let fullscreen = self.ivars().fullscreen.borrow().is_some();
@@ -1043,12 +1036,10 @@ impl WindowDelegate {
         // Otherwise, we don't change the mask until we exit fullscreen.
     }
 
-    #[inline]
     pub fn is_resizable(&self) -> bool {
         self.window().isResizable()
     }
 
-    #[inline]
     pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
         let mut mask = self.window().styleMask();
 
@@ -1077,7 +1068,6 @@ impl WindowDelegate {
         }
     }
 
-    #[inline]
     pub fn enabled_buttons(&self) -> WindowButtons {
         let mut buttons = WindowButtons::empty();
         if self.window().isMiniaturizable() {
@@ -1113,7 +1103,6 @@ impl WindowDelegate {
         self.window().invalidateCursorRectsForView(&view);
     }
 
-    #[inline]
     pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
         let associate_mouse_cursor = match mode {
             CursorGrabMode::Locked => false,
@@ -1128,7 +1117,6 @@ impl WindowDelegate {
             .map_err(|status| ExternalError::Os(os_error!(OsError::CGError(status))))
     }
 
-    #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         let view = self.view();
         let state_changed = view.set_cursor_visible(visible);
@@ -1137,12 +1125,10 @@ impl WindowDelegate {
         }
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         self.window().backingScaleFactor() as _
     }
 
-    #[inline]
     pub fn set_cursor_position(&self, cursor_position: Position) -> Result<(), ExternalError> {
         let physical_window_position = self.inner_position().unwrap();
         let scale_factor = self.scale_factor();
@@ -1160,7 +1146,6 @@ impl WindowDelegate {
         Ok(())
     }
 
-    #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         let mtm = MainThreadMarker::from(self);
         let event = NSApplication::sharedApplication(mtm).currentEvent().unwrap();
@@ -1168,15 +1153,12 @@ impl WindowDelegate {
         Ok(())
     }
 
-    #[inline]
     pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    #[inline]
     pub fn show_window_menu(&self, _position: Position) {}
 
-    #[inline]
     pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
         self.window().setIgnoresMouseEvents(!hittest);
         Ok(())
@@ -1226,7 +1208,6 @@ impl WindowDelegate {
         self.set_maximized(maximized);
     }
 
-    #[inline]
     pub fn set_minimized(&self, minimized: bool) {
         let is_minimized = self.window().isMiniaturized();
         if is_minimized == minimized {
@@ -1240,12 +1221,10 @@ impl WindowDelegate {
         }
     }
 
-    #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         Some(self.window().isMiniaturized())
     }
 
-    #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         let mtm = MainThreadMarker::from(self);
         let is_zoomed = self.is_zoomed();
@@ -1280,17 +1259,14 @@ impl WindowDelegate {
         }
     }
 
-    #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         self.ivars().fullscreen.borrow().clone()
     }
 
-    #[inline]
     pub fn is_maximized(&self) -> bool {
         self.is_zoomed()
     }
 
-    #[inline]
     pub(crate) fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         let mtm = MainThreadMarker::from(self);
         let app = NSApplication::sharedApplication(mtm);
@@ -1470,7 +1446,6 @@ impl WindowDelegate {
         };
     }
 
-    #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         if decorations == self.ivars().decorations.get() {
             return;
@@ -1504,12 +1479,10 @@ impl WindowDelegate {
         self.set_style_mask(new_mask);
     }
 
-    #[inline]
     pub fn is_decorated(&self) -> bool {
         self.ivars().decorations.get()
     }
 
-    #[inline]
     pub fn set_window_level(&self, level: WindowLevel) {
         let level = match level {
             WindowLevel::AlwaysOnTop => ffi::kCGFloatingWindowLevel as NSWindowLevel,
@@ -1519,7 +1492,6 @@ impl WindowDelegate {
         self.window().setLevel(level);
     }
 
-    #[inline]
     pub fn set_window_icon(&self, _icon: Option<Icon>) {
         // macOS doesn't have window icons. Though, there is
         // `setRepresentedFilename`, but that's semantically distinct and should
@@ -1531,7 +1503,6 @@ impl WindowDelegate {
         // https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/WinPanel/Tasks/SettingWindowTitle.html
     }
 
-    #[inline]
     pub fn set_ime_cursor_area(&self, spot: Position, size: Size) {
         let scale_factor = self.scale_factor();
         let logical_spot = spot.to_logical(scale_factor);
@@ -1543,15 +1514,12 @@ impl WindowDelegate {
         self.view().set_ime_cursor_area(logical_spot, size);
     }
 
-    #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         self.view().set_ime_allowed(allowed);
     }
 
-    #[inline]
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
-    #[inline]
     pub fn focus_window(&self) {
         let mtm = MainThreadMarker::from(self);
         let is_minimized = self.window().isMiniaturized();
@@ -1564,7 +1532,6 @@ impl WindowDelegate {
         }
     }
 
-    #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
         let mtm = MainThreadMarker::from(self);
         let ns_request_type = request_type.map(|ty| match ty {
@@ -1576,31 +1543,26 @@ impl WindowDelegate {
         }
     }
 
-    #[inline]
     // Allow directly accessing the current monitor internally without unwrapping.
     pub(crate) fn current_monitor_inner(&self) -> Option<MonitorHandle> {
         let display_id = get_display_id(&*self.window().screen()?);
         Some(MonitorHandle::new(display_id))
     }
 
-    #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
         self.current_monitor_inner()
     }
 
-    #[inline]
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         monitor::available_monitors()
     }
 
-    #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let monitor = monitor::primary_monitor();
         Some(monitor)
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> rwh_06::RawWindowHandle {
         let window_handle = rwh_06::AppKitWindowHandle::new({
             let ptr = Retained::as_ptr(&self.view()) as *mut _;
@@ -1618,7 +1580,6 @@ impl WindowDelegate {
         }
     }
 
-    #[inline]
     pub fn has_focus(&self) -> bool {
         self.window().isKeyWindow()
     }
@@ -1642,7 +1603,6 @@ impl WindowDelegate {
         unsafe { self.window().setAppearance(theme_to_appearance(theme).as_deref()) };
     }
 
-    #[inline]
     pub fn set_content_protected(&self, protected: bool) {
         self.window().setSharingType(if protected {
             NSWindowSharingType::NSWindowSharingNone
@@ -1676,12 +1636,10 @@ fn restore_and_release_display(monitor: &MonitorHandle) {
 }
 
 impl WindowExtMacOS for WindowDelegate {
-    #[inline]
     fn simple_fullscreen(&self) -> bool {
         self.ivars().is_simple_fullscreen.get()
     }
 
-    #[inline]
     fn set_simple_fullscreen(&self, fullscreen: bool) -> bool {
         let mtm = MainThreadMarker::from(self);
 
@@ -1747,37 +1705,30 @@ impl WindowExtMacOS for WindowDelegate {
         }
     }
 
-    #[inline]
     fn has_shadow(&self) -> bool {
         self.window().hasShadow()
     }
 
-    #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
         self.window().setHasShadow(has_shadow)
     }
 
-    #[inline]
     fn set_tabbing_identifier(&self, identifier: &str) {
         self.window().setTabbingIdentifier(&NSString::from_str(identifier))
     }
 
-    #[inline]
     fn tabbing_identifier(&self) -> String {
         self.window().tabbingIdentifier().to_string()
     }
 
-    #[inline]
     fn select_next_tab(&self) {
         self.window().selectNextTab(None)
     }
 
-    #[inline]
     fn select_previous_tab(&self) {
         unsafe { self.window().selectPreviousTab(None) }
     }
 
-    #[inline]
     fn select_tab_at_index(&self, index: usize) {
         if let Some(group) = self.window().tabGroup() {
             if let Some(windows) = unsafe { self.window().tabbedWindows() } {
@@ -1788,7 +1739,6 @@ impl WindowExtMacOS for WindowDelegate {
         }
     }
 
-    #[inline]
     fn num_tabs(&self) -> usize {
         unsafe { self.window().tabbedWindows() }.map(|windows| windows.len()).unwrap_or(1)
     }

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -120,7 +120,6 @@ pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -217,7 +217,6 @@ impl Inner {
         None
     }
 
-    #[inline]
     pub fn set_resize_increments(&self, _increments: Option<Size>) {
         warn!("`Window::set_resize_increments` is ignored on iOS")
     }
@@ -231,12 +230,10 @@ impl Inner {
         false
     }
 
-    #[inline]
     pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {
         warn!("`Window::set_enabled_buttons` is ignored on iOS");
     }
 
-    #[inline]
     pub fn enabled_buttons(&self) -> WindowButtons {
         warn!("`Window::enabled_buttons` is ignored on iOS");
         WindowButtons::all()
@@ -270,7 +267,6 @@ impl Inner {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    #[inline]
     pub fn show_window_menu(&self, _position: Position) {}
 
     pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), ExternalError> {
@@ -425,7 +421,6 @@ impl Inner {
         self.window.isKeyWindow()
     }
 
-    #[inline]
     pub fn set_theme(&self, _theme: Option<Theme>) {
         warn!("`Window::set_theme` is ignored on iOS");
     }
@@ -537,7 +532,6 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub(crate) fn raw_window_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
@@ -549,7 +543,6 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub(crate) fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {

--- a/src/platform_impl/linux/common/xkb/compose.rs
+++ b/src/platform_impl/linux/common/xkb/compose.rs
@@ -84,7 +84,6 @@ impl XkbComposeState {
         })
     }
 
-    #[inline]
     pub fn feed(&mut self, keysym: xkb_keysym_t) -> ComposeStatus {
         let feed_result = unsafe { (XKBCH.xkb_compose_state_feed)(self.state.as_ptr(), keysym) };
         match feed_result {
@@ -95,14 +94,12 @@ impl XkbComposeState {
         }
     }
 
-    #[inline]
     pub fn reset(&mut self) {
         unsafe {
             (XKBCH.xkb_compose_state_reset)(self.state.as_ptr());
         }
     }
 
-    #[inline]
     pub fn status(&mut self) -> xkb_compose_status {
         unsafe { (XKBCH.xkb_compose_state_get_status)(self.state.as_ptr()) }
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -232,32 +232,26 @@ macro_rules! x11_or_wayland {
 }
 
 impl MonitorHandle {
-    #[inline]
     pub fn name(&self) -> Option<String> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.name())
     }
 
-    #[inline]
     pub fn native_identifier(&self) -> u32 {
         x11_or_wayland!(match self; MonitorHandle(m) => m.native_identifier())
     }
 
-    #[inline]
     pub fn position(&self) -> Option<PhysicalPosition<i32>> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.position())
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         x11_or_wayland!(match self; MonitorHandle(m) => m.scale_factor() as _)
     }
 
-    #[inline]
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.current_video_mode())
     }
 
-    #[inline]
     pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoModeHandle>> {
         x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
     }
@@ -272,22 +266,18 @@ pub enum VideoModeHandle {
 }
 
 impl VideoModeHandle {
-    #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.size())
     }
 
-    #[inline]
     pub fn bit_depth(&self) -> Option<NonZeroU16> {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.bit_depth())
     }
 
-    #[inline]
     pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.refresh_rate_millihertz())
     }
 
-    #[inline]
     pub fn monitor(&self) -> MonitorHandle {
         x11_or_wayland!(match self; VideoModeHandle(m) => m.monitor(); as MonitorHandle)
     }
@@ -302,227 +292,182 @@ impl Window {
         f(self)
     }
 
-    #[inline]
     pub fn id(&self) -> WindowId {
         x11_or_wayland!(match self; Window(w) => w.id())
     }
 
-    #[inline]
     pub fn set_title(&self, title: &str) {
         x11_or_wayland!(match self; Window(w) => w.set_title(title));
     }
 
-    #[inline]
     pub fn set_transparent(&self, transparent: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_transparent(transparent));
     }
 
-    #[inline]
     pub fn set_blur(&self, blur: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_blur(blur));
     }
 
-    #[inline]
     pub fn set_visible(&self, visible: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_visible(visible))
     }
 
-    #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         x11_or_wayland!(match self; Window(w) => w.is_visible())
     }
 
-    #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         x11_or_wayland!(match self; Window(w) => w.outer_position())
     }
 
-    #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         x11_or_wayland!(match self; Window(w) => w.inner_position())
     }
 
-    #[inline]
     pub fn set_outer_position(&self, position: Position) {
         x11_or_wayland!(match self; Window(w) => w.set_outer_position(position))
     }
 
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         x11_or_wayland!(match self; Window(w) => w.inner_size())
     }
 
-    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         x11_or_wayland!(match self; Window(w) => w.outer_size())
     }
 
-    #[inline]
     pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         x11_or_wayland!(match self; Window(w) => w.request_inner_size(size))
     }
 
-    #[inline]
     pub(crate) fn request_activation_token(&self) -> Result<AsyncRequestSerial, NotSupportedError> {
         x11_or_wayland!(match self; Window(w) => w.request_activation_token())
     }
 
-    #[inline]
     pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
         x11_or_wayland!(match self; Window(w) => w.set_min_inner_size(dimensions))
     }
 
-    #[inline]
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
         x11_or_wayland!(match self; Window(w) => w.set_max_inner_size(dimensions))
     }
 
-    #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         x11_or_wayland!(match self; Window(w) => w.resize_increments())
     }
 
-    #[inline]
     pub fn set_resize_increments(&self, increments: Option<Size>) {
         x11_or_wayland!(match self; Window(w) => w.set_resize_increments(increments))
     }
 
-    #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_resizable(resizable))
     }
 
-    #[inline]
     pub fn is_resizable(&self) -> bool {
         x11_or_wayland!(match self; Window(w) => w.is_resizable())
     }
 
-    #[inline]
     pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
         x11_or_wayland!(match self; Window(w) => w.set_enabled_buttons(buttons))
     }
 
-    #[inline]
     pub fn enabled_buttons(&self) -> WindowButtons {
         x11_or_wayland!(match self; Window(w) => w.enabled_buttons())
     }
 
-    #[inline]
     pub fn set_cursor(&self, cursor: Cursor) {
         x11_or_wayland!(match self; Window(w) => w.set_cursor(cursor))
     }
 
-    #[inline]
     pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
         x11_or_wayland!(match self; Window(window) => window.set_cursor_grab(mode))
     }
 
-    #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         x11_or_wayland!(match self; Window(window) => window.set_cursor_visible(visible))
     }
 
-    #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         x11_or_wayland!(match self; Window(window) => window.drag_window())
     }
 
-    #[inline]
     pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
         x11_or_wayland!(match self; Window(window) => window.drag_resize_window(direction))
     }
 
-    #[inline]
     pub fn show_window_menu(&self, position: Position) {
         x11_or_wayland!(match self; Window(w) => w.show_window_menu(position))
     }
 
-    #[inline]
     pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
         x11_or_wayland!(match self; Window(w) => w.set_cursor_hittest(hittest))
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         x11_or_wayland!(match self; Window(w) => w.scale_factor())
     }
 
-    #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
         x11_or_wayland!(match self; Window(w) => w.set_cursor_position(position))
     }
 
-    #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_maximized(maximized))
     }
 
-    #[inline]
     pub fn is_maximized(&self) -> bool {
         x11_or_wayland!(match self; Window(w) => w.is_maximized())
     }
 
-    #[inline]
     pub fn set_minimized(&self, minimized: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_minimized(minimized))
     }
 
-    #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         x11_or_wayland!(match self; Window(w) => w.is_minimized())
     }
 
-    #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         x11_or_wayland!(match self; Window(w) => w.fullscreen())
     }
 
-    #[inline]
     pub(crate) fn set_fullscreen(&self, monitor: Option<Fullscreen>) {
         x11_or_wayland!(match self; Window(w) => w.set_fullscreen(monitor))
     }
 
-    #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_decorations(decorations))
     }
 
-    #[inline]
     pub fn is_decorated(&self) -> bool {
         x11_or_wayland!(match self; Window(w) => w.is_decorated())
     }
 
-    #[inline]
     pub fn set_window_level(&self, level: WindowLevel) {
         x11_or_wayland!(match self; Window(w) => w.set_window_level(level))
     }
 
-    #[inline]
     pub fn set_window_icon(&self, window_icon: Option<Icon>) {
         x11_or_wayland!(match self; Window(w) => w.set_window_icon(window_icon.map(|icon| icon.inner)))
     }
 
-    #[inline]
     pub fn set_ime_cursor_area(&self, position: Position, size: Size) {
         x11_or_wayland!(match self; Window(w) => w.set_ime_cursor_area(position, size))
     }
 
-    #[inline]
     pub fn reset_dead_keys(&self) {
         common::xkb::reset_dead_keys()
     }
 
-    #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         x11_or_wayland!(match self; Window(w) => w.set_ime_allowed(allowed))
     }
 
-    #[inline]
     pub fn set_ime_purpose(&self, purpose: ImePurpose) {
         x11_or_wayland!(match self; Window(w) => w.set_ime_purpose(purpose))
     }
 
-    #[inline]
     pub fn focus_window(&self) {
         x11_or_wayland!(match self; Window(w) => w.focus_window())
     }
@@ -531,22 +476,18 @@ impl Window {
         x11_or_wayland!(match self; Window(w) => w.request_user_attention(request_type))
     }
 
-    #[inline]
     pub fn request_redraw(&self) {
         x11_or_wayland!(match self; Window(w) => w.request_redraw())
     }
 
-    #[inline]
     pub fn pre_present_notify(&self) {
         x11_or_wayland!(match self; Window(w) => w.pre_present_notify())
     }
 
-    #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
         Some(x11_or_wayland!(match self; Window(w) => w.current_monitor()?; as MonitorHandle))
     }
 
-    #[inline]
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         match self {
             #[cfg(x11_platform)]
@@ -560,31 +501,26 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         Some(x11_or_wayland!(match self; Window(w) => w.primary_monitor()?; as MonitorHandle))
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         x11_or_wayland!(match self; Window(window) => window.raw_window_handle_rwh_06())
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
         x11_or_wayland!(match self; Window(window) => window.raw_display_handle_rwh_06())
     }
 
-    #[inline]
     pub fn set_theme(&self, theme: Option<Theme>) {
         x11_or_wayland!(match self; Window(window) => window.set_theme(theme))
     }
 
-    #[inline]
     pub fn theme(&self) -> Option<Theme> {
         x11_or_wayland!(match self; Window(window) => window.theme())
     }
@@ -593,7 +529,6 @@ impl Window {
         x11_or_wayland!(match self; Window(window) => window.set_content_protected(protected))
     }
 
-    #[inline]
     pub fn has_focus(&self) -> bool {
         x11_or_wayland!(match self; Window(window) => window.has_focus())
     }
@@ -756,7 +691,6 @@ impl EventLoop {
         Ok(EventLoop::X(x11::EventLoop::new(xconn)))
     }
 
-    #[inline]
     pub fn is_wayland(&self) -> bool {
         match *self {
             #[cfg(wayland_platform)]
@@ -819,7 +753,6 @@ pub(crate) enum OwnedDisplayHandle {
 
 impl OwnedDisplayHandle {
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -498,7 +498,6 @@ impl EventLoop {
         std::mem::swap(&mut self.window_ids, &mut window_ids);
     }
 
-    #[inline]
     pub fn window_target(&self) -> &dyn RootActiveEventLoop {
         &self.active_event_loop
     }
@@ -608,7 +607,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
         self.exit.get().is_some()
     }
 
-    #[inline]
     fn listen_device_events(&self, _allowed: DeviceEvents) {}
 
     fn create_custom_cursor(
@@ -620,7 +618,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
         })
     }
 
-    #[inline]
     fn system_theme(&self) -> Option<Theme> {
         None
     }

--- a/src/platform_impl/linux/wayland/event_loop/sink.rs
+++ b/src/platform_impl/linux/wayland/event_loop/sink.rs
@@ -20,13 +20,11 @@ impl EventSink {
     }
 
     /// Return `true` if there're pending events.
-    #[inline]
     pub fn is_empty(&self) -> bool {
         self.window_events.is_empty()
     }
 
     /// Add new device event to a queue.
-    #[inline]
     pub fn push_device_event(&mut self, event: DeviceEvent, device_id: DeviceId) {
         self.window_events.push(Event::DeviceEvent {
             event,
@@ -35,17 +33,14 @@ impl EventSink {
     }
 
     /// Add new window event to a queue.
-    #[inline]
     pub fn push_window_event(&mut self, event: WindowEvent, window_id: WindowId) {
         self.window_events.push(Event::WindowEvent { event, window_id: RootWindowId(window_id) });
     }
 
-    #[inline]
     pub fn append(&mut self, other: &mut Self) {
         self.window_events.append(&mut other.window_events);
     }
 
-    #[inline]
     pub(crate) fn drain(&mut self) -> Drain<'_, Event> {
         self.window_events.drain(..)
     }

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -81,7 +81,6 @@ impl FingerId {
 }
 
 /// Get the WindowId out of the surface.
-#[inline]
 fn make_wid(surface: &WlSurface) -> WindowId {
     WindowId(surface.id().as_ptr() as u64)
 }

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -13,24 +13,20 @@ pub struct MonitorHandle {
 }
 
 impl MonitorHandle {
-    #[inline]
     pub(crate) fn new(proxy: WlOutput) -> Self {
         Self { proxy }
     }
 
-    #[inline]
     pub fn name(&self) -> Option<String> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         output_data.with_output_info(|info| info.name.clone())
     }
 
-    #[inline]
     pub fn native_identifier(&self) -> u32 {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         output_data.with_output_info(|info| info.id)
     }
 
-    #[inline]
     pub fn position(&self) -> Option<PhysicalPosition<i32>> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         Some(output_data.with_output_info(|info| {
@@ -47,13 +43,11 @@ impl MonitorHandle {
         }))
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> i32 {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         output_data.scale_factor()
     }
 
-    #[inline]
     pub fn current_video_mode(&self) -> Option<PlatformVideoModeHandle> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         output_data.with_output_info(|info| {
@@ -65,7 +59,6 @@ impl MonitorHandle {
         })
     }
 
-    #[inline]
     pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoModeHandle> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         let modes = output_data.with_output_info(|info| info.modes.clone());
@@ -120,17 +113,14 @@ impl VideoModeHandle {
         }
     }
 
-    #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         self.size
     }
 
-    #[inline]
     pub fn bit_depth(&self) -> Option<NonZeroU16> {
         None
     }
 
-    #[inline]
     pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
         self.refresh_rate_millihertz
     }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -223,50 +223,41 @@ impl Window {
 }
 
 impl Window {
-    #[inline]
     pub fn id(&self) -> WindowId {
         self.window_id
     }
 
-    #[inline]
     pub fn set_title(&self, title: impl ToString) {
         let new_title = title.to_string();
         self.window_state.lock().unwrap().set_title(new_title);
     }
 
-    #[inline]
     pub fn set_visible(&self, _visible: bool) {
         // Not possible on Wayland.
     }
 
-    #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         None
     }
 
-    #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         Err(NotSupportedError::new())
     }
 
-    #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         Err(NotSupportedError::new())
     }
 
-    #[inline]
     pub fn set_outer_position(&self, _: Position) {
         // Not possible on Wayland.
     }
 
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         let window_state = self.window_state.lock().unwrap();
         let scale_factor = window_state.scale_factor();
         super::logical_to_physical_rounded(window_state.inner_size(), scale_factor)
     }
 
-    #[inline]
     pub fn request_redraw(&self) {
         // NOTE: try to not wake up the loop when the event was already scheduled and not yet
         // processed by the loop, because if at this point the value was `true` it could only
@@ -282,19 +273,16 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn pre_present_notify(&self) {
         self.window_state.lock().unwrap().request_frame_callback();
     }
 
-    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         let window_state = self.window_state.lock().unwrap();
         let scale_factor = window_state.scale_factor();
         super::logical_to_physical_rounded(window_state.outer_size(), scale_factor)
     }
 
-    #[inline]
     pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let mut window_state = self.window_state.lock().unwrap();
         let new_size = window_state.request_inner_size(size);
@@ -303,7 +291,6 @@ impl Window {
     }
 
     /// Set the minimum inner size for the window.
-    #[inline]
     pub fn set_min_inner_size(&self, min_size: Option<Size>) {
         let scale_factor = self.scale_factor();
         let min_size = min_size.map(|size| size.to_logical(scale_factor));
@@ -313,7 +300,6 @@ impl Window {
     }
 
     /// Set the maximum inner size for the window.
-    #[inline]
     pub fn set_max_inner_size(&self, max_size: Option<Size>) {
         let scale_factor = self.scale_factor();
         let max_size = max_size.map(|size| size.to_logical(scale_factor));
@@ -322,45 +308,37 @@ impl Window {
         self.request_redraw();
     }
 
-    #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
-    #[inline]
     pub fn set_resize_increments(&self, _increments: Option<Size>) {
         warn!("`set_resize_increments` is not implemented for Wayland");
     }
 
-    #[inline]
     pub fn set_transparent(&self, transparent: bool) {
         self.window_state.lock().unwrap().set_transparent(transparent);
     }
 
-    #[inline]
     pub fn has_focus(&self) -> bool {
         self.window_state.lock().unwrap().has_focus()
     }
 
-    #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         // XXX clients don't know whether they are minimized or not.
         None
     }
 
-    #[inline]
     pub fn show_window_menu(&self, position: Position) {
         let scale_factor = self.scale_factor();
         let position = position.to_logical(scale_factor);
         self.window_state.lock().unwrap().show_window_menu(position);
     }
 
-    #[inline]
     pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
         self.window_state.lock().unwrap().drag_resize_window(direction)
     }
 
-    #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         if self.window_state.lock().unwrap().set_resizable(resizable) {
             // NOTE: Requires commit to be applied.
@@ -368,49 +346,39 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn is_resizable(&self) -> bool {
         self.window_state.lock().unwrap().resizable()
     }
 
-    #[inline]
     pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {
         // TODO(kchibisov) v5 of the xdg_shell allows that.
     }
 
-    #[inline]
     pub fn enabled_buttons(&self) -> WindowButtons {
         // TODO(kchibisov) v5 of the xdg_shell allows that.
         WindowButtons::all()
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         self.window_state.lock().unwrap().scale_factor()
     }
 
-    #[inline]
     pub fn set_blur(&self, blur: bool) {
         self.window_state.lock().unwrap().set_blur(blur);
     }
 
-    #[inline]
     pub fn set_decorations(&self, decorate: bool) {
         self.window_state.lock().unwrap().set_decorate(decorate)
     }
 
-    #[inline]
     pub fn is_decorated(&self) -> bool {
         self.window_state.lock().unwrap().is_decorated()
     }
 
-    #[inline]
     pub fn set_window_level(&self, _level: WindowLevel) {}
 
-    #[inline]
     pub(crate) fn set_window_icon(&self, _window_icon: Option<PlatformIcon>) {}
 
-    #[inline]
     pub fn set_minimized(&self, minimized: bool) {
         // You can't unminimize the window on Wayland.
         if !minimized {
@@ -421,7 +389,6 @@ impl Window {
         self.window.set_minimized();
     }
 
-    #[inline]
     pub fn is_maximized(&self) -> bool {
         self.window_state
             .lock()
@@ -432,7 +399,6 @@ impl Window {
             .unwrap_or_default()
     }
 
-    #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         if maximized {
             self.window.set_maximized()
@@ -441,7 +407,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         let is_fullscreen = self
             .window_state
@@ -460,7 +425,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub(crate) fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         match fullscreen {
             Some(Fullscreen::Exclusive(_)) => {
@@ -480,7 +444,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_cursor(&self, cursor: Cursor) {
         let window_state = &mut self.window_state.lock().unwrap();
 
@@ -490,7 +453,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         self.window_state.lock().unwrap().set_cursor_visible(visible);
     }
@@ -537,12 +499,10 @@ impl Window {
         Ok(serial)
     }
 
-    #[inline]
     pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
         self.window_state.lock().unwrap().set_cursor_grab(mode)
     }
 
-    #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
         let scale_factor = self.scale_factor();
         let position = position.to_logical(scale_factor);
@@ -554,12 +514,10 @@ impl Window {
             .map(|_| self.request_redraw())
     }
 
-    #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         self.window_state.lock().unwrap().drag_window()
     }
 
-    #[inline]
     pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
         let surface = self.window.wl_surface();
 
@@ -576,7 +534,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_ime_cursor_area(&self, position: Position, size: Size) {
         let window_state = self.window_state.lock().unwrap();
         if window_state.ime_allowed() {
@@ -587,7 +544,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         let mut window_state = self.window_state.lock().unwrap();
 
@@ -598,38 +554,31 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_ime_purpose(&self, purpose: ImePurpose) {
         self.window_state.lock().unwrap().set_ime_purpose(purpose);
     }
 
-    #[inline]
     pub fn focus_window(&self) {}
 
-    #[inline]
     pub fn surface(&self) -> &WlSurface {
         self.window.wl_surface()
     }
 
-    #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
         let data = self.window.wl_surface().data::<SurfaceData>()?;
         data.outputs().next().map(MonitorHandle::new)
     }
 
-    #[inline]
     pub fn available_monitors(&self) -> Vec<MonitorHandle> {
         self.monitors.lock().unwrap().clone()
     }
 
-    #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         // XXX there's no such concept on Wayland.
         None
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         Ok(rwh_06::WaylandWindowHandle::new({
             let ptr = self.window.wl_surface().id().as_ptr();
@@ -639,7 +588,6 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
@@ -650,19 +598,16 @@ impl Window {
         .into())
     }
 
-    #[inline]
     pub fn set_theme(&self, theme: Option<Theme>) {
         self.window_state.lock().unwrap().set_theme(theme)
     }
 
-    #[inline]
     pub fn theme(&self) -> Option<Theme> {
         self.window_state.lock().unwrap().theme()
     }
 
     pub fn set_content_protected(&self, _protected: bool) {}
 
-    #[inline]
     pub fn title(&self) -> String {
         self.window_state.lock().unwrap().title().to_owned()
     }

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -382,7 +382,6 @@ impl WindowState {
         }
     }
 
-    #[inline]
     fn is_stateless(configure: &WindowConfigure) -> bool {
         !(configure.is_maximized() || configure.is_fullscreen() || configure.is_tiled())
     }
@@ -488,7 +487,6 @@ impl WindowState {
     }
 
     /// Get the stored resizable state.
-    #[inline]
     pub fn resizable(&self) -> bool {
         self.resizable
     }
@@ -496,7 +494,6 @@ impl WindowState {
     /// Set the resizable state on the window.
     ///
     /// Returns `true` when the state was applied.
-    #[inline]
     pub fn set_resizable(&mut self, resizable: bool) -> bool {
         if self.resizable == resizable {
             return false;
@@ -520,30 +517,25 @@ impl WindowState {
     }
 
     /// Whether the window is focused by any seat.
-    #[inline]
     pub fn has_focus(&self) -> bool {
         !self.seat_focus.is_empty()
     }
 
     /// Whether the IME is allowed.
-    #[inline]
     pub fn ime_allowed(&self) -> bool {
         self.ime_allowed
     }
 
     /// Get the size of the window.
-    #[inline]
     pub fn inner_size(&self) -> LogicalSize<u32> {
         self.size
     }
 
     /// Whether the window received initial configure event from the compositor.
-    #[inline]
     pub fn is_configured(&self) -> bool {
         self.last_configure.is_some()
     }
 
-    #[inline]
     pub fn is_decorated(&mut self) -> bool {
         let csd = self
             .last_configure
@@ -559,7 +551,6 @@ impl WindowState {
     }
 
     /// Get the outer size of the window.
-    #[inline]
     pub fn outer_size(&self) -> LogicalSize<u32> {
         self.frame
             .as_ref()
@@ -679,7 +670,6 @@ impl WindowState {
     }
 
     /// Get the scale factor of the window.
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         self.scale_factor
     }
@@ -793,7 +783,6 @@ impl WindowState {
     }
 
     /// The current theme for CSD decorations.
-    #[inline]
     pub fn theme(&self) -> Option<Theme> {
         self.theme
     }
@@ -903,7 +892,6 @@ impl WindowState {
     }
 
     /// Whether show or hide client side decorations.
-    #[inline]
     pub fn set_decorate(&mut self, decorate: bool) {
         if decorate == self.decorate {
             return;
@@ -928,13 +916,11 @@ impl WindowState {
     }
 
     /// Add seat focus for the window.
-    #[inline]
     pub fn add_seat_focus(&mut self, seat: ObjectId) {
         self.seat_focus.insert(seat);
     }
 
     /// Remove seat focus from the window.
-    #[inline]
     pub fn remove_seat_focus(&mut self, seat: &ObjectId) {
         self.seat_focus.remove(seat);
     }
@@ -987,7 +973,6 @@ impl WindowState {
     }
 
     /// Set the scale factor for the given window.
-    #[inline]
     pub fn set_scale_factor(&mut self, scale_factor: f64) {
         self.scale_factor = scale_factor;
 
@@ -1002,7 +987,6 @@ impl WindowState {
     }
 
     /// Make window background blurred
-    #[inline]
     pub fn set_blur(&mut self, blurred: bool) {
         if blurred && self.blur.is_none() {
             if let Some(blur_manager) = self.blur_manager.as_ref() {
@@ -1042,14 +1026,12 @@ impl WindowState {
     }
 
     /// Mark the window as transparent.
-    #[inline]
     pub fn set_transparent(&mut self, transparent: bool) {
         self.transparent = transparent;
         self.reload_transparency_hint();
     }
 
     /// Register text input on the top-level.
-    #[inline]
     pub fn text_input_entered(&mut self, text_input: &ZwpTextInputV3) {
         if !self.text_inputs.iter().any(|t| t == text_input) {
             self.text_inputs.push(text_input.clone());
@@ -1057,7 +1039,6 @@ impl WindowState {
     }
 
     /// The text input left the top-level.
-    #[inline]
     pub fn text_input_left(&mut self, text_input: &ZwpTextInputV3) {
         if let Some(position) = self.text_inputs.iter().position(|t| t == text_input) {
             self.text_inputs.remove(position);
@@ -1065,7 +1046,6 @@ impl WindowState {
     }
 
     /// Get the cached title.
-    #[inline]
     pub fn title(&self) -> &str {
         &self.title
     }

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -23,7 +23,6 @@ pub enum ImeContextCreationError {
 type XIMProcNonnull = unsafe extern "C" fn(ffi::XIM, ffi::XPointer, ffi::XPointer);
 
 /// Wrapper for creating XIM callbacks.
-#[inline]
 fn create_xim_callback(client_data: ffi::XPointer, callback: XIMProcNonnull) -> ffi::XIMCallback {
     XIMCallback { client_data, callback: Some(callback) }
 }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -623,7 +623,6 @@ impl AsRawFd for EventLoop {
 
 impl ActiveEventLoop {
     /// Returns the `XConnection` of this events loop.
-    #[inline]
     pub(crate) fn x_connection(&self) -> &Arc<XConnection> {
         &self.xconn
     }
@@ -832,7 +831,6 @@ pub(crate) struct Window(Arc<UnownedWindow>);
 impl Deref for Window {
     type Target = UnownedWindow;
 
-    #[inline]
     fn deref(&self) -> &UnownedWindow {
         &self.0
     }
@@ -1104,14 +1102,12 @@ impl Device {
         }
     }
 
-    #[inline]
     fn physical_device(info: &ffi::XIDeviceInfo) -> bool {
         info._use == ffi::XISlaveKeyboard
             || info._use == ffi::XISlavePointer
             || info._use == ffi::XIFloatingSlave
     }
 
-    #[inline]
     fn classes(info: &ffi::XIDeviceInfo) -> &[*const ffi::XIAnyClassInfo] {
         unsafe {
             slice::from_raw_parts(
@@ -1123,7 +1119,6 @@ impl Device {
 }
 
 /// Convert the raw X11 representation for a 32-bit floating point to a double.
-#[inline]
 fn xinput_fp1616_to_float(fp: xinput::Fp1616) -> f64 {
     (fp as f64) / ((1 << 16) as f64)
 }

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -29,22 +29,18 @@ pub struct VideoModeHandle {
 }
 
 impl VideoModeHandle {
-    #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         self.size.into()
     }
 
-    #[inline]
     pub fn bit_depth(&self) -> Option<NonZeroU16> {
         self.bit_depth
     }
 
-    #[inline]
     pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
         self.refresh_rate_millihertz
     }
 
-    #[inline]
     pub fn monitor(&self) -> MonitorHandle {
         self.monitor.clone().unwrap()
     }
@@ -94,7 +90,6 @@ impl std::hash::Hash for MonitorHandle {
     }
 }
 
-#[inline]
 pub fn mode_refresh_rate_millihertz(mode: &randr::ModeInfo) -> Option<NonZeroU32> {
     if mode.dot_clock > 0 && mode.htotal > 0 && mode.vtotal > 0 {
         #[allow(clippy::unnecessary_cast)]
@@ -144,7 +139,6 @@ impl MonitorHandle {
         Some(self.name.clone())
     }
 
-    #[inline]
     pub fn native_identifier(&self) -> u32 {
         self.id as _
     }
@@ -153,17 +147,14 @@ impl MonitorHandle {
         Some(self.position.into())
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         self.scale_factor
     }
 
-    #[inline]
     pub fn current_video_mode(&self) -> Option<PlatformVideoModeHandle> {
         self.video_modes.iter().find(|mode| mode.current).cloned().map(PlatformVideoModeHandle::X)
     }
 
-    #[inline]
     pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoModeHandle> {
         let monitor = self.clone();
         self.video_modes.clone().into_iter().map(move |mut x| {
@@ -264,7 +255,6 @@ impl XConnection {
         }
     }
 
-    #[inline]
     pub fn primary_monitor(&self) -> Result<MonitorHandle, X11Error> {
         Ok(self
             .available_monitors()?

--- a/src/platform_impl/linux/x11/util/cookie.rs
+++ b/src/platform_impl/linux/x11/util/cookie.rs
@@ -25,12 +25,10 @@ impl GenericEventCookie {
         }
     }
 
-    #[inline]
     pub fn extension(&self) -> u8 {
         self.cookie.extension as u8
     }
 
-    #[inline]
     pub fn evtype(&self) -> c_int {
         self.cookie.evtype
     }
@@ -40,7 +38,6 @@ impl GenericEventCookie {
     /// ## SAFETY
     ///
     /// The caller must ensure that the event has the `T` inside of it.
-    #[inline]
     pub unsafe fn as_event<T>(&self) -> &T {
         unsafe { &*(self.cookie.data as *const _) }
     }

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -668,7 +668,6 @@ impl UnownedWindow {
         )
     }
 
-    #[inline]
     pub fn set_theme(&self, theme: Option<Theme>) {
         self.set_theme_inner(theme).expect("Failed to change window theme").ignore_error();
 
@@ -830,14 +829,12 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         let shared_state = self.shared_state_lock();
 
         shared_state.desired_fullscreen.clone().unwrap_or_else(|| shared_state.fullscreen.clone())
     }
 
-    #[inline]
     pub(crate) fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         if let Some(flusher) =
             self.set_fullscreen_inner(fullscreen).expect("Failed to change window fullscreen state")
@@ -881,7 +878,6 @@ impl UnownedWindow {
         Some(self.xconn.primary_monitor().expect("Failed to get primary monitor"))
     }
 
-    #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         let atoms = self.xconn.atoms();
         let state_atom = atoms[_NET_WM_STATE];
@@ -901,7 +897,6 @@ impl UnownedWindow {
     }
 
     /// Refresh the API for the given monitor.
-    #[inline]
     pub(super) fn refresh_dpi_for_monitor(
         &self,
         new_monitor: &X11MonitorHandle,
@@ -975,7 +970,6 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub fn set_minimized(&self, minimized: bool) {
         self.set_minimized_inner(minimized)
             .expect_then_ignore_error("Failed to change window minimization");
@@ -983,7 +977,6 @@ impl UnownedWindow {
         self.xconn.flush_requests().expect("Failed to change window minimization");
     }
 
-    #[inline]
     pub fn is_maximized(&self) -> bool {
         let atoms = self.xconn.atoms();
         let state_atom = atoms[_NET_WM_STATE];
@@ -1012,7 +1005,6 @@ impl UnownedWindow {
         self.set_netwm(maximized.into(), (horz_atom, vert_atom, 0, 0))
     }
 
-    #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         self.set_maximized_inner(maximized)
             .expect_then_ignore_error("Failed to change window maximization");
@@ -1042,17 +1034,14 @@ impl UnownedWindow {
         )
     }
 
-    #[inline]
     pub fn set_title(&self, title: &str) {
         self.set_title_inner(title).expect_then_ignore_error("Failed to set window title");
 
         self.xconn.flush_requests().expect("Failed to set window title");
     }
 
-    #[inline]
     pub fn set_transparent(&self, _transparent: bool) {}
 
-    #[inline]
     pub fn set_blur(&self, _blur: bool) {}
 
     fn set_decorations_inner(&self, decorations: bool) -> Result<VoidCookie<'_>, X11Error> {
@@ -1064,7 +1053,6 @@ impl UnownedWindow {
         self.xconn.set_motif_hints(self.xwindow, &hints)
     }
 
-    #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         self.set_decorations_inner(decorations)
             .expect_then_ignore_error("Failed to set decoration state");
@@ -1072,7 +1060,6 @@ impl UnownedWindow {
         self.invalidate_cached_frame_extents();
     }
 
-    #[inline]
     pub fn is_decorated(&self) -> bool {
         self.shared_state_lock().is_decorated
     }
@@ -1096,7 +1083,6 @@ impl UnownedWindow {
         self.toggle_atom(_NET_WM_STATE_BELOW, level == WindowLevel::AlwaysOnBottom)
     }
 
-    #[inline]
     pub fn set_window_level(&self, level: WindowLevel) {
         self.set_window_level_inner(level)
             .expect_then_ignore_error("Failed to set window-level state");
@@ -1129,7 +1115,6 @@ impl UnownedWindow {
         )
     }
 
-    #[inline]
     pub(crate) fn set_window_icon(&self, icon: Option<PlatformIcon>) {
         match icon {
             Some(icon) => self.set_icon_inner(icon),
@@ -1140,7 +1125,6 @@ impl UnownedWindow {
         self.xconn.flush_requests().expect("Failed to set icons");
     }
 
-    #[inline]
     pub fn set_visible(&self, visible: bool) {
         let mut shared_state = self.shared_state_lock();
 
@@ -1175,7 +1159,6 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         Some(self.shared_state_lock().visibility == Visibility::Yes)
     }
@@ -1200,7 +1183,6 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let extents = self.shared_state_lock().frame_extents.clone();
         if let Some(extents) = extents {
@@ -1221,7 +1203,6 @@ impl UnownedWindow {
             .unwrap()
     }
 
-    #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         Ok(self.inner_position_physical().into())
     }
@@ -1254,7 +1235,6 @@ impl UnownedWindow {
         self.set_position_inner(x, y).expect_then_ignore_error("Failed to call `XMoveWindow`");
     }
 
-    #[inline]
     pub fn set_outer_position(&self, position: Position) {
         let (x, y) = position.to_physical::<i32>(self.scale_factor()).into();
         self.set_position_physical(x, y);
@@ -1269,12 +1249,10 @@ impl UnownedWindow {
             .unwrap()
     }
 
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         self.inner_size_physical().into()
     }
 
-    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         let extents = self.shared_state_lock().frame_extents.clone();
         if let Some(extents) = extents {
@@ -1301,7 +1279,6 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let scale_factor = self.scale_factor();
         let size = size.to_physical::<u32>(scale_factor).into();
@@ -1347,7 +1324,6 @@ impl UnownedWindow {
         .expect("Failed to call `XSetWMNormalHints`");
     }
 
-    #[inline]
     pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
         self.shared_state_lock().min_inner_size = dimensions;
         let physical_dimensions =
@@ -1363,7 +1339,6 @@ impl UnownedWindow {
         .expect("Failed to call `XSetWMNormalHints`");
     }
 
-    #[inline]
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
         self.shared_state_lock().max_inner_size = dimensions;
         let physical_dimensions =
@@ -1371,7 +1346,6 @@ impl UnownedWindow {
         self.set_max_inner_size_physical(physical_dimensions);
     }
 
-    #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         WmSizeHints::get(
             self.xconn.xcb_connection(),
@@ -1385,7 +1359,6 @@ impl UnownedWindow {
         .map(|(width, height)| (width as u32, height as u32).into())
     }
 
-    #[inline]
     pub fn set_resize_increments(&self, increments: Option<Size>) {
         self.shared_state_lock().resize_increments = increments;
         let physical_increments =
@@ -1455,32 +1428,26 @@ impl UnownedWindow {
         .expect("Failed to call `XSetWMNormalHints`");
     }
 
-    #[inline]
     pub fn is_resizable(&self) -> bool {
         self.shared_state_lock().is_resizable
     }
 
-    #[inline]
     pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {}
 
-    #[inline]
     pub fn enabled_buttons(&self) -> WindowButtons {
         WindowButtons::all()
     }
 
     #[allow(dead_code)]
-    #[inline]
     pub fn xlib_display(&self) -> *mut c_void {
         self.xconn.display as _
     }
 
     #[allow(dead_code)]
-    #[inline]
     pub fn xlib_window(&self) -> c_ulong {
         self.xwindow as ffi::Window
     }
 
-    #[inline]
     pub fn set_cursor(&self, cursor: Cursor) {
         match cursor {
             Cursor::Icon(icon) => {
@@ -1510,7 +1477,6 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
         let mut grabbed_lock = self.cursor_grabbed_mode.lock().unwrap();
         if mode == *grabbed_lock {
@@ -1588,7 +1554,6 @@ impl UnownedWindow {
         result
     }
 
-    #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         #[allow(clippy::mutex_atomic)]
         let mut visible_lock = self.cursor_visible.lock().unwrap();
@@ -1612,7 +1577,6 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         self.shared_state_lock().last_monitor.scale_factor
     }
@@ -1631,13 +1595,11 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
         let (x, y) = position.to_physical::<i32>(self.scale_factor()).into();
         self.set_cursor_position_physical(x, y)
     }
 
-    #[inline]
     pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
         let mut rectangles: Vec<Rectangle> = Vec::new();
         if hittest {
@@ -1664,7 +1626,6 @@ impl UnownedWindow {
         self.drag_initiate(util::MOVERESIZE_MOVE)
     }
 
-    #[inline]
     pub fn show_window_menu(&self, _position: Position) {}
 
     /// Resizes the window while it is being dragged.
@@ -1733,7 +1694,6 @@ impl UnownedWindow {
         })
     }
 
-    #[inline]
     pub fn set_ime_cursor_area(&self, spot: Position, _size: Size) {
         let (x, y) = spot.to_physical::<i32>(self.scale_factor()).into();
         let _ = self.ime_sender.lock().unwrap().send(ImeRequest::Position(
@@ -1743,7 +1703,6 @@ impl UnownedWindow {
         ));
     }
 
-    #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         let _ = self
             .ime_sender
@@ -1752,10 +1711,8 @@ impl UnownedWindow {
             .send(ImeRequest::Allow(self.xwindow as ffi::Window, allowed));
     }
 
-    #[inline]
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
-    #[inline]
     pub fn focus_window(&self) {
         let atoms = self.xconn.atoms();
         let state_atom = atoms[WM_STATE];
@@ -1794,7 +1751,6 @@ impl UnownedWindow {
         }
     }
 
-    #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
         let mut wm_hints =
             WmHints::get(self.xconn.xcb_connection(), self.xwindow as xproto::Window)
@@ -1809,7 +1765,6 @@ impl UnownedWindow {
             .expect_then_ignore_error("Failed to set WM hints");
     }
 
-    #[inline]
     pub(crate) fn generate_activation_token(&self) -> Result<String, X11Error> {
         // Get the title from the WM_NAME property.
         let atoms = self.xconn.atoms();
@@ -1828,14 +1783,12 @@ impl UnownedWindow {
         Ok(token)
     }
 
-    #[inline]
     pub fn request_activation_token(&self) -> Result<AsyncRequestSerial, NotSupportedError> {
         let serial = AsyncRequestSerial::get();
         self.activation_sender.send((self.id(), serial));
         Ok(serial)
     }
 
-    #[inline]
     pub fn id(&self) -> WindowId {
         WindowId(self.xwindow as _)
     }
@@ -1844,18 +1797,15 @@ impl UnownedWindow {
         self.sync_counter_id
     }
 
-    #[inline]
     pub fn request_redraw(&self) {
         self.redraw_sender.send(WindowId(self.xwindow as _));
     }
 
-    #[inline]
     pub fn pre_present_notify(&self) {
         // TODO timer
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         let mut window_handle = rwh_06::XlibWindowHandle::new(self.xlib_window());
         window_handle.visual_id = self.visual as c_ulong;
@@ -1863,7 +1813,6 @@ impl UnownedWindow {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
@@ -1877,14 +1826,12 @@ impl UnownedWindow {
         .into())
     }
 
-    #[inline]
     pub fn theme(&self) -> Option<Theme> {
         None
     }
 
     pub fn set_content_protected(&self, _protected: bool) {}
 
-    #[inline]
     pub fn has_focus(&self) -> bool {
         self.shared_state_lock().has_focus
     }

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -169,7 +169,6 @@ impl XConnection {
     }
 
     /// Checks whether an error has been triggered by the previous function calls.
-    #[inline]
     pub fn check_errors(&self) -> Result<(), XError> {
         let error = self.latest_error.lock().unwrap().take();
         if let Some(error) = error {
@@ -179,43 +178,36 @@ impl XConnection {
         }
     }
 
-    #[inline]
     pub fn randr_version(&self) -> (u32, u32) {
         self.randr_version
     }
 
     /// Get the underlying XCB connection.
-    #[inline]
     pub fn xcb_connection(&self) -> &XCBConnection {
         self.xcb.as_ref().expect("xcb_connection somehow called after drop?")
     }
 
     /// Get the list of atoms.
-    #[inline]
     pub fn atoms(&self) -> &Atoms {
         &self.atoms
     }
 
     /// Get the index of the default screen.
-    #[inline]
     pub fn default_screen_index(&self) -> usize {
         self.default_screen
     }
 
     /// Get the default screen.
-    #[inline]
     pub fn default_root(&self) -> &xproto::Screen {
         &self.xcb_connection().setup().roots[self.default_screen]
     }
 
     /// Get the resource database.
-    #[inline]
     pub fn database(&self) -> RwLockReadGuard<'_, resource_manager::Database> {
         self.database.read().unwrap_or_else(|e| e.into_inner())
     }
 
     /// Reload the resource database.
-    #[inline]
     pub fn reload_database(&self) -> Result<(), super::X11Error> {
         let database = resource_manager::new_from_default(self.xcb_connection())?;
         *self.database.write().unwrap_or_else(|e| e.into_inner()) = database;
@@ -223,13 +215,11 @@ impl XConnection {
     }
 
     /// Get the latest timestamp.
-    #[inline]
     pub fn timestamp(&self) -> u32 {
         self.timestamp.load(Ordering::Relaxed)
     }
 
     /// Set the last witnessed timestamp.
-    #[inline]
     pub fn set_timestamp(&self, timestamp: u32) {
         // Store the timestamp in the slot if it's greater than the last one.
         let mut last_timestamp = self.timestamp.load(Ordering::Relaxed);
@@ -253,7 +243,6 @@ impl XConnection {
     }
 
     /// Get the atom for Xsettings.
-    #[inline]
     pub fn xsettings_screen(&self) -> Option<xproto::Atom> {
         self.xsettings_screen
     }
@@ -266,7 +255,6 @@ impl fmt::Debug for XConnection {
 }
 
 impl Drop for XConnection {
-    #[inline]
     fn drop(&mut self) {
         self.xcb = None;
         unsafe { (self.xlib.XCloseDisplay)(self.display) };
@@ -308,7 +296,6 @@ pub enum XNotSupported {
 }
 
 impl From<ffi::OpenError> for XNotSupported {
-    #[inline]
     fn from(err: ffi::OpenError) -> XNotSupported {
         XNotSupported::LibraryOpenError(err)
     }
@@ -325,7 +312,6 @@ impl XNotSupported {
 }
 
 impl Error for XNotSupported {
-    #[inline]
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match *self {
             XNotSupported::LibraryOpenError(ref err) => Some(err),

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -796,7 +796,6 @@ pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -150,34 +150,28 @@ impl Window {
         Ok(())
     }
 
-    #[inline]
     pub fn id(&self) -> WindowId {
         WindowId { fd: self.window_socket.fd as u64 }
     }
 
-    #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         Some(MonitorHandle)
     }
 
-    #[inline]
     pub fn available_monitors(&self) -> VecDeque<MonitorHandle> {
         let mut v = VecDeque::with_capacity(1);
         v.push_back(MonitorHandle);
         v
     }
 
-    #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
         Some(MonitorHandle)
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         MonitorHandle.scale_factor()
     }
 
-    #[inline]
     pub fn request_redraw(&self) {
         let window_id = self.id();
         let mut redraws = self.redraws.lock().unwrap();
@@ -188,15 +182,12 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn pre_present_notify(&self) {}
 
-    #[inline]
     pub fn reset_dead_keys(&self) {
         // TODO?
     }
 
-    #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self.window_socket.fpath(&mut buf).expect("failed to read properties");
@@ -204,20 +195,17 @@ impl Window {
         Ok((properties.x, properties.y).into())
     }
 
-    #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
         // TODO: adjust for window decorations
         self.inner_position()
     }
 
-    #[inline]
     pub fn set_outer_position(&self, position: Position) {
         // TODO: adjust for window decorations
         let (x, y): (i32, i32) = position.to_physical::<i32>(self.scale_factor()).into();
         self.window_socket.write(format!("P,{x},{y}").as_bytes()).expect("failed to set position");
     }
 
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self.window_socket.fpath(&mut buf).expect("failed to read properties");
@@ -225,26 +213,21 @@ impl Window {
         (properties.w, properties.h).into()
     }
 
-    #[inline]
     pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let (w, h): (u32, u32) = size.to_physical::<u32>(self.scale_factor()).into();
         self.window_socket.write(format!("S,{w},{h}").as_bytes()).expect("failed to set size");
         None
     }
 
-    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         // TODO: adjust for window decorations
         self.inner_size()
     }
 
-    #[inline]
     pub fn set_min_inner_size(&self, _: Option<Size>) {}
 
-    #[inline]
     pub fn set_max_inner_size(&self, _: Option<Size>) {}
 
-    #[inline]
     pub fn title(&self) -> String {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self.window_socket.fpath(&mut buf).expect("failed to read properties");
@@ -252,84 +235,66 @@ impl Window {
         properties.title.to_string()
     }
 
-    #[inline]
     pub fn set_title(&self, title: &str) {
         self.window_socket.write(format!("T,{title}").as_bytes()).expect("failed to set title");
     }
 
-    #[inline]
     pub fn set_transparent(&self, transparent: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_TRANSPARENT, transparent);
     }
 
-    #[inline]
     pub fn set_blur(&self, _blur: bool) {}
 
-    #[inline]
     pub fn set_visible(&self, visible: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_HIDDEN, !visible);
     }
 
-    #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         Some(!self.get_flag(ORBITAL_FLAG_HIDDEN).unwrap_or(false))
     }
 
-    #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
-    #[inline]
     pub fn set_resize_increments(&self, _increments: Option<Size>) {}
 
-    #[inline]
     pub fn set_resizable(&self, resizeable: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_RESIZABLE, resizeable);
     }
 
-    #[inline]
     pub fn is_resizable(&self) -> bool {
         self.get_flag(ORBITAL_FLAG_RESIZABLE).unwrap_or(false)
     }
 
-    #[inline]
     pub fn set_minimized(&self, _minimized: bool) {}
 
-    #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         None
     }
 
-    #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_MAXIMIZED, maximized);
     }
 
-    #[inline]
     pub fn is_maximized(&self) -> bool {
         self.get_flag(ORBITAL_FLAG_MAXIMIZED).unwrap_or(false)
     }
 
-    #[inline]
     pub(crate) fn set_fullscreen(&self, _monitor: Option<Fullscreen>) {}
 
-    #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         None
     }
 
-    #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         let _ = self.set_flag(ORBITAL_FLAG_BORDERLESS, !decorations);
     }
 
-    #[inline]
     pub fn is_decorated(&self) -> bool {
         !self.get_flag(ORBITAL_FLAG_BORDERLESS).unwrap_or(false)
     }
 
-    #[inline]
     pub fn set_window_level(&self, level: window::WindowLevel) {
         match level {
             window::WindowLevel::AlwaysOnBottom => {
@@ -345,33 +310,24 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_window_icon(&self, _window_icon: Option<crate::icon::Icon>) {}
 
-    #[inline]
     pub fn set_ime_cursor_area(&self, _position: Position, _size: Size) {}
 
-    #[inline]
     pub fn set_ime_allowed(&self, _allowed: bool) {}
 
-    #[inline]
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
-    #[inline]
     pub fn focus_window(&self) {}
 
-    #[inline]
     pub fn request_user_attention(&self, _request_type: Option<window::UserAttentionType>) {}
 
-    #[inline]
     pub fn set_cursor(&self, _: Cursor) {}
 
-    #[inline]
     pub fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
     }
 
-    #[inline]
     pub fn set_cursor_grab(
         &self,
         mode: window::CursorGrabMode,
@@ -390,12 +346,10 @@ impl Window {
         Ok(())
     }
 
-    #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         let _ = self.window_socket.write(format!("M,C,{}", if visible { 1 } else { 0 }).as_bytes());
     }
 
-    #[inline]
     pub fn drag_window(&self) -> Result<(), error::ExternalError> {
         self.window_socket
             .write(b"D")
@@ -403,7 +357,6 @@ impl Window {
         Ok(())
     }
 
-    #[inline]
     pub fn drag_resize_window(
         &self,
         direction: window::ResizeDirection,
@@ -424,16 +377,13 @@ impl Window {
         Ok(())
     }
 
-    #[inline]
     pub fn show_window_menu(&self, _position: Position) {}
 
-    #[inline]
     pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
         Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         let handle = rwh_06::OrbitalWindowHandle::new({
             let window = self.window_socket.fd as *mut _;
@@ -443,32 +393,26 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
         Ok(rwh_06::RawDisplayHandle::Orbital(rwh_06::OrbitalDisplayHandle::new()))
     }
 
-    #[inline]
     pub fn set_enabled_buttons(&self, _buttons: window::WindowButtons) {}
 
-    #[inline]
     pub fn enabled_buttons(&self) -> window::WindowButtons {
         window::WindowButtons::all()
     }
 
-    #[inline]
     pub fn theme(&self) -> Option<window::Theme> {
         None
     }
 
-    #[inline]
     pub fn has_focus(&self) -> bool {
         false
     }
 
-    #[inline]
     pub fn set_theme(&self, _theme: Option<window::Theme>) {}
 
     pub fn set_content_protected(&self, _protected: bool) {}

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -711,7 +711,6 @@ pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -207,47 +207,38 @@ impl Canvas {
         position
     }
 
-    #[inline]
     pub fn old_size(&self) -> PhysicalSize<u32> {
         self.common.old_size.get()
     }
 
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         self.common.current_size.get()
     }
 
-    #[inline]
     pub fn set_old_size(&self, size: PhysicalSize<u32>) {
         self.common.old_size.set(size)
     }
 
-    #[inline]
     pub fn set_current_size(&self, size: PhysicalSize<u32>) {
         self.common.current_size.set(size)
     }
 
-    #[inline]
     pub fn window(&self) -> &web_sys::Window {
         &self.common.window
     }
 
-    #[inline]
     pub fn navigator(&self) -> &Navigator {
         &self.common.navigator
     }
 
-    #[inline]
     pub fn document(&self) -> &Document {
         &self.common.document
     }
 
-    #[inline]
     pub fn raw(&self) -> &HtmlCanvasElement {
         &self.common.raw
     }
 
-    #[inline]
     pub fn style(&self) -> &Style {
         &self.common.style
     }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -93,7 +93,6 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         MainThreadMarker::new()
             .map(|main_thread| {
@@ -108,7 +107,6 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub(crate) fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
@@ -129,7 +127,6 @@ impl Inner {
         // Intentionally a no-op
     }
 
-    #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         None
     }
@@ -160,18 +157,15 @@ impl Inner {
         )
     }
 
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         self.canvas.inner_size()
     }
 
-    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         // Note: the canvas element has no window decorations, so this is equal to `inner_size`.
         self.inner_size()
     }
 
-    #[inline]
     pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let size = size.to_logical(self.scale_factor());
         backend::set_canvas_size(
@@ -183,7 +177,6 @@ impl Inner {
         None
     }
 
-    #[inline]
     pub fn set_min_inner_size(&self, dimensions: Option<Size>) {
         let dimensions = dimensions.map(|dimensions| dimensions.to_logical(self.scale_factor()));
         backend::set_canvas_min_size(
@@ -194,7 +187,6 @@ impl Inner {
         )
     }
 
-    #[inline]
     pub fn set_max_inner_size(&self, dimensions: Option<Size>) {
         let dimensions = dimensions.map(|dimensions| dimensions.to_logical(self.scale_factor()));
         backend::set_canvas_max_size(
@@ -205,17 +197,14 @@ impl Inner {
         )
     }
 
-    #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
-    #[inline]
     pub fn set_resize_increments(&self, _increments: Option<Size>) {
         // Intentionally a no-op: users can't resize canvas elements
     }
 
-    #[inline]
     pub fn set_resizable(&self, _resizable: bool) {
         // Intentionally a no-op: users can't resize canvas elements
     }
@@ -224,30 +213,24 @@ impl Inner {
         true
     }
 
-    #[inline]
     pub fn set_enabled_buttons(&self, _buttons: WindowButtons) {}
 
-    #[inline]
     pub fn enabled_buttons(&self) -> WindowButtons {
         WindowButtons::all()
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         super::backend::scale_factor(&self.window)
     }
 
-    #[inline]
     pub fn set_cursor(&self, cursor: Cursor) {
         self.canvas.cursor.set_cursor(cursor)
     }
 
-    #[inline]
     pub fn set_cursor_position(&self, _position: Position) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    #[inline]
     pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
         match mode {
             CursorGrabMode::None => self.canvas.document().exit_pointer_lock(),
@@ -264,52 +247,42 @@ impl Inner {
         Ok(())
     }
 
-    #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         self.canvas.cursor.set_cursor_visible(visible)
     }
 
-    #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    #[inline]
     pub fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    #[inline]
     pub fn show_window_menu(&self, _position: Position) {}
 
-    #[inline]
     pub fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), ExternalError> {
         Err(ExternalError::NotSupported(NotSupportedError::new()))
     }
 
-    #[inline]
     pub fn set_minimized(&self, _minimized: bool) {
         // Intentionally a no-op, as canvases cannot be 'minimized'
     }
 
-    #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         // Canvas cannot be 'minimized'
         Some(false)
     }
 
-    #[inline]
     pub fn set_maximized(&self, _maximized: bool) {
         // Intentionally a no-op, as canvases cannot be 'maximized'
     }
 
-    #[inline]
     pub fn is_maximized(&self) -> bool {
         // Canvas cannot be 'maximized'
         false
     }
 
-    #[inline]
     pub(crate) fn fullscreen(&self) -> Option<Fullscreen> {
         if self.canvas.is_fullscreen() {
             Some(Fullscreen::Borderless(Some(self.monitor.current_monitor())))
@@ -318,7 +291,6 @@ impl Inner {
         }
     }
 
-    #[inline]
     pub(crate) fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         if let Some(fullscreen) = fullscreen {
             self.canvas.request_fullscreen(fullscreen);
@@ -327,7 +299,6 @@ impl Inner {
         }
     }
 
-    #[inline]
     pub fn set_decorations(&self, _decorations: bool) {
         // Intentionally a no-op, no canvas decorations
     }
@@ -336,65 +307,52 @@ impl Inner {
         true
     }
 
-    #[inline]
     pub fn set_window_level(&self, _level: WindowLevel) {
         // Intentionally a no-op, no window ordering
     }
 
-    #[inline]
     pub fn set_window_icon(&self, _window_icon: Option<Icon>) {
         // Currently an intentional no-op
     }
 
-    #[inline]
     pub fn set_ime_cursor_area(&self, _position: Position, _size: Size) {
         // Currently not implemented
     }
 
-    #[inline]
     pub fn set_ime_allowed(&self, _allowed: bool) {
         // Currently not implemented
     }
 
-    #[inline]
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {
         // Currently not implemented
     }
 
-    #[inline]
     pub fn focus_window(&self) {
         let _ = self.canvas.raw().focus();
     }
 
-    #[inline]
     pub fn request_user_attention(&self, _request_type: Option<UserAttentionType>) {
         // Currently an intentional no-op
     }
 
-    #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
         Some(self.monitor.current_monitor())
     }
 
-    #[inline]
     pub fn available_monitors(&self) -> Vec<MonitorHandle> {
         self.monitor.available_monitors()
     }
 
-    #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         self.monitor.primary_monitor()
     }
 
-    #[inline]
     pub fn id(&self) -> WindowId {
         self.id
     }
 
-    #[inline]
     pub fn set_theme(&self, _theme: Option<Theme>) {}
 
-    #[inline]
     pub fn theme(&self) -> Option<Theme> {
         backend::is_dark_mode(&self.window).map(|is_dark_mode| {
             if is_dark_mode {
@@ -407,7 +365,6 @@ impl Inner {
 
     pub fn set_content_protected(&self, _protected: bool) {}
 
-    #[inline]
     pub fn has_focus(&self) -> bool {
         self.canvas.has_focus.get()
     }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -588,7 +588,6 @@ pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -658,12 +658,10 @@ fn destructure_key_lparam(lparam: LPARAM) -> KeyLParam {
     }
 }
 
-#[inline]
 fn new_ex_scancode(scancode: u8, extended: bool) -> ExScancode {
     (scancode as u16) | (if extended { 0xe000 } else { 0 })
 }
 
-#[inline]
 fn ex_scancode_from_lparam(lparam: LPARAM) -> ExScancode {
     let lparam = destructure_key_lparam(lparam);
     new_ex_scancode(lparam.scancode, lparam.extended)

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -165,18 +165,15 @@ impl MonitorHandle {
         MonitorHandle(hmonitor)
     }
 
-    #[inline]
     pub fn name(&self) -> Option<String> {
         let monitor_info = get_monitor_info(self.0).unwrap();
         Some(decode_wide(&monitor_info.szDevice).to_string_lossy().to_string())
     }
 
-    #[inline]
     pub fn native_identifier(&self) -> String {
         self.name().unwrap()
     }
 
-    #[inline]
     pub fn hmonitor(&self) -> HMONITOR {
         self.0
     }
@@ -189,7 +186,6 @@ impl MonitorHandle {
         }
     }
 
-    #[inline]
     pub fn position(&self) -> Option<PhysicalPosition<i32>> {
         get_monitor_info(self.0)
             .map(|info| {
@@ -199,12 +195,10 @@ impl MonitorHandle {
             .ok()
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         dpi_to_scale_factor(get_monitor_dpi(self.0).unwrap_or(96))
     }
 
-    #[inline]
     pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
         let monitor_info = get_monitor_info(self.0).ok()?;
         let device_name = monitor_info.szDevice.as_ptr();
@@ -221,7 +215,6 @@ impl MonitorHandle {
         }
     }
 
-    #[inline]
     pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
         // EnumDisplaySettingsExW can return duplicate values (or some of the
         // fields are probably changing, but we aren't looking at those fields

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -130,7 +130,6 @@ impl Window {
 
     pub fn set_blur(&self, _blur: bool) {}
 
-    #[inline]
     pub fn set_visible(&self, visible: bool) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -142,12 +141,10 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         Some(unsafe { IsWindowVisible(self.window) == 1 })
     }
 
-    #[inline]
     pub fn request_redraw(&self) {
         // NOTE: mark that we requested a redraw to handle requests during `WM_PAINT` handling.
         self.window_state.lock().unwrap().redraw_requested = true;
@@ -156,10 +153,8 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn pre_present_notify(&self) {}
 
-    #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         util::WindowArea::Outer
             .get_rect(self.hwnd())
@@ -170,7 +165,6 @@ impl Window {
             )
     }
 
-    #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let mut position: POINT = unsafe { mem::zeroed() };
         if unsafe { ClientToScreen(self.hwnd(), &mut position) } == false.into() {
@@ -182,7 +176,6 @@ impl Window {
         Ok(PhysicalPosition::new(position.x, position.y))
     }
 
-    #[inline]
     pub fn set_outer_position(&self, position: Position) {
         let (x, y): (i32, i32) = position.to_physical::<i32>(self.scale_factor()).into();
 
@@ -209,7 +202,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         let mut rect: RECT = unsafe { mem::zeroed() };
         if unsafe { GetClientRect(self.hwnd(), &mut rect) } == false.into() {
@@ -221,7 +213,6 @@ impl Window {
         PhysicalSize::new((rect.right - rect.left) as u32, (rect.bottom - rect.top) as u32)
     }
 
-    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         util::WindowArea::Outer
             .get_rect(self.hwnd())
@@ -231,7 +222,6 @@ impl Window {
             .unwrap()
     }
 
-    #[inline]
     pub fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let scale_factor = self.scale_factor();
         let physical_size = size.to_physical::<u32>(scale_factor);
@@ -253,7 +243,6 @@ impl Window {
         None
     }
 
-    #[inline]
     pub fn set_min_inner_size(&self, size: Option<Size>) {
         self.window_state_lock().min_size = size;
         // Make windows re-check the window size bounds.
@@ -261,7 +250,6 @@ impl Window {
         self.request_inner_size(size.into());
     }
 
-    #[inline]
     pub fn set_max_inner_size(&self, size: Option<Size>) {
         self.window_state_lock().max_size = size;
         // Make windows re-check the window size bounds.
@@ -269,19 +257,16 @@ impl Window {
         self.request_inner_size(size.into());
     }
 
-    #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         let w = self.window_state_lock();
         let scale_factor = w.scale_factor;
         w.resize_increments.map(|size| size.to_physical(scale_factor))
     }
 
-    #[inline]
     pub fn set_resize_increments(&self, increments: Option<Size>) {
         self.window_state_lock().resize_increments = increments;
     }
 
-    #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -294,13 +279,11 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn is_resizable(&self) -> bool {
         let window_state = self.window_state_lock();
         window_state.window_flags.contains(WindowFlags::RESIZABLE)
     }
 
-    #[inline]
     pub fn set_enabled_buttons(&self, buttons: WindowButtons) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -331,13 +314,11 @@ impl Window {
     }
 
     /// Returns the `hwnd` of this window.
-    #[inline]
     pub fn hwnd(&self) -> HWND {
         self.window
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub unsafe fn rwh_06_no_thread_check(
         &self,
     ) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
@@ -351,7 +332,6 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         // TODO: Write a test once integration framework is ready to ensure that it holds.
         // If we aren't in the GUI thread, we can't return the window.
@@ -365,14 +345,12 @@ impl Window {
     }
 
     #[cfg(feature = "rwh_06")]
-    #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
         Ok(rwh_06::RawDisplayHandle::Windows(rwh_06::WindowsDisplayHandle::new()))
     }
 
-    #[inline]
     pub fn set_cursor(&self, cursor: Cursor) {
         match cursor {
             Cursor::Icon(icon) => {
@@ -392,7 +370,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
         let confine = match mode {
             CursorGrabMode::None => false,
@@ -419,7 +396,6 @@ impl Window {
         rx.recv().unwrap()
     }
 
-    #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -438,12 +414,10 @@ impl Window {
         rx.recv().unwrap().ok();
     }
 
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         self.window_state_lock().scale_factor
     }
 
-    #[inline]
     pub fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
         let scale_factor = self.scale_factor();
         let (x, y) = position.to_physical::<i32>(scale_factor).into();
@@ -490,7 +464,6 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         unsafe {
             self.handle_os_dragging(HTCAPTION as WPARAM);
@@ -499,7 +472,6 @@ impl Window {
         Ok(())
     }
 
-    #[inline]
     pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
         unsafe {
             self.handle_os_dragging(match direction {
@@ -592,14 +564,12 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn show_window_menu(&self, position: Position) {
         unsafe {
             self.handle_showing_window_menu(position);
         }
     }
 
-    #[inline]
     pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -612,12 +582,10 @@ impl Window {
         Ok(())
     }
 
-    #[inline]
     pub fn id(&self) -> WindowId {
         WindowId(self.hwnd())
     }
 
-    #[inline]
     pub fn set_minimized(&self, minimized: bool) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -635,12 +603,10 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         Some(util::is_minimized(self.hwnd()))
     }
 
-    #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -653,19 +619,16 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn is_maximized(&self) -> bool {
         let window_state = self.window_state_lock();
         window_state.window_flags.contains(WindowFlags::MAXIMIZED)
     }
 
-    #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         let window_state = self.window_state_lock();
         window_state.fullscreen.clone()
     }
 
-    #[inline]
     pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -816,7 +779,6 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -829,13 +791,11 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn is_decorated(&self) -> bool {
         let window_state = self.window_state_lock();
         window_state.window_flags.contains(WindowFlags::MARKER_DECORATIONS)
     }
 
-    #[inline]
     pub fn set_window_level(&self, level: WindowLevel) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -849,12 +809,10 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
         Some(monitor::current_monitor(self.hwnd()))
     }
 
-    #[inline]
     pub fn set_window_icon(&self, window_icon: Option<Icon>) {
         if let Some(ref window_icon) = window_icon {
             window_icon.inner.set_for_window(self.hwnd(), IconType::Small);
@@ -864,12 +822,10 @@ impl Window {
         self.window_state_lock().window_icon = window_icon;
     }
 
-    #[inline]
     pub fn set_enable(&self, enabled: bool) {
         unsafe { EnableWindow(self.hwnd(), enabled.into()) };
     }
 
-    #[inline]
     pub fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {
         if let Some(ref taskbar_icon) = taskbar_icon {
             taskbar_icon.inner.set_for_window(self.hwnd(), IconType::Big);
@@ -879,7 +835,6 @@ impl Window {
         self.window_state_lock().taskbar_icon = taskbar_icon;
     }
 
-    #[inline]
     pub fn set_ime_cursor_area(&self, spot: Position, size: Size) {
         let window = self.window;
         let state = self.window_state.clone();
@@ -889,7 +844,6 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         let window = self.window;
         let state = self.window_state.clone();
@@ -899,10 +853,8 @@ impl Window {
         })
     }
 
-    #[inline]
     pub fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
-    #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
         let window = self.window;
         let active_window_handle = unsafe { GetActiveWindow() };
@@ -929,17 +881,14 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn set_theme(&self, theme: Option<Theme>) {
         try_theme(self.window, theme);
     }
 
-    #[inline]
     pub fn theme(&self) -> Option<Theme> {
         Some(self.window_state_lock().current_theme)
     }
 
-    #[inline]
     pub fn has_focus(&self) -> bool {
         let window_state = self.window_state.lock().unwrap();
         window_state.has_active_focus()
@@ -952,13 +901,11 @@ impl Window {
         util::decode_wide(&buf).to_string_lossy().to_string()
     }
 
-    #[inline]
     pub fn set_skip_taskbar(&self, skip: bool) {
         self.window_state_lock().skip_taskbar = skip;
         unsafe { set_skip_taskbar(self.hwnd(), skip) };
     }
 
-    #[inline]
     pub fn set_undecorated_shadow(&self, shadow: bool) {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
@@ -971,7 +918,6 @@ impl Window {
         });
     }
 
-    #[inline]
     pub fn set_system_backdrop(&self, backdrop_type: BackdropType) {
         unsafe {
             DwmSetWindowAttribute(
@@ -983,7 +929,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn focus_window(&self) {
         let window_flags = self.window_state_lock().window_flags();
 
@@ -996,7 +941,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_content_protected(&self, protected: bool) {
         unsafe {
             SetWindowDisplayAffinity(
@@ -1006,7 +950,6 @@ impl Window {
         };
     }
 
-    #[inline]
     pub fn reset_dead_keys(&self) {
         // `ToUnicode` consumes the dead-key by default, so we are constructing a fake (but valid)
         // key input which we can call `ToUnicode` with.
@@ -1026,7 +969,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_border_color(&self, color: Color) {
         unsafe {
             DwmSetWindowAttribute(
@@ -1038,7 +980,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_title_background_color(&self, color: Color) {
         unsafe {
             DwmSetWindowAttribute(
@@ -1050,7 +991,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_title_text_color(&self, color: Color) {
         unsafe {
             DwmSetWindowAttribute(
@@ -1062,7 +1002,6 @@ impl Window {
         }
     }
 
-    #[inline]
     pub fn set_corner_preference(&self, preference: CornerPreference) {
         unsafe {
             DwmSetWindowAttribute(
@@ -1076,7 +1015,6 @@ impl Window {
 }
 
 impl Drop for Window {
-    #[inline]
     fn drop(&mut self) {
         unsafe {
             // The window must be destroyed from the same thread that created it, so we send a

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -22,7 +22,6 @@ impl<T> Lazy<T> {
 impl<T> Deref for Lazy<T> {
     type Target = T;
 
-    #[inline]
     fn deref(&self) -> &'_ T {
         self.cell.get_or_init(self.init)
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -200,7 +200,6 @@ impl WindowAttributes {
     /// If this is not set, some platform-specific dimensions will be used.
     ///
     /// See [`Window::request_inner_size`] for details.
-    #[inline]
     pub fn with_inner_size<S: Into<Size>>(mut self, size: S) -> Self {
         self.inner_size = Some(size.into());
         self
@@ -212,7 +211,6 @@ impl WindowAttributes {
     /// from reserved).
     ///
     /// See [`Window::set_min_inner_size`] for details.
-    #[inline]
     pub fn with_min_inner_size<S: Into<Size>>(mut self, min_size: S) -> Self {
         self.min_inner_size = Some(min_size.into());
         self
@@ -224,7 +222,6 @@ impl WindowAttributes {
     /// the primary monitor's dimensions by the platform.
     ///
     /// See [`Window::set_max_inner_size`] for details.
-    #[inline]
     pub fn with_max_inner_size<S: Into<Size>>(mut self, max_size: S) -> Self {
         self.max_inner_size = Some(max_size.into());
         self
@@ -248,7 +245,6 @@ impl WindowAttributes {
     ///   specifics of the Window Manager.
     /// - **X11:** The top left corner of the window, the window's "outer" position.
     /// - **Others:** Ignored.
-    #[inline]
     pub fn with_position<P: Into<Position>>(mut self, position: P) -> Self {
         self.position = Some(position.into());
         self
@@ -281,7 +277,6 @@ impl WindowAttributes {
     /// The default is `"winit window"`.
     ///
     /// See [`Window::set_title`] for details.
-    #[inline]
     pub fn with_title<T: Into<String>>(mut self, title: T) -> Self {
         self.title = title.into();
         self
@@ -409,7 +404,6 @@ impl WindowAttributes {
     /// The default is `None`.
     ///
     /// See [`Window::set_resize_increments`] for details.
-    #[inline]
     pub fn with_resize_increments<S: Into<Size>>(mut self, resize_increments: S) -> Self {
         self.resize_increments = Some(resize_increments.into());
         self
@@ -453,7 +447,6 @@ impl WindowAttributes {
     /// The default is [`CursorIcon::Default`].
     ///
     /// See [`Window::set_cursor()`] for more details.
-    #[inline]
     pub fn with_cursor(mut self, cursor: impl Into<Cursor>) -> Self {
         self.cursor = cursor.into();
         self
@@ -495,7 +488,6 @@ impl Window {
     }
 
     /// Returns an identifier unique to the window.
-    #[inline]
     pub fn id(&self) -> WindowId {
         let _span = tracing::debug_span!("winit::Window::id",).entered();
 
@@ -563,7 +555,6 @@ impl Window {
     /// [android_1]: https://developer.android.com/training/multiscreen/screendensities
     /// [web_1]: https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
     /// [`contentScaleFactor`]: https://developer.apple.com/documentation/uikit/uiview/1622657-contentscalefactor?language=objc
-    #[inline]
     pub fn scale_factor(&self) -> f64 {
         let _span = tracing::debug_span!("winit::Window::scale_factor",).entered();
 
@@ -597,7 +588,6 @@ impl Window {
     ///   `requestAnimationFrame`.
     ///
     /// [`WindowEvent::RedrawRequested`]: crate::event::WindowEvent::RedrawRequested
-    #[inline]
     pub fn request_redraw(&self) {
         let _span = tracing::debug_span!("winit::Window::request_redraw",).entered();
 
@@ -636,7 +626,6 @@ impl Window {
     /// - **Wayland:** Schedules a frame callback to throttle [`WindowEvent::RedrawRequested`].
     ///
     /// [`WindowEvent::RedrawRequested`]: crate::event::WindowEvent::RedrawRequested
-    #[inline]
     pub fn pre_present_notify(&self) {
         let _span = tracing::debug_span!("winit::Window::pre_present_notify",).entered();
 
@@ -678,7 +667,6 @@ impl Window {
     /// - **Android / Wayland:** Always returns [`NotSupportedError`].
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
-    #[inline]
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let _span = tracing::debug_span!("winit::Window::inner_position",).entered();
 
@@ -701,7 +689,6 @@ impl Window {
     ///   window in the screen space coordinate system.
     /// - **Web:** Returns the top-left coordinates relative to the viewport.
     /// - **Android / Wayland:** Always returns [`NotSupportedError`].
-    #[inline]
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let _span = tracing::debug_span!("winit::Window::outer_position",).entered();
 
@@ -734,7 +721,6 @@ impl Window {
     /// - **Android / Wayland:** Unsupported.
     ///
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-    #[inline]
     pub fn set_outer_position<P: Into<Position>>(&self, position: P) {
         let position = position.into();
         let _span = tracing::debug_span!(
@@ -758,7 +744,6 @@ impl Window {
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-    #[inline]
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         let _span = tracing::debug_span!("winit::Window::inner_size",).entered();
 
@@ -799,7 +784,6 @@ impl Window {
     ///
     /// [`WindowEvent::Resized`]: crate::event::WindowEvent::Resized
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-    #[inline]
     #[must_use]
     pub fn request_inner_size<S: Into<Size>>(&self, size: S) -> Option<PhysicalSize<u32>> {
         let size = size.into();
@@ -822,7 +806,6 @@ impl Window {
     ///   in screen space coordinates.
     /// - **Web:** Returns the size of the canvas element. _Note: this returns the same value as
     ///   [`Window::inner_size`]._
-    #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         let _span = tracing::debug_span!("winit::Window::outer_size",).entered();
         self.window.maybe_wait_on_main(|w| w.outer_size())
@@ -845,7 +828,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Orbital:** Unsupported.
-    #[inline]
     pub fn set_min_inner_size<S: Into<Size>>(&self, min_size: Option<S>) {
         let min_size = min_size.map(|s| s.into());
         let _span = tracing::debug_span!(
@@ -873,7 +855,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Orbital:** Unsupported.
-    #[inline]
     pub fn set_max_inner_size<S: Into<Size>>(&self, max_size: Option<S>) {
         let max_size = max_size.map(|s| s.into());
         let _span = tracing::debug_span!(
@@ -889,7 +870,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web / Wayland / Orbital:** Always returns [`None`].
-    #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         let _span = tracing::debug_span!("winit::Window::resize_increments",).entered();
         self.window.maybe_wait_on_main(|w| w.resize_increments())
@@ -906,7 +886,6 @@ impl Window {
     ///   numbers.
     /// - **Wayland:** Not implemented.
     /// - **iOS / Android / Web / Orbital:** Unsupported.
-    #[inline]
     pub fn set_resize_increments<S: Into<Size>>(&self, increments: Option<S>) {
         let increments = increments.map(Into::into);
         let _span = tracing::debug_span!(
@@ -925,7 +904,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android:** Unsupported.
-    #[inline]
     pub fn set_title(&self, title: &str) {
         let _span = tracing::debug_span!("winit::Window::set_title", title).entered();
         self.window.maybe_wait_on_main(|w| w.set_title(title))
@@ -946,7 +924,6 @@ impl Window {
     /// - **Web / iOS / Android:** Unsupported.
     /// - **X11:** Can only be set while building the window, with
     ///   [`WindowAttributes::with_transparent`].
-    #[inline]
     pub fn set_transparent(&self, transparent: bool) {
         let _span = tracing::debug_span!("winit::Window::set_transparent", transparent).entered();
         self.window.maybe_queue_on_main(move |w| w.set_transparent(transparent))
@@ -960,7 +937,6 @@ impl Window {
     ///
     /// - **Android / iOS / X11 / Web / Windows:** Unsupported.
     /// - **Wayland:** Only works with org_kde_kwin_blur_manager protocol.
-    #[inline]
     pub fn set_blur(&self, blur: bool) {
         let _span = tracing::debug_span!("winit::Window::set_blur", blur).entered();
         self.window.maybe_queue_on_main(move |w| w.set_blur(blur))
@@ -974,7 +950,6 @@ impl Window {
     ///
     /// - **Android / Wayland / Web:** Unsupported.
     /// - **iOS:** Can only be called on the main thread.
-    #[inline]
     pub fn set_visible(&self, visible: bool) {
         let _span = tracing::debug_span!("winit::Window::set_visible", visible).entered();
         self.window.maybe_queue_on_main(move |w| w.set_visible(visible))
@@ -989,7 +964,6 @@ impl Window {
     ///
     /// - **X11:** Not implemented.
     /// - **Wayland / iOS / Android / Web:** Unsupported.
-    #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         let _span = tracing::debug_span!("winit::Window::is_visible",).entered();
         self.window.maybe_wait_on_main(|w| w.is_visible())
@@ -1010,7 +984,6 @@ impl Window {
     /// - **iOS / Android / Web:** Unsupported.
     ///
     /// [`WindowEvent::Resized`]: crate::event::WindowEvent::Resized
-    #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         let _span = tracing::debug_span!("winit::Window::set_resizable", resizable).entered();
         self.window.maybe_queue_on_main(move |w| w.set_resizable(resizable))
@@ -1022,7 +995,6 @@ impl Window {
     ///
     /// - **X11:** Not implemented.
     /// - **iOS / Android / Web:** Unsupported.
-    #[inline]
     pub fn is_resizable(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::is_resizable",).entered();
         self.window.maybe_wait_on_main(|w| w.is_resizable())
@@ -1060,7 +1032,6 @@ impl Window {
     ///
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     /// - **Wayland:** Un-minimize is unsupported.
-    #[inline]
     pub fn set_minimized(&self, minimized: bool) {
         let _span = tracing::debug_span!("winit::Window::set_minimized", minimized).entered();
         self.window.maybe_queue_on_main(move |w| w.set_minimized(minimized))
@@ -1078,7 +1049,6 @@ impl Window {
     ///
     /// - **Wayland**: always `None`.
     /// - **iOS / Android / Web / Orbital:** Unsupported.
-    #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         let _span = tracing::debug_span!("winit::Window::is_minimized",).entered();
         self.window.maybe_wait_on_main(|w| w.is_minimized())
@@ -1089,7 +1059,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web:** Unsupported.
-    #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         let _span = tracing::debug_span!("winit::Window::set_maximized", maximized).entered();
         self.window.maybe_queue_on_main(move |w| w.set_maximized(maximized))
@@ -1100,7 +1069,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web:** Unsupported.
-    #[inline]
     pub fn is_maximized(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::is_maximized",).entered();
         self.window.maybe_wait_on_main(|w| w.is_maximized())
@@ -1134,7 +1102,6 @@ impl Window {
     ///   or calling without a [transient activation] does nothing.
     ///
     /// [transient activation]: https://developer.mozilla.org/en-US/docs/Glossary/Transient_activation
-    #[inline]
     pub fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         let _span = tracing::debug_span!(
             "winit::Window::set_fullscreen",
@@ -1152,7 +1119,6 @@ impl Window {
     /// - **Android / Orbital:** Will always return `None`.
     /// - **Wayland:** Can return `Borderless(None)` when there are no monitors.
     /// - **Web:** Can only return `None` or `Borderless`.
-    #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         let _span = tracing::debug_span!("winit::Window::fullscreen",).entered();
         self.window.maybe_wait_on_main(|w| w.fullscreen().map(|f| f.into()))
@@ -1167,7 +1133,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web:** No effect.
-    #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         let _span = tracing::debug_span!("winit::Window::set_decorations", decorations).entered();
         self.window.maybe_queue_on_main(move |w| w.set_decorations(decorations))
@@ -1181,7 +1146,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web:** Always returns `true`.
-    #[inline]
     pub fn is_decorated(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::is_decorated",).entered();
         self.window.maybe_wait_on_main(|w| w.is_decorated())
@@ -1215,7 +1179,6 @@ impl Window {
     ///
     /// - **X11:** Has no universal guidelines for icon sizes, so you're at the whims of the WM.
     ///   That said, it's usually in the same ballpark as on Windows.
-    #[inline]
     pub fn set_window_icon(&self, window_icon: Option<Icon>) {
         let _span = tracing::debug_span!("winit::Window::set_window_icon",).entered();
         self.window.maybe_queue_on_main(move |w| w.set_window_icon(window_icon))
@@ -1255,7 +1218,6 @@ impl Window {
     ///
     /// [chinese]: https://support.apple.com/guide/chinese-input-method/use-the-candidate-window-cim12992/104/mac/12.0
     /// [japanese]: https://support.apple.com/guide/japanese-input-method/use-the-candidate-window-jpim10262/6.3/mac/12.0
-    #[inline]
     pub fn set_ime_cursor_area<P: Into<Position>, S: Into<Size>>(&self, position: P, size: S) {
         let position = position.into();
         let size = size.into();
@@ -1289,7 +1251,6 @@ impl Window {
     ///
     /// [`Ime`]: crate::event::WindowEvent::Ime
     /// [`KeyboardInput`]: crate::event::WindowEvent::KeyboardInput
-    #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         let _span = tracing::debug_span!("winit::Window::set_ime_allowed", allowed).entered();
         self.window.maybe_queue_on_main(move |w| w.set_ime_allowed(allowed))
@@ -1300,7 +1261,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web / Windows / X11 / macOS / Orbital:** Unsupported.
-    #[inline]
     pub fn set_ime_purpose(&self, purpose: ImePurpose) {
         let _span = tracing::debug_span!(
             "winit::Window::set_ime_purpose",
@@ -1320,7 +1280,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Wayland / Orbital:** Unsupported.
-    #[inline]
     pub fn focus_window(&self) {
         let _span = tracing::debug_span!("winit::Window::focus_window",).entered();
         self.window.maybe_queue_on_main(|w| w.focus_window())
@@ -1331,7 +1290,6 @@ impl Window {
     /// This queries the same state information as [`WindowEvent::Focused`].
     ///
     /// [`WindowEvent::Focused`]: crate::event::WindowEvent::Focused
-    #[inline]
     pub fn has_focus(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::has_focus",).entered();
         self.window.maybe_wait_on_main(|w| w.has_focus())
@@ -1350,7 +1308,6 @@ impl Window {
     /// - **macOS:** `None` has no effect.
     /// - **X11:** Requests for user attention must be manually cleared.
     /// - **Wayland:** Requires `xdg_activation_v1` protocol, `None` has no effect.
-    #[inline]
     pub fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
         let _span = tracing::debug_span!(
             "winit::Window::request_user_attention",
@@ -1371,7 +1328,6 @@ impl Window {
     /// - **X11:** Sets `_GTK_THEME_VARIANT` hint to `dark` or `light` and if `None` is used, it
     ///   will default to  [`Theme::Dark`].
     /// - **iOS / Android / Web / Orbital:** Unsupported.
-    #[inline]
     pub fn set_theme(&self, theme: Option<Theme>) {
         let _span = tracing::debug_span!(
             "winit::Window::set_theme",
@@ -1389,7 +1345,6 @@ impl Window {
     ///
     /// - **iOS / Android / x11 / Orbital:** Unsupported.
     /// - **Wayland:** Only returns theme overrides.
-    #[inline]
     pub fn theme(&self) -> Option<Theme> {
         let _span = tracing::debug_span!("winit::Window::theme",).entered();
         self.window.maybe_wait_on_main(|w| w.theme())
@@ -1415,7 +1370,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / x11 / Wayland / Web:** Unsupported. Always returns an empty string.
-    #[inline]
     pub fn title(&self) -> String {
         let _span = tracing::debug_span!("winit::Window::title",).entered();
         self.window.maybe_wait_on_main(|w| w.title())
@@ -1431,7 +1385,6 @@ impl Window {
     /// - **iOS / Android / Orbital:** Unsupported.
     /// - **Web:** Custom cursors have to be loaded and decoded first, until then the previous
     ///   cursor is shown.
-    #[inline]
     pub fn set_cursor(&self, cursor: impl Into<Cursor>) {
         let cursor = cursor.into();
         let _span = tracing::debug_span!("winit::Window::set_cursor",).entered();
@@ -1456,7 +1409,6 @@ impl Window {
     ///
     /// - **Wayland**: Cursor must be in [`CursorGrabMode::Locked`].
     /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
-    #[inline]
     pub fn set_cursor_position<P: Into<Position>>(&self, position: P) -> Result<(), ExternalError> {
         let position = position.into();
         let _span = tracing::debug_span!(
@@ -1482,7 +1434,6 @@ impl Window {
     ///     .unwrap();
     /// # }
     /// ```
-    #[inline]
     pub fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
         let _span = tracing::debug_span!(
             "winit::Window::set_cursor_grab",
@@ -1504,7 +1455,6 @@ impl Window {
     /// - **macOS:** The cursor is hidden as long as the window has input focus, even if the cursor
     ///   is outside of the window.
     /// - **iOS / Android:** Unsupported.
-    #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         let _span = tracing::debug_span!("winit::Window::set_cursor_visible", visible).entered();
         self.window.maybe_queue_on_main(move |w| w.set_cursor_visible(visible))
@@ -1521,7 +1471,6 @@ impl Window {
     /// - **Wayland:** Requires the cursor to be inside the window to be dragged.
     /// - **macOS:** May prevent the button release event to be triggered.
     /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
-    #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         let _span = tracing::debug_span!("winit::Window::drag_window",).entered();
         self.window.maybe_wait_on_main(|w| w.drag_window())
@@ -1536,7 +1485,6 @@ impl Window {
     ///
     /// - **macOS:** Always returns an [`ExternalError::NotSupported`]
     /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
-    #[inline]
     pub fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
         let _span = tracing::debug_span!(
             "winit::Window::drag_resize_window",
@@ -1574,7 +1522,6 @@ impl Window {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
-    #[inline]
     pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
         let _span = tracing::debug_span!("winit::Window::set_cursor_hittest", hittest).entered();
         self.window.maybe_wait_on_main(|w| w.set_cursor_hittest(hittest))
@@ -1586,7 +1533,6 @@ impl Window {
     /// Returns the monitor on which the window currently resides.
     ///
     /// Returns `None` if current monitor can't be detected.
-    #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
         let _span = tracing::debug_span!("winit::Window::current_monitor",).entered();
         self.window.maybe_wait_on_main(|w| w.current_monitor().map(|inner| MonitorHandle { inner }))
@@ -1609,7 +1555,6 @@ impl Window {
     ///
     #[rustfmt::skip]
     /// [`ActiveEventLoop::available_monitors`]: crate::event_loop::ActiveEventLoop::available_monitors
-    #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
         let _span = tracing::debug_span!("winit::Window::available_monitors",).entered();
         self.window.maybe_wait_on_main(|w| {
@@ -1635,7 +1580,6 @@ impl Window {
     ///
     #[rustfmt::skip]
     /// [`ActiveEventLoop::primary_monitor`]: crate::event_loop::ActiveEventLoop::primary_monitor
-    #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let _span = tracing::debug_span!("winit::Window::primary_monitor",).entered();
         self.window.maybe_wait_on_main(|w| w.primary_monitor().map(|inner| MonitorHandle { inner }))


### PR DESCRIPTION
As discussed in the last meeting, this PR removes unnecessary `#[inline]` hints, which hurt compile times and sometimes even performance.
To summarize:
- Adding `#[inline]` to generic functions is not recommended.
- Adding `#[inline]` to non-public functions is not recommended.
- Adding `#[inline]` to public functions because they *only* call a private function is not recommended, unless that private  function is small and is annotated with `#[inline]` as well.

`#[inline]` should only be used for **small** non-generic public functions or after some benchmarking.

See https://matklad.github.io/2021/07/09/inline-in-rust.html and https://github.com/rust-lang/hashbrown/pull/119#issuecomment-537539046 for more detailed information and recommendations.