### PR TITLE
Implement ability to make non-activating window on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ objc2-app-kit = { version = "0.2.2", features = [
     "NSMenu",
     "NSMenuItem",
     "NSOpenGLView",
+    "NSPanel",
     "NSPasteboard",
     "NSResponder",
     "NSRunningApplication",

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -76,6 +76,7 @@ changelog entry.
 - Added `Window::surface_position`, which is the position of the surface inside the window.
 - Added `Window::safe_area`, which describes the area of the surface that is unobstructed.
 - On X11, Wayland, Windows and macOS, improved scancode conversions for more obscure key codes.
+- Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`
 
 ### Changed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -76,7 +76,7 @@ changelog entry.
 - Added `Window::surface_position`, which is the position of the surface inside the window.
 - Added `Window::safe_area`, which describes the area of the surface that is unobstructed.
 - On X11, Wayland, Windows and macOS, improved scancode conversions for more obscure key codes.
-- Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`
+- Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`.
 
 ### Changed
 

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -332,7 +332,7 @@ pub trait WindowAttributesExtMacOS {
     fn with_borderless_game(self, borderless_game: bool) -> Self;
     /// See [`WindowExtMacOS::set_unified_titlebar`] for details on what this means if set.
     fn with_unified_titlebar(self, unified_titlebar: bool) -> Self;
-    /// Use [`NSPanel`] window with [`NonactivatingPanel`] window style mask instead of [`NSWindow`]
+    /// Use [`NSPanel`] window with [`NonactivatingPanel`] window style mask instead of [`NSWindow`].
     ///
     /// [`NSWindow`]: https://developer.apple.com/documentation/appkit/NSWindow?language=objc
     /// [`NSPanel`]: https://developer.apple.com/documentation/appkit/NSPanel?language=objc

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -332,7 +332,8 @@ pub trait WindowAttributesExtMacOS {
     fn with_borderless_game(self, borderless_game: bool) -> Self;
     /// See [`WindowExtMacOS::set_unified_titlebar`] for details on what this means if set.
     fn with_unified_titlebar(self, unified_titlebar: bool) -> Self;
-    /// Use [`NSPanel`] window with [`NonactivatingPanel`] window style mask instead of [`NSWindow`].
+    /// Use [`NSPanel`] window with [`NonactivatingPanel`] window style mask instead of
+    /// [`NSWindow`].
     ///
     /// [`NSWindow`]: https://developer.apple.com/documentation/appkit/NSWindow?language=objc
     /// [`NSPanel`]: https://developer.apple.com/documentation/appkit/NSPanel?language=objc

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -332,6 +332,12 @@ pub trait WindowAttributesExtMacOS {
     fn with_borderless_game(self, borderless_game: bool) -> Self;
     /// See [`WindowExtMacOS::set_unified_titlebar`] for details on what this means if set.
     fn with_unified_titlebar(self, unified_titlebar: bool) -> Self;
+    /// Use [`NSPanel`] window with [`NonactivatingPanel`] window style mask instead of [`NSWindow`]
+    ///
+    /// [`NSWindow`]: https://developer.apple.com/documentation/appkit/NSWindow?language=objc
+    /// [`NSPanel`]: https://developer.apple.com/documentation/appkit/NSPanel?language=objc
+    /// [`NonactivatingPanel`]: https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct/nonactivatingpanel?language=objc
+    fn with_panel(self, panel: bool) -> Self;
 }
 
 impl WindowAttributesExtMacOS for WindowAttributes {
@@ -410,6 +416,12 @@ impl WindowAttributesExtMacOS for WindowAttributes {
     #[inline]
     fn with_unified_titlebar(mut self, unified_titlebar: bool) -> Self {
         self.platform_specific.unified_titlebar = unified_titlebar;
+        self
+    }
+
+    #[inline]
+    fn with_panel(mut self, panel: bool) -> Self {
+        self.platform_specific.panel = panel;
         self
     }
 }


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Fixes https://github.com/rust-windowing/winit/issues/3894. I don't really have any experience with macOS-related programming, so not really sure if it is technically correct but it does seem to work properly 