### PR TITLE
Set `ActivationPolicy::Regular` for macos in window example

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -33,6 +33,11 @@ use winit::window::{
     Cursor, CursorGrabMode, CustomCursor, CustomCursorSource, Fullscreen, Icon, ResizeDirection,
     Theme, Window, WindowAttributes, WindowId,
 };
+#[cfg(macos_platform)]
+use winit::{
+    event_loop::EventLoopBuilder,
+    platform::macos::{ActivationPolicy, EventLoopBuilderExtMacOS},
+};
 
 #[path = "util/tracing.rs"]
 mod tracing;
@@ -46,8 +51,17 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     tracing::init();
 
-    let event_loop = EventLoop::new()?;
     let (sender, receiver) = mpsc::channel();
+
+    #[cfg(macos_platform)]
+    let event_loop = {
+        let mut builder = EventLoopBuilder::default();
+        builder.with_activation_policy(ActivationPolicy::Regular);
+        builder.build()?
+    };
+
+    #[cfg(not(macos_platform))]
+    let event_loop = EventLoop::new()?;
 
     // Wire the user event from another thread.
     #[cfg(not(web_platform))]


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

This fixes https://github.com/rust-windowing/winit/issues/3958. But possibly the default in Winit ought to change back, as it doesn't seem right that all users on macOS need to set this policy.

If I'm reading https://github.com/rust-windowing/winit/pull/3920 right, then it may be that this needs to be explicitly set when a rust binary is run standalone, but will be set automatically if the rust binary is wrapped in a macOS app package. I'm not quite sure how best to handle this. Perhaps we can detect which environment we're in somehow.

Unfortunately `NSApplication::activationPolicy()` seems to return `2` regardless of whether the `setActivationPolicy()` method is called, but keyboard events only work if it is.


