### PR TITLE
dpi: Add `Rect`, `PhysicalRect` and `LogicalRect`

### DIFF
--- a/dpi/CHANGELOG.md
+++ b/dpi/CHANGELOG.md
@@ -11,6 +11,8 @@ Unreleased` header.
 
 ## Unreleased
 
+- Add `Rect`, `PhysicalRect` and `LogicalRect`.
+
 ## 0.1.1
 
 - Derive `Debug`, `Copy`, `Clone`, `PartialEq`, `Serialize`, `Deserialize` traits for `PixelUnit`.


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/3956.

I haven't added the same `From` impls as `[Physical|Logical][Size|Position]` have, since I wasn't sure which were relevant.