### PR TITLE
wayland: use correct rounding in logical->physical conversions

### DIFF
--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -30,7 +30,7 @@ use sink::EventSink;
 
 use super::state::{WindowCompositorUpdate, WinitState};
 use super::window::state::FrameCallbackState;
-use super::{logical_to_physical_rounded, WindowId};
+use super::WindowId;
 
 type WaylandDispatcher = calloop::Dispatcher<'static, WaylandSource<WinitState>, WinitState>;
 
@@ -304,8 +304,8 @@ impl EventLoop {
                     let windows = state.windows.get_mut();
                     let window = windows.get(&window_id).unwrap().lock().unwrap();
                     let scale_factor = window.scale_factor();
-                    let size = logical_to_physical_rounded(window.surface_size(), scale_factor);
-                    (size, scale_factor)
+                    let size = window.surface_size() * scale_factor;
+                    (size, scale_factor.to_f64())
                 });
 
                 // Stash the old window size.
@@ -346,7 +346,7 @@ impl EventLoop {
                     let window = windows.get(&window_id).unwrap().lock().unwrap();
 
                     let scale_factor = window.scale_factor();
-                    let size = logical_to_physical_rounded(window.surface_size(), scale_factor);
+                    let size = window.surface_size() * scale_factor;
 
                     // Mark the window as needed a redraw.
                     state

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -7,11 +7,11 @@ use sctk::reexports::client::Proxy;
 pub use window::Window;
 
 pub(super) use crate::cursor::OnlyCursorImage as CustomCursor;
-use crate::dpi::{LogicalSize, PhysicalSize};
 use crate::window::WindowId;
 
 mod event_loop;
 mod output;
+mod scale;
 mod seat;
 mod state;
 mod types;
@@ -31,11 +31,4 @@ impl FingerId {
 #[inline]
 fn make_wid(surface: &WlSurface) -> WindowId {
     WindowId::from_raw(surface.id().as_ptr() as usize)
-}
-
-/// The default routine does floor, but we need round on Wayland.
-fn logical_to_physical_rounded(size: LogicalSize<u32>, scale_factor: f64) -> PhysicalSize<u32> {
-    let width = size.width as f64 * scale_factor;
-    let height = size.height as f64 * scale_factor;
-    (width.round(), height.round()).into()
 }

--- a/src/platform_impl/linux/wayland/scale.rs
+++ b/src/platform_impl/linux/wayland/scale.rs
@@ -1,0 +1,52 @@
+use std::ops::Mul;
+
+use dpi::{LogicalSize, PhysicalSize};
+
+/// A wp-fractional-scale scale.
+///
+/// This type implements the `physical_size = round_half_up(logical_size * scale)`
+/// operation with infinite precision as required by the protocol.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct Scale {
+    scale: u64,
+}
+
+const BASE: u32 = 120;
+const BASE_U64: u64 = BASE as u64;
+const BASE_F64: f64 = BASE as f64;
+
+impl Scale {
+    pub fn from_wp_fractional_scale(v: u32) -> Self {
+        assert!(v > 0);
+        Self { scale: v as u64 }
+    }
+
+    pub fn from_integer_scale(v: u32) -> Self {
+        Self::from_wp_fractional_scale(v.saturating_mul(BASE))
+    }
+
+    pub fn to_f64(self) -> f64 {
+        self.scale as f64 / BASE_F64
+    }
+
+    pub fn round_up(self) -> u32 {
+        ((self.scale + BASE_U64 - 1) / BASE_U64) as u32
+    }
+
+    fn surface_to_buffer<const N: usize>(self, sizes: [u32; N]) -> [u32; N] {
+        sizes.map(|surface| {
+            // buffer = floor((surface * scale + 60) / 120)
+            let buffer = (surface as u64 * self.scale + BASE_U64 / 2) / BASE_U64;
+            buffer.min(u32::MAX as u64) as u32
+        })
+    }
+}
+
+impl Mul<Scale> for LogicalSize<u32> {
+    type Output = PhysicalSize<u32>;
+
+    fn mul(self, scale: Scale) -> Self::Output {
+        let [width, height] = scale.surface_to_buffer([self.width, self.height]);
+        PhysicalSize { width, height }
+    }
+}

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -76,7 +76,7 @@ impl PointerHandler for WinitState {
                 None => continue,
             };
 
-            let scale_factor = window.scale_factor();
+            let scale_factor = window.scale_factor_f64();
             let position: PhysicalPosition<f64> =
                 LogicalPosition::new(event.position.0, event.position.1).to_physical(scale_factor);
 

--- a/src/platform_impl/linux/wayland/seat/touch/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/touch/mod.rs
@@ -26,7 +26,7 @@ impl TouchHandler for WinitState {
     ) {
         let window_id = wayland::make_wid(&surface);
         let scale_factor = match self.windows.get_mut().get(&window_id) {
-            Some(window) => window.lock().unwrap().scale_factor(),
+            Some(window) => window.lock().unwrap().scale_factor_f64(),
             None => return,
         };
 
@@ -90,7 +90,7 @@ impl TouchHandler for WinitState {
 
         let window_id = wayland::make_wid(&touch_point.surface);
         let scale_factor = match self.windows.get_mut().get(&window_id) {
-            Some(window) => window.lock().unwrap().scale_factor(),
+            Some(window) => window.lock().unwrap().scale_factor_f64(),
             None => return,
         };
 
@@ -142,7 +142,7 @@ impl TouchHandler for WinitState {
 
         let window_id = wayland::make_wid(&touch_point.surface);
         let scale_factor = match self.windows.get_mut().get(&window_id) {
-            Some(window) => window.lock().unwrap().scale_factor(),
+            Some(window) => window.lock().unwrap().scale_factor_f64(),
             None => return,
         };
 
@@ -175,7 +175,7 @@ impl TouchHandler for WinitState {
         for (id, touch_point) in seat_state.touch_map.drain() {
             let window_id = wayland::make_wid(&touch_point.surface);
             let scale_factor = match self.windows.get_mut().get(&window_id) {
-                Some(window) => window.lock().unwrap().scale_factor(),
+                Some(window) => window.lock().unwrap().scale_factor_f64(),
                 None => return,
             };
 

--- a/src/platform_impl/linux/wayland/state.rs
+++ b/src/platform_impl/linux/wayland/state.rs
@@ -24,6 +24,7 @@ use sctk::subcompositor::SubcompositorState;
 use crate::error::OsError;
 use crate::platform_impl::wayland::event_loop::sink::EventSink;
 use crate::platform_impl::wayland::output::MonitorHandle;
+use crate::platform_impl::wayland::scale::Scale;
 use crate::platform_impl::wayland::seat::{
     PointerConstraintsState, RelativePointerState, TextInputState, WinitPointerData,
     WinitPointerDataExt, WinitSeatState,
@@ -200,7 +201,7 @@ impl WinitState {
     pub fn scale_factor_changed(
         &mut self,
         surface: &WlSurface,
-        scale_factor: f64,
+        scale_factor: Scale,
         is_legacy: bool,
     ) {
         // Check if the cursor surface.
@@ -372,7 +373,9 @@ impl CompositorHandler for WinitState {
         surface: &WlSurface,
         scale_factor: i32,
     ) {
-        self.scale_factor_changed(surface, scale_factor as f64, true)
+        assert!(scale_factor >= 0);
+        let scale = Scale::from_integer_scale(scale_factor as u32);
+        self.scale_factor_changed(surface, scale, true)
     }
 
     fn frame(&mut self, _: &Connection, _: &QueueHandle<Self>, surface: &WlSurface, _: u32) {

--- a/src/platform_impl/linux/wayland/types/wp_fractional_scaling.rs
+++ b/src/platform_impl/linux/wayland/types/wp_fractional_scaling.rs
@@ -9,10 +9,8 @@ use sctk::reexports::protocols::wp::fractional_scale::v1::client::wp_fractional_
     Event as FractionalScalingEvent, WpFractionalScaleV1,
 };
 
+use crate::platform_impl::wayland::scale::Scale;
 use crate::platform_impl::wayland::state::WinitState;
-
-/// The scaling factor denominator.
-const SCALE_DENOMINATOR: f64 = 120.;
 
 /// Fractional scaling manager.
 #[derive(Debug)]
@@ -68,7 +66,8 @@ impl Dispatch<WpFractionalScaleV1, FractionalScaling, WinitState> for Fractional
         _: &QueueHandle<WinitState>,
     ) {
         if let FractionalScalingEvent::PreferredScale { scale } = event {
-            state.scale_factor_changed(&data.surface, scale as f64 / SCALE_DENOMINATOR, false);
+            let scale = Scale::from_wp_fractional_scale(scale);
+            state.scale_factor_changed(&data.surface, scale, false);
         }
     }
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -322,7 +322,7 @@ impl CoreWindow for Window {
     fn surface_size(&self) -> PhysicalSize<u32> {
         let window_state = self.window_state.lock().unwrap();
         let scale_factor = window_state.scale_factor();
-        super::logical_to_physical_rounded(window_state.surface_size(), scale_factor)
+        window_state.surface_size() * scale_factor
     }
 
     fn request_surface_size(&self, size: Size) -> Option<PhysicalSize<u32>> {
@@ -335,7 +335,7 @@ impl CoreWindow for Window {
     fn outer_size(&self) -> PhysicalSize<u32> {
         let window_state = self.window_state.lock().unwrap();
         let scale_factor = window_state.scale_factor();
-        super::logical_to_physical_rounded(window_state.outer_size(), scale_factor)
+        window_state.outer_size() * scale_factor
     }
 
     fn set_min_surface_size(&self, min_size: Option<Size>) {
@@ -474,7 +474,7 @@ impl CoreWindow for Window {
 
     #[inline]
     fn scale_factor(&self) -> f64 {
-        self.window_state.lock().unwrap().scale_factor()
+        self.window_state.lock().unwrap().scale_factor_f64()
     }
 
     #[inline]
@@ -500,7 +500,7 @@ impl CoreWindow for Window {
     fn set_ime_cursor_area(&self, position: Position, size: Size) {
         let window_state = self.window_state.lock().unwrap();
         if window_state.ime_allowed() {
-            let scale_factor = window_state.scale_factor();
+            let scale_factor = window_state.scale_factor_f64();
             let position = position.to_logical(scale_factor);
             let size = size.to_logical(scale_factor);
             window_state.set_ime_cursor_area(position, size);


### PR DESCRIPTION
```rust
/// A wp-fractional-scale scale.
///
/// This type implements the `physical_size = round_half_up(logical_size * scale)`
/// operation with infinite precision as required by the protocol.
#[derive(Copy, Clone, Debug, Eq, PartialEq)]
pub struct Scale {
        scale: u64,
}
```

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
