### PR TITLE
Fix function name of `with_any_thread` in doc and error message

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -72,7 +72,7 @@ impl EventLoopBuilder {
     /// Attempting to create the event loop off the main thread will panic. This
     /// restriction isn't strictly necessary on all platforms, but is imposed to
     /// eliminate any nasty surprises when porting to platforms that require it.
-    /// `EventLoopBuilderExt::any_thread` functions are exposed in the relevant
+    /// `EventLoopBuilderExt::with_any_thread` functions are exposed in the relevant
     /// [`platform`] module if the target platform supports creating an event
     /// loop on any thread.
     ///

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -114,7 +114,7 @@ pub enum CornerPreference {
 
 /// A wrapper around a [`Window`] that ignores thread-specific window handle limitations.
 ///
-/// See [`WindowBorrowExtWindows::with_any_thread`] for more information.
+/// See [`WindowBorrowExtWindows::any_thread`] for more information.
 #[derive(Clone, Debug)]
 pub struct AnyThread<W: Window>(W);
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -114,7 +114,7 @@ pub enum CornerPreference {
 
 /// A wrapper around a [`Window`] that ignores thread-specific window handle limitations.
 ///
-/// See [`WindowBorrowExtWindows::any_thread`] for more information.
+/// See [`WindowBorrowExtWindows::with_any_thread`] for more information.
 #[derive(Clone, Debug)]
 pub struct AnyThread<W: Window>(W);
 

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -321,8 +321,8 @@ impl EventLoop {
                 "Initializing the event loop outside of the main thread is a significant \
                  cross-platform compatibility hazard. If you absolutely need to create an \
                  EventLoop on a different thread, you can use the \
-                 `EventLoopBuilderExtX11::any_thread` or `EventLoopBuilderExtWayland::any_thread` \
-                 functions."
+                 `EventLoopBuilderExtX11::with_any_thread` or \
+                 `EventLoopBuilderExtWayland::with_any_thread` functions."
             );
         }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -180,7 +180,7 @@ impl EventLoop {
                 "Initializing the event loop outside of the main thread is a significant \
                  cross-platform compatibility hazard. If you absolutely need to create an \
                  EventLoop on a different thread, you can use the \
-                 `EventLoopBuilderExtWindows::any_thread` function."
+                 `EventLoopBuilderExtWindows::with_any_thread` function."
             );
         }
 


### PR DESCRIPTION
I found some documents and error messages refer to `with_any_thread()` as `any_thread()`. This pull request fixes the typo. 

Since this changes only documentation, I didn't do any tests on my local.

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
