### PR TITLE
macOS/iOS: Remove window activation hacks

### DIFF
--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -3,15 +3,6 @@
 //! Winit has an OS requirement of iOS 8 or higher, and is regularly tested on
 //! iOS 9.3.
 //!
-//! ## Window initialization
-//!
-//! iOS's main `UIApplicationMain` does some init work that's required by all
-//! UI-related code (see issue [#1705]). It is best to create your windows
-//! inside [`ApplicationHandler::resumed`].
-//!
-//! [#1705]: https://github.com/rust-windowing/winit/issues/1705
-//! [`ApplicationHandler::resumed`]: crate::application::ApplicationHandler::resumed
-//!
 //! ## Building app
 //!
 //! To build ios app you will need rustc built for this targets:

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -3,20 +3,6 @@
 //! Winit has an OS requirement of macOS 10.11 or higher (same as Rust
 //! itself), and is regularly tested on macOS 10.14.
 //!
-//! ## Window initialization
-//!
-//! A lot of functionality expects the application to be ready before you
-//! start doing anything; this includes creating windows, fetching monitors,
-//! drawing, and so on, see issues [#2238], [#2051] and [#2087].
-//!
-//! If you encounter problems, you should try doing your initialization inside
-//! [`ApplicationHandler::resumed`].
-//!
-//! [#2238]: https://github.com/rust-windowing/winit/issues/2238
-//! [#2051]: https://github.com/rust-windowing/winit/issues/2051
-//! [#2087]: https://github.com/rust-windowing/winit/issues/2087
-//! [`ApplicationHandler::resumed`]: crate::application::ApplicationHandler::resumed
-//!
 //! ## Custom `NSApplicationDelegate`
 //!
 //! Winit usually handles everything related to the lifecycle events of the application. Sometimes,

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -558,6 +558,11 @@ fn new_window(
             masks |= NSWindowStyleMask::FullSizeContentView;
         }
 
+        // NOTE: This should only be created after the application has started launching,
+        // (`applicationWillFinishLaunching:` at the earliest), otherwise you'll run into very
+        // confusing issues with the window not being properly activated.
+        //
+        // Winit ensures this by not allowing access to `ActiveEventLoop` before handling events.
         let window: Option<Retained<WinitWindow>> = unsafe {
             msg_send_id![
                 super(mtm.alloc().set_ivars(())),

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -78,6 +78,11 @@ impl WinitUIWindow {
         frame: CGRect,
         view_controller: &UIViewController,
     ) -> Retained<Self> {
+        // NOTE: This should only be created after the application has started launching,
+        // (`application:willFinishLaunchingWithOptions:` at the earliest), otherwise you'll run
+        // into very confusing issues with the window not being properly activated.
+        //
+        // Winit ensures this by not allowing access to `ActiveEventLoop` before handling events.
         let this: Retained<Self> = unsafe { msg_send_id![mtm.alloc(), initWithFrame: frame] };
 
         this.setRootViewController(Some(view_controller));
@@ -490,8 +495,7 @@ impl Window {
 
         let view_controller = WinitViewController::new(mtm, &window_attributes, &view);
         let window = WinitUIWindow::new(mtm, &window_attributes, frame, &view_controller);
-
-        app_state::set_key_window(mtm, &window);
+        window.makeKeyAndVisible();
 
         // Like the Windows and macOS backends, we send a `ScaleFactorChanged` and `Resized`
         // event on window creation if the DPI factor != 1.0


### PR DESCRIPTION
No longer necessary after https://github.com/rust-windowing/winit/pull/3447 and https://github.com/rust-windowing/winit/pull/3826.

- [x] Tested on macOS
- [x] Tested on iOS
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
  - I did not feel it is necessary to note in the changelog, as this 
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
