### PR TITLE
windows: Fix the event loop to wake on accessibility requests

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -200,4 +200,4 @@ changelog entry.
 - On macOS, fixed the scancode conversion for audio volume keys.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
-- On Windows, fixed the event loop to wake on accessibility requests.
+- On Windows, fixed the event loop not waking on accessibility requests.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -200,3 +200,4 @@ changelog entry.
 - On macOS, fixed the scancode conversion for audio volume keys.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
+- On Windows, fixed the event loop to wake on accessibility requests.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -736,6 +736,7 @@ fn wait_for_messages_impl(
         let (num_handles, raw_handles) =
             if use_timer { (1, [high_resolution_timer.unwrap()]) } else { (0, [ptr::null_mut()]) };
 
+        // We must use `QS_ALLINPUT` to wake on accessibility messages.
         let result = MsgWaitForMultipleObjectsEx(
             num_handles,
             raw_handles.as_ptr() as *const _,

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -43,7 +43,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     GetMenu, LoadCursorW, MsgWaitForMultipleObjectsEx, PeekMessageW, PostMessageW,
     RegisterClassExW, RegisterWindowMessageA, SetCursor, SetWindowPos, TranslateMessage,
     CREATESTRUCTW, GWL_STYLE, GWL_USERDATA, HTCAPTION, HTCLIENT, MINMAXINFO, MNC_CLOSE, MSG,
-    MWMO_INPUTAVAILABLE, NCCALCSIZE_PARAMS, PM_REMOVE, PT_TOUCH, QS_ALLEVENTS, RI_MOUSE_HWHEEL,
+    MWMO_INPUTAVAILABLE, NCCALCSIZE_PARAMS, PM_REMOVE, PT_TOUCH, QS_ALLINPUT, RI_MOUSE_HWHEEL,
     RI_MOUSE_WHEEL, SC_MINIMIZE, SC_RESTORE, SIZE_MAXIMIZED, SWP_NOACTIVATE, SWP_NOMOVE,
     SWP_NOSIZE, SWP_NOZORDER, WHEEL_DELTA, WINDOWPOS, WMSZ_BOTTOM, WMSZ_BOTTOMLEFT,
     WMSZ_BOTTOMRIGHT, WMSZ_LEFT, WMSZ_RIGHT, WMSZ_TOP, WMSZ_TOPLEFT, WMSZ_TOPRIGHT,
@@ -740,7 +740,7 @@ fn wait_for_messages_impl(
             num_handles,
             raw_handles.as_ptr() as *const _,
             wait_duration_ms,
-            QS_ALLEVENTS,
+            QS_ALLINPUT,
             MWMO_INPUTAVAILABLE,
         );
         if result == WAIT_FAILED {


### PR DESCRIPTION
Fixes #4055.

It turns out this is easy to test even though AccessKit doesn't yet support winit master. If you run the `window` example on Windows with the NVDA screen reader running without this fix, NVDA doesn't read the window title, or reads it with a severe delay. With this fix, it reads the window title immediately as expected, even though the application doesn't implement accessibility.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
