### PR TITLE
api: unify error handling

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -17,7 +17,7 @@ use rwh_06::{DisplayHandle, HasDisplayHandle};
 use softbuffer::{Context, Surface};
 use winit::application::ApplicationHandler;
 use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
-use winit::error::ExternalError;
+use winit::error::RequestError;
 use winit::event::{DeviceEvent, DeviceId, Ime, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop};
 use winit::keyboard::{Key, ModifiersState};
@@ -76,7 +76,7 @@ struct Application {
     receiver: Receiver<Action>,
     sender: Sender<Action>,
     /// Custom cursors assets.
-    custom_cursors: Result<Vec<CustomCursor>, ExternalError>,
+    custom_cursors: Result<Vec<CustomCursor>, RequestError>,
     /// Application icon.
     icon: Icon,
     windows: HashMap<WindowId, WindowState>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,45 +1,40 @@
-use std::{error, fmt};
+use std::error::Error;
+use std::fmt::{self, Display};
 
-use crate::platform_impl;
-
-// TODO: Rename
-/// An error that may be generated when requesting Winit state
+/// A general error that may occur while running or creating
+/// the event loop.
 #[derive(Debug)]
-pub enum ExternalError {
-    /// The operation is not supported by the backend.
-    NotSupported(NotSupportedError),
-    /// The operation was ignored.
-    Ignored,
-    /// The OS cannot perform the operation.
-    Os(OsError),
-}
-
-/// The error type for when the requested operation is not supported by the backend.
-#[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct NotSupportedError {
-    _marker: (),
-}
-
-/// The error type for when the OS cannot perform the requested operation.
-#[derive(Debug)]
-pub struct OsError {
-    line: u32,
-    file: &'static str,
-    error: platform_impl::OsError,
-}
-
-/// A general error that may occur while running the Winit event loop
-#[derive(Debug)]
+#[non_exhaustive]
 pub enum EventLoopError {
-    /// The operation is not supported by the backend.
-    NotSupported(NotSupportedError),
-    /// The OS cannot perform the operation.
-    Os(OsError),
     /// The event loop can't be re-created.
     RecreationAttempt,
     /// Application has exit with an error status.
     ExitFailure(i32),
+    /// Got unspecified OS-specific error during the request.
+    Os(OsError),
+    /// Creating the event loop with the requested configuration is not supported.
+    NotSupported(NotSupportedError),
+}
+
+impl fmt::Display for EventLoopError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RecreationAttempt => write!(f, "EventLoop can't be recreated"),
+            Self::Os(err) => err.fmt(f),
+            Self::ExitFailure(status) => write!(f, "Exit Failure: {status}"),
+            Self::NotSupported(err) => err.fmt(f),
+        }
+    }
+}
+
+impl Error for EventLoopError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Self::Os(err) = self {
+            err.source()
+        } else {
+            None
+        }
+    }
 }
 
 impl From<OsError> for EventLoopError {
@@ -48,18 +43,102 @@ impl From<OsError> for EventLoopError {
     }
 }
 
-impl NotSupportedError {
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn new() -> NotSupportedError {
-        NotSupportedError { _marker: () }
+impl From<NotSupportedError> for EventLoopError {
+    fn from(value: NotSupportedError) -> Self {
+        Self::NotSupported(value)
     }
+}
+
+/// A general error that may occur during a request to the windowing system.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum RequestError {
+    /// The request is not supported.
+    NotSupported(NotSupportedError),
+    /// The request was ignored by the operating system.
+    Ignored,
+    /// Got unspecified OS specific error during the request.
+    Os(OsError),
+}
+
+impl Display for RequestError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotSupported(err) => err.fmt(f),
+            Self::Ignored => write!(f, "The request was ignored"),
+            Self::Os(err) => err.fmt(f),
+        }
+    }
+}
+impl Error for RequestError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        if let Self::Os(err) = self {
+            err.source()
+        } else {
+            None
+        }
+    }
+}
+
+impl From<NotSupportedError> for RequestError {
+    fn from(value: NotSupportedError) -> Self {
+        Self::NotSupported(value)
+    }
+}
+
+impl From<OsError> for RequestError {
+    fn from(value: OsError) -> Self {
+        Self::Os(value)
+    }
+}
+
+/// The requested operation is not supported.
+#[derive(Debug)]
+pub struct NotSupportedError {
+    /// The reason why a certain operation is not supported.
+    reason: &'static str,
+}
+
+impl NotSupportedError {
+    pub(crate) fn new(reason: &'static str) -> Self {
+        Self { reason }
+    }
+}
+
+impl fmt::Display for NotSupportedError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Operation is not supported: {}", self.reason)
+    }
+}
+impl Error for NotSupportedError {}
+
+/// Unclassified error from the OS.
+#[derive(Debug)]
+pub struct OsError {
+    line: u32,
+    file: &'static str,
+    error: Box<dyn Error + Send + Sync + 'static>,
 }
 
 impl OsError {
     #[allow(dead_code)]
-    pub(crate) fn new(line: u32, file: &'static str, error: platform_impl::OsError) -> OsError {
-        OsError { line, file, error }
+    pub(crate) fn new(
+        line: u32,
+        file: &'static str,
+        error: impl Into<Box<dyn Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self { line, file, error: error.into() }
+    }
+}
+
+impl Display for OsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.pad(&format!("os error at {}:{}: {}", self.file, self.line, self.error))
+    }
+}
+impl Error for OsError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.error.as_ref())
     }
 }
 
@@ -68,65 +147,4 @@ macro_rules! os_error {
     ($error:expr) => {{
         crate::error::OsError::new(line!(), file!(), $error)
     }};
-}
-
-impl fmt::Display for OsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.pad(&format!("os error at {}:{}: {}", self.file, self.line, self.error))
-    }
-}
-
-impl fmt::Display for ExternalError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            ExternalError::NotSupported(e) => e.fmt(f),
-            ExternalError::Ignored => write!(f, "Operation was ignored"),
-            ExternalError::Os(e) => e.fmt(f),
-        }
-    }
-}
-
-impl fmt::Debug for NotSupportedError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.debug_struct("NotSupportedError").finish()
-    }
-}
-
-impl fmt::Display for NotSupportedError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        f.pad("the requested operation is not supported by Winit")
-    }
-}
-
-impl fmt::Display for EventLoopError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
-        match self {
-            EventLoopError::RecreationAttempt => write!(f, "EventLoop can't be recreated"),
-            EventLoopError::NotSupported(e) => e.fmt(f),
-            EventLoopError::Os(e) => e.fmt(f),
-            EventLoopError::ExitFailure(status) => write!(f, "Exit Failure: {status}"),
-        }
-    }
-}
-
-impl error::Error for OsError {}
-impl error::Error for ExternalError {}
-impl error::Error for NotSupportedError {}
-impl error::Error for EventLoopError {}
-
-#[cfg(test)]
-#[allow(clippy::redundant_clone)]
-mod tests {
-    use super::*;
-
-    // Eat attributes for testing
-    #[test]
-    fn ensure_fmt_does_not_panic() {
-        let _ = format!("{:?}, {}", NotSupportedError::new(), NotSupportedError::new().clone());
-        let _ = format!(
-            "{:?}, {}",
-            ExternalError::NotSupported(NotSupportedError::new()),
-            ExternalError::NotSupported(NotSupportedError::new())
-        );
-    }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -46,7 +46,7 @@ use smol_str::SmolStr;
 use web_time::Instant;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::error::ExternalError;
+use crate::error::RequestError;
 use crate::event_loop::AsyncRequestSerial;
 use crate::keyboard::{self, ModifiersKeyState, ModifiersKeys, ModifiersState};
 use crate::platform_impl;
@@ -1016,12 +1016,12 @@ impl SurfaceSizeWriter {
     pub fn request_surface_size(
         &mut self,
         new_surface_size: PhysicalSize<u32>,
-    ) -> Result<(), ExternalError> {
+    ) -> Result<(), RequestError> {
         if let Some(inner) = self.new_surface_size.upgrade() {
             *inner.lock().unwrap() = new_surface_size;
             Ok(())
         } else {
-            Err(ExternalError::Ignored)
+            Err(RequestError::Ignored)
         }
     }
 }

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -20,7 +20,7 @@ use std::time::{Duration, Instant};
 use web_time::{Duration, Instant};
 
 use crate::application::ApplicationHandler;
-use crate::error::{EventLoopError, ExternalError, OsError};
+use crate::error::{EventLoopError, RequestError};
 use crate::monitor::MonitorHandle;
 use crate::platform_impl;
 use crate::utils::AsAny;
@@ -268,7 +268,7 @@ impl EventLoop {
     pub fn create_custom_cursor(
         &self,
         custom_cursor: CustomCursorSource,
-    ) -> Result<CustomCursor, ExternalError> {
+    ) -> Result<CustomCursor, RequestError> {
         self.event_loop.window_target().create_custom_cursor(custom_cursor)
     }
 }
@@ -324,7 +324,7 @@ pub trait ActiveEventLoop: AsAny {
     fn create_window(
         &self,
         window_attributes: WindowAttributes,
-    ) -> Result<Box<dyn Window>, OsError>;
+    ) -> Result<Box<dyn Window>, RequestError>;
 
     /// Create custom cursor.
     ///
@@ -334,7 +334,7 @@ pub trait ActiveEventLoop: AsAny {
     fn create_custom_cursor(
         &self,
         custom_cursor: CustomCursorSource,
-    ) -> Result<CustomCursor, ExternalError>;
+    ) -> Result<CustomCursor, RequestError>;
 
     /// Returns the list of all the monitors available on the system.
     ///

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -23,7 +23,7 @@
 
 use std::env;
 
-use crate::error::NotSupportedError;
+use crate::error::{NotSupportedError, RequestError};
 use crate::event_loop::{ActiveEventLoop, AsyncRequestSerial};
 #[cfg(wayland_platform)]
 use crate::platform::wayland::ActiveEventLoopExtWayland;
@@ -46,7 +46,7 @@ pub trait WindowExtStartupNotify {
     /// Request a new activation token.
     ///
     /// The token will be delivered inside
-    fn request_activation_token(&self) -> Result<AsyncRequestSerial, NotSupportedError>;
+    fn request_activation_token(&self) -> Result<AsyncRequestSerial, RequestError>;
 }
 
 pub trait WindowAttributesExtStartupNotify {
@@ -73,7 +73,7 @@ impl EventLoopExtStartupNotify for dyn ActiveEventLoop + '_ {
 }
 
 impl WindowExtStartupNotify for dyn Window + '_ {
-    fn request_activation_token(&self) -> Result<AsyncRequestSerial, NotSupportedError> {
+    fn request_activation_token(&self) -> Result<AsyncRequestSerial, RequestError> {
         #[cfg(wayland_platform)]
         if let Some(window) = self.as_any().downcast_ref::<crate::platform_impl::wayland::Window>()
         {
@@ -87,7 +87,7 @@ impl WindowExtStartupNotify for dyn Window + '_ {
             return window.request_activation_token();
         }
 
-        Err(NotSupportedError::new())
+        Err(NotSupportedError::new("startup notify is not supported").into())
     }
 }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -14,7 +14,7 @@ use tracing::{debug, trace, warn};
 use crate::application::ApplicationHandler;
 use crate::cursor::Cursor;
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
-use crate::error::{self, EventLoopError, ExternalError, NotSupportedError};
+use crate::error::{EventLoopError, NotSupportedError, RequestError};
 use crate::event::{self, Force, StartCause, SurfaceSizeWriter};
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
@@ -592,15 +592,15 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: WindowAttributes,
-    ) -> Result<Box<dyn CoreWindow>, error::OsError> {
+    ) -> Result<Box<dyn CoreWindow>, RequestError> {
         Ok(Box::new(Window::new(self, window_attributes)?))
     }
 
     fn create_custom_cursor(
         &self,
         _source: CustomCursorSource,
-    ) -> Result<CustomCursor, ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    ) -> Result<CustomCursor, RequestError> {
+        Err(NotSupportedError::new("create_custom_cursor is not supported").into())
     }
 
     fn available_monitors(&self) -> Box<dyn Iterator<Item = RootMonitorHandle>> {
@@ -715,7 +715,7 @@ impl Window {
     pub(crate) fn new(
         el: &ActiveEventLoop,
         _window_attrs: window::WindowAttributes,
-    ) -> Result<Self, error::OsError> {
+    ) -> Result<Self, RequestError> {
         // FIXME this ignores requested window attributes
 
         Ok(Self { app: el.app.clone(), redraw_requester: el.redraw_requester.clone() })
@@ -796,12 +796,12 @@ impl CoreWindow for Window {
 
     fn pre_present_notify(&self) {}
 
-    fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
-        Err(error::NotSupportedError::new())
+    fn inner_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
+        Err(NotSupportedError::new("inner_position is not supported").into())
     }
 
-    fn outer_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
-        Err(error::NotSupportedError::new())
+    fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
+        Err(NotSupportedError::new("outer_position is not supported").into())
     }
 
     fn set_outer_position(&self, _position: Position) {
@@ -896,29 +896,29 @@ impl CoreWindow for Window {
 
     fn set_cursor(&self, _: Cursor) {}
 
-    fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
+    fn set_cursor_position(&self, _: Position) -> Result<(), RequestError> {
+        Err(NotSupportedError::new("set_cursor_position is not supported").into())
     }
 
-    fn set_cursor_grab(&self, _: CursorGrabMode) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
+    fn set_cursor_grab(&self, _: CursorGrabMode) -> Result<(), RequestError> {
+        Err(NotSupportedError::new("set_cursor_grab is not supported").into())
     }
 
     fn set_cursor_visible(&self, _: bool) {}
 
-    fn drag_window(&self) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
+    fn drag_window(&self) -> Result<(), RequestError> {
+        Err(NotSupportedError::new("drag_window is not supported").into())
     }
 
-    fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
+    fn drag_resize_window(&self, _direction: ResizeDirection) -> Result<(), RequestError> {
+        Err(NotSupportedError::new("drag_resize_window").into())
     }
 
     #[inline]
     fn show_window_menu(&self, _position: Position) {}
 
-    fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
+    fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), RequestError> {
+        Err(NotSupportedError::new("set_cursor_hittest is not supported").into())
     }
 
     fn set_theme(&self, _theme: Option<Theme>) {}

--- a/src/platform_impl/apple/appkit/cursor.rs
+++ b/src/platform_impl/apple/appkit/cursor.rs
@@ -11,9 +11,8 @@ use objc2_foundation::{
     NSString,
 };
 
-use super::OsError;
 use crate::cursor::{CursorImage, OnlyCursorImageSource};
-use crate::error::ExternalError;
+use crate::error::RequestError;
 use crate::window::CursorIcon;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -25,12 +24,12 @@ unsafe impl Send for CustomCursor {}
 unsafe impl Sync for CustomCursor {}
 
 impl CustomCursor {
-    pub(crate) fn new(cursor: OnlyCursorImageSource) -> Result<CustomCursor, ExternalError> {
+    pub(crate) fn new(cursor: OnlyCursorImageSource) -> Result<CustomCursor, RequestError> {
         cursor_from_image(&cursor.0).map(Self)
     }
 }
 
-pub(crate) fn cursor_from_image(cursor: &CursorImage) -> Result<Retained<NSCursor>, ExternalError> {
+pub(crate) fn cursor_from_image(cursor: &CursorImage) -> Result<Retained<NSCursor>, RequestError> {
     let width = cursor.width;
     let height = cursor.height;
 
@@ -48,7 +47,7 @@ pub(crate) fn cursor_from_image(cursor: &CursorImage) -> Result<Retained<NSCurso
             width as isize * 4,
             32,
         )
-    }.ok_or_else(|| ExternalError::Os(os_error!(OsError::CreationError("parent view should be installed in a window"))))?;
+    }.ok_or_else(|| os_error!("parent view should be installed in a window"))?;
     let bitmap_data = unsafe { slice::from_raw_parts_mut(bitmap.bitmapData(), cursor.rgba.len()) };
     bitmap_data.copy_from_slice(&cursor.rgba);
 

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -29,7 +29,7 @@ use super::event::dummy_event;
 use super::monitor;
 use super::observer::setup_control_flow_observers;
 use crate::application::ApplicationHandler;
-use crate::error::{EventLoopError, ExternalError};
+use crate::error::{EventLoopError, RequestError};
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
     EventLoopProxy as RootEventLoopProxy, OwnedDisplayHandle as RootOwnedDisplayHandle,
@@ -103,14 +103,14 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: crate::window::WindowAttributes,
-    ) -> Result<Box<dyn crate::window::Window>, crate::error::OsError> {
+    ) -> Result<Box<dyn crate::window::Window>, RequestError> {
         Ok(Box::new(Window::new(self, window_attributes)?))
     }
 
     fn create_custom_cursor(
         &self,
         source: CustomCursorSource,
-    ) -> Result<RootCustomCursor, ExternalError> {
+    ) -> Result<RootCustomCursor, RequestError> {
         Ok(RootCustomCursor { inner: CustomCursor::new(source.inner)? })
     }
 

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -14,8 +14,6 @@ mod view;
 mod window;
 mod window_delegate;
 
-use std::fmt;
-
 pub(crate) use self::cursor::CustomCursor as PlatformCustomCursor;
 pub(crate) use self::event::{physicalkey_to_scancode, scancode_to_physicalkey, KeyEventExtra};
 pub(crate) use self::event_loop::{
@@ -48,20 +46,5 @@ pub struct FingerId;
 impl FingerId {
     pub const fn dummy() -> Self {
         FingerId
-    }
-}
-
-#[derive(Debug)]
-pub enum OsError {
-    CGError(core_graphics::base::CGError),
-    CreationError(&'static str),
-}
-
-impl fmt::Display for OsError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            OsError::CGError(e) => f.pad(&format!("CGError {e}")),
-            OsError::CreationError(e) => f.pad(e),
-        }
     }
 }

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -25,7 +25,7 @@ use super::super::notification_center::create_observer;
 use super::app_state::{send_occluded_event_for_all_windows, AppState, EventWrapper};
 use super::{app_state, monitor, MonitorHandle};
 use crate::application::ApplicationHandler;
-use crate::error::{EventLoopError, ExternalError, NotSupportedError, OsError};
+use crate::error::{EventLoopError, NotSupportedError, RequestError};
 use crate::event::Event;
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
@@ -49,15 +49,15 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: crate::window::WindowAttributes,
-    ) -> Result<Box<dyn CoreWindow>, OsError> {
+    ) -> Result<Box<dyn CoreWindow>, RequestError> {
         Ok(Box::new(Window::new(self, window_attributes)?))
     }
 
     fn create_custom_cursor(
         &self,
         _source: CustomCursorSource,
-    ) -> Result<CustomCursor, ExternalError> {
-        Err(ExternalError::NotSupported(NotSupportedError::new()))
+    ) -> Result<CustomCursor, RequestError> {
+        Err(NotSupportedError::new("create_custom_cursor is not supported").into())
     }
 
     fn available_monitors(&self) -> Box<dyn Iterator<Item = RootMonitorHandle>> {

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -1,18 +1,14 @@
 //! Winit's Wayland backend.
 
-use std::fmt::Display;
-use std::sync::Arc;
-
 pub use event_loop::{ActiveEventLoop, EventLoop, EventLoopProxy};
 pub use output::{MonitorHandle, VideoModeHandle};
-use sctk::reexports::client::globals::{BindError, GlobalError};
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
-use sctk::reexports::client::{self, ConnectError, DispatchError, Proxy};
+use sctk::reexports::client::Proxy;
 pub use window::Window;
 
 pub(super) use crate::cursor::OnlyCursorImage as CustomCursor;
 use crate::dpi::{LogicalSize, PhysicalSize};
-pub use crate::platform_impl::platform::{OsError, WindowId};
+pub use crate::platform_impl::platform::WindowId;
 
 mod event_loop;
 mod output;
@@ -20,46 +16,6 @@ mod seat;
 mod state;
 mod types;
 mod window;
-
-#[derive(Debug)]
-pub enum WaylandError {
-    /// Error connecting to the socket.
-    Connection(ConnectError),
-
-    /// Error binding the global.
-    Global(GlobalError),
-
-    // Bind error.
-    Bind(BindError),
-
-    /// Error during the dispatching the event queue.
-    Dispatch(DispatchError),
-
-    /// Calloop error.
-    Calloop(calloop::Error),
-
-    /// Wayland
-    Wire(client::backend::WaylandError),
-}
-
-impl Display for WaylandError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            WaylandError::Connection(error) => error.fmt(f),
-            WaylandError::Global(error) => error.fmt(f),
-            WaylandError::Bind(error) => error.fmt(f),
-            WaylandError::Dispatch(error) => error.fmt(f),
-            WaylandError::Calloop(error) => error.fmt(f),
-            WaylandError::Wire(error) => error.fmt(f),
-        }
-    }
-}
-
-impl From<WaylandError> for OsError {
-    fn from(value: WaylandError) -> Self {
-        Self::WaylandError(Arc::new(value))
-    }
-}
 
 /// Dummy device id, since Wayland doesn't have device events.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -16,13 +16,13 @@ use super::event_loop::sink::EventSink;
 use super::output::MonitorHandle;
 use super::state::WinitState;
 use super::types::xdg_activation::XdgActivationTokenData;
-use super::{ActiveEventLoop, WaylandError, WindowId};
+use super::{ActiveEventLoop, WindowId};
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
-use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
+use crate::error::{NotSupportedError, RequestError};
 use crate::event::{Ime, WindowEvent};
 use crate::event_loop::AsyncRequestSerial;
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
-use crate::platform_impl::{Fullscreen, MonitorHandle as PlatformMonitorHandle, OsError};
+use crate::platform_impl::{Fullscreen, MonitorHandle as PlatformMonitorHandle};
 use crate::window::{
     Cursor, CursorGrabMode, Fullscreen as CoreFullscreen, ImePurpose, ResizeDirection, Theme,
     UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons,
@@ -77,7 +77,7 @@ impl Window {
     pub(crate) fn new(
         event_loop_window_target: &ActiveEventLoop,
         attributes: WindowAttributes,
-    ) -> Result<Self, RootOsError> {
+    ) -> Result<Self, RequestError> {
         let queue_handle = event_loop_window_target.queue_handle.clone();
         let mut state = event_loop_window_target.state.borrow_mut();
 
@@ -190,15 +190,11 @@ impl Window {
         let event_queue = wayland_source.queue();
 
         // Do a roundtrip.
-        event_queue.roundtrip(&mut state).map_err(|error| {
-            os_error!(OsError::WaylandError(Arc::new(WaylandError::Dispatch(error))))
-        })?;
+        event_queue.roundtrip(&mut state).map_err(|err| os_error!(err))?;
 
         // XXX Wait for the initial configure to arrive.
         while !window_state.lock().unwrap().is_configured() {
-            event_queue.blocking_dispatch(&mut state).map_err(|error| {
-                os_error!(OsError::WaylandError(Arc::new(WaylandError::Dispatch(error))))
-            })?;
+            event_queue.blocking_dispatch(&mut state).map_err(|err| os_error!(err))?;
         }
 
         // Wake-up event loop, so it'll send initial redraw requested.
@@ -223,10 +219,10 @@ impl Window {
 }
 
 impl Window {
-    pub fn request_activation_token(&self) -> Result<AsyncRequestSerial, NotSupportedError> {
+    pub fn request_activation_token(&self) -> Result<AsyncRequestSerial, RequestError> {
         let xdg_activation = match self.xdg_activation.as_ref() {
             Some(xdg_activation) => xdg_activation,
-            None => return Err(NotSupportedError::new()),
+            None => return Err(NotSupportedError::new("xdg_activation_v1 is not available").into()),
         };
 
         let serial = AsyncRequestSerial::get();
@@ -309,12 +305,14 @@ impl CoreWindow for Window {
         crate::platform_impl::common::xkb::reset_dead_keys()
     }
 
-    fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-        Err(NotSupportedError::new())
+    fn inner_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
+        Err(NotSupportedError::new("window position information is not available on Wayland")
+            .into())
     }
 
-    fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
-        Err(NotSupportedError::new())
+    fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
+        Err(NotSupportedError::new("window position information is not available on Wayland")
+            .into())
     }
 
     fn set_outer_position(&self, _position: Position) {
@@ -576,7 +574,7 @@ impl CoreWindow for Window {
         }
     }
 
-    fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
+    fn set_cursor_position(&self, position: Position) -> Result<(), RequestError> {
         let scale_factor = self.scale_factor();
         let position = position.to_logical(scale_factor);
         self.window_state
@@ -587,7 +585,7 @@ impl CoreWindow for Window {
             .map(|_| self.request_redraw())
     }
 
-    fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
+    fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), RequestError> {
         self.window_state.lock().unwrap().set_cursor_grab(mode)
     }
 
@@ -595,11 +593,11 @@ impl CoreWindow for Window {
         self.window_state.lock().unwrap().set_cursor_visible(visible);
     }
 
-    fn drag_window(&self) -> Result<(), ExternalError> {
+    fn drag_window(&self) -> Result<(), RequestError> {
         self.window_state.lock().unwrap().drag_window()
     }
 
-    fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+    fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), RequestError> {
         self.window_state.lock().unwrap().drag_resize_window(direction)
     }
 
@@ -609,16 +607,14 @@ impl CoreWindow for Window {
         self.window_state.lock().unwrap().show_window_menu(position);
     }
 
-    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
+    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), RequestError> {
         let surface = self.window.wl_surface();
 
         if hittest {
             surface.set_input_region(None);
             Ok(())
         } else {
-            let region = Region::new(&*self.compositor).map_err(|_| {
-                ExternalError::Os(os_error!(OsError::Misc("failed to set input region.")))
-            })?;
+            let region = Region::new(&*self.compositor).map_err(|err| os_error!(err))?;
             region.add(0, 0, 0, 0);
             surface.set_input_region(Some(region.wl_region()));
             Ok(())

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -1,7 +1,8 @@
+use std::error::Error;
 use std::ffi::CStr;
 use std::os::raw::c_short;
 use std::sync::Arc;
-use std::{mem, ptr};
+use std::{fmt, mem, ptr};
 
 use x11_dl::xlib::{XIMCallback, XIMPreeditCaretCallbackStruct, XIMPreeditDrawCallbackStruct};
 
@@ -18,6 +19,19 @@ pub enum ImeContextCreationError {
     /// Got null pointer from Xlib but without exact reason.
     Null,
 }
+
+impl fmt::Display for ImeContextCreationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ImeContextCreationError::XError(err) => err.fmt(f),
+            ImeContextCreationError::Null => {
+                write!(f, "got null pointer from Xlib without exact reason")
+            },
+        }
+    }
+}
+
+impl Error for ImeContextCreationError {}
 
 /// The callback used by XIM preedit functions.
 type XIMProcNonnull = unsafe extern "C" fn(ffi::XIM, ffi::XPointer, ffi::XPointer);

--- a/src/platform_impl/linux/x11/util/cursor.rs
+++ b/src/platform_impl/linux/x11/util/cursor.rs
@@ -9,8 +9,8 @@ use x11rb::protocol::xproto;
 
 use super::super::ActiveEventLoop;
 use super::*;
-use crate::error::ExternalError;
-use crate::platform_impl::{OsError, PlatformCustomCursorSource};
+use crate::error::RequestError;
+use crate::platform_impl::PlatformCustomCursorSource;
 use crate::window::CursorIcon;
 
 impl XConnection {
@@ -193,7 +193,7 @@ impl CustomCursor {
     pub(crate) fn new(
         event_loop: &ActiveEventLoop,
         mut cursor: PlatformCustomCursorSource,
-    ) -> Result<CustomCursor, ExternalError> {
+    ) -> Result<CustomCursor, RequestError> {
         // Reverse RGBA order to BGRA.
         cursor.0.rgba.chunks_mut(4).for_each(|chunk| {
             let chunk: &mut [u8; 4] = chunk.try_into().unwrap();
@@ -215,7 +215,7 @@ impl CustomCursor {
                 cursor.0.hotspot_y,
                 &cursor.0.rgba,
             )
-            .map_err(|err| ExternalError::Os(os_error!(OsError::XError(err.into()))))?;
+            .map_err(|err| os_error!(err))?;
 
         Ok(Self { inner: Arc::new(CustomCursorInner { xconn: event_loop.xconn.clone(), cursor }) })
     }

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -1,9 +1,7 @@
 #![cfg(target_os = "redox")]
 
-use std::fmt::{self, Display, Formatter};
 use std::num::{NonZeroU16, NonZeroU32};
-use std::str;
-use std::sync::Arc;
+use std::{fmt, str};
 
 use smol_str::SmolStr;
 
@@ -14,6 +12,11 @@ mod event_loop;
 
 pub use self::window::Window;
 mod window;
+
+pub(crate) use crate::cursor::{
+    NoCustomCursor as PlatformCustomCursor, NoCustomCursor as PlatformCustomCursorSource,
+};
+pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 struct RedoxSocket {
     fd: usize,
@@ -172,26 +175,6 @@ impl<'a> fmt::Display for WindowProperties<'a> {
         )
     }
 }
-
-#[derive(Clone, Debug)]
-pub struct OsError(Arc<syscall::Error>);
-
-impl OsError {
-    fn new(error: syscall::Error) -> Self {
-        Self(Arc::new(error))
-    }
-}
-
-impl Display for OsError {
-    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        self.0.fmt(fmt)
-    }
-}
-
-pub(crate) use crate::cursor::{
-    NoCustomCursor as PlatformCustomCursor, NoCustomCursor as PlatformCustomCursorSource,
-};
-pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct MonitorHandle;

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -1,12 +1,10 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
-use super::{
-    ActiveEventLoop, MonitorHandle, OsError, RedoxSocket, TimeSocket, WindowId, WindowProperties,
-};
+use super::{ActiveEventLoop, MonitorHandle, RedoxSocket, TimeSocket, WindowId, WindowProperties};
 use crate::cursor::Cursor;
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
-use crate::error;
+use crate::error::{NotSupportedError, RequestError};
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::window::{self, Fullscreen, ImePurpose, Window as CoreWindow, WindowId as CoreWindowId};
 
@@ -32,7 +30,7 @@ impl Window {
     pub(crate) fn new(
         el: &ActiveEventLoop,
         attrs: window::WindowAttributes,
-    ) -> Result<Self, error::OsError> {
+    ) -> Result<Self, RequestError> {
         let scale = MonitorHandle.scale_factor();
 
         let (x, y) = if let Some(pos) = attrs.position {
@@ -125,20 +123,17 @@ impl Window {
         })
     }
 
-    fn get_flag(&self, flag: char) -> Result<bool, error::ExternalError> {
+    fn get_flag(&self, flag: char) -> Result<bool, RequestError> {
         let mut buf: [u8; 4096] = [0; 4096];
-        let path = self
-            .window_socket
-            .fpath(&mut buf)
-            .map_err(|err| error::ExternalError::Os(os_error!(OsError::new(err))))?;
+        let path = self.window_socket.fpath(&mut buf).map_err(|err| os_error!(format!("{err}")))?;
         let properties = WindowProperties::new(path);
         Ok(properties.flags.contains(flag))
     }
 
-    fn set_flag(&self, flag: char, value: bool) -> Result<(), error::ExternalError> {
+    fn set_flag(&self, flag: char, value: bool) -> Result<(), RequestError> {
         self.window_socket
             .write(format!("F,{flag},{}", if value { 1 } else { 0 }).as_bytes())
-            .map_err(|err| error::ExternalError::Os(os_error!(OsError::new(err))))?;
+            .map_err(|err| os_error!(format!("{err}")))?;
         Ok(())
     }
 
@@ -204,7 +199,7 @@ impl CoreWindow for Window {
     }
 
     #[inline]
-    fn inner_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
+    fn inner_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self.window_socket.fpath(&mut buf).expect("failed to read properties");
         let properties = WindowProperties::new(path);
@@ -212,7 +207,7 @@ impl CoreWindow for Window {
     }
 
     #[inline]
-    fn outer_position(&self) -> Result<PhysicalPosition<i32>, error::NotSupportedError> {
+    fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
         // TODO: adjust for window decorations
         self.inner_position()
     }
@@ -372,12 +367,12 @@ impl CoreWindow for Window {
     fn set_cursor(&self, _: Cursor) {}
 
     #[inline]
-    fn set_cursor_position(&self, _: Position) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
+    fn set_cursor_position(&self, _: Position) -> Result<(), RequestError> {
+        Err(NotSupportedError::new("set_cursor_position is not supported").into())
     }
 
     #[inline]
-    fn set_cursor_grab(&self, mode: window::CursorGrabMode) -> Result<(), error::ExternalError> {
+    fn set_cursor_grab(&self, mode: window::CursorGrabMode) -> Result<(), RequestError> {
         let (grab, relative) = match mode {
             window::CursorGrabMode::None => (false, false),
             window::CursorGrabMode::Confined => (true, false),
@@ -385,10 +380,10 @@ impl CoreWindow for Window {
         };
         self.window_socket
             .write(format!("M,G,{}", if grab { 1 } else { 0 }).as_bytes())
-            .map_err(|err| error::ExternalError::Os(os_error!(OsError::new(err))))?;
+            .map_err(|err| os_error!(format!("{err}")))?;
         self.window_socket
             .write(format!("M,R,{}", if relative { 1 } else { 0 }).as_bytes())
-            .map_err(|err| error::ExternalError::Os(os_error!(OsError::new(err))))?;
+            .map_err(|err| os_error!(format!("{err}")))?;
         Ok(())
     }
 
@@ -398,18 +393,13 @@ impl CoreWindow for Window {
     }
 
     #[inline]
-    fn drag_window(&self) -> Result<(), error::ExternalError> {
-        self.window_socket
-            .write(b"D")
-            .map_err(|err| error::ExternalError::Os(os_error!(OsError::new(err))))?;
+    fn drag_window(&self) -> Result<(), RequestError> {
+        self.window_socket.write(b"D").map_err(|err| os_error!(format!("{err}")))?;
         Ok(())
     }
 
     #[inline]
-    fn drag_resize_window(
-        &self,
-        direction: window::ResizeDirection,
-    ) -> Result<(), error::ExternalError> {
+    fn drag_resize_window(&self, direction: window::ResizeDirection) -> Result<(), RequestError> {
         let arg = match direction {
             window::ResizeDirection::East => "R",
             window::ResizeDirection::North => "T",
@@ -422,7 +412,7 @@ impl CoreWindow for Window {
         };
         self.window_socket
             .write(format!("D,{}", arg).as_bytes())
-            .map_err(|err| error::ExternalError::Os(os_error!(OsError::new(err))))?;
+            .map_err(|err| os_error!(format!("{err}")))?;
         Ok(())
     }
 
@@ -430,8 +420,8 @@ impl CoreWindow for Window {
     fn show_window_menu(&self, _position: Position) {}
 
     #[inline]
-    fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), error::ExternalError> {
-        Err(error::ExternalError::NotSupported(error::NotSupportedError::new()))
+    fn set_cursor_hittest(&self, _hittest: bool) -> Result<(), RequestError> {
+        Err(NotSupportedError::new("set_cursor_hittest is not supported").into())
     }
 
     #[inline]

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -11,7 +11,7 @@ use super::event::DeviceId;
 use super::runner::{EventWrapper, WeakShared};
 use super::window::WindowId;
 use super::{backend, runner, EventLoopProxy};
-use crate::error::{ExternalError, NotSupportedError};
+use crate::error::{NotSupportedError, RequestError};
 use crate::event::{
     DeviceId as RootDeviceId, ElementState, Event, FingerId as RootFingerId, KeyEvent, Touch,
     TouchPhase, WindowEvent,
@@ -606,7 +606,10 @@ impl ActiveEventLoop {
     }
 
     pub(crate) fn has_multiple_screens(&self) -> Result<bool, NotSupportedError> {
-        self.runner.monitor().is_extended().ok_or(NotSupportedError::new())
+        self.runner
+            .monitor()
+            .is_extended()
+            .ok_or(NotSupportedError::new("has_multiple_screens is not supported"))
     }
 
     pub(crate) fn request_detailed_monitor_permission(&self) -> MonitorPermissionFuture {
@@ -631,7 +634,7 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: crate::window::WindowAttributes,
-    ) -> Result<Box<dyn crate::window::Window>, crate::error::OsError> {
+    ) -> Result<Box<dyn crate::window::Window>, RequestError> {
         let window = Window::new(self, window_attributes)?;
         Ok(Box::new(window))
     }
@@ -639,7 +642,7 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_custom_cursor(
         &self,
         source: CustomCursorSource,
-    ) -> Result<RootCustomCursor, ExternalError> {
+    ) -> Result<RootCustomCursor, RequestError> {
         Ok(RootCustomCursor { inner: CustomCursor::new(self, source.inner) })
     }
 

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -37,7 +37,6 @@ pub(crate) use cursor::{
     CustomCursorSource as PlatformCustomCursorSource,
 };
 
-pub use self::error::OsError;
 pub use self::event::{DeviceId, FingerId};
 pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -22,10 +22,10 @@ use super::media_query_handle::MediaQueryListHandle;
 use super::pointer::PointerHandler;
 use super::{event, fullscreen, ButtonsState, ResizeScaleHandle};
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
-use crate::error::OsError as RootOE;
+use crate::error::RequestError;
 use crate::event::{Force, MouseButton, MouseScrollDelta, SurfaceSizeWriter};
 use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
-use crate::platform_impl::{Fullscreen, OsError};
+use crate::platform_impl::Fullscreen;
 use crate::window::{WindowAttributes, WindowId as RootWindowId};
 
 #[allow(dead_code)]
@@ -83,13 +83,13 @@ impl Canvas {
         navigator: Navigator,
         document: Document,
         attr: WindowAttributes,
-    ) -> Result<Self, RootOE> {
+    ) -> Result<Self, RequestError> {
         let canvas = match attr.platform_specific.canvas.map(Arc::try_unwrap) {
             Some(Ok(canvas)) => canvas.into_inner(main_thread),
             Some(Err(canvas)) => canvas.get(main_thread).clone(),
             None => document
                 .create_element("canvas")
-                .map_err(|_| os_error!(OsError("Failed to create canvas element".to_owned())))?
+                .map_err(|_| os_error!("Failed to create canvas element"))?
                 .unchecked_into(),
         };
 
@@ -109,7 +109,7 @@ impl Canvas {
         if attr.platform_specific.focusable {
             canvas
                 .set_attribute("tabindex", "0")
-                .map_err(|_| os_error!(OsError("Failed to set a tabindex".to_owned())))?;
+                .map_err(|_| os_error!("Failed to set a tabindex"))?;
         }
 
         let style = Style::new(&window, &canvas);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -56,7 +56,7 @@ use super::window::set_skip_taskbar;
 use super::SelectedCursor;
 use crate::application::ApplicationHandler;
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::error::{EventLoopError, ExternalError, OsError};
+use crate::error::{EventLoopError, RequestError};
 use crate::event::{
     Event, FingerId as RootFingerId, Force, Ime, RawKeyEvent, SurfaceSizeWriter, Touch, TouchPhase,
     WindowEvent,
@@ -521,14 +521,14 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn create_window(
         &self,
         window_attributes: WindowAttributes,
-    ) -> Result<Box<dyn CoreWindow>, OsError> {
+    ) -> Result<Box<dyn CoreWindow>, RequestError> {
         Ok(Box::new(Window::new(self, window_attributes)?))
     }
 
     fn create_custom_cursor(
         &self,
         source: CustomCursorSource,
-    ) -> Result<RootCustomCursor, ExternalError> {
+    ) -> Result<RootCustomCursor, RequestError> {
         Ok(RootCustomCursor { inner: WinCursor::new(&source.inner.0)? })
     }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -103,8 +103,6 @@ fn wrap_device_id(id: u32) -> RootDeviceId {
     RootDeviceId(DeviceId(id))
 }
 
-pub type OsError = std::io::Error;
-
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct KeyEventExtra {
     pub text_with_all_modifiers: Option<SmolStr>,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -47,7 +47,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 
 use crate::cursor::Cursor;
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
-use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
+use crate::error::{NotSupportedError, RequestError};
 use crate::icon::Icon;
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::platform::windows::{BackdropType, Color, CornerPreference};
@@ -89,7 +89,7 @@ impl Window {
     pub(crate) fn new(
         event_loop: &ActiveEventLoop,
         w_attr: WindowAttributes,
-    ) -> Result<Window, RootOsError> {
+    ) -> Result<Window, RequestError> {
         // We dispatch an `init` function because of code style.
         // First person to remove the need for cloning here gets a cookie!
         //
@@ -411,7 +411,7 @@ impl CoreWindow for Window {
 
     fn pre_present_notify(&self) {}
 
-    fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+    fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
         util::WindowArea::Outer
             .get_rect(self.hwnd())
             .map(|rect| Ok(PhysicalPosition::new(rect.left, rect.top)))
@@ -421,7 +421,7 @@ impl CoreWindow for Window {
             )
     }
 
-    fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
+    fn inner_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
         let mut position: POINT = unsafe { mem::zeroed() };
         if unsafe { ClientToScreen(self.hwnd(), &mut position) } == false.into() {
             panic!(
@@ -588,12 +588,12 @@ impl CoreWindow for Window {
         }
     }
 
-    fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError> {
+    fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), RequestError> {
         let confine = match mode {
             CursorGrabMode::None => false,
             CursorGrabMode::Confined => true,
             CursorGrabMode::Locked => {
-                return Err(ExternalError::NotSupported(NotSupportedError::new()))
+                return Err(NotSupportedError::new("locked cursor is not supported").into())
             },
         };
 
@@ -608,9 +608,10 @@ impl CoreWindow for Window {
                 .unwrap()
                 .mouse
                 .set_cursor_flags(window, |f| f.set(CursorFlags::GRABBED, confine))
-                .map_err(|e| ExternalError::Os(os_error!(e)));
+                .map_err(|err| os_error!(err).into());
             let _ = tx.send(result);
         });
+
         rx.recv().unwrap()
     }
 
@@ -636,23 +637,23 @@ impl CoreWindow for Window {
         self.window_state_lock().scale_factor
     }
 
-    fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError> {
+    fn set_cursor_position(&self, position: Position) -> Result<(), RequestError> {
         let scale_factor = self.scale_factor();
         let (x, y) = position.to_physical::<i32>(scale_factor).into();
 
         let mut point = POINT { x, y };
         unsafe {
             if ClientToScreen(self.hwnd(), &mut point) == false.into() {
-                return Err(ExternalError::Os(os_error!(io::Error::last_os_error())));
+                return Err(os_error!(io::Error::last_os_error()).into());
             }
             if SetCursorPos(point.x, point.y) == false.into() {
-                return Err(ExternalError::Os(os_error!(io::Error::last_os_error())));
+                return Err(os_error!(io::Error::last_os_error()).into());
             }
         }
         Ok(())
     }
 
-    fn drag_window(&self) -> Result<(), ExternalError> {
+    fn drag_window(&self) -> Result<(), RequestError> {
         unsafe {
             self.handle_os_dragging(HTCAPTION as WPARAM);
         }
@@ -660,7 +661,7 @@ impl CoreWindow for Window {
         Ok(())
     }
 
-    fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError> {
+    fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), RequestError> {
         unsafe {
             self.handle_os_dragging(match direction {
                 ResizeDirection::East => HTRIGHT,
@@ -683,7 +684,7 @@ impl CoreWindow for Window {
         }
     }
 
-    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
+    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), RequestError> {
         let window = self.window;
         let window_state = Arc::clone(&self.window_state);
         self.thread_executor.execute_in_thread(move || {
@@ -1249,7 +1250,7 @@ impl<'a> InitData<'a> {
 unsafe fn init(
     attributes: WindowAttributes,
     event_loop: &ActiveEventLoop,
-) -> Result<Window, RootOsError> {
+) -> Result<Window, RequestError> {
     let title = util::encode_wide(&attributes.title);
 
     let class_name = util::encode_wide(&attributes.platform_specific.class_name);
@@ -1332,7 +1333,7 @@ unsafe fn init(
     }
 
     if handle == 0 {
-        return Err(os_error!(io::Error::last_os_error()));
+        return Err(os_error!(io::Error::last_os_error()).into());
     }
 
     // If the handle is non-null, then window creation must have succeeded, which means

--- a/src/window.rs
+++ b/src/window.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 pub use crate::cursor::{BadImage, Cursor, CustomCursor, CustomCursorSource, MAX_CURSOR_SIZE};
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
-use crate::error::{ExternalError, NotSupportedError};
+use crate::error::RequestError;
 pub use crate::icon::{BadIcon, Icon};
 use crate::monitor::{MonitorHandle, VideoModeHandle};
 use crate::platform_impl::{self, PlatformSpecificWindowAttributes};
@@ -601,10 +601,10 @@ pub trait Window: AsAny + Send + Sync {
     ///   coordinate system.
     /// - **Web:** Returns the top-left coordinates relative to the viewport. _Note: this returns
     ///   the same value as [`Window::outer_position`]._
-    /// - **Android / Wayland:** Always returns [`NotSupportedError`].
+    /// - **Android / Wayland:** Always returns [`RequestError::NotSupported`].
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
-    fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError>;
+    fn inner_position(&self) -> Result<PhysicalPosition<i32>, RequestError>;
 
     /// Returns the position of the top-left hand corner of the window relative to the
     /// top-left hand corner of the desktop.
@@ -621,8 +621,8 @@ pub trait Window: AsAny + Send + Sync {
     /// - **iOS:** Returns the top left coordinates of the window in the screen space coordinate
     ///   system.
     /// - **Web:** Returns the top-left coordinates relative to the viewport.
-    /// - **Android / Wayland:** Always returns [`NotSupportedError`].
-    fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError>;
+    /// - **Android / Wayland:** Always returns [`RequestError::NotSupported`].
+    fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError>;
 
     /// Modifies the position of the window.
     ///
@@ -1160,8 +1160,8 @@ pub trait Window: AsAny + Send + Sync {
     /// ## Platform-specific
     ///
     /// - **Wayland**: Cursor must be in [`CursorGrabMode::Locked`].
-    /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
-    fn set_cursor_position(&self, position: Position) -> Result<(), ExternalError>;
+    /// - **iOS / Android / Web / Orbital:** Always returns an [`RequestError::NotSupported`].
+    fn set_cursor_position(&self, position: Position) -> Result<(), RequestError>;
 
     /// Set grabbing [mode][CursorGrabMode] on the cursor preventing it from leaving the window.
     ///
@@ -1178,7 +1178,7 @@ pub trait Window: AsAny + Send + Sync {
     ///     .unwrap();
     /// # }
     /// ```
-    fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), ExternalError>;
+    fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), RequestError>;
 
     /// Modifies the cursor's visibility.
     ///
@@ -1204,8 +1204,8 @@ pub trait Window: AsAny + Send + Sync {
     /// - **X11:** Un-grabs the cursor.
     /// - **Wayland:** Requires the cursor to be inside the window to be dragged.
     /// - **macOS:** May prevent the button release event to be triggered.
-    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
-    fn drag_window(&self) -> Result<(), ExternalError>;
+    /// - **iOS / Android / Web:** Always returns an [`RequestError::NotSupported`].
+    fn drag_window(&self) -> Result<(), RequestError>;
 
     /// Resizes the window with the left mouse button until the button is released.
     ///
@@ -1214,9 +1214,9 @@ pub trait Window: AsAny + Send + Sync {
     ///
     /// ## Platform-specific
     ///
-    /// - **macOS:** Always returns an [`ExternalError::NotSupported`]
-    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
-    fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), ExternalError>;
+    /// - **macOS:** Always returns an [`RequestError::NotSupported`]
+    /// - **iOS / Android / Web:** Always returns an [`RequestError::NotSupported`].
+    fn drag_resize_window(&self, direction: ResizeDirection) -> Result<(), RequestError>;
 
     /// Show [window menu] at a specified position .
     ///
@@ -1237,8 +1237,8 @@ pub trait Window: AsAny + Send + Sync {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Always returns an [`ExternalError::NotSupported`].
-    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError>;
+    /// - **iOS / Android / Web / Orbital:** Always returns an [`RequestError::NotSupported`].
+    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), RequestError>;
 
     /// Returns the monitor on which the window currently resides.
     ///
@@ -1345,8 +1345,8 @@ pub enum CursorGrabMode {
     ///
     /// ## Platform-specific
     ///
-    /// - **macOS:** Not implemented. Always returns [`ExternalError::NotSupported`] for now.
-    /// - **iOS / Android / Web:** Always returns an [`ExternalError::NotSupported`].
+    /// - **macOS:** Not implemented. Always returns [`RequestError::NotSupported`] for now.
+    /// - **iOS / Android / Web:** Always returns an [`RequestError::NotSupported`].
     Confined,
 
     /// The cursor is locked inside the window area to the certain position.
@@ -1356,9 +1356,9 @@ pub enum CursorGrabMode {
     ///
     /// ## Platform-specific
     ///
-    /// - **X11 / Windows:** Not implemented. Always returns [`ExternalError::NotSupported`] for
+    /// - **X11 / Windows:** Not implemented. Always returns [`RequestError::NotSupported`] for
     ///   now.
-    /// - **iOS / Android:** Always returns an [`ExternalError::NotSupported`].
+    /// - **iOS / Android:** Always returns an [`RequestError::NotSupported`].
     Locked,
 }
 


### PR DESCRIPTION
Make error infrastructure more backend agnostic and let backends just forward the os errors opaquely.

--

Only done for X11/Wayland for now.
