### PR TITLE
x11: iterate only visuals from the matching screen

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -195,3 +195,4 @@ changelog entry.
 - On macOS, fix crash when calling `drag_window()` without a left click present.
 - On X11, key events forward to IME anyway, even when it's disabled.
 - On Windows, make `ControlFlow::WaitUntil` work more precisely using `CREATE_WAITABLE_TIMER_HIGH_RESOLUTION`.
+- On X11, creating windows on screen that is not the first one (e.g. `DISPLAY=:0.1`) works again.

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -511,11 +511,13 @@ impl UnownedWindow {
             None => xconn.default_screen_index() as c_int,
         };
 
-        let screen_id_usize = usize::try_from(screen_id)
-            .map_err(|_| NotSupportedError::new("screen id must be non-negative"))?;
-        let screen = xconn.xcb_connection().setup().roots.get(screen_id_usize).ok_or(
-            NotSupportedError::new("requested screen id not present in server's response"),
-        )?;
+        let screen = {
+            let screen_id_usize = usize::try_from(screen_id)
+                .map_err(|_| NotSupportedError::new("screen id must be non-negative"))?;
+            xconn.xcb_connection().setup().roots.get(screen_id_usize).ok_or(
+                NotSupportedError::new("requested screen id not present in server's response"),
+            )?
+        };
 
         // An iterator over the visuals matching screen id combined with their depths.
         let mut all_visuals = screen


### PR DESCRIPTION
**Before** this PR, running the `window` example on a X11 screen that is not the first one (like `DISPLAY=0.1`) always fails with
`failed to create initial window: Os(OsError { line: 617, file: "src/platform_impl/linux/x11/window.rs", error: X11Error(X11Error { error_kind: Match, error_code: 8, sequence: 218, bad_value: 1321, minor_opcode: 0, major_opcode: 1, extension_name: None, request_name: Some("CreateWindow") }) })
`

_Here `1321` is the parent (root) window id of my screen 1, but what the X server really tries to say here (AFAICS) is "the passed visual id is not available for the passed parent window id"._

<details><summary>Full invocation</summary>

```
[tonari@tonari-prague-dev winit]$ DISPLAY=:0.1 cargo run --example window
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/examples/window`
2024-10-28T09:07:19.861207Z  WARN winit::platform_impl::linux::x11::xdisplay: error setting XSETTINGS; Xft options won't reload automatically
2024-10-28T09:07:19.872845Z  INFO window: Starting to send user event every second
2024-10-28T09:07:19.873864Z  INFO window: Loading cursor assets
2024-10-28T09:07:19.874587Z  INFO window: Ready to create surfaces
2024-10-28T09:07:19.874648Z  INFO window: Monitors information
2024-10-28T09:07:19.875266Z  INFO window: Primary monitor: HDMI-1
2024-10-28T09:07:19.875301Z  INFO window:   1920x1080x24 @ 60.0 Hz
2024-10-28T09:07:19.875321Z  INFO window:   Position: 0,0
2024-10-28T09:07:19.875337Z  INFO window:   Scale factor: 1
2024-10-28T09:07:19.875354Z  INFO window:   Available modes (width x height x bit-depth):
2024-10-28T09:07:19.875427Z  INFO window:     2560x1440x24 @ 59.950 Hz
2024-10-28T09:07:19.875448Z  INFO window:     3840x2160x24 @ 29.969 Hz
2024-10-28T09:07:19.875456Z  INFO window:     3840x2160x24 @ 25.0 Hz
2024-10-28T09:07:19.875464Z  INFO window:     3840x2160x24 @ 23.975 Hz
2024-10-28T09:07:19.875474Z  INFO window:     2560x1440x24 @ 74.964 Hz
2024-10-28T09:07:19.875482Z  INFO window:     1920x1080x24 @ 75.1 Hz
2024-10-28T09:07:19.875490Z  INFO window:     1920x1080x24 @ 60.0 Hz
2024-10-28T09:07:19.875497Z  INFO window:     1920x1080x24 @ 59.939 Hz
2024-10-28T09:07:19.875505Z  INFO window:     1920x1080x24 @ 50.0 Hz
2024-10-28T09:07:19.875513Z  INFO window:     1920x1080x24 @ 29.971 Hz
2024-10-28T09:07:19.875521Z  INFO window:     1680x1050x24 @ 59.954 Hz
2024-10-28T09:07:19.875529Z  INFO window:     1600x900x24 @ 60.0 Hz
2024-10-28T09:07:19.875537Z  INFO window:     1280x1024x24 @ 75.24 Hz
2024-10-28T09:07:19.875545Z  INFO window:     1280x1024x24 @ 60.19 Hz
2024-10-28T09:07:19.875554Z  INFO window:     1280x800x24 @ 59.810 Hz
2024-10-28T09:07:19.875561Z  INFO window:     1280x720x24 @ 60.0 Hz
2024-10-28T09:07:19.875570Z  INFO window:     1280x720x24 @ 59.943 Hz
2024-10-28T09:07:19.875577Z  INFO window:     1280x720x24 @ 50.0 Hz
2024-10-28T09:07:19.875585Z  INFO window:     1152x864x24 @ 59.997 Hz
2024-10-28T09:07:19.875593Z  INFO window:     1024x768x24 @ 75.28 Hz
2024-10-28T09:07:19.875601Z  INFO window:     1024x768x24 @ 60.3 Hz
2024-10-28T09:07:19.875609Z  INFO window:     800x600x24 @ 75.0 Hz
2024-10-28T09:07:19.875616Z  INFO window:     800x600x24 @ 60.316 Hz
2024-10-28T09:07:19.875624Z  INFO window:     720x576x24 @ 50.0 Hz
2024-10-28T09:07:19.875633Z  INFO window:     720x480x24 @ 59.940 Hz
2024-10-28T09:07:19.875641Z  INFO window:     640x480x24 @ 75.0 Hz
2024-10-28T09:07:19.875649Z  INFO window:     640x480x24 @ 59.940 Hz
2024-10-28T09:07:19.875656Z  INFO window:     640x480x24 @ 59.928 Hz
2024-10-28T09:07:19.875727Z  INFO winit::platform_impl::linux::x11::window: Guessed window scale factor: 1
thread 'main' panicked at examples/window.rs:540:46:
failed to create initial window: Os(OsError { line: 617, file: "src/platform_impl/linux/x11/window.rs", error: X11Error(X11Error { error_kind: Match, error_code: 8, sequence: 218, bad_value: 1321, minor_opcode: 0, major_opcode: 1, extension_name: None, request_name: Some("CreateWindow") }) })
```

</details>

**After** this PR, it works as expected and shows the window on the correct screen.

<details><summary>Full invocation</summary>

```
Switched to a new branch 'x11-visuals-from-correct-screen'
[tonari@tonari-prague-dev winit]$ DISPLAY=:0.1 cargo run --example window
   Compiling winit v0.30.5 (/home/tonari/winit)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.58s
     Running `target/debug/examples/window`
2024-10-28T11:04:41.894003Z  WARN winit::platform_impl::linux::x11::xdisplay: error setting XSETTINGS; Xft options won't reload automatically
2024-10-28T11:04:41.907683Z  INFO window: Starting to send user event every second
2024-10-28T11:04:41.908744Z  INFO window: Loading cursor assets
2024-10-28T11:04:41.909714Z  INFO window: Ready to create surfaces
2024-10-28T11:04:41.909731Z  INFO window: Monitors information
2024-10-28T11:04:41.909985Z  INFO window: Primary monitor: HDMI-1
2024-10-28T11:04:41.910014Z  INFO window:   1920x1080x24 @ 60.0 Hz
2024-10-28T11:04:41.910027Z  INFO window:   Position: 0,0
2024-10-28T11:04:41.910038Z  INFO window:   Scale factor: 1
2024-10-28T11:04:41.910050Z  INFO window:   Available modes (width x height x bit-depth):
2024-10-28T11:04:41.910075Z  INFO window:     2560x1440x24 @ 59.950 Hz
2024-10-28T11:04:41.910090Z  INFO window:     3840x2160x24 @ 29.969 Hz
2024-10-28T11:04:41.910103Z  INFO window:     3840x2160x24 @ 25.0 Hz
2024-10-28T11:04:41.910115Z  INFO window:     3840x2160x24 @ 23.975 Hz
2024-10-28T11:04:41.910127Z  INFO window:     2560x1440x24 @ 74.964 Hz
2024-10-28T11:04:41.910140Z  INFO window:     1920x1080x24 @ 75.1 Hz
2024-10-28T11:04:41.910152Z  INFO window:     1920x1080x24 @ 60.0 Hz
2024-10-28T11:04:41.910164Z  INFO window:     1920x1080x24 @ 59.939 Hz
2024-10-28T11:04:41.910176Z  INFO window:     1920x1080x24 @ 50.0 Hz
2024-10-28T11:04:41.910189Z  INFO window:     1920x1080x24 @ 29.971 Hz
2024-10-28T11:04:41.910201Z  INFO window:     1680x1050x24 @ 59.954 Hz
2024-10-28T11:04:41.910213Z  INFO window:     1600x900x24 @ 60.0 Hz
2024-10-28T11:04:41.910226Z  INFO window:     1280x1024x24 @ 75.24 Hz
2024-10-28T11:04:41.910238Z  INFO window:     1280x1024x24 @ 60.19 Hz
2024-10-28T11:04:41.910250Z  INFO window:     1280x800x24 @ 59.810 Hz
2024-10-28T11:04:41.910262Z  INFO window:     1280x720x24 @ 60.0 Hz
2024-10-28T11:04:41.910275Z  INFO window:     1280x720x24 @ 59.943 Hz
2024-10-28T11:04:41.910287Z  INFO window:     1280x720x24 @ 50.0 Hz
2024-10-28T11:04:41.910299Z  INFO window:     1152x864x24 @ 59.997 Hz
2024-10-28T11:04:41.910311Z  INFO window:     1024x768x24 @ 75.28 Hz
2024-10-28T11:04:41.910323Z  INFO window:     1024x768x24 @ 60.3 Hz
2024-10-28T11:04:41.910335Z  INFO window:     800x600x24 @ 75.0 Hz
2024-10-28T11:04:41.910348Z  INFO window:     800x600x24 @ 60.316 Hz
2024-10-28T11:04:41.910359Z  INFO window:     720x576x24 @ 50.0 Hz
2024-10-28T11:04:41.910372Z  INFO window:     720x480x24 @ 59.940 Hz
2024-10-28T11:04:41.910384Z  INFO window:     640x480x24 @ 75.0 Hz
2024-10-28T11:04:41.910396Z  INFO window:     640x480x24 @ 59.940 Hz
2024-10-28T11:04:41.910408Z  INFO window:     640x480x24 @ 59.928 Hz
2024-10-28T11:04:41.910498Z  INFO winit::platform_impl::linux::x11::window: Guessed window scale factor: 1
2024-10-28T11:04:41.940700Z  INFO window: Theme: Dark
2024-10-28T11:04:41.940845Z  INFO window: Surface resized to PhysicalSize { width: 800, height: 600 }
2024-10-28T11:04:41.941295Z  INFO window: Created new window with id=2097170
2024-10-28T11:04:41.941353Z  INFO window: Keyboard bindings:
2024-10-28T11:04:41.941384Z  INFO window: Ctrl+Q          - CloseWindow (Close window)
2024-10-28T11:04:41.941402Z  INFO window: Ctrl+H          - PrintHelp (Print help)
2024-10-28T11:04:41.941409Z  INFO window: Ctrl+F          - ToggleFullscreen (Toggle fullscreen)
2024-10-28T11:04:41.941415Z  INFO window: Ctrl+D          - ToggleDecorations (Toggle decorations)
2024-10-28T11:04:41.941422Z  INFO window: Ctrl+I          - ToggleImeInput (Toggle IME input)
2024-10-28T11:04:41.941429Z  INFO window: Ctrl+L          - CycleCursorGrab (Cycle through cursor grab mode)
2024-10-28T11:04:41.941435Z  INFO window: Ctrl+P          - ToggleResizeIncrements (Use resize increments when resizing window)
2024-10-28T11:04:41.941441Z  INFO window: Ctrl+R          - ToggleResizable (Toggle window resizable state)
2024-10-28T11:04:41.941448Z  INFO window: Alt+R          - RequestResize (Request a resize)
2024-10-28T11:04:41.941456Z  INFO window: Alt+Ctrl+M          - DumpMonitors (Dump monitor information)
2024-10-28T11:04:41.941463Z  INFO window: Ctrl+M          - ToggleMaximize (Maximize)
2024-10-28T11:04:41.941469Z  INFO window: Alt+M          - Minimize (Minimize)
2024-10-28T11:04:41.941475Z  INFO window: Ctrl+N          - CreateNewWindow (Create new window)
2024-10-28T11:04:41.941481Z  INFO window: Ctrl+C          - NextCursor (Advance the cursor to the next value)
2024-10-28T11:04:41.941487Z  INFO window: Alt+C          - NextCustomCursor (Advance custom cursor to the next value)
2024-10-28T11:04:41.941494Z  INFO window: Ctrl+Z          - ToggleCursorVisibility (Hide cursor)
2024-10-28T11:04:41.941499Z  INFO window: K          - SetTheme(None) (Change to the system theme)
2024-10-28T11:04:41.941510Z  INFO window: Super+K          - SetTheme(Some(Light)) (Change to a light theme)
2024-10-28T11:04:41.941517Z  INFO window: Ctrl+K          - SetTheme(Some(Dark)) (Change to a dark theme)
2024-10-28T11:04:41.941524Z  INFO window: Ctrl+S          - Message (Prints a message through a user wake up)
2024-10-28T11:04:41.941532Z  INFO window: Mouse bindings:
2024-10-28T11:04:41.941542Z  INFO window: Alt+LMB        - DragResizeWindow (Start window drag-resize)
2024-10-28T11:04:41.941548Z  INFO window: Ctrl+LMB        - DragWindow (Start window drag)
2024-10-28T11:04:41.941554Z  INFO window: Ctrl+RMB        - ShowWindowMenu (Show window menu)
2024-10-28T11:04:41.941819Z  INFO window: IME disabled for Window=2097170
2024-10-28T11:04:41.941838Z  INFO window: IME enabled for Window=2097170
2024-10-28T11:04:41.941864Z  INFO window: Window=2097170 unfocused
2024-10-28T11:04:41.946149Z  INFO window: User wake up
2024-10-28T11:04:42.908043Z  INFO window: User wake up
2024-10-28T11:04:43.908155Z  INFO window: User wake up
2024-10-28T11:04:44.908218Z  INFO window: User wake up
2024-10-28T11:04:45.908360Z  INFO window: User wake up
2024-10-28T11:04:46.908438Z  INFO window: User wake up
```

</details>

### Explanation

The "visuals" in X11 are per-screen. We therefore cannot iterate all visuals of all available screens - we should iterate just the matching screen instead.

I think this is a regression introduced by https://github.com/rust-windowing/winit/pull/2825 - specifically https://github.com/rust-windowing/winit/pull/2825/files#diff-7eb9227ac71734e693b64fd604d60cb5374e2601745bf4e5ae4ef619d9ef37caR222-R225

The previous (XLib-based) code factored in the screen_id in the `xconn.xlib.XMatchVisualInfo` call.

Note that this issue only appears in [_separate screen X11 multihead setup_](https://wiki.archlinux.org/title/Multihead#Separate_screens), which become less common these days (but we use it in our application for precise multi-monitor vsync / page flipping).

CC @bschwind @mbernat.

---

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- ~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- ~Created or updated an example program if it would help users understand this functionality~
- ~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~
