### PR TITLE
Fix `MonitorHandle` `PartialEq` and `Hash` on iOS

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -210,3 +210,4 @@ changelog entry.
 - On X11, creating windows while passing `with_x11_screen(non_default_screen)` works again.
 - On X11, fix XInput handling that prevented a new window from getting the focus in some cases.
 - On iOS, fixed `SurfaceResized` and `Window::surface_size` not reporting the size of the actual surface.
+- On iOS, fixed `MonitorHandle`'s `PartialEq` and `Hash` implementations.

--- a/src/platform_impl/apple/uikit/monitor.rs
+++ b/src/platform_impl/apple/uikit/monitor.rs
@@ -101,13 +101,20 @@ impl Clone for MonitorHandle {
 
 impl hash::Hash for MonitorHandle {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        (self as *const Self).hash(state);
+        // SAFETY: Only getting the pointer.
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        Retained::as_ptr(self.ui_screen.get(mtm)).hash(state);
     }
 }
 
 impl PartialEq for MonitorHandle {
     fn eq(&self, other: &Self) -> bool {
-        ptr::eq(self, other)
+        // SAFETY: Only getting the pointer.
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        ptr::eq(
+            Retained::as_ptr(self.ui_screen.get(mtm)),
+            Retained::as_ptr(other.ui_screen.get(mtm)),
+        )
     }
 }
 
@@ -121,8 +128,10 @@ impl PartialOrd for MonitorHandle {
 
 impl Ord for MonitorHandle {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // SAFETY: Only getting the pointer.
         // TODO: Make a better ordering
-        (self as *const Self).cmp(&(other as *const Self))
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+        Retained::as_ptr(self.ui_screen.get(mtm)).cmp(&Retained::as_ptr(other.ui_screen.get(mtm)))
     }
 }
 
@@ -239,4 +248,28 @@ fn refresh_rate_millihertz(uiscreen: &UIScreen) -> Option<NonZeroU32> {
 pub fn uiscreens(mtm: MainThreadMarker) -> VecDeque<MonitorHandle> {
     #[allow(deprecated)]
     UIScreen::screens(mtm).into_iter().map(MonitorHandle::new).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use objc2_foundation::NSSet;
+
+    use super::*;
+
+    // Test that UIScreen pointer comparisons are correct.
+    #[test]
+    #[allow(deprecated)]
+    fn screen_comparisons() {
+        // Test code, doesn't matter that it's not thread safe
+        let mtm = unsafe { MainThreadMarker::new_unchecked() };
+
+        assert!(ptr::eq(&*UIScreen::mainScreen(mtm), &*UIScreen::mainScreen(mtm)));
+
+        let main = UIScreen::mainScreen(mtm);
+        assert!(UIScreen::screens(mtm).iter().any(|screen| ptr::eq(screen, &*main)));
+
+        assert!(unsafe {
+            NSSet::setWithArray(&UIScreen::screens(mtm)).containsObject(&UIScreen::mainScreen(mtm))
+        });
+    }
 }


### PR DESCRIPTION
See https://github.com/bevyengine/bevy/issues/16541, we were comparing the pointer addresses of `MonitorHandle` (which changes every time a new one is created) instead of `UIScreen` (which is more stable).

TODO:
- [x] Actually test this.
  - Tested on the iOS simulator (with a single screen) and Mac Catalyst (with two monitors).
- [x] Make a test for it.
- [x] Add an entry to the changelog.
