### PR TITLE
Update `smol_str` to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ cursor-icon = "1.1.0"
 dpi = { version = "0.1.1", path = "dpi" }
 rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"], optional = true }
 serde = { workspace = true, optional = true }
-smol_str = "0.2.0"
+smol_str = "0.3.1"
 tracing = { version = "0.1.40", default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
- [X] Tested on all platforms changed
  - Tested on my own machine (Windows 10 Intel x64)
  - Have _not_ tested on other platforms, but am not expecting issues as [`smol_str` 0.2 to 0.3](https://github.com/rust-analyzer/smol_str/blob/master/CHANGELOG.md#030---2024-09-04) was a relatively minor set of changes.
- [X] ~~Added an entry to the `changelog` module if knowledge of this change could be valuable to users~~
- [X] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [X] ~~Created or updated an example program if it would help users understand this functionality~~
- [X] ~~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~~

# Objective

Update `smol_str` to 0.3.1, allowing other projects to update as well.

## Solution

Updated `smol_str` to 0.3.1 with no other changes required.

## Motivation

Bevy would like to update to the latest version but is [blocked](https://github.com/bevyengine/bevy/pull/15113) due to `winit` 
