### PR TITLE
Return error on missing event instead of panicking.

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -149,7 +149,6 @@ changelog entry.
     the primary finger in a multi-touch interaction.
   - In the same spirit rename `DeviceEvent::MouseMotion` to `PointerMotion`.
   - Remove `Force::Calibrated::altitude_angle`.
-- Change signature of `apple::appkit::WindowDelegate::drag_window()` to return `Result<(), RequestError>`.
 
 ### Removed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -188,4 +188,4 @@ changelog entry.
 - On macOS, fix `WindowEvent::Moved` sometimes being triggered unnecessarily on resize.
 - On macOS, package manifest definitions of `LSUIElement` will no longer be overridden with the
   default activation policy, unless explicitly provided during initialization.
-- On macOS `drag_window()` without a left click present, will result in error instead of panic.
+- On macOS, fix crash when calling `drag_window()` without a left click present.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -149,6 +149,7 @@ changelog entry.
     the primary finger in a multi-touch interaction.
   - In the same spirit rename `DeviceEvent::MouseMotion` to `PointerMotion`.
   - Remove `Force::Calibrated::altitude_angle`.
+- Change signature of `apple::appkit::WindowDelegate::drag_window()` to return `Result<(), RequestError>`.
 
 ### Removed
 
@@ -185,5 +186,6 @@ changelog entry.
 
 - On Orbital, `MonitorHandle::name()` now returns `None` instead of a dummy name.
 - On macOS, fix `WindowEvent::Moved` sometimes being triggered unnecessarily on resize.
-- On MacOS, package manifest definitions of `LSUIElement` will no longer be overridden with the
+- On macOS, package manifest definitions of `LSUIElement` will no longer be overridden with the
   default activation policy, unless explicitly provided during initialization.
+- On macOS `drag_window()` without a left click present, will result in error instead of panic.

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -284,8 +284,7 @@ impl CoreWindow for Window {
     }
 
     fn drag_window(&self) -> Result<(), RequestError> {
-        self.maybe_wait_on_main(|delegate| delegate.drag_window());
-        Ok(())
+        self.maybe_wait_on_main(|delegate| delegate.drag_window())
     }
 
     fn drag_resize_window(

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1171,10 +1171,11 @@ impl WindowDelegate {
     }
 
     #[inline]
-    pub fn drag_window(&self) {
+    pub fn drag_window(&self) -> Result<(), RequestError> {
         let mtm = MainThreadMarker::from(self);
-        let event = NSApplication::sharedApplication(mtm).currentEvent().unwrap();
+        let event = NSApplication::sharedApplication(mtm).currentEvent().ok_or(RequestError::Ignored)?;
         self.window().performWindowDragWithEvent(&event);
+        Ok(())
     }
 
     #[inline]

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1173,7 +1173,8 @@ impl WindowDelegate {
     #[inline]
     pub fn drag_window(&self) -> Result<(), RequestError> {
         let mtm = MainThreadMarker::from(self);
-        let event = NSApplication::sharedApplication(mtm).currentEvent().ok_or(RequestError::Ignored)?;
+        let event =
+            NSApplication::sharedApplication(mtm).currentEvent().ok_or(RequestError::Ignored)?;
         self.window().performWindowDragWithEvent(&event);
         Ok(())
     }


### PR DESCRIPTION
Problem: winit would panic when `appkit::drag_window()` was called without a left click event being present. This problem was discovered while reviewing this [PR for bevy](https://github.com/bevyengine/bevy/pull/15674#issuecomment-2401699844).

Solution: Return a result from `drag_window()`. In winit 0.30.5 `drag_window()` already returned a result, but 'main' branch had no return value. So this reverts the function signature to an earlier one.

It seems like this affects macOS. I exercised this on an M2 macOS machine using the "window" example.

- [x] Tested on all platforms changed
- [X] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
