### PR TITLE
x11: add workaround for disabling IME on gnome

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -71,6 +71,7 @@ changelog entry.
 - Added `Window::safe_area`, which describes the area of the surface that is unobstructed.
 - On X11, Wayland, Windows and macOS, improved scancode conversions for more obscure key codes.
 - Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`.
+- On X11, add a workaround for disabling IME on GNOME.
 
 ### Changed
 

--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -82,7 +82,9 @@ impl InputMethod {
         }
 
         let preedit_style = preedit_style.unwrap_or_else(|| none_style.unwrap());
-        let none_style = none_style.unwrap_or(preedit_style);
+        // Always initialize none style even when it's not advertised, since it seems to work
+        // regardless...
+        let none_style = none_style.unwrap_or(Style::None(XIM_NONE_STYLE));
 
         Some(InputMethod { im, _name: name, preedit_style, none_style })
     }


### PR DESCRIPTION
GNOME doesn't list that there's a _NONE_ style at all, but it still works if you use it.