### PR TITLE
Replace `Window::safe_area` with `Window::insets`

### DIFF
--- a/examples/window.rs
+++ b/examples/window.rs
@@ -940,6 +940,8 @@ impl WindowState {
     /// Draw the window contents.
     #[cfg(not(android_platform))]
     fn draw(&mut self) -> Result<(), Box<dyn Error>> {
+        use winit::window::InsetKind;
+
         if self.occluded {
             info!("Skipping drawing occluded window={:?}", self.window.id());
             return Ok(());
@@ -949,7 +951,7 @@ impl WindowState {
 
         // Draw a different color inside the safe area
         let surface_size = self.window.surface_size();
-        let insets = self.window.safe_area();
+        let insets = self.window.insets(InsetKind::SafeArea);
         for y in 0..surface_size.height {
             for x in 0..surface_size.width {
                 let index = y as usize * surface_size.width as usize + x as usize;

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -74,7 +74,8 @@ changelog entry.
 - On X11, the `window` example now understands the `X11_VISUAL_ID` and `X11_SCREEN_ID` env
   variables to test the respective modifiers of window creation.
 - Added `Window::surface_position`, which is the position of the surface inside the window.
-- Added `Window::safe_area`, which describes the area of the surface that is unobstructed.
+- Added `Window::insets`, which lets you read the distance from the edge of the window taken by a certain `InsetKind`.
+- Added `InsetKind::SafeArea`, used with `Window::insets`, which describes the area of the surface that is unobstructed.
 
 ### Changed
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -24,7 +24,7 @@ use crate::event_loop::{
 use crate::monitor::MonitorHandle as RootMonitorHandle;
 use crate::platform::pump_events::PumpStatus;
 use crate::window::{
-    self, CursorGrabMode, CustomCursor, CustomCursorSource, Fullscreen, ImePurpose,
+    self, CursorGrabMode, CustomCursor, CustomCursorSource, Fullscreen, ImePurpose, InsetKind,
     ResizeDirection, Theme, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
     WindowLevel,
 };
@@ -857,7 +857,7 @@ impl CoreWindow for Window {
         screen_size(&self.app)
     }
 
-    fn safe_area(&self) -> PhysicalInsets<u32> {
+    fn insets(&self, kind: InsetKind) -> PhysicalInsets<u32> {
         PhysicalInsets::new(0, 0, 0, 0)
     }
 

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -11,8 +11,8 @@ use super::window_delegate::WindowDelegate;
 use crate::error::RequestError;
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::window::{
-    Cursor, Fullscreen, Icon, ImePurpose, Theme, UserAttentionType, Window as CoreWindow,
-    WindowAttributes, WindowButtons, WindowId, WindowLevel,
+    Cursor, Fullscreen, Icon, ImePurpose, InsetKind, Theme, UserAttentionType,
+    Window as CoreWindow, WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
 pub(crate) struct Window {
@@ -131,8 +131,8 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.outer_size())
     }
 
-    fn safe_area(&self) -> dpi::PhysicalInsets<u32> {
-        self.maybe_wait_on_main(|delegate| delegate.safe_area())
+    fn insets(&self, kind: InsetKind) -> dpi::PhysicalInsets<u32> {
+        self.maybe_wait_on_main(|delegate| delegate.insets(kind))
     }
 
     fn set_min_surface_size(&self, min_size: Option<Size>) {

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -43,7 +43,7 @@ use crate::error::{NotSupportedError, RequestError};
 use crate::event::{SurfaceSizeWriter, WindowEvent};
 use crate::platform::macos::{OptionAsAlt, WindowExtMacOS};
 use crate::window::{
-    Cursor, CursorGrabMode, Icon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
+    Cursor, CursorGrabMode, Icon, ImePurpose, InsetKind, ResizeDirection, Theme, UserAttentionType,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
@@ -983,7 +983,14 @@ impl WindowDelegate {
         logical.to_physical(self.scale_factor())
     }
 
-    pub fn safe_area(&self) -> PhysicalInsets<u32> {
+    pub fn insets(&self, kind: InsetKind) -> PhysicalInsets<u32> {
+        match kind {
+            InsetKind::SafeArea => self.safe_area(),
+            _ => PhysicalInsets::new(0, 0, 0, 0),
+        }
+    }
+
+    fn safe_area(&self) -> PhysicalInsets<u32> {
         // Only available on macOS 11.0
         let insets = if self.view().respondsToSelector(sel!(safeAreaInsets)) {
             // Includes NSWindowStyleMask::FullSizeContentView by default, and the notch because

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -28,8 +28,8 @@ use crate::icon::Icon;
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::platform::ios::{ScreenEdge, StatusBarStyle, ValidOrientations};
 use crate::window::{
-    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
-    WindowAttributes, WindowButtons, WindowId, WindowLevel,
+    CursorGrabMode, ImePurpose, InsetKind, ResizeDirection, Theme, UserAttentionType,
+    Window as CoreWindow, WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
 declare_class!(
@@ -204,7 +204,14 @@ impl Inner {
         Some(self.surface_size())
     }
 
-    pub fn safe_area(&self) -> PhysicalInsets<u32> {
+    pub fn insets(&self, kind: InsetKind) -> PhysicalInsets<u32> {
+        match kind {
+            InsetKind::SafeArea => self.safe_area(),
+            _ => PhysicalInsets::new(0, 0, 0, 0),
+        }
+    }
+
+    fn safe_area(&self) -> PhysicalInsets<u32> {
         // Only available on iOS 11.0
         let insets = if app_state::os_capabilities().safe_area {
             self.view.safeAreaInsets()
@@ -627,8 +634,8 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.outer_size())
     }
 
-    fn safe_area(&self) -> PhysicalInsets<u32> {
-        self.maybe_wait_on_main(|delegate| delegate.safe_area())
+    fn insets(&self, kind: InsetKind) -> PhysicalInsets<u32> {
+        self.maybe_wait_on_main(|delegate| delegate.insets(kind))
     }
 
     fn set_min_surface_size(&self, min_size: Option<Size>) {

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -24,8 +24,8 @@ use crate::event_loop::AsyncRequestSerial;
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
 use crate::platform_impl::{Fullscreen, MonitorHandle as PlatformMonitorHandle};
 use crate::window::{
-    Cursor, CursorGrabMode, Fullscreen as CoreFullscreen, ImePurpose, ResizeDirection, Theme,
-    UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
+    Cursor, CursorGrabMode, Fullscreen as CoreFullscreen, ImePurpose, InsetKind, ResizeDirection,
+    Theme, UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
     WindowLevel,
 };
 
@@ -335,7 +335,7 @@ impl CoreWindow for Window {
         super::logical_to_physical_rounded(window_state.outer_size(), scale_factor)
     }
 
-    fn safe_area(&self) -> PhysicalInsets<u32> {
+    fn insets(&self, _kind: InsetKind) -> PhysicalInsets<u32> {
         PhysicalInsets::new(0, 0, 0, 0)
     }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -35,8 +35,8 @@ use crate::platform_impl::{
     VideoModeHandle as PlatformVideoModeHandle,
 };
 use crate::window::{
-    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
-    WindowAttributes, WindowButtons, WindowId, WindowLevel,
+    CursorGrabMode, ImePurpose, InsetKind, ResizeDirection, Theme, UserAttentionType,
+    Window as CoreWindow, WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
 pub(crate) struct Window(Arc<UnownedWindow>);
@@ -106,8 +106,8 @@ impl CoreWindow for Window {
         self.0.outer_size()
     }
 
-    fn safe_area(&self) -> PhysicalInsets<u32> {
-        self.0.safe_area()
+    fn insets(&self, kind: InsetKind) -> PhysicalInsets<u32> {
+        self.0.insets(kind)
     }
 
     fn set_min_surface_size(&self, min_size: Option<Size>) {
@@ -1592,7 +1592,7 @@ impl UnownedWindow {
         }
     }
 
-    fn safe_area(&self) -> PhysicalInsets<u32> {
+    fn insets(&self, _kind: InsetKind) -> PhysicalInsets<u32> {
         PhysicalInsets::new(0, 0, 0, 0)
     }
 

--- a/src/platform_impl/orbital/window.rs
+++ b/src/platform_impl/orbital/window.rs
@@ -7,7 +7,7 @@ use crate::cursor::Cursor;
 use crate::dpi::{PhysicalInsets, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{NotSupportedError, RequestError};
 use crate::monitor::MonitorHandle as CoreMonitorHandle;
-use crate::window::{self, Fullscreen, ImePurpose, Window as CoreWindow, WindowId};
+use crate::window::{self, Fullscreen, ImePurpose, InsetKind, Window as CoreWindow, WindowId};
 
 // These values match the values uses in the `window_new` function in orbital:
 // https://gitlab.redox-os.org/redox-os/orbital/-/blob/master/src/scheme.rs
@@ -239,7 +239,7 @@ impl CoreWindow for Window {
         self.surface_size()
     }
 
-    fn safe_area(&self) -> PhysicalInsets<u32> {
+    fn insets(&self, _kind: InsetKind) -> PhysicalInsets<u32> {
         PhysicalInsets::new(0, 0, 0, 0)
     }
 

--- a/src/platform_impl/web/window.rs
+++ b/src/platform_impl/web/window.rs
@@ -91,6 +91,34 @@ impl Window {
             lock::is_cursor_lock_raw(inner.canvas.navigator(), inner.canvas.document())
         })
     }
+
+    fn safe_area(&self) -> PhysicalInsets<u32> {
+        self.inner.queue(|inner| {
+            let (safe_start_pos, safe_size) = inner.safe_area.get();
+            let safe_end_pos = LogicalPosition::new(
+                safe_start_pos.x + safe_size.width,
+                safe_start_pos.y + safe_size.height,
+            );
+
+            let surface_start_pos = inner.canvas.position();
+            let surface_size = LogicalSize::new(
+                backend::style_size_property(inner.canvas.style(), "width"),
+                backend::style_size_property(inner.canvas.style(), "height"),
+            );
+            let surface_end_pos = LogicalPosition::new(
+                surface_start_pos.x + surface_size.width,
+                surface_start_pos.y + surface_size.height,
+            );
+
+            let top = f64::max(safe_start_pos.y - surface_start_pos.y, 0.);
+            let left = f64::max(safe_start_pos.x - surface_start_pos.x, 0.);
+            let bottom = f64::max(surface_end_pos.y - safe_end_pos.y, 0.);
+            let right = f64::max(surface_end_pos.x - safe_end_pos.x, 0.);
+
+            let insets = LogicalInsets::new(top, left, bottom, right);
+            insets.to_physical(inner.scale_factor())
+        })
+    }
 }
 
 impl RootWindow for Window {
@@ -155,32 +183,11 @@ impl RootWindow for Window {
         self.surface_size()
     }
 
-    fn safe_area(&self) -> PhysicalInsets<u32> {
-        self.inner.queue(|inner| {
-            let (safe_start_pos, safe_size) = inner.safe_area.get();
-            let safe_end_pos = LogicalPosition::new(
-                safe_start_pos.x + safe_size.width,
-                safe_start_pos.y + safe_size.height,
-            );
-
-            let surface_start_pos = inner.canvas.position();
-            let surface_size = LogicalSize::new(
-                backend::style_size_property(inner.canvas.style(), "width"),
-                backend::style_size_property(inner.canvas.style(), "height"),
-            );
-            let surface_end_pos = LogicalPosition::new(
-                surface_start_pos.x + surface_size.width,
-                surface_start_pos.y + surface_size.height,
-            );
-
-            let top = f64::max(safe_start_pos.y - surface_start_pos.y, 0.);
-            let left = f64::max(safe_start_pos.x - surface_start_pos.x, 0.);
-            let bottom = f64::max(surface_end_pos.y - safe_end_pos.y, 0.);
-            let right = f64::max(surface_end_pos.x - safe_end_pos.x, 0.);
-
-            let insets = LogicalInsets::new(top, left, bottom, right);
-            insets.to_physical(inner.scale_factor())
-        })
+    fn insets(&self, kind: InsetKind) -> PhysicalInsets<u32> {
+        match kind {
+            InsetKind::SafeArea => self.safe_area(),
+            _ => PhysicalInsets::new(0, 0, 0, 0),
+        }
     }
 
     fn set_min_surface_size(&self, min_size: Option<Size>) {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -68,7 +68,7 @@ use crate::platform_impl::platform::window_state::{
 };
 use crate::platform_impl::platform::{monitor, util, Fullscreen, SelectedCursor};
 use crate::window::{
-    CursorGrabMode, Fullscreen as CoreFullscreen, ImePurpose, ResizeDirection, Theme,
+    CursorGrabMode, Fullscreen as CoreFullscreen, ImePurpose, InsetKind, ResizeDirection, Theme,
     UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
     WindowLevel,
 };
@@ -494,7 +494,7 @@ impl CoreWindow for Window {
         None
     }
 
-    fn safe_area(&self) -> PhysicalInsets<u32> {
+    fn insets(&self, _kind: InsetKind) -> PhysicalInsets<u32> {
         PhysicalInsets::new(0, 0, 0, 0)
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -713,26 +713,19 @@ pub trait Window: AsAny + Send + Sync {
     ///   [`Window::surface_size`]._
     fn outer_size(&self) -> PhysicalSize<u32>;
 
-    /// The inset area of the surface that is unobstructed.
+    /// Request the size of a specific [`InsetKind`].
     ///
-    /// On some devices, especially mobile devices, the screen is not a perfect rectangle, and may
-    /// have rounded corners, notches, bezels, and so on. When drawing your content, you usually
-    /// want to draw your background and other such unimportant content on the entire surface, while
-    /// you will want to restrict important content such as text, interactable or visual indicators
-    /// to the part of the screen that is actually visible; for this, you use the safe area.
+    /// When drawing your content, you usually want to draw your background and
+    /// other such unimportant content on the entire surface, while you will
+    /// want to restrict important content such as text, interactable or visual
+    /// indicators to the part of the screen that is actually visible; for this,
+    /// you use insets to compute the area within which you can draw your
+    /// important content.
     ///
-    /// The safe area is a rectangle that is defined relative to the origin at the top-left corner
-    /// of the surface, and the size extending downwards to the right. The area will not extend
-    /// beyond [the bounds of the surface][Window::surface_size].
-    ///
-    /// Note that the safe area does not take occlusion from other windows into account; in a way,
-    /// it is only a "hardware"-level occlusion.
-    ///
-    /// If the entire content of the surface is visible, this returns `(0, 0, 0, 0)`.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Android / Orbital / Wayland / Windows / X11:** Unimplemented, returns `(0, 0, 0, 0)`.
+    /// On some devices, especially mobile devices, the screen is not a perfect
+    /// rectangle, and may have rounded corners, notches, bezels, and so on.
+    /// Some areas of the window may also be used by the platform itself for
+    /// drawing its own elements.
     ///
     /// ## Examples
     ///
@@ -746,7 +739,7 @@ pub trait Window: AsAny + Send + Sync {
     /// let surface_size = window.surface_size();
     /// # let insets = dpi::PhysicalInsets::new(0, 0, 0, 0);
     /// # #[cfg(requires_window)]
-    /// let insets = window.safe_area();
+    /// let insets = window.insets(InsetKind::SafeArea);
     ///
     /// let origin = PhysicalPosition::new(insets.left, insets.top);
     /// let size = PhysicalSize::new(
@@ -754,7 +747,7 @@ pub trait Window: AsAny + Send + Sync {
     ///     surface_size.height - insets.top - insets.bottom,
     /// );
     /// ```
-    fn safe_area(&self) -> PhysicalInsets<u32>;
+    fn insets(&self, kind: InsetKind) -> PhysicalInsets<u32>;
 
     /// Sets a minimum dimensions of the window's surface.
     ///
@@ -1548,4 +1541,39 @@ impl ActivationToken {
     pub(crate) fn _new(_token: String) -> Self {
         Self { _token }
     }
+}
+
+/// Kind of window inset that a [`Window`] may have.
+///
+/// Insets are a set of distances from the edges of a window which are used by
+/// the platform for a specific purpose. They may be "hardware" insets, such as
+/// the camera notch on a mobile device, or "software" insets, such as the space
+/// which the native window control buttons take up.
+///
+/// Use [`Window::insets`] to get the inset distances for a specific kind of
+/// inset.
+#[non_exhaustive]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum InsetKind {
+    /// The inset area of the surface that is guaranteed to be unobstructed by
+    /// any other inset - the "safest" inset.
+    ///
+    /// The safe area is a rectangle that is defined relative to the origin at
+    /// the top-left corner of the surface, and the size extending downwards to
+    /// the right. The area will not extend beyond
+    /// [the bounds of the surface][Window::surface_size].
+    ///
+    /// Note that the safe area does not take occlusion from other windows into
+    /// account; in a way, it is only a "hardware"-level occlusion.
+    ///
+    /// If the entire content of the surface is visible, this returns
+    /// `(0, 0, 0, 0)`.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Android / Orbital / Wayland / Windows / X11:** Unimplemented,
+    ///   returns `(0, 0, 0, 0)`.
+    ///
+    SafeArea,
 }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented

https://github.com/rust-windowing/winit/pull/3890 added the `Window::safe_area` API, for getting the distances from the window edge which are safe to draw important content in. This PR replaces `window.safe_area()` with `window.insets(InsetKind::SafeArea)`:
- removes `safe_area()` and adds `insets(InsetKind)`
- adds `enum InsetKind` with only one variant (for now): `SafeArea`
- moves some `safe_area` docs to `InsetKind::SafeArea`

This opens the door to being able to read the size of different window `InsetKind`s in the future, such as the inset of window control buttons, or the inset of a specific hardware feature like a camera notch.

Tested on Wayland.