### PR TITLE
[WIP] Split out `Surface` from `Window`

### DIFF
--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -35,7 +35,7 @@ use crate::platform_impl::{
     VideoModeHandle as PlatformVideoModeHandle,
 };
 use crate::window::{
-    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
+    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow, Surface as CoreSurface,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
@@ -61,7 +61,7 @@ impl Window {
     }
 }
 
-impl CoreWindow for Window {
+impl CoreSurface for Window {
     fn id(&self) -> WindowId {
         self.0.id()
     }
@@ -78,6 +78,40 @@ impl CoreWindow for Window {
         self.0.pre_present_notify()
     }
 
+    fn surface_size(&self) -> PhysicalSize<u32> {
+        self.0.surface_size()
+    }
+
+    fn request_surface_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
+        self.0.request_surface_size(size)
+    }
+
+    fn set_transparent(&self, transparent: bool) {
+        self.0.set_transparent(transparent);
+    }
+
+    fn set_cursor(&self, cursor: Cursor) {
+        self.0.set_cursor(cursor);
+    }
+
+    fn set_cursor_position(&self, position: Position) -> Result<(), RequestError> {
+        self.0.set_cursor_position(position)
+    }
+
+    fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), RequestError> {
+        self.0.set_cursor_grab(mode)
+    }
+
+    fn set_cursor_visible(&self, visible: bool) {
+        self.0.set_cursor_visible(visible);
+    }
+
+    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), RequestError> {
+        self.0.set_cursor_hittest(hittest)
+    }
+}
+
+impl CoreWindow for Window {
     fn reset_dead_keys(&self) {
         common::xkb::reset_dead_keys();
     }
@@ -92,14 +126,6 @@ impl CoreWindow for Window {
 
     fn set_outer_position(&self, position: Position) {
         self.0.set_outer_position(position)
-    }
-
-    fn surface_size(&self) -> PhysicalSize<u32> {
-        self.0.surface_size()
-    }
-
-    fn request_surface_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
-        self.0.request_surface_size(size)
     }
 
     fn outer_size(&self) -> PhysicalSize<u32> {
@@ -124,10 +150,6 @@ impl CoreWindow for Window {
 
     fn set_title(&self, title: &str) {
         self.0.set_title(title);
-    }
-
-    fn set_transparent(&self, transparent: bool) {
-        self.0.set_transparent(transparent);
     }
 
     fn set_blur(&self, blur: bool) {
@@ -238,22 +260,6 @@ impl CoreWindow for Window {
         self.0.title()
     }
 
-    fn set_cursor(&self, cursor: Cursor) {
-        self.0.set_cursor(cursor);
-    }
-
-    fn set_cursor_position(&self, position: Position) -> Result<(), RequestError> {
-        self.0.set_cursor_position(position)
-    }
-
-    fn set_cursor_grab(&self, mode: CursorGrabMode) -> Result<(), RequestError> {
-        self.0.set_cursor_grab(mode)
-    }
-
-    fn set_cursor_visible(&self, visible: bool) {
-        self.0.set_cursor_visible(visible);
-    }
-
     fn drag_window(&self) -> Result<(), RequestError> {
         self.0.drag_window()
     }
@@ -264,10 +270,6 @@ impl CoreWindow for Window {
 
     fn show_window_menu(&self, position: Position) {
         self.0.show_window_menu(position);
-    }
-
-    fn set_cursor_hittest(&self, hittest: bool) -> Result<(), RequestError> {
-        self.0.set_cursor_hittest(hittest)
     }
 
     fn current_monitor(&self) -> Option<crate::monitor::MonitorHandle> {


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
