### PR TITLE
api: move primary from FingerId to Pointer events

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -67,8 +67,8 @@ changelog entry.
 - On macOS, add `WindowExtMacOS::set_unified_titlebar` and `WindowAttributesExtMacOS::with_unified_titlebar`
   to use a larger style of titlebar.
 - Add `WindowId::into_raw()` and `from_raw()`.
-- Add `PointerKind`, `PointerSource`, `ButtonSource`, `FingerId` and `position` to all pointer
-  events as part of the pointer event overhaul.
+- Add `PointerKind`, `PointerSource`, `ButtonSource`, `FingerId`, `primary` and `position` to all
+  pointer events as part of the pointer event overhaul.
 - Add `DeviceId::into_raw()` and `from_raw()`.
 
 ### Changed
@@ -138,6 +138,8 @@ changelog entry.
   - Rename `CursorEntered` to `PointerEntered`.
   - Rename `CursorLeft` to `PointerLeft`.
   - Rename `MouseInput` to `PointerButton`.
+  - Add `primary` to every `PointerEvent` as a way to identify discard non-primary pointers in a
+    multi-touch interaction.
   - Add `position` to every `PointerEvent`.
   - `PointerMoved` is **not sent** after `PointerEntered` anymore.
   - Remove `Touch`, which is folded into the `Pointer*` events.
@@ -150,8 +152,6 @@ changelog entry.
     type to a generic mouse button.
   - New `FingerId` added to `PointerKind::Touch` and `PointerSource::Touch` able to uniquely
     identify a finger in a multi-touch interaction. Replaces the old `Touch::id`.
-  - On Web and Windows, add `FingerIdExt*::is_primary()`, exposing a way to determine
-    the primary finger in a multi-touch interaction.
   - In the same spirit rename `DeviceEvent::MouseMotion` to `PointerMotion`.
   - Remove `Force::Calibrated::altitude_angle`.
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -634,12 +634,23 @@ impl DeviceId {
 /// Whenever a touch event is received it contains a `FingerId` which uniquely identifies the finger
 /// used for the current interaction.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FingerId(pub(crate) platform_impl::FingerId);
+pub struct FingerId(pub(crate) usize);
 
 impl FingerId {
-    #[cfg(test)]
-    pub(crate) const fn dummy() -> Self {
-        FingerId(platform_impl::FingerId::dummy())
+    /// Convert the [`FingerId`] into the underlying integer.
+    ///
+    /// This is useful if you need to pass the ID across an FFI boundary, or store it in an atomic.
+    #[allow(dead_code)]
+    pub(crate) const fn into_raw(self) -> usize {
+        self.0
+    }
+
+    /// Construct a [`FingerId`] from the underlying integer.
+    ///
+    /// This should only be called with integers returned from [`FingerId::into_raw`].
+    #[allow(dead_code)]
+    pub(crate) const fn from_raw(id: usize) -> Self {
+        Self(id)
     }
 }
 
@@ -1154,7 +1165,7 @@ mod tests {
         ($closure:expr) => {{
             #[allow(unused_mut)]
             let mut x = $closure;
-            let fid = event::FingerId::dummy();
+            let fid = event::FingerId::from_raw(0);
 
             #[allow(deprecated)]
             {
@@ -1291,7 +1302,7 @@ mod tests {
         });
         let _ = event::StartCause::Init.clone();
 
-        let fid = crate::event::FingerId::dummy().clone();
+        let fid = crate::event::FingerId::from_raw(0).clone();
         HashSet::new().insert(fid);
         let mut set = [fid, fid, fid];
         set.sort_unstable();

--- a/src/event.rs
+++ b/src/event.rs
@@ -245,6 +245,12 @@ pub enum WindowEvent {
         /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
         position: PhysicalPosition<f64>,
 
+        /// Indicates whether the event is created by a primary pointer.
+        ///
+        /// A pointer is considered primary when it's a mouse, the first finger in a multi-touch
+        /// interaction, or an unknown pointer source.
+        primary: bool,
+
         source: PointerSource,
     },
 
@@ -263,6 +269,12 @@ pub enum WindowEvent {
         /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
         /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
         position: PhysicalPosition<f64>,
+
+        /// Indicates whether the event is created by a primary pointer.
+        ///
+        /// A pointer is considered primary when it's a mouse, the first finger in a multi-touch
+        /// interaction, or an unknown pointer source.
+        primary: bool,
 
         kind: PointerKind,
     },
@@ -283,6 +295,12 @@ pub enum WindowEvent {
         /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
         /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
         position: Option<PhysicalPosition<f64>>,
+
+        /// Indicates whether the event is created by a primary pointer.
+        ///
+        /// A pointer is considered primary when it's a mouse, the first finger in a multi-touch
+        /// interaction, or an unknown pointer source.
+        primary: bool,
 
         kind: PointerKind,
     },
@@ -306,6 +324,12 @@ pub enum WindowEvent {
         /// [`padding`]: https://developer.mozilla.org/en-US/docs/Web/CSS/padding
         /// [`transform`]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform
         position: PhysicalPosition<f64>,
+
+        /// Indicates whether the event is created by a primary pointer.
+        ///
+        /// A pointer is considered primary when it's a mouse, the first finger in a multi-touch
+        /// interaction, or an unknown pointer source.
+        primary: bool,
 
         button: ButtonSource,
     },
@@ -1162,16 +1186,19 @@ mod tests {
                 with_window_event(Ime(Enabled));
                 with_window_event(PointerMoved {
                     device_id: None,
+                    primary: true,
                     position: (0, 0).into(),
                     source: PointerSource::Mouse,
                 });
                 with_window_event(ModifiersChanged(event::Modifiers::default()));
                 with_window_event(PointerEntered {
                     device_id: None,
+                    primary: true,
                     position: (0, 0).into(),
                     kind: PointerKind::Mouse,
                 });
                 with_window_event(PointerLeft {
+                    primary: true,
                     device_id: None,
                     position: Some((0, 0).into()),
                     kind: PointerKind::Mouse,
@@ -1183,12 +1210,14 @@ mod tests {
                 });
                 with_window_event(PointerButton {
                     device_id: None,
+                    primary: true,
                     state: event::ElementState::Pressed,
                     position: (0, 0).into(),
                     button: event::MouseButton::Other(0).into(),
                 });
                 with_window_event(PointerButton {
                     device_id: None,
+                    primary: true,
                     state: event::ElementState::Released,
                     position: (0, 0).into(),
                     button: event::ButtonSource::Touch {

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -21,6 +21,7 @@ pub mod windows;
 #[cfg(any(x11_platform, docsrs))]
 pub mod x11;
 
+#[allow(unused_imports)]
 #[cfg(any(
     windows_platform,
     macos_platform,

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -57,7 +57,6 @@ use web_sys::HtmlCanvasElement;
 use crate::application::ApplicationHandler;
 use crate::cursor::CustomCursorSource;
 use crate::error::NotSupportedError;
-use crate::event::FingerId;
 use crate::event_loop::{ActiveEventLoop, EventLoop};
 use crate::monitor::MonitorHandle;
 use crate::platform_impl::PlatformCustomCursorSource;
@@ -780,16 +779,3 @@ impl Display for OrientationLockError {
 }
 
 impl Error for OrientationLockError {}
-
-/// Additional methods on [`FingerId`] that are specific to Web.
-pub trait FingerIdExtWeb {
-    /// Indicates if the finger represents the first contact in a multi-touch interaction.
-    #[allow(clippy::wrong_self_convention)]
-    fn is_primary(self) -> bool;
-}
-
-impl FingerIdExtWeb for FingerId {
-    fn is_primary(self) -> bool {
-        self.0.is_primary()
-    }
-}

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use windows_sys::Win32::Foundation::HANDLE;
 
 use crate::dpi::PhysicalSize;
-use crate::event::{DeviceId, FingerId};
+use crate::event::DeviceId;
 use crate::event_loop::EventLoopBuilder;
 use crate::monitor::MonitorHandle;
 use crate::window::{BadIcon, Icon, Window, WindowAttributes};
@@ -667,20 +667,6 @@ impl DeviceIdExtWindows for DeviceId {
         } else {
             None
         }
-    }
-}
-
-/// Additional methods on `FingerId` that are specific to Windows.
-pub trait FingerIdExtWindows {
-    /// Indicates if the finger represents the first contact in a multi-touch interaction.
-    #[allow(clippy::wrong_self_convention)]
-    fn is_primary(self) -> bool;
-}
-
-impl FingerIdExtWindows for FingerId {
-    #[inline]
-    fn is_primary(self) -> bool {
-        self.0.is_primary()
     }
 }
 

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -26,13 +26,3 @@ pub(crate) use self::window_delegate::PlatformSpecificWindowAttributes;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FingerId;
-
-impl FingerId {
-    #[cfg(test)]
-    pub const fn dummy() -> Self {
-        FingerId
-    }
-}

--- a/src/platform_impl/apple/appkit/view.rs
+++ b/src/platform_impl/apple/appkit/view.rs
@@ -657,6 +657,7 @@ declare_class!(
 
             self.queue_event(WindowEvent::PointerEntered {
                 device_id: None,
+                primary: true,
                 position,
                 kind: PointerKind::Mouse,
             });
@@ -670,6 +671,7 @@ declare_class!(
 
             self.queue_event(WindowEvent::PointerLeft {
                 device_id: None,
+                primary: true,
                 position: Some(position),
                 kind: PointerKind::Mouse,
             });
@@ -1061,6 +1063,7 @@ impl WinitView {
 
         self.queue_event(WindowEvent::PointerButton {
             device_id: None,
+            primary: true,
             state: button_state,
             position,
             button: button.into(),
@@ -1087,6 +1090,7 @@ impl WinitView {
 
         self.queue_event(WindowEvent::PointerMoved {
             device_id: None,
+            primary: true,
             position: view_point.to_physical(self.scale_factor()),
             source: PointerSource::Mouse,
         });

--- a/src/platform_impl/apple/mod.rs
+++ b/src/platform_impl/apple/mod.rs
@@ -7,7 +7,9 @@ mod notification_center;
 #[cfg(not(target_os = "macos"))]
 mod uikit;
 
+#[allow(unused_imports)]
 #[cfg(target_os = "macos")]
 pub use self::appkit::*;
+#[allow(unused_imports)]
 #[cfg(not(target_os = "macos"))]
 pub use self::uikit::*;

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -21,16 +21,6 @@ pub(crate) use crate::cursor::{
 pub(crate) use crate::icon::NoIcon as PlatformIcon;
 pub(crate) use crate::platform_impl::Fullscreen;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FingerId(usize);
-
-impl FingerId {
-    #[cfg(test)]
-    pub const fn dummy() -> Self {
-        FingerId(0)
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct KeyEventExtra {}
 

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -34,6 +34,9 @@ pub struct WinitViewState {
     rotation_last_delta: Cell<CGFloat>,
     pinch_last_delta: Cell<CGFloat>,
     pan_last_delta: Cell<CGPoint>,
+
+    primary_finger: Cell<Option<usize>>,
+    fingers: Cell<u8>,
 }
 
 declare_class!(
@@ -371,6 +374,9 @@ impl WinitView {
             rotation_last_delta: Cell::new(0.0),
             pinch_last_delta: Cell::new(0.0),
             pan_last_delta: Cell::new(CGPoint { x: 0.0, y: 0.0 }),
+
+            primary_finger: Cell::new(None),
+            fingers: Cell::new(0),
         });
         let this: Retained<Self> = unsafe { msg_send_id![super(this), initWithFrame: frame] };
 
@@ -515,12 +521,33 @@ impl WinitView {
             let window_id = window.id();
             let finger_id = RootFingerId(FingerId(touch_id));
 
+            let ivars = self.ivars();
+
             match phase {
                 UITouchPhase::Began => {
+                    let primary = if let UITouchType::Pencil = touch_type {
+                        true
+                    } else {
+                        ivars.fingers.set(ivars.fingers.get() + 1);
+                        match ivars.primary_finger.get() {
+                            Some(primary_id) => primary_id == touch_id,
+                            None => {
+                                debug_assert_eq!(
+                                    ivars.fingers.get(),
+                                    1,
+                                    "number of fingers were not counted correctly"
+                                );
+                                ivars.primary_finger.set(Some(touch_id));
+                                true
+                            },
+                        }
+                    };
+
                     touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
                         window_id,
                         event: WindowEvent::PointerEntered {
                             device_id: None,
+                            primary,
                             position,
                             kind: if let UITouchType::Pencil = touch_type {
                                 PointerKind::Unknown
@@ -533,6 +560,7 @@ impl WinitView {
                         window_id,
                         event: WindowEvent::PointerButton {
                             device_id: None,
+                            primary,
                             state: ElementState::Pressed,
                             position,
                             button: if let UITouchType::Pencil = touch_type {
@@ -544,26 +572,44 @@ impl WinitView {
                     }));
                 },
                 UITouchPhase::Moved => {
+                    let (primary, source) = if let UITouchType::Pencil = touch_type {
+                        (true, PointerSource::Unknown)
+                    } else {
+                        (ivars.primary_finger.get().unwrap() == touch_id, PointerSource::Touch {
+                            finger_id,
+                            force,
+                        })
+                    };
+
                     touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
                         window_id,
                         event: WindowEvent::PointerMoved {
                             device_id: None,
+                            primary,
                             position,
-                            source: if let UITouchType::Pencil = touch_type {
-                                PointerSource::Unknown
-                            } else {
-                                PointerSource::Touch { finger_id, force }
-                            },
+                            source,
                         },
                     }));
                 },
                 // 2 is UITouchPhase::Stationary and is not expected here
                 UITouchPhase::Ended | UITouchPhase::Cancelled => {
+                    let primary = if let UITouchType::Pencil = touch_type {
+                        true
+                    } else {
+                        ivars.fingers.set(ivars.fingers.get() - 1);
+                        let primary = ivars.primary_finger.get().unwrap() == touch_id;
+                        if ivars.fingers.get() == 0 {
+                            ivars.primary_finger.set(None);
+                        }
+                        primary
+                    };
+
                     if let UITouchPhase::Ended = phase {
                         touch_events.push(EventWrapper::StaticEvent(Event::WindowEvent {
                             window_id,
                             event: WindowEvent::PointerButton {
                                 device_id: None,
+                                primary,
                                 state: ElementState::Released,
                                 position,
                                 button: if let UITouchType::Pencil = touch_type {
@@ -579,6 +625,7 @@ impl WinitView {
                         window_id,
                         event: WindowEvent::PointerLeft {
                             device_id: None,
+                            primary,
                             position: Some(position),
                             kind: if let UITouchType::Pencil = touch_type {
                                 PointerKind::Unknown

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -107,24 +107,6 @@ impl Default for PlatformSpecificWindowAttributes {
 pub(crate) static X11_BACKEND: Lazy<Mutex<Result<Arc<XConnection>, XNotSupported>>> =
     Lazy::new(|| Mutex::new(XConnection::new(Some(x_error_callback)).map(Arc::new)));
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum FingerId {
-    #[cfg(x11_platform)]
-    X(x11::FingerId),
-    #[cfg(wayland_platform)]
-    Wayland(wayland::FingerId),
-}
-
-impl FingerId {
-    #[cfg(test)]
-    pub const fn dummy() -> Self {
-        #[cfg(wayland_platform)]
-        return FingerId::Wayland(wayland::FingerId::dummy());
-        #[cfg(all(not(wayland_platform), x11_platform))]
-        return FingerId::X(x11::FingerId::dummy());
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum MonitorHandle {
     #[cfg(x11_platform)]

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -17,16 +17,6 @@ mod state;
 mod types;
 mod window;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FingerId(i32);
-
-impl FingerId {
-    #[cfg(test)]
-    pub const fn dummy() -> Self {
-        FingerId(0)
-    }
-}
-
 /// Get the WindowId out of the surface.
 #[inline]
 fn make_wid(surface: &WlSurface) -> WindowId {

--- a/src/platform_impl/linux/wayland/seat/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/mod.rs
@@ -40,6 +40,9 @@ pub struct WinitSeatState {
     /// The mapping from touched points to the surfaces they're present.
     touch_map: AHashMap<i32, TouchPoint>,
 
+    /// Id of the first touch event.
+    first_touch_id: Option<i32>,
+
     /// The text input bound on the seat.
     text_input: Option<Arc<ZwpTextInputV3>>,
 

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -124,6 +124,7 @@ impl PointerHandler for WinitState {
                 PointerEventKind::Enter { .. } => {
                     self.events_sink.push_window_event(
                         WindowEvent::PointerEntered {
+                            primary: true,
                             device_id: None,
                             position,
                             kind: PointerKind::Mouse,
@@ -144,6 +145,7 @@ impl PointerHandler for WinitState {
 
                     self.events_sink.push_window_event(
                         WindowEvent::PointerLeft {
+                            primary: true,
                             device_id: None,
                             position: Some(position),
                             kind: PointerKind::Mouse,
@@ -154,6 +156,7 @@ impl PointerHandler for WinitState {
                 PointerEventKind::Motion { .. } => {
                     self.events_sink.push_window_event(
                         WindowEvent::PointerMoved {
+                            primary: true,
                             device_id: None,
                             position,
                             source: PointerSource::Mouse,
@@ -174,6 +177,7 @@ impl PointerHandler for WinitState {
                     };
                     self.events_sink.push_window_event(
                         WindowEvent::PointerButton {
+                            primary: true,
                             device_id: None,
                             state,
                             position,

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1034,12 +1034,14 @@ impl EventProcessor {
         let event = match event.detail as u32 {
             xlib::Button1 => WindowEvent::PointerButton {
                 device_id,
+                primary: true,
                 state,
                 position,
                 button: MouseButton::Left.into(),
             },
             xlib::Button2 => WindowEvent::PointerButton {
                 device_id,
+                primary: true,
                 state,
                 position,
                 button: MouseButton::Middle.into(),
@@ -1047,6 +1049,7 @@ impl EventProcessor {
 
             xlib::Button3 => WindowEvent::PointerButton {
                 device_id,
+                primary: true,
                 state,
                 position,
                 button: MouseButton::Right.into(),
@@ -1069,6 +1072,7 @@ impl EventProcessor {
             },
             8 => WindowEvent::PointerButton {
                 device_id,
+                primary: true,
                 state,
                 position,
                 button: MouseButton::Back.into(),
@@ -1076,12 +1080,14 @@ impl EventProcessor {
 
             9 => WindowEvent::PointerButton {
                 device_id,
+                primary: true,
                 state,
                 position,
                 button: MouseButton::Forward.into(),
             },
             x => WindowEvent::PointerButton {
                 device_id,
+                primary: true,
                 state,
                 position,
                 button: MouseButton::Other(x as u16).into(),
@@ -1116,6 +1122,7 @@ impl EventProcessor {
                 window_id,
                 event: WindowEvent::PointerMoved {
                     device_id,
+                    primary: true,
                     position,
                     source: PointerSource::Mouse,
                 },
@@ -1205,6 +1212,7 @@ impl EventProcessor {
                 window_id,
                 event: WindowEvent::PointerEntered {
                     device_id,
+                    primary: true,
                     position,
                     kind: PointerKind::Mouse,
                 },
@@ -1229,6 +1237,7 @@ impl EventProcessor {
                 window_id: mkwid(window),
                 event: WindowEvent::PointerLeft {
                     device_id: Some(mkdid(event.deviceid as xinput::DeviceId)),
+                    primary: true,
                     position: Some(PhysicalPosition::new(event.event_x, event.event_y)),
                     kind: PointerKind::Mouse,
                 },
@@ -1289,7 +1298,12 @@ impl EventProcessor {
 
         let event = Event::WindowEvent {
             window_id,
-            event: WindowEvent::PointerMoved { device_id, position, source: PointerSource::Mouse },
+            event: WindowEvent::PointerMoved {
+                device_id,
+                primary: true,
+                position,
+                source: PointerSource::Mouse,
+            },
         };
         callback(&self.target, event);
     }
@@ -1360,11 +1374,14 @@ impl EventProcessor {
 
             // Mouse cursor position changes when touch events are received.
             // Only the first concurrently active touch ID moves the mouse cursor.
-            if is_first_touch(&mut self.first_touch, &mut self.num_touch, id, phase) {
+            let is_first_touch =
+                is_first_touch(&mut self.first_touch, &mut self.num_touch, id, phase);
+            if is_first_touch {
                 let event = Event::WindowEvent {
                     window_id,
                     event: WindowEvent::PointerMoved {
                         device_id: None,
+                        primary: true,
                         position: position.cast(),
                         source: PointerSource::Mouse,
                     },
@@ -1381,6 +1398,7 @@ impl EventProcessor {
                         window_id,
                         event: WindowEvent::PointerEntered {
                             device_id,
+                            primary: is_first_touch,
                             position,
                             kind: PointerKind::Touch(finger_id),
                         },
@@ -1390,6 +1408,7 @@ impl EventProcessor {
                         window_id,
                         event: WindowEvent::PointerButton {
                             device_id,
+                            primary: is_first_touch,
                             state: ElementState::Pressed,
                             position,
                             button: ButtonSource::Touch { finger_id, force: None },
@@ -1402,6 +1421,7 @@ impl EventProcessor {
                         window_id,
                         event: WindowEvent::PointerMoved {
                             device_id,
+                            primary: is_first_touch,
                             position,
                             source: PointerSource::Touch { finger_id, force: None },
                         },
@@ -1413,6 +1433,7 @@ impl EventProcessor {
                         window_id,
                         event: WindowEvent::PointerButton {
                             device_id,
+                            primary: is_first_touch,
                             state: ElementState::Released,
                             position,
                             button: ButtonSource::Touch { finger_id, force: None },
@@ -1423,6 +1444,7 @@ impl EventProcessor {
                         window_id,
                         event: WindowEvent::PointerLeft {
                             device_id,
+                            primary: is_first_touch,
                             position: Some(position),
                             kind: PointerKind::Touch(finger_id),
                         },

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -22,8 +22,9 @@ use xkbcommon_dl::xkb_mod_mask_t;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::event::{
-    ButtonSource, DeviceEvent, DeviceId, ElementState, Event, Ime, MouseButton, MouseScrollDelta,
-    PointerKind, PointerSource, RawKeyEvent, SurfaceSizeWriter, TouchPhase, WindowEvent,
+    ButtonSource, DeviceEvent, DeviceId, ElementState, Event, FingerId, Ime, MouseButton,
+    MouseScrollDelta, PointerKind, PointerSource, RawKeyEvent, SurfaceSizeWriter, TouchPhase,
+    WindowEvent,
 };
 use crate::keyboard::ModifiersState;
 use crate::platform_impl::common::xkb::{self, XkbState};
@@ -33,7 +34,7 @@ use crate::platform_impl::platform::x11::ActiveEventLoop;
 use crate::platform_impl::x11::atoms::*;
 use crate::platform_impl::x11::util::cookie::GenericEventCookie;
 use crate::platform_impl::x11::{
-    mkdid, mkfid, mkwid, util, CookieResultExt, Device, DeviceInfo, Dnd, DndState, ImeReceiver,
+    mkdid, mkwid, util, CookieResultExt, Device, DeviceInfo, Dnd, DndState, ImeReceiver,
     ScrollOrientation, UnownedWindow, WindowId,
 };
 
@@ -1390,7 +1391,7 @@ impl EventProcessor {
             }
 
             let device_id = Some(mkdid(xev.deviceid as xinput::DeviceId));
-            let finger_id = mkfid(id);
+            let finger_id = FingerId::from_raw(id as usize);
 
             match phase {
                 xinput2::XI_TouchBegin => {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -805,17 +805,6 @@ impl<'a> Deref for DeviceInfo<'a> {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FingerId(u32);
-
-impl FingerId {
-    #[cfg(test)]
-    #[allow(unused)]
-    pub const fn dummy() -> Self {
-        FingerId(0)
-    }
-}
-
 #[derive(Clone)]
 pub struct EventLoopProxy {
     ping: Ping,
@@ -992,10 +981,6 @@ fn mkwid(w: xproto::Window) -> crate::window::WindowId {
 }
 fn mkdid(w: xinput::DeviceId) -> DeviceId {
     DeviceId::from_raw(w as i64)
-}
-
-fn mkfid(w: u32) -> crate::event::FingerId {
-    crate::event::FingerId(crate::platform_impl::FingerId::X(FingerId(w)))
 }
 
 #[derive(Debug)]

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -22,6 +22,7 @@ use self::apple as platform;
 use self::linux as platform;
 #[cfg(orbital_platform)]
 use self::orbital as platform;
+#[allow(unused_imports)]
 pub use self::platform::*;
 #[cfg(web_platform)]
 use self::web as platform;

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -404,6 +404,7 @@ impl EventLoop {
             EventOption::Mouse(MouseEvent { x, y }) => {
                 app.window_event(window_target, window_id, event::WindowEvent::PointerMoved {
                     device_id: None,
+                    primary: true,
                     position: (x, y).into(),
                     source: event::PointerSource::Mouse,
                 });
@@ -417,6 +418,7 @@ impl EventLoop {
                 while let Some((button, state)) = event_state.mouse(left, middle, right) {
                     app.window_event(window_target, window_id, event::WindowEvent::PointerButton {
                         device_id: None,
+                        primary: true,
                         state,
                         position: dpi::PhysicalPosition::default(),
                         button: button.into(),
@@ -458,12 +460,14 @@ impl EventLoop {
                 let event = if entered {
                     event::WindowEvent::PointerEntered {
                         device_id: None,
+                        primary: true,
                         position: dpi::PhysicalPosition::default(),
                         kind: event::PointerKind::Mouse,
                     }
                 } else {
                     event::WindowEvent::PointerLeft {
                         device_id: None,
+                        primary: true,
                         position: None,
                         kind: event::PointerKind::Mouse,
                     }

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -99,16 +99,6 @@ impl TimeSocket {
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct PlatformSpecificEventLoopAttributes {}
 
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct FingerId;
-
-impl FingerId {
-    #[cfg(test)]
-    pub const fn dummy() -> Self {
-        FingerId
-    }
-}
-
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct PlatformSpecificWindowAttributes;
 

--- a/src/platform_impl/web/event.rs
+++ b/src/platform_impl/web/event.rs
@@ -1,4 +1,4 @@
-use crate::event::{DeviceId, FingerId as RootFingerId};
+use crate::event::DeviceId;
 
 pub(crate) fn mkdid(pointer_id: i32) -> Option<DeviceId> {
     if let Ok(pointer_id) = u32::try_from(pointer_id) {
@@ -8,27 +8,5 @@ pub(crate) fn mkdid(pointer_id: i32) -> Option<DeviceId> {
     } else {
         tracing::error!("found unexpected negative `PointerEvent.pointerId`: {pointer_id}");
         None
-    }
-}
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FingerId {
-    pointer_id: i32,
-}
-
-impl FingerId {
-    pub fn new(pointer_id: i32) -> Self {
-        Self { pointer_id }
-    }
-
-    #[cfg(test)]
-    pub const fn dummy() -> Self {
-        Self { pointer_id: -1 }
-    }
-}
-
-impl From<FingerId> for RootFingerId {
-    fn from(id: FingerId) -> Self {
-        Self(id)
     }
 }

--- a/src/platform_impl/web/event.rs
+++ b/src/platform_impl/web/event.rs
@@ -14,21 +14,16 @@ pub(crate) fn mkdid(pointer_id: i32) -> Option<DeviceId> {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId {
     pointer_id: i32,
-    primary: bool,
 }
 
 impl FingerId {
-    pub fn new(pointer_id: i32, primary: bool) -> Self {
-        Self { pointer_id, primary }
+    pub fn new(pointer_id: i32) -> Self {
+        Self { pointer_id }
     }
 
     #[cfg(test)]
     pub const fn dummy() -> Self {
-        Self { pointer_id: -1, primary: false }
-    }
-
-    pub fn is_primary(self) -> bool {
-        self.primary
+        Self { pointer_id: -1 }
     }
 }
 

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -197,7 +197,7 @@ impl ActiveEventLoop {
             let has_focus = has_focus.clone();
             let modifiers = self.modifiers.clone();
 
-            move |active_modifiers, device_id, position, kind| {
+            move |active_modifiers, device_id, primary, position, kind| {
                 let focus = (has_focus.get() && modifiers.get() != active_modifiers).then(|| {
                     modifiers.set(active_modifiers);
                     Event::WindowEvent {
@@ -208,7 +208,12 @@ impl ActiveEventLoop {
 
                 runner.send_events(focus.into_iter().chain(iter::once(Event::WindowEvent {
                     window_id,
-                    event: WindowEvent::PointerLeft { device_id, position: Some(position), kind },
+                    event: WindowEvent::PointerLeft {
+                        device_id,
+                        primary,
+                        position: Some(position),
+                        kind,
+                    },
                 })))
             }
         });
@@ -218,7 +223,7 @@ impl ActiveEventLoop {
             let has_focus = has_focus.clone();
             let modifiers = self.modifiers.clone();
 
-            move |active_modifiers, device_id, position, kind| {
+            move |active_modifiers, device_id, primary, position, kind| {
                 let focus = (has_focus.get() && modifiers.get() != active_modifiers).then(|| {
                     modifiers.set(active_modifiers);
                     Event::WindowEvent {
@@ -229,7 +234,7 @@ impl ActiveEventLoop {
 
                 runner.send_events(focus.into_iter().chain(iter::once(Event::WindowEvent {
                     window_id,
-                    event: WindowEvent::PointerEntered { device_id, position, kind },
+                    event: WindowEvent::PointerEntered { device_id, primary, position, kind },
                 })))
             }
         });
@@ -241,21 +246,31 @@ impl ActiveEventLoop {
                 let modifiers = self.modifiers.clone();
 
                 move |device_id, events| {
-                    runner.send_events(events.flat_map(|(active_modifiers, position, source)| {
-                        let modifiers = (has_focus.get() && modifiers.get() != active_modifiers)
-                            .then(|| {
-                                modifiers.set(active_modifiers);
-                                Event::WindowEvent {
-                                    window_id,
-                                    event: WindowEvent::ModifiersChanged(active_modifiers.into()),
-                                }
-                            });
+                    runner.send_events(events.flat_map(
+                        |(active_modifiers, primary, position, source)| {
+                            let modifiers = (has_focus.get()
+                                && modifiers.get() != active_modifiers)
+                                .then(|| {
+                                    modifiers.set(active_modifiers);
+                                    Event::WindowEvent {
+                                        window_id,
+                                        event: WindowEvent::ModifiersChanged(
+                                            active_modifiers.into(),
+                                        ),
+                                    }
+                                });
 
-                        modifiers.into_iter().chain(iter::once(Event::WindowEvent {
-                            window_id,
-                            event: WindowEvent::PointerMoved { device_id, position, source },
-                        }))
-                    }));
+                            modifiers.into_iter().chain(iter::once(Event::WindowEvent {
+                                window_id,
+                                event: WindowEvent::PointerMoved {
+                                    device_id,
+                                    primary,
+                                    position,
+                                    source,
+                                },
+                            }))
+                        },
+                    ));
                 }
             },
             {
@@ -263,7 +278,7 @@ impl ActiveEventLoop {
                 let has_focus = has_focus.clone();
                 let modifiers = self.modifiers.clone();
 
-                move |active_modifiers, device_id, position, state, button| {
+                move |active_modifiers, device_id, primary, position, state, button| {
                     let modifiers =
                         (has_focus.get() && modifiers.get() != active_modifiers).then(|| {
                             modifiers.set(active_modifiers);
@@ -275,7 +290,13 @@ impl ActiveEventLoop {
 
                     runner.send_events(modifiers.into_iter().chain([Event::WindowEvent {
                         window_id,
-                        event: WindowEvent::PointerButton { device_id, state, position, button },
+                        event: WindowEvent::PointerButton {
+                            device_id,
+                            primary,
+                            state,
+                            position,
+                            button,
+                        },
                     }]));
                 }
             },
@@ -285,7 +306,7 @@ impl ActiveEventLoop {
             let runner = self.runner.clone();
             let modifiers = self.modifiers.clone();
 
-            move |active_modifiers, device_id, position, button| {
+            move |active_modifiers, device_id, primary, position, button| {
                 let modifiers = (modifiers.get() != active_modifiers).then(|| {
                     modifiers.set(active_modifiers);
                     Event::WindowEvent {
@@ -298,6 +319,7 @@ impl ActiveEventLoop {
                     window_id,
                     event: WindowEvent::PointerButton {
                         device_id,
+                        primary,
                         state: ElementState::Pressed,
                         position,
                         button,
@@ -311,7 +333,7 @@ impl ActiveEventLoop {
             let has_focus = has_focus.clone();
             let modifiers = self.modifiers.clone();
 
-            move |active_modifiers, device_id, position, button| {
+            move |active_modifiers, device_id, primary, position, button| {
                 let modifiers =
                     (has_focus.get() && modifiers.get() != active_modifiers).then(|| {
                         modifiers.set(active_modifiers);
@@ -325,6 +347,7 @@ impl ActiveEventLoop {
                     window_id,
                     event: WindowEvent::PointerButton {
                         device_id,
+                        primary,
                         state: ElementState::Released,
                         position,
                         button,

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -37,7 +37,6 @@ pub(crate) use cursor::{
     CustomCursorSource as PlatformCustomCursorSource,
 };
 
-pub use self::event::FingerId;
 pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle,
     PlatformSpecificEventLoopAttributes,

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -331,28 +331,32 @@ impl Canvas {
 
     pub fn on_pointer_leave<F>(&self, handler: F)
     where
-        F: 'static + FnMut(ModifiersState, Option<DeviceId>, PhysicalPosition<f64>, PointerKind),
+        F: 'static
+            + FnMut(ModifiersState, Option<DeviceId>, bool, PhysicalPosition<f64>, PointerKind),
     {
         self.handlers.borrow_mut().pointer_handler.on_pointer_leave(&self.common, handler)
     }
 
     pub fn on_pointer_enter<F>(&self, handler: F)
     where
-        F: 'static + FnMut(ModifiersState, Option<DeviceId>, PhysicalPosition<f64>, PointerKind),
+        F: 'static
+            + FnMut(ModifiersState, Option<DeviceId>, bool, PhysicalPosition<f64>, PointerKind),
     {
         self.handlers.borrow_mut().pointer_handler.on_pointer_enter(&self.common, handler)
     }
 
     pub fn on_pointer_release<C>(&self, handler: C)
     where
-        C: 'static + FnMut(ModifiersState, Option<DeviceId>, PhysicalPosition<f64>, ButtonSource),
+        C: 'static
+            + FnMut(ModifiersState, Option<DeviceId>, bool, PhysicalPosition<f64>, ButtonSource),
     {
         self.handlers.borrow_mut().pointer_handler.on_pointer_release(&self.common, handler)
     }
 
     pub fn on_pointer_press<C>(&self, handler: C)
     where
-        C: 'static + FnMut(ModifiersState, Option<DeviceId>, PhysicalPosition<f64>, ButtonSource),
+        C: 'static
+            + FnMut(ModifiersState, Option<DeviceId>, bool, PhysicalPosition<f64>, ButtonSource),
     {
         self.handlers.borrow_mut().pointer_handler.on_pointer_press(
             &self.common,
@@ -366,12 +370,15 @@ impl Canvas {
         C: 'static
             + FnMut(
                 Option<DeviceId>,
-                &mut dyn Iterator<Item = (ModifiersState, PhysicalPosition<f64>, PointerSource)>,
+                &mut dyn Iterator<
+                    Item = (ModifiersState, bool, PhysicalPosition<f64>, PointerSource),
+                >,
             ),
         B: 'static
             + FnMut(
                 ModifiersState,
                 Option<DeviceId>,
+                bool,
                 PhysicalPosition<f64>,
                 ElementState,
                 ButtonSource,

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -6,9 +6,8 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{KeyboardEvent, MouseEvent, Navigator, PointerEvent, WheelEvent};
 
-use super::super::FingerId;
 use super::Engine;
-use crate::event::{MouseButton, MouseScrollDelta, PointerKind};
+use crate::event::{FingerId, MouseButton, MouseScrollDelta, PointerKind};
 use crate::keyboard::{Key, KeyLocation, ModifiersState, NamedKey, PhysicalKey};
 
 bitflags::bitflags! {
@@ -164,7 +163,7 @@ pub fn mouse_scroll_delta(
 pub fn pointer_type(event: &PointerEvent, pointer_id: i32) -> PointerKind {
     match event.pointer_type().as_str() {
         "mouse" => PointerKind::Mouse,
-        "touch" => PointerKind::Touch(FingerId::new(pointer_id).into()),
+        "touch" => PointerKind::Touch(FingerId::from_raw(pointer_id as usize)),
         _ => PointerKind::Unknown,
     }
 }

--- a/src/platform_impl/web/web_sys/event.rs
+++ b/src/platform_impl/web/web_sys/event.rs
@@ -164,7 +164,7 @@ pub fn mouse_scroll_delta(
 pub fn pointer_type(event: &PointerEvent, pointer_id: i32) -> PointerKind {
     match event.pointer_type().as_str() {
         "mouse" => PointerKind::Mouse,
-        "touch" => PointerKind::Touch(FingerId::new(pointer_id, event.is_primary()).into()),
+        "touch" => PointerKind::Touch(FingerId::new(pointer_id).into()),
         _ => PointerKind::Unknown,
     }
 }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1621,6 +1621,7 @@ unsafe fn public_window_callback_inner(
                             window_id: WindowId::from_raw(window as usize),
                             event: PointerEntered {
                                 device_id: None,
+                                primary: true,
                                 position,
                                 kind: PointerKind::Mouse,
                             },
@@ -1646,6 +1647,7 @@ unsafe fn public_window_callback_inner(
                             window_id: WindowId::from_raw(window as usize),
                             event: PointerLeft {
                                 device_id: None,
+                                primary: true,
                                 position: Some(position),
                                 kind: PointerKind::Mouse,
                             },
@@ -1667,7 +1669,12 @@ unsafe fn public_window_callback_inner(
 
                 userdata.send_event(Event::WindowEvent {
                     window_id: WindowId::from_raw(window as usize),
-                    event: PointerMoved { device_id: None, position, source: PointerSource::Mouse },
+                    event: PointerMoved {
+                        device_id: None,
+                        primary: true,
+                        position,
+                        source: PointerSource::Mouse,
+                    },
                 });
             }
 
@@ -1685,7 +1692,7 @@ unsafe fn public_window_callback_inner(
 
             userdata.send_event(Event::WindowEvent {
                 window_id: WindowId::from_raw(window as usize),
-                event: PointerLeft { device_id: None, position: None, kind: Mouse },
+                event: PointerLeft { device_id: None, primary: true, position: None, kind: Mouse },
             });
 
             result = ProcResult::Value(0);
@@ -1762,6 +1769,7 @@ unsafe fn public_window_callback_inner(
                 window_id: WindowId::from_raw(window as usize),
                 event: PointerButton {
                     device_id: None,
+                    primary: true,
                     state: Pressed,
                     position,
                     button: Left.into(),
@@ -1787,6 +1795,7 @@ unsafe fn public_window_callback_inner(
                 window_id: WindowId::from_raw(window as usize),
                 event: PointerButton {
                     device_id: None,
+                    primary: true,
                     state: Released,
                     position,
                     button: Left.into(),
@@ -1812,6 +1821,7 @@ unsafe fn public_window_callback_inner(
                 window_id: WindowId::from_raw(window as usize),
                 event: PointerButton {
                     device_id: None,
+                    primary: true,
                     state: Pressed,
                     position,
                     button: Right.into(),
@@ -1837,6 +1847,7 @@ unsafe fn public_window_callback_inner(
                 window_id: WindowId::from_raw(window as usize),
                 event: PointerButton {
                     device_id: None,
+                    primary: true,
                     state: Released,
                     position,
                     button: Right.into(),
@@ -1862,6 +1873,7 @@ unsafe fn public_window_callback_inner(
                 window_id: WindowId::from_raw(window as usize),
                 event: PointerButton {
                     device_id: None,
+                    primary: true,
                     state: Pressed,
                     position,
                     button: Middle.into(),
@@ -1887,6 +1899,7 @@ unsafe fn public_window_callback_inner(
                 window_id: WindowId::from_raw(window as usize),
                 event: PointerButton {
                     device_id: None,
+                    primary: true,
                     state: Released,
                     position,
                     button: Middle.into(),
@@ -1913,6 +1926,7 @@ unsafe fn public_window_callback_inner(
                 window_id: WindowId::from_raw(window as usize),
                 event: PointerButton {
                     device_id: None,
+                    primary: true,
                     state: Pressed,
                     position,
                     button: match xbutton {
@@ -1944,6 +1958,7 @@ unsafe fn public_window_callback_inner(
                 window_id: WindowId::from_raw(window as usize),
                 event: PointerButton {
                     device_id: None,
+                    primary: true,
                     state: Released,
                     position,
                     button: match xbutton {
@@ -1997,16 +2012,15 @@ unsafe fn public_window_callback_inner(
                     let position = PhysicalPosition::new(x, y);
 
                     let window_id = WindowId::from_raw(window as usize);
-                    let finger_id = RootFingerId(FingerId {
-                        id: input.dwID,
-                        primary: util::has_flag(input.dwFlags, TOUCHEVENTF_PRIMARY),
-                    });
+                    let finger_id = RootFingerId(FingerId { id: input.dwID });
+                    let primary = util::has_flag(input.dwFlags, TOUCHEVENTF_PRIMARY);
 
                     if util::has_flag(input.dwFlags, TOUCHEVENTF_DOWN) {
                         userdata.send_event(Event::WindowEvent {
                             window_id,
                             event: WindowEvent::PointerEntered {
                                 device_id: None,
+                                primary,
                                 position,
                                 kind: PointerKind::Touch(finger_id),
                             },
@@ -2015,6 +2029,7 @@ unsafe fn public_window_callback_inner(
                             window_id,
                             event: WindowEvent::PointerButton {
                                 device_id: None,
+                                primary,
                                 state: Pressed,
                                 position,
                                 button: Touch { finger_id, force: None },
@@ -2025,6 +2040,7 @@ unsafe fn public_window_callback_inner(
                             window_id,
                             event: WindowEvent::PointerButton {
                                 device_id: None,
+                                primary,
                                 state: Released,
                                 position,
                                 button: Touch { finger_id, force: None },
@@ -2034,6 +2050,7 @@ unsafe fn public_window_callback_inner(
                             window_id,
                             event: WindowEvent::PointerLeft {
                                 device_id: None,
+                                primary,
                                 position: Some(position),
                                 kind: PointerKind::Touch(finger_id),
                             },
@@ -2043,6 +2060,7 @@ unsafe fn public_window_callback_inner(
                             window_id,
                             event: WindowEvent::PointerMoved {
                                 device_id: None,
+                                primary,
                                 position,
                                 source: PointerSource::Touch { finger_id, force: None },
                             },
@@ -2165,16 +2183,15 @@ unsafe fn public_window_callback_inner(
                     let position = PhysicalPosition::new(x, y);
 
                     let window_id = WindowId::from_raw(window as usize);
-                    let finger_id = RootFingerId(FingerId {
-                        id: pointer_info.pointerId,
-                        primary: util::has_flag(pointer_info.pointerFlags, POINTER_FLAG_PRIMARY),
-                    });
+                    let finger_id = RootFingerId(FingerId { id: pointer_info.pointerId });
+                    let primary = util::has_flag(pointer_info.pointerFlags, POINTER_FLAG_PRIMARY);
 
                     if util::has_flag(pointer_info.pointerFlags, POINTER_FLAG_DOWN) {
                         userdata.send_event(Event::WindowEvent {
                             window_id,
                             event: WindowEvent::PointerEntered {
                                 device_id: None,
+                                primary,
                                 position,
                                 kind: if let PT_TOUCH = pointer_info.pointerType {
                                     PointerKind::Touch(finger_id)
@@ -2187,6 +2204,7 @@ unsafe fn public_window_callback_inner(
                             window_id,
                             event: WindowEvent::PointerButton {
                                 device_id: None,
+                                primary,
                                 state: Pressed,
                                 position,
                                 button: if let PT_TOUCH = pointer_info.pointerType {
@@ -2201,6 +2219,7 @@ unsafe fn public_window_callback_inner(
                             window_id,
                             event: WindowEvent::PointerButton {
                                 device_id: None,
+                                primary,
                                 state: Released,
                                 position,
                                 button: if let PT_TOUCH = pointer_info.pointerType {
@@ -2214,6 +2233,7 @@ unsafe fn public_window_callback_inner(
                             window_id,
                             event: WindowEvent::PointerLeft {
                                 device_id: None,
+                                primary,
                                 position: Some(position),
                                 kind: if let PT_TOUCH = pointer_info.pointerType {
                                     PointerKind::Touch(finger_id)
@@ -2227,6 +2247,7 @@ unsafe fn public_window_callback_inner(
                             window_id,
                             event: WindowEvent::PointerMoved {
                                 device_id: None,
+                                primary,
                                 position,
                                 source: if let PT_TOUCH = pointer_info.pointerType {
                                     PointerSource::Touch { finger_id, force }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -65,8 +65,7 @@ use crate::application::ApplicationHandler;
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::error::{EventLoopError, RequestError};
 use crate::event::{
-    Event, FingerId as RootFingerId, Force, Ime, RawKeyEvent, SurfaceSizeWriter, TouchPhase,
-    WindowEvent,
+    Event, FingerId, Force, Ime, RawKeyEvent, SurfaceSizeWriter, TouchPhase, WindowEvent,
 };
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
@@ -87,7 +86,7 @@ use crate::platform_impl::platform::window::InitData;
 use crate::platform_impl::platform::window_state::{
     CursorFlags, ImeState, WindowFlags, WindowState,
 };
-use crate::platform_impl::platform::{raw_input, util, wrap_device_id, FingerId, Fullscreen};
+use crate::platform_impl::platform::{raw_input, util, wrap_device_id, Fullscreen};
 use crate::platform_impl::Window;
 use crate::utils::Lazy;
 use crate::window::{
@@ -2012,7 +2011,7 @@ unsafe fn public_window_callback_inner(
                     let position = PhysicalPosition::new(x, y);
 
                     let window_id = WindowId::from_raw(window as usize);
-                    let finger_id = RootFingerId(FingerId { id: input.dwID });
+                    let finger_id = FingerId::from_raw(input.dwID as usize);
                     let primary = util::has_flag(input.dwFlags, TOUCHEVENTF_PRIMARY);
 
                     if util::has_flag(input.dwFlags, TOUCHEVENTF_DOWN) {
@@ -2183,7 +2182,7 @@ unsafe fn public_window_callback_inner(
                     let position = PhysicalPosition::new(x, y);
 
                     let window_id = WindowId::from_raw(window as usize);
-                    let finger_id = RootFingerId(FingerId { id: pointer_info.pointerId });
+                    let finger_id = FingerId::from_raw(pointer_info.pointerId as usize);
                     let primary = util::has_flag(pointer_info.pointerFlags, POINTER_FLAG_PRIMARY);
 
                     if util::has_flag(pointer_info.pointerFlags, POINTER_FLAG_DOWN) {

--- a/src/platform_impl/windows/keyboard.rs
+++ b/src/platform_impl/windows/keyboard.rs
@@ -97,7 +97,7 @@ impl KeyEventBuilder {
                     MatchResult::MessagesToDispatch(self.pending.complete_multi(key_events))
                 },
                 WM_KILLFOCUS => {
-                    // sythesize keyup events
+                    // synthesize keyup events
                     let kbd_state = get_kbd_state();
                     let key_events = Self::synthesize_kbd_state(ElementState::Released, &kbd_state);
                     MatchResult::MessagesToDispatch(self.pending.complete_multi(key_events))
@@ -333,11 +333,11 @@ impl KeyEventBuilder {
         // We are synthesizing the press event for caps-lock first for the following reasons:
         // 1. If caps-lock is *not* held down but *is* active, then we have to synthesize all
         //    printable keys, respecting the caps-lock state.
-        // 2. If caps-lock is held down, we could choose to sythesize its keypress after every other
-        //    key, in which case all other keys *must* be sythesized as if the caps-lock state was
-        //    be the opposite of what it currently is.
+        // 2. If caps-lock is held down, we could choose to synthesize its keypress after every
+        //    other key, in which case all other keys *must* be sythesized as if the caps-lock state
+        //    was be the opposite of what it currently is.
         // --
-        // For the sake of simplicity we are choosing to always sythesize
+        // For the sake of simplicity we are choosing to always synthesize
         // caps-lock first, and always use the current caps-lock state
         // to determine the produced text
         if is_key_pressed!(VK_CAPITAL) {

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -59,18 +59,6 @@ impl Default for PlatformSpecificWindowAttributes {
 unsafe impl Send for PlatformSpecificWindowAttributes {}
 unsafe impl Sync for PlatformSpecificWindowAttributes {}
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FingerId {
-    id: u32,
-}
-
-impl FingerId {
-    #[cfg(test)]
-    pub const fn dummy() -> Self {
-        FingerId { id: 0 }
-    }
-}
-
 fn wrap_device_id(id: u32) -> DeviceId {
     DeviceId::from_raw(id as i64)
 }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -62,19 +62,12 @@ unsafe impl Sync for PlatformSpecificWindowAttributes {}
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FingerId {
     id: u32,
-    primary: bool,
 }
 
 impl FingerId {
     #[cfg(test)]
     pub const fn dummy() -> Self {
-        FingerId { id: 0, primary: false }
-    }
-}
-
-impl FingerId {
-    pub fn is_primary(self) -> bool {
-        self.primary
+        FingerId { id: 0 }
     }
 }
 


### PR DESCRIPTION
Whether the pointer event is primary or not generally matters for the
context where all input is done by the same event, so users can
_ignore_ non-primary events since they are likely from users clicking
something else with their other fingers.

Having it only on a FingerId made it useless, since it's usually used
to avoid multi-touch, but if you start mapping on touch event you
already can track things like that yourself.

Fixes #3943.

--

@daxpedda I left the web, since it's starting to get messy with those callbacks, so you might want to refactor things to your liking. I could still plumb those bools though.
That's also the reason PR doesn't really build.

@madsmtm I did only `true` for `ios`, which is likely fine, but I guess we could track based on some `Option<Touch>`? I decided not to, since ios uses pointer casts for its id, etc.
