### PR TITLE
api: add `DeviceId::{into,from}_raw`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -65,6 +65,7 @@ changelog entry.
 - Add `WindowId::into_raw()` and `from_raw()`.
 - Add `PointerKind`, `PointerSource`, `ButtonSource`, `FingerId` and `position` to all pointer
   events as part of the pointer event overhaul.
+- Add `DeviceId::into_raw()` and `from_raw()`.
 
 ### Changed
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -585,7 +585,25 @@ impl From<MouseButton> for ButtonSource {
 /// on-screen cursor and keyboard focus) or physical. Virtual devices typically aggregate inputs
 /// from multiple physical devices.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId(pub(crate) platform_impl::DeviceId);
+pub struct DeviceId(i64);
+
+impl DeviceId {
+    /// Convert the [`DeviceId`] into the underlying integer.
+    ///
+    /// This is useful if you need to pass the ID across an FFI boundary, or store it in an atomic.
+    #[allow(dead_code)]
+    pub(crate) const fn into_raw(self) -> i64 {
+        self.0
+    }
+
+    /// Construct a [`DeviceId`] from the underlying integer.
+    ///
+    /// This should only be called with integers returned from [`DeviceId::into_raw`].
+    #[allow(dead_code)]
+    pub(crate) const fn from_raw(id: i64) -> Self {
+        Self(id)
+    }
+}
 
 /// Identifier of a finger in a touch event.
 ///

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -9,6 +9,8 @@ use std::path::Path;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[cfg(windows_platform)]
+use windows_sys::Win32::Foundation::HANDLE;
 
 use crate::dpi::PhysicalSize;
 use crate::event::{DeviceId, FingerId};
@@ -656,10 +658,15 @@ pub trait DeviceIdExtWindows {
     fn persistent_identifier(&self) -> Option<String>;
 }
 
+#[cfg(windows_platform)]
 impl DeviceIdExtWindows for DeviceId {
-    #[inline]
     fn persistent_identifier(&self) -> Option<String> {
-        self.0.persistent_identifier()
+        let raw_id = self.into_raw();
+        if raw_id != 0 {
+            crate::platform_impl::raw_input::get_raw_input_device_name(raw_id as HANDLE)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -15,7 +15,7 @@ use crate::application::ApplicationHandler;
 use crate::cursor::Cursor;
 use crate::dpi::{PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{EventLoopError, NotSupportedError, RequestError};
-use crate::event::{self, Force, StartCause, SurfaceSizeWriter};
+use crate::event::{self, DeviceId, Force, StartCause, SurfaceSizeWriter};
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
     EventLoopProxy as RootEventLoopProxy, OwnedDisplayHandle as RootOwnedDisplayHandle,
@@ -314,7 +314,7 @@ impl EventLoop {
         let mut input_status = InputStatus::Handled;
         match event {
             InputEvent::MotionEvent(motion_event) => {
-                let device_id = Some(event::DeviceId(DeviceId(motion_event.device_id())));
+                let device_id = Some(DeviceId::from_raw(motion_event.device_id() as i64));
                 let action = motion_event.action();
 
                 let pointers: Option<
@@ -452,7 +452,7 @@ impl EventLoop {
                         );
 
                         let event = event::WindowEvent::KeyboardInput {
-                            device_id: Some(event::DeviceId(DeviceId(key.device_id()))),
+                            device_id: Some(DeviceId::from_raw(key.device_id() as i64)),
                             event: event::KeyEvent {
                                 state,
                                 physical_key: keycodes::to_physical_key(keycode),
@@ -727,9 +727,6 @@ impl OwnedDisplayHandle {
         Ok(rwh_06::AndroidDisplayHandle::new().into())
     }
 }
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct DeviceId(i32);
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FingerId(i32);

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -28,9 +28,6 @@ pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId;
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId;
 
 impl FingerId {

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -21,13 +21,6 @@ pub(crate) use crate::cursor::{
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
-/// There is no way to detect which device that performed a certain event in
-/// UIKit (i.e. you can't differentiate between different external keyboards,
-/// or whether it was the main touchscreen, assistive technologies, or some
-/// other pointer device that caused a touch event).
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId(usize);
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -108,15 +108,6 @@ pub(crate) static X11_BACKEND: Lazy<Mutex<Result<Arc<XConnection>, XNotSupported
     Lazy::new(|| Mutex::new(XConnection::new(Some(x_error_callback)).map(Arc::new)));
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum DeviceId {
-    #[cfg(x11_platform)]
-    X(x11::DeviceId),
-    #[cfg(wayland_platform)]
-    #[allow(unused)]
-    Wayland(wayland::DeviceId),
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum FingerId {
     #[cfg(x11_platform)]
     X(x11::FingerId),

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -17,10 +17,6 @@ mod state;
 mod types;
 mod window;
 
-/// Dummy device id, since Wayland doesn't have device events.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId;
-
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId(i32);
 

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -22,7 +22,7 @@ use xkbcommon_dl::xkb_mod_mask_t;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::event::{
-    ButtonSource, DeviceEvent, ElementState, Event, Ime, MouseButton, MouseScrollDelta,
+    ButtonSource, DeviceEvent, DeviceId, ElementState, Event, Ime, MouseButton, MouseScrollDelta,
     PointerKind, PointerSource, RawKeyEvent, SurfaceSizeWriter, TouchPhase, WindowEvent,
 };
 use crate::keyboard::ModifiersState;
@@ -33,8 +33,8 @@ use crate::platform_impl::platform::x11::ActiveEventLoop;
 use crate::platform_impl::x11::atoms::*;
 use crate::platform_impl::x11::util::cookie::GenericEventCookie;
 use crate::platform_impl::x11::{
-    mkdid, mkfid, mkwid, util, CookieResultExt, Device, DeviceId, DeviceInfo, Dnd, DndState,
-    ImeReceiver, ScrollOrientation, UnownedWindow, WindowId,
+    mkdid, mkfid, mkwid, util, CookieResultExt, Device, DeviceInfo, Dnd, DndState, ImeReceiver,
+    ScrollOrientation, UnownedWindow, WindowId,
 };
 
 /// The maximum amount of X modifiers to replay.
@@ -319,7 +319,7 @@ impl EventProcessor {
         let mut devices = self.devices.borrow_mut();
         if let Some(info) = DeviceInfo::get(&self.target.xconn, device as _) {
             for info in info.iter() {
-                devices.insert(DeviceId(info.deviceid as _), Device::new(info));
+                devices.insert(mkdid(info.deviceid as xinput::DeviceId), Device::new(info));
             }
         }
     }
@@ -1119,7 +1119,7 @@ impl EventProcessor {
             slice::from_raw_parts(event.valuators.mask, event.valuators.mask_len as usize)
         };
         let mut devices = self.devices.borrow_mut();
-        let physical_device = match devices.get_mut(&DeviceId(event.sourceid as xinput::DeviceId)) {
+        let physical_device = match devices.get_mut(&mkdid(event.sourceid as xinput::DeviceId)) {
             Some(device) => device,
             None => return,
         };
@@ -1178,7 +1178,7 @@ impl EventProcessor {
                 if device_info.deviceid == event.sourceid
                     || device_info.attachment == event.sourceid
                 {
-                    let device_id = DeviceId(device_info.deviceid as _);
+                    let device_id = mkdid(device_info.deviceid as xinput::DeviceId);
                     if let Some(device) = devices.get_mut(&device_id) {
                         device.reset_scroll_position(device_info);
                     }
@@ -1273,8 +1273,8 @@ impl EventProcessor {
         let device_id = self
             .devices
             .borrow()
-            .get(&DeviceId(xev.deviceid as xinput::DeviceId))
-            .map(|device| mkdid(device.attachment as _));
+            .get(&mkdid(xev.deviceid as xinput::DeviceId))
+            .map(|device| mkdid(device.attachment as xinput::DeviceId));
 
         let event = Event::WindowEvent {
             window_id,
@@ -1520,7 +1520,7 @@ impl EventProcessor {
                 self.init_device(info.deviceid as xinput::DeviceId);
             } else if 0 != info.flags & (xinput2::XISlaveRemoved | xinput2::XIMasterRemoved) {
                 let mut devices = self.devices.borrow_mut();
-                devices.remove(&DeviceId(info.deviceid as xinput::DeviceId));
+                devices.remove(&mkdid(info.deviceid as xinput::DeviceId));
             }
         }
     }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -24,7 +24,7 @@ use x11rb::xcb_ffi::ReplyOrIdError;
 
 use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, RequestError};
-use crate::event::{Event, StartCause, WindowEvent};
+use crate::event::{DeviceId, Event, StartCause, WindowEvent};
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
     OwnedDisplayHandle as RootOwnedDisplayHandle,
@@ -806,9 +806,6 @@ impl<'a> Deref for DeviceInfo<'a> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId(xinput::DeviceId);
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId(u32);
 
 impl FingerId {
@@ -993,8 +990,8 @@ impl<'a, E: fmt::Debug> CookieResultExt for Result<VoidCookie<'a>, E> {
 fn mkwid(w: xproto::Window) -> crate::window::WindowId {
     crate::window::WindowId::from_raw(w as _)
 }
-fn mkdid(w: xinput::DeviceId) -> crate::event::DeviceId {
-    crate::event::DeviceId(crate::platform_impl::DeviceId::X(DeviceId(w)))
+fn mkdid(w: xinput::DeviceId) -> DeviceId {
+    DeviceId::from_raw(w as i64)
 }
 
 fn mkfid(w: u32) -> crate::event::FingerId {

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -100,9 +100,6 @@ impl TimeSocket {
 pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct DeviceId;
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct FingerId;
 
 impl FingerId {

--- a/src/platform_impl/web/event.rs
+++ b/src/platform_impl/web/event.rs
@@ -1,18 +1,13 @@
-use crate::event::FingerId as RootFingerId;
+use crate::event::{DeviceId, FingerId as RootFingerId};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId(pub(crate) u32);
-
-impl DeviceId {
-    pub fn new(pointer_id: i32) -> Option<Self> {
-        if let Ok(pointer_id) = u32::try_from(pointer_id) {
-            Some(Self(pointer_id))
-        } else if pointer_id == -1 {
-            None
-        } else {
-            tracing::error!("found unexpected negative `PointerEvent.pointerId`: {pointer_id}");
-            None
-        }
+pub(crate) fn mkdid(pointer_id: i32) -> Option<DeviceId> {
+    if let Ok(pointer_id) = u32::try_from(pointer_id) {
+        Some(DeviceId::from_raw(pointer_id as i64))
+    } else if pointer_id == -1 {
+        None
+    } else {
+        tracing::error!("found unexpected negative `PointerEvent.pointerId`: {pointer_id}");
+        None
     }
 }
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -9,16 +9,13 @@ use wasm_bindgen::JsCast;
 use web_sys::{Document, KeyboardEvent, Navigator, PageTransitionEvent, PointerEvent, WheelEvent};
 use web_time::{Duration, Instant};
 
+use super::super::event;
 use super::super::main_thread::MainThreadMarker;
 use super::super::monitor::MonitorHandler;
-use super::super::DeviceId;
 use super::backend;
 use super::state::State;
 use crate::dpi::PhysicalSize;
-use crate::event::{
-    DeviceEvent, DeviceId as RootDeviceId, ElementState, Event, RawKeyEvent, StartCause,
-    WindowEvent,
-};
+use crate::event::{DeviceEvent, ElementState, Event, RawKeyEvent, StartCause, WindowEvent};
 use crate::event_loop::{ControlFlow, DeviceEvents};
 use crate::platform::web::{PollStrategy, WaitUntilStrategy};
 use crate::platform_impl::platform::backend::EventListenerHandle;
@@ -286,7 +283,7 @@ impl Shared {
                 }
 
                 // chorded button event
-                let device_id = DeviceId::new(event.pointer_id()).map(RootDeviceId);
+                let device_id = event::mkdid(event.pointer_id());
 
                 if let Some(button) = backend::event::mouse_button(&event) {
                     let state = if backend::event::mouse_buttons(&event).contains(button.into()) {
@@ -344,7 +341,7 @@ impl Shared {
 
                 let button = backend::event::mouse_button(&event).expect("no mouse button pressed");
                 runner.send_event(Event::DeviceEvent {
-                    device_id: DeviceId::new(event.pointer_id()).map(RootDeviceId),
+                    device_id: event::mkdid(event.pointer_id()),
                     event: DeviceEvent::Button {
                         button: button.to_id().into(),
                         state: ElementState::Pressed,
@@ -363,7 +360,7 @@ impl Shared {
 
                 let button = backend::event::mouse_button(&event).expect("no mouse button pressed");
                 runner.send_event(Event::DeviceEvent {
-                    device_id: DeviceId::new(event.pointer_id()).map(RootDeviceId),
+                    device_id: event::mkdid(event.pointer_id()),
                     event: DeviceEvent::Button {
                         button: button.to_id().into(),
                         state: ElementState::Released,

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use cursor::{
     CustomCursorSource as PlatformCustomCursorSource,
 };
 
-pub use self::event::{DeviceId, FingerId};
+pub use self::event::FingerId;
 pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle,
     PlatformSpecificEventLoopAttributes,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -12,7 +12,6 @@ use web_sys::{
 };
 
 use super::super::cursor::CursorHandler;
-use super::super::event::DeviceId;
 use super::super::main_thread::MainThreadMarker;
 use super::animation_frame::AnimationFrameHandler;
 use super::event_handle::EventListenerHandle;
@@ -23,7 +22,8 @@ use super::{event, fullscreen, ResizeScaleHandle};
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::error::RequestError;
 use crate::event::{
-    ButtonSource, ElementState, MouseScrollDelta, PointerKind, PointerSource, SurfaceSizeWriter,
+    ButtonSource, DeviceId, ElementState, MouseScrollDelta, PointerKind, PointerSource,
+    SurfaceSizeWriter,
 };
 use crate::keyboard::{Key, KeyLocation, ModifiersState, PhysicalKey};
 use crate::platform_impl::Fullscreen;

--- a/src/platform_impl/web/web_sys/pointer.rs
+++ b/src/platform_impl/web/web_sys/pointer.rs
@@ -3,13 +3,13 @@ use std::rc::Rc;
 
 use web_sys::PointerEvent;
 
-use super::super::event::DeviceId;
 use super::canvas::Common;
 use super::event;
 use super::event_handle::EventListenerHandle;
 use crate::dpi::PhysicalPosition;
-use crate::event::{ButtonSource, ElementState, Force, PointerKind, PointerSource};
+use crate::event::{ButtonSource, DeviceId, ElementState, Force, PointerKind, PointerSource};
 use crate::keyboard::ModifiersState;
+use crate::platform_impl::web::event::mkdid;
 
 #[allow(dead_code)]
 pub(super) struct PointerHandler {
@@ -42,7 +42,7 @@ impl PointerHandler {
             Some(canvas_common.add_event("pointerout", move |event: PointerEvent| {
                 let modifiers = event::mouse_modifiers(&event);
                 let pointer_id = event.pointer_id();
-                let device_id = DeviceId::new(pointer_id);
+                let device_id = mkdid(pointer_id);
                 let position =
                     event::mouse_position(&event).to_physical(super::scale_factor(&window));
                 let kind = event::pointer_type(&event, pointer_id);
@@ -59,7 +59,7 @@ impl PointerHandler {
             Some(canvas_common.add_event("pointerover", move |event: PointerEvent| {
                 let modifiers = event::mouse_modifiers(&event);
                 let pointer_id = event.pointer_id();
-                let device_id = DeviceId::new(pointer_id);
+                let device_id = mkdid(pointer_id);
                 let position =
                     event::mouse_position(&event).to_physical(super::scale_factor(&window));
                 let kind = event::pointer_type(&event, pointer_id);
@@ -91,7 +91,7 @@ impl PointerHandler {
 
                 handler(
                     modifiers,
-                    DeviceId::new(pointer_id),
+                    mkdid(pointer_id),
                     event::mouse_position(&event).to_physical(super::scale_factor(&window)),
                     source,
                 )
@@ -142,7 +142,7 @@ impl PointerHandler {
 
                 handler(
                     modifiers,
-                    DeviceId::new(pointer_id),
+                    mkdid(pointer_id),
                     event::mouse_position(&event).to_physical(super::scale_factor(&window)),
                     source,
                 )
@@ -175,7 +175,7 @@ impl PointerHandler {
         self.on_cursor_move =
             Some(canvas_common.add_event("pointermove", move |event: PointerEvent| {
                 let pointer_id = event.pointer_id();
-                let device_id = DeviceId::new(pointer_id);
+                let device_id = mkdid(pointer_id);
                 let kind = event::pointer_type(&event, pointer_id);
 
                 // chorded button event

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -1,5 +1,5 @@
 use smol_str::SmolStr;
-use windows_sys::Win32::Foundation::{HANDLE, HWND};
+use windows_sys::Win32::Foundation::HWND;
 use windows_sys::Win32::UI::WindowsAndMessaging::{HMENU, WINDOW_LONG_PTR_INDEX};
 
 pub(crate) use self::event_loop::{
@@ -11,7 +11,7 @@ pub(crate) use self::keyboard::{physicalkey_to_scancode, scancode_to_physicalkey
 pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::Window;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
-use crate::event::DeviceId as RootDeviceId;
+use crate::event::DeviceId;
 use crate::icon::Icon;
 use crate::keyboard::Key;
 use crate::platform::windows::{BackdropType, Color, CornerPreference};
@@ -60,19 +60,6 @@ unsafe impl Send for PlatformSpecificWindowAttributes {}
 unsafe impl Sync for PlatformSpecificWindowAttributes {}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeviceId(u32);
-
-impl DeviceId {
-    pub fn persistent_identifier(&self) -> Option<String> {
-        if self.0 != 0 {
-            raw_input::get_raw_input_device_name(self.0 as HANDLE)
-        } else {
-            None
-        }
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId {
     id: u32,
     primary: bool,
@@ -91,8 +78,8 @@ impl FingerId {
     }
 }
 
-fn wrap_device_id(id: u32) -> RootDeviceId {
-    RootDeviceId(DeviceId(id))
+fn wrap_device_id(id: u32) -> DeviceId {
+    DeviceId::from_raw(id as i64)
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -166,6 +153,6 @@ mod ime;
 mod keyboard;
 mod keyboard_layout;
 mod monitor;
-mod raw_input;
+pub(crate) mod raw_input;
 mod window;
 mod window_state;


### PR DESCRIPTION
The same as for `WindowId`.

This also removes the internal platform ID.

--

I'm not sure what type to pick here, since some use u32, some i32. I think `i64` would be the best, but then, negative values for DeviceId are strange?

Also, it's not that clear to what IDs should be limited.

For now I'm just using `u64`.