### PR TITLE
chore: always pull raw-window-handle

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ version = "0.30.5"
 
 [package.metadata.docs.rs]
 features = [
-    "rwh_06",
     "serde",
     "mint",
     # Enabled to get docs to compile
@@ -55,9 +54,8 @@ targets = [
 [features]
 android-game-activity = ["android-activity/game-activity"]
 android-native-activity = ["android-activity/native-activity"]
-default = ["rwh_06", "x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
+default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 mint = ["dpi/mint"]
-rwh_06 = ["dep:rwh_06", "ndk/rwh_06"]
 serde = ["dep:serde", "cursor-icon/serde", "smol_str/serde", "dpi/serde", "bitflags/serde"]
 wayland = [
     "wayland-client",
@@ -81,7 +79,7 @@ cfg_aliases = "0.2.1"
 bitflags = "2"
 cursor-icon = "1.1.0"
 dpi = { version = "0.1.1", path = "dpi" }
-rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"], optional = true }
+rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"] }
 serde = { workspace = true, optional = true }
 smol_str = "0.2.0"
 tracing = { version = "0.1.40", default-features = false }
@@ -102,7 +100,7 @@ softbuffer = { version = "0.4.6", default-features = false, features = [
 # Android
 [target.'cfg(target_os = "android")'.dependencies]
 android-activity = "0.6.0"
-ndk = { version = "0.9.0", default-features = false }
+ndk = { version = "0.9.0", features = ["rwh_06"], default-features = false }
 
 # AppKit or UIKit
 [target.'cfg(target_vendor = "apple")'.dependencies]
@@ -345,11 +343,9 @@ wasm-bindgen-test = "0.3"
 [[example]]
 doc-scrape-examples = true
 name = "window"
-required-features = ["rwh_06"]
 
 [[example]]
 name = "child_window"
-required-features = ["rwh_06"]
 
 [workspace]
 members = ["dpi"]

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -11,7 +11,7 @@
 pub use platform::cleanup_window;
 pub use platform::fill_window;
 
-#[cfg(all(feature = "rwh_06", not(any(target_os = "android", target_os = "ios"))))]
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod platform {
     use std::cell::RefCell;
     use std::collections::HashMap;
@@ -106,7 +106,7 @@ mod platform {
     }
 }
 
-#[cfg(not(all(feature = "rwh_06", not(any(target_os = "android", target_os = "ios")))))]
+#[cfg(any(target_os = "android", target_os = "ios"))]
 mod platform {
     pub fn fill_window(_window: &dyn winit::window::Window) {
         // No-op on mobile platforms.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -273,7 +273,6 @@ impl EventLoop {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for EventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         rwh_06::HasDisplayHandle::display_handle(self.event_loop.window_target().rwh_06_handle())
@@ -407,11 +406,9 @@ pub trait ActiveEventLoop: AsAny {
     fn owned_display_handle(&self) -> OwnedDisplayHandle;
 
     /// Get the raw-window-handle handle.
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle;
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for dyn ActiveEventLoop + '_ {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         self.rwh_06_handle().display_handle()
@@ -432,7 +429,7 @@ impl rwh_06::HasDisplayHandle for dyn ActiveEventLoop + '_ {
 /// - A reference-counted pointer to the underlying type.
 #[derive(Clone, PartialEq, Eq)]
 pub struct OwnedDisplayHandle {
-    #[cfg_attr(not(feature = "rwh_06"), allow(dead_code))]
+    #[allow(dead_code)]
     pub(crate) platform: platform_impl::OwnedDisplayHandle,
 }
 
@@ -443,7 +440,6 @@ impl fmt::Debug for OwnedDisplayHandle {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for OwnedDisplayHandle {
     #[inline]
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,6 @@
 // Re-export DPI types so that users don't have to put it in Cargo.toml.
 #[doc(inline)]
 pub use dpi;
-#[cfg(feature = "rwh_06")]
 pub use rwh_06 as raw_window_handle;
 
 pub mod application;

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -135,7 +135,6 @@ impl<W: Window> Deref for AnyThread<W> {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl<W: Window> rwh_06::HasWindowHandle for AnyThread<W> {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         // SAFETY: The top level user has asserted this is only used safely.
@@ -337,7 +336,6 @@ pub trait WindowExtWindows {
     /// });
     /// # }
     /// ```
-    #[cfg(feature = "rwh_06")]
     unsafe fn window_handle_any_thread(
         &self,
     ) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError>;
@@ -401,7 +399,6 @@ impl WindowExtWindows for dyn Window + '_ {
         window.set_corner_preference(preference)
     }
 
-    #[cfg(feature = "rwh_06")]
     unsafe fn window_handle_any_thread(
         &self,
     ) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
@@ -435,16 +432,8 @@ pub trait WindowBorrowExtWindows: Borrow<dyn Window> + Sized {
     /// Win32 APIs.
     ///
     /// [`Window`]: crate::window::Window
-    #[cfg_attr(
-        feature = "rwh_06",
-        doc = "[`HasWindowHandle`]: rwh_06::HasWindowHandle",
-        doc = "[`window_handle_any_thread`]: WindowExtWindows::window_handle_any_thread"
-    )]
-    #[cfg_attr(
-        not(feature = "rwh_06"),
-        doc = "[`HasWindowHandle`]: #only-available-with-rwh_06",
-        doc = "[`window_handle_any_thread`]: #only-available-with-rwh_06"
-    )]
+    /// [`HasWindowHandle`]: rwh_06::HasWindowHandle
+    /// [`window_handle_any_thread`]: WindowExtWindows::window_handle_any_thread
     unsafe fn any_thread(self) -> AnyThread<Self>
     where
         Self: Window,

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -718,13 +718,11 @@ impl RootActiveEventLoop for ActiveEventLoop {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::AndroidDisplayHandle::new();
@@ -736,7 +734,6 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,
@@ -771,7 +768,6 @@ impl Window {
         self.app.content_rect()
     }
 
-    #[cfg(feature = "rwh_06")]
     // Allow the usage of HasRawWindowHandle inside this function
     #[allow(deprecated)]
     fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
@@ -789,13 +785,11 @@ impl Window {
         }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn raw_display_handle_rwh_06(&self) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
         Ok(rwh_06::RawDisplayHandle::Android(rwh_06::AndroidDisplayHandle::new()))
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_display_handle_rwh_06()?;
@@ -803,7 +797,6 @@ impl rwh_06::HasDisplayHandle for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_window_handle_rwh_06()?;
@@ -981,12 +974,10 @@ impl CoreWindow for Window {
 
     fn reset_dead_keys(&self) {}
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
     }

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -155,13 +155,11 @@ impl RootActiveEventLoop for ActiveEventLoop {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::RawDisplayHandle::AppKit(rwh_06::AppKitDisplayHandle::new());
@@ -395,7 +393,6 @@ impl EventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -42,7 +42,6 @@ impl Window {
         self.delegate.get_on_main(|delegate| f(delegate))
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub(crate) fn raw_window_handle_rwh_06(
         &self,
@@ -54,7 +53,6 @@ impl Window {
         }
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub(crate) fn raw_display_handle_rwh_06(
         &self,
@@ -74,7 +72,6 @@ impl Drop for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_display_handle_rwh_06()?;
@@ -82,7 +79,6 @@ impl rwh_06::HasDisplayHandle for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_window_handle_rwh_06()?;
@@ -323,12 +319,10 @@ impl CoreWindow for Window {
         })
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
     }

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -692,7 +692,6 @@ impl WindowDelegate {
         let window = new_window(app_state, &attrs, mtm)
             .ok_or_else(|| os_error!("couldn't create `NSWindow`"))?;
 
-        #[cfg(feature = "rwh_06")]
         match attrs.parent_window.map(|handle| handle.0) {
             Some(rwh_06::RawWindowHandle::AppKit(handle)) => {
                 // SAFETY: Caller ensures the pointer is valid or NULL
@@ -1631,7 +1630,6 @@ impl WindowDelegate {
         Some(monitor)
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> rwh_06::RawWindowHandle {
         let window_handle = rwh_06::AppKitWindowHandle::new({

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -98,13 +98,11 @@ impl RootActiveEventLoop for ActiveEventLoop {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::RawDisplayHandle::UiKit(rwh_06::UiKitDisplayHandle::new());
@@ -116,7 +114,6 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -420,7 +420,6 @@ impl Inner {
         self.window.id()
     }
 
-    #[cfg(feature = "rwh_06")]
     pub fn raw_window_handle_rwh_06(&self) -> rwh_06::RawWindowHandle {
         let mut window_handle = rwh_06::UiKitWindowHandle::new({
             let ui_view = Retained::as_ptr(&self.view) as _;
@@ -546,7 +545,6 @@ impl Window {
         self.inner.get_on_main(|inner| f(inner))
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub(crate) fn raw_window_handle_rwh_06(
         &self,
@@ -558,7 +556,6 @@ impl Window {
         }
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub(crate) fn raw_display_handle_rwh_06(
         &self,
@@ -567,7 +564,6 @@ impl Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_display_handle_rwh_06()?;
@@ -575,7 +571,6 @@ impl rwh_06::HasDisplayHandle for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_window_handle_rwh_06()?;
@@ -815,12 +810,10 @@ impl CoreWindow for Window {
         })
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
     }

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -420,7 +420,6 @@ pub(crate) enum OwnedDisplayHandle {
 }
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -637,7 +637,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
         }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
@@ -657,7 +656,6 @@ impl ActiveEventLoop {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         use sctk::reexports::client::Proxy;

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -248,7 +248,6 @@ impl Drop for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::WaylandWindowHandle::new({
@@ -260,7 +259,6 @@ impl rwh_06::HasWindowHandle for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::WaylandDisplayHandle::new({
@@ -648,13 +646,11 @@ impl CoreWindow for Window {
     }
 
     /// Get the raw-window-handle v0.6 display handle.
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 
     /// Get the raw-window-handle v0.6 window handle.
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
     }

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -647,7 +647,6 @@ impl ActiveEventLoop {
             .expect_then_ignore_error("Failed to update device event filter");
     }
 
-    #[cfg(feature = "rwh_06")]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
@@ -748,13 +747,11 @@ impl RootActiveEventLoop for ActiveEventLoop {
         RootOwnedDisplayHandle { platform: handle }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_display_handle_rwh_06()?;

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -294,18 +294,15 @@ impl CoreWindow for Window {
             .map(|inner| crate::monitor::MonitorHandle { inner })
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.0.raw_display_handle_rwh_06()?;
@@ -313,7 +310,6 @@ impl rwh_06::HasDisplayHandle for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = self.0.raw_window_handle_rwh_06()?;
@@ -443,15 +439,12 @@ impl UnownedWindow {
     ) -> Result<UnownedWindow, RequestError> {
         let xconn = &event_loop.xconn;
         let atoms = xconn.atoms();
-        #[cfg(feature = "rwh_06")]
         let root = match window_attrs.parent_window.as_ref().map(|handle| handle.0) {
             Some(rwh_06::RawWindowHandle::Xlib(handle)) => handle.window as xproto::Window,
             Some(rwh_06::RawWindowHandle::Xcb(handle)) => handle.window.get(),
             Some(raw) => unreachable!("Invalid raw window handle {raw:?} on X11"),
             None => event_loop.root,
         };
-        #[cfg(not(feature = "rwh_06"))]
-        let root = event_loop.root;
 
         let mut monitors = leap!(xconn.available_monitors());
         let guessed_monitor = if monitors.is_empty() {
@@ -2157,7 +2150,6 @@ impl UnownedWindow {
         // TODO timer
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         let mut window_handle = rwh_06::XlibWindowHandle::new(self.xlib_window());
@@ -2165,7 +2157,6 @@ impl UnownedWindow {
         Ok(window_handle.into())
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -759,13 +759,11 @@ impl RootActiveEventLoop for ActiveEventLoop {
         event_loop::OwnedDisplayHandle { platform: OwnedDisplayHandle }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::RawDisplayHandle::Orbital(rwh_06::OrbitalDisplayHandle::new());
@@ -777,7 +775,6 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -137,7 +137,6 @@ impl Window {
         Ok(())
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         let handle = rwh_06::OrbitalWindowHandle::new({
@@ -147,7 +146,6 @@ impl Window {
         Ok(rwh_06::RawWindowHandle::Orbital(handle))
     }
 
-    #[cfg(feature = "rwh_06")]
     #[inline]
     fn raw_display_handle_rwh_06(&self) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
         Ok(rwh_06::RawDisplayHandle::Orbital(rwh_06::OrbitalDisplayHandle::new()))
@@ -447,18 +445,15 @@ impl CoreWindow for Window {
 
     fn set_content_protected(&self, _protected: bool) {}
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_window_handle_rwh_06()?;
@@ -466,7 +461,6 @@ impl rwh_06::HasWindowHandle for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_display_handle_rwh_06()?;

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -550,13 +550,11 @@ impl RootActiveEventLoop for ActiveEventLoop {
         RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::RawDisplayHandle::Web(rwh_06::WebDisplayHandle::new());
@@ -568,7 +566,6 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -375,18 +375,15 @@ impl RootWindow for Window {
         self.inner.queue(|inner| inner.monitor.primary_monitor()).map(RootMonitorHandle::from)
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         MainThreadMarker::new()
@@ -408,7 +405,6 @@ impl rwh_06::HasWindowHandle for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         Ok(rwh_06::DisplayHandle::web())

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -524,7 +524,6 @@ impl RootActiveEventLoop for ActiveEventLoop {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::RawDisplayHandle::Windows(rwh_06::WindowsDisplayHandle::new());
@@ -536,7 +535,6 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
 pub(crate) struct OwnedDisplayHandle;
 
 impl OwnedDisplayHandle {
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub fn raw_display_handle_rwh_06(
         &self,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -106,7 +106,6 @@ impl Window {
         self.window
     }
 
-    #[cfg(feature = "rwh_06")]
     pub unsafe fn rwh_06_no_thread_check(
         &self,
     ) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
@@ -119,7 +118,6 @@ impl Window {
         Ok(rwh_06::RawWindowHandle::Win32(window_handle))
     }
 
-    #[cfg(feature = "rwh_06")]
     pub fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
         // TODO: Write a test once integration framework is ready to ensure that it holds.
         // If we aren't in the GUI thread, we can't return the window.
@@ -132,7 +130,6 @@ impl Window {
         unsafe { self.rwh_06_no_thread_check() }
     }
 
-    #[cfg(feature = "rwh_06")]
     pub fn raw_display_handle_rwh_06(
         &self,
     ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
@@ -349,7 +346,6 @@ impl Drop for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for Window {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_display_handle_rwh_06()?;
@@ -357,7 +353,6 @@ impl rwh_06::HasDisplayHandle for Window {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for Window {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         let raw = self.raw_window_handle_rwh_06()?;
@@ -1054,12 +1049,10 @@ impl CoreWindow for Window {
         }
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
         self
     }
 
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
         self
     }
@@ -1288,7 +1281,6 @@ unsafe fn init(
         },
     };
 
-    #[cfg(feature = "rwh_06")]
     let parent = match attributes.parent_window.as_ref().map(|handle| handle.0) {
         Some(rwh_06::RawWindowHandle::Win32(handle)) => {
             window_flags.set(WindowFlags::CHILD, true);
@@ -1300,9 +1292,6 @@ unsafe fn init(
         Some(raw) => unreachable!("Invalid raw window handle {raw:?} on Windows"),
         None => fallback_parent(),
     };
-
-    #[cfg(not(feature = "rwh_06"))]
-    let parent = fallback_parent();
 
     let menu = attributes.platform_specific.menu;
     let fullscreen = attributes.fullscreen.clone();

--- a/src/window.rs
+++ b/src/window.rs
@@ -67,7 +67,6 @@ pub struct WindowAttributes {
     pub window_level: WindowLevel,
     pub active: bool,
     pub cursor: Cursor,
-    #[cfg(feature = "rwh_06")]
     pub(crate) parent_window: Option<SendSyncRawWindowHandle>,
     pub fullscreen: Option<Fullscreen>,
     // Platform-specific configuration.
@@ -98,7 +97,6 @@ impl Default for WindowAttributes {
             preferred_theme: None,
             content_protected: false,
             cursor: Cursor::default(),
-            #[cfg(feature = "rwh_06")]
             parent_window: None,
             active: true,
             platform_specific: Default::default(),
@@ -113,17 +111,13 @@ impl Default for WindowAttributes {
 /// The user has to account for that when using [`WindowAttributes::with_parent_window()`],
 /// which is `unsafe`.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg(feature = "rwh_06")]
 pub(crate) struct SendSyncRawWindowHandle(pub(crate) rwh_06::RawWindowHandle);
 
-#[cfg(feature = "rwh_06")]
 unsafe impl Send for SendSyncRawWindowHandle {}
-#[cfg(feature = "rwh_06")]
 unsafe impl Sync for SendSyncRawWindowHandle {}
 
 impl WindowAttributes {
     /// Get the parent window stored on the attributes.
-    #[cfg(feature = "rwh_06")]
     pub fn parent_window(&self) -> Option<&rwh_06::RawWindowHandle> {
         self.parent_window.as_ref().map(|handle| &handle.0)
     }
@@ -409,7 +403,6 @@ impl WindowAttributes {
     ///   <https://docs.microsoft.com/en-us/windows/win32/winmsg/window-features#child-windows>
     /// - **X11**: A child window is confined to the client area of its parent window.
     /// - **Android / iOS / Wayland / Web:** Unsupported.
-    #[cfg(feature = "rwh_06")]
     #[inline]
     pub unsafe fn with_parent_window(
         mut self,
@@ -1276,11 +1269,9 @@ pub trait Window: AsAny + Send + Sync {
     fn primary_monitor(&self) -> Option<MonitorHandle>;
 
     /// Get the raw-window-handle v0.6 display handle.
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_display_handle(&self) -> &dyn rwh_06::HasDisplayHandle;
 
     /// Get the raw-window-handle v0.6 window handle.
-    #[cfg(feature = "rwh_06")]
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle;
 }
 
@@ -1306,14 +1297,12 @@ impl std::hash::Hash for dyn Window + '_ {
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasDisplayHandle for dyn Window + '_ {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         self.rwh_06_display_handle().display_handle()
     }
 }
 
-#[cfg(feature = "rwh_06")]
 impl rwh_06::HasWindowHandle for dyn Window + '_ {
     fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
         self.rwh_06_window_handle().window_handle()


### PR DESCRIPTION
Winit is not useful without it and we don't provide older versions anymore.