### PR TITLE
x11: fix `WindowAttributesExtX11::with_x11_screen()`, extend example

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -31,6 +31,8 @@ use winit::platform::startup_notify::{
 };
 #[cfg(web_platform)]
 use winit::platform::web::{ActiveEventLoopExtWeb, CustomCursorExtWeb, WindowAttributesExtWeb};
+#[cfg(x11_platform)]
+use winit::platform::x11::WindowAttributesExtX11;
 use winit::window::{
     Cursor, CursorGrabMode, CustomCursor, CustomCursorSource, Fullscreen, Icon, ResizeDirection,
     Theme, Window, WindowAttributes, WindowId,
@@ -147,6 +149,28 @@ impl Application {
             startup_notify::reset_activation_token_env();
             info!("Using token {:?} to activate a window", token);
             window_attributes = window_attributes.with_activation_token(token);
+        }
+
+        #[cfg(x11_platform)]
+        match std::env::var("X11_VISUAL_ID") {
+            Ok(visual_id_str) => {
+                info!("Using X11 visual id {visual_id_str}");
+                let visual_id = visual_id_str.parse()?;
+                window_attributes = window_attributes.with_x11_visual(visual_id);
+            },
+            Err(_) => info!("Set the X11_VISUAL_ID env variable to request specific X11 visual"),
+        }
+
+        #[cfg(x11_platform)]
+        match std::env::var("X11_SCREEN_ID") {
+            Ok(screen_id_str) => {
+                info!("Placing the window on X11 screen {screen_id_str}");
+                let screen_id = screen_id_str.parse()?;
+                window_attributes = window_attributes.with_x11_screen(screen_id);
+            },
+            Err(_) => info!(
+                "Set the X11_SCREEN_ID env variable to place the window on non-default screen"
+            ),
         }
 
         #[cfg(macos_platform)]

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -70,6 +70,8 @@ changelog entry.
 - Add `PointerKind`, `PointerSource`, `ButtonSource`, `FingerId`, `primary` and `position` to all
   pointer events as part of the pointer event overhaul.
 - Add `DeviceId::into_raw()` and `from_raw()`.
+- On X11, the `window` example now understands the `X11_VISUAL_ID` and `X11_SCREEN_ID` env
+  variables to test the respective modifiers of window creation.
 
 ### Changed
 
@@ -196,3 +198,4 @@ changelog entry.
 - On X11, key events forward to IME anyway, even when it's disabled.
 - On Windows, make `ControlFlow::WaitUntil` work more precisely using `CREATE_WAITABLE_TIMER_HIGH_RESOLUTION`.
 - On X11, creating windows on screen that is not the first one (e.g. `DISPLAY=:0.1`) works again.
+- On X11, creating windows while passing `with_x11_screen(non_default_screen)` works again.


### PR DESCRIPTION
This is a kind of follow-up to https://github.com/rust-windowing/winit/pull/3973.

There's an API to programmatically specify X11 screen id (override what is determined from the `DISPLAY` env variable), but it doesn't work.

Setting up X Server with 2 screens and calling `DISPLAY=:0 X11_SCREEN_ID=1 cargo run --example window` should be equivalent to calling `DISPLAY=:0.1 cargo run --example window`

The latter works now (and places the window on the correct screen), but the former yields

`failed to create initial window: Os(OsError { line: 620, file: "src/platform_impl/linux/x11/window.rs", error: X11Error(X11Error { error_kind: Match, error_code: 8, sequence: 219, bad_value: 1319, minor_opcode: 0, major_opcode: 1, extension_name: None, request_name: Some("CreateWindow") }) })`

_Here `1319` is the root window id for screen 0, which doesn't match the screen 1 that we request._

The problem is that we need to factor in the screen id when determining the parent (root) window when not explicitly set. This patch does that.

CC @bschwind @mbernat.

---

There is also a soft-prerequisite commit that extends the `window` example to make the code change more easily testable. I've done the simplest possible thing and accept the optional parameters as env variables. Let me know if that's fine.

---

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- ~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~
- [x] Created or updated an example program if it would help users understand this functionality
- ~Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented~
