### PR TITLE
Android: map hover events to their winit equivalents.

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -134,4 +134,6 @@ changelog entry.
 
 ### Fixed
 
+- On Android, map hover events to their winit equivalents. These events
+  are required for accessibility.
 - On Orbital, `MonitorHandle::name()` now returns `None` instead of a dummy name.


### PR DESCRIPTION
These events are required for accessibility.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
