### PR TITLE
Move `Fullscreen` enum into platforms

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -193,3 +193,36 @@ impl MonitorHandle {
         self.inner.video_modes().map(|video_mode| VideoModeHandle { video_mode })
     }
 }
+
+/// Fullscreen modes.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Fullscreen {
+    Exclusive(VideoModeHandle),
+
+    /// Providing `None` to `Borderless` will fullscreen on the current monitor.
+    Borderless(Option<MonitorHandle>),
+}
+
+impl From<Fullscreen> for platform_impl::Fullscreen {
+    fn from(f: Fullscreen) -> Self {
+        match f {
+            Fullscreen::Exclusive(mode) => Self::Exclusive(mode.video_mode),
+            Fullscreen::Borderless(Some(handle)) => Self::Borderless(Some(handle.inner)),
+            Fullscreen::Borderless(None) => Self::Borderless(None),
+        }
+    }
+}
+
+impl From<platform_impl::Fullscreen> for Fullscreen {
+    fn from(f: platform_impl::Fullscreen) -> Self {
+        match f {
+            platform_impl::Fullscreen::Exclusive(video_mode) => {
+                Self::Exclusive(VideoModeHandle { video_mode })
+            },
+            platform_impl::Fullscreen::Borderless(Some(inner)) => {
+                Self::Borderless(Some(MonitorHandle { inner }))
+            },
+            platform_impl::Fullscreen::Borderless(None) => Self::Borderless(None),
+        }
+    }
+}

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -23,8 +23,8 @@ use crate::event_loop::{
 use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform::pump_events::PumpStatus;
 use crate::window::{
-    self, CursorGrabMode, CustomCursor, CustomCursorSource, Fullscreen, ImePurpose,
-    ResizeDirection, Theme, Window as CoreWindow, WindowAttributes, WindowButtons, WindowLevel,
+    self, CursorGrabMode, CustomCursor, CustomCursorSource, ImePurpose, ResizeDirection, Theme,
+    Window as CoreWindow, WindowAttributes, WindowButtons, WindowLevel,
 };
 
 mod keycodes;
@@ -1004,6 +1004,12 @@ impl VideoModeHandle {
     pub fn monitor(&self) -> MonitorHandle {
         unreachable!()
     }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Fullscreen {
+    Exclusive(VideoModeHandle),
+    Borderless(Option<MonitorHandle>),
 }
 
 fn screen_size(app: &AndroidApp) -> PhysicalSize<u32> {

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -20,13 +20,12 @@ pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle,
     PlatformSpecificEventLoopAttributes,
 };
-pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
+pub(crate) use self::monitor::{Fullscreen, MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::{Window, WindowId};
 pub(crate) use self::window_delegate::PlatformSpecificWindowAttributes;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
 use crate::event::DeviceId as RootDeviceId;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
-pub(crate) use crate::platform_impl::Fullscreen;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DeviceId;

--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -298,6 +298,12 @@ impl MonitorHandle {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Fullscreen {
+    Exclusive(VideoModeHandle),
+    Borderless(Option<MonitorHandle>),
+}
+
 pub(crate) fn get_display_id(screen: &NSScreen) -> u32 {
     let key = ns_string!("NSScreenNumber");
 

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -13,14 +13,13 @@ pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle,
     PlatformSpecificEventLoopAttributes,
 };
-pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
+pub(crate) use self::monitor::{Fullscreen, MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::{PlatformSpecificWindowAttributes, Window, WindowId};
 pub(crate) use crate::cursor::{
     NoCustomCursor as PlatformCustomCursor, NoCustomCursor as PlatformCustomCursorSource,
 };
 use crate::event::DeviceId as RootDeviceId;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
-pub(crate) use crate::platform_impl::Fullscreen;
 
 /// There is no way to detect which device that performed a certain event in
 /// UIKit (i.e. you can't differentiate between different external keyboards,

--- a/src/platform_impl/apple/uikit/monitor.rs
+++ b/src/platform_impl/apple/uikit/monitor.rs
@@ -240,3 +240,9 @@ pub fn uiscreens(mtm: MainThreadMarker) -> VecDeque<MonitorHandle> {
     #[allow(deprecated)]
     UIScreen::screens(mtm).into_iter().map(MonitorHandle::new).collect()
 }
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Fullscreen {
+    Exclusive(VideoModeHandle),
+    Borderless(Option<MonitorHandle>),
+}

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -260,6 +260,12 @@ impl VideoModeHandle {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Fullscreen {
+    Exclusive(VideoModeHandle),
+    Borderless(Option<MonitorHandle>),
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct KeyEventExtra {
     pub text_with_all_modifiers: Option<SmolStr>,

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -1,6 +1,3 @@
-use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoModeHandle as RootVideoModeHandle};
-use crate::window::Fullscreen as RootFullscreen;
-
 #[cfg(android_platform)]
 mod android;
 #[cfg(target_vendor = "apple")]
@@ -27,38 +24,6 @@ pub use self::platform::*;
 use self::web as platform;
 #[cfg(windows_platform)]
 use self::windows as platform;
-
-/// Helper for converting between platform-specific and generic
-/// [`VideoModeHandle`]/[`MonitorHandle`]
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum Fullscreen {
-    Exclusive(VideoModeHandle),
-    Borderless(Option<MonitorHandle>),
-}
-
-impl From<RootFullscreen> for Fullscreen {
-    fn from(f: RootFullscreen) -> Self {
-        match f {
-            RootFullscreen::Exclusive(mode) => Self::Exclusive(mode.video_mode),
-            RootFullscreen::Borderless(Some(handle)) => Self::Borderless(Some(handle.inner)),
-            RootFullscreen::Borderless(None) => Self::Borderless(None),
-        }
-    }
-}
-
-impl From<Fullscreen> for RootFullscreen {
-    fn from(f: Fullscreen) -> Self {
-        match f {
-            Fullscreen::Exclusive(video_mode) => {
-                Self::Exclusive(RootVideoModeHandle { video_mode })
-            },
-            Fullscreen::Borderless(Some(inner)) => {
-                Self::Borderless(Some(RootMonitorHandle { inner }))
-            },
-            Fullscreen::Borderless(None) => Self::Borderless(None),
-        }
-    }
-}
 
 #[cfg(all(
     not(ios_platform),

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -227,6 +227,12 @@ impl VideoModeHandle {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Fullscreen {
+    Exclusive(VideoModeHandle),
+    Borderless(Option<MonitorHandle>),
+}
+
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct KeyEventExtra {
     pub key_without_modifiers: Key,

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -44,8 +44,8 @@ pub(crate) use self::event_loop::{
 };
 pub(crate) use self::keyboard::KeyEventExtra;
 pub(crate) use self::monitor::{
-    HasMonitorPermissionFuture, MonitorHandle, MonitorPermissionFuture, OrientationLockFuture,
-    VideoModeHandle,
+    Fullscreen, HasMonitorPermissionFuture, MonitorHandle, MonitorPermissionFuture,
+    OrientationLockFuture, VideoModeHandle,
 };
 use self::web_sys as backend;
 pub use self::window::{PlatformSpecificWindowAttributes, Window, WindowId};

--- a/src/platform_impl/web/monitor.rs
+++ b/src/platform_impl/web/monitor.rs
@@ -34,6 +34,12 @@ use crate::platform::web::{
     MonitorPermissionError, Orientation, OrientationData, OrientationLock, OrientationLockError,
 };
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Fullscreen {
+    Exclusive(VideoModeHandle),
+    Borderless(Option<MonitorHandle>),
+}
+
 #[derive(Clone, Eq)]
 pub struct MonitorHandle {
     /// [`None`] means [`web_sys::Screen`], which is always the same.

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -8,14 +8,13 @@ pub(crate) use self::event_loop::{
 pub use self::icon::WinIcon as PlatformIcon;
 pub(crate) use self::icon::{SelectedCursor, WinCursor as PlatformCustomCursor, WinIcon};
 pub(crate) use self::keyboard::{physicalkey_to_scancode, scancode_to_physicalkey};
-pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
+pub(crate) use self::monitor::{Fullscreen, MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::Window;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
 use crate::event::DeviceId as RootDeviceId;
 use crate::icon::Icon;
 use crate::keyboard::Key;
 use crate::platform::windows::{BackdropType, Color, CornerPreference};
-use crate::platform_impl::Fullscreen;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct PlatformSpecificWindowAttributes {

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -17,6 +17,12 @@ use crate::monitor::VideoModeHandle as RootVideoModeHandle;
 use crate::platform_impl::platform::dpi::{dpi_to_scale_factor, get_monitor_dpi};
 use crate::platform_impl::platform::util::has_flag;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Fullscreen {
+    Exclusive(VideoModeHandle),
+    Borderless(Option<MonitorHandle>),
+}
+
 #[derive(Clone)]
 pub struct VideoModeHandle {
     pub(crate) size: (u32, u32),

--- a/src/window.rs
+++ b/src/window.rs
@@ -10,7 +10,8 @@ pub use crate::cursor::{BadImage, Cursor, CustomCursor, CustomCursorSource, MAX_
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::RequestError;
 pub use crate::icon::{BadIcon, Icon};
-use crate::monitor::{MonitorHandle, VideoModeHandle};
+pub use crate::monitor::Fullscreen;
+use crate::monitor::MonitorHandle;
 use crate::platform_impl::{self, PlatformSpecificWindowAttributes};
 use crate::utils::AsAny;
 
@@ -931,6 +932,7 @@ pub trait Window: AsAny + Send + Sync {
     ///   or calling without a [transient activation] does nothing.
     ///
     /// [transient activation]: https://developer.mozilla.org/en-US/docs/Glossary/Transient_activation
+    /// [`VideoModeHandle`]: crate::monitor::VideoModeHandle
     fn set_fullscreen(&self, fullscreen: Option<Fullscreen>);
 
     /// Gets the window's current fullscreen state.
@@ -1390,15 +1392,6 @@ impl From<ResizeDirection> for CursorIcon {
             West => CursorIcon::WResize,
         }
     }
-}
-
-/// Fullscreen modes.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub enum Fullscreen {
-    Exclusive(VideoModeHandle),
-
-    /// Providing `None` to `Borderless` will fullscreen on the current monitor.
-    Borderless(Option<MonitorHandle>),
 }
 
 /// The theme variant to use.


### PR DESCRIPTION
This is a bit of duplication, but needed if we intend to split the backends into separate crates, since we need to convert between the root crate's `VideoModeHandle` and `MonitorHandle`s, and the platform's types.