### PR TITLE
24 11 21 main thread

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -158,6 +158,8 @@ changelog entry.
   - In the same spirit rename `DeviceEvent::MouseMotion` to `PointerMotion`.
   - Remove `Force::Calibrated::altitude_angle`.
   - On X11, use bottom-right corner for IME hotspot in `Window::set_ime_cursor_area`.
+- Main thread check is now more lax on Windows due to it not being fully reliable: it now produces a log instead
+  of a hard panic, and is not checked without `cfg(debug_assertions)`.
 
 ### Removed
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -71,7 +71,7 @@ impl EventLoopBuilder {
     ///
     /// ## Panics
     ///
-    /// Attempting to create the event loop off the main thread will panic. This
+    /// Attempting to create the event loop off the main thread may log or panic. This
     /// restriction isn't strictly necessary on all platforms, but is imposed to
     /// eliminate any nasty surprises when porting to platforms that require it.
     /// `EventLoopBuilderExt::with_any_thread` functions are exposed in the relevant


### PR DESCRIPTION
The check on Windows to enforce that the event loop is created from the main thread is not fully reliable (https://github.com/rust-windowing/winit/issues/3999). Given that this check is not necessary on Windows and only exists more as an assert to enforce platform consistency in development, I have made it more lax:

* It now produces a tracing::warn!() message instead of an outright panic.
* The check is only compiled in with cfg(debug_assertions)

Fixes #3999

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [x] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
