### PR TITLE
iOS: Never queue application-level events

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -163,6 +163,7 @@ changelog entry.
 - On X11, use bottom-right corner for IME hotspot in `Window::set_ime_cursor_area`.
 - On macOS and iOS, no longer emit `ScaleFactorChanged` upon window creation.
 - On macOS, no longer emit `Focused` upon window creation.
+- On iOS, emit more events immediately, instead of queuing them.
 
 ### Removed
 

--- a/src/platform_impl/apple/event_handler.rs
+++ b/src/platform_impl/apple/event_handler.rs
@@ -106,7 +106,6 @@ impl EventHandler {
         self.inner.try_borrow().is_err()
     }
 
-    #[cfg(target_os = "macos")]
     pub(crate) fn ready(&self) -> bool {
         matches!(self.inner.try_borrow().as_deref(), Ok(Some(_)))
     }

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -23,11 +23,10 @@ use objc2_ui_kit::{
 use rwh_06::HasDisplayHandle;
 
 use super::super::notification_center::create_observer;
-use super::app_state::{send_occluded_event_for_all_windows, AppState, EventWrapper};
+use super::app_state::{send_occluded_event_for_all_windows, AppState};
 use super::{app_state, monitor, MonitorHandle};
 use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, NotSupportedError, RequestError};
-use crate::event::Event;
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
     EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider,
@@ -174,17 +173,13 @@ impl EventLoop {
             &center,
             // `applicationDidBecomeActive:`
             unsafe { UIApplicationDidBecomeActiveNotification },
-            move |_| {
-                app_state::handle_nonuser_event(mtm, EventWrapper::StaticEvent(Event::Resumed));
-            },
+            move |_| app_state::handle_resumed(mtm),
         );
         let _will_resign_active_observer = create_observer(
             &center,
             // `applicationWillResignActive:`
             unsafe { UIApplicationWillResignActiveNotification },
-            move |_| {
-                app_state::handle_nonuser_event(mtm, EventWrapper::StaticEvent(Event::Suspended));
-            },
+            move |_| app_state::handle_suspended(mtm),
         );
         let _will_enter_foreground_observer = create_observer(
             &center,
@@ -231,12 +226,7 @@ impl EventLoop {
             &center,
             // `applicationDidReceiveMemoryWarning:`
             unsafe { UIApplicationDidReceiveMemoryWarningNotification },
-            move |_| {
-                app_state::handle_nonuser_event(
-                    mtm,
-                    EventWrapper::StaticEvent(Event::MemoryWarning),
-                );
-            },
+            move |_| app_state::handle_memory_warning(mtm),
         );
 
         Ok(EventLoop {

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -17,8 +17,8 @@ use super::app_state::{self, EventWrapper};
 use super::window::WinitUIWindow;
 use crate::dpi::PhysicalPosition;
 use crate::event::{
-    ButtonSource, ElementState, Event, FingerId, Force, KeyEvent, PointerKind, PointerSource,
-    TouchPhase, WindowEvent,
+    ButtonSource, ElementState, FingerId, Force, KeyEvent, PointerKind, PointerSource, TouchPhase,
+    WindowEvent,
 };
 use crate::keyboard::{Key, KeyCode, KeyLocation, NamedKey, NativeKeyCode, PhysicalKey};
 use crate::platform_impl::KeyEventExtra;
@@ -60,10 +60,10 @@ declare_class!(
             let window = self.window().unwrap();
             app_state::handle_nonuser_event(
                 mtm,
-                EventWrapper::StaticEvent(Event::WindowEvent {
+                EventWrapper::Window {
                     window_id: window.id(),
                     event: WindowEvent::RedrawRequested,
-                }),
+                },
             );
             let _: () = unsafe { msg_send![super(self), drawRect: rect] };
         }
@@ -84,10 +84,10 @@ declare_class!(
             let window = self.window().unwrap();
             app_state::handle_nonuser_event(
                 mtm,
-                EventWrapper::StaticEvent(Event::WindowEvent {
+                EventWrapper::Window {
                     window_id: window.id(),
                     event: WindowEvent::SurfaceResized(size),
-                }),
+                },
             );
         }
 
@@ -131,12 +131,11 @@ declare_class!(
                         suggested_size: size.to_physical(scale_factor),
                     },
                 ))
-                .chain(std::iter::once(EventWrapper::StaticEvent(
-                    Event::WindowEvent {
+                .chain(std::iter::once(EventWrapper::Window {
                         window_id,
                         event: WindowEvent::SurfaceResized(size.to_physical(scale_factor)),
                     },
-                ))),
+                )),
             );
         }
 
@@ -192,14 +191,14 @@ declare_class!(
                 state => panic!("unexpected recognizer state: {state:?}"),
             };
 
-            let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
+            let gesture_event = EventWrapper::Window {
                 window_id: window.id(),
                 event: WindowEvent::PinchGesture {
                     device_id: None,
                     delta: delta as f64,
                     phase,
                 },
-            });
+            };
 
             let mtm = MainThreadMarker::new().unwrap();
             app_state::handle_nonuser_event(mtm, gesture_event);
@@ -210,12 +209,12 @@ declare_class!(
             let window = self.window().unwrap();
 
             if recognizer.state() == UIGestureRecognizerState::Ended {
-                let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
+                let gesture_event = EventWrapper::Window {
                     window_id: window.id(),
                     event: WindowEvent::DoubleTapGesture {
                         device_id: None,
                     },
-                });
+                };
 
                 let mtm = MainThreadMarker::new().unwrap();
                 app_state::handle_nonuser_event(mtm, gesture_event);
@@ -252,14 +251,14 @@ declare_class!(
             };
 
             // Make delta negative to match macos, convert to degrees
-            let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
+            let gesture_event = EventWrapper::Window {
                 window_id: window.id(),
                 event: WindowEvent::RotationGesture {
                     device_id: None,
                     delta: -delta.to_degrees() as _,
                     phase,
                 },
-            });
+            };
 
             let mtm = MainThreadMarker::new().unwrap();
             app_state::handle_nonuser_event(mtm, gesture_event);
@@ -303,14 +302,14 @@ declare_class!(
             };
 
 
-            let gesture_event = EventWrapper::StaticEvent(Event::WindowEvent {
+            let gesture_event = EventWrapper::Window {
                 window_id: window.id(),
                 event: WindowEvent::PanGesture {
                     device_id: None,
                     delta: PhysicalPosition::new(dx as _, dy as _),
                     phase,
                 },
-            });
+            };
 
             let mtm = MainThreadMarker::new().unwrap();
             app_state::handle_nonuser_event(mtm, gesture_event);
@@ -538,7 +537,7 @@ impl WinitView {
                         }
                     };
 
-                    touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
+                    touch_events.push(EventWrapper::Window {
                         window_id,
                         event: WindowEvent::PointerEntered {
                             device_id: None,
@@ -550,8 +549,8 @@ impl WinitView {
                                 PointerKind::Touch(finger_id)
                             },
                         },
-                    }));
-                    touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
+                    });
+                    touch_events.push(EventWrapper::Window {
                         window_id,
                         event: WindowEvent::PointerButton {
                             device_id: None,
@@ -564,7 +563,7 @@ impl WinitView {
                                 ButtonSource::Touch { finger_id, force }
                             },
                         },
-                    }));
+                    });
                 },
                 UITouchPhase::Moved => {
                     let (primary, source) = if let UITouchType::Pencil = touch_type {
@@ -576,7 +575,7 @@ impl WinitView {
                         })
                     };
 
-                    touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
+                    touch_events.push(EventWrapper::Window {
                         window_id,
                         event: WindowEvent::PointerMoved {
                             device_id: None,
@@ -584,7 +583,7 @@ impl WinitView {
                             position,
                             source,
                         },
-                    }));
+                    });
                 },
                 // 2 is UITouchPhase::Stationary and is not expected here
                 UITouchPhase::Ended | UITouchPhase::Cancelled => {
@@ -600,7 +599,7 @@ impl WinitView {
                     };
 
                     if let UITouchPhase::Ended = phase {
-                        touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
+                        touch_events.push(EventWrapper::Window {
                             window_id,
                             event: WindowEvent::PointerButton {
                                 device_id: None,
@@ -613,10 +612,10 @@ impl WinitView {
                                     ButtonSource::Touch { finger_id, force }
                                 },
                             },
-                        }));
+                        });
                     }
 
-                    touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
+                    touch_events.push(EventWrapper::Window {
                         window_id,
                         event: WindowEvent::PointerLeft {
                             device_id: None,
@@ -628,7 +627,7 @@ impl WinitView {
                                 PointerKind::Touch(finger_id)
                             },
                         },
-                    }));
+                    });
                 },
                 _ => panic!("unexpected touch phase: {phase:?}"),
             }
@@ -647,29 +646,25 @@ impl WinitView {
             text.to_string().chars().flat_map(|c| {
                 let text = smol_str::SmolStr::from_iter([c]);
                 // Emit both press and release events
-                [ElementState::Pressed, ElementState::Released].map(|state| {
-                    EventWrapper::StaticEvent(Event::WindowEvent {
-                        window_id,
-                        event: WindowEvent::KeyboardInput {
-                            event: KeyEvent {
-                                text: if state == ElementState::Pressed {
-                                    Some(text.clone())
-                                } else {
-                                    None
-                                },
-                                state,
-                                location: KeyLocation::Standard,
-                                repeat: false,
-                                logical_key: Key::Character(text.clone()),
-                                physical_key: PhysicalKey::Unidentified(
-                                    NativeKeyCode::Unidentified,
-                                ),
-                                platform_specific: KeyEventExtra {},
+                [ElementState::Pressed, ElementState::Released].map(|state| EventWrapper::Window {
+                    window_id,
+                    event: WindowEvent::KeyboardInput {
+                        device_id: None,
+                        event: KeyEvent {
+                            text: if state == ElementState::Pressed {
+                                Some(text.clone())
+                            } else {
+                                None
                             },
-                            is_synthetic: false,
-                            device_id: None,
+                            state,
+                            location: KeyLocation::Standard,
+                            repeat: false,
+                            logical_key: Key::Character(text.clone()),
+                            physical_key: PhysicalKey::Unidentified(NativeKeyCode::Unidentified),
+                            platform_specific: KeyEventExtra {},
                         },
-                    })
+                        is_synthetic: false,
+                    },
                 })
             }),
         );
@@ -681,23 +676,21 @@ impl WinitView {
         let mtm = MainThreadMarker::new().unwrap();
         app_state::handle_nonuser_events(
             mtm,
-            [ElementState::Pressed, ElementState::Released].map(|state| {
-                EventWrapper::StaticEvent(Event::WindowEvent {
-                    window_id,
-                    event: WindowEvent::KeyboardInput {
-                        device_id: None,
-                        event: KeyEvent {
-                            state,
-                            logical_key: Key::Named(NamedKey::Backspace),
-                            physical_key: PhysicalKey::Code(KeyCode::Backspace),
-                            platform_specific: KeyEventExtra {},
-                            repeat: false,
-                            location: KeyLocation::Standard,
-                            text: None,
-                        },
-                        is_synthetic: false,
+            [ElementState::Pressed, ElementState::Released].map(|state| EventWrapper::Window {
+                window_id,
+                event: WindowEvent::KeyboardInput {
+                    device_id: None,
+                    event: KeyEvent {
+                        state,
+                        logical_key: Key::Named(NamedKey::Backspace),
+                        physical_key: PhysicalKey::Code(KeyCode::Backspace),
+                        platform_specific: KeyEventExtra {},
+                        repeat: false,
+                        location: KeyLocation::Standard,
+                        text: None,
                     },
-                })
+                    is_synthetic: false,
+                },
             }),
         );
     }

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -23,7 +23,7 @@ use crate::dpi::{
     Position, Size,
 };
 use crate::error::{NotSupportedError, RequestError};
-use crate::event::{Event, WindowEvent};
+use crate::event::WindowEvent;
 use crate::icon::Icon;
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::platform::ios::{ScreenEdge, StatusBarStyle, ValidOrientations};
@@ -51,10 +51,10 @@ declare_class!(
             let mtm = MainThreadMarker::new().unwrap();
             app_state::handle_nonuser_event(
                 mtm,
-                EventWrapper::StaticEvent(Event::WindowEvent {
+                EventWrapper::Window {
                     window_id: self.id(),
                     event: WindowEvent::Focused(true),
-                }),
+                },
             );
             let _: () = unsafe { msg_send![super(self), becomeKeyWindow] };
         }
@@ -64,10 +64,10 @@ declare_class!(
             let mtm = MainThreadMarker::new().unwrap();
             app_state::handle_nonuser_event(
                 mtm,
-                EventWrapper::StaticEvent(Event::WindowEvent {
+                EventWrapper::Window {
                     window_id: self.id(),
                     event: WindowEvent::Focused(false),
-                }),
+                },
             );
             let _: () = unsafe { msg_send![super(self), resignKeyWindow] };
         }


### PR DESCRIPTION
Events like `resumed`, `new_events`, `about_to_wait`, and so on will never happen as a result of programmer action, so we'll never need to queue those. This allows us to remove the need for the old `Event` struct in the iOS backend.

Furthermore, we can now remove `InUserCallback`, since that state is already stored inside `EventHandler`.

I've tried to otherwise keep the semantics as close to the original by calling `handle_nonuser_events(mtm, [])`, which flushes pending events.

- [x] Tested on all platforms changed
