### PR TITLE
Add `ActiveEventLoopExtWindows::rwh_06_window_handle`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -32,7 +32,6 @@ with it, the migration guide should be added below the entry, like:
   To migrate it we should do X, Y, and then Z, for example:
 
   // Code snippet.
-
 ```
 
 The migration guide could reference other migration examples in the current
@@ -56,6 +55,7 @@ changelog entry.
 
   Keep in mind that handles do not auto-upgrade after permissions are granted and have to be
   re-created to make full use of this feature.
+
 - Implement `Clone`, `Copy`, `Debug`, `Deserialize`, `Eq`, `Hash`, `Ord`, `PartialEq`, `PartialOrd`
   and `Serialize` on many types.
 - Add `MonitorHandle::current_video_mode()`.
@@ -73,6 +73,7 @@ changelog entry.
 - Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`.
 - `ActivationToken::from_raw` and `ActivationToken::into_raw`.
 - On X11, add a workaround for disabling IME on GNOME.
+- Added `ActiveEventLoopExtWindows::rwh_06_window_handle` to get access the event loop window target HWND.
 
 ### Changed
 
@@ -88,6 +89,7 @@ changelog entry.
   Winit will now only indicate that wake up happened, you will have to pair
   this with an external mechanism like `std::sync::mpsc::channel` if you want
   to send specific data to be processed on the main thread.
+
 - Changed `EventLoopProxy::send_event` to `EventLoopProxy::wake_up`, it now
   only wakes up the loop.
 - On X11, implement smooth resizing through the sync extension API.
@@ -99,6 +101,7 @@ changelog entry.
 
   `ApplicationHandler::resumed/suspended()` are now only emitted by iOS, Web
   and Android, and now signify actually resuming/suspending the application.
+
 - Rename `platform::web::*ExtWebSys` to `*ExtWeb`.
 - Change signature of `EventLoop::run_app`, `EventLoopExtPumpEvents::pump_app_events` and
   `EventLoopExtRunOnDemand::run_app_on_demand` to accept a `impl ApplicationHandler` directly,
@@ -116,6 +119,7 @@ changelog entry.
   `application:didFinishLaunchingWithOptions:` and provide the desired behaviour yourself.
 - On X11, remove our dependency on libXcursor. (#3749)
 - Renamed the following APIs to make it clearer that the sizes apply to the underlying surface:
+
   - `WindowEvent::Resized` to `SurfaceResized`.
   - `InnerSizeWriter` to `SurfaceSizeWriter`.
   - `WindowAttributes.inner_size` to `surface_size`.
@@ -132,6 +136,7 @@ changelog entry.
   - `Window::set_max_inner_size` to `set_max_surface_size`.
 
   To migrate, you can probably just replace all instances of `inner_size` with `surface_size` in your codebase.
+
 - Every event carrying a `DeviceId` now uses `Option<DeviceId>` instead. A `None` value signifies that the
   device can't be uniquely identified.
 - Pointer `WindowEvent`s were overhauled. The new events can handle any type of pointer, serving as
@@ -181,6 +186,7 @@ changelog entry.
 
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside
   of `winit` using `objc2-ui-kit` and calling `UIDevice::currentDevice().userInterfaceIdiom()`.
+
 - On Web, remove unused `platform::web::CustomCursorError::Animation`.
 - Remove the `rwh_04` and `rwh_05` cargo feature and the corresponding `raw-window-handle` v0.4 and
   v0.5 support. v0.6 remains in place and is enabled by default.
@@ -193,7 +199,7 @@ changelog entry.
   `WindowId::into_raw()` and `from_raw()`.
 - Remove `dummy()` from `WindowId` and `DeviceId`.
 - Remove `WindowEvent::Touch` and `Touch` in favor of the new `PointerKind`, `PointerSource` and
- `ButtonSource` as part of the new pointer event overhaul.
+  `ButtonSource` as part of the new pointer event overhaul.
 - Remove `Force::altitude_angle`.
 - Removed `Window::inner_position`, use the new `Window::surface_position` instead.
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -14,7 +14,7 @@ use windows_sys::Win32::Foundation::HANDLE;
 
 use crate::dpi::PhysicalSize;
 use crate::event::DeviceId;
-use crate::event_loop::EventLoopBuilder;
+use crate::event_loop::{ActiveEventLoop, EventLoopBuilder};
 use crate::monitor::MonitorHandle;
 use crate::window::{BadIcon, Icon, Window, WindowAttributes};
 
@@ -230,6 +230,20 @@ impl EventLoopBuilderExtWindows for EventLoopBuilder {
     {
         self.platform_specific.msg_hook = Some(Box::new(callback));
         self
+    }
+}
+
+pub trait ActiveEventLoopExtWindows {
+    fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle;
+}
+
+impl ActiveEventLoopExtWindows for dyn ActiveEventLoop + '_ {
+    fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle {
+        let event_loop = self
+            .as_any()
+            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .expect("non Windows event loop on Windows");
+        event_loop
     }
 }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -132,7 +132,7 @@ pub(crate) enum ProcResult {
 }
 
 pub struct EventLoop {
-    window_target: ActiveEventLoop,
+    pub window_target: ActiveEventLoop,
     msg_hook: Option<Box<dyn FnMut(*const c_void) -> bool + 'static>>,
     // It is a timer used on timed waits.
     // It is created lazily in case if we have `ControlFlow::WaitUntil`.
@@ -529,6 +529,15 @@ impl rwh_06::HasDisplayHandle for ActiveEventLoop {
     fn display_handle(&self) -> Result<rwh_06::DisplayHandle<'_>, rwh_06::HandleError> {
         let raw = rwh_06::RawDisplayHandle::Windows(rwh_06::WindowsDisplayHandle::new());
         unsafe { Ok(rwh_06::DisplayHandle::borrow_raw(raw)) }
+    }
+}
+
+impl rwh_06::HasWindowHandle for ActiveEventLoop {
+    fn window_handle(&self) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
+        let hwnd = unsafe { std::num::NonZero::new_unchecked(self.thread_msg_target) };
+        let win32 = rwh_06::Win32WindowHandle::new(hwnd);
+        let raw = rwh_06::RawWindowHandle::Win32(win32);
+        unsafe { Ok(rwh_06::WindowHandle::borrow_raw(raw)) }
     }
 }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -2,7 +2,9 @@ use smol_str::SmolStr;
 use windows_sys::Win32::Foundation::HWND;
 use windows_sys::Win32::UI::WindowsAndMessaging::{HMENU, WINDOW_LONG_PTR_INDEX};
 
-pub(crate) use self::event_loop::{EventLoop, PlatformSpecificEventLoopAttributes};
+pub(crate) use self::event_loop::{
+    ActiveEventLoop, EventLoop, PlatformSpecificEventLoopAttributes,
+};
 pub use self::icon::WinIcon as PlatformIcon;
 pub(crate) use self::icon::{SelectedCursor, WinCursor as PlatformCustomCursor, WinIcon};
 pub(crate) use self::keyboard::{physicalkey_to_scancode, scancode_to_physicalkey};


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
