### PR TITLE
macOS: add option to explicitly hide menu/dock in Borderless

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -63,6 +63,8 @@ changelog entry.
   and `Serialize` on many types.
 - Add `MonitorHandle::current_video_mode()`.
 - Add basic iOS IME support. The soft keyboard can now be shown using `Window::set_ime_allowed`.
+- On macOS, add `WindowExtMacOS::set_borderless_game` and `WindowAttributesExtMacOS::with_borderless_game`
+  to fully disable the menu bar and dock in Borderless Fullscreen as commonly done in games.
 
 ### Changed
 

--- a/src/changelog/v0.30.md
+++ b/src/changelog/v0.30.md
@@ -1,3 +1,10 @@
+## 0.30.6
+
+### Added
+
+- On macOS, add `WindowExtMacOS::set_borderless_game` and `WindowAttributesExtMacOS::with_borderless_game`
+  to fully disable the menu bar and dock in Borderless Fullscreen as commonly done in games.
+
 ## 0.30.5
 
 ### Added

--- a/src/changelog/v0.30.md
+++ b/src/changelog/v0.30.md
@@ -1,10 +1,3 @@
-## 0.30.6
-
-### Added
-
-- On macOS, add `WindowExtMacOS::set_borderless_game` and `WindowAttributesExtMacOS::with_borderless_game`
-  to fully disable the menu bar and dock in Borderless Fullscreen as commonly done in games.
-
 ## 0.30.5
 
 ### Added

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -162,6 +162,12 @@ pub trait WindowExtMacOS {
 
     /// Getter for the [`WindowExtMacOS::set_option_as_alt`].
     fn option_as_alt(&self) -> OptionAsAlt;
+
+    /// Disable the Menu Bar and Dock in Borderless Fullscreen mode. Useful for games.
+    fn set_borderless_game(&self, borderless_game: bool);
+
+    /// Getter for the [`WindowExtMacOS::set_borderless_game`].
+    fn is_borderless_game(&self) -> bool;
 }
 
 impl WindowExtMacOS for Window {
@@ -234,6 +240,16 @@ impl WindowExtMacOS for Window {
     fn option_as_alt(&self) -> OptionAsAlt {
         self.window.maybe_wait_on_main(|w| w.option_as_alt())
     }
+
+    #[inline]
+    fn set_borderless_game(&self, borderless_game: bool) {
+        self.window.maybe_wait_on_main(|w| w.set_borderless_game(borderless_game))
+    }
+
+    #[inline]
+    fn is_borderless_game(&self) -> bool {
+        self.window.maybe_wait_on_main(|w| w.is_borderless_game())
+    }
 }
 
 /// Corresponds to `NSApplicationActivationPolicy`.
@@ -285,6 +301,8 @@ pub trait WindowAttributesExtMacOS {
     ///
     /// See [`WindowExtMacOS::set_option_as_alt`] for details on what this means if set.
     fn with_option_as_alt(self, option_as_alt: OptionAsAlt) -> Self;
+    /// See [`WindowExtMacOS::set_borderless_game`] for details on what this means if set.
+    fn with_borderless_game(self, borderless_game: bool) -> Self;
 }
 
 impl WindowAttributesExtMacOS for WindowAttributes {
@@ -351,6 +369,12 @@ impl WindowAttributesExtMacOS for WindowAttributes {
     #[inline]
     fn with_option_as_alt(mut self, option_as_alt: OptionAsAlt) -> Self {
         self.platform_specific.option_as_alt = option_as_alt;
+        self
+    }
+
+    #[inline]
+    fn with_borderless_game(mut self, borderless_game: bool) -> Self {
+        self.platform_specific.borderless_game = borderless_game;
         self
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -245,12 +245,14 @@ impl WindowExtMacOS for dyn Window + '_ {
 
     #[inline]
     fn set_borderless_game(&self, borderless_game: bool) {
-        self.window.maybe_wait_on_main(|w| w.set_borderless_game(borderless_game))
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.set_borderless_game(borderless_game))
     }
 
     #[inline]
     fn is_borderless_game(&self) -> bool {
-        self.window.maybe_wait_on_main(|w| w.is_borderless_game())
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.is_borderless_game())
     }
 }
 

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1436,9 +1436,7 @@ impl WindowDelegate {
                 // by setting the presentation options. We do this here rather than in
                 // `window:willUseFullScreenPresentationOptions` because for some reason
                 // the menu bar remains interactable despite being hidden.
-                if self.ivars().is_borderless_game.get()
-                    && matches!(fullscreen, Fullscreen::Borderless(_))
-                {
+                if self.is_borderless_game() && matches!(fullscreen, Fullscreen::Borderless(_)) {
                     let presentation_options = NSApplicationPresentationOptions::NSApplicationPresentationHideDock
                             | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar;
                     app.setPresentationOptions(presentation_options);

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -56,6 +56,7 @@ pub struct PlatformSpecificWindowAttributes {
     pub accepts_first_mouse: bool,
     pub tabbing_identifier: Option<String>,
     pub option_as_alt: OptionAsAlt,
+    pub borderless_game: bool,
 }
 
 impl Default for PlatformSpecificWindowAttributes {
@@ -73,6 +74,7 @@ impl Default for PlatformSpecificWindowAttributes {
             accepts_first_mouse: true,
             tabbing_identifier: None,
             option_as_alt: Default::default(),
+            borderless_game: false,
         }
     }
 }
@@ -121,6 +123,7 @@ pub(crate) struct State {
     standard_frame: Cell<Option<NSRect>>,
     is_simple_fullscreen: Cell<bool>,
     saved_style: Cell<Option<NSWindowStyleMask>>,
+    is_borderless_game: Cell<bool>,
 }
 
 declare_class!(
@@ -280,6 +283,13 @@ declare_class!(
                 options = NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
                     | NSApplicationPresentationOptions::NSApplicationPresentationHideDock
                     | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar;
+            }
+            if let Some(Fullscreen::Borderless(_)) = &*fullscreen {
+                if self.ivars().is_borderless_game.get() {
+                    options = NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
+                        | NSApplicationPresentationOptions::NSApplicationPresentationHideDock
+                        | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar;
+                }
             }
 
             options
@@ -726,6 +736,7 @@ impl WindowDelegate {
             standard_frame: Cell::new(None),
             is_simple_fullscreen: Cell::new(false),
             saved_style: Cell::new(None),
+            is_borderless_game: Cell::new(attrs.platform_specific.borderless_game),
         });
         let delegate: Retained<WindowDelegate> = unsafe { msg_send_id![super(delegate), init] };
 
@@ -1807,6 +1818,14 @@ impl WindowExtMacOS for WindowDelegate {
 
     fn option_as_alt(&self) -> OptionAsAlt {
         self.view().option_as_alt()
+    }
+
+    fn set_borderless_game(&self, borderless_game: bool) {
+        self.ivars().is_borderless_game.set(borderless_game);
+    }
+
+    fn is_borderless_game(&self) -> bool {
+        self.ivars().is_borderless_game.get()
     }
 }
 


### PR DESCRIPTION
Addresses #3880 

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
