### PR TITLE
Merge all `WindowId` into a single type in the core crate

### DIFF
--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -24,7 +24,8 @@ use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform::pump_events::PumpStatus;
 use crate::window::{
     self, CursorGrabMode, CustomCursor, CustomCursorSource, Fullscreen, ImePurpose,
-    ResizeDirection, Theme, Window as CoreWindow, WindowAttributes, WindowButtons, WindowLevel,
+    ResizeDirection, Theme, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
+    WindowLevel,
 };
 
 mod keycodes;
@@ -122,6 +123,9 @@ impl Default for PlatformSpecificEventLoopAttributes {
     }
 }
 
+// Android currently only supports one window
+const GLOBAL_WINDOW: WindowId = WindowId::from_raw(0);
+
 impl EventLoop {
     pub(crate) fn new(
         attributes: &PlatformSpecificEventLoopAttributes,
@@ -187,22 +191,19 @@ impl EventLoop {
                 },
                 MainEvent::GainedFocus => {
                     HAS_FOCUS.store(true, Ordering::Relaxed);
-                    let window_id = window::WindowId(WindowId);
                     let event = event::WindowEvent::Focused(true);
-                    app.window_event(&self.window_target, window_id, event);
+                    app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                 },
                 MainEvent::LostFocus => {
                     HAS_FOCUS.store(false, Ordering::Relaxed);
-                    let window_id = window::WindowId(WindowId);
                     let event = event::WindowEvent::Focused(false);
-                    app.window_event(&self.window_target, window_id, event);
+                    app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                 },
                 MainEvent::ConfigChanged { .. } => {
                     let old_scale_factor = scale_factor(&self.android_app);
                     let scale_factor = scale_factor(&self.android_app);
                     if (scale_factor - old_scale_factor).abs() < f64::EPSILON {
                         let new_surface_size = Arc::new(Mutex::new(screen_size(&self.android_app)));
-                        let window_id = window::WindowId(WindowId);
                         let event = event::WindowEvent::ScaleFactorChanged {
                             surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(
                                 &new_surface_size,
@@ -210,7 +211,7 @@ impl EventLoop {
                             scale_factor,
                         };
 
-                        app.window_event(&self.window_target, window_id, event);
+                        app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                     }
                 },
                 MainEvent::LowMemory => {
@@ -286,17 +287,15 @@ impl EventLoop {
                 } else {
                     PhysicalSize::new(0, 0)
                 };
-                let window_id = window::WindowId(WindowId);
                 let event = event::WindowEvent::SurfaceResized(size);
-                app.window_event(&self.window_target, window_id, event);
+                app.window_event(&self.window_target, GLOBAL_WINDOW, event);
             }
 
             pending_redraw |= self.redraw_flag.get_and_reset();
             if pending_redraw {
                 pending_redraw = false;
-                let window_id = window::WindowId(WindowId);
                 let event = event::WindowEvent::RedrawRequested;
-                app.window_event(&self.window_target, window_id, event);
+                app.window_event(&self.window_target, GLOBAL_WINDOW, event);
             }
         }
 
@@ -315,7 +314,6 @@ impl EventLoop {
         let mut input_status = InputStatus::Handled;
         match event {
             InputEvent::MotionEvent(motion_event) => {
-                let window_id = window::WindowId(WindowId);
                 let device_id = Some(event::DeviceId(DeviceId(motion_event.device_id())));
                 let action = motion_event.action();
 
@@ -361,7 +359,7 @@ impl EventLoop {
                                         _ => event::PointerKind::Unknown,
                                     },
                                 };
-                                app.window_event(&self.window_target, window_id, event);
+                                app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                                 let event = event::WindowEvent::PointerButton {
                                     device_id,
                                     state: event::ElementState::Pressed,
@@ -375,7 +373,7 @@ impl EventLoop {
                                         _ => event::ButtonSource::Unknown(0),
                                     },
                                 };
-                                app.window_event(&self.window_target, window_id, event);
+                                app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                             },
                             MotionAction::Move => {
                                 let event = event::WindowEvent::PointerMoved {
@@ -390,7 +388,7 @@ impl EventLoop {
                                         _ => event::PointerSource::Unknown,
                                     },
                                 };
-                                app.window_event(&self.window_target, window_id, event);
+                                app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                             },
                             MotionAction::Up | MotionAction::PointerUp | MotionAction::Cancel => {
                                 if let MotionAction::Up | MotionAction::PointerUp = action {
@@ -407,7 +405,7 @@ impl EventLoop {
                                             _ => event::ButtonSource::Unknown(0),
                                         },
                                     };
-                                    app.window_event(&self.window_target, window_id, event);
+                                    app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                                 }
 
                                 let event = event::WindowEvent::PointerLeft {
@@ -422,7 +420,7 @@ impl EventLoop {
                                         _ => event::PointerKind::Unknown,
                                     },
                                 };
-                                app.window_event(&self.window_target, window_id, event);
+                                app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                             },
                             _ => unreachable!(),
                         }
@@ -453,7 +451,6 @@ impl EventLoop {
                             &mut self.combining_accent,
                         );
 
-                        let window_id = window::WindowId(WindowId);
                         let event = event::WindowEvent::KeyboardInput {
                             device_id: Some(event::DeviceId(DeviceId(key.device_id()))),
                             event: event::KeyEvent {
@@ -468,7 +465,7 @@ impl EventLoop {
                             is_synthetic: false,
                         };
 
-                        app.window_event(&self.window_target, window_id, event);
+                        app.window_event(&self.window_target, GLOBAL_WINDOW, event);
                     },
                 }
             },
@@ -732,19 +729,6 @@ impl OwnedDisplayHandle {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub(crate) struct WindowId;
-
-impl WindowId {
-    pub const fn into_raw(self) -> u64 {
-        0
-    }
-
-    pub const fn from_raw(_id: u64) -> Self {
-        Self
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DeviceId(i32);
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -824,8 +808,8 @@ impl rwh_06::HasWindowHandle for Window {
 }
 
 impl CoreWindow for Window {
-    fn id(&self) -> window::WindowId {
-        window::WindowId(WindowId)
+    fn id(&self) -> WindowId {
+        GLOBAL_WINDOW
     }
 
     fn primary_monitor(&self) -> Option<RootMonitorHandle> {

--- a/src/platform_impl/apple/appkit/app_state.rs
+++ b/src/platform_impl/apple/appkit/app_state.rs
@@ -10,12 +10,12 @@ use objc2_foundation::{MainThreadMarker, NSNotification};
 
 use super::super::event_handler::EventHandler;
 use super::event_loop::{stop_app_immediately, ActiveEventLoop, PanicInfo};
+use super::menu;
 use super::observer::{EventLoopWaker, RunLoop};
-use super::{menu, WindowId};
 use crate::application::ApplicationHandler;
 use crate::event::{StartCause, WindowEvent};
 use crate::event_loop::ControlFlow;
-use crate::window::WindowId as RootWindowId;
+use crate::window::WindowId;
 
 #[derive(Debug)]
 pub(super) struct AppState {
@@ -245,7 +245,7 @@ impl AppState {
         // -> Don't go back into the event handler when our callstack originates from there
         if !self.event_handler.in_use() {
             self.with_handler(|app, event_loop| {
-                app.window_event(event_loop, RootWindowId(window_id), WindowEvent::RedrawRequested);
+                app.window_event(event_loop, window_id, WindowEvent::RedrawRequested);
             });
 
             // `pump_events` will request to stop immediately _after_ dispatching RedrawRequested
@@ -357,7 +357,7 @@ impl AppState {
         let redraw = mem::take(&mut *self.pending_redraw.borrow_mut());
         for window_id in redraw {
             self.with_handler(|app, event_loop| {
-                app.window_event(event_loop, RootWindowId(window_id), WindowEvent::RedrawRequested);
+                app.window_event(event_loop, window_id, WindowEvent::RedrawRequested);
             });
         }
         self.with_handler(|app, event_loop| {

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -21,7 +21,7 @@ pub(crate) use self::event_loop::{
     PlatformSpecificEventLoopAttributes,
 };
 pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
-pub(crate) use self::window::{Window, WindowId};
+pub(crate) use self::window::Window;
 pub(crate) use self::window_delegate::PlatformSpecificWindowAttributes;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;

--- a/src/platform_impl/apple/appkit/view.rs
+++ b/src/platform_impl/apple/appkit/view.rs
@@ -31,7 +31,6 @@ use crate::event::{
 };
 use crate::keyboard::{Key, KeyCode, KeyLocation, ModifiersState, NamedKey};
 use crate::platform::macos::OptionAsAlt;
-use crate::window::WindowId as RootWindowId;
 
 #[derive(Debug)]
 struct CursorState {
@@ -842,7 +841,7 @@ impl WinitView {
     }
 
     fn queue_event(&self, event: WindowEvent) {
-        let window_id = RootWindowId(self.window().id());
+        let window_id = self.window().id();
         self.ivars().app_state.maybe_queue_with_handler(move |app, event_loop| {
             app.window_event(event_loop, window_id, event);
         });

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -12,7 +12,7 @@ use crate::error::RequestError;
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::window::{
     Cursor, Fullscreen, Icon, ImePurpose, Theme, UserAttentionType, Window as CoreWindow,
-    WindowAttributes, WindowButtons, WindowLevel,
+    WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
 pub(crate) struct Window {
@@ -92,7 +92,7 @@ impl rwh_06::HasWindowHandle for Window {
 
 impl CoreWindow for Window {
     fn id(&self) -> crate::window::WindowId {
-        self.maybe_wait_on_main(|delegate| crate::window::WindowId(delegate.id()))
+        self.maybe_wait_on_main(|delegate| delegate.id())
     }
 
     fn scale_factor(&self) -> f64 {
@@ -335,19 +335,6 @@ impl CoreWindow for Window {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(pub usize);
-
-impl WindowId {
-    pub const fn into_raw(self) -> u64 {
-        self.0 as u64
-    }
-
-    pub const fn from_raw(id: u64) -> Self {
-        Self(id as usize)
-    }
-}
-
 declare_class!(
     #[derive(Debug)]
     pub struct WinitWindow;
@@ -378,6 +365,6 @@ declare_class!(
 
 impl WinitWindow {
     pub(super) fn id(&self) -> WindowId {
-        WindowId(self as *const Self as usize)
+        WindowId::from_raw(self as *const Self as usize)
     }
 }

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -33,14 +33,14 @@ use super::monitor::{self, flip_window_screen_coordinates, get_display_id};
 use super::observer::RunLoop;
 use super::view::WinitView;
 use super::window::WinitWindow;
-use super::{ffi, Fullscreen, MonitorHandle, WindowId};
+use super::{ffi, Fullscreen, MonitorHandle};
 use crate::dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{NotSupportedError, RequestError};
 use crate::event::{SurfaceSizeWriter, WindowEvent};
 use crate::platform::macos::{OptionAsAlt, WindowExtMacOS};
 use crate::window::{
     Cursor, CursorGrabMode, Icon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
-    WindowAttributes, WindowButtons, WindowId as RootWindowId, WindowLevel,
+    WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -819,7 +819,7 @@ impl WindowDelegate {
     }
 
     pub(crate) fn queue_event(&self, event: WindowEvent) {
-        let window_id = RootWindowId(self.window().id());
+        let window_id = self.window().id();
         self.ivars().app_state.maybe_queue_with_handler(move |app, event_loop| {
             app.window_event(event_loop, window_id, event);
         });

--- a/src/platform_impl/apple/uikit/app_state.rs
+++ b/src/platform_impl/apple/uikit/app_state.rs
@@ -29,7 +29,6 @@ use crate::application::ApplicationHandler;
 use crate::dpi::PhysicalSize;
 use crate::event::{Event, StartCause, SurfaceSizeWriter, WindowEvent};
 use crate::event_loop::ControlFlow;
-use crate::window::WindowId as RootWindowId;
 
 macro_rules! bug {
     ($($msg:tt)*) => {
@@ -599,7 +598,7 @@ pub(crate) fn send_occluded_event_for_all_windows(application: &UIApplication, o
                 &*ptr
             };
             events.push(EventWrapper::StaticEvent(Event::WindowEvent {
-                window_id: RootWindowId(window.id()),
+                window_id: window.id(),
                 event: WindowEvent::Occluded(occluded),
             }));
         }
@@ -626,7 +625,7 @@ pub fn handle_main_events_cleared(mtm: MainThreadMarker) {
         .into_iter()
         .map(|window| {
             EventWrapper::StaticEvent(Event::WindowEvent {
-                window_id: RootWindowId(window.id()),
+                window_id: window.id(),
                 event: WindowEvent::RedrawRequested,
             })
         })
@@ -655,7 +654,7 @@ pub(crate) fn terminated(application: &UIApplication) {
                 &*ptr
             };
             events.push(EventWrapper::StaticEvent(Event::WindowEvent {
-                window_id: RootWindowId(window.id()),
+                window_id: window.id(),
                 event: WindowEvent::Destroyed,
             }));
         }
@@ -673,7 +672,7 @@ fn handle_hidpi_proxy(mtm: MainThreadMarker, event: ScaleFactorChanged) {
     let ScaleFactorChanged { suggested_size, scale_factor, window } = event;
     let new_surface_size = Arc::new(Mutex::new(suggested_size));
     let event = Event::WindowEvent {
-        window_id: RootWindowId(window.id()),
+        window_id: window.id(),
         event: WindowEvent::ScaleFactorChanged {
             scale_factor,
             surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -14,7 +14,7 @@ pub(crate) use self::event_loop::{
     PlatformSpecificEventLoopAttributes,
 };
 pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
-pub(crate) use self::window::{PlatformSpecificWindowAttributes, Window, WindowId};
+pub(crate) use self::window::{PlatformSpecificWindowAttributes, Window};
 pub(crate) use crate::cursor::{
     NoCustomCursor as PlatformCustomCursor, NoCustomCursor as PlatformCustomCursorSource,
 };

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -22,7 +22,7 @@ use crate::event::{
 };
 use crate::keyboard::{Key, KeyCode, KeyLocation, NamedKey, NativeKeyCode, PhysicalKey};
 use crate::platform_impl::KeyEventExtra;
-use crate::window::{WindowAttributes, WindowId as RootWindowId};
+use crate::window::WindowAttributes;
 
 pub struct WinitViewState {
     pinch_gesture_recognizer: RefCell<Option<Retained<UIPinchGestureRecognizer>>>,
@@ -58,7 +58,7 @@ declare_class!(
             app_state::handle_nonuser_event(
                 mtm,
                 EventWrapper::StaticEvent(Event::WindowEvent {
-                    window_id: RootWindowId(window.id()),
+                    window_id: window.id(),
                     event: WindowEvent::RedrawRequested,
                 }),
             );
@@ -93,7 +93,7 @@ declare_class!(
             app_state::handle_nonuser_event(
                 mtm,
                 EventWrapper::StaticEvent(Event::WindowEvent {
-                    window_id: RootWindowId(window.id()),
+                    window_id: window.id(),
                     event: WindowEvent::SurfaceResized(size),
                 }),
             );
@@ -132,7 +132,7 @@ declare_class!(
                 width: screen_frame.size.width as f64,
                 height: screen_frame.size.height as f64,
             };
-            let window_id = RootWindowId(window.id());
+            let window_id = window.id();
             app_state::handle_nonuser_events(
                 mtm,
                 std::iter::once(EventWrapper::ScaleFactorChanged(
@@ -197,7 +197,7 @@ declare_class!(
             };
 
             let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
-                window_id: RootWindowId(window.id()),
+                window_id: window.id(),
                 event: WindowEvent::PinchGesture {
                     device_id: None,
                     delta: delta as f64,
@@ -215,7 +215,7 @@ declare_class!(
 
             if recognizer.state() == UIGestureRecognizerState::Ended {
                 let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
-                    window_id: RootWindowId(window.id()),
+                    window_id: window.id(),
                     event: WindowEvent::DoubleTapGesture {
                         device_id: None,
                     },
@@ -257,7 +257,7 @@ declare_class!(
 
             // Make delta negative to match macos, convert to degrees
             let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
-                window_id: RootWindowId(window.id()),
+                window_id: window.id(),
                 event: WindowEvent::RotationGesture {
                     device_id: None,
                     delta: -delta.to_degrees() as _,
@@ -308,7 +308,7 @@ declare_class!(
 
 
             let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
-                window_id: RootWindowId(window.id()),
+                window_id: window.id(),
                 event: WindowEvent::PanGesture {
                     device_id: None,
                     delta: PhysicalPosition::new(dx as _, dy as _),
@@ -512,7 +512,7 @@ impl WinitView {
                     scale_factor as f64,
                 )
             };
-            let window_id = RootWindowId(window.id());
+            let window_id = window.id();
             let finger_id = RootFingerId(FingerId(touch_id));
 
             match phase {
@@ -597,7 +597,7 @@ impl WinitView {
 
     fn handle_insert_text(&self, text: &NSString) {
         let window = self.window().unwrap();
-        let window_id = RootWindowId(window.id());
+        let window_id = window.id();
         let mtm = MainThreadMarker::new().unwrap();
         // send individual events for each character
         app_state::handle_nonuser_events(
@@ -635,7 +635,7 @@ impl WinitView {
 
     fn handle_delete_backward(&self) {
         let window = self.window().unwrap();
-        let window_id = RootWindowId(window.id());
+        let window_id = window.id();
         let mtm = MainThreadMarker::new().unwrap();
         app_state::handle_nonuser_events(
             mtm,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -108,19 +108,6 @@ pub(crate) static X11_BACKEND: Lazy<Mutex<Result<Arc<XConnection>, XNotSupported
     Lazy::new(|| Mutex::new(XConnection::new(Some(x_error_callback)).map(Arc::new)));
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(u64);
-
-impl WindowId {
-    pub const fn into_raw(self) -> u64 {
-        self.0
-    }
-
-    pub const fn from_raw(id: u64) -> Self {
-        Self(id)
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DeviceId {
     #[cfg(x11_platform)]
     X(x11::DeviceId),

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -312,13 +312,12 @@ impl EventLoop {
                 let old_physical_size = physical_size;
 
                 let new_surface_size = Arc::new(Mutex::new(physical_size));
-                let root_window_id = crate::window::WindowId(window_id);
                 let event = WindowEvent::ScaleFactorChanged {
                     scale_factor,
                     surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),
                 };
 
-                app.window_event(&self.active_event_loop, root_window_id, event);
+                app.window_event(&self.active_event_loop, window_id, event);
 
                 let physical_size = *new_surface_size.lock().unwrap();
                 drop(new_surface_size);
@@ -361,13 +360,11 @@ impl EventLoop {
                     size
                 });
 
-                let window_id = crate::window::WindowId(window_id);
                 let event = WindowEvent::SurfaceResized(physical_size);
                 app.window_event(&self.active_event_loop, window_id, event);
             }
 
             if compositor_update.close_window {
-                let window_id = crate::window::WindowId(window_id);
                 app.window_event(&self.active_event_loop, window_id, WindowEvent::CloseRequested);
             }
         }
@@ -437,8 +434,7 @@ impl EventLoop {
             });
 
             if let Some(event) = event {
-                let window_id = crate::window::WindowId(*window_id);
-                app.window_event(&self.active_event_loop, window_id, event);
+                app.window_event(&self.active_event_loop, *window_id, event);
             }
         }
 

--- a/src/platform_impl/linux/wayland/event_loop/sink.rs
+++ b/src/platform_impl/linux/wayland/event_loop/sink.rs
@@ -2,9 +2,8 @@
 
 use std::vec::Drain;
 
-use super::WindowId;
 use crate::event::{DeviceEvent, Event, WindowEvent};
-use crate::window::WindowId as RootWindowId;
+use crate::window::WindowId;
 
 /// An event loop's sink to deliver events from the Wayland event callbacks
 /// to the winit's user.
@@ -33,7 +32,7 @@ impl EventSink {
     /// Add new window event to a queue.
     #[inline]
     pub fn push_window_event(&mut self, event: WindowEvent, window_id: WindowId) {
-        self.window_events.push(Event::WindowEvent { event, window_id: RootWindowId(window_id) });
+        self.window_events.push(Event::WindowEvent { event, window_id });
     }
 
     #[inline]

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -8,7 +8,7 @@ pub use window::Window;
 
 pub(super) use crate::cursor::OnlyCursorImage as CustomCursor;
 use crate::dpi::{LogicalSize, PhysicalSize};
-pub use crate::platform_impl::platform::WindowId;
+use crate::window::WindowId;
 
 mod event_loop;
 mod output;
@@ -34,7 +34,7 @@ impl FingerId {
 /// Get the WindowId out of the surface.
 #[inline]
 fn make_wid(surface: &WlSurface) -> WindowId {
-    WindowId(surface.id().as_ptr() as u64)
+    WindowId::from_raw(surface.id().as_ptr() as usize)
 }
 
 /// The default routine does floor, but we need round on Wayland.

--- a/src/platform_impl/linux/wayland/types/xdg_activation.rs
+++ b/src/platform_impl/linux/wayland/types/xdg_activation.rs
@@ -14,8 +14,7 @@ use sctk::reexports::protocols::xdg::activation::v1::client::xdg_activation_v1::
 
 use crate::event_loop::AsyncRequestSerial;
 use crate::platform_impl::wayland::state::WinitState;
-use crate::platform_impl::WindowId;
-use crate::window::ActivationToken;
+use crate::window::{ActivationToken, WindowId};
 
 pub struct XdgActivationState {
     xdg_activation: XdgActivationV1,

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -16,7 +16,7 @@ use super::event_loop::sink::EventSink;
 use super::output::MonitorHandle;
 use super::state::WinitState;
 use super::types::xdg_activation::XdgActivationTokenData;
-use super::{ActiveEventLoop, WindowId};
+use super::ActiveEventLoop;
 use crate::dpi::{LogicalSize, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{NotSupportedError, RequestError};
 use crate::event::{Ime, WindowEvent};
@@ -25,8 +25,8 @@ use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::platform_impl::{Fullscreen, MonitorHandle as PlatformMonitorHandle};
 use crate::window::{
     Cursor, CursorGrabMode, Fullscreen as CoreFullscreen, ImePurpose, ResizeDirection, Theme,
-    UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons,
-    WindowId as CoreWindowId, WindowLevel,
+    UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
+    WindowLevel,
 };
 
 pub(crate) mod state;
@@ -273,8 +273,8 @@ impl rwh_06::HasDisplayHandle for Window {
 }
 
 impl CoreWindow for Window {
-    fn id(&self) -> CoreWindowId {
-        CoreWindowId(self.window_id)
+    fn id(&self) -> WindowId {
+        self.window_id
     }
 
     fn request_redraw(&self) {

--- a/src/platform_impl/linux/wayland/window/state.rs
+++ b/src/platform_impl/linux/wayland/window/state.rs
@@ -38,8 +38,8 @@ use crate::platform_impl::wayland::seat::{
 use crate::platform_impl::wayland::state::{WindowCompositorUpdate, WinitState};
 use crate::platform_impl::wayland::types::cursor::{CustomCursor, SelectedCursor};
 use crate::platform_impl::wayland::types::kwin_blur::KWinBlurManager;
-use crate::platform_impl::{PlatformCustomCursor, WindowId};
-use crate::window::{CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme};
+use crate::platform_impl::PlatformCustomCursor;
+use crate::window::{CursorGrabMode, CursorIcon, ImePurpose, ResizeDirection, Theme, WindowId};
 
 #[cfg(feature = "sctk-adwaita")]
 pub type WinitFrame = sctk_adwaita::AdwaitaFrame<WinitState>;

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -329,7 +329,7 @@ impl EventProcessor {
         F: Fn(&Arc<UnownedWindow>) -> Ret,
     {
         let mut deleted = false;
-        let window_id = WindowId(window_id as _);
+        let window_id = WindowId::from_raw(window_id as _);
         let result = self
             .target
             .windows
@@ -798,7 +798,7 @@ impl EventProcessor {
 
         // In the event that the window's been destroyed without being dropped first, we
         // cleanup again here.
-        self.target.windows.borrow_mut().remove(&WindowId(window as _));
+        self.target.windows.borrow_mut().remove(&WindowId::from_raw(window as _));
 
         // Since all XIM stuff needs to happen from the same thread, we destroy the input
         // context here instead of when dropping the window.

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -100,21 +100,6 @@ impl TimeSocket {
 pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct WindowId {
-    fd: u64,
-}
-
-impl WindowId {
-    pub const fn into_raw(self) -> u64 {
-        self.fd
-    }
-
-    pub const fn from_raw(id: u64) -> Self {
-        Self { fd: id }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct DeviceId;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -1,4 +1,4 @@
-use super::{backend, window, HasMonitorPermissionFuture, MonitorPermissionFuture};
+use super::{backend, HasMonitorPermissionFuture, MonitorPermissionFuture};
 use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, NotSupportedError};
 use crate::event::Event;

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -49,7 +49,7 @@ struct Execution {
     suspended: Cell<bool>,
     event_loop_recreation: Cell<bool>,
     events: RefCell<VecDeque<EventWrapper>>,
-    id: Cell<u64>,
+    id: Cell<usize>,
     window: web_sys::Window,
     navigator: Navigator,
     document: Document,
@@ -438,7 +438,7 @@ impl Shared {
 
     // Generate a strictly increasing ID
     // This is used to differentiate windows when handling events
-    pub fn generate_id(&self) -> u64 {
+    pub fn generate_id(&self) -> usize {
         let id = self.0.id.get();
         self.0.id.set(id.checked_add(1).expect("exhausted `WindowId`"));
 

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -48,5 +48,5 @@ pub(crate) use self::monitor::{
     VideoModeHandle,
 };
 use self::web_sys as backend;
-pub use self::window::{PlatformSpecificWindowAttributes, Window, WindowId};
+pub use self::window::{PlatformSpecificWindowAttributes, Window};
 pub(crate) use crate::icon::NoIcon as PlatformIcon;

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -14,7 +14,6 @@ use web_sys::{
 use super::super::cursor::CursorHandler;
 use super::super::event::DeviceId;
 use super::super::main_thread::MainThreadMarker;
-use super::super::WindowId;
 use super::animation_frame::AnimationFrameHandler;
 use super::event_handle::EventListenerHandle;
 use super::intersection_handle::IntersectionObserverHandle;
@@ -28,7 +27,7 @@ use crate::event::{
 };
 use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
 use crate::platform_impl::Fullscreen;
-use crate::window::{WindowAttributes, WindowId as RootWindowId};
+use crate::window::{WindowAttributes, WindowId};
 
 #[allow(dead_code)]
 pub struct Canvas {
@@ -490,7 +489,7 @@ impl Canvas {
         let new_size = {
             let new_size = Arc::new(Mutex::new(current_size));
             event_handler(crate::event::Event::WindowEvent {
-                window_id: RootWindowId(self.id),
+                window_id: self.id,
                 event: crate::event::WindowEvent::ScaleFactorChanged {
                     scale_factor: scale,
                     surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_size)),
@@ -518,7 +517,7 @@ impl Canvas {
             // Then we at least send a resized event.
             self.set_old_size(new_size);
             runner.send_event(crate::event::Event::WindowEvent {
-                window_id: RootWindowId(self.id),
+                window_id: self.id,
                 event: crate::event::WindowEvent::SurfaceResized(new_size),
             })
         }

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -14,7 +14,7 @@ use crate::icon::Icon;
 use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::window::{
     Cursor, CursorGrabMode, Fullscreen as RootFullscreen, ImePurpose, ResizeDirection, Theme,
-    UserAttentionType, Window as RootWindow, WindowAttributes, WindowButtons, WindowId as RootWI,
+    UserAttentionType, Window as RootWindow, WindowAttributes, WindowButtons, WindowId,
     WindowLevel,
 };
 
@@ -53,7 +53,7 @@ impl Window {
         target.register(&canvas, id);
 
         let runner = target.runner.clone();
-        let destroy_fn = Box::new(move || runner.notify_destroy_window(RootWI(id)));
+        let destroy_fn = Box::new(move || runner.notify_destroy_window(id));
 
         let inner = Inner {
             id,
@@ -65,7 +65,7 @@ impl Window {
 
         let canvas = Rc::downgrade(&inner.canvas);
         let (dispatcher, runner) = Dispatcher::new(target.runner.main_thread(), inner);
-        target.runner.add_canvas(RootWI(id), canvas, runner);
+        target.runner.add_canvas(id, canvas, runner);
 
         Ok(Window { inner: dispatcher })
     }
@@ -91,8 +91,8 @@ impl Window {
 }
 
 impl RootWindow for Window {
-    fn id(&self) -> RootWI {
-        RootWI(self.inner.queue(|inner| inner.id))
+    fn id(&self) -> WindowId {
+        self.inner.queue(|inner| inner.id)
     }
 
     fn scale_factor(&self) -> f64 {
@@ -429,19 +429,6 @@ impl Drop for Inner {
         }
     }
 }
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(pub(crate) u64);
-
-impl WindowId {
-    pub const fn into_raw(self) -> u64 {
-        self.0
-    }
-
-    pub const fn from_raw(id: u64) -> Self {
-        Self(id)
-    }
-}
-
 #[derive(Clone, Debug)]
 pub struct PlatformSpecificWindowAttributes {
     pub(crate) canvas: Option<Arc<MainThreadSafe<backend::RawCanvasType>>>,

--- a/src/platform_impl/windows/drop_handler.rs
+++ b/src/platform_impl/windows/drop_handler.rs
@@ -15,8 +15,7 @@ use crate::event::Event;
 use crate::platform_impl::platform::definitions::{
     IDataObjectVtbl, IDropTarget, IDropTargetVtbl, IUnknownVtbl,
 };
-use crate::platform_impl::platform::WindowId;
-use crate::window::WindowId as RootWindowId;
+use crate::window::WindowId;
 
 #[repr(C)]
 pub struct FileDropHandlerData {
@@ -86,7 +85,7 @@ impl FileDropHandler {
         let hdrop = unsafe {
             Self::iterate_filenames(pDataObj, |filename| {
                 drop_handler.send_event(Event::WindowEvent {
-                    window_id: RootWindowId(WindowId(drop_handler.window)),
+                    window_id: WindowId::from_raw(drop_handler.window as usize),
                     event: HoveredFile(filename),
                 });
             })
@@ -120,7 +119,7 @@ impl FileDropHandler {
         let drop_handler = unsafe { Self::from_interface(this) };
         if drop_handler.hovered_is_valid {
             drop_handler.send_event(Event::WindowEvent {
-                window_id: RootWindowId(WindowId(drop_handler.window)),
+                window_id: WindowId::from_raw(drop_handler.window as usize),
                 event: HoveredFileCancelled,
             });
         }
@@ -140,7 +139,7 @@ impl FileDropHandler {
         let hdrop = unsafe {
             Self::iterate_filenames(pDataObj, |filename| {
                 drop_handler.send_event(Event::WindowEvent {
-                    window_id: RootWindowId(WindowId(drop_handler.window)),
+                    window_id: WindowId::from_raw(drop_handler.window as usize),
                     event: DroppedFile(filename),
                 });
             })

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -53,7 +53,7 @@ pub(crate) enum RunnerState {
 
 enum BufferedEvent {
     Event(Event),
-    ScaleFactorChanged(WindowId, f64, PhysicalSize<u32>),
+    ScaleFactorChanged(HWND, f64, PhysicalSize<u32>),
 }
 
 impl EventLoopRunner {
@@ -360,7 +360,7 @@ impl BufferedEvent {
                 event: WindowEvent::ScaleFactorChanged { scale_factor, surface_size_writer },
                 window_id,
             } => BufferedEvent::ScaleFactorChanged(
-                window_id,
+                window_id.into_raw() as HWND,
                 scale_factor,
                 *surface_size_writer.new_surface_size.upgrade().unwrap().lock().unwrap(),
             ),
@@ -371,10 +371,10 @@ impl BufferedEvent {
     pub fn dispatch_event(self, dispatch: impl FnOnce(Event)) {
         match self {
             Self::Event(event) => dispatch(event),
-            Self::ScaleFactorChanged(window_id, scale_factor, new_surface_size) => {
+            Self::ScaleFactorChanged(window, scale_factor, new_surface_size) => {
                 let user_new_surface_size = Arc::new(Mutex::new(new_surface_size));
                 dispatch(Event::WindowEvent {
-                    window_id,
+                    window_id: WindowId::from_raw(window as usize),
                     event: WindowEvent::ScaleFactorChanged {
                         scale_factor,
                         surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(
@@ -388,12 +388,11 @@ impl BufferedEvent {
 
                 if surface_size != new_surface_size {
                     let window_flags = unsafe {
-                        let userdata =
-                            get_window_long(window_id.0.into(), GWL_USERDATA) as *mut WindowData;
+                        let userdata = get_window_long(window, GWL_USERDATA) as *mut WindowData;
                         (*userdata).window_state_lock().window_flags
                     };
 
-                    window_flags.set_size((window_id.0).0, surface_size);
+                    window_flags.set_size(window, surface_size);
                 }
             },
         }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -101,27 +101,6 @@ pub struct KeyEventExtra {
     pub key_without_modifiers: Key,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(HWND);
-unsafe impl Send for WindowId {}
-unsafe impl Sync for WindowId {}
-
-impl WindowId {
-    pub const fn into_raw(self) -> u64 {
-        self.0 as u64
-    }
-
-    pub const fn from_raw(id: u64) -> Self {
-        Self(id as HWND)
-    }
-}
-
-impl From<WindowId> for HWND {
-    fn from(window_id: WindowId) -> Self {
-        window_id.0
-    }
-}
-
 #[inline(always)]
 const fn get_xbutton_wparam(x: u32) -> u16 {
     hiword(x)

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -66,11 +66,11 @@ use crate::platform_impl::platform::keyboard::KeyEventBuilder;
 use crate::platform_impl::platform::window_state::{
     CursorFlags, SavedWindow, WindowFlags, WindowState,
 };
-use crate::platform_impl::platform::{monitor, util, Fullscreen, SelectedCursor, WindowId};
+use crate::platform_impl::platform::{monitor, util, Fullscreen, SelectedCursor};
 use crate::window::{
     CursorGrabMode, Fullscreen as CoreFullscreen, ImePurpose, ResizeDirection, Theme,
-    UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons,
-    WindowId as CoreWindowId, WindowLevel,
+    UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
+    WindowLevel,
 };
 
 /// The Win32 implementation of the main `Window` object.
@@ -696,8 +696,8 @@ impl CoreWindow for Window {
         Ok(())
     }
 
-    fn id(&self) -> CoreWindowId {
-        CoreWindowId(WindowId(self.hwnd()))
+    fn id(&self) -> WindowId {
+        WindowId::from_raw(self.hwnd() as usize)
     }
 
     fn set_minimized(&self, minimized: bool) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -11,7 +11,7 @@ use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::RequestError;
 pub use crate::icon::{BadIcon, Icon};
 use crate::monitor::{MonitorHandle, VideoModeHandle};
-use crate::platform_impl::{self, PlatformSpecificWindowAttributes};
+use crate::platform_impl::PlatformSpecificWindowAttributes;
 use crate::utils::AsAny;
 
 /// Identifier of a window. Unique for each window.
@@ -21,21 +21,21 @@ use crate::utils::AsAny;
 /// Whenever you receive an event specific to a window, this event contains a `WindowId` which you
 /// can then compare to the ids of your windows.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct WindowId(pub(crate) platform_impl::WindowId);
+pub struct WindowId(usize);
 
 impl WindowId {
     /// Convert the `WindowId` into the underlying integer.
     ///
     /// This is useful if you need to pass the ID across an FFI boundary, or store it in an atomic.
-    pub const fn into_raw(self) -> u64 {
-        self.0.into_raw()
+    pub const fn into_raw(self) -> usize {
+        self.0
     }
 
     /// Construct a `WindowId` from the underlying integer.
     ///
     /// This should only be called with integers returned from [`WindowId::into_raw`].
-    pub const fn from_raw(id: u64) -> Self {
-        Self(platform_impl::WindowId::from_raw(id))
+    pub const fn from_raw(id: usize) -> Self {
+        Self(id)
     }
 }
 


### PR DESCRIPTION
WindowId is a window _identifier_, and as such doesn't store anything (unlike a _handle_). So we can safely make only be defined once, in the core crate.

There are a few backends where we still use `into_raw` internally; I consider these patterns discouraged, we should not be passing around important state in the window id.

Builds upon #3864.