### PR TITLE
Change docs on `WaitUntil` to not suggest `Poll`

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -148,11 +148,12 @@ pub enum ControlFlow {
     /// When the current loop iteration finishes, suspend the thread until either another event
     /// arrives or the given time is reached.
     ///
-    /// Useful for implementing efficient timers. Applications which want to render at the
-    /// display's native refresh rate should instead use [`Poll`] and the VSync functionality
-    /// of a graphics API to reduce odds of missed frames.
+    /// Useful for implementing efficient timers, but should not be relied on for real-time needs
+    /// like rendering (VSync) or audio. Applications which want to render at the display's native
+    /// refresh rate should instead issue a [`Window::request_redraw`] at the end of
+    /// [`WindowEvent::RedrawRequested`].
     ///
-    /// [`Poll`]: Self::Poll
+    /// [`WindowEvent::RedrawRequested`]: crate::window::WindowEvent::RedrawRequested
     WaitUntil(Instant),
 }
 


### PR DESCRIPTION
We should generally avoid recommending `Poll` in our docs.

Suggested in [here](https://xi.zulipchat.com/#narrow/stream/147921-general/topic/I've.20made.20a.20Vello.20game.20engine.20to.20prove.20that.20i.20was.20wrong.2E/near/469103394).