### PR TITLE
Implement the pointer event overhaul

### DIFF
--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -44,7 +44,7 @@ fn main() -> Result<(), impl std::error::Error> {
                     self.windows.clear();
                     event_loop.exit();
                 },
-                WindowEvent::CursorEntered { device_id: _ } => {
+                WindowEvent::PointerEntered { device_id: _, .. } => {
                     // On x11, println when the cursor entered in a window even if the child window
                     // is created by some key inputs.
                     // the child windows are always placed at (0, 0) with size (200, 200) in the

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -446,20 +446,23 @@ impl ApplicationHandler for Application {
                     }
                 }
             },
-            WindowEvent::MouseInput { button, state, .. } => {
+            WindowEvent::PointerButton { button, state, .. } => {
+                info!("Pointer button {button:?} {state:?}");
                 let mods = window.modifiers;
-                if let Some(action) =
-                    state.is_pressed().then(|| Self::process_mouse_binding(button, &mods)).flatten()
+                if let Some(action) = state
+                    .is_pressed()
+                    .then(|| Self::process_mouse_binding(button.mouse_button(), &mods))
+                    .flatten()
                 {
                     self.handle_action_with_window(event_loop, window_id, action);
                 }
             },
-            WindowEvent::CursorLeft { .. } => {
-                info!("Cursor left Window={window_id:?}");
+            WindowEvent::PointerLeft { .. } => {
+                info!("Pointer left Window={window_id:?}");
                 window.cursor_left();
             },
-            WindowEvent::CursorMoved { position, .. } => {
-                info!("Moved cursor to {position:?}");
+            WindowEvent::PointerMoved { position, .. } => {
+                info!("Moved pointer to {position:?}");
                 window.cursor_moved(position);
             },
             WindowEvent::ActivationTokenDone { token: _token, .. } => {
@@ -510,11 +513,10 @@ impl ApplicationHandler for Application {
             WindowEvent::TouchpadPressure { .. }
             | WindowEvent::HoveredFileCancelled
             | WindowEvent::KeyboardInput { .. }
-            | WindowEvent::CursorEntered { .. }
+            | WindowEvent::PointerEntered { .. }
             | WindowEvent::DroppedFile(_)
             | WindowEvent::HoveredFile(_)
             | WindowEvent::Destroyed
-            | WindowEvent::Touch(_)
             | WindowEvent::Moved(_) => (),
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -226,53 +226,89 @@ pub enum WindowEvent {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     Ime(Ime),
 
-    /// The cursor has moved on the window.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
-    ///
-    /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
-    /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
-    /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-    CursorMoved {
+    /// The pointer has moved on the window.
+    PointerMoved {
         device_id: Option<DeviceId>,
 
-        /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range
-        /// of this data is limited by the display area and it may have been transformed by
-        /// the OS to implement effects such as cursor acceleration, it should not be used
-        /// to implement non-cursor-like interactions such as 3D camera control. For that,
-        /// consider [`DeviceEvent::MouseMotion`].
+        /// (x,y) coordinates in pixels relative to the top-left corner of the window. Because the
+        /// range of this data is limited by the display area and it may have been
+        /// transformed by the OS to implement effects such as pointer acceleration, it
+        /// should not be used to implement non-pointer-like interactions such as 3D camera
+        /// control. For that, consider [`DeviceEvent::PointerMotion`].
+        ///
+        /// ## Platform-specific
+        ///
+        /// **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
+        ///
+        /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
+        /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
+        /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
         position: PhysicalPosition<f64>,
+
+        source: PointerSource,
     },
 
-    /// The cursor has entered the window.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
-    ///
-    /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
-    /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
-    /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-    CursorEntered { device_id: Option<DeviceId> },
+    /// The pointer has entered the window.
+    PointerEntered {
+        device_id: Option<DeviceId>,
 
-    /// The cursor has left the window.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
-    ///
-    /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
-    /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
-    /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-    CursorLeft { device_id: Option<DeviceId> },
+        /// The position of the pointer when it entered the window.
+        ///
+        /// ## Platform-specific
+        ///
+        /// - **Orbital: Always emits `(0., 0.)`.
+        /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
+        ///
+        /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
+        /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
+        /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
+        position: PhysicalPosition<f64>,
+
+        kind: PointerKind,
+    },
+
+    /// The pointer has left the window.
+    PointerLeft {
+        device_id: Option<DeviceId>,
+
+        /// The position of the pointer when it left the window. The position reported can be
+        /// outside the bounds of the window.
+        ///
+        /// ## Platform-specific
+        ///
+        /// - **Orbital/Windows:** Always emits [`None`].
+        /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
+        ///
+        /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
+        /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
+        /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
+        position: Option<PhysicalPosition<f64>>,
+
+        kind: PointerKind,
+    },
 
     /// A mouse wheel movement or touchpad scroll occurred.
     MouseWheel { device_id: Option<DeviceId>, delta: MouseScrollDelta, phase: TouchPhase },
 
     /// An mouse button press has been received.
-    MouseInput { device_id: Option<DeviceId>, state: ElementState, button: MouseButton },
+    PointerButton {
+        device_id: Option<DeviceId>,
+        state: ElementState,
+
+        /// The position of the pointer when the button was pressed.
+        ///
+        /// ## Platform-specific
+        ///
+        /// - **Orbital: Always emits `(0., 0.)`.
+        /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
+        ///
+        /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
+        /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
+        /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
+        position: PhysicalPosition<f64>,
+
+        button: ButtonSource,
+    },
 
     /// Two-finger pinch gesture, often used for magnification.
     ///
@@ -345,18 +381,6 @@ pub enum WindowEvent {
     /// The parameters are: pressure level (value between 0 and 1 representing how hard the
     /// touchpad is being pressed) and stage (integer representing the click level).
     TouchpadPressure { device_id: Option<DeviceId>, pressure: f32, stage: i64 },
-
-    /// Touch event has been received
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
-    /// - **macOS:** Unsupported.
-    ///
-    /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
-    /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
-    /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-    Touch(Touch),
 
     /// The window's scale factor has changed.
     ///
@@ -431,6 +455,129 @@ pub enum WindowEvent {
     RedrawRequested,
 }
 
+/// Represents the kind type of a pointer event.
+///
+/// ## Platform-specific
+///
+/// **Wayland/X11:** [`Unknown`](Self::Unknown) device types are converted to known variants by the
+/// system.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PointerKind {
+    Mouse,
+    /// See [`PointerSource::Touch`] for more details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **macOS:** Unsupported.
+    Touch(FingerId),
+    Unknown,
+}
+
+/// Represents the pointer type and its data for a pointer event.
+///
+/// **Wayland/X11:** [`Unknown`](Self::Unknown) device types are converted to known variants by the
+/// system.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PointerSource {
+    Mouse,
+    /// Represents a touch event.
+    ///
+    /// Every time the user touches the screen, a [`WindowEvent::PointerEntered`] and a
+    /// [`WindowEvent::PointerButton`] with [`ElementState::Pressed`] event with an unique
+    /// identifier for the finger is emitted. When a finger is lifted, a
+    /// [`WindowEvent::PointerButton`] with [`ElementState::Released`] and a
+    /// [`WindowEvent::PointerLeft`] event is generated with the same [`FingerId`].
+    ///
+    /// After a [`WindowEvent::PointerEntered`] event has been emitted, there may be zero or more
+    /// [`WindowEvent::PointerMoved`] events when the finger is moved or the touch pressure
+    /// changes.
+    ///
+    /// A [`WindowEvent::PointerLeft`] without a [`WindowEvent::PointerButton`] with
+    /// [`ElementState::Released`] event is emitted when the system has canceled tracking this
+    /// touch, such as when the window loses focus, or on mobile devices if the user moves the
+    /// device against their face.
+    ///
+    /// The [`FingerId`] may be reused by the system after a [`WindowEvent::PointerLeft`] event.
+    /// The user should assume that a new [`WindowEvent::PointerEntered`] event received with the
+    /// same ID has nothing to do with the old finger and is a new finger.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **macOS:** Unsupported.
+    Touch {
+        finger_id: FingerId,
+
+        /// Describes how hard the screen was pressed. May be [`None`] if the hardware does not
+        /// support pressure sensitivity.
+        ///
+        /// ## Platform-specific
+        ///
+        /// - **MacOS / Orbital / Wayland / X11:** Always emits [`None`].
+        /// - **Android:** Will never be [`None`]. If the device doesn't support pressure
+        ///   sensitivity, force will either be 0.0 or 1.0. Also see the
+        ///   [android documentation](https://developer.android.com/reference/android/view/MotionEvent#AXIS_PRESSURE).#[derive(Debug, Clone, Copy, PartialEq)]
+        /// - **Web:** Will never be [`None`]. If the device doesn't support pressure sensitivity,
+        ///   force will be 0.5 when a button is pressed or 0.0 otherwise.
+        force: Option<Force>,
+    },
+    Unknown,
+}
+
+impl From<PointerSource> for PointerKind {
+    fn from(source: PointerSource) -> Self {
+        match source {
+            PointerSource::Mouse => Self::Mouse,
+            PointerSource::Touch { finger_id, .. } => Self::Touch(finger_id),
+            PointerSource::Unknown => Self::Unknown,
+        }
+    }
+}
+
+/// Represents the pointer type of a [`WindowEvent::PointerButton`].
+///
+/// **Wayland/X11:** [`Unknown`](Self::Unknown) device types are converted to known variants by the
+/// system.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ButtonSource {
+    Mouse(MouseButton),
+    /// See [`PointerSource::Touch`] for more details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// **macOS:** Unsupported.
+    Touch {
+        finger_id: FingerId,
+        force: Option<Force>,
+    },
+    Unknown(u16),
+}
+
+impl ButtonSource {
+    /// Convert any [`ButtonSource`] to an equivalent [`MouseButton`]. If a pointer type has no
+    /// special handling in an application, this method can be used to handle it like any generic
+    /// mouse input.
+    pub fn mouse_button(self) -> MouseButton {
+        match self {
+            ButtonSource::Mouse(mouse) => mouse,
+            ButtonSource::Touch { .. } => MouseButton::Left,
+            ButtonSource::Unknown(button) => match button {
+                0 => MouseButton::Left,
+                1 => MouseButton::Middle,
+                2 => MouseButton::Right,
+                3 => MouseButton::Back,
+                4 => MouseButton::Forward,
+                _ => MouseButton::Other(button),
+            },
+        }
+    }
+}
+
+impl From<MouseButton> for ButtonSource {
+    fn from(mouse: MouseButton) -> Self {
+        Self::Mouse(mouse)
+    }
+}
+
 /// Identifier of an input device.
 ///
 /// Whenever you receive an event arising from a particular input device, this event contains a
@@ -459,7 +606,7 @@ impl FingerId {
 /// Useful for interactions that diverge significantly from a conventional 2D GUI, such as 3D camera
 /// or first-person game controls. Many physical actions, such as mouse movement, can produce both
 /// device and window events. Because window events typically arise from virtual devices
-/// (corresponding to GUI cursors and keyboard focus) the device IDs may not match.
+/// (corresponding to GUI pointers and keyboard focus) the device IDs may not match.
 ///
 /// Note that these events are delivered regardless of input focus.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -467,7 +614,7 @@ pub enum DeviceEvent {
     /// Change in physical position of a pointing device.
     ///
     /// This represents raw, unfiltered physical motion. Not to be confused with
-    /// [`WindowEvent::CursorMoved`].
+    /// [`WindowEvent::PointerMoved`].
     ///
     /// ## Platform-specific
     ///
@@ -484,7 +631,7 @@ pub enum DeviceEvent {
     ///
     #[rustfmt::skip]
     /// [`CursorGrabMode::Locked`]: crate::window::CursorGrabMode::Locked
-    MouseMotion {
+    PointerMotion {
         /// (x, y) change in position in unspecified units.
         ///
         /// Different devices may use different units.
@@ -813,50 +960,6 @@ pub enum TouchPhase {
     Cancelled,
 }
 
-/// Represents a touch event
-///
-/// Every time the user touches the screen, a new [`TouchPhase::Started`] event with an unique
-/// identifier for the finger is generated. When the finger is lifted, an [`TouchPhase::Ended`]
-/// event is generated with the same finger id.
-///
-/// After a `Started` event has been emitted, there may be zero or more `Move`
-/// events when the finger is moved or the touch pressure changes.
-///
-/// The finger id may be reused by the system after an `Ended` event. The user
-/// should assume that a new `Started` event received with the same id has nothing
-/// to do with the old finger and is a new finger.
-///
-/// A [`TouchPhase::Cancelled`] event is emitted when the system has canceled tracking this
-/// touch, such as when the window loses focus, or on iOS if the user moves the
-/// device against their face.
-///
-/// ## Platform-specific
-///
-/// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
-/// - **macOS:** Unsupported.
-///
-/// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border
-/// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
-/// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Touch {
-    pub device_id: Option<DeviceId>,
-    pub phase: TouchPhase,
-    pub location: PhysicalPosition<f64>,
-    /// Describes how hard the screen was pressed. May be `None` if the platform
-    /// does not support pressure sensitivity.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - Only available on **iOS** 9.0+, **Windows** 8+, **Web**, and **Android**.
-    /// - **Android**: This will never be [None]. If the device doesn't support pressure
-    ///   sensitivity, force will either be 0.0 or 1.0. Also see the
-    ///   [android documentation](https://developer.android.com/reference/android/view/MotionEvent#AXIS_PRESSURE).
-    pub force: Option<Force>,
-    /// Unique identifier of a finger.
-    pub finger_id: FingerId,
-}
-
 /// Describes the force of a touch event
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -877,12 +980,6 @@ pub enum Force {
         /// The value of this field is sufficiently high to provide a wide
         /// dynamic range for values of the `force` field.
         max_possible_force: f64,
-        /// The altitude (in radians) of the stylus.
-        ///
-        /// A value of 0 radians indicates that the stylus is parallel to the
-        /// surface. The value of this property is Pi/2 when the stylus is
-        /// perpendicular to the surface.
-        altitude_angle: Option<f64>,
     },
     /// If the platform reports the force as normalized, we have no way of
     /// knowing how much pressure 1.0 corresponds to – we know it's the maximum
@@ -899,13 +996,7 @@ impl Force {
     /// consistent across devices.
     pub fn normalized(&self) -> f64 {
         match self {
-            Force::Calibrated { force, max_possible_force, altitude_angle } => {
-                let force = match altitude_angle {
-                    Some(altitude_angle) => force / altitude_angle.sin(),
-                    None => *force,
-                };
-                force / max_possible_force
-            },
+            Force::Calibrated { force, max_possible_force } => force / max_possible_force,
             Force::Normalized(force) => *force,
         }
     }
@@ -1028,6 +1119,7 @@ mod tests {
                 use crate::event::Event::*;
                 use crate::event::Ime::Enabled;
                 use crate::event::WindowEvent::*;
+                use crate::event::{PointerKind, PointerSource};
                 use crate::window::WindowId;
 
                 // Mainline events.
@@ -1050,19 +1142,41 @@ mod tests {
                 with_window_event(HoveredFile("x.txt".into()));
                 with_window_event(HoveredFileCancelled);
                 with_window_event(Ime(Enabled));
-                with_window_event(CursorMoved { device_id: None, position: (0, 0).into() });
+                with_window_event(PointerMoved {
+                    device_id: None,
+                    position: (0, 0).into(),
+                    source: PointerSource::Mouse,
+                });
                 with_window_event(ModifiersChanged(event::Modifiers::default()));
-                with_window_event(CursorEntered { device_id: None });
-                with_window_event(CursorLeft { device_id: None });
+                with_window_event(PointerEntered {
+                    device_id: None,
+                    position: (0, 0).into(),
+                    kind: PointerKind::Mouse,
+                });
+                with_window_event(PointerLeft {
+                    device_id: None,
+                    position: Some((0, 0).into()),
+                    kind: PointerKind::Mouse,
+                });
                 with_window_event(MouseWheel {
                     device_id: None,
                     delta: event::MouseScrollDelta::LineDelta(0.0, 0.0),
                     phase: event::TouchPhase::Started,
                 });
-                with_window_event(MouseInput {
+                with_window_event(PointerButton {
                     device_id: None,
                     state: event::ElementState::Pressed,
-                    button: event::MouseButton::Other(0),
+                    position: (0, 0).into(),
+                    button: event::MouseButton::Other(0).into(),
+                });
+                with_window_event(PointerButton {
+                    device_id: None,
+                    state: event::ElementState::Released,
+                    position: (0, 0).into(),
+                    button: event::ButtonSource::Touch {
+                        finger_id: fid,
+                        force: Some(event::Force::Normalized(0.0)),
+                    },
                 });
                 with_window_event(PinchGesture {
                     device_id: None,
@@ -1081,13 +1195,6 @@ mod tests {
                     phase: event::TouchPhase::Started,
                 });
                 with_window_event(TouchpadPressure { device_id: None, pressure: 0.0, stage: 0 });
-                with_window_event(Touch(event::Touch {
-                    device_id: None,
-                    phase: event::TouchPhase::Started,
-                    location: (0.0, 0.0).into(),
-                    finger_id: fid,
-                    force: Some(event::Force::Normalized(0.0)),
-                }));
                 with_window_event(ThemeChanged(crate::window::Theme::Light));
                 with_window_event(Occluded(true));
             }
@@ -1099,7 +1206,7 @@ mod tests {
                 let with_device_event =
                     |dev_ev| x(event::Event::DeviceEvent { device_id: None, event: dev_ev });
 
-                with_device_event(MouseMotion { delta: (0.0, 0.0).into() });
+                with_device_event(PointerMotion { delta: (0.0, 0.0).into() });
                 with_device_event(MouseWheel {
                     delta: event::MouseScrollDelta::LineDelta(0.0, 0.0),
                 });
@@ -1122,15 +1229,10 @@ mod tests {
         let force = event::Force::Normalized(0.0);
         assert_eq!(force.normalized(), 0.0);
 
-        let force2 =
-            event::Force::Calibrated { force: 5.0, max_possible_force: 2.5, altitude_angle: None };
+        let force2 = event::Force::Calibrated { force: 5.0, max_possible_force: 2.5 };
         assert_eq!(force2.normalized(), 2.0);
 
-        let force3 = event::Force::Calibrated {
-            force: 5.0,
-            max_possible_force: 2.5,
-            altitude_angle: Some(std::f64::consts::PI / 2.0),
-        };
+        let force3 = event::Force::Calibrated { force: 5.0, max_possible_force: 2.5 };
         assert_eq!(force3.normalized(), 2.0);
     }
 
@@ -1154,16 +1256,6 @@ mod tests {
         HashSet::new().insert(event::MouseButton::Left.clone());
         HashSet::new().insert(event::Ime::Enabled);
 
-        let _ = event::Touch {
-            device_id: None,
-            phase: event::TouchPhase::Started,
-            location: (0.0, 0.0).into(),
-            finger_id: fid,
-            force: Some(event::Force::Normalized(0.0)),
-        }
-        .clone();
-        let _ =
-            event::Force::Calibrated { force: 0.0, max_possible_force: 0.0, altitude_angle: None }
-                .clone();
+        let _ = event::Force::Calibrated { force: 0.0, max_possible_force: 0.0 }.clone();
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -420,7 +420,7 @@ impl rwh_06::HasDisplayHandle for dyn ActiveEventLoop + '_ {
 
 /// A proxy for the underlying display handle.
 ///
-/// The purpose of this type is to provide a cheaply clonable handle to the underlying
+/// The purpose of this type is to provide a cheaply cloneable handle to the underlying
 /// display handle. This is often used by graphics APIs to connect to the underlying APIs.
 /// It is difficult to keep a handle to the [`EventLoop`] type or the [`ActiveEventLoop`]
 /// type. In contrast, this type involves no lifetimes and can be persisted for as long as

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -29,17 +29,16 @@
 //! The following APIs can't take them into account and will therefore provide inaccurate results:
 //! - [`WindowEvent::SurfaceResized`] and [`Window::(set_)surface_size()`]
 //! - [`WindowEvent::Occluded`]
-//! - [`WindowEvent::CursorMoved`], [`WindowEvent::CursorEntered`], [`WindowEvent::CursorLeft`], and
-//!   [`WindowEvent::Touch`].
+//! - [`WindowEvent::PointerMoved`], [`WindowEvent::PointerEntered`] and
+//!   [`WindowEvent::PointerLeft`].
 //! - [`Window::set_outer_position()`]
 //!
 //! [`WindowEvent::SurfaceResized`]: crate::event::WindowEvent::SurfaceResized
 //! [`Window::(set_)surface_size()`]: crate::window::Window::surface_size
 //! [`WindowEvent::Occluded`]: crate::event::WindowEvent::Occluded
-//! [`WindowEvent::CursorMoved`]: crate::event::WindowEvent::CursorMoved
-//! [`WindowEvent::CursorEntered`]: crate::event::WindowEvent::CursorEntered
-//! [`WindowEvent::CursorLeft`]: crate::event::WindowEvent::CursorLeft
-//! [`WindowEvent::Touch`]: crate::event::WindowEvent::Touch
+//! [`WindowEvent::PointerMoved`]: crate::event::WindowEvent::PointerMoved
+//! [`WindowEvent::PointerEntered`]: crate::event::WindowEvent::PointerEntered
+//! [`WindowEvent::PointerLeft`]: crate::event::WindowEvent::PointerLeft
 //! [`Window::set_outer_position()`]: crate::window::Window::set_outer_position
 
 use std::cell::Ref;

--- a/src/platform_impl/apple/appkit/app.rs
+++ b/src/platform_impl/apple/appkit/app.rs
@@ -60,7 +60,7 @@ fn maybe_dispatch_device_event(app_state: &Rc<AppState>, event: &NSEvent) {
 
             if delta_x != 0.0 || delta_y != 0.0 {
                 app_state.maybe_queue_with_handler(move |app, event_loop| {
-                    app.device_event(event_loop, None, DeviceEvent::MouseMotion {
+                    app.device_event(event_loop, None, DeviceEvent::PointerMotion {
                         delta: (delta_x, delta_y),
                     });
                 });

--- a/src/platform_impl/linux/common/xkb/keymap.rs
+++ b/src/platform_impl/linux/common/xkb/keymap.rs
@@ -638,7 +638,7 @@ pub fn keysym_to_key(keysym: u32) -> Key {
         // keysyms::ISO_Release_Margin_Left => NamedKey::IsoReleaseMarginLeft,
         // keysyms::ISO_Release_Margin_Right => NamedKey::IsoReleaseMarginRight,
         // keysyms::ISO_Release_Both_Margins => NamedKey::IsoReleaseBothMargins,
-        // keysyms::ISO_Fast_Cursor_Left => NamedKey::IsoFastCursorLeft,
+        // keysyms::ISO_Fast_Cursor_Left => NamedKey::IsoFastPointerLeft,
         // keysyms::ISO_Fast_Cursor_Right => NamedKey::IsoFastCursorRight,
         // keysyms::ISO_Fast_Cursor_Up => NamedKey::IsoFastCursorUp,
         // keysyms::ISO_Fast_Cursor_Down => NamedKey::IsoFastCursorDown,

--- a/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/relative_pointer.rs
@@ -68,7 +68,7 @@ impl Dispatch<ZwpRelativePointerV1, GlobalData, WinitState> for RelativePointerS
         };
         state
             .events_sink
-            .push_device_event(DeviceEvent::MouseMotion { delta: (dx_unaccel, dy_unaccel) });
+            .push_device_event(DeviceEvent::PointerMotion { delta: (dx_unaccel, dy_unaccel) });
     }
 }
 

--- a/src/platform_impl/linux/wayland/seat/touch/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/touch/mod.rs
@@ -8,7 +8,7 @@ use sctk::seat::touch::{TouchData, TouchHandler};
 use tracing::warn;
 
 use crate::dpi::LogicalPosition;
-use crate::event::{Touch, TouchPhase, WindowEvent};
+use crate::event::{ButtonSource, ElementState, PointerKind, PointerSource, WindowEvent};
 use crate::platform_impl::wayland::state::WinitState;
 use crate::platform_impl::wayland::{self, FingerId};
 
@@ -42,16 +42,25 @@ impl TouchHandler for WinitState {
         let location = LogicalPosition::<f64>::from(position);
         seat_state.touch_map.insert(id, TouchPoint { surface, location });
 
+        let position = location.to_physical(scale_factor);
+        let finger_id =
+            crate::event::FingerId(crate::platform_impl::FingerId::Wayland(FingerId(id)));
+
         self.events_sink.push_window_event(
-            WindowEvent::Touch(Touch {
+            WindowEvent::PointerEntered {
                 device_id: None,
-                phase: TouchPhase::Started,
-                location: location.to_physical(scale_factor),
-                force: None,
-                finger_id: crate::event::FingerId(crate::platform_impl::FingerId::Wayland(
-                    FingerId(id),
-                )),
-            }),
+                position,
+                kind: PointerKind::Touch(finger_id),
+            },
+            window_id,
+        );
+        self.events_sink.push_window_event(
+            WindowEvent::PointerButton {
+                device_id: None,
+                state: ElementState::Pressed,
+                position,
+                button: ButtonSource::Touch { finger_id, force: None },
+            },
             window_id,
         );
     }
@@ -85,16 +94,25 @@ impl TouchHandler for WinitState {
             None => return,
         };
 
+        let position = touch_point.location.to_physical(scale_factor);
+        let finger_id =
+            crate::event::FingerId(crate::platform_impl::FingerId::Wayland(FingerId(id)));
+
         self.events_sink.push_window_event(
-            WindowEvent::Touch(Touch {
+            WindowEvent::PointerButton {
                 device_id: None,
-                phase: TouchPhase::Ended,
-                location: touch_point.location.to_physical(scale_factor),
-                force: None,
-                finger_id: crate::event::FingerId(crate::platform_impl::FingerId::Wayland(
-                    FingerId(id),
-                )),
-            }),
+                state: ElementState::Released,
+                position,
+                button: ButtonSource::Touch { finger_id, force: None },
+            },
+            window_id,
+        );
+        self.events_sink.push_window_event(
+            WindowEvent::PointerLeft {
+                device_id: None,
+                position: Some(position),
+                kind: PointerKind::Touch(finger_id),
+            },
             window_id,
         );
     }
@@ -131,15 +149,16 @@ impl TouchHandler for WinitState {
         touch_point.location = LogicalPosition::<f64>::from(position);
 
         self.events_sink.push_window_event(
-            WindowEvent::Touch(Touch {
+            WindowEvent::PointerMoved {
                 device_id: None,
-                phase: TouchPhase::Moved,
-                location: touch_point.location.to_physical(scale_factor),
-                force: None,
-                finger_id: crate::event::FingerId(crate::platform_impl::FingerId::Wayland(
-                    FingerId(id),
-                )),
-            }),
+                position: touch_point.location.to_physical(scale_factor),
+                source: PointerSource::Touch {
+                    finger_id: crate::event::FingerId(crate::platform_impl::FingerId::Wayland(
+                        FingerId(id),
+                    )),
+                    force: None,
+                },
+            },
             window_id,
         );
     }
@@ -160,18 +179,16 @@ impl TouchHandler for WinitState {
                 None => return,
             };
 
-            let location = touch_point.location.to_physical(scale_factor);
+            let position = touch_point.location.to_physical(scale_factor);
 
             self.events_sink.push_window_event(
-                WindowEvent::Touch(Touch {
+                WindowEvent::PointerLeft {
                     device_id: None,
-                    phase: TouchPhase::Cancelled,
-                    location,
-                    force: None,
-                    finger_id: crate::event::FingerId(crate::platform_impl::FingerId::Wayland(
-                        FingerId(id),
+                    position: Some(position),
+                    kind: PointerKind::Touch(crate::event::FingerId(
+                        crate::platform_impl::FingerId::Wayland(FingerId(id)),
                     )),
-                }),
+                },
                 window_id,
             );
         }

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -407,11 +407,15 @@ impl EventLoop {
                 app.window_event(
                     window_target,
                     RootWindowId(window_id),
-                    event::WindowEvent::CursorMoved { device_id: None, position: (x, y).into() },
+                    event::WindowEvent::PointerMoved {
+                        device_id: None,
+                        position: (x, y).into(),
+                        source: event::PointerSource::Mouse,
+                    },
                 );
             },
             EventOption::MouseRelative(MouseRelativeEvent { dx, dy }) => {
-                app.device_event(window_target, None, event::DeviceEvent::MouseMotion {
+                app.device_event(window_target, None, event::DeviceEvent::PointerMotion {
                     delta: (dx as f64, dy as f64),
                 });
             },
@@ -420,7 +424,12 @@ impl EventLoop {
                     app.window_event(
                         window_target,
                         RootWindowId(window_id),
-                        event::WindowEvent::MouseInput { device_id: None, state, button },
+                        event::WindowEvent::PointerButton {
+                            device_id: None,
+                            state,
+                            position: dpi::PhysicalPosition::default(),
+                            button: button.into(),
+                        },
                     );
                 }
             },
@@ -469,9 +478,17 @@ impl EventLoop {
             // TODO: Screen, Clipboard, Drop
             EventOption::Hover(HoverEvent { entered }) => {
                 let event = if entered {
-                    event::WindowEvent::CursorEntered { device_id: None }
+                    event::WindowEvent::PointerEntered {
+                        device_id: None,
+                        position: dpi::PhysicalPosition::default(),
+                        kind: event::PointerKind::Mouse,
+                    }
                 } else {
-                    event::WindowEvent::CursorLeft { device_id: None }
+                    event::WindowEvent::PointerLeft {
+                        device_id: None,
+                        position: None,
+                        kind: event::PointerKind::Mouse,
+                    }
                 };
 
                 app.window_event(window_target, RootWindowId(window_id), event);

--- a/src/platform_impl/web/event.rs
+++ b/src/platform_impl/web/event.rs
@@ -1,5 +1,7 @@
-#[derive(Debug, Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
-pub struct DeviceId(u32);
+use crate::event::FingerId as RootFingerId;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DeviceId(pub(crate) u32);
 
 impl DeviceId {
     pub fn new(pointer_id: i32) -> Option<Self> {
@@ -32,5 +34,11 @@ impl FingerId {
 
     pub fn is_primary(self) -> bool {
         self.primary
+    }
+}
+
+impl From<FingerId> for RootFingerId {
+    fn from(id: FingerId) -> Self {
+        Self(id)
     }
 }

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -297,7 +297,7 @@ impl Shared {
 
                     runner.send_event(Event::DeviceEvent {
                         device_id,
-                        event: DeviceEvent::Button { button: button.to_id(), state },
+                        event: DeviceEvent::Button { button: button.to_id().into(), state },
                     });
 
                     return;
@@ -310,7 +310,7 @@ impl Shared {
 
                     Event::DeviceEvent {
                         device_id,
-                        event: DeviceEvent::MouseMotion { delta: (delta.x, delta.y) },
+                        event: DeviceEvent::PointerMotion { delta: (delta.x, delta.y) },
                     }
                 }));
             }),
@@ -346,7 +346,7 @@ impl Shared {
                 runner.send_event(Event::DeviceEvent {
                     device_id: DeviceId::new(event.pointer_id()).map(RootDeviceId),
                     event: DeviceEvent::Button {
-                        button: button.to_id(),
+                        button: button.to_id().into(),
                         state: ElementState::Pressed,
                     },
                 });
@@ -365,7 +365,7 @@ impl Shared {
                 runner.send_event(Event::DeviceEvent {
                     device_id: DeviceId::new(event.pointer_id()).map(RootDeviceId),
                     event: DeviceEvent::Button {
-                        button: button.to_id(),
+                        button: button.to_id().into(),
                         state: ElementState::Released,
                     },
                 });

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -6,8 +6,9 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{KeyboardEvent, MouseEvent, Navigator, PointerEvent, WheelEvent};
 
+use super::super::FingerId;
 use super::Engine;
-use crate::event::{MouseButton, MouseScrollDelta};
+use crate::event::{MouseButton, MouseScrollDelta, PointerKind};
 use crate::keyboard::{Key, KeyLocation, ModifiersState, NamedKey, PhysicalKey};
 
 bitflags::bitflags! {
@@ -68,14 +69,14 @@ pub fn mouse_button(event: &MouseEvent) -> Option<MouseButton> {
 }
 
 impl MouseButton {
-    pub fn to_id(self) -> u32 {
+    pub fn to_id(self) -> u16 {
         match self {
             MouseButton::Left => 0,
             MouseButton::Right => 1,
             MouseButton::Middle => 2,
             MouseButton::Back => 3,
             MouseButton::Forward => 4,
-            MouseButton::Other(value) => value.into(),
+            MouseButton::Other(value) => value,
         }
     }
 }
@@ -157,6 +158,14 @@ pub fn mouse_scroll_delta(
             Some(MouseScrollDelta::PixelDelta(delta))
         },
         _ => None,
+    }
+}
+
+pub fn pointer_type(event: &PointerEvent, pointer_id: i32) -> PointerKind {
+    match event.pointer_type().as_str() {
+        "mouse" => PointerKind::Mouse,
+        "touch" => PointerKind::Touch(FingerId::new(pointer_id, event.is_primary()).into()),
+        _ => PointerKind::Unknown,
     }
 }
 

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -18,7 +18,6 @@ use wasm_bindgen::JsCast;
 use web_sys::{Document, HtmlCanvasElement, Navigator, PageTransitionEvent, VisibilityState};
 
 pub use self::canvas::{Canvas, Style};
-pub use self::event::ButtonsState;
 pub use self::event_handle::EventListenerHandle;
 pub use self::resize_scaling::ResizeScaleHandle;
 pub use self::schedule::Schedule;

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -14,7 +14,7 @@ use windows_sys::Win32::UI::HiDpi::{
     DPI_AWARENESS_CONTEXT, MONITOR_DPI_TYPE, PROCESS_DPI_AWARENESS,
 };
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::GetActiveWindow;
-use windows_sys::Win32::UI::Input::Pointer::{POINTER_INFO, POINTER_PEN_INFO, POINTER_TOUCH_INFO};
+use windows_sys::Win32::UI::Input::Pointer::{POINTER_INFO, POINTER_TOUCH_INFO};
 use windows_sys::Win32::UI::WindowsAndMessaging::{
     ClipCursor, GetClientRect, GetClipCursor, GetSystemMetrics, GetWindowPlacement, GetWindowRect,
     IsIconic, ShowCursor, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM,
@@ -244,9 +244,6 @@ pub type GetPointerDeviceRects = unsafe extern "system" fn(
 pub type GetPointerTouchInfo =
     unsafe extern "system" fn(pointerId: u32, touchInfo: *mut POINTER_TOUCH_INFO) -> BOOL;
 
-pub type GetPointerPenInfo =
-    unsafe extern "system" fn(pointId: u32, penInfo: *mut POINTER_PEN_INFO) -> BOOL;
-
 pub(crate) static GET_DPI_FOR_WINDOW: Lazy<Option<GetDpiForWindow>> =
     Lazy::new(|| get_function!("user32.dll", GetDpiForWindow));
 pub(crate) static ADJUST_WINDOW_RECT_EX_FOR_DPI: Lazy<Option<AdjustWindowRectExForDpi>> =
@@ -269,5 +266,3 @@ pub(crate) static GET_POINTER_DEVICE_RECTS: Lazy<Option<GetPointerDeviceRects>> 
     Lazy::new(|| get_function!("user32.dll", GetPointerDeviceRects));
 pub(crate) static GET_POINTER_TOUCH_INFO: Lazy<Option<GetPointerTouchInfo>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerTouchInfo));
-pub(crate) static GET_POINTER_PEN_INFO: Lazy<Option<GetPointerPenInfo>> =
-    Lazy::new(|| get_function!("user32.dll", GetPointerPenInfo));


### PR DESCRIPTION
### Description

This implements #3833, please see it for all the details.

This implementation deviates on `PointerLeft::position`, which is now an `Option`, because Windows (and maybe MacOS) doesn't have this kind of information.
It also adds `FingerId` to `PointerType`, which was an oversight of #3833.

Notably I also removed pen/stylus handling in iOS and Windows, which is now emitted as `PointerType::Unknown`.
I plan to reintroduce the same code and expand on it in #3810.

#3874 was a side-product of this PR.

### Summary of the changes
- Rename `CursorMoved` to `PointerMoved`.
- Rename `CursorEntered` to `PointerEntered`.
- Rename `CursorLeft` to `PointerLeft`.
- Rename `MouseInput` to `PointerButton`.
- Add `position` to every `PointerEvent`.
- Remove `Touch`, which is folded into the `Pointer*` events.
- New `PointerType` added to `PointerEntered` and `PointerLeft`, signifying which pointer type is the source of this event.
- New `PointerSource` added to `PointerMoved`, similar to `PointerType` but holding additional data.
- New `ButtonSource` added to `PointerButton`, similar to `PointerType` but holding pointer type specific buttons. Use `ButtonSource::mouse_button()` to easily normalize any pointer button type to a generic mouse button.
- In the same spirit rename `DeviceEvent::MouseMotion` to `PointerMotion`.
- Remove `Force::Calibrated::altitude_angle`.

### Follow-ups
- Implement pen/stylus input in #3810.
- Add touch pressure support to X11.
- Add a reliable way to detect pointer types to X11.
- Potentially differentiate between `TouchPad` and `TouchScreen`. `Touch` will remain in place for backends who can not differentiate between these pointer types.

---

Addresses https://github.com/rust-windowing/winit/issues/1555.
Addresses https://github.com/rust-windowing/winit/issues/99.
Fixes https://github.com/rust-windowing/winit/issues/336.
Fixes https://github.com/rust-windowing/winit/issues/883.
Fixes https://github.com/rust-windowing/winit/issues/1909.
Replaces #3001.