### PR TITLE
api: make VideoModeHandle into VideoMode

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -160,8 +160,8 @@ changelog entry.
 - On macOS, no longer emit `Focused` upon window creation.
 - On iOS, emit more events immediately, instead of queuing them.
 - Update `smol_str` to version `0.3`
-- `VideoModeHandle` to `VideoMode` which stores plain data.
-- `Fullscreen::Exclusive` to take `(MonitorHandle, VideoMode)`.
+- Rename `VideoModeHandle` to `VideoMode` which stores plain data.
+- Make `Fullscreen::Exclusive` to take `(MonitorHandle, VideoMode)`.
 
 ### Removed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -160,8 +160,8 @@ changelog entry.
 - On macOS, no longer emit `Focused` upon window creation.
 - On iOS, emit more events immediately, instead of queuing them.
 - Update `smol_str` to version `0.3`
-- Rename `VideoModeHandle` to `VideoMode` which stores plain data.
-- Make `Fullscreen::Exclusive` to take `(MonitorHandle, VideoMode)`.
+- Rename `VideoModeHandle` to `VideoMode`, now it only stores plain data.
+- Make `Fullscreen::Exclusive` contain `(MonitorHandle, VideoMode)`.
 
 ### Removed
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -160,6 +160,8 @@ changelog entry.
 - On macOS, no longer emit `Focused` upon window creation.
 - On iOS, emit more events immediately, instead of queuing them.
 - Update `smol_str` to version `0.3`
+- `VideoModeHandle` to `VideoMode` which stores plain data.
+- `Fullscreen::Exclusive` to take `(MonitorHandle, VideoMode)`.
 
 ### Removed
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -7,7 +7,7 @@ use crate::platform_impl;
 
 /// Describes a fullscreen video mode of a monitor.
 ///
-/// Can be acquired with [`MonitorHandle::video_modes`].
+/// Can be retrieved with [`MonitorHandle::video_modes()`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct VideoMode {
     pub(crate) size: PhysicalSize<u32>,
@@ -39,24 +39,18 @@ impl VideoMode {
 
 impl fmt::Display for VideoMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}x{} {}{}",
-            self.size.width,
-            self.size.height,
-            self.refresh_rate_millihertz.map(|rate| format!("@ {rate} mHz ")).unwrap_or_default(),
-            self.bit_depth.map(|bit_depth| format!("({bit_depth} bpp)")).unwrap_or_default(),
-        )
+        write!(f, "{}x{}", self.size.width, self.size.height)?;
+
+        if let Some(refresh_rate) = self.refresh_rate_millihertz.as_ref() {
+            write!(f, "@{refresh_rate}mHz")?;
+        }
+
+        if let Some(bit_depth) = self.bit_depth.as_ref() {
+            write!(f, " ({bit_depth} bpp)")?;
+        }
+
+        Ok(())
     }
-}
-
-/// Fullscreen modes.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum Fullscreen {
-    Exclusive(MonitorHandle, VideoMode),
-
-    /// Providing `None` to `Borderless` will fullscreen on the current monitor.
-    Borderless(Option<MonitorHandle>),
 }
 
 /// Handle to a monitor.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,87 +1,62 @@
 //! Types useful for interacting with a user's monitors.
+use std::fmt;
 use std::num::{NonZeroU16, NonZeroU32};
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::platform_impl;
 
-/// A handle to a fullscreen video mode of a specific monitor.
+/// Describes a fullscreen video mode of a monitor.
 ///
-/// This can be acquired with [`MonitorHandle::video_modes`].
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct VideoModeHandle {
-    pub(crate) video_mode: platform_impl::VideoModeHandle,
+/// Can be acquired with [`MonitorHandle::video_modes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VideoMode {
+    pub(crate) size: PhysicalSize<u32>,
+    pub(crate) bit_depth: Option<NonZeroU16>,
+    pub(crate) refresh_rate_millihertz: Option<NonZeroU32>,
 }
 
-impl std::fmt::Debug for VideoModeHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.video_mode.fmt(f)
-    }
-}
-
-impl PartialOrd for VideoModeHandle {
-    fn partial_cmp(&self, other: &VideoModeHandle) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for VideoModeHandle {
-    fn cmp(&self, other: &VideoModeHandle) -> std::cmp::Ordering {
-        self.monitor().cmp(&other.monitor()).then(
-            self.size()
-                .cmp(&other.size())
-                .then(
-                    self.refresh_rate_millihertz()
-                        .cmp(&other.refresh_rate_millihertz())
-                        .then(self.bit_depth().cmp(&other.bit_depth())),
-                )
-                .reverse(),
-        )
-    }
-}
-
-impl VideoModeHandle {
+impl VideoMode {
     /// Returns the resolution of this video mode. This **must not** be used to create your
     /// rendering surface. Use [`Window::surface_size()`] instead.
     ///
     /// [`Window::surface_size()`]: crate::window::Window::surface_size
-    #[inline]
     pub fn size(&self) -> PhysicalSize<u32> {
-        self.video_mode.size()
+        self.size
     }
 
     /// Returns the bit depth of this video mode, as in how many bits you have
     /// available per color. This is generally 24 bits or 32 bits on modern
     /// systems, depending on whether the alpha channel is counted or not.
-    #[inline]
     pub fn bit_depth(&self) -> Option<NonZeroU16> {
-        self.video_mode.bit_depth()
+        self.bit_depth
     }
 
     /// Returns the refresh rate of this video mode in mHz.
-    #[inline]
     pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
-        self.video_mode.refresh_rate_millihertz()
-    }
-
-    /// Returns the monitor that this video mode is valid for. Each monitor has
-    /// a separate set of valid video modes.
-    #[inline]
-    pub fn monitor(&self) -> MonitorHandle {
-        MonitorHandle { inner: self.video_mode.monitor() }
+        self.refresh_rate_millihertz
     }
 }
 
-impl std::fmt::Display for VideoModeHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for VideoMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}x{} {}{}",
-            self.size().width,
-            self.size().height,
-            self.refresh_rate_millihertz().map(|rate| format!("@ {rate} mHz ")).unwrap_or_default(),
-            self.bit_depth().map(|bit_depth| format!("({bit_depth} bpp)")).unwrap_or_default(),
+            self.size.width,
+            self.size.height,
+            self.refresh_rate_millihertz.map(|rate| format!("@ {rate} mHz ")).unwrap_or_default(),
+            self.bit_depth.map(|bit_depth| format!("({bit_depth} bpp)")).unwrap_or_default(),
         )
     }
