### PR TITLE
Use wrapper type for CFUUID

### DIFF
--- a/src/platform_impl/apple/appkit/ffi.rs
+++ b/src/platform_impl/apple/appkit/ffi.rs
@@ -67,7 +67,25 @@ pub type CGDisplayModeRef = *mut c_void;
 // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html#//apple_ref/doc/uid/TP40001067-CH210-BBCFFIEG
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
-    pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
+    fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
+}
+
+/// Convenice wrapper around `CFUUIDRef` which releases on drop.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct CfUuid(pub(crate) CFUUIDRef);
+
+impl CfUuid {
+    pub fn from_display_id(value: CGDirectDisplayID) -> Self {
+        CfUuid(unsafe { CGDisplayCreateUUIDFromDisplayID(value) })
+    }
+}
+
+impl Drop for CfUuid {
+    fn drop(&mut self) {
+        unsafe {
+            core_foundation::base::CFRelease(self.0 as *const _);
+        }
+    }
 }
 
 #[link(name = "CoreGraphics", kind = "framework")]

--- a/src/platform_impl/apple/appkit/ffi.rs
+++ b/src/platform_impl/apple/appkit/ffi.rs
@@ -67,25 +67,7 @@ pub type CGDisplayModeRef = *mut c_void;
 // https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html#//apple_ref/doc/uid/TP40001067-CH210-BBCFFIEG
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
-    fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
-}
-
-/// Convenice wrapper around `CFUUIDRef` which releases on drop.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct CfUuid(pub(crate) CFUUIDRef);
-
-impl CfUuid {
-    pub fn from_display_id(value: CGDirectDisplayID) -> Self {
-        CfUuid(unsafe { CGDisplayCreateUUIDFromDisplayID(value) })
-    }
-}
-
-impl Drop for CfUuid {
-    fn drop(&mut self) {
-        unsafe {
-            core_foundation::base::CFRelease(self.0 as *const _);
-        }
-    }
+    pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> CFUUIDRef;
 }
 
 #[link(name = "CoreGraphics", kind = "framework")]

--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -134,8 +134,7 @@ impl VideoModeHandle {
 #[derive(Clone)]
 pub struct MonitorHandle(CGDirectDisplayID);
 
-#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-struct MonitorUuid([u8; 16]);
+type MonitorUuid = [u8; 16];
 
 impl MonitorHandle {
     /// Internal comparisons of [`MonitorHandle`]s are done first requesting a UUID for the handle.
@@ -144,7 +143,7 @@ impl MonitorHandle {
             CFUUID::wrap_under_create_rule(ffi::CGDisplayCreateUUIDFromDisplayID(self.0))
         };
         let uuid = unsafe { CFUUIDGetUUIDBytes(cf_uuid.as_concrete_TypeRef()) };
-        MonitorUuid([
+        MonitorUuid::from([
             uuid.byte0,
             uuid.byte1,
             uuid.byte2,

--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -133,15 +133,19 @@ impl VideoModeHandle {
 #[derive(Clone)]
 pub struct MonitorHandle(CGDirectDisplayID);
 
+impl MonitorHandle {
+    /// Internal comparisons of [`MonitorHandle`]s are done first requesting a UUID for the handle.
+    fn uuid(&self) -> ffi::CfUuid {
+        ffi::CfUuid::from_display_id(self.0)
+    }
+}
+
 // `CGDirectDisplayID` changes on video mode change, so we cannot rely on that
 // for comparisons, but we can use `CGDisplayCreateUUIDFromDisplayID` to get an
 // unique identifier that persists even across system reboots
 impl PartialEq for MonitorHandle {
     fn eq(&self, other: &Self) -> bool {
-        unsafe {
-            ffi::CGDisplayCreateUUIDFromDisplayID(self.0)
-                == ffi::CGDisplayCreateUUIDFromDisplayID(other.0)
-        }
+        self.uuid() == other.uuid()
     }
 }
 
@@ -155,18 +159,13 @@ impl PartialOrd for MonitorHandle {
 
 impl Ord for MonitorHandle {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        unsafe {
-            ffi::CGDisplayCreateUUIDFromDisplayID(self.0)
-                .cmp(&ffi::CGDisplayCreateUUIDFromDisplayID(other.0))
-        }
+        self.uuid().cmp(&other.uuid())
     }
 }
 
 impl std::hash::Hash for MonitorHandle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        unsafe {
-            ffi::CGDisplayCreateUUIDFromDisplayID(self.0).hash(state);
-        }
+        self.uuid().hash(state);
     }
 }
 
@@ -287,12 +286,10 @@ impl MonitorHandle {
     }
 
     pub(crate) fn ns_screen(&self, mtm: MainThreadMarker) -> Option<Retained<NSScreen>> {
-        let uuid = unsafe { ffi::CGDisplayCreateUUIDFromDisplayID(self.0) };
+        let uuid = self.uuid();
         NSScreen::screens(mtm).into_iter().find(|screen| {
             let other_native_id = get_display_id(screen);
-            let other_uuid = unsafe {
-                ffi::CGDisplayCreateUUIDFromDisplayID(other_native_id as CGDirectDisplayID)
-            };
+            let other_uuid = ffi::CfUuid::from_display_id(other_native_id);
             uuid == other_uuid
         })
     }


### PR DESCRIPTION
This no longer exposes `CGDisplayCreateUUIDFromDisplayID` and instead offers a new `CfUuid` type that can be created from a display ID and also cleans itself up on drop.

Closes #4031

---

- [ ] Tested on all platforms changed
  - [ ] Tested examples on macOS 15.1.1
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
