### PR TITLE
macOS: Fix safe area on macOS 10.14 and below

### DIFF
--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -990,19 +990,24 @@ impl WindowDelegate {
             // we've set it up with `additionalSafeAreaInsets`.
             unsafe { self.view().safeAreaInsets() }
         } else {
-            let content_rect = self.window().contentRectForFrameRect(self.window().frame());
-            // Includes NSWindowStyleMask::FullSizeContentView
-            // Convert from window coordinates to view coordinates
-            let safe_rect = unsafe {
-                self.view().convertRect_fromView(self.window().contentLayoutRect(), None)
+            // If `safeAreaInsets` is not available, we'll have to do the calculation ourselves.
+
+            let window_rect = unsafe {
+                self.window().convertRectFromScreen(
+                    self.window().contentRectForFrameRect(self.window().frame()),
+                )
             };
+            // This includes NSWindowStyleMask::FullSizeContentView.
+            let layout_rect = unsafe { self.window().contentLayoutRect() };
+
+            // Calculate the insets from window coordinates in AppKit's coordinate system.
             NSEdgeInsets {
-                top: safe_rect.origin.y - content_rect.origin.y,
-                left: safe_rect.origin.x - content_rect.origin.x,
-                bottom: (content_rect.size.height + content_rect.origin.x)
-                    - (safe_rect.size.height + safe_rect.origin.x),
-                right: (content_rect.size.width + content_rect.origin.y)
-                    - (safe_rect.size.width + safe_rect.origin.y),
+                top: (window_rect.size.height + window_rect.origin.y)
+                    - (layout_rect.size.height + layout_rect.origin.y),
+                left: layout_rect.origin.x - window_rect.origin.x,
+                bottom: layout_rect.origin.y - window_rect.origin.y,
+                right: (window_rect.size.width + window_rect.origin.x)
+                    - (layout_rect.size.width + layout_rect.origin.x),
             }
         };
         let insets = LogicalInsets::new(insets.top, insets.left, insets.bottom, insets.right);


### PR DESCRIPTION
Similar to https://github.com/rust-windowing/winit/pull/4027, I didn't test the implementation of `safe_area` properly on older devices when I made it in #3890, likely after migrating that from rectangles to insets.

- [x] Tested on all platforms changed
  - Tested on macOS 14.7.1 and macOS 10.12.6
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
  - This is going to go in the same release as the PR the bug was introduced in, so have not added a changelog entry.
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