+}
+
+/// Fullscreen modes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Fullscreen {
+    Exclusive(MonitorHandle, VideoMode),
+
+    /// Providing `None` to `Borderless` will fullscreen on the current monitor.
+    Borderless(Option<MonitorHandle>),
 }
 
 /// Handle to a monitor.
@@ -188,13 +163,13 @@ impl MonitorHandle {
 
     /// Returns the currently active video mode of this monitor.
     #[inline]
-    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
-        self.inner.current_video_mode().map(|video_mode| VideoModeHandle { video_mode })
+    pub fn current_video_mode(&self) -> Option<VideoMode> {
+        self.inner.current_video_mode()
     }
 
     /// Returns all fullscreen video modes supported by this monitor.
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
-        self.inner.video_modes().map(|video_mode| VideoModeHandle { video_mode })
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+        self.inner.video_modes()
     }
 }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -41,11 +41,11 @@ impl fmt::Display for VideoMode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}x{}", self.size.width, self.size.height)?;
 
-        if let Some(refresh_rate) = self.refresh_rate_millihertz.as_ref() {
+        if let Some(refresh_rate) = self.refresh_rate_millihertz {
             write!(f, "@{refresh_rate}mHz")?;
         }
 
-        if let Some(bit_depth) = self.bit_depth.as_ref() {
+        if let Some(bit_depth) = self.bit_depth {
             write!(f, " ({bit_depth} bpp)")?;
         }
 

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -107,7 +107,7 @@ use std::os::raw::c_void;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::monitor::{MonitorHandle, VideoModeHandle};
+use crate::monitor::{MonitorHandle, VideoMode};
 use crate::window::{Window, WindowAttributes};
 
 /// Additional methods on [`Window`] that are specific to iOS.
@@ -384,10 +384,10 @@ pub trait MonitorHandleExtIOS {
     /// [`UIScreen`]: https://developer.apple.com/documentation/uikit/uiscreen?language=objc
     fn ui_screen(&self) -> *mut c_void;
 
-    /// Returns the preferred [`VideoModeHandle`] for this monitor.
+    /// Returns the preferred [`VideoMode`] for this monitor.
     ///
     /// This translates to a call to [`-[UIScreen preferredMode]`](https://developer.apple.com/documentation/uikit/uiscreen/1617823-preferredmode?language=objc).
-    fn preferred_video_mode(&self) -> VideoModeHandle;
+    fn preferred_video_mode(&self) -> VideoMode;
 }
 
 impl MonitorHandleExtIOS for MonitorHandle {
@@ -399,8 +399,8 @@ impl MonitorHandleExtIOS for MonitorHandle {
     }
 
     #[inline]
-    fn preferred_video_mode(&self) -> VideoModeHandle {
-        VideoModeHandle { video_mode: self.inner.preferred_video_mode() }
+    fn preferred_video_mode(&self) -> VideoMode {
+        self.inner.preferred_video_mode()
     }
 }
 

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -1,6 +1,5 @@
 use std::cell::Cell;
 use std::hash::Hash;
-use std::num::{NonZeroU16, NonZeroU32};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -21,7 +20,7 @@ use crate::event_loop::{
     EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider,
     OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
-use crate::monitor::MonitorHandle as RootMonitorHandle;
+use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode};
 use crate::platform::pump_events::PumpStatus;
 use crate::window::{
     self, CursorGrabMode, CustomCursor, CustomCursorSource, Fullscreen, ImePurpose,
@@ -1021,32 +1020,11 @@ impl MonitorHandle {
         unreachable!()
     }
 
-    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoMode> {
         unreachable!()
     }
 
-    pub fn video_modes(&self) -> std::iter::Empty<VideoModeHandle> {
-        unreachable!()
-    }
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct VideoModeHandle;
-
-impl VideoModeHandle {
-    pub fn size(&self) -> PhysicalSize<u32> {
-        unreachable!()
-    }
-
-    pub fn bit_depth(&self) -> Option<NonZeroU16> {
-        unreachable!()
-    }
-
-    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
-        unreachable!()
-    }
-
-    pub fn monitor(&self) -> MonitorHandle {
+    pub fn video_modes(&self) -> std::iter::Empty<VideoMode> {
         unreachable!()
     }
 }

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -19,7 +19,7 @@ pub(crate) use self::event::{physicalkey_to_scancode, scancode_to_physicalkey, K
 pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, PlatformSpecificEventLoopAttributes,
 };
-pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
+pub(crate) use self::monitor::MonitorHandle;
 pub(crate) use self::window::Window;
 pub(crate) use self::window_delegate::PlatformSpecificWindowAttributes;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -64,7 +64,7 @@ impl Window {
 impl Drop for Window {
     fn drop(&mut self) {
         // Restore the video mode.
-        if matches!(self.fullscreen(), Some(Fullscreen::Exclusive(_))) {
+        if matches!(self.fullscreen(), Some(Fullscreen::Exclusive(_, _))) {
             self.set_fullscreen(None);
         }
 

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -12,7 +12,7 @@ use std::fmt;
 pub(crate) use self::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, PlatformSpecificEventLoopAttributes,
 };
-pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
+pub(crate) use self::monitor::MonitorHandle;
 pub(crate) use self::window::{PlatformSpecificWindowAttributes, Window};
 pub(crate) use crate::cursor::{
     NoCustomCursor as PlatformCustomCursor, NoCustomCursor as PlatformCustomCursorSource,

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -4,7 +4,6 @@
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
 use std::env;
-use std::num::{NonZeroU16, NonZeroU32};
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 use std::time::Duration;
 #[cfg(x11_platform)]
@@ -17,13 +16,14 @@ pub(crate) use self::common::xkb::{physicalkey_to_scancode, scancode_to_physical
 use self::x11::{XConnection, XError, XNotSupported};
 use crate::application::ApplicationHandler;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
+use crate::dpi::PhysicalPosition;
 #[cfg(x11_platform)]
 use crate::dpi::Size;
-use crate::dpi::{PhysicalPosition, PhysicalSize};
 use crate::error::{EventLoopError, NotSupportedError};
 use crate::event_loop::ActiveEventLoop;
 pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 use crate::keyboard::Key;
+use crate::monitor::VideoMode;
 use crate::platform::pump_events::PumpStatus;
 #[cfg(x11_platform)]
 use crate::platform::x11::{WindowType as XWindowType, XlibErrorHook};
@@ -165,43 +165,13 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoMode> {
         x11_or_wayland!(match self; MonitorHandle(m) => m.current_video_mode())
     }
 
     #[inline]
-    pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoModeHandle>> {
+    pub fn video_modes(&self) -> Box<dyn Iterator<Item = VideoMode>> {
         x11_or_wayland!(match self; MonitorHandle(m) => Box::new(m.video_modes()))
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum VideoModeHandle {
-    #[cfg(x11_platform)]
-    X(x11::VideoModeHandle),
-    #[cfg(wayland_platform)]
-    Wayland(wayland::VideoModeHandle),
-}
-
-impl VideoModeHandle {
-    #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        x11_or_wayland!(match self; VideoModeHandle(m) => m.size())
-    }
-
-    #[inline]
-    pub fn bit_depth(&self) -> Option<NonZeroU16> {
-        x11_or_wayland!(match self; VideoModeHandle(m) => m.bit_depth())
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
-        x11_or_wayland!(match self; VideoModeHandle(m) => m.refresh_rate_millihertz())
-    }
-
-    #[inline]
-    pub fn monitor(&self) -> MonitorHandle {
-        x11_or_wayland!(match self; VideoModeHandle(m) => m.monitor(); as MonitorHandle)
     }
 }
 

--- a/src/platform_impl/linux/wayland/mod.rs
+++ b/src/platform_impl/linux/wayland/mod.rs
@@ -1,7 +1,7 @@
 //! Winit's Wayland backend.
 
 pub use event_loop::{ActiveEventLoop, EventLoop};
-pub use output::{MonitorHandle, VideoModeHandle};
+pub use output::MonitorHandle;
 use sctk::reexports::client::protocol::wl_surface::WlSurface;
 use sctk::reexports::client::Proxy;
 pub use window::Window;

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -96,7 +96,7 @@ impl std::hash::Hash for MonitorHandle {
     }
 }
 
-/// Convert the wayland's [`Mode`] to winit's [`VideoMode`].
+/// Convert Wayland's [`Mode`] to winit's [`VideoMode`].
 fn wayland_mode_to_core_mode(mode: Mode) -> VideoMode {
     VideoMode {
         size: (mode.dimensions.0, mode.dimensions.1).into(),

--- a/src/platform_impl/linux/wayland/output.rs
+++ b/src/platform_impl/linux/wayland/output.rs
@@ -1,11 +1,11 @@
-use std::num::{NonZeroU16, NonZeroU32};
+use std::num::NonZeroU32;
 
 use sctk::output::{Mode, OutputData};
 use sctk::reexports::client::protocol::wl_output::WlOutput;
 use sctk::reexports::client::Proxy;
 
-use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
-use crate::platform_impl::platform::VideoModeHandle as PlatformVideoModeHandle;
+use crate::dpi::{LogicalPosition, PhysicalPosition};
+use crate::monitor::VideoMode;
 
 #[derive(Clone, Debug)]
 pub struct MonitorHandle {
@@ -54,27 +54,19 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn current_video_mode(&self) -> Option<PlatformVideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoMode> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         output_data.with_output_info(|info| {
             let mode = info.modes.iter().find(|mode| mode.current).cloned();
-
-            mode.map(|mode| {
-                PlatformVideoModeHandle::Wayland(VideoModeHandle::new(self.clone(), mode))
-            })
+            mode.map(wayland_mode_to_core_mode)
         })
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoModeHandle> {
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
         let output_data = self.proxy.data::<OutputData>().unwrap();
         let modes = output_data.with_output_info(|info| info.modes.clone());
-
-        let monitor = self.clone();
-
-        modes.into_iter().map(move |mode| {
-            PlatformVideoModeHandle::Wayland(VideoModeHandle::new(monitor.clone(), mode))
-        })
+        modes.into_iter().map(wayland_mode_to_core_mode)
     }
 }
 
@@ -104,38 +96,11 @@ impl std::hash::Hash for MonitorHandle {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct VideoModeHandle {
-    pub(crate) size: PhysicalSize<u32>,
-    pub(crate) refresh_rate_millihertz: Option<NonZeroU32>,
-    pub(crate) monitor: MonitorHandle,
-}
-
-impl VideoModeHandle {
-    fn new(monitor: MonitorHandle, mode: Mode) -> Self {
-        VideoModeHandle {
-            size: (mode.dimensions.0 as u32, mode.dimensions.1 as u32).into(),
-            refresh_rate_millihertz: NonZeroU32::new(mode.refresh_rate as u32),
-            monitor: monitor.clone(),
-        }
-    }
-
-    #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.size
-    }
-
-    #[inline]
-    pub fn bit_depth(&self) -> Option<NonZeroU16> {
-        None
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
-        self.refresh_rate_millihertz
-    }
-
-    pub fn monitor(&self) -> MonitorHandle {
-        self.monitor.clone()
+/// Convert the wayland's [`Mode`] to winit's [`VideoMode`].
+fn wayland_mode_to_core_mode(mode: Mode) -> VideoMode {
+    VideoMode {
+        size: (mode.dimensions.0, mode.dimensions.1).into(),
+        bit_depth: None,
+        refresh_rate_millihertz: NonZeroU32::new(mode.refresh_rate as u32),
     }
 }

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -139,7 +139,7 @@ impl Window {
 
         // Set startup mode.
         match attributes.fullscreen.map(Into::into) {
-            Some(Fullscreen::Exclusive(_)) => {
+            Some(Fullscreen::Exclusive(..)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland");
             },
             #[cfg_attr(not(x11_platform), allow(clippy::bind_instead_of_map))]
@@ -438,7 +438,7 @@ impl CoreWindow for Window {
 
     fn set_fullscreen(&self, fullscreen: Option<CoreFullscreen>) {
         match fullscreen {
-            Some(CoreFullscreen::Exclusive(_)) => {
+            Some(CoreFullscreen::Exclusive(..)) => {
                 warn!("`Fullscreen::Exclusive` is ignored on Wayland");
             },
             #[cfg_attr(not(x11_platform), allow(clippy::bind_instead_of_map))]

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -1,11 +1,11 @@
-use std::num::{NonZeroU16, NonZeroU32};
+use std::num::NonZeroU32;
 
 use x11rb::connection::RequestConnection;
 use x11rb::protocol::randr::{self, ConnectionExt as _};
 use x11rb::protocol::xproto;
 
 use super::{util, X11Error, XConnection};
-use crate::dpi::{PhysicalPosition, PhysicalSize};
+use crate::dpi::PhysicalPosition;
 use crate::monitor::VideoMode;
 
 // Used for testing. This should always be committed as false.
@@ -21,20 +21,14 @@ impl XConnection {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VideoModeHandle {
     pub(crate) current: bool,
-    pub(crate) size: PhysicalSize<u32>,
-    pub(crate) bit_depth: Option<NonZeroU16>,
-    pub(crate) refresh_rate_millihertz: Option<NonZeroU32>,
+    pub(crate) mode: VideoMode,
     pub(crate) native_mode: randr::Mode,
     pub(crate) monitor: Option<MonitorHandle>,
 }
 
 impl From<VideoModeHandle> for VideoMode {
-    fn from(mode: VideoModeHandle) -> Self {
-        Self {
-            size: mode.size,
-            bit_depth: mode.bit_depth,
-            refresh_rate_millihertz: mode.refresh_rate_millihertz,
-        }
+    fn from(handle: VideoModeHandle) -> Self {
+        handle.mode
     }
 }
 

--- a/src/platform_impl/linux/x11/monitor.rs
+++ b/src/platform_impl/linux/x11/monitor.rs
@@ -6,7 +6,7 @@ use x11rb::protocol::xproto;
 
 use super::{util, X11Error, XConnection};
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::platform_impl::VideoModeHandle as PlatformVideoModeHandle;
+use crate::monitor::VideoMode;
 
 // Used for testing. This should always be committed as false.
 const DISABLE_MONITOR_LIST_CACHING: bool = false;
@@ -21,32 +21,20 @@ impl XConnection {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VideoModeHandle {
     pub(crate) current: bool,
-    pub(crate) size: (u32, u32),
+    pub(crate) size: PhysicalSize<u32>,
     pub(crate) bit_depth: Option<NonZeroU16>,
     pub(crate) refresh_rate_millihertz: Option<NonZeroU32>,
     pub(crate) native_mode: randr::Mode,
     pub(crate) monitor: Option<MonitorHandle>,
 }
 
-impl VideoModeHandle {
-    #[inline]
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.size.into()
-    }
-
-    #[inline]
-    pub fn bit_depth(&self) -> Option<NonZeroU16> {
-        self.bit_depth
-    }
-
-    #[inline]
-    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
-        self.refresh_rate_millihertz
-    }
-
-    #[inline]
-    pub fn monitor(&self) -> MonitorHandle {
-        self.monitor.clone().unwrap()
+impl From<VideoModeHandle> for VideoMode {
+    fn from(mode: VideoModeHandle) -> Self {
+        Self {
+            size: mode.size,
+            bit_depth: mode.bit_depth,
+            refresh_rate_millihertz: mode.refresh_rate_millihertz,
+        }
     }
 }
 
@@ -65,7 +53,7 @@ pub struct MonitorHandle {
     /// Used to determine which windows are on this monitor
     pub(crate) rect: util::AaRect,
     /// Supported video modes on this monitor
-    video_modes: Vec<VideoModeHandle>,
+    pub(crate) video_modes: Vec<VideoModeHandle>,
 }
 
 impl PartialEq for MonitorHandle {
@@ -159,17 +147,13 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn current_video_mode(&self) -> Option<PlatformVideoModeHandle> {
-        self.video_modes.iter().find(|mode| mode.current).cloned().map(PlatformVideoModeHandle::X)
+    pub fn current_video_mode(&self) -> Option<VideoMode> {
+        self.video_modes.iter().find(|mode| mode.current).cloned().map(Into::into)
     }
 
     #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = PlatformVideoModeHandle> {
-        let monitor = self.clone();
-        self.video_modes.clone().into_iter().map(move |mut x| {
-            x.monitor = Some(monitor.clone());
-            PlatformVideoModeHandle::X(x)
-        })
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+        self.video_modes.clone().into_iter().map(Into::into)
     }
 }
 

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -7,6 +7,7 @@ use x11rb::protocol::randr::{self, ConnectionExt as _};
 
 use super::*;
 use crate::dpi::validate_scale_factor;
+use crate::monitor::VideoMode;
 use crate::platform_impl::platform::x11::{monitor, VideoModeHandle};
 
 /// Represents values of `WINIT_HIDPI_FACTOR`.
@@ -85,9 +86,11 @@ impl XConnection {
             .map(|mode| {
                 VideoModeHandle {
                     current: mode.id == current_mode,
-                    size: (mode.width as u32, mode.height as u32).into(),
-                    refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode),
-                    bit_depth: NonZeroU16::new(bit_depth as u16),
+                    mode: VideoMode {
+                        size: (mode.width as u32, mode.height as u32).into(),
+                        refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode),
+                        bit_depth: NonZeroU16::new(bit_depth as u16),
+                    },
                     native_mode: mode.id,
                     // This is populated in `MonitorHandle::video_modes` as the
                     // video mode is returned to the user

--- a/src/platform_impl/linux/x11/util/randr.rs
+++ b/src/platform_impl/linux/x11/util/randr.rs
@@ -85,7 +85,7 @@ impl XConnection {
             .map(|mode| {
                 VideoModeHandle {
                     current: mode.id == current_mode,
-                    size: (mode.width.into(), mode.height.into()),
+                    size: (mode.width as u32, mode.height as u32).into(),
                     refresh_rate_millihertz: monitor::mode_refresh_rate_millihertz(mode),
                     bit_depth: NonZeroU16::new(bit_depth as u16),
                     native_mode: mode.id,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1088,10 +1088,7 @@ impl UnownedWindow {
 
                 if let Some(native_mode) = video_mode.and_then(|requested| {
                     monitor.video_modes.iter().find_map(|mode| {
-                        if mode.refresh_rate_millihertz == requested.refresh_rate_millihertz
-                            && mode.size == requested.size
-                            && mode.bit_depth == requested.bit_depth
-                        {
+                        if mode.mode == requested {
                             Some(mode.native_mode)
                         } else {
                             None

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -32,7 +32,6 @@ use crate::platform_impl::x11::{
 };
 use crate::platform_impl::{
     common, Fullscreen, MonitorHandle as PlatformMonitorHandle, PlatformCustomCursor, PlatformIcon,
-    VideoModeHandle as PlatformVideoModeHandle,
 };
 use crate::window::{
     CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
@@ -327,7 +326,7 @@ impl Drop for Window {
         let xconn = &window.xconn;
 
         // Restore the video mode on drop.
-        if let Some(Fullscreen::Exclusive(_)) = window.fullscreen() {
+        if let Some(Fullscreen::Exclusive(..)) = window.fullscreen() {
             window.set_fullscreen(None);
         }
 
@@ -1035,20 +1034,17 @@ impl UnownedWindow {
             // fullscreen, so we can restore it upon exit, as XRandR does not
             // provide a mechanism to set this per app-session or restore this
             // to the desktop video mode as macOS and Windows do
-            (&None, &Some(Fullscreen::Exclusive(PlatformVideoModeHandle::X(ref video_mode))))
-            | (
-                &Some(Fullscreen::Borderless(_)),
-                &Some(Fullscreen::Exclusive(PlatformVideoModeHandle::X(ref video_mode))),
-            ) => {
-                let monitor = video_mode.monitor.as_ref().unwrap();
+            (&None, &Some(Fullscreen::Exclusive(ref monitor, _)))
+            | (&Some(Fullscreen::Borderless(_)), &Some(Fullscreen::Exclusive(ref monitor, _))) => {
+                let id = monitor.native_identifier();
                 shared_state_lock.desktop_video_mode = Some((
-                    monitor.id,
-                    self.xconn.get_crtc_mode(monitor.id).expect("Failed to get desktop video mode"),
+                    id,
+                    self.xconn.get_crtc_mode(id).expect("Failed to get desktop video mode"),
                 ));
             },
             // Restore desktop video mode upon exiting exclusive fullscreen
-            (&Some(Fullscreen::Exclusive(_)), &None)
-            | (&Some(Fullscreen::Exclusive(_)), &Some(Fullscreen::Borderless(_))) => {
+            (&Some(Fullscreen::Exclusive(..)), &None)
+            | (&Some(Fullscreen::Exclusive(..)), &Some(Fullscreen::Borderless(_))) => {
                 let (monitor_id, mode_id) = shared_state_lock.desktop_video_mode.take().unwrap();
                 self.xconn
                     .set_crtc_config(monitor_id, mode_id)
@@ -1072,8 +1068,8 @@ impl UnownedWindow {
             },
             Some(fullscreen) => {
                 let (video_mode, monitor) = match fullscreen {
-                    Fullscreen::Exclusive(PlatformVideoModeHandle::X(ref video_mode)) => {
-                        (Some(video_mode), video_mode.monitor.clone().unwrap())
+                    Fullscreen::Exclusive(PlatformMonitorHandle::X(monitor), video_mode) => {
+                        (Some(video_mode), monitor.clone())
                     },
                     Fullscreen::Borderless(Some(PlatformMonitorHandle::X(monitor))) => {
                         (None, monitor)
@@ -1090,7 +1086,18 @@ impl UnownedWindow {
                     return Ok(None);
                 }
 
-                if let Some(video_mode) = video_mode {
+                if let Some(native_mode) = video_mode.and_then(|requested| {
+                    monitor.video_modes.iter().find_map(|mode| {
+                        if mode.refresh_rate_millihertz == requested.refresh_rate_millihertz
+                            && mode.size == requested.size
+                            && mode.bit_depth == requested.bit_depth
+                        {
+                            Some(mode.native_mode)
+                        } else {
+                            None
+                        }
+                    })
+                }) {
                     // FIXME: this is actually not correct if we're setting the
                     // video mode to a resolution higher than the current
                     // desktop resolution, because XRandR does not automatically
@@ -1117,7 +1124,7 @@ impl UnownedWindow {
                     // this will make someone unhappy, but it's very unusual for
                     // games to want to do this anyway).
                     self.xconn
-                        .set_crtc_config(monitor.id, video_mode.native_mode)
+                        .set_crtc_config(monitor.id, native_mode)
                         .expect("failed to set video mode");
                 }
 

--- a/src/platform_impl/mod.rs
+++ b/src/platform_impl/mod.rs
@@ -1,4 +1,4 @@
-use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoModeHandle as RootVideoModeHandle};
+use crate::monitor::{MonitorHandle as RootMonitorHandle, VideoMode};
 use crate::window::Fullscreen as RootFullscreen;
 
 #[cfg(android_platform)]
@@ -30,17 +30,19 @@ use self::web as platform;
 use self::windows as platform;
 
 /// Helper for converting between platform-specific and generic
-/// [`VideoModeHandle`]/[`MonitorHandle`]
+/// [`VideoMode`]/[`MonitorHandle`]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum Fullscreen {
-    Exclusive(VideoModeHandle),
+    Exclusive(MonitorHandle, VideoMode),
     Borderless(Option<MonitorHandle>),
 }
 
 impl From<RootFullscreen> for Fullscreen {
     fn from(f: RootFullscreen) -> Self {
         match f {
-            RootFullscreen::Exclusive(mode) => Self::Exclusive(mode.video_mode),
+            RootFullscreen::Exclusive(handle, video_mode) => {
+                Self::Exclusive(handle.inner, video_mode)
+            },
             RootFullscreen::Borderless(Some(handle)) => Self::Borderless(Some(handle.inner)),
             RootFullscreen::Borderless(None) => Self::Borderless(None),
         }
@@ -50,8 +52,8 @@ impl From<RootFullscreen> for Fullscreen {
 impl From<Fullscreen> for RootFullscreen {
     fn from(f: Fullscreen) -> Self {
         match f {
-            Fullscreen::Exclusive(video_mode) => {
-                Self::Exclusive(RootVideoModeHandle { video_mode })
+            Fullscreen::Exclusive(inner, video_mode) => {
+                Self::Exclusive(RootMonitorHandle { inner }, video_mode)
             },
             Fullscreen::Borderless(Some(inner)) => {
                 Self::Borderless(Some(RootMonitorHandle { inner }))

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -1,16 +1,16 @@
 #![cfg(target_os = "redox")]
 
-use std::num::{NonZeroU16, NonZeroU32};
 use std::{fmt, str};
 
 use smol_str::SmolStr;
 
 pub(crate) use self::event_loop::{ActiveEventLoop, EventLoop};
-use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::keyboard::Key;
-mod event_loop;
-
 pub use self::window::Window;
+use crate::dpi::PhysicalPosition;
+use crate::keyboard::Key;
+use crate::monitor::VideoMode;
+
+mod event_loop;
 mod window;
 
 pub(crate) use crate::cursor::{
@@ -151,38 +151,13 @@ impl MonitorHandle {
         1.0 // TODO
     }
 
-    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoMode> {
         // (it is guaranteed to support 32 bit color though)
-        Some(VideoModeHandle { monitor: self.clone() })
-    }
-
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
-        self.current_video_mode().into_iter()
-    }
-}
-
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct VideoModeHandle {
-    monitor: MonitorHandle,
-}
-
-impl VideoModeHandle {
-    pub fn size(&self) -> PhysicalSize<u32> {
-        // TODO
-        PhysicalSize::default()
-    }
-
-    pub fn bit_depth(&self) -> Option<NonZeroU16> {
         None
     }
 
-    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
-        // TODO
-        None
-    }
-
-    pub fn monitor(&self) -> MonitorHandle {
-        self.monitor.clone()
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+        std::iter::empty()
     }
 }
 

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -43,7 +43,6 @@ pub(crate) use self::event_loop::{
 pub(crate) use self::keyboard::KeyEventExtra;
 pub(crate) use self::monitor::{
     HasMonitorPermissionFuture, MonitorHandle, MonitorPermissionFuture, OrientationLockFuture,
-    VideoModeHandle,
 };
 use self::web_sys as backend;
 pub use self::window::{PlatformSpecificWindowAttributes, Window};

--- a/src/platform_impl/web/web_sys/fullscreen.rs
+++ b/src/platform_impl/web/web_sys/fullscreen.rs
@@ -55,7 +55,7 @@ pub(crate) fn request_fullscreen(
     let canvas: &RequestFullscreen = canvas.unchecked_ref();
 
     match fullscreen {
-        Fullscreen::Exclusive(_) => error!("Exclusive full screen mode is not supported"),
+        Fullscreen::Exclusive(..) => error!("Exclusive full screen mode is not supported"),
         Fullscreen::Borderless(Some(monitor)) => {
             if !monitor::has_screen_details_support(window) {
                 error!(

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1311,8 +1311,8 @@ unsafe fn public_window_callback_inner(
                                 *fullscreen_monitor = Some(MonitorHandle::new(new_monitor));
                             }
                         },
-                        Fullscreen::Exclusive(ref video_mode) => {
-                            let old_monitor = video_mode.monitor.hmonitor();
+                        Fullscreen::Exclusive(ref monitor, _) => {
+                            let old_monitor = monitor.hmonitor();
                             if let Ok(old_monitor_info) = monitor::get_monitor_info(old_monitor) {
                                 let old_monitor_rect = old_monitor_info.monitorInfo.rcMonitor;
                                 window_pos.x = old_monitor_rect.left;

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -6,7 +6,7 @@ pub(crate) use self::event_loop::{EventLoop, PlatformSpecificEventLoopAttributes
 pub use self::icon::WinIcon as PlatformIcon;
 pub(crate) use self::icon::{SelectedCursor, WinCursor as PlatformCustomCursor, WinIcon};
 pub(crate) use self::keyboard::{physicalkey_to_scancode, scancode_to_physicalkey};
-pub(crate) use self::monitor::{MonitorHandle, VideoModeHandle};
+pub(crate) use self::monitor::MonitorHandle;
 pub(crate) use self::window::Window;
 pub(crate) use crate::cursor::OnlyCursorImageSource as PlatformCustomCursorSource;
 use crate::event::DeviceId;

--- a/src/platform_impl/windows/monitor.rs
+++ b/src/platform_impl/windows/monitor.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{HashSet, VecDeque};
 use std::hash::Hash;
 use std::num::{NonZeroU16, NonZeroU32};
 use std::{io, mem, ptr};
@@ -13,26 +13,20 @@ use windows_sys::Win32::Graphics::Gdi::{
 
 use super::util::decode_wide;
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::monitor::VideoModeHandle as RootVideoModeHandle;
+use crate::monitor::VideoMode;
 use crate::platform_impl::platform::dpi::{dpi_to_scale_factor, get_monitor_dpi};
 use crate::platform_impl::platform::util::has_flag;
 
 #[derive(Clone)]
 pub struct VideoModeHandle {
-    pub(crate) size: (u32, u32),
-    pub(crate) bit_depth: Option<NonZeroU16>,
-    pub(crate) refresh_rate_millihertz: Option<NonZeroU32>,
-    pub(crate) monitor: MonitorHandle,
+    pub(crate) mode: VideoMode,
     // DEVMODEW is huge so we box it to avoid blowing up the size of winit::window::Fullscreen
     pub(crate) native_video_mode: Box<DEVMODEW>,
 }
 
 impl PartialEq for VideoModeHandle {
     fn eq(&self, other: &Self) -> bool {
-        self.size == other.size
-            && self.bit_depth == other.bit_depth
-            && self.refresh_rate_millihertz == other.refresh_rate_millihertz
-            && self.monitor == other.monitor
+        self.mode == other.mode
     }
 }
 
@@ -40,53 +34,29 @@ impl Eq for VideoModeHandle {}
 
 impl std::hash::Hash for VideoModeHandle {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.size.hash(state);
-        self.bit_depth.hash(state);
-        self.refresh_rate_millihertz.hash(state);
-        self.monitor.hash(state);
+        self.mode.hash(state);
     }
 }
 
 impl std::fmt::Debug for VideoModeHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("VideoModeHandle")
-            .field("size", &self.size)
-            .field("bit_depth", &self.bit_depth)
-            .field("refresh_rate_millihertz", &self.refresh_rate_millihertz)
-            .field("monitor", &self.monitor)
-            .finish()
+        f.debug_struct("VideoMode").field("mode", &self.mode).finish()
     }
 }
 
 impl VideoModeHandle {
-    fn new(monitor: MonitorHandle, mode: DEVMODEW) -> Self {
+    fn new(native_video_mode: DEVMODEW) -> Self {
         const REQUIRED_FIELDS: u32 =
             DM_BITSPERPEL | DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY;
-        assert!(has_flag(mode.dmFields, REQUIRED_FIELDS));
+        assert!(has_flag(native_video_mode.dmFields, REQUIRED_FIELDS));
 
-        VideoModeHandle {
-            size: (mode.dmPelsWidth, mode.dmPelsHeight),
-            bit_depth: NonZeroU16::new(mode.dmBitsPerPel as u16),
-            refresh_rate_millihertz: NonZeroU32::new(mode.dmDisplayFrequency * 1000),
-            monitor,
-            native_video_mode: Box::new(mode),
-        }
-    }
+        let mode = VideoMode {
+            size: (native_video_mode.dmPelsWidth, native_video_mode.dmPelsHeight).into(),
+            bit_depth: NonZeroU16::new(native_video_mode.dmBitsPerPel as u16),
+            refresh_rate_millihertz: NonZeroU32::new(native_video_mode.dmDisplayFrequency * 1000),
+        };
 
-    pub fn size(&self) -> PhysicalSize<u32> {
-        self.size.into()
-    }
-
-    pub fn bit_depth(&self) -> Option<NonZeroU16> {
-        self.bit_depth
-    }
-
-    pub fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
-        self.refresh_rate_millihertz
-    }
-
-    pub fn monitor(&self) -> MonitorHandle {
-        self.monitor.clone()
+        VideoModeHandle { mode, native_video_mode: Box::new(native_video_mode) }
     }
 }
 
@@ -193,7 +163,7 @@ impl MonitorHandle {
     }
 
     #[inline]
-    pub fn current_video_mode(&self) -> Option<VideoModeHandle> {
+    pub fn current_video_mode(&self) -> Option<VideoMode> {
         let monitor_info = get_monitor_info(self.0).ok()?;
         let device_name = monitor_info.szDevice.as_ptr();
         unsafe {
@@ -204,29 +174,26 @@ impl MonitorHandle {
             {
                 None
             } else {
-                Some(VideoModeHandle::new(self.clone(), mode))
+                Some(VideoModeHandle::new(mode).mode)
             }
         }
     }
 
-    #[inline]
-    pub fn video_modes(&self) -> impl Iterator<Item = VideoModeHandle> {
+    pub(crate) fn video_mode_handles(&self) -> impl Iterator<Item = VideoModeHandle> {
         // EnumDisplaySettingsExW can return duplicate values (or some of the
         // fields are probably changing, but we aren't looking at those fields
         // anyway), so we're using a BTreeSet deduplicate
-        let mut modes = BTreeSet::<RootVideoModeHandle>::new();
-        let mod_map = |mode: RootVideoModeHandle| mode.video_mode;
+        let mut modes = HashSet::<VideoModeHandle>::new();
 
         let monitor_info = match get_monitor_info(self.0) {
             Ok(monitor_info) => monitor_info,
             Err(error) => {
                 tracing::warn!("Error from get_monitor_info: {error}");
-                return modes.into_iter().map(mod_map);
+                return modes.into_iter();
             },
         };
 
         let device_name = monitor_info.szDevice.as_ptr();
-
         let mut i = 0;
         loop {
             let mut mode: DEVMODEW = unsafe { mem::zeroed() };
@@ -236,13 +203,15 @@ impl MonitorHandle {
             }
 
             // Use Ord impl of RootVideoModeHandle
-            modes.insert(RootVideoModeHandle {
-                video_mode: VideoModeHandle::new(self.clone(), mode),
-            });
+            modes.insert(VideoModeHandle::new(mode));
 
             i += 1;
         }
 
-        modes.into_iter().map(mod_map)
+        modes.into_iter()
+    }
+
+    pub fn video_modes(&self) -> impl Iterator<Item = VideoMode> {
+        self.video_mode_handles().map(|mode| mode.mode)
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -10,7 +10,7 @@ pub use crate::cursor::{BadImage, Cursor, CustomCursor, CustomCursorSource, MAX_
 use crate::dpi::{PhysicalInsets, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::RequestError;
 pub use crate::icon::{BadIcon, Icon};
-use crate::monitor::{MonitorHandle, VideoModeHandle};
+use crate::monitor::{MonitorHandle, VideoMode};
 use crate::platform_impl::PlatformSpecificWindowAttributes;
 use crate::utils::AsAny;
 
@@ -963,7 +963,7 @@ pub trait Window: AsAny + Send + Sync {
     /// - **Wayland:** Does not support exclusive fullscreen mode and will no-op a request.
     /// - **Windows:** Screen saver is disabled in fullscreen mode.
     /// - **Android / Orbital:** Unsupported.
-    /// - **Web:** Passing a [`MonitorHandle`] or [`VideoModeHandle`] that was not created with
+    /// - **Web:** Passing a [`MonitorHandle`] or [`VideoMode`] that was not created with
     #[cfg_attr(
         any(web_platform, docsrs),
         doc = "  [detailed monitor permissions][crate::platform::web::ActiveEventLoopExtWeb::request_detailed_monitor_permission]"
@@ -1436,7 +1436,7 @@ pub enum Fullscreen {
     /// This changes the video mode of the monitor for fullscreen windows and,
     /// if applicable, captures the monitor for exclusive use by this
     /// application.
-    Exclusive(VideoModeHandle),
+    Exclusive(MonitorHandle, VideoMode),
 
     /// Providing `None` to `Borderless` will fullscreen on the current monitor.
     Borderless(Option<MonitorHandle>),


### PR DESCRIPTION
The video mode is generally a static data and not a reference to some video mode. This changes the exclusive fullscreen API to match that and accept a monitor now.

---

Extracted from #3927
