### PR TITLE
doc: mention `DeviceEvent::MouseMotion` in `WindowEvent::CursorMoved`

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -241,7 +241,8 @@ pub enum WindowEvent {
         /// (x,y) coords in pixels relative to the top-left corner of the window. Because the range
         /// of this data is limited by the display area and it may have been transformed by
         /// the OS to implement effects such as cursor acceleration, it should not be used
-        /// to implement non-cursor-like interactions such as 3D camera control.
+        /// to implement non-cursor-like interactions such as 3D camera control. For that,
+        /// consider [`DeviceEvent::MouseMotion`].
         position: PhysicalPosition<f64>,
     },
 


### PR DESCRIPTION
Quick documentation addition: I was looking at the docs for `CursorMoved` and wasn't sure how to correctly get relative motion for a 3D camera. I've added a x-ref doc link to `MouseMotion` to help others in a similar predicament.