### PR TITLE
Rename "inner size" to "surface size"

### DIFF
--- a/examples/child_window.rs
+++ b/examples/child_window.rs
@@ -24,7 +24,7 @@ fn main() -> Result<(), impl std::error::Error> {
             let attributes = WindowAttributes::default()
                 .with_title("parent window")
                 .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
-                .with_inner_size(LogicalSize::new(640.0f32, 480.0f32));
+                .with_surface_size(LogicalSize::new(640.0f32, 480.0f32));
             let window = event_loop.create_window(attributes).unwrap();
 
             println!("Parent window id: {:?})", window.id());
@@ -79,7 +79,7 @@ fn main() -> Result<(), impl std::error::Error> {
         let parent = parent.raw_window_handle().unwrap();
         let mut window_attributes = WindowAttributes::default()
             .with_title("child window")
-            .with_inner_size(LogicalSize::new(200.0f32, 200.0f32))
+            .with_surface_size(LogicalSize::new(200.0f32, 200.0f32))
             .with_position(Position::Logical(LogicalPosition::new(0.0, 0.0)))
             .with_visible(true);
         // `with_parent_window` is unsafe. Parent window must be a valid window.

--- a/examples/run_on_demand.rs
+++ b/examples/run_on_demand.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
             let window_attributes = WindowAttributes::default()
                 .with_title("Fantastic window number one!")
-                .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0));
+                .with_surface_size(winit::dpi::LogicalSize::new(128.0, 128.0));
             let window = event_loop.create_window(window_attributes).unwrap();
             self.window_id = Some(window.id());
             self.window = Some(window);

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -72,7 +72,7 @@ mod platform {
 
     pub fn fill_window(window: &dyn Window) {
         GC.with(|gc| {
-            let size = window.inner_size();
+            let size = window.surface_size();
             let (Some(width), Some(height)) =
                 (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
             else {

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -389,7 +389,7 @@ impl ApplicationHandler for Application {
         };
 
         match event {
-            WindowEvent::Resized(size) => {
+            WindowEvent::SurfaceResized(size) => {
                 window.resize(size);
             },
             WindowEvent::Focused(focused) => {
@@ -793,9 +793,9 @@ impl WindowState {
         Ok(())
     }
 
-    /// Resize the window to the new size.
+    /// Resize the surface to the new size.
     fn resize(&mut self, size: PhysicalSize<u32>) {
-        info!("Resized to {size:?}");
+        info!("Surface resized to {size:?}");
         #[cfg(not(any(android_platform, ios_platform)))]
         {
             let (width, height) = match (NonZeroU32::new(size.width), NonZeroU32::new(size.height))

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -607,7 +607,7 @@ impl WindowState {
         let ime = true;
         window.set_ime_allowed(ime);
 
-        let size = window.inner_size();
+        let size = window.surface_size();
         let mut state = Self {
             #[cfg(macos_platform)]
             option_as_alt: window.option_as_alt(),
@@ -725,19 +725,19 @@ impl WindowState {
         self.window.set_option_as_alt(self.option_as_alt);
     }
 
-    /// Swap the window dimensions with `request_inner_size`.
+    /// Swap the window dimensions with `request_surface_size`.
     fn swap_dimensions(&mut self) {
-        let old_inner_size = self.window.inner_size();
-        let mut inner_size = old_inner_size;
+        let old_surface_size = self.window.surface_size();
+        let mut surface_size = old_surface_size;
 
-        mem::swap(&mut inner_size.width, &mut inner_size.height);
-        info!("Requesting resize from {old_inner_size:?} to {inner_size:?}");
+        mem::swap(&mut surface_size.width, &mut surface_size.height);
+        info!("Requesting resize from {old_surface_size:?} to {surface_size:?}");
 
-        if let Some(new_inner_size) = self.window.request_inner_size(inner_size.into()) {
-            if old_inner_size == new_inner_size {
+        if let Some(new_surface_size) = self.window.request_surface_size(surface_size.into()) {
+            if old_surface_size == new_surface_size {
                 info!("Inner size change got ignored");
             } else {
-                self.resize(new_inner_size);
+                self.resize(new_surface_size);
             }
         } else {
             info!("Request inner size is asynchronous");
@@ -840,7 +840,7 @@ impl WindowState {
             },
         };
 
-        let win_size = self.window.inner_size();
+        let win_size = self.window.surface_size();
         let border_size = BORDER_SIZE * self.window.scale_factor();
 
         let x_direction = if position.x < border_size {

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -681,12 +681,12 @@ impl WindowState {
 
     /// Toggle resize increments on a window.
     fn toggle_resize_increments(&mut self) {
-        let new_increments = match self.window.resize_increments() {
+        let new_increments = match self.window.surface_resize_increments() {
             Some(_) => None,
             None => Some(LogicalSize::new(25.0, 25.0).into()),
         };
         info!("Had increments: {}", new_increments.is_none());
-        self.window.set_resize_increments(new_increments);
+        self.window.set_surface_resize_increments(new_increments);
     }
 
     /// Toggle fullscreen.

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -740,7 +740,7 @@ impl WindowState {
                 self.resize(new_surface_size);
             }
         } else {
-            info!("Request inner size is asynchronous");
+            info!("Requesting surface size is asynchronous");
         }
     }
 

--- a/examples/x11_embed.rs
+++ b/examples/x11_embed.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
             let window_attributes = WindowAttributes::default()
                 .with_title("An embedded window!")
-                .with_inner_size(winit::dpi::LogicalSize::new(128.0, 128.0))
+                .with_surface_size(winit::dpi::LogicalSize::new(128.0, 128.0))
                 .with_embed_parent_window(self.parent_window_id);
 
             self.window = Some(event_loop.create_window(window_attributes).unwrap());

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -105,6 +105,23 @@ changelog entry.
 - On iOS, no longer act as-if the application successfully open all URLs. Override
   `application:didFinishLaunchingWithOptions:` and provide the desired behaviour yourself.
 - On X11, remove our dependency on libXcursor. (#3749)
+- Renamed the following APIs to make it clearer that the sizes apply to the underlying surface:
+  - `WindowEvent::Resized` to `SurfaceResized`.
+  - `InnerSizeWriter` to `SurfaceSizeWriter`.
+  - `WindowAttributes.inner_size` to `surface_size`.
+  - `WindowAttributes.min_inner_size` to `min_surface_size`.
+  - `WindowAttributes.max_inner_size` to `max_surface_size`.
+  - `WindowAttributes.resize_increments` to `surface_resize_increments`.
+  - `WindowAttributes::with_inner_size` to `with_surface_size`.
+  - `WindowAttributes::with_min_inner_size` to `with_min_surface_size`.
+  - `WindowAttributes::with_max_inner_size` to `with_max_surface_size`.
+  - `WindowAttributes::with_resize_increments` to `with_surface_resize_increments`.
+  - `Window::inner_size` to `surface_size`.
+  - `Window::request_inner_size` to `request_surface_size`.
+  - `Window::set_min_inner_size` to `set_min_surface_size`.
+  - `Window::set_max_inner_size` to `set_max_surface_size`.
+
+  To migrate, you can probably just replace all instances of `inner_size` with `surface_size` in your codebase.
 
 ### Removed
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -999,22 +999,22 @@ pub enum MouseScrollDelta {
 /// [`WindowEvent`].
 #[derive(Debug, Clone)]
 pub struct SurfaceSizeWriter {
-    pub(crate) new_inner_size: Weak<Mutex<PhysicalSize<u32>>>,
+    pub(crate) new_surface_size: Weak<Mutex<PhysicalSize<u32>>>,
 }
 
 impl SurfaceSizeWriter {
     #[cfg(not(orbital_platform))]
-    pub(crate) fn new(new_inner_size: Weak<Mutex<PhysicalSize<u32>>>) -> Self {
-        Self { new_inner_size }
+    pub(crate) fn new(new_surface_size: Weak<Mutex<PhysicalSize<u32>>>) -> Self {
+        Self { new_surface_size }
     }
 
     /// Try to request inner size which will be set synchronously on the window.
-    pub fn request_inner_size(
+    pub fn request_surface_size(
         &mut self,
-        new_inner_size: PhysicalSize<u32>,
+        new_surface_size: PhysicalSize<u32>,
     ) -> Result<(), ExternalError> {
-        if let Some(inner) = self.new_inner_size.upgrade() {
-            *inner.lock().unwrap() = new_inner_size;
+        if let Some(inner) = self.new_surface_size.upgrade() {
+            *inner.lock().unwrap() = new_surface_size;
             Ok(())
         } else {
             Err(ExternalError::Ignored)
@@ -1024,7 +1024,7 @@ impl SurfaceSizeWriter {
 
 impl PartialEq for SurfaceSizeWriter {
     fn eq(&self, other: &Self) -> bool {
-        self.new_inner_size.as_ptr() == other.new_inner_size.as_ptr()
+        self.new_surface_size.as_ptr() == other.new_surface_size.as_ptr()
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -149,7 +149,7 @@ pub enum WindowEvent {
     ActivationTokenDone { serial: AsyncRequestSerial, token: ActivationToken },
 
     /// The size of the window has changed. Contains the client area's new dimensions.
-    Resized(PhysicalSize<u32>),
+    SurfaceResized(PhysicalSize<u32>),
 
     /// The position of the window has changed. Contains the window's new position.
     ///
@@ -1066,7 +1066,7 @@ mod tests {
                 with_window_event(Destroyed);
                 with_window_event(Focused(true));
                 with_window_event(Moved((0, 0).into()));
-                with_window_event(Resized((0, 0).into()));
+                with_window_event(SurfaceResized((0, 0).into()));
                 with_window_event(DroppedFile("x.txt".into()));
                 with_window_event(HoveredFile("x.txt".into()));
                 with_window_event(HoveredFileCancelled);

--- a/src/event.rs
+++ b/src/event.rs
@@ -148,7 +148,12 @@ pub enum WindowEvent {
     /// [`request_activation_token`]: crate::platform::startup_notify::WindowExtStartupNotify::request_activation_token
     ActivationTokenDone { serial: AsyncRequestSerial, token: ActivationToken },
 
-    /// The size of the window has changed. Contains the client area's new dimensions.
+    /// The size of the window's surface has changed.
+    ///
+    /// Contains the new dimensions of the surface (can also be retrieved with
+    /// [`Window::surface_size`]).
+    ///
+    /// [`Window::surface_size`]: crate::window::Window::surface_size
     SurfaceResized(PhysicalSize<u32>),
 
     /// The position of the window has changed. Contains the window's new position.
@@ -366,7 +371,7 @@ pub enum WindowEvent {
     /// For more information about DPI in general, see the [`dpi`] crate.
     ScaleFactorChanged {
         scale_factor: f64,
-        /// Handle to update inner size during scale changes.
+        /// Handle to update surface size during scale changes.
         ///
         /// See [`SurfaceSizeWriter`] docs for more details.
         surface_size_writer: SurfaceSizeWriter,
@@ -995,8 +1000,7 @@ pub enum MouseScrollDelta {
     PixelDelta(PhysicalPosition<f64>),
 }
 
-/// Handle to synchronously change the size of the window from the
-/// [`WindowEvent`].
+/// Handle to synchronously change the size of the window from the [`WindowEvent`].
 #[derive(Debug, Clone)]
 pub struct SurfaceSizeWriter {
     pub(crate) new_surface_size: Weak<Mutex<PhysicalSize<u32>>>,
@@ -1008,7 +1012,7 @@ impl SurfaceSizeWriter {
         Self { new_surface_size }
     }
 
-    /// Try to request inner size which will be set synchronously on the window.
+    /// Try to request surface size which will be set synchronously on the window.
     pub fn request_surface_size(
         &mut self,
         new_surface_size: PhysicalSize<u32>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -360,7 +360,7 @@ pub enum WindowEvent {
     /// * Changing the display's scale factor (e.g. in Control Panel on Windows).
     /// * Moving the window to a display with a different scale factor.
     ///
-    /// To update the window size, use the provided [`InnerSizeWriter`] handle. By default, the
+    /// To update the window size, use the provided [`SurfaceSizeWriter`] handle. By default, the
     /// window is resized to the value suggested by the OS, but it can be changed to any value.
     ///
     /// For more information about DPI in general, see the [`dpi`] crate.
@@ -368,8 +368,8 @@ pub enum WindowEvent {
         scale_factor: f64,
         /// Handle to update inner size during scale changes.
         ///
-        /// See [`InnerSizeWriter`] docs for more details.
-        inner_size_writer: InnerSizeWriter,
+        /// See [`SurfaceSizeWriter`] docs for more details.
+        surface_size_writer: SurfaceSizeWriter,
     },
 
     /// The system window theme has changed.
@@ -998,11 +998,11 @@ pub enum MouseScrollDelta {
 /// Handle to synchronously change the size of the window from the
 /// [`WindowEvent`].
 #[derive(Debug, Clone)]
-pub struct InnerSizeWriter {
+pub struct SurfaceSizeWriter {
     pub(crate) new_inner_size: Weak<Mutex<PhysicalSize<u32>>>,
 }
 
-impl InnerSizeWriter {
+impl SurfaceSizeWriter {
     #[cfg(not(orbital_platform))]
     pub(crate) fn new(new_inner_size: Weak<Mutex<PhysicalSize<u32>>>) -> Self {
         Self { new_inner_size }
@@ -1022,13 +1022,13 @@ impl InnerSizeWriter {
     }
 }
 
-impl PartialEq for InnerSizeWriter {
+impl PartialEq for SurfaceSizeWriter {
     fn eq(&self, other: &Self) -> bool {
         self.new_inner_size.as_ptr() == other.new_inner_size.as_ptr()
     }
 }
 
-impl Eq for InnerSizeWriter {}
+impl Eq for SurfaceSizeWriter {}
 
 #[cfg(test)]
 mod tests {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -47,9 +47,9 @@ impl Ord for VideoModeHandle {
 
 impl VideoModeHandle {
     /// Returns the resolution of this video mode. This **must not** be used to create your
-    /// rendering surface. Use [`Window::inner_size()`] instead.
+    /// rendering surface. Use [`Window::surface_size()`] instead.
     ///
-    /// [`Window::inner_size()`]: crate::window::Window::inner_size
+    /// [`Window::surface_size()`]: crate::window::Window::surface_size
     #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
         self.video_mode.size()

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -27,13 +27,13 @@
 //! - [`padding`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
 //!
 //! The following APIs can't take them into account and will therefore provide inaccurate results:
-//! - [`WindowEvent::Resized`] and [`Window::(set_)inner_size()`]
+//! - [`WindowEvent::SurfaceResized`] and [`Window::(set_)inner_size()`]
 //! - [`WindowEvent::Occluded`]
 //! - [`WindowEvent::CursorMoved`], [`WindowEvent::CursorEntered`], [`WindowEvent::CursorLeft`], and
 //!   [`WindowEvent::Touch`].
 //! - [`Window::set_outer_position()`]
 //!
-//! [`WindowEvent::Resized`]: crate::event::WindowEvent::Resized
+//! [`WindowEvent::SurfaceResized`]: crate::event::WindowEvent::SurfaceResized
 //! [`Window::(set_)inner_size()`]: crate::window::Window::inner_size
 //! [`WindowEvent::Occluded`]: crate::event::WindowEvent::Occluded
 //! [`WindowEvent::CursorMoved`]: crate::event::WindowEvent::CursorMoved

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -27,14 +27,14 @@
 //! - [`padding`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
 //!
 //! The following APIs can't take them into account and will therefore provide inaccurate results:
-//! - [`WindowEvent::SurfaceResized`] and [`Window::(set_)inner_size()`]
+//! - [`WindowEvent::SurfaceResized`] and [`Window::(set_)surface_size()`]
 //! - [`WindowEvent::Occluded`]
 //! - [`WindowEvent::CursorMoved`], [`WindowEvent::CursorEntered`], [`WindowEvent::CursorLeft`], and
 //!   [`WindowEvent::Touch`].
 //! - [`Window::set_outer_position()`]
 //!
 //! [`WindowEvent::SurfaceResized`]: crate::event::WindowEvent::SurfaceResized
-//! [`Window::(set_)inner_size()`]: crate::window::Window::inner_size
+//! [`Window::(set_)surface_size()`]: crate::window::Window::surface_size
 //! [`WindowEvent::Occluded`]: crate::event::WindowEvent::Occluded
 //! [`WindowEvent::CursorMoved`]: crate::event::WindowEvent::CursorMoved
 //! [`WindowEvent::CursorEntered`]: crate::event::WindowEvent::CursorEntered

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -287,7 +287,7 @@ impl EventLoop {
                     PhysicalSize::new(0, 0)
                 };
                 let window_id = window::WindowId(WindowId);
-                let event = event::WindowEvent::Resized(size);
+                let event = event::WindowEvent::SurfaceResized(size);
                 app.window_event(&self.window_target, window_id, event);
             }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -15,7 +15,7 @@ use crate::application::ApplicationHandler;
 use crate::cursor::Cursor;
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{self, EventLoopError, ExternalError, NotSupportedError};
-use crate::event::{self, Force, InnerSizeWriter, StartCause};
+use crate::event::{self, Force, StartCause, SurfaceSizeWriter};
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
     EventLoopProxy as RootEventLoopProxy, OwnedDisplayHandle as RootOwnedDisplayHandle,
@@ -204,7 +204,7 @@ impl EventLoop {
                         let new_inner_size = Arc::new(Mutex::new(screen_size(&self.android_app)));
                         let window_id = window::WindowId(WindowId);
                         let event = event::WindowEvent::ScaleFactorChanged {
-                            inner_size_writer: InnerSizeWriter::new(Arc::downgrade(
+                            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(
                                 &new_inner_size,
                             )),
                             scale_factor,

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -201,11 +201,11 @@ impl EventLoop {
                     let old_scale_factor = scale_factor(&self.android_app);
                     let scale_factor = scale_factor(&self.android_app);
                     if (scale_factor - old_scale_factor).abs() < f64::EPSILON {
-                        let new_inner_size = Arc::new(Mutex::new(screen_size(&self.android_app)));
+                        let new_surface_size = Arc::new(Mutex::new(screen_size(&self.android_app)));
                         let window_id = window::WindowId(WindowId);
                         let event = event::WindowEvent::ScaleFactorChanged {
                             surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(
-                                &new_inner_size,
+                                &new_surface_size,
                             )),
                             scale_factor,
                         };
@@ -808,21 +808,21 @@ impl CoreWindow for Window {
         // no effect
     }
 
-    fn inner_size(&self) -> PhysicalSize<u32> {
+    fn surface_size(&self) -> PhysicalSize<u32> {
         self.outer_size()
     }
 
-    fn request_inner_size(&self, _size: Size) -> Option<PhysicalSize<u32>> {
-        Some(self.inner_size())
+    fn request_surface_size(&self, _size: Size) -> Option<PhysicalSize<u32>> {
+        Some(self.surface_size())
     }
 
     fn outer_size(&self) -> PhysicalSize<u32> {
         screen_size(&self.app)
     }
 
-    fn set_min_inner_size(&self, _: Option<Size>) {}
+    fn set_min_surface_size(&self, _: Option<Size>) {}
 
-    fn set_max_inner_size(&self, _: Option<Size>) {}
+    fn set_max_surface_size(&self, _: Option<Size>) {}
 
     fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -824,11 +824,11 @@ impl CoreWindow for Window {
 
     fn set_max_surface_size(&self, _: Option<Size>) {}
 
-    fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+    fn surface_resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
-    fn set_resize_increments(&self, _increments: Option<Size>) {}
+    fn set_surface_resize_increments(&self, _increments: Option<Size>) {}
 
     fn set_title(&self, _title: &str) {}
 

--- a/src/platform_impl/apple/appkit/view.rs
+++ b/src/platform_impl/apple/appkit/view.rs
@@ -198,7 +198,7 @@ declare_class!(
             // 2. Even when a window resize does occur on a new tabbed window, it contains the wrong size (includes tab height).
             let logical_size = LogicalSize::new(rect.size.width as f64, rect.size.height as f64);
             let size = logical_size.to_physical::<u32>(self.scale_factor());
-            self.queue_event(WindowEvent::Resized(size));
+            self.queue_event(WindowEvent::SurfaceResized(size));
         }
 
         #[method(drawRect:)]

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -127,24 +127,24 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.set_outer_position(position));
     }
 
-    fn inner_size(&self) -> dpi::PhysicalSize<u32> {
-        self.maybe_wait_on_main(|delegate| delegate.inner_size())
+    fn surface_size(&self) -> dpi::PhysicalSize<u32> {
+        self.maybe_wait_on_main(|delegate| delegate.surface_size())
     }
 
-    fn request_inner_size(&self, size: Size) -> Option<dpi::PhysicalSize<u32>> {
-        self.maybe_wait_on_main(|delegate| delegate.request_inner_size(size))
+    fn request_surface_size(&self, size: Size) -> Option<dpi::PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.request_surface_size(size))
     }
 
     fn outer_size(&self) -> dpi::PhysicalSize<u32> {
         self.maybe_wait_on_main(|delegate| delegate.outer_size())
     }
 
-    fn set_min_inner_size(&self, min_size: Option<Size>) {
-        self.maybe_wait_on_main(|delegate| delegate.set_min_inner_size(min_size))
+    fn set_min_surface_size(&self, min_size: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_min_surface_size(min_size))
     }
 
-    fn set_max_inner_size(&self, max_size: Option<Size>) {
-        self.maybe_wait_on_main(|delegate| delegate.set_max_inner_size(max_size));
+    fn set_max_surface_size(&self, max_size: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_max_surface_size(max_size));
     }
 
     fn resize_increments(&self) -> Option<dpi::PhysicalSize<u32>> {

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -147,12 +147,12 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.set_max_surface_size(max_size));
     }
 
-    fn resize_increments(&self) -> Option<dpi::PhysicalSize<u32>> {
-        self.maybe_wait_on_main(|delegate| delegate.resize_increments())
+    fn surface_resize_increments(&self) -> Option<dpi::PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.surface_resize_increments())
     }
 
-    fn set_resize_increments(&self, increments: Option<Size>) {
-        self.maybe_wait_on_main(|delegate| delegate.set_resize_increments(increments));
+    fn set_surface_resize_increments(&self, increments: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_surface_resize_increments(increments));
     }
 
     fn set_title(&self, title: &str) {

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -36,7 +36,7 @@ use super::window::WinitWindow;
 use super::{ffi, Fullscreen, MonitorHandle, OsError, WindowId};
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
-use crate::event::{InnerSizeWriter, WindowEvent};
+use crate::event::{SurfaceSizeWriter, WindowEvent};
 use crate::platform::macos::{OptionAsAlt, WindowExtMacOS};
 use crate::window::{
     Cursor, CursorGrabMode, Icon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
@@ -829,7 +829,7 @@ impl WindowDelegate {
         let new_inner_size = Arc::new(Mutex::new(suggested_size));
         self.queue_event(WindowEvent::ScaleFactorChanged {
             scale_factor,
-            inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
+            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_inner_size)),
         });
         let physical_size = *new_inner_size.lock().unwrap();
         drop(new_inner_size);

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -161,7 +161,7 @@ declare_class!(
         #[method(windowDidResize:)]
         fn window_did_resize(&self, _: Option<&AnyObject>) {
             trace_scope!("windowDidResize:");
-            // NOTE: WindowEvent::Resized is reported in frameDidChange.
+            // NOTE: WindowEvent::SurfaceResized is reported in frameDidChange.
             self.emit_move_event();
         }
 
@@ -839,7 +839,7 @@ impl WindowDelegate {
             let size = NSSize::new(logical_size.width, logical_size.height);
             window.setContentSize(size);
         }
-        self.queue_event(WindowEvent::Resized(physical_size));
+        self.queue_event(WindowEvent::SurfaceResized(physical_size));
     }
 
     fn emit_move_event(&self) {

--- a/src/platform_impl/apple/uikit/app_state.rs
+++ b/src/platform_impl/apple/uikit/app_state.rs
@@ -27,7 +27,7 @@ use super::window::WinitUIWindow;
 use super::ActiveEventLoop;
 use crate::application::ApplicationHandler;
 use crate::dpi::PhysicalSize;
-use crate::event::{Event, InnerSizeWriter, StartCause, WindowEvent};
+use crate::event::{Event, SurfaceSizeWriter, StartCause, WindowEvent};
 use crate::event_loop::ControlFlow;
 use crate::window::WindowId as RootWindowId;
 
@@ -674,7 +674,7 @@ fn handle_hidpi_proxy(mtm: MainThreadMarker, event: ScaleFactorChanged) {
         window_id: RootWindowId(window.id()),
         event: WindowEvent::ScaleFactorChanged {
             scale_factor,
-            inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
+            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_inner_size)),
         },
     };
     handle_event(mtm, event);

--- a/src/platform_impl/apple/uikit/app_state.rs
+++ b/src/platform_impl/apple/uikit/app_state.rs
@@ -27,7 +27,7 @@ use super::window::WinitUIWindow;
 use super::ActiveEventLoop;
 use crate::application::ApplicationHandler;
 use crate::dpi::PhysicalSize;
-use crate::event::{Event, SurfaceSizeWriter, StartCause, WindowEvent};
+use crate::event::{Event, StartCause, SurfaceSizeWriter, WindowEvent};
 use crate::event_loop::ControlFlow;
 use crate::window::WindowId as RootWindowId;
 
@@ -669,18 +669,18 @@ pub(crate) fn terminated(application: &UIApplication) {
 
 fn handle_hidpi_proxy(mtm: MainThreadMarker, event: ScaleFactorChanged) {
     let ScaleFactorChanged { suggested_size, scale_factor, window } = event;
-    let new_inner_size = Arc::new(Mutex::new(suggested_size));
+    let new_surface_size = Arc::new(Mutex::new(suggested_size));
     let event = Event::WindowEvent {
         window_id: RootWindowId(window.id()),
         event: WindowEvent::ScaleFactorChanged {
             scale_factor,
-            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_inner_size)),
+            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),
         },
     };
     handle_event(mtm, event);
     let (view, screen_frame) = get_view_and_screen_frame(&window);
-    let physical_size = *new_inner_size.lock().unwrap();
-    drop(new_inner_size);
+    let physical_size = *new_surface_size.lock().unwrap();
+    drop(new_surface_size);
     let logical_size = physical_size.to_logical(scale_factor);
     let size = CGSize::new(logical_size.width, logical_size.height);
     let new_frame: CGRect = CGRect::new(screen_frame.origin, size);

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -93,7 +93,7 @@ declare_class!(
                 mtm,
                 EventWrapper::StaticEvent(Event::WindowEvent {
                     window_id: RootWindowId(window.id()),
-                    event: WindowEvent::Resized(size),
+                    event: WindowEvent::SurfaceResized(size),
                 }),
             );
         }
@@ -144,7 +144,7 @@ declare_class!(
                 .chain(std::iter::once(EventWrapper::StaticEvent(
                     Event::WindowEvent {
                         window_id,
-                        event: WindowEvent::Resized(size.to_physical(scale_factor)),
+                        event: WindowEvent::SurfaceResized(size.to_physical(scale_factor)),
                     },
                 ))),
             );

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -510,7 +510,7 @@ impl Window {
         let window = WinitUIWindow::new(mtm, &window_attributes, frame, &view_controller);
         window.makeKeyAndVisible();
 
-        // Like the Windows and macOS backends, we send a `ScaleFactorChanged` and `Resized`
+        // Like the Windows and macOS backends, we send a `ScaleFactorChanged` and `SurfaceResized`
         // event on window creation if the DPI factor != 1.0
         let scale_factor = view.contentScaleFactor();
         let scale_factor = scale_factor as f64;
@@ -534,7 +534,7 @@ impl Window {
                 .chain(std::iter::once(EventWrapper::StaticEvent(
                     Event::WindowEvent {
                         window_id,
-                        event: WindowEvent::Resized(size.to_physical(scale_factor)),
+                        event: WindowEvent::SurfaceResized(size.to_physical(scale_factor)),
                     },
                 ))),
             );

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -219,13 +219,13 @@ impl Inner {
         warn!("`Window::set_max_surface_size` is ignored on iOS")
     }
 
-    pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+    pub fn surface_resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
     #[inline]
-    pub fn set_resize_increments(&self, _increments: Option<Size>) {
-        warn!("`Window::set_resize_increments` is ignored on iOS")
+    pub fn set_surface_resize_increments(&self, _increments: Option<Size>) {
+        warn!("`Window::set_surface_resize_increments` is ignored on iOS")
     }
 
     pub fn set_resizable(&self, _resizable: bool) {
@@ -642,12 +642,12 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.set_max_surface_size(max_size));
     }
 
-    fn resize_increments(&self) -> Option<dpi::PhysicalSize<u32>> {
-        self.maybe_wait_on_main(|delegate| delegate.resize_increments())
+    fn surface_resize_increments(&self) -> Option<dpi::PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.surface_resize_increments())
     }
 
-    fn set_resize_increments(&self, increments: Option<Size>) {
-        self.maybe_wait_on_main(|delegate| delegate.set_resize_increments(increments));
+    fn set_surface_resize_increments(&self, increments: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_surface_resize_increments(increments));
     }
 
     fn set_title(&self, title: &str) {

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -187,7 +187,7 @@ impl Inner {
         self.window.setBounds(bounds);
     }
 
-    pub fn inner_size(&self) -> PhysicalSize<u32> {
+    pub fn surface_size(&self) -> PhysicalSize<u32> {
         let scale_factor = self.scale_factor();
         let safe_area = self.safe_area_screen_space();
         let size = LogicalSize {
@@ -207,16 +207,16 @@ impl Inner {
         size.to_physical(scale_factor)
     }
 
-    pub fn request_inner_size(&self, _size: Size) -> Option<PhysicalSize<u32>> {
-        Some(self.inner_size())
+    pub fn request_surface_size(&self, _size: Size) -> Option<PhysicalSize<u32>> {
+        Some(self.surface_size())
     }
 
-    pub fn set_min_inner_size(&self, _dimensions: Option<Size>) {
-        warn!("`Window::set_min_inner_size` is ignored on iOS")
+    pub fn set_min_surface_size(&self, _dimensions: Option<Size>) {
+        warn!("`Window::set_min_surface_size` is ignored on iOS")
     }
 
-    pub fn set_max_inner_size(&self, _dimensions: Option<Size>) {
-        warn!("`Window::set_max_inner_size` is ignored on iOS")
+    pub fn set_max_surface_size(&self, _dimensions: Option<Size>) {
+        warn!("`Window::set_max_surface_size` is ignored on iOS")
     }
 
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
@@ -469,11 +469,11 @@ impl Window {
     ) -> Result<Window, RootOsError> {
         let mtm = event_loop.mtm;
 
-        if window_attributes.min_inner_size.is_some() {
-            warn!("`WindowAttributes::min_inner_size` is ignored on iOS");
+        if window_attributes.min_surface_size.is_some() {
+            warn!("`WindowAttributes::min_surface_size` is ignored on iOS");
         }
-        if window_attributes.max_inner_size.is_some() {
-            warn!("`WindowAttributes::max_inner_size` is ignored on iOS");
+        if window_attributes.max_surface_size.is_some() {
+            warn!("`WindowAttributes::max_surface_size` is ignored on iOS");
         }
 
         // TODO: transparency, visible
@@ -489,7 +489,7 @@ impl Window {
 
         let screen_bounds = screen.bounds();
 
-        let frame = match window_attributes.inner_size {
+        let frame = match window_attributes.surface_size {
             Some(dim) => {
                 let scale_factor = screen.scale();
                 let size = dim.to_logical::<f64>(scale_factor as f64);
@@ -622,24 +622,24 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.set_outer_position(position));
     }
 
-    fn inner_size(&self) -> dpi::PhysicalSize<u32> {
-        self.maybe_wait_on_main(|delegate| delegate.inner_size())
+    fn surface_size(&self) -> dpi::PhysicalSize<u32> {
+        self.maybe_wait_on_main(|delegate| delegate.surface_size())
     }
 
-    fn request_inner_size(&self, size: Size) -> Option<dpi::PhysicalSize<u32>> {
-        self.maybe_wait_on_main(|delegate| delegate.request_inner_size(size))
+    fn request_surface_size(&self, size: Size) -> Option<dpi::PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.request_surface_size(size))
     }
 
     fn outer_size(&self) -> dpi::PhysicalSize<u32> {
         self.maybe_wait_on_main(|delegate| delegate.outer_size())
     }
 
-    fn set_min_inner_size(&self, min_size: Option<Size>) {
-        self.maybe_wait_on_main(|delegate| delegate.set_min_inner_size(min_size))
+    fn set_min_surface_size(&self, min_size: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_min_surface_size(min_size))
     }
 
-    fn set_max_inner_size(&self, max_size: Option<Size>) {
-        self.maybe_wait_on_main(|delegate| delegate.set_max_inner_size(max_size));
+    fn set_max_surface_size(&self, max_size: Option<Size>) {
+        self.maybe_wait_on_main(|delegate| delegate.set_max_surface_size(max_size));
     }
 
     fn resize_increments(&self) -> Option<dpi::PhysicalSize<u32>> {

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -16,7 +16,7 @@ use crate::application::ApplicationHandler;
 use crate::cursor::OnlyCursorImage;
 use crate::dpi::LogicalSize;
 use crate::error::{EventLoopError, ExternalError, OsError as RootOsError};
-use crate::event::{Event, InnerSizeWriter, StartCause, WindowEvent};
+use crate::event::{Event, SurfaceSizeWriter, StartCause, WindowEvent};
 use crate::event_loop::{ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents};
 use crate::platform::pump_events::PumpStatus;
 use crate::platform_impl::platform::min_timeout;
@@ -328,7 +328,7 @@ impl EventLoop {
                 let root_window_id = crate::window::WindowId(window_id);
                 let event = WindowEvent::ScaleFactorChanged {
                     scale_factor,
-                    inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
+                    surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_inner_size)),
                 };
 
                 app.window_event(&self.active_event_loop, root_window_id, event);

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -375,7 +375,7 @@ impl EventLoop {
                 });
 
                 let window_id = crate::window::WindowId(window_id);
-                let event = WindowEvent::Resized(physical_size);
+                let event = WindowEvent::SurfaceResized(physical_size);
                 app.window_event(&self.active_event_loop, window_id, event);
             }
 

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -348,7 +348,7 @@ impl CoreWindow for Window {
         self.request_redraw();
     }
 
-    /// Set the maximum inner size for the window.
+    /// Set the maximum surface size for the window.
     #[inline]
     fn set_max_surface_size(&self, max_size: Option<Size>) {
         let scale_factor = self.scale_factor();

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -89,7 +89,7 @@ impl Window {
             state.xdg_activation.as_ref().map(|activation_state| activation_state.global().clone());
         let display = event_loop_window_target.connection.display();
 
-        let size: Size = attributes.inner_size.unwrap_or(LogicalSize::new(800., 600.).into());
+        let size: Size = attributes.surface_size.unwrap_or(LogicalSize::new(800., 600.).into());
 
         // We prefer server side decorations, however to not have decorations we ask for client
         // side decorations instead.
@@ -129,10 +129,10 @@ impl Window {
 
         // Set the min and max sizes. We must set the hints upon creating a window, so
         // we use the default `1.` scaling...
-        let min_size = attributes.min_inner_size.map(|size| size.to_logical(1.));
-        let max_size = attributes.max_inner_size.map(|size| size.to_logical(1.));
-        window_state.set_min_inner_size(min_size);
-        window_state.set_max_inner_size(max_size);
+        let min_size = attributes.min_surface_size.map(|size| size.to_logical(1.));
+        let max_size = attributes.max_surface_size.map(|size| size.to_logical(1.));
+        window_state.set_min_surface_size(min_size);
+        window_state.set_max_surface_size(max_size);
 
         // Non-resizable implies that the min and max sizes are set to the same value.
         window_state.set_resizable(attributes.resizable);
@@ -321,15 +321,15 @@ impl CoreWindow for Window {
         // Not possible.
     }
 
-    fn inner_size(&self) -> PhysicalSize<u32> {
+    fn surface_size(&self) -> PhysicalSize<u32> {
         let window_state = self.window_state.lock().unwrap();
         let scale_factor = window_state.scale_factor();
-        super::logical_to_physical_rounded(window_state.inner_size(), scale_factor)
+        super::logical_to_physical_rounded(window_state.surface_size(), scale_factor)
     }
 
-    fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
+    fn request_surface_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let mut window_state = self.window_state.lock().unwrap();
-        let new_size = window_state.request_inner_size(size);
+        let new_size = window_state.request_surface_size(size);
         self.request_redraw();
         Some(new_size)
     }
@@ -340,20 +340,20 @@ impl CoreWindow for Window {
         super::logical_to_physical_rounded(window_state.outer_size(), scale_factor)
     }
 
-    fn set_min_inner_size(&self, min_size: Option<Size>) {
+    fn set_min_surface_size(&self, min_size: Option<Size>) {
         let scale_factor = self.scale_factor();
         let min_size = min_size.map(|size| size.to_logical(scale_factor));
-        self.window_state.lock().unwrap().set_min_inner_size(min_size);
+        self.window_state.lock().unwrap().set_min_surface_size(min_size);
         // NOTE: Requires commit to be applied.
         self.request_redraw();
     }
 
     /// Set the maximum inner size for the window.
     #[inline]
-    fn set_max_inner_size(&self, max_size: Option<Size>) {
+    fn set_max_surface_size(&self, max_size: Option<Size>) {
         let scale_factor = self.scale_factor();
         let max_size = max_size.map(|size| size.to_logical(scale_factor));
-        self.window_state.lock().unwrap().set_max_inner_size(max_size);
+        self.window_state.lock().unwrap().set_max_surface_size(max_size);
         // NOTE: Requires commit to be applied.
         self.request_redraw();
     }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -358,12 +358,12 @@ impl CoreWindow for Window {
         self.request_redraw();
     }
 
-    fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+    fn surface_resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
-    fn set_resize_increments(&self, _increments: Option<Size>) {
-        warn!("`set_resize_increments` is not implemented for Wayland");
+    fn set_surface_resize_increments(&self, _increments: Option<Size>) {
+        warn!("`set_surface_resize_increments` is not implemented for Wayland");
     }
 
     fn set_title(&self, title: &str) {

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -46,7 +46,7 @@ pub type WinitFrame = sctk_adwaita::AdwaitaFrame<WinitState>;
 #[cfg(not(feature = "sctk-adwaita"))]
 pub type WinitFrame = sctk::shell::xdg::fallback_frame::FallbackFrame<WinitState>;
 
-// Minimum window inner size.
+// Minimum window surface size.
 const MIN_WINDOW_SIZE: LogicalSize<u32> = LogicalSize::new(2, 1);
 
 /// The state of the window which is being updated from the [`WinitState`].
@@ -112,7 +112,7 @@ pub struct WindowState {
     /// The text inputs observed on the window.
     text_inputs: Vec<ZwpTextInputV3>,
 
-    /// The inner size of the window, as in without client side decorations.
+    /// The surface size of the window, as in without client side decorations.
     size: LogicalSize<u32>,
 
     /// Whether the CSD fail to create, so we don't try to create them on each iteration.
@@ -361,7 +361,7 @@ impl WindowState {
         }
     }
 
-    /// Compute the bounds for the inner size of the surface.
+    /// Compute the bounds for the surface size of the surface.
     fn surface_size_bounds(
         &self,
         configure: &WindowConfigure,
@@ -636,7 +636,7 @@ impl WindowState {
         logical_to_physical_rounded(self.surface_size(), self.scale_factor())
     }
 
-    /// Resize the window to the new inner size.
+    /// Resize the window to the new surface size.
     fn resize(&mut self, surface_size: LogicalSize<u32>) {
         self.size = surface_size;
 
@@ -673,7 +673,7 @@ impl WindowState {
 
         // Update the target viewport, this is used if and only if fractional scaling is in use.
         if let Some(viewport) = self.viewport.as_ref() {
-            // Set inner size without the borders.
+            // Set surface size without the borders.
             viewport.set_destination(self.size.width as _, self.size.height as _);
         }
     }

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -122,8 +122,8 @@ pub struct WindowState {
     decorate: bool,
 
     /// Min size.
-    min_inner_size: LogicalSize<u32>,
-    max_inner_size: Option<LogicalSize<u32>>,
+    min_surface_size: LogicalSize<u32>,
+    max_surface_size: Option<LogicalSize<u32>>,
 
     /// The size of the window when no states were applied to it. The primary use for it
     /// is to fallback to original window size, before it was maximized, if the compositor
@@ -197,8 +197,8 @@ impl WindowState {
             ime_allowed: false,
             ime_purpose: ImePurpose::Normal,
             last_configure: None,
-            max_inner_size: None,
-            min_inner_size: MIN_WINDOW_SIZE,
+            max_surface_size: None,
+            min_surface_size: MIN_WINDOW_SIZE,
             pointer_constraints,
             pointers: Default::default(),
             queue_handle: queue_handle.clone(),
@@ -328,7 +328,7 @@ impl WindowState {
 
         // Apply configure bounds only when compositor let the user decide what size to pick.
         if constrain {
-            let bounds = self.inner_size_bounds(&configure);
+            let bounds = self.surface_size_bounds(&configure);
             new_size.width =
                 bounds.0.map(|bound_w| new_size.width.min(bound_w.get())).unwrap_or(new_size.width);
             new_size.height = bounds
@@ -353,7 +353,7 @@ impl WindowState {
         // NOTE: Set the configure before doing a resize, since we query it during it.
         self.last_configure = Some(configure);
 
-        if state_change_requires_resize || new_size != self.inner_size() {
+        if state_change_requires_resize || new_size != self.surface_size() {
             self.resize(new_size);
             true
         } else {
@@ -362,7 +362,7 @@ impl WindowState {
     }
 
     /// Compute the bounds for the inner size of the surface.
-    fn inner_size_bounds(
+    fn surface_size_bounds(
         &self,
         configure: &WindowConfigure,
     ) -> (Option<NonZeroU32>, Option<NonZeroU32>) {
@@ -507,8 +507,8 @@ impl WindowState {
             // Restore min/max sizes of the window.
             self.reload_min_max_hints();
         } else {
-            self.set_min_inner_size(Some(self.size));
-            self.set_max_inner_size(Some(self.size));
+            self.set_min_surface_size(Some(self.size));
+            self.set_max_surface_size(Some(self.size));
         }
 
         // Reload the state on the frame as well.
@@ -533,7 +533,7 @@ impl WindowState {
 
     /// Get the size of the window.
     #[inline]
-    pub fn inner_size(&self) -> LogicalSize<u32> {
+    pub fn surface_size(&self) -> LogicalSize<u32> {
         self.size
     }
 
@@ -628,21 +628,21 @@ impl WindowState {
     }
 
     /// Try to resize the window when the user can do so.
-    pub fn request_inner_size(&mut self, inner_size: Size) -> PhysicalSize<u32> {
+    pub fn request_surface_size(&mut self, surface_size: Size) -> PhysicalSize<u32> {
         if self.last_configure.as_ref().map(Self::is_stateless).unwrap_or(true) {
-            self.resize(inner_size.to_logical(self.scale_factor()))
+            self.resize(surface_size.to_logical(self.scale_factor()))
         }
 
-        logical_to_physical_rounded(self.inner_size(), self.scale_factor())
+        logical_to_physical_rounded(self.surface_size(), self.scale_factor())
     }
 
     /// Resize the window to the new inner size.
-    fn resize(&mut self, inner_size: LogicalSize<u32>) {
-        self.size = inner_size;
+    fn resize(&mut self, surface_size: LogicalSize<u32>) {
+        self.size = surface_size;
 
         // Update the stateless size.
         if Some(true) == self.last_configure.as_ref().map(Self::is_stateless) {
-            self.stateless_size = inner_size;
+            self.stateless_size = surface_size;
         }
 
         // Update the inner frame.
@@ -753,7 +753,7 @@ impl WindowState {
     }
 
     /// Set maximum inner window size.
-    pub fn set_min_inner_size(&mut self, size: Option<LogicalSize<u32>>) {
+    pub fn set_min_surface_size(&mut self, size: Option<LogicalSize<u32>>) {
         // Ensure that the window has the right minimum size.
         let mut size = size.unwrap_or(MIN_WINDOW_SIZE);
         size.width = size.width.max(MIN_WINDOW_SIZE.width);
@@ -766,12 +766,12 @@ impl WindowState {
             .map(|frame| frame.add_borders(size.width, size.height).into())
             .unwrap_or(size);
 
-        self.min_inner_size = size;
+        self.min_surface_size = size;
         self.window.set_min_size(Some(size.into()));
     }
 
     /// Set maximum inner window size.
-    pub fn set_max_inner_size(&mut self, size: Option<LogicalSize<u32>>) {
+    pub fn set_max_surface_size(&mut self, size: Option<LogicalSize<u32>>) {
         let size = size.map(|size| {
             self.frame
                 .as_ref()
@@ -779,7 +779,7 @@ impl WindowState {
                 .unwrap_or(size)
         });
 
-        self.max_inner_size = size;
+        self.max_surface_size = size;
         self.window.set_max_size(size.map(Into::into));
     }
 
@@ -812,8 +812,8 @@ impl WindowState {
 
     /// Reload the hints for minimum and maximum sizes.
     pub fn reload_min_max_hints(&mut self) {
-        self.set_min_inner_size(Some(self.min_inner_size));
-        self.set_max_inner_size(self.max_inner_size);
+        self.set_min_surface_size(Some(self.min_surface_size));
+        self.set_max_surface_size(self.max_surface_size);
     }
 
     /// Set the grabbing state on the surface.

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -598,7 +598,7 @@ impl EventProcessor {
         // `XSendEvent` (synthetic `ConfigureNotify`) -> position relative to root
         // `XConfigureNotify` (real `ConfigureNotify`) -> position relative to parent
         // https://tronche.com/gui/x/icccm/sec-4.html#s-4.1.5
-        // We don't want to send `Moved` when this is false, since then every `Resized`
+        // We don't want to send `Moved` when this is false, since then every `SurfaceResized`
         // (whether the window moved or not) is accompanied by an extraneous `Moved` event
         // that has a position relative to the parent window.
         let is_synthetic = xev.send_event == xlib::True;
@@ -757,7 +757,7 @@ impl EventProcessor {
         if resized {
             callback(&self.target, Event::WindowEvent {
                 window_id,
-                event: WindowEvent::Resized(new_inner_size.into()),
+                event: WindowEvent::SurfaceResized(new_inner_size.into()),
             });
         }
     }

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -604,13 +604,13 @@ impl EventProcessor {
         let is_synthetic = xev.send_event == xlib::True;
 
         // These are both in physical space.
-        let new_inner_size = (xev.width as u32, xev.height as u32);
+        let new_surface_size = (xev.width as u32, xev.height as u32);
         let new_inner_position = (xev.x, xev.y);
 
         let (mut resized, moved) = {
             let mut shared_state_lock = window.shared_state_lock();
 
-            let resized = util::maybe_change(&mut shared_state_lock.size, new_inner_size);
+            let resized = util::maybe_change(&mut shared_state_lock.size, new_surface_size);
             let moved = if is_synthetic {
                 util::maybe_change(&mut shared_state_lock.inner_position, new_inner_position)
             } else {
@@ -671,7 +671,7 @@ impl EventProcessor {
 
             let last_scale_factor = shared_state_lock.last_monitor.scale_factor;
             let new_scale_factor = {
-                let window_rect = util::AaRect::new(new_outer_position, new_inner_size);
+                let window_rect = util::AaRect::new(new_outer_position, new_surface_size);
                 let monitor = self
                     .target
                     .xconn
@@ -695,27 +695,30 @@ impl EventProcessor {
                     &shared_state_lock,
                 );
 
-                let old_inner_size = PhysicalSize::new(width, height);
-                let new_inner_size = PhysicalSize::new(new_width, new_height);
+                let old_surface_size = PhysicalSize::new(width, height);
+                let new_surface_size = PhysicalSize::new(new_width, new_height);
 
                 // Unlock shared state to prevent deadlock in callback below
                 drop(shared_state_lock);
 
-                let inner_size = Arc::new(Mutex::new(new_inner_size));
+                let surface_size = Arc::new(Mutex::new(new_surface_size));
                 callback(&self.target, Event::WindowEvent {
                     window_id,
                     event: WindowEvent::ScaleFactorChanged {
                         scale_factor: new_scale_factor,
-                        surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&inner_size)),
+                        surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&surface_size)),
                     },
                 });
 
-                let new_inner_size = *inner_size.lock().unwrap();
-                drop(inner_size);
+                let new_surface_size = *surface_size.lock().unwrap();
+                drop(surface_size);
 
-                if new_inner_size != old_inner_size {
-                    window.request_inner_size_physical(new_inner_size.width, new_inner_size.height);
-                    window.shared_state_lock().dpi_adjusted = Some(new_inner_size.into());
+                if new_surface_size != old_surface_size {
+                    window.request_surface_size_physical(
+                        new_surface_size.width,
+                        new_surface_size.height,
+                    );
+                    window.shared_state_lock().dpi_adjusted = Some(new_surface_size.into());
                     // if the DPI factor changed, force a resize event to ensure the logical
                     // size is computed with the right DPI factor
                     resized = true;
@@ -736,13 +739,13 @@ impl EventProcessor {
             // XResizeWindow requests, making Xorg, the winit client, and the WM
             // consume 100% of CPU.
             if let Some(adjusted_size) = shared_state_lock.dpi_adjusted {
-                if new_inner_size == adjusted_size || !util::wm_name_is_one_of(&["Xfwm4"]) {
+                if new_surface_size == adjusted_size || !util::wm_name_is_one_of(&["Xfwm4"]) {
                     // When this finally happens, the event will not be synthetic.
                     shared_state_lock.dpi_adjusted = None;
                 } else {
                     // Unlock shared state to prevent deadlock in callback below
                     drop(shared_state_lock);
-                    window.request_inner_size_physical(adjusted_size.0, adjusted_size.1);
+                    window.request_surface_size_physical(adjusted_size.0, adjusted_size.1);
                 }
             }
 
@@ -757,7 +760,7 @@ impl EventProcessor {
         if resized {
             callback(&self.target, Event::WindowEvent {
                 window_id,
-                event: WindowEvent::SurfaceResized(new_inner_size.into()),
+                event: WindowEvent::SurfaceResized(new_surface_size.into()),
             });
         }
     }

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -22,8 +22,8 @@ use xkbcommon_dl::xkb_mod_mask_t;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::event::{
-    DeviceEvent, ElementState, Event, Ime, InnerSizeWriter, MouseButton, MouseScrollDelta,
-    RawKeyEvent, Touch, TouchPhase, WindowEvent,
+    DeviceEvent, ElementState, Event, Ime, MouseButton, MouseScrollDelta, RawKeyEvent,
+    SurfaceSizeWriter, Touch, TouchPhase, WindowEvent,
 };
 use crate::keyboard::ModifiersState;
 use crate::platform_impl::common::xkb::{self, XkbState};
@@ -706,7 +706,7 @@ impl EventProcessor {
                     window_id,
                     event: WindowEvent::ScaleFactorChanged {
                         scale_factor: new_scale_factor,
-                        inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&inner_size)),
+                        surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&inner_size)),
                     },
                 });
 

--- a/src/platform_impl/linux/x11/util/geometry.rs
+++ b/src/platform_impl/linux/x11/util/geometry.rs
@@ -76,7 +76,7 @@ impl FrameExtentsHeuristic {
         }
     }
 
-    pub fn inner_size_to_outer(&self, width: u32, height: u32) -> (u32, u32) {
+    pub fn surface_size_to_outer(&self, width: u32, height: u32) -> (u32, u32) {
         (
             width.saturating_add(
                 self.frame_extents.left.saturating_add(self.frame_extents.right) as _
@@ -98,7 +98,7 @@ impl XConnection {
         self.xcb_connection().translate_coordinates(window, root, 0, 0)?.reply().map_err(Into::into)
     }
 
-    // This is adequate for inner_size
+    // This is adequate for surface_size
     pub fn get_geometry(
         &self,
         window: xproto::Window,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -23,7 +23,7 @@ use super::{
 use crate::cursor::{Cursor, CustomCursor as RootCustomCursor};
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{ExternalError, NotSupportedError, OsError as RootOsError};
-use crate::event::{Event, InnerSizeWriter, WindowEvent};
+use crate::event::{Event, SurfaceSizeWriter, WindowEvent};
 use crate::event_loop::AsyncRequestSerial;
 use crate::platform::x11::WindowType;
 use crate::platform_impl::x11::atoms::*;
@@ -1230,7 +1230,7 @@ impl UnownedWindow {
                 window_id,
                 event: WindowEvent::ScaleFactorChanged {
                     scale_factor: new_monitor.scale_factor,
-                    inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&inner_size)),
+                    surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&inner_size)),
                 },
             });
 

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -476,7 +476,7 @@ impl EventLoop {
                 app.window_event(
                     window_target,
                     RootWindowId(window_id),
-                    event::WindowEvent::Resized((width, height).into()),
+                    event::WindowEvent::SurfaceResized((width, height).into()),
                 );
 
                 // Acknowledge resize after event loop.
@@ -523,7 +523,7 @@ impl EventLoop {
                 let window_id = RootWindowId(window_id);
 
                 // Send resize event on create to indicate first size.
-                let event = event::WindowEvent::Resized((properties.w, properties.h).into());
+                let event = event::WindowEvent::SurfaceResized((properties.w, properties.h).into());
                 app.window_event(&self.window_target, window_id, event);
 
                 // Send moved event on create to indicate first position.

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -42,13 +42,13 @@ impl Window {
             (-1, -1)
         };
 
-        let (w, h): (u32, u32) = if let Some(size) = attrs.inner_size {
+        let (w, h): (u32, u32) = if let Some(size) = attrs.surface_size {
             size.to_physical::<u32>(scale).into()
         } else {
             (1024, 768)
         };
 
-        // TODO: min/max inner_size
+        // TODO: min/max surface_size
 
         // Async by default.
         let mut flag_str = ORBITAL_FLAG_ASYNC.to_string();
@@ -225,7 +225,7 @@ impl CoreWindow for Window {
     }
 
     #[inline]
-    fn inner_size(&self) -> PhysicalSize<u32> {
+    fn surface_size(&self) -> PhysicalSize<u32> {
         let mut buf: [u8; 4096] = [0; 4096];
         let path = self.window_socket.fpath(&mut buf).expect("failed to read properties");
         let properties = WindowProperties::new(path);
@@ -233,7 +233,7 @@ impl CoreWindow for Window {
     }
 
     #[inline]
-    fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
+    fn request_surface_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         let (w, h): (u32, u32) = size.to_physical::<u32>(self.scale_factor()).into();
         self.window_socket.write(format!("S,{w},{h}").as_bytes()).expect("failed to set size");
         None
@@ -242,14 +242,14 @@ impl CoreWindow for Window {
     #[inline]
     fn outer_size(&self) -> PhysicalSize<u32> {
         // TODO: adjust for window decorations
-        self.inner_size()
+        self.surface_size()
     }
 
     #[inline]
-    fn set_min_inner_size(&self, _: Option<Size>) {}
+    fn set_min_surface_size(&self, _: Option<Size>) {}
 
     #[inline]
-    fn set_max_inner_size(&self, _: Option<Size>) {}
+    fn set_max_surface_size(&self, _: Option<Size>) {}
 
     #[inline]
     fn title(&self) -> String {

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -283,12 +283,12 @@ impl CoreWindow for Window {
     }
 
     #[inline]
-    fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+    fn surface_resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
     #[inline]
-    fn set_resize_increments(&self, _increments: Option<Size>) {}
+    fn set_surface_resize_increments(&self, _increments: Option<Size>) {}
 
     #[inline]
     fn set_resizable(&self, resizeable: bool) {

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -556,7 +556,7 @@ impl ActiveEventLoop {
                         canvas.set_old_size(new_size);
                         runner.send_event(Event::WindowEvent {
                             window_id: RootWindowId(id),
-                            event: WindowEvent::Resized(new_size),
+                            event: WindowEvent::SurfaceResized(new_size),
                         });
                         canvas.request_animation_frame();
                     }

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -513,8 +513,8 @@ impl Canvas {
         };
 
         if current_size != new_size {
-            // Then we resize the canvas to the new size, a new
-            // `Resized` event will be sent by the `ResizeObserver`:
+            // Then we resize the canvas to the new size, a new `SurfaceResized` event will be sent
+            // by the `ResizeObserver`:
             let new_size = new_size.to_logical(scale);
             super::set_canvas_size(self.document(), self.raw(), self.style(), new_size);
 
@@ -530,7 +530,7 @@ impl Canvas {
             self.set_old_size(new_size);
             runner.send_event(crate::event::Event::WindowEvent {
                 window_id: RootWindowId(self.id),
-                event: crate::event::WindowEvent::Resized(new_size),
+                event: crate::event::WindowEvent::SurfaceResized(new_size),
             })
         }
     }

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -23,7 +23,7 @@ use super::pointer::PointerHandler;
 use super::{event, fullscreen, ButtonsState, ResizeScaleHandle};
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
-use crate::event::{Force, InnerSizeWriter, MouseButton, MouseScrollDelta};
+use crate::event::{Force, SurfaceSizeWriter, MouseButton, MouseScrollDelta};
 use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
 use crate::platform_impl::{Fullscreen, OsError};
 use crate::window::{WindowAttributes, WindowId as RootWindowId};
@@ -504,7 +504,7 @@ impl Canvas {
                 window_id: RootWindowId(self.id),
                 event: crate::event::WindowEvent::ScaleFactorChanged {
                     scale_factor: scale,
-                    inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_size)),
+                    surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_size)),
                 },
             });
 

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -23,7 +23,7 @@ use super::pointer::PointerHandler;
 use super::{event, fullscreen, ButtonsState, ResizeScaleHandle};
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::OsError as RootOE;
-use crate::event::{Force, SurfaceSizeWriter, MouseButton, MouseScrollDelta};
+use crate::event::{Force, MouseButton, MouseScrollDelta, SurfaceSizeWriter};
 use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
 use crate::platform_impl::{Fullscreen, OsError};
 use crate::window::{WindowAttributes, WindowId as RootWindowId};
@@ -126,17 +126,17 @@ impl Canvas {
             current_size: Rc::default(),
         };
 
-        if let Some(size) = attr.inner_size {
+        if let Some(size) = attr.surface_size {
             let size = size.to_logical(super::scale_factor(&common.window));
             super::set_canvas_size(&common.document, &common.raw, &common.style, size);
         }
 
-        if let Some(size) = attr.min_inner_size {
+        if let Some(size) = attr.min_surface_size {
             let size = size.to_logical(super::scale_factor(&common.window));
             super::set_canvas_min_size(&common.document, &common.raw, &common.style, Some(size));
         }
 
-        if let Some(size) = attr.max_inner_size {
+        if let Some(size) = attr.max_surface_size {
             let size = size.to_logical(super::scale_factor(&common.window));
             super::set_canvas_max_size(&common.document, &common.raw, &common.style, Some(size));
         }
@@ -213,7 +213,7 @@ impl Canvas {
     }
 
     #[inline]
-    pub fn inner_size(&self) -> PhysicalSize<u32> {
+    pub fn surface_size(&self) -> PhysicalSize<u32> {
         self.common.current_size.get()
     }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -127,11 +127,11 @@ impl RootWindow for Window {
         })
     }
 
-    fn inner_size(&self) -> PhysicalSize<u32> {
-        self.inner.queue(|inner| inner.canvas.inner_size())
+    fn surface_size(&self) -> PhysicalSize<u32> {
+        self.inner.queue(|inner| inner.canvas.surface_size())
     }
 
-    fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
+    fn request_surface_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
         self.inner.queue(|inner| {
             let size = size.to_logical(self.scale_factor());
             backend::set_canvas_size(
@@ -145,11 +145,11 @@ impl RootWindow for Window {
     }
 
     fn outer_size(&self) -> PhysicalSize<u32> {
-        // Note: the canvas element has no window decorations, so this is equal to `inner_size`.
-        self.inner_size()
+        // Note: the canvas element has no window decorations, so this is equal to `surface_size`.
+        self.surface_size()
     }
 
-    fn set_min_inner_size(&self, min_size: Option<Size>) {
+    fn set_min_surface_size(&self, min_size: Option<Size>) {
         self.inner.dispatch(move |inner| {
             let dimensions = min_size.map(|min_size| min_size.to_logical(inner.scale_factor()));
             backend::set_canvas_min_size(
@@ -161,7 +161,7 @@ impl RootWindow for Window {
         })
     }
 
-    fn set_max_inner_size(&self, max_size: Option<Size>) {
+    fn set_max_surface_size(&self, max_size: Option<Size>) {
         self.inner.dispatch(move |inner| {
             let dimensions = max_size.map(|dimensions| dimensions.to_logical(inner.scale_factor()));
             backend::set_canvas_max_size(

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -173,11 +173,11 @@ impl RootWindow for Window {
         })
     }
 
-    fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+    fn surface_resize_increments(&self) -> Option<PhysicalSize<u32>> {
         None
     }
 
-    fn set_resize_increments(&self, _: Option<Size>) {
+    fn set_surface_resize_increments(&self, _: Option<Size>) {
         // Intentionally a no-op: users can't resize canvas elements
     }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1274,14 +1274,14 @@ unsafe fn public_window_callback_inner(
         },
 
         WM_SIZE => {
-            use crate::event::WindowEvent::Resized;
+            use crate::event::WindowEvent::SurfaceResized;
             let w = super::loword(lparam as u32) as u32;
             let h = super::hiword(lparam as u32) as u32;
 
             let physical_size = PhysicalSize::new(w, h);
             let event = Event::WindowEvent {
                 window_id: CoreWindowId(WindowId(window)),
-                event: Resized(physical_size),
+                event: SurfaceResized(physical_size),
             };
 
             {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -58,7 +58,7 @@ use crate::application::ApplicationHandler;
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::error::{EventLoopError, ExternalError, OsError};
 use crate::event::{
-    Event, FingerId as RootFingerId, Force, Ime, InnerSizeWriter, RawKeyEvent, Touch, TouchPhase,
+    Event, FingerId as RootFingerId, Force, Ime, SurfaceSizeWriter, RawKeyEvent, Touch, TouchPhase,
     WindowEvent,
 };
 use crate::event_loop::{
@@ -2172,7 +2172,7 @@ unsafe fn public_window_callback_inner(
                 window_id: CoreWindowId(WindowId(window)),
                 event: ScaleFactorChanged {
                     scale_factor: new_scale_factor,
-                    inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&new_inner_size)),
+                    surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_inner_size)),
                 },
             });
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2131,7 +2131,7 @@ unsafe fn public_window_callback_inner(
             // New size as suggested by Windows.
             let suggested_rect = unsafe { *(lparam as *const RECT) };
 
-            // The window rect provided is the window's outer size, not it's inner size. However,
+            // The window rect provided is the window's outer size, not it's surface size. However,
             // win32 doesn't provide an `UnadjustWindowRectEx` function to get the client rect from
             // the outer rect, so we instead adjust the window rect to get the decoration margins
             // and remove them from the outer size.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1308,7 +1308,7 @@ unsafe fn public_window_callback_inner(
             let scale_factor = userdata.window_state_lock().scale_factor;
             let Some(inc) = userdata
                 .window_state_lock()
-                .resize_increments
+                .surface_resize_increments
                 .map(|inc| inc.to_physical(scale_factor))
                 .filter(|inc| inc.width > 0 && inc.height > 0)
             else {

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -9,7 +9,7 @@ use windows_sys::Win32::Foundation::HWND;
 
 use super::ControlFlow;
 use crate::dpi::PhysicalSize;
-use crate::event::{Event, InnerSizeWriter, StartCause, WindowEvent};
+use crate::event::{Event, SurfaceSizeWriter, StartCause, WindowEvent};
 use crate::platform_impl::platform::event_loop::{WindowData, GWL_USERDATA};
 use crate::platform_impl::platform::get_window_long;
 use crate::window::WindowId;
@@ -357,12 +357,12 @@ impl BufferedEvent {
     pub fn from_event(event: Event) -> BufferedEvent {
         match event {
             Event::WindowEvent {
-                event: WindowEvent::ScaleFactorChanged { scale_factor, inner_size_writer },
+                event: WindowEvent::ScaleFactorChanged { scale_factor, surface_size_writer },
                 window_id,
             } => BufferedEvent::ScaleFactorChanged(
                 window_id,
                 scale_factor,
-                *inner_size_writer.new_inner_size.upgrade().unwrap().lock().unwrap(),
+                *surface_size_writer.new_inner_size.upgrade().unwrap().lock().unwrap(),
             ),
             event => BufferedEvent::Event(event),
         }
@@ -377,7 +377,7 @@ impl BufferedEvent {
                     window_id,
                     event: WindowEvent::ScaleFactorChanged {
                         scale_factor,
-                        inner_size_writer: InnerSizeWriter::new(Arc::downgrade(
+                        surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(
                             &user_new_innner_size,
                         )),
                     },

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -513,14 +513,14 @@ impl CoreWindow for Window {
         let _ = self.request_surface_size(size.into());
     }
 
-    fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
+    fn surface_resize_increments(&self) -> Option<PhysicalSize<u32>> {
         let w = self.window_state_lock();
         let scale_factor = w.scale_factor;
-        w.resize_increments.map(|size| size.to_physical(scale_factor))
+        w.surface_resize_increments.map(|size| size.to_physical(scale_factor))
     }
 
-    fn set_resize_increments(&self, increments: Option<Size>) {
-        self.window_state_lock().resize_increments = increments;
+    fn set_surface_resize_increments(&self, increments: Option<Size>) {
+        self.window_state_lock().surface_resize_increments = increments;
     }
 
     fn set_resizable(&self, resizable: bool) {

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -30,7 +30,7 @@ pub(crate) struct WindowState {
     pub min_size: Option<Size>,
     pub max_size: Option<Size>,
 
-    pub resize_increments: Option<Size>,
+    pub surface_resize_increments: Option<Size>,
 
     pub window_icon: Option<Icon>,
     pub taskbar_icon: Option<Icon>,
@@ -154,7 +154,7 @@ impl WindowState {
             min_size: attributes.min_surface_size,
             max_size: attributes.max_surface_size,
 
-            resize_increments: attributes.resize_increments,
+            surface_resize_increments: attributes.surface_resize_increments,
 
             window_icon: attributes.window_icon.clone(),
             taskbar_icon: None,

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -151,8 +151,8 @@ impl WindowState {
                 last_position: None,
             },
 
-            min_size: attributes.min_inner_size,
-            max_size: attributes.max_inner_size,
+            min_size: attributes.min_surface_size,
+            max_size: attributes.max_surface_size,
 
             resize_increments: attributes.resize_increments,
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -674,7 +674,7 @@ pub trait Window: AsAny + Send + Sync {
     /// inner size is returned immediately, and the user one is ignored.
     ///
     /// When `None` is returned, it means that the request went to the display system,
-    /// and the actual size will be delivered later with the [`WindowEvent::Resized`].
+    /// and the actual size will be delivered later with the [`WindowEvent::SurfaceResized`].
     ///
     /// See [`Window::inner_size`] for more information about the values.
     ///
@@ -696,7 +696,7 @@ pub trait Window: AsAny + Send + Sync {
     ///
     /// - **Web:** Sets the size of the canvas element. Doesn't account for CSS [`transform`].
     ///
-    /// [`WindowEvent::Resized`]: crate::event::WindowEvent::Resized
+    /// [`WindowEvent::SurfaceResized`]: crate::event::WindowEvent::SurfaceResized
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     #[must_use]
     fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>>;
@@ -828,8 +828,8 @@ pub trait Window: AsAny + Send + Sync {
     /// Sets whether the window is resizable or not.
     ///
     /// Note that making the window unresizable doesn't exempt you from handling
-    /// [`WindowEvent::Resized`], as that event can still be triggered by DPI scaling, entering
-    /// fullscreen mode, etc. Also, the window could still be resized by calling
+    /// [`WindowEvent::SurfaceResized`], as that event can still be triggered by DPI scaling,
+    /// entering fullscreen mode, etc. Also, the window could still be resized by calling
     /// [`Window::request_inner_size`].
     ///
     /// ## Platform-specific
@@ -839,7 +839,7 @@ pub trait Window: AsAny + Send + Sync {
     /// - **X11:** Due to a bug in XFCE, this has no effect on Xfwm.
     /// - **iOS / Android / Web:** Unsupported.
     ///
-    /// [`WindowEvent::Resized`]: crate::event::WindowEvent::Resized
+    /// [`WindowEvent::SurfaceResized`]: crate::event::WindowEvent::SurfaceResized
     fn set_resizable(&self, resizable: bool);
 
     /// Gets the window's current resizable state.

--- a/src/window.rs
+++ b/src/window.rs
@@ -137,7 +137,7 @@ impl WindowAttributes {
         self.parent_window.as_ref().map(|handle| &handle.0)
     }
 
-    /// Requests the window to be of specific dimensions.
+    /// Requests the surface to be of specific dimensions.
     ///
     /// If this is not set, some platform-specific dimensions will be used.
     ///
@@ -148,10 +148,9 @@ impl WindowAttributes {
         self
     }
 
-    /// Sets the minimum dimensions a window can have.
+    /// Sets the minimum dimensions the surface can have.
     ///
-    /// If this is not set, the window will have no minimum dimensions (aside
-    /// from reserved).
+    /// If this is not set, the surface will have no minimum dimensions (aside from reserved).
     ///
     /// See [`Window::set_min_surface_size`] for details.
     #[inline]
@@ -160,9 +159,9 @@ impl WindowAttributes {
         self
     }
 
-    /// Sets the maximum dimensions a window can have.
+    /// Sets the maximum dimensions the surface can have.
     ///
-    /// If this is not set, the window will have no maximum or will be set to
+    /// If this is not set, the surface will have no maximum, or the maximum will be restricted to
     /// the primary monitor's dimensions by the platform.
     ///
     /// See [`Window::set_max_surface_size`] for details.
@@ -653,9 +652,9 @@ pub trait Window: AsAny + Send + Sync {
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     fn set_outer_position(&self, position: Position);
 
-    /// Returns the physical size of the window's client area.
+    /// Returns the size of the window's render-able surface.
     ///
-    /// The client area is the content of the window, excluding the title bar and borders.
+    /// This is the dimensions you should pass to things like Wgpu or Glutin when configuring.
     ///
     /// ## Platform-specific
     ///
@@ -667,14 +666,14 @@ pub trait Window: AsAny + Send + Sync {
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     fn surface_size(&self) -> PhysicalSize<u32>;
 
-    /// Request the new size for the window.
+    /// Request the new size for the surface.
     ///
     /// On platforms where the size is entirely controlled by the user the
     /// applied size will be returned immediately, resize event in such case
     /// may not be generated.
     ///
-    /// On platforms where resizing is disallowed by the windowing system, the current
-    /// inner size is returned immediately, and the user one is ignored.
+    /// On platforms where resizing is disallowed by the windowing system, the current surface size
+    /// is returned immediately, and the user one is ignored.
     ///
     /// When `None` is returned, it means that the request went to the display system,
     /// and the actual size will be delivered later with the [`WindowEvent::SurfaceResized`].
@@ -704,10 +703,10 @@ pub trait Window: AsAny + Send + Sync {
     #[must_use]
     fn request_surface_size(&self, size: Size) -> Option<PhysicalSize<u32>>;
 
-    /// Returns the physical size of the entire window.
+    /// Returns the size of the entire window.
     ///
-    /// These dimensions include the title bar and borders. If you don't want that (and you usually
-    /// don't), use [`Window::surface_size`] instead.
+    /// These dimensions include window decorations like the title bar and borders. If you don't
+    /// want that (and you usually don't), use [`Window::surface_size`] instead.
     ///
     /// ## Platform-specific
     ///
@@ -716,7 +715,7 @@ pub trait Window: AsAny + Send + Sync {
     ///   [`Window::surface_size`]._
     fn outer_size(&self) -> PhysicalSize<u32>;
 
-    /// Sets a minimum dimension size for the window.
+    /// Sets a minimum dimensions of the window's surface.
     ///
     /// ```no_run
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
@@ -735,7 +734,7 @@ pub trait Window: AsAny + Send + Sync {
     /// - **iOS / Android / Orbital:** Unsupported.
     fn set_min_surface_size(&self, min_size: Option<Size>);
 
-    /// Sets a maximum dimension size for the window.
+    /// Sets a maximum dimensions of the window's surface.
     ///
     /// ```no_run
     /// # use winit::dpi::{LogicalSize, PhysicalSize};
@@ -754,17 +753,17 @@ pub trait Window: AsAny + Send + Sync {
     /// - **iOS / Android / Orbital:** Unsupported.
     fn set_max_surface_size(&self, max_size: Option<Size>);
 
-    /// Returns window resize increments if any were set.
+    /// Returns surface resize increments if any were set.
     ///
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web / Wayland / Orbital:** Always returns [`None`].
     fn surface_resize_increments(&self) -> Option<PhysicalSize<u32>>;
 
-    /// Sets window resize increments.
+    /// Sets resize increments of the surface.
     ///
-    /// This is a niche constraint hint usually employed by terminal emulators
-    /// and other apps that need "blocky" resizes.
+    /// This is a niche constraint hint usually employed by terminal emulators and other such apps
+    /// that need "blocky" resizes.
     ///
     /// ## Platform-specific
     ///

--- a/src/window.rs
+++ b/src/window.rs
@@ -60,6 +60,7 @@ pub struct WindowAttributes {
     pub surface_size: Option<Size>,
     pub min_surface_size: Option<Size>,
     pub max_surface_size: Option<Size>,
+    pub surface_resize_increments: Option<Size>,
     pub position: Option<Position>,
     pub resizable: bool,
     pub enabled_buttons: WindowButtons,
@@ -71,7 +72,6 @@ pub struct WindowAttributes {
     pub decorations: bool,
     pub window_icon: Option<Icon>,
     pub preferred_theme: Option<Theme>,
-    pub resize_increments: Option<Size>,
     pub content_protected: bool,
     pub window_level: WindowLevel,
     pub active: bool,
@@ -91,6 +91,7 @@ impl Default for WindowAttributes {
             surface_size: None,
             min_surface_size: None,
             max_surface_size: None,
+            surface_resize_increments: None,
             position: None,
             resizable: true,
             enabled_buttons: WindowButtons::all(),
@@ -104,7 +105,6 @@ impl Default for WindowAttributes {
             window_level: Default::default(),
             window_icon: None,
             preferred_theme: None,
-            resize_increments: None,
             content_protected: false,
             cursor: Cursor::default(),
             #[cfg(feature = "rwh_06")]
@@ -169,6 +169,20 @@ impl WindowAttributes {
     #[inline]
     pub fn with_max_surface_size<S: Into<Size>>(mut self, max_size: S) -> Self {
         self.max_surface_size = Some(max_size.into());
+        self
+    }
+
+    /// Build window with resize increments hint.
+    ///
+    /// The default is `None`.
+    ///
+    /// See [`Window::set_surface_resize_increments`] for details.
+    #[inline]
+    pub fn with_surface_resize_increments<S: Into<Size>>(
+        mut self,
+        surface_resize_increments: S,
+    ) -> Self {
+        self.surface_resize_increments = Some(surface_resize_increments.into());
         self
     }
 
@@ -343,17 +357,6 @@ impl WindowAttributes {
     #[inline]
     pub fn with_theme(mut self, theme: Option<Theme>) -> Self {
         self.preferred_theme = theme;
-        self
-    }
-
-    /// Build window with resize increments hint.
-    ///
-    /// The default is `None`.
-    ///
-    /// See [`Window::set_resize_increments`] for details.
-    #[inline]
-    pub fn with_resize_increments<S: Into<Size>>(mut self, resize_increments: S) -> Self {
-        self.resize_increments = Some(resize_increments.into());
         self
     }
 
@@ -756,7 +759,7 @@ pub trait Window: AsAny + Send + Sync {
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Web / Wayland / Orbital:** Always returns [`None`].
-    fn resize_increments(&self) -> Option<PhysicalSize<u32>>;
+    fn surface_resize_increments(&self) -> Option<PhysicalSize<u32>>;
 
     /// Sets window resize increments.
     ///
@@ -769,7 +772,7 @@ pub trait Window: AsAny + Send + Sync {
     ///   numbers.
     /// - **Wayland:** Not implemented.
     /// - **iOS / Android / Web / Orbital:** Unsupported.
-    fn set_resize_increments(&self, increments: Option<Size>);
+    fn set_surface_resize_increments(&self, increments: Option<Size>);
 
     /// Modifies the title of the window.
     ///

--- a/src/window.rs
+++ b/src/window.rs
@@ -57,9 +57,9 @@ impl From<u64> for WindowId {
 /// Attributes used when creating a window.
 #[derive(Debug, Clone, PartialEq)]
 pub struct WindowAttributes {
-    pub inner_size: Option<Size>,
-    pub min_inner_size: Option<Size>,
-    pub max_inner_size: Option<Size>,
+    pub surface_size: Option<Size>,
+    pub min_surface_size: Option<Size>,
+    pub max_surface_size: Option<Size>,
     pub position: Option<Position>,
     pub resizable: bool,
     pub enabled_buttons: WindowButtons,
@@ -88,9 +88,9 @@ impl Default for WindowAttributes {
     #[inline]
     fn default() -> WindowAttributes {
         WindowAttributes {
-            inner_size: None,
-            min_inner_size: None,
-            max_inner_size: None,
+            surface_size: None,
+            min_surface_size: None,
+            max_surface_size: None,
             position: None,
             resizable: true,
             enabled_buttons: WindowButtons::all(),
@@ -141,10 +141,10 @@ impl WindowAttributes {
     ///
     /// If this is not set, some platform-specific dimensions will be used.
     ///
-    /// See [`Window::request_inner_size`] for details.
+    /// See [`Window::request_surface_size`] for details.
     #[inline]
-    pub fn with_inner_size<S: Into<Size>>(mut self, size: S) -> Self {
-        self.inner_size = Some(size.into());
+    pub fn with_surface_size<S: Into<Size>>(mut self, size: S) -> Self {
+        self.surface_size = Some(size.into());
         self
     }
 
@@ -153,10 +153,10 @@ impl WindowAttributes {
     /// If this is not set, the window will have no minimum dimensions (aside
     /// from reserved).
     ///
-    /// See [`Window::set_min_inner_size`] for details.
+    /// See [`Window::set_min_surface_size`] for details.
     #[inline]
-    pub fn with_min_inner_size<S: Into<Size>>(mut self, min_size: S) -> Self {
-        self.min_inner_size = Some(min_size.into());
+    pub fn with_min_surface_size<S: Into<Size>>(mut self, min_size: S) -> Self {
+        self.min_surface_size = Some(min_size.into());
         self
     }
 
@@ -165,10 +165,10 @@ impl WindowAttributes {
     /// If this is not set, the window will have no maximum or will be set to
     /// the primary monitor's dimensions by the platform.
     ///
-    /// See [`Window::set_max_inner_size`] for details.
+    /// See [`Window::set_max_surface_size`] for details.
     #[inline]
-    pub fn with_max_inner_size<S: Into<Size>>(mut self, max_size: S) -> Self {
-        self.max_inner_size = Some(max_size.into());
+    pub fn with_max_surface_size<S: Into<Size>>(mut self, max_size: S) -> Self {
+        self.max_surface_size = Some(max_size.into());
         self
     }
 
@@ -182,7 +182,7 @@ impl WindowAttributes {
     ///
     /// - **macOS:** The top left corner position of the window content, the window's "inner"
     ///   position. The window title bar will be placed above it. The window will be positioned such
-    ///   that it fits on screen, maintaining set `inner_size` if any. If you need to precisely
+    ///   that it fits on screen, maintaining set `surface_size` if any. If you need to precisely
     ///   position the top left corner of the whole window you have to use
     ///   [`Window::set_outer_position`] after creating the window.
     /// - **Windows:** The top left corner position of the window title bar, the window's "outer"
@@ -662,7 +662,7 @@ pub trait Window: AsAny + Send + Sync {
     ///
     /// [safe area]: https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
-    fn inner_size(&self) -> PhysicalSize<u32>;
+    fn surface_size(&self) -> PhysicalSize<u32>;
 
     /// Request the new size for the window.
     ///
@@ -676,7 +676,7 @@ pub trait Window: AsAny + Send + Sync {
     /// When `None` is returned, it means that the request went to the display system,
     /// and the actual size will be delivered later with the [`WindowEvent::SurfaceResized`].
     ///
-    /// See [`Window::inner_size`] for more information about the values.
+    /// See [`Window::surface_size`] for more information about the values.
     ///
     /// The request could automatically un-maximize the window if it's maximized.
     ///
@@ -685,10 +685,10 @@ pub trait Window: AsAny + Send + Sync {
     /// # use winit::window::Window;
     /// # fn scope(window: &dyn Window) {
     /// // Specify the size in logical dimensions like this:
-    /// let _ = window.request_inner_size(LogicalSize::new(400.0, 200.0).into());
+    /// let _ = window.request_surface_size(LogicalSize::new(400.0, 200.0).into());
     ///
     /// // Or specify the size in physical dimensions like this:
-    /// let _ = window.request_inner_size(PhysicalSize::new(400, 200).into());
+    /// let _ = window.request_surface_size(PhysicalSize::new(400, 200).into());
     /// # }
     /// ```
     ///
@@ -699,18 +699,18 @@ pub trait Window: AsAny + Send + Sync {
     /// [`WindowEvent::SurfaceResized`]: crate::event::WindowEvent::SurfaceResized
     /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
     #[must_use]
-    fn request_inner_size(&self, size: Size) -> Option<PhysicalSize<u32>>;
+    fn request_surface_size(&self, size: Size) -> Option<PhysicalSize<u32>>;
 
     /// Returns the physical size of the entire window.
     ///
     /// These dimensions include the title bar and borders. If you don't want that (and you usually
-    /// don't), use [`Window::inner_size`] instead.
+    /// don't), use [`Window::surface_size`] instead.
     ///
     /// ## Platform-specific
     ///
     /// - **iOS:** Returns the [`PhysicalSize`] of the window in screen space coordinates.
     /// - **Web:** Returns the size of the canvas element. _Note: this returns the same value as
-    ///   [`Window::inner_size`]._
+    ///   [`Window::surface_size`]._
     fn outer_size(&self) -> PhysicalSize<u32>;
 
     /// Sets a minimum dimension size for the window.
@@ -720,17 +720,17 @@ pub trait Window: AsAny + Send + Sync {
     /// # use winit::window::Window;
     /// # fn scope(window: &dyn Window) {
     /// // Specify the size in logical dimensions like this:
-    /// window.set_min_inner_size(Some(LogicalSize::new(400.0, 200.0).into()));
+    /// window.set_min_surface_size(Some(LogicalSize::new(400.0, 200.0).into()));
     ///
     /// // Or specify the size in physical dimensions like this:
-    /// window.set_min_inner_size(Some(PhysicalSize::new(400, 200).into()));
+    /// window.set_min_surface_size(Some(PhysicalSize::new(400, 200).into()));
     /// # }
     /// ```
     ///
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Orbital:** Unsupported.
-    fn set_min_inner_size(&self, min_size: Option<Size>);
+    fn set_min_surface_size(&self, min_size: Option<Size>);
 
     /// Sets a maximum dimension size for the window.
     ///
@@ -739,17 +739,17 @@ pub trait Window: AsAny + Send + Sync {
     /// # use winit::window::Window;
     /// # fn scope(window: &dyn Window) {
     /// // Specify the size in logical dimensions like this:
-    /// window.set_max_inner_size(Some(LogicalSize::new(400.0, 200.0).into()));
+    /// window.set_max_surface_size(Some(LogicalSize::new(400.0, 200.0).into()));
     ///
     /// // Or specify the size in physical dimensions like this:
-    /// window.set_max_inner_size(Some(PhysicalSize::new(400, 200).into()));
+    /// window.set_max_surface_size(Some(PhysicalSize::new(400, 200).into()));
     /// # }
     /// ```
     ///
     /// ## Platform-specific
     ///
     /// - **iOS / Android / Orbital:** Unsupported.
-    fn set_max_inner_size(&self, max_size: Option<Size>);
+    fn set_max_surface_size(&self, max_size: Option<Size>);
 
     /// Returns window resize increments if any were set.
     ///
@@ -830,7 +830,7 @@ pub trait Window: AsAny + Send + Sync {
     /// Note that making the window unresizable doesn't exempt you from handling
     /// [`WindowEvent::SurfaceResized`], as that event can still be triggered by DPI scaling,
     /// entering fullscreen mode, etc. Also, the window could still be resized by calling
-    /// [`Window::request_inner_size`].
+    /// [`Window::request_surface_size`].
     ///
     /// ## Platform-specific
     ///


### PR DESCRIPTION
As discussed in https://github.com/rust-windowing/winit/issues/2308, using "inner" in the name is confusing, and could mean many different things. Let's rename it to "surface", and define that to mean the size of the drawable surface, i.e. the dimensions that `wgpu` and `glutin` should be configured with.

See the changelog entry for the full list of changed APIs.

Some backends (at least iOS/UIKit) are still not be returning the actual surface size, but I wanted to address that separately (along with introducing `Window::safe_area`).

- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
