### PR TITLE
macOS: add ability to make titlebar unified

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ objc2-app-kit = { version = "0.2.2", features = [
     "NSScreen",
     "NSTextInputClient",
     "NSTextInputContext",
+    "NSToolbar",
     "NSView",
     "NSWindow",
     "NSWindowScripting",

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -64,6 +64,8 @@ changelog entry.
 - Add a `standard_key_binding` method to the `ApplicationHandlerExtMacOS` trait. This allows handling of standard keybindings such as "go to end of line" on macOS.
 - On macOS, add `WindowExtMacOS::set_borderless_game` and `WindowAttributesExtMacOS::with_borderless_game`
   to fully disable the menu bar and dock in Borderless Fullscreen as commonly done in games.
+- On macOS, add `WindowExtMacOS::set_unified_titlebar` and `WindowAttributesExtMacOS::with_unified_titlebar`
+  to use a larger style of titlebar.
 - Add `WindowId::into_raw()` and `from_raw()`.
 - Add `PointerKind`, `PointerSource`, `ButtonSource`, `FingerId` and `position` to all pointer
   events as part of the pointer event overhaul.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -157,6 +157,13 @@ pub trait WindowExtMacOS {
 
     /// Getter for the [`WindowExtMacOS::set_borderless_game`].
     fn is_borderless_game(&self) -> bool;
+
+    /// Makes the titlebar bigger, effectively adding more space around the
+    /// window controls if the titlebar is invisible.
+    fn set_unified_titlebar(&self, unified_titlebar: bool);
+
+    /// Getter for the [`WindowExtMacOS::set_unified_titlebar`].
+    fn unified_titlebar(&self) -> bool;
 }
 
 impl WindowExtMacOS for dyn Window + '_ {
@@ -255,6 +262,18 @@ impl WindowExtMacOS for dyn Window + '_ {
         let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.is_borderless_game())
     }
+
+    #[inline]
+    fn set_unified_titlebar(&self, unified_titlebar: bool) {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.set_unified_titlebar(unified_titlebar))
+    }
+
+    #[inline]
+    fn unified_titlebar(&self) -> bool {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.maybe_wait_on_main(|w| w.unified_titlebar())
+    }
 }
 
 /// Corresponds to `NSApplicationActivationPolicy`.
@@ -308,6 +327,8 @@ pub trait WindowAttributesExtMacOS {
     fn with_option_as_alt(self, option_as_alt: OptionAsAlt) -> Self;
     /// See [`WindowExtMacOS::set_borderless_game`] for details on what this means if set.
     fn with_borderless_game(self, borderless_game: bool) -> Self;
+    /// See [`WindowExtMacOS::set_unified_titlebar`] for details on what this means if set.
+    fn with_unified_titlebar(self, unified_titlebar: bool) -> Self;
 }
 
 impl WindowAttributesExtMacOS for WindowAttributes {
@@ -380,6 +401,12 @@ impl WindowAttributesExtMacOS for WindowAttributes {
     #[inline]
     fn with_borderless_game(mut self, borderless_game: bool) -> Self {
         self.platform_specific.borderless_game = borderless_game;
+        self
+    }
+
+    #[inline]
+    fn with_unified_titlebar(mut self, unified_titlebar: bool) -> Self {
+        self.platform_specific.unified_titlebar = unified_titlebar;
         self
     }
 }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

---

Adds `WindowExtMacOS::set_unified_titlebar` and `WindowAttributesExtMacOS::with_unified_titlebar`, which allow you to use a larger titlebar style on macOS.

| Without unified titlebar (default)                                                                                                                | With unified titlebar                                                                                                                             |
|---------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="912" alt="Screenshot 2024-10-22 at 8 31 52 PM" src="https://github.com/user-attachments/assets/114d9476-b320-4875-9421-546577e8a15a"> | <img width="912" alt="Screenshot 2024-10-22 at 8 32 23 PM" src="https://github.com/user-attachments/assets/a7663c2c-e6f4-48f9-9eff-6818a460e945"> |

The titlebar can be made transparent and the title can be hidden and there will be extra space around the window controls.

My code is probably not perfect, I would gladly accept edits or suggestions!