### PR TITLE
api: make OwnedDisplayHandle wrap an opaque type

### DIFF
--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 #[cfg(not(web_platform))]
 use std::time::{Duration, Instant};
 
+use rwh_06::{DisplayHandle, HandleError, HasDisplayHandle};
 #[cfg(web_platform)]
 use web_time::{Duration, Instant};
 
@@ -274,9 +275,9 @@ impl EventLoop {
     }
 }
 
-impl rwh_06::HasDisplayHandle for EventLoop {
-    fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        rwh_06::HasDisplayHandle::display_handle(self.event_loop.window_target().rwh_06_handle())
+impl HasDisplayHandle for EventLoop {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        HasDisplayHandle::display_handle(self.event_loop.window_target().rwh_06_handle())
     }
 }
 
@@ -407,11 +408,11 @@ pub trait ActiveEventLoop: AsAny {
     fn owned_display_handle(&self) -> OwnedDisplayHandle;
 
     /// Get the raw-window-handle handle.
-    fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle;
+    fn rwh_06_handle(&self) -> &dyn HasDisplayHandle;
 }
 
-impl rwh_06::HasDisplayHandle for dyn ActiveEventLoop + '_ {
-    fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
+impl HasDisplayHandle for dyn ActiveEventLoop + '_ {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
         self.rwh_06_handle().display_handle()
     }
 }
@@ -428,30 +429,39 @@ impl rwh_06::HasDisplayHandle for dyn ActiveEventLoop + '_ {
 ///
 /// - A zero-sized type that is likely optimized out.
 /// - A reference-counted pointer to the underlying type.
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub struct OwnedDisplayHandle {
-    #[allow(dead_code)]
-    pub(crate) platform: platform_impl::OwnedDisplayHandle,
+    pub(crate) handle: Arc<dyn HasDisplayHandle>,
+}
+
+impl OwnedDisplayHandle {
+    pub(crate) fn new(handle: Arc<dyn HasDisplayHandle>) -> Self {
+        Self { handle }
+    }
+}
+
+impl HasDisplayHandle for OwnedDisplayHandle {
+    fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
+        self.handle.display_handle()
+    }
 }
 
 impl fmt::Debug for OwnedDisplayHandle {
-    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OwnedDisplayHandle").finish_non_exhaustive()
     }
 }
 
-impl rwh_06::HasDisplayHandle for OwnedDisplayHandle {
-    #[inline]
-    fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
-        let raw = self.platform.raw_display_handle_rwh_06()?;
-
-        // SAFETY: The underlying display handle should be safe.
-        let handle = unsafe { rwh_06::DisplayHandle::borrow_raw(raw) };
-
-        Ok(handle)
+impl PartialEq for OwnedDisplayHandle {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.display_handle(), other.display_handle()) {
+            (Ok(lhs), Ok(rhs)) => lhs == rhs,
+            _ => false,
+        }
     }
 }
+
+impl Eq for OwnedDisplayHandle {}
 
 pub(crate) trait EventLoopProxyProvider: Send + Sync {
     /// See [`EventLoopProxy::wake_up`] for details.

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -17,7 +17,7 @@ mod window_delegate;
 pub(crate) use self::cursor::CustomCursor as PlatformCustomCursor;
 pub(crate) use self::event::{physicalkey_to_scancode, scancode_to_physicalkey, KeyEventExtra};
 pub(crate) use self::event_loop::{
-    ActiveEventLoop, EventLoop, OwnedDisplayHandle, PlatformSpecificEventLoopAttributes,
+    ActiveEventLoop, EventLoop, PlatformSpecificEventLoopAttributes,
 };
 pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::Window;

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -10,8 +10,7 @@ mod window;
 use std::fmt;
 
 pub(crate) use self::event_loop::{
-    ActiveEventLoop, EventLoop, EventLoopProxy, OwnedDisplayHandle,
-    PlatformSpecificEventLoopAttributes,
+    ActiveEventLoop, EventLoop, EventLoopProxy, PlatformSpecificEventLoopAttributes,
 };
 pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
 pub(crate) use self::window::{PlatformSpecificWindowAttributes, Window};

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -396,58 +396,6 @@ impl AsRawFd for EventLoop {
     }
 }
 
-#[derive(Clone)]
-#[allow(dead_code)]
-pub(crate) enum OwnedDisplayHandle {
-    #[cfg(x11_platform)]
-    X(Arc<XConnection>),
-    #[cfg(wayland_platform)]
-    Wayland(wayland_client::Connection),
-}
-
-impl OwnedDisplayHandle {
-    #[inline]
-    pub fn raw_display_handle_rwh_06(
-        &self,
-    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
-        use std::ptr::NonNull;
-
-        match self {
-            #[cfg(x11_platform)]
-            Self::X(xconn) => Ok(rwh_06::XlibDisplayHandle::new(
-                NonNull::new(xconn.display.cast()),
-                xconn.default_screen_index() as _,
-            )
-            .into()),
-
-            #[cfg(wayland_platform)]
-            Self::Wayland(conn) => {
-                use sctk::reexports::client::Proxy;
-
-                Ok(rwh_06::WaylandDisplayHandle::new(
-                    NonNull::new(conn.display().id().as_ptr().cast()).unwrap(),
-                )
-                .into())
-            },
-        }
-    }
-}
-
-impl PartialEq for OwnedDisplayHandle {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            #[cfg(x11_platform)]
-            (Self::X(this), Self::X(other)) => Arc::as_ptr(this).eq(&Arc::as_ptr(other)),
-            #[cfg(wayland_platform)]
-            (Self::Wayland(this), Self::Wayland(other)) => this.eq(other),
-            #[cfg(all(x11_platform, wayland_platform))]
-            _ => false,
-        }
-    }
-}
-
-impl Eq for OwnedDisplayHandle {}
-
 /// Returns the minimum `Option<Duration>`, taking into account that `None`
 /// equates to an infinite timeout, not a zero timeout (so can't just use
 /// `Option::min`)

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -87,7 +87,7 @@ impl Window {
         let compositor = state.compositor_state.clone();
         let xdg_activation =
             state.xdg_activation.as_ref().map(|activation_state| activation_state.global().clone());
-        let display = event_loop_window_target.connection.display();
+        let display = event_loop_window_target.handle.connection.display();
 
         let size: Size = attributes.surface_size.unwrap_or(LogicalSize::new(800., 600.).into());
 
@@ -103,7 +103,7 @@ impl Window {
             state.xdg_shell.create_window(surface.clone(), default_decorations, &queue_handle);
 
         let mut window_state = WindowState::new(
-            event_loop_window_target.connection.clone(),
+            event_loop_window_target.handle.clone(),
             &event_loop_window_target.queue_handle,
             &state,
             size,

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -19,8 +19,9 @@ use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, NotSupportedError, RequestError};
 use crate::event::{self, Ime, Modifiers, StartCause};
 use crate::event_loop::{
-    self, ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
+    ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
     EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider,
+    OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
 use crate::keyboard::{
     Key, KeyCode, KeyLocation, ModifiersKeys, ModifiersState, NamedKey, NativeKey, NativeKeyCode,
@@ -741,8 +742,8 @@ impl RootActiveEventLoop for ActiveEventLoop {
         self.exit.get()
     }
 
-    fn owned_display_handle(&self) -> event_loop::OwnedDisplayHandle {
-        event_loop::OwnedDisplayHandle { platform: OwnedDisplayHandle }
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        CoreOwnedDisplayHandle::new(Arc::new(OwnedDisplayHandle))
     }
 
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
@@ -757,14 +758,12 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub(crate) struct OwnedDisplayHandle;
 
-impl OwnedDisplayHandle {
-    #[inline]
-    pub fn raw_display_handle_rwh_06(
-        &self,
-    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
-        Ok(rwh_06::OrbitalDisplayHandle::new().into())
+impl rwh_06::HasDisplayHandle for OwnedDisplayHandle {
+    fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
+        let raw = rwh_06::RawDisplayHandle::Orbital(rwh_06::OrbitalDisplayHandle::new());
+        unsafe { Ok(rwh_06::DisplayHandle::borrow_raw(raw)) }
     }
 }

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -5,7 +5,7 @@ use std::{fmt, str};
 
 use smol_str::SmolStr;
 
-pub(crate) use self::event_loop::{ActiveEventLoop, EventLoop, OwnedDisplayHandle};
+pub(crate) use self::event_loop::{ActiveEventLoop, EventLoop};
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::keyboard::Key;
 mod event_loop;

--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod runner;
 mod state;
 mod window_target;
 
-pub(crate) use window_target::{ActiveEventLoop, OwnedDisplayHandle};
+pub(crate) use window_target::ActiveEventLoop;
 
 pub struct EventLoop {
     elw: ActiveEventLoop,

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use cursor::{
 };
 
 pub(crate) use self::event_loop::{
-    ActiveEventLoop, EventLoop, OwnedDisplayHandle, PlatformSpecificEventLoopAttributes,
+    ActiveEventLoop, EventLoop, PlatformSpecificEventLoopAttributes,
 };
 pub(crate) use self::keyboard::KeyEventExtra;
 pub(crate) use self::monitor::{

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -70,7 +70,7 @@ use crate::event::{
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
     EventLoopProxy as RootEventLoopProxy, EventLoopProxyProvider,
-    OwnedDisplayHandle as RootOwnedDisplayHandle,
+    OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
 use crate::keyboard::ModifiersState;
 use crate::monitor::MonitorHandle as RootMonitorHandle;
@@ -516,8 +516,8 @@ impl RootActiveEventLoop for ActiveEventLoop {
         self.runner_shared.set_exit_code(0)
     }
 
-    fn owned_display_handle(&self) -> RootOwnedDisplayHandle {
-        RootOwnedDisplayHandle { platform: OwnedDisplayHandle }
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        CoreOwnedDisplayHandle::new(Arc::new(OwnedDisplayHandle))
     }
 
     fn rwh_06_handle(&self) -> &dyn rwh_06::HasDisplayHandle {
@@ -532,15 +532,13 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub(crate) struct OwnedDisplayHandle;
 
-impl OwnedDisplayHandle {
-    #[inline]
-    pub fn raw_display_handle_rwh_06(
-        &self,
-    ) -> Result<rwh_06::RawDisplayHandle, rwh_06::HandleError> {
-        Ok(rwh_06::WindowsDisplayHandle::new().into())
+impl rwh_06::HasDisplayHandle for OwnedDisplayHandle {
+    fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
+        let raw = rwh_06::RawDisplayHandle::Windows(rwh_06::WindowsDisplayHandle::new());
+        unsafe { Ok(rwh_06::DisplayHandle::borrow_raw(raw)) }
     }
 }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -2,9 +2,7 @@ use smol_str::SmolStr;
 use windows_sys::Win32::Foundation::HWND;
 use windows_sys::Win32::UI::WindowsAndMessaging::{HMENU, WINDOW_LONG_PTR_INDEX};
 
-pub(crate) use self::event_loop::{
-    EventLoop, OwnedDisplayHandle, PlatformSpecificEventLoopAttributes,
-};
+pub(crate) use self::event_loop::{EventLoop, PlatformSpecificEventLoopAttributes};
 pub use self::icon::WinIcon as PlatformIcon;
 pub(crate) use self::icon::{SelectedCursor, WinCursor as PlatformCustomCursor, WinIcon};
 pub(crate) use self::keyboard::{physicalkey_to_scancode, scancode_to_physicalkey};


### PR DESCRIPTION
This will help in case we want to linger the event loop during drop
to prevent use after free in the consumers code.f

--

Depends on #3980