### PR TITLE
X11 non-default screen fixes (rebased on 0.30.x)

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -31,6 +31,8 @@ use winit::platform::macos::{OptionAsAlt, WindowAttributesExtMacOS, WindowExtMac
 use winit::platform::startup_notify::{
     self, EventLoopExtStartupNotify, WindowAttributesExtStartupNotify, WindowExtStartupNotify,
 };
+#[cfg(x11_platform)]
+use winit::platform::x11::WindowAttributesExtX11;
 
 #[path = "util/tracing.rs"]
 mod tracing;
@@ -138,6 +140,28 @@ impl Application {
             startup_notify::reset_activation_token_env();
             info!("Using token {:?} to activate a window", token);
             window_attributes = window_attributes.with_activation_token(token);
+        }
+
+        #[cfg(x11_platform)]
+        match std::env::var("X11_VISUAL_ID") {
+            Ok(visual_id_str) => {
+                info!("Using X11 visual id {visual_id_str}");
+                let visual_id = visual_id_str.parse()?;
+                window_attributes = window_attributes.with_x11_visual(visual_id);
+            },
+            Err(_) => info!("Set the X11_VISUAL_ID env variable to request specific X11 visual"),
+        }
+
+        #[cfg(x11_platform)]
+        match std::env::var("X11_SCREEN_ID") {
+            Ok(screen_id_str) => {
+                info!("Placing the window on X11 screen {screen_id_str}");
+                let screen_id = screen_id_str.parse()?;
+                window_attributes = window_attributes.with_x11_screen(screen_id);
+            },
+            Err(_) => info!(
+                "Set the X11_SCREEN_ID env variable to place the window on non-default screen"
+            ),
         }
 
         #[cfg(macos_platform)]

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -144,15 +144,29 @@ impl UnownedWindow {
     ) -> Result<UnownedWindow, RootOsError> {
         let xconn = &event_loop.xconn;
         let atoms = xconn.atoms();
+
+        let screen_id = match window_attrs.platform_specific.x11.screen_id {
+            Some(id) => id,
+            None => xconn.default_screen_index() as c_int,
+        };
+
+        let screen = {
+            let screen_id_usize = usize::try_from(screen_id)
+                .map_err(|_| os_error!(OsError::Misc("screen id must be non-negative")))?;
+            xconn.xcb_connection().setup().roots.get(screen_id_usize).ok_or(os_error!(
+                OsError::Misc("requested screen id not present in server's response")
+            ))?
+        };
+
         #[cfg(feature = "rwh_06")]
         let root = match window_attrs.parent_window.as_ref().map(|handle| handle.0) {
             Some(rwh_06::RawWindowHandle::Xlib(handle)) => handle.window as xproto::Window,
             Some(rwh_06::RawWindowHandle::Xcb(handle)) => handle.window.get(),
             Some(raw) => unreachable!("Invalid raw window handle {raw:?} on X11"),
-            None => event_loop.root,
+            None => screen.root,
         };
         #[cfg(not(feature = "rwh_06"))]
-        let root = event_loop.root;
+        let root = screen.root;
 
         let mut monitors = leap!(xconn.available_monitors());
         let guessed_monitor = if monitors.is_empty() {
@@ -205,19 +219,6 @@ impl UnownedWindow {
             }
             debug!("Calculated physical dimensions: {}x{}", dimensions.0, dimensions.1);
             dimensions
-        };
-
-        let screen_id = match window_attrs.platform_specific.x11.screen_id {
-            Some(id) => id,
-            None => xconn.default_screen_index() as c_int,
-        };
-
-        let screen = {
-            let screen_id_usize = usize::try_from(screen_id)
-                .map_err(|_| os_error!(OsError::Misc("screen id must be non-negative")))?;
-            xconn.xcb_connection().setup().roots.get(screen_id_usize).ok_or(os_error!(
-                OsError::Misc("requested screen id not present in server's response")
-            ))?
         };
 
         // An iterator over the visuals matching screen id combined with their depths.

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -212,13 +212,18 @@ impl UnownedWindow {
             None => xconn.default_screen_index() as c_int,
         };
 
-        // An iterator over all of the visuals combined with their depths.
-        let mut all_visuals = xconn
-            .xcb_connection()
-            .setup()
-            .roots
+        let screen = {
+            let screen_id_usize = usize::try_from(screen_id)
+                .map_err(|_| os_error!(OsError::Misc("screen id must be non-negative")))?;
+            xconn.xcb_connection().setup().roots.get(screen_id_usize).ok_or(os_error!(
+                OsError::Misc("requested screen id not present in server's response")
+            ))?
+        };
+
+        // An iterator over the visuals matching screen id combined with their depths.
+        let mut all_visuals = screen
+            .allowed_depths
             .iter()
-            .flat_map(|root| &root.allowed_depths)
             .flat_map(|depth| depth.visuals.iter().map(move |visual| (visual, depth.depth)));
 
         // creating


### PR DESCRIPTION
- this is a rebase of https://github.com/rust-windowing/winit/pull/3973 + https://github.com/rust-windowing/winit/pull/3974 on `v0.30.x` branch which we needed

I'm drafting this until https://github.com/rust-windowing/winit/pull/3974 is merged to `master`. Opening early for (our) documentation purposes. If this turns out useful, I'll have to also check-in the changelogs.

CC @mbernat @bschwind.

<!--
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
-->