### PR TITLE
Update to `objc2` v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,7 +183,6 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = [
     "NSObjCRuntime",
     "NSOperation",
     "NSString",
-    "NSProcessInfo",
     "NSThread",
     "NSSet",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,17 +105,11 @@ ndk = { version = "0.9.0", features = ["rwh_06"], default-features = false }
 # AppKit or UIKit
 [target.'cfg(target_vendor = "apple")'.dependencies]
 block2 = "0.6.0"
-core-foundation = "0.9.3"
 dispatch2 = { version = "0.2.0", default-features = false, features = ["std", "objc2"] }
 objc2 = "0.6.0"
-objc2-core-foundation = { version = "0.3.0", default-features = false, features = [
-    "std",
-    "CFCGTypes",
-] }
 
 # AppKit
 [target.'cfg(target_os = "macos")'.dependencies]
-core-graphics = "0.23.1"
 objc2-app-kit = { version = "0.3.0", default-features = false, features = [
     "std",
     "objc2-core-foundation",
@@ -148,6 +142,33 @@ objc2-app-kit = { version = "0.3.0", default-features = false, features = [
     "NSWindowScripting",
     "NSWindowTabGroup",
 ] }
+objc2-core-foundation = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "block2",
+    "CFBase",
+    "CFCGTypes",
+    "CFData",
+    "CFRunLoop",
+    "CFString",
+    "CFUUID",
+] }
+objc2-core-graphics = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "libc",
+    "CGDirectDisplay",
+    "CGDisplayConfiguration",
+    "CGDisplayFade",
+    "CGError",
+    "CGRemoteOperation",
+    "CGWindowLevel",
+] }
+objc2-core-video = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "objc2-core-graphics",
+    "CVBase",
+    "CVReturn",
+    "CVDisplayLink",
+] }
 objc2-foundation = { version = "0.3.0", default-features = false, features = [
     "std",
     "block2",
@@ -173,6 +194,13 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = [
 
 # UIKit
 [target.'cfg(all(target_vendor = "apple", not(target_os = "macos")))'.dependencies]
+objc2-core-foundation = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "CFCGTypes",
+    "CFBase",
+    "CFRunLoop",
+    "CFString",
+] }
 objc2-foundation = { version = "0.3.0", default-features = false, features = [
     "std",
     "block2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,14 +104,21 @@ ndk = { version = "0.9.0", features = ["rwh_06"], default-features = false }
 
 # AppKit or UIKit
 [target.'cfg(target_vendor = "apple")'.dependencies]
-block2 = "0.5.1"
+block2 = "0.6.0"
 core-foundation = "0.9.3"
-objc2 = "0.5.2"
+dispatch2 = { version = "0.2.0", default-features = false, features = ["std", "objc2"] }
+objc2 = "0.6.0"
+objc2-core-foundation = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "CFCGTypes",
+] }
 
 # AppKit
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.23.1"
-objc2-app-kit = { version = "0.2.2", features = [
+objc2-app-kit = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "objc2-core-foundation",
     "NSAppearance",
     "NSApplication",
     "NSBitmapImageRep",
@@ -141,9 +148,10 @@ objc2-app-kit = { version = "0.2.2", features = [
     "NSWindowScripting",
     "NSWindowTabGroup",
 ] }
-objc2-foundation = { version = "0.2.2", features = [
+objc2-foundation = { version = "0.3.0", default-features = false, features = [
+    "std",
     "block2",
-    "dispatch",
+    "objc2-core-foundation",
     "NSArray",
     "NSAttributedString",
     "NSData",
@@ -165,9 +173,10 @@ objc2-foundation = { version = "0.2.2", features = [
 
 # UIKit
 [target.'cfg(all(target_vendor = "apple", not(target_os = "macos")))'.dependencies]
-objc2-foundation = { version = "0.2.2", features = [
+objc2-foundation = { version = "0.3.0", default-features = false, features = [
+    "std",
     "block2",
-    "dispatch",
+    "objc2-core-foundation",
     "NSArray",
     "NSEnumerator",
     "NSGeometry",
@@ -178,7 +187,9 @@ objc2-foundation = { version = "0.2.2", features = [
     "NSThread",
     "NSSet",
 ] }
-objc2-ui-kit = { version = "0.2.2", features = [
+objc2-ui-kit = { version = "0.3.0", default-features = false, features = [
+    "std",
+    "objc2-core-foundation",
     "UIApplication",
     "UIDevice",
     "UIEvent",

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -184,6 +184,7 @@ changelog entry.
   The `WindowEvent::DragMoved` event is entirely new, and is emitted whenever the pointer moves
   whilst files are being dragged over the window. It doesn't contain any file paths, just the
   pointer position.
+- Updated `objc2` to `v0.6`.
 
 ### Removed
 

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -394,7 +394,7 @@ impl MonitorHandleExtIOS for MonitorHandle {
     #[inline]
     fn ui_screen(&self) -> *mut c_void {
         // SAFETY: The marker is only used to get the pointer of the screen
-        let mtm = unsafe { objc2_foundation::MainThreadMarker::new_unchecked() };
+        let mtm = unsafe { objc2::MainThreadMarker::new_unchecked() };
         objc2::rc::Retained::as_ptr(self.inner.ui_screen(mtm)) as *mut c_void
     }
 

--- a/src/platform_impl/apple/appkit/app_state.rs
+++ b/src/platform_impl/apple/appkit/app_state.rs
@@ -5,8 +5,9 @@ use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::Arc;
 use std::time::Instant;
 
+use objc2::MainThreadMarker;
 use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSRunningApplication};
-use objc2_foundation::{MainThreadMarker, NSNotification};
+use objc2_foundation::NSNotification;
 
 use super::super::event_handler::EventHandler;
 use super::event_loop::{stop_app_immediately, ActiveEventLoop, EventLoopProxy, PanicInfo};

--- a/src/platform_impl/apple/appkit/app_state.rs
+++ b/src/platform_impl/apple/appkit/app_state.rs
@@ -5,6 +5,7 @@ use std::sync::atomic::Ordering as AtomicOrdering;
 use std::sync::Arc;
 use std::time::Instant;
 
+use dispatch2::MainThreadBound;
 use objc2::MainThreadMarker;
 use objc2_app_kit::{NSApplication, NSApplicationActivationPolicy, NSRunningApplication};
 use objc2_foundation::NSNotification;
@@ -46,22 +47,10 @@ pub(super) struct AppState {
     // as such should be careful to not add fields that, in turn, strongly reference those.
 }
 
-// TODO(madsmtm): Use `MainThreadBound` once that is possible in `static`s.
-struct StaticMainThreadBound<T>(T);
-
-impl<T> StaticMainThreadBound<T> {
-    const fn get(&self, _mtm: MainThreadMarker) -> &T {
-        &self.0
-    }
-}
-
-unsafe impl<T> Send for StaticMainThreadBound<T> {}
-unsafe impl<T> Sync for StaticMainThreadBound<T> {}
-
-// SAFETY: Creating `StaticMainThreadBound` in a `const` context, where there is no concept of the
+// SAFETY: Creating `MainThreadBound` in a `const` context, where there is no concept of the
 // main thread.
-static GLOBAL: StaticMainThreadBound<OnceCell<Rc<AppState>>> =
-    StaticMainThreadBound(OnceCell::new());
+static GLOBAL: MainThreadBound<OnceCell<Rc<AppState>>> =
+    MainThreadBound::new(OnceCell::new(), unsafe { MainThreadMarker::new_unchecked() });
 
 impl AppState {
     pub(super) fn setup_global(

--- a/src/platform_impl/apple/appkit/cursor.rs
+++ b/src/platform_impl/apple/appkit/cursor.rs
@@ -4,7 +4,7 @@ use std::sync::OnceLock;
 
 use objc2::rc::Retained;
 use objc2::runtime::Sel;
-use objc2::{msg_send, sel, AllocAnyThread, ClassType};
+use objc2::{available, msg_send, sel, AllocAnyThread, ClassType};
 use objc2_app_kit::{NSBitmapImageRep, NSCursor, NSDeviceRGBColorSpace, NSImage};
 use objc2_foundation::{
     ns_string, NSData, NSDictionary, NSNumber, NSObject, NSPoint, NSSize, NSString,
@@ -204,7 +204,9 @@ pub(crate) fn cursor_from_icon(icon: CursorIcon) -> Retained<NSCursor> {
         CursorIcon::EwResize | CursorIcon::ColResize => NSCursor::resizeLeftRightCursor(),
         CursorIcon::NsResize | CursorIcon::RowResize => NSCursor::resizeUpDownCursor(),
         CursorIcon::Help => _helpCursor(),
+        CursorIcon::ZoomIn if available!(macos = 15.0) => unsafe { NSCursor::zoomInCursor() },
         CursorIcon::ZoomIn => _zoomInCursor(),
+        CursorIcon::ZoomOut if available!(macos = 15.0) => unsafe { NSCursor::zoomOutCursor() },
         CursorIcon::ZoomOut => _zoomOutCursor(),
         CursorIcon::NeResize => _windowResizeNorthEastCursor(),
         CursorIcon::NwResize => _windowResizeNorthWestCursor(),

--- a/src/platform_impl/apple/appkit/event.rs
+++ b/src/platform_impl/apple/appkit/event.rs
@@ -2,9 +2,10 @@ use std::ffi::c_void;
 
 use core_foundation::base::CFRelease;
 use core_foundation::data::{CFDataGetBytePtr, CFDataRef};
+use dispatch2::run_on_main;
 use objc2::rc::Retained;
 use objc2_app_kit::{NSEvent, NSEventModifierFlags, NSEventSubtype, NSEventType};
-use objc2_foundation::{run_on_main, NSPoint};
+use objc2_foundation::NSPoint;
 use smol_str::SmolStr;
 
 use super::ffi;
@@ -123,8 +124,8 @@ pub(crate) fn create_key_event(ns_event: &NSEvent, is_press: bool, is_repeat: bo
         let key_without_modifiers = get_modifierless_char(scancode);
 
         let modifiers = unsafe { ns_event.modifierFlags() };
-        let has_ctrl = modifiers.contains(NSEventModifierFlags::NSEventModifierFlagControl);
-        let has_cmd = modifiers.contains(NSEventModifierFlags::NSEventModifierFlagCommand);
+        let has_ctrl = modifiers.contains(NSEventModifierFlags::Control);
+        let has_cmd = modifiers.contains(NSEventModifierFlags::Command);
 
         let logical_key = match text_with_all_modifiers.as_ref() {
             // Only checking for ctrl and cmd here, not checking for alt because we DO want to
@@ -308,26 +309,19 @@ pub(super) fn event_mods(event: &NSEvent) -> Modifiers {
     let mut state = ModifiersState::empty();
     let mut pressed_mods = ModifiersKeys::empty();
 
-    state
-        .set(ModifiersState::SHIFT, flags.contains(NSEventModifierFlags::NSEventModifierFlagShift));
+    state.set(ModifiersState::SHIFT, flags.contains(NSEventModifierFlags::Shift));
     pressed_mods.set(ModifiersKeys::LSHIFT, flags.contains(NX_DEVICELSHIFTKEYMASK));
     pressed_mods.set(ModifiersKeys::RSHIFT, flags.contains(NX_DEVICERSHIFTKEYMASK));
 
-    state.set(
-        ModifiersState::CONTROL,
-        flags.contains(NSEventModifierFlags::NSEventModifierFlagControl),
-    );
+    state.set(ModifiersState::CONTROL, flags.contains(NSEventModifierFlags::Control));
     pressed_mods.set(ModifiersKeys::LCONTROL, flags.contains(NX_DEVICELCTLKEYMASK));
     pressed_mods.set(ModifiersKeys::RCONTROL, flags.contains(NX_DEVICERCTLKEYMASK));
 
-    state.set(ModifiersState::ALT, flags.contains(NSEventModifierFlags::NSEventModifierFlagOption));
+    state.set(ModifiersState::ALT, flags.contains(NSEventModifierFlags::Option));
     pressed_mods.set(ModifiersKeys::LALT, flags.contains(NX_DEVICELALTKEYMASK));
     pressed_mods.set(ModifiersKeys::RALT, flags.contains(NX_DEVICERALTKEYMASK));
 
-    state.set(
-        ModifiersState::SUPER,
-        flags.contains(NSEventModifierFlags::NSEventModifierFlagCommand),
-    );
+    state.set(ModifiersState::SUPER, flags.contains(NSEventModifierFlags::Command));
     pressed_mods.set(ModifiersKeys::LSUPER, flags.contains(NX_DEVICELCMDKEYMASK));
     pressed_mods.set(ModifiersKeys::RSUPER, flags.contains(NX_DEVICERCMDKEYMASK));
 

--- a/src/platform_impl/apple/appkit/event.rs
+++ b/src/platform_impl/apple/appkit/event.rs
@@ -1,10 +1,9 @@
-use std::ffi::c_void;
+use std::ptr::NonNull;
 
-use core_foundation::base::CFRelease;
-use core_foundation::data::{CFDataGetBytePtr, CFDataRef};
 use dispatch2::run_on_main;
 use objc2::rc::Retained;
 use objc2_app_kit::{NSEvent, NSEventModifierFlags, NSEventSubtype, NSEventType};
+use objc2_core_foundation::{CFData, CFDataGetBytePtr, CFRetained};
 use objc2_foundation::NSPoint;
 use smol_str::SmolStr;
 
@@ -23,29 +22,27 @@ pub struct KeyEventExtra {
 
 /// Ignores ALL modifiers.
 pub fn get_modifierless_char(scancode: u16) -> Key {
-    let mut string = [0; 16];
-    let input_source;
-    let layout;
-    unsafe {
-        input_source = ffi::TISCopyCurrentKeyboardLayoutInputSource();
-        if input_source.is_null() {
-            tracing::error!("`TISCopyCurrentKeyboardLayoutInputSource` returned null ptr");
-            return Key::Unidentified(NativeKey::MacOS(scancode));
-        }
-        let layout_data =
-            ffi::TISGetInputSourceProperty(input_source, ffi::kTISPropertyUnicodeKeyLayoutData);
-        if layout_data.is_null() {
-            CFRelease(input_source as *mut c_void);
-            tracing::error!("`TISGetInputSourceProperty` returned null ptr");
-            return Key::Unidentified(NativeKey::MacOS(scancode));
-        }
-        layout = CFDataGetBytePtr(layout_data as CFDataRef) as *const ffi::UCKeyboardLayout;
-    }
+    let Some(ptr) = NonNull::new(unsafe { ffi::TISCopyCurrentKeyboardLayoutInputSource() }) else {
+        tracing::error!("`TISCopyCurrentKeyboardLayoutInputSource` returned null ptr");
+        return Key::Unidentified(NativeKey::MacOS(scancode));
+    };
+    let input_source = unsafe { CFRetained::from_raw(ptr) };
+
+    let layout_data = unsafe {
+        ffi::TISGetInputSourceProperty(&input_source, ffi::kTISPropertyUnicodeKeyLayoutData)
+    };
+    let Some(layout_data) = (unsafe { layout_data.cast::<CFData>().as_ref() }) else {
+        tracing::error!("`TISGetInputSourceProperty` returned null ptr");
+        return Key::Unidentified(NativeKey::MacOS(scancode));
+    };
+
+    let layout = unsafe { CFDataGetBytePtr(layout_data).cast() };
     let keyboard_type = run_on_main(|_mtm| unsafe { ffi::LMGetKbdType() });
 
     let mut result_len = 0;
     let mut dead_keys = 0;
     let modifiers = 0;
+    let mut string = [0; 16];
     let translate_result = unsafe {
         ffi::UCKeyTranslate(
             layout,
@@ -60,9 +57,6 @@ pub fn get_modifierless_char(scancode: u16) -> Key {
             string.as_mut_ptr(),
         )
     };
-    unsafe {
-        CFRelease(input_source as *mut c_void);
-    }
     if translate_result != 0 {
         tracing::error!("`UCKeyTranslate` returned with the non-zero value: {}", translate_result);
         return Key::Unidentified(NativeKey::MacOS(scancode));

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -15,7 +15,7 @@ use core_foundation::runloop::{
 };
 use objc2::rc::{autoreleasepool, Retained};
 use objc2::runtime::ProtocolObject;
-use objc2::{msg_send, sel, ClassType, MainThreadMarker};
+use objc2::{available, msg_send, ClassType, MainThreadMarker};
 use objc2_app_kit::{
     NSApplication, NSApplicationActivationPolicy, NSApplicationDidFinishLaunchingNotification,
     NSApplicationWillTerminateNotification, NSWindow,
@@ -130,7 +130,8 @@ impl RootActiveEventLoop for ActiveEventLoop {
     fn system_theme(&self) -> Option<Theme> {
         let app = NSApplication::sharedApplication(self.mtm);
 
-        if app.respondsToSelector(sel!(effectiveAppearance)) {
+        // Dark appearance was introduced in macOS 10.14
+        if available!(macos = 10.14) {
             Some(super::window_delegate::appearance_to_theme(&app.effectiveAppearance()))
         } else {
             Some(Theme::Light)

--- a/src/platform_impl/apple/appkit/menu.rs
+++ b/src/platform_impl/apple/appkit/menu.rs
@@ -1,8 +1,8 @@
 use objc2::rc::Retained;
 use objc2::runtime::Sel;
-use objc2::sel;
+use objc2::{sel, MainThreadMarker};
 use objc2_app_kit::{NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
-use objc2_foundation::{ns_string, MainThreadMarker, NSProcessInfo, NSString};
+use objc2_foundation::{ns_string, NSProcessInfo, NSString};
 
 struct KeyEquivalent<'a> {
     key: &'a NSString,
@@ -48,10 +48,7 @@ pub fn initialize(app: &NSApplication) {
         Some(sel!(hideOtherApplications:)),
         Some(KeyEquivalent {
             key: ns_string!("h"),
-            masks: Some(
-                NSEventModifierFlags::NSEventModifierFlagOption
-                    | NSEventModifierFlags::NSEventModifierFlagCommand,
-            ),
+            masks: Some(NSEventModifierFlags::Option | NSEventModifierFlags::Command),
         }),
     );
 

--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -1,23 +1,33 @@
 #![allow(clippy::unnecessary_cast)]
 
 use std::collections::VecDeque;
-use std::fmt;
 use std::num::{NonZeroU16, NonZeroU32};
+use std::ptr::NonNull;
+use std::{fmt, ptr};
 
-use core_foundation::array::{CFArrayGetCount, CFArrayGetValueAtIndex};
-use core_foundation::base::{CFRelease, TCFType};
-use core_foundation::string::CFString;
-use core_foundation::uuid::{CFUUIDGetUUIDBytes, CFUUID};
-use core_graphics::display::{
-    CGDirectDisplayID, CGDisplay, CGDisplayBounds, CGDisplayCopyDisplayMode,
-};
 use dispatch2::run_on_main;
 use objc2::rc::Retained;
 use objc2::MainThreadMarker;
 use objc2_app_kit::NSScreen;
+use objc2_core_foundation::{
+    CFArrayGetCount, CFArrayGetValueAtIndex, CFRetained, CFUUIDGetUUIDBytes,
+};
+#[allow(deprecated)]
+use objc2_core_graphics::{
+    CGDirectDisplayID, CGDisplayBounds, CGDisplayCopyAllDisplayModes, CGDisplayCopyDisplayMode,
+    CGDisplayMode, CGDisplayModeCopyPixelEncoding, CGDisplayModeGetPixelHeight,
+    CGDisplayModeGetPixelWidth, CGDisplayModeGetRefreshRate, CGDisplayModelNumber,
+    CGGetActiveDisplayList, CGMainDisplayID,
+};
+#[allow(deprecated)]
+use objc2_core_video::{
+    kCVReturnSuccess, CVDisplayLinkCreateWithCGDisplay,
+    CVDisplayLinkGetNominalOutputVideoRefreshPeriod, CVTimeFlags,
+};
 use objc2_foundation::{ns_string, NSNumber, NSPoint, NSRect};
 
 use super::ffi;
+use super::util::cgerr;
 use crate::dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use crate::monitor::VideoMode;
 
@@ -51,27 +61,11 @@ impl std::fmt::Debug for VideoModeHandle {
     }
 }
 
-pub struct NativeDisplayMode(pub ffi::CGDisplayModeRef);
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NativeDisplayMode(pub CFRetained<CGDisplayMode>);
 
 unsafe impl Send for NativeDisplayMode {}
 unsafe impl Sync for NativeDisplayMode {}
-
-impl Drop for NativeDisplayMode {
-    fn drop(&mut self) {
-        unsafe {
-            ffi::CGDisplayModeRelease(self.0);
-        }
-    }
-}
-
-impl Clone for NativeDisplayMode {
-    fn clone(&self) -> Self {
-        unsafe {
-            ffi::CGDisplayModeRetain(self.0);
-        }
-        NativeDisplayMode(self.0)
-    }
-}
 
 impl VideoModeHandle {
     fn new(
@@ -80,10 +74,9 @@ impl VideoModeHandle {
         refresh_rate_millihertz: Option<NonZeroU32>,
     ) -> Self {
         unsafe {
-            let pixel_encoding = CFString::wrap_under_create_rule(
-                ffi::CGDisplayModeCopyPixelEncoding(native_mode.0),
-            )
-            .to_string();
+            #[allow(deprecated)]
+            let pixel_encoding =
+                CGDisplayModeCopyPixelEncoding(Some(&native_mode.0)).unwrap().to_string();
             let bit_depth = if pixel_encoding.eq_ignore_ascii_case(ffi::IO32BitDirectPixels) {
                 32
             } else if pixel_encoding.eq_ignore_ascii_case(ffi::IO16BitDirectPixels) {
@@ -96,8 +89,8 @@ impl VideoModeHandle {
 
             let mode = VideoMode {
                 size: PhysicalSize::new(
-                    ffi::CGDisplayModeGetPixelWidth(native_mode.0) as u32,
-                    ffi::CGDisplayModeGetPixelHeight(native_mode.0) as u32,
+                    CGDisplayModeGetPixelWidth(Some(&native_mode.0)) as u32,
+                    CGDisplayModeGetPixelHeight(Some(&native_mode.0)) as u32,
                 ),
                 refresh_rate_millihertz,
                 bit_depth: NonZeroU16::new(bit_depth),
@@ -111,33 +104,12 @@ impl VideoModeHandle {
 #[derive(Clone)]
 pub struct MonitorHandle(CGDirectDisplayID);
 
-type MonitorUuid = [u8; 16];
-
 impl MonitorHandle {
     /// Internal comparisons of [`MonitorHandle`]s are done first requesting a UUID for the handle.
-    fn uuid(&self) -> MonitorUuid {
-        let cf_uuid = unsafe {
-            CFUUID::wrap_under_create_rule(ffi::CGDisplayCreateUUIDFromDisplayID(self.0))
-        };
-        let uuid = unsafe { CFUUIDGetUUIDBytes(cf_uuid.as_concrete_TypeRef()) };
-        MonitorUuid::from([
-            uuid.byte0,
-            uuid.byte1,
-            uuid.byte2,
-            uuid.byte3,
-            uuid.byte4,
-            uuid.byte5,
-            uuid.byte6,
-            uuid.byte7,
-            uuid.byte8,
-            uuid.byte9,
-            uuid.byte10,
-            uuid.byte11,
-            uuid.byte12,
-            uuid.byte13,
-            uuid.byte14,
-            uuid.byte15,
-        ])
+    fn uuid(&self) -> [u8; 16] {
+        let ptr = unsafe { ffi::CGDisplayCreateUUIDFromDisplayID(self.0) };
+        let cf_uuid = unsafe { CFRetained::from_raw(NonNull::new(ptr).unwrap()) };
+        unsafe { CFUUIDGetUUIDBytes(&cf_uuid) }.into()
     }
 }
 
@@ -171,19 +143,32 @@ impl std::hash::Hash for MonitorHandle {
 }
 
 pub fn available_monitors() -> VecDeque<MonitorHandle> {
-    if let Ok(displays) = CGDisplay::active_displays() {
-        let mut monitors = VecDeque::with_capacity(displays.len());
-        for display in displays {
-            monitors.push_back(MonitorHandle(display));
-        }
-        monitors
-    } else {
-        VecDeque::with_capacity(0)
+    let mut expected_count = 0;
+    let res = cgerr(unsafe { CGGetActiveDisplayList(0, ptr::null_mut(), &mut expected_count) });
+    if res.is_err() {
+        return VecDeque::with_capacity(0);
     }
+
+    let mut displays: Vec<CGDirectDisplayID> = vec![0; expected_count as usize];
+    let mut actual_count = 0;
+    let res = cgerr(unsafe {
+        CGGetActiveDisplayList(expected_count, displays.as_mut_ptr(), &mut actual_count)
+    });
+    displays.truncate(actual_count as usize);
+
+    if res.is_err() {
+        return VecDeque::with_capacity(0);
+    }
+
+    let mut monitors = VecDeque::with_capacity(displays.len());
+    for display in displays {
+        monitors.push_back(MonitorHandle(display));
+    }
+    monitors
 }
 
 pub fn primary_monitor() -> MonitorHandle {
-    MonitorHandle(CGDisplay::main().id)
+    MonitorHandle(unsafe { CGMainDisplayID() })
 }
 
 impl fmt::Debug for MonitorHandle {
@@ -205,8 +190,7 @@ impl MonitorHandle {
     // TODO: Be smarter about this:
     // <https://github.com/glfw/glfw/blob/57cbded0760a50b9039ee0cb3f3c14f60145567c/src/cocoa_monitor.m#L44-L126>
     pub fn name(&self) -> Option<String> {
-        let MonitorHandle(display_id) = *self;
-        let screen_num = CGDisplay::new(display_id).model_number();
+        let screen_num = unsafe { CGDisplayModelNumber(self.0) };
         Some(format!("Monitor #{screen_num}"))
     }
 
@@ -220,7 +204,7 @@ impl MonitorHandle {
         // This is already in screen coordinates. If we were using `NSScreen`,
         // then a conversion would've been needed:
         // flip_window_screen_coordinates(self.ns_screen(mtm)?.frame())
-        let bounds = unsafe { CGDisplayBounds(self.native_identifier()) };
+        let bounds = unsafe { CGDisplayBounds(self.0) };
         let position = LogicalPosition::new(bounds.origin.x, bounds.origin.y);
         Some(position.to_physical(self.scale_factor()))
     }
@@ -236,12 +220,12 @@ impl MonitorHandle {
 
     fn refresh_rate_millihertz(&self) -> Option<NonZeroU32> {
         let current_display_mode =
-            NativeDisplayMode(unsafe { CGDisplayCopyDisplayMode(self.0) } as _);
+            NativeDisplayMode(unsafe { CGDisplayCopyDisplayMode(self.0) }.unwrap());
         refresh_rate_millihertz(self.0, &current_display_mode)
     }
 
     pub fn current_video_mode(&self) -> Option<VideoMode> {
-        let mode = NativeDisplayMode(unsafe { CGDisplayCopyDisplayMode(self.0) } as _);
+        let mode = NativeDisplayMode(unsafe { CGDisplayCopyDisplayMode(self.0) }.unwrap());
         let refresh_rate_millihertz = refresh_rate_millihertz(self.0, &mode);
         Some(VideoModeHandle::new(self.clone(), mode, refresh_rate_millihertz).mode)
     }
@@ -256,22 +240,20 @@ impl MonitorHandle {
 
         unsafe {
             let modes = {
-                let array = ffi::CGDisplayCopyAllDisplayModes(self.0, std::ptr::null());
-                assert!(!array.is_null(), "failed to get list of display modes");
-                let array_count = CFArrayGetCount(array);
+                let array = CGDisplayCopyAllDisplayModes(self.0, None)
+                    .expect("failed to get list of display modes");
+                let array_count = CFArrayGetCount(&array);
                 let modes: Vec<_> = (0..array_count)
                     .map(move |i| {
-                        let mode = CFArrayGetValueAtIndex(array, i) as *mut _;
-                        ffi::CGDisplayModeRetain(mode);
-                        mode
+                        let mode = CFArrayGetValueAtIndex(&array, i) as *mut CGDisplayMode;
+                        CFRetained::from_raw(NonNull::new(mode).unwrap())
                     })
                     .collect();
-                CFRelease(array as *const _);
                 modes
             };
 
             modes.into_iter().map(move |mode| {
-                let cg_refresh_rate_hertz = ffi::CGDisplayModeGetRefreshRate(mode).round() as i64;
+                let cg_refresh_rate_hertz = CGDisplayModeGetRefreshRate(Some(&mode)).round() as i64;
 
                 // CGDisplayModeGetRefreshRate returns 0.0 for any display that
                 // isn't a CRT
@@ -336,7 +318,7 @@ pub(crate) fn flip_window_screen_coordinates(frame: NSRect) -> NSPoint {
     // It is intentional that we use `CGMainDisplayID` (as opposed to
     // `NSScreen::mainScreen`), because that's what the screen coordinates
     // are relative to, no matter which display the window is currently on.
-    let main_screen_height = CGDisplay::main().bounds().size.height;
+    let main_screen_height = unsafe { CGDisplayBounds(CGMainDisplayID()) }.size.height;
 
     let y = main_screen_height - frame.size.height - frame.origin.y;
     NSPoint::new(frame.origin.x, y)
@@ -344,25 +326,29 @@ pub(crate) fn flip_window_screen_coordinates(frame: NSRect) -> NSPoint {
 
 fn refresh_rate_millihertz(id: CGDirectDisplayID, mode: &NativeDisplayMode) -> Option<NonZeroU32> {
     unsafe {
-        let refresh_rate = ffi::CGDisplayModeGetRefreshRate(mode.0);
+        let refresh_rate = CGDisplayModeGetRefreshRate(Some(&mode.0));
         if refresh_rate > 0.0 {
             return NonZeroU32::new((refresh_rate * 1000.0).round() as u32);
         }
 
         let mut display_link = std::ptr::null_mut();
-        if ffi::CVDisplayLinkCreateWithCGDisplay(id, &mut display_link) != ffi::kCVReturnSuccess {
+        #[allow(deprecated)]
+        if CVDisplayLinkCreateWithCGDisplay(id, NonNull::from(&mut display_link))
+            != kCVReturnSuccess
+        {
             return None;
         }
-        let time = ffi::CVDisplayLinkGetNominalOutputVideoRefreshPeriod(display_link);
-        ffi::CVDisplayLinkRelease(display_link);
+        let display_link = CFRetained::from_raw(NonNull::new(display_link).unwrap());
+        #[allow(deprecated)]
+        let time = CVDisplayLinkGetNominalOutputVideoRefreshPeriod(&display_link);
 
         // This value is indefinite if an invalid display link was specified
-        if time.flags & ffi::kCVTimeIsIndefinite != 0 {
+        if time.flags & CVTimeFlags::IsIndefinite.0 != 0 {
             return None;
         }
 
-        (time.time_scale as i64)
-            .checked_div(time.time_value)
+        (time.timeScale as i64)
+            .checked_div(time.timeValue)
             .map(|v| (v * 1000) as u32)
             .and_then(NonZeroU32::new)
     }

--- a/src/platform_impl/apple/appkit/observer.rs
+++ b/src/platform_impl/apple/appkit/observer.rs
@@ -9,22 +9,18 @@ use std::ptr;
 use std::rc::Weak;
 use std::time::Instant;
 
-use block2::Block;
-use core_foundation::base::{CFIndex, CFOptionFlags, CFRelease, CFTypeRef};
-use core_foundation::date::CFAbsoluteTimeGetCurrent;
-use core_foundation::runloop::{
-    kCFRunLoopAfterWaiting, kCFRunLoopBeforeWaiting, kCFRunLoopCommonModes, kCFRunLoopDefaultMode,
-    kCFRunLoopExit, CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddTimer, CFRunLoopGetMain,
-    CFRunLoopObserverCallBack, CFRunLoopObserverContext, CFRunLoopObserverCreate,
-    CFRunLoopObserverRef, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
-    CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CFRunLoopWakeUp,
-};
 use objc2::MainThreadMarker;
+use objc2_core_foundation::{
+    kCFRunLoopCommonModes, kCFRunLoopDefaultMode, CFAbsoluteTimeGetCurrent, CFIndex, CFRetained,
+    CFRunLoop, CFRunLoopActivity, CFRunLoopAddObserver, CFRunLoopAddTimer, CFRunLoopGetMain,
+    CFRunLoopObserver, CFRunLoopObserverCallBack, CFRunLoopObserverContext,
+    CFRunLoopObserverCreate, CFRunLoopPerformBlock, CFRunLoopTimer, CFRunLoopTimerCreate,
+    CFRunLoopTimerInvalidate, CFRunLoopTimerSetNextFireDate, CFRunLoopWakeUp,
+};
 use tracing::error;
 
 use super::app_state::AppState;
 use super::event_loop::{stop_app_on_panic, PanicInfo};
-use super::ffi;
 
 unsafe fn control_flow_handler<F>(panic_info: *mut c_void, f: F)
 where
@@ -48,8 +44,8 @@ where
 }
 
 // begin is queued with the highest priority to ensure it is processed before other observers
-extern "C" fn control_flow_begin_handler(
-    _: CFRunLoopObserverRef,
+extern "C-unwind" fn control_flow_begin_handler(
+    _: *mut CFRunLoopObserver,
     activity: CFRunLoopActivity,
     panic_info: *mut c_void,
 ) {
@@ -57,7 +53,7 @@ extern "C" fn control_flow_begin_handler(
         control_flow_handler(panic_info, |panic_info| {
             #[allow(non_upper_case_globals)]
             match activity {
-                kCFRunLoopAfterWaiting => {
+                CFRunLoopActivity::AfterWaiting => {
                     // trace!("Triggered `CFRunLoopAfterWaiting`");
                     AppState::get(MainThreadMarker::new().unwrap()).wakeup(panic_info);
                     // trace!("Completed `CFRunLoopAfterWaiting`");
@@ -70,8 +66,8 @@ extern "C" fn control_flow_begin_handler(
 
 // end is queued with the lowest priority to ensure it is processed after other observers
 // without that, LoopExiting would  get sent after AboutToWait
-extern "C" fn control_flow_end_handler(
-    _: CFRunLoopObserverRef,
+extern "C-unwind" fn control_flow_end_handler(
+    _: *mut CFRunLoopObserver,
     activity: CFRunLoopActivity,
     panic_info: *mut c_void,
 ) {
@@ -79,12 +75,12 @@ extern "C" fn control_flow_end_handler(
         control_flow_handler(panic_info, |panic_info| {
             #[allow(non_upper_case_globals)]
             match activity {
-                kCFRunLoopBeforeWaiting => {
+                CFRunLoopActivity::BeforeWaiting => {
                     // trace!("Triggered `CFRunLoopBeforeWaiting`");
                     AppState::get(MainThreadMarker::new().unwrap()).cleared(panic_info);
                     // trace!("Completed `CFRunLoopBeforeWaiting`");
                 },
-                kCFRunLoopExit => (), // unimplemented!(), // not expected to ever happen
+                CFRunLoopActivity::Exit => (), /* unimplemented!(), // not expected to ever happen */
                 _ => unreachable!(),
             }
         });
@@ -92,44 +88,32 @@ extern "C" fn control_flow_end_handler(
 }
 
 #[derive(Debug)]
-pub struct RunLoop(CFRunLoopRef);
-
-impl Default for RunLoop {
-    fn default() -> Self {
-        Self(ptr::null_mut())
-    }
-}
+pub struct RunLoop(CFRetained<CFRunLoop>);
 
 impl RunLoop {
     pub fn main(mtm: MainThreadMarker) -> Self {
         // SAFETY: We have a MainThreadMarker here, which means we know we're on the main thread, so
         // scheduling (and scheduling a non-`Send` block) to that thread is allowed.
         let _ = mtm;
-        RunLoop(unsafe { CFRunLoopGetMain() })
+        RunLoop(unsafe { CFRunLoopGetMain() }.unwrap())
     }
 
     pub fn wakeup(&self) {
-        unsafe { CFRunLoopWakeUp(self.0) }
+        unsafe { CFRunLoopWakeUp(&self.0) }
     }
 
     unsafe fn add_observer(
         &self,
-        flags: CFOptionFlags,
+        flags: CFRunLoopActivity,
+        // The lower the value, the sooner this will run
         priority: CFIndex,
         handler: CFRunLoopObserverCallBack,
         context: *mut CFRunLoopObserverContext,
     ) {
-        let observer = unsafe {
-            CFRunLoopObserverCreate(
-                ptr::null_mut(),
-                flags,
-                ffi::TRUE, // Indicates we want this to run repeatedly
-                priority,  // The lower the value, the sooner this will run
-                handler,
-                context,
-            )
-        };
-        unsafe { CFRunLoopAddObserver(self.0, observer, kCFRunLoopCommonModes) };
+        let observer =
+            unsafe { CFRunLoopObserverCreate(None, flags.0, true, priority, handler, context) }
+                .unwrap();
+        unsafe { CFRunLoopAddObserver(&self.0, Some(&observer), kCFRunLoopCommonModes) };
     }
 
     /// Submit a closure to run on the main thread as the next step in the run loop, before other
@@ -166,10 +150,6 @@ impl RunLoop {
     /// put the event at the very front of the queue, to be handled as soon as possible after
     /// handling whatever event it's currently handling.
     pub fn queue_closure(&self, closure: impl FnOnce() + 'static) {
-        extern "C" {
-            fn CFRunLoopPerformBlock(rl: CFRunLoopRef, mode: CFTypeRef, block: &Block<dyn Fn()>);
-        }
-
         // Convert `FnOnce()` to `Block<dyn Fn()>`.
         let closure = Cell::new(Some(closure));
         let block = block2::RcBlock::new(move || {
@@ -195,10 +175,10 @@ impl RunLoop {
         // and be delivered to the application afterwards.
         //
         // [#1779]: https://github.com/rust-windowing/winit/issues/1779
-        let mode = unsafe { kCFRunLoopDefaultMode as CFTypeRef };
+        let mode = unsafe { kCFRunLoopDefaultMode.unwrap() };
 
         // SAFETY: The runloop is valid, the mode is a `CFStringRef`, and the block is `'static`.
-        unsafe { CFRunLoopPerformBlock(self.0, mode, &block) }
+        unsafe { CFRunLoopPerformBlock(&self.0, Some(mode), Some(&block)) }
     }
 }
 
@@ -213,15 +193,15 @@ pub fn setup_control_flow_observers(mtm: MainThreadMarker, panic_info: Weak<Pani
             copyDescription: None,
         };
         run_loop.add_observer(
-            kCFRunLoopAfterWaiting,
+            CFRunLoopActivity::AfterWaiting,
             CFIndex::MIN,
-            control_flow_begin_handler,
+            Some(control_flow_begin_handler),
             &mut context as *mut _,
         );
         run_loop.add_observer(
-            kCFRunLoopExit | kCFRunLoopBeforeWaiting,
+            CFRunLoopActivity::Exit | CFRunLoopActivity::BeforeWaiting,
             CFIndex::MAX,
-            control_flow_end_handler,
+            Some(control_flow_end_handler),
             &mut context as *mut _,
         );
     }
@@ -229,7 +209,7 @@ pub fn setup_control_flow_observers(mtm: MainThreadMarker, panic_info: Weak<Pani
 
 #[derive(Debug)]
 pub struct EventLoopWaker {
-    timer: CFRunLoopTimerRef,
+    timer: CFRetained<CFRunLoopTimer>,
 
     /// An arbitrary instant in the past, that will trigger an immediate wake
     /// We save this as the `next_fire_date` for consistency so we can
@@ -244,30 +224,28 @@ pub struct EventLoopWaker {
 
 impl Drop for EventLoopWaker {
     fn drop(&mut self) {
-        unsafe {
-            CFRunLoopTimerInvalidate(self.timer);
-            CFRelease(self.timer as _);
-        }
+        unsafe { CFRunLoopTimerInvalidate(&self.timer) };
     }
 }
 
 impl EventLoopWaker {
     pub(crate) fn new() -> Self {
-        extern "C" fn wakeup_main_loop(_timer: CFRunLoopTimerRef, _info: *mut c_void) {}
+        extern "C-unwind" fn wakeup_main_loop(_timer: *mut CFRunLoopTimer, _info: *mut c_void) {}
         unsafe {
             // Create a timer with a 0.1µs interval (1ns does not work) to mimic polling.
             // It is initially setup with a first fire time really far into the
             // future, but that gets changed to fire immediately in did_finish_launching
             let timer = CFRunLoopTimerCreate(
-                ptr::null_mut(),
+                None,
                 f64::MAX,
                 0.000_000_1,
                 0,
                 0,
-                wakeup_main_loop,
+                Some(wakeup_main_loop),
                 ptr::null_mut(),
-            );
-            CFRunLoopAddTimer(CFRunLoopGetMain(), timer, kCFRunLoopCommonModes);
+            )
+            .unwrap();
+            CFRunLoopAddTimer(&CFRunLoopGetMain().unwrap(), Some(&timer), kCFRunLoopCommonModes);
             Self { timer, start_instant: Instant::now(), next_fire_date: None }
         }
     }
@@ -275,14 +253,14 @@ impl EventLoopWaker {
     pub fn stop(&mut self) {
         if self.next_fire_date.is_some() {
             self.next_fire_date = None;
-            unsafe { CFRunLoopTimerSetNextFireDate(self.timer, f64::MAX) }
+            unsafe { CFRunLoopTimerSetNextFireDate(&self.timer, f64::MAX) };
         }
     }
 
     pub fn start(&mut self) {
         if self.next_fire_date != Some(self.start_instant) {
             self.next_fire_date = Some(self.start_instant);
-            unsafe { CFRunLoopTimerSetNextFireDate(self.timer, f64::MIN) }
+            unsafe { CFRunLoopTimerSetNextFireDate(&self.timer, f64::MIN) };
         }
     }
 
@@ -300,7 +278,7 @@ impl EventLoopWaker {
                         let duration = instant - now;
                         let fsecs = duration.subsec_nanos() as f64 / 1_000_000_000.0
                             + duration.as_secs() as f64;
-                        CFRunLoopTimerSetNextFireDate(self.timer, current + fsecs)
+                        CFRunLoopTimerSetNextFireDate(&self.timer, current + fsecs);
                     }
                 }
             },

--- a/src/platform_impl/apple/appkit/observer.rs
+++ b/src/platform_impl/apple/appkit/observer.rs
@@ -19,7 +19,7 @@ use core_foundation::runloop::{
     CFRunLoopObserverRef, CFRunLoopRef, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
     CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate, CFRunLoopWakeUp,
 };
-use objc2_foundation::MainThreadMarker;
+use objc2::MainThreadMarker;
 use tracing::error;
 
 use super::app_state::AppState;

--- a/src/platform_impl/apple/appkit/util.rs
+++ b/src/platform_impl/apple/appkit/util.rs
@@ -1,4 +1,7 @@
+use objc2_core_graphics::CGError;
 use tracing::trace;
+
+use crate::error::OsError;
 
 macro_rules! trace_scope {
     ($s:literal) => {
@@ -24,5 +27,14 @@ impl Drop for TraceGuard {
     #[inline]
     fn drop(&mut self) {
         trace!(target = self.module_path, "Completed `{}`", self.called_from_fn);
+    }
+}
+
+#[track_caller]
+pub(crate) fn cgerr(err: CGError) -> Result<(), OsError> {
+    if err == CGError::Success {
+        Ok(())
+    } else {
+        Err(os_error!(format!("CGError {err:?}")))
     }
 }

--- a/src/platform_impl/apple/appkit/window.rs
+++ b/src/platform_impl/apple/appkit/window.rs
@@ -1,10 +1,11 @@
 #![allow(clippy::unnecessary_cast)]
 
+use dispatch2::MainThreadBound;
 use dpi::{Position, Size};
 use objc2::rc::{autoreleasepool, Retained};
-use objc2::{declare_class, mutability, ClassType, DeclaredClass};
+use objc2::{define_class, MainThreadMarker, Message};
 use objc2_app_kit::{NSPanel, NSResponder, NSWindow};
-use objc2_foundation::{MainThreadBound, MainThreadMarker, NSObject};
+use objc2_foundation::NSObject;
 
 use super::event_loop::ActiveEventLoop;
 use super::window_delegate::WindowDelegate;
@@ -332,27 +333,21 @@ impl CoreWindow for Window {
     }
 }
 
-declare_class!(
+define_class!(
+    #[unsafe(super(NSWindow, NSResponder, NSObject))]
+    #[name = "WinitWindow"]
     #[derive(Debug)]
     pub struct WinitWindow;
 
-    unsafe impl ClassType for WinitWindow {
-        #[inherits(NSResponder, NSObject)]
-        type Super = NSWindow;
-        type Mutability = mutability::MainThreadOnly;
-        const NAME: &'static str = "WinitWindow";
-    }
-
-    impl DeclaredClass for WinitWindow {}
-
-    unsafe impl WinitWindow {
-        #[method(canBecomeMainWindow)]
+    /// This documentation attribute makes rustfmt work for some reason?
+    impl WinitWindow {
+        #[unsafe(method(canBecomeMainWindow))]
         fn can_become_main_window(&self) -> bool {
             trace_scope!("canBecomeMainWindow");
             true
         }
 
-        #[method(canBecomeKeyWindow)]
+        #[unsafe(method(canBecomeKeyWindow))]
         fn can_become_key_window(&self) -> bool {
             trace_scope!("canBecomeKeyWindow");
             true
@@ -360,23 +355,17 @@ declare_class!(
     }
 );
 
-declare_class!(
+define_class!(
+    #[unsafe(super(NSPanel, NSWindow, NSResponder, NSObject))]
+    #[name = "WinitPanel"]
     #[derive(Debug)]
     pub struct WinitPanel;
 
-    unsafe impl ClassType for WinitPanel {
-        #[inherits(NSWindow, NSResponder, NSObject)]
-        type Super = NSPanel;
-        type Mutability = mutability::MainThreadOnly;
-        const NAME: &'static str = "WinitPanel";
-    }
-
-    impl DeclaredClass for WinitPanel {}
-
-    unsafe impl WinitPanel {
+    /// This documentation attribute makes rustfmt work for some reason?
+    impl WinitPanel {
         // although NSPanel can become key window
         // it doesn't if window doesn't have NSWindowStyleMask::Titled
-        #[method(canBecomeKeyWindow)]
+        #[unsafe(method(canBecomeKeyWindow))]
         fn can_become_key_window(&self) -> bool {
             trace_scope!("canBecomeKeyWindow");
             true

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -10,7 +10,8 @@ use core_graphics::display::CGDisplay;
 use objc2::rc::{autoreleasepool, Retained};
 use objc2::runtime::{AnyObject, ProtocolObject};
 use objc2::{
-    define_class, msg_send, sel, ClassType, DefinedClass, MainThreadMarker, MainThreadOnly, Message,
+    available, define_class, msg_send, sel, ClassType, DefinedClass, MainThreadMarker,
+    MainThreadOnly, Message,
 };
 use objc2_app_kit::{
     NSAppKitVersionNumber, NSAppKitVersionNumber10_12, NSAppearance, NSAppearanceCustomization,
@@ -1781,7 +1782,7 @@ impl WindowDelegate {
                 let mtm = MainThreadMarker::from(self);
                 let app = NSApplication::sharedApplication(mtm);
 
-                if app.respondsToSelector(sel!(effectiveAppearance)) {
+                if available!(macos = 10.14) {
                     Some(super::window_delegate::appearance_to_theme(&app.effectiveAppearance()))
                 } else {
                     Some(Theme::Light)
@@ -1943,6 +1944,10 @@ impl WindowExtMacOS for WindowDelegate {
 
     #[inline]
     fn select_tab_at_index(&self, index: usize) {
+        if !available!(macos = 10.13) {
+            tracing::warn!("window tab groups are only available on macOS 10.13+");
+            return;
+        }
         if let Some(group) = self.window().tabGroup() {
             if let Some(windows) = unsafe { self.window().tabbedWindows() } {
                 if index < windows.len() {

--- a/src/platform_impl/apple/notification_center.rs
+++ b/src/platform_impl/apple/notification_center.rs
@@ -2,7 +2,10 @@ use std::ptr::NonNull;
 
 use block2::RcBlock;
 use objc2::rc::Retained;
-use objc2_foundation::{NSNotification, NSNotificationCenter, NSNotificationName, NSObject};
+use objc2::runtime::ProtocolObject;
+use objc2_foundation::{
+    NSNotification, NSNotificationCenter, NSNotificationName, NSObjectProtocol,
+};
 
 /// Observe the given notification.
 ///
@@ -12,7 +15,7 @@ pub fn create_observer(
     center: &NSNotificationCenter,
     name: &NSNotificationName,
     handler: impl Fn(&NSNotification) + 'static,
-) -> Retained<NSObject> {
+) -> Retained<ProtocolObject<dyn NSObjectProtocol>> {
     let block = RcBlock::new(move |notification: NonNull<NSNotification>| {
         handler(unsafe { notification.as_ref() });
     });

--- a/src/platform_impl/apple/uikit/app_state.rs
+++ b/src/platform_impl/apple/uikit/app_state.rs
@@ -15,12 +15,10 @@ use core_foundation::runloop::{
     CFRunLoopTimerInvalidate, CFRunLoopTimerRef, CFRunLoopTimerSetNextFireDate,
 };
 use objc2::rc::Retained;
-use objc2::sel;
-use objc2_foundation::{
-    CGRect, CGSize, MainThreadMarker, NSInteger, NSObjectProtocol, NSOperatingSystemVersion,
-    NSProcessInfo,
-};
-use objc2_ui_kit::{UIApplication, UICoordinateSpace, UIView, UIWindow};
+use objc2::{sel, MainThreadMarker};
+use objc2_core_foundation::{CGRect, CGSize};
+use objc2_foundation::{NSInteger, NSObjectProtocol, NSOperatingSystemVersion, NSProcessInfo};
+use objc2_ui_kit::{UIApplication, UICoordinateSpace, UIView};
 
 use super::super::event_handler::EventHandler;
 use super::window::WinitUIWindow;
@@ -440,13 +438,7 @@ pub(crate) fn send_occluded_event_for_all_windows(application: &UIApplication, o
     let mut events = Vec::new();
     #[allow(deprecated)]
     for window in application.windows().iter() {
-        if window.is_kind_of::<WinitUIWindow>() {
-            // SAFETY: We just checked that the window is a `winit` window
-            let window = unsafe {
-                let ptr: *const UIWindow = window;
-                let ptr: *const WinitUIWindow = ptr.cast();
-                &*ptr
-            };
+        if let Ok(window) = window.downcast::<WinitUIWindow>() {
             events.push(EventWrapper::Window {
                 window_id: window.id(),
                 event: WindowEvent::Occluded(occluded),
@@ -510,13 +502,7 @@ pub(crate) fn terminated(application: &UIApplication) {
     let mut events = Vec::new();
     #[allow(deprecated)]
     for window in application.windows().iter() {
-        if window.is_kind_of::<WinitUIWindow>() {
-            // SAFETY: We just checked that the window is a `winit` window
-            let window = unsafe {
-                let ptr: *const UIWindow = window;
-                let ptr: *const WinitUIWindow = ptr.cast();
-                &*ptr
-            };
+        if let Ok(window) = window.downcast::<WinitUIWindow>() {
             events.push(EventWrapper::Window {
                 window_id: window.id(),
                 event: WindowEvent::Destroyed,

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -3,8 +3,9 @@ use std::cell::{Cell, RefCell};
 
 use objc2::rc::Retained;
 use objc2::runtime::{NSObjectProtocol, ProtocolObject};
-use objc2::{declare_class, msg_send, msg_send_id, mutability, sel, ClassType, DeclaredClass};
-use objc2_foundation::{CGFloat, CGPoint, CGRect, MainThreadMarker, NSObject, NSSet, NSString};
+use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadMarker};
+use objc2_core_foundation::{CGFloat, CGPoint, CGRect};
+use objc2_foundation::{NSObject, NSSet, NSString};
 use objc2_ui_kit::{
     UIEvent, UIForceTouchCapability, UIGestureRecognizer, UIGestureRecognizerDelegate,
     UIGestureRecognizerState, UIKeyInput, UIPanGestureRecognizer, UIPinchGestureRecognizer,
@@ -39,36 +40,26 @@ pub struct WinitViewState {
     fingers: Cell<u8>,
 }
 
-declare_class!(
+define_class!(
+    #[unsafe(super(UIView, UIResponder, NSObject))]
+    #[name = "WinitUIView"]
+    #[ivars = WinitViewState]
     pub(crate) struct WinitView;
 
-    unsafe impl ClassType for WinitView {
-        #[inherits(UIResponder, NSObject)]
-        type Super = UIView;
-        type Mutability = mutability::MainThreadOnly;
-        const NAME: &'static str = "WinitUIView";
-    }
-
-    impl DeclaredClass for WinitView {
-        type Ivars = WinitViewState;
-    }
-
-    unsafe impl WinitView {
-        #[method(drawRect:)]
+    /// This documentation attribute makes rustfmt work for some reason?
+    impl WinitView {
+        #[unsafe(method(drawRect:))]
         fn draw_rect(&self, rect: CGRect) {
             let mtm = MainThreadMarker::new().unwrap();
             let window = self.window().unwrap();
-            app_state::handle_nonuser_event(
-                mtm,
-                EventWrapper::Window {
-                    window_id: window.id(),
-                    event: WindowEvent::RedrawRequested,
-                },
-            );
+            app_state::handle_nonuser_event(mtm, EventWrapper::Window {
+                window_id: window.id(),
+                event: WindowEvent::RedrawRequested,
+            });
             let _: () = unsafe { msg_send![super(self), drawRect: rect] };
         }
 
-        #[method(layoutSubviews)]
+        #[unsafe(method(layoutSubviews))]
         fn layout_subviews(&self) {
             let mtm = MainThreadMarker::new().unwrap();
             let _: () = unsafe { msg_send![super(self), layoutSubviews] };
@@ -82,16 +73,13 @@ declare_class!(
             .to_physical(scale_factor);
 
             let window = self.window().unwrap();
-            app_state::handle_nonuser_event(
-                mtm,
-                EventWrapper::Window {
-                    window_id: window.id(),
-                    event: WindowEvent::SurfaceResized(size),
-                },
-            );
+            app_state::handle_nonuser_event(mtm, EventWrapper::Window {
+                window_id: window.id(),
+                event: WindowEvent::SurfaceResized(size),
+            });
         }
 
-        #[method(setContentScaleFactor:)]
+        #[unsafe(method(setContentScaleFactor:))]
         fn set_content_scale_factor(&self, untrusted_scale_factor: CGFloat) {
             let mtm = MainThreadMarker::new().unwrap();
             let _: () =
@@ -124,49 +112,46 @@ declare_class!(
             let window_id = window.id();
             app_state::handle_nonuser_events(
                 mtm,
-                std::iter::once(EventWrapper::ScaleFactorChanged(
-                    app_state::ScaleFactorChanged {
-                        window,
-                        scale_factor,
-                        suggested_size: size.to_physical(scale_factor),
-                    },
-                ))
+                std::iter::once(EventWrapper::ScaleFactorChanged(app_state::ScaleFactorChanged {
+                    window,
+                    scale_factor,
+                    suggested_size: size.to_physical(scale_factor),
+                }))
                 .chain(std::iter::once(EventWrapper::Window {
-                        window_id,
-                        event: WindowEvent::SurfaceResized(size.to_physical(scale_factor)),
-                    },
-                )),
+                    window_id,
+                    event: WindowEvent::SurfaceResized(size.to_physical(scale_factor)),
+                })),
             );
         }
 
-        #[method(safeAreaInsetsDidChange)]
+        #[unsafe(method(safeAreaInsetsDidChange))]
         fn safe_area_changed(&self) {
             debug!("safeAreaInsetsDidChange was called, requesting redraw");
             // When the safe area changes we want to make sure to emit a redraw event
             self.setNeedsDisplay();
         }
 
-        #[method(touchesBegan:withEvent:)]
+        #[unsafe(method(touchesBegan:withEvent:))]
         fn touches_began(&self, touches: &NSSet<UITouch>, _event: Option<&UIEvent>) {
             self.handle_touches(touches)
         }
 
-        #[method(touchesMoved:withEvent:)]
+        #[unsafe(method(touchesMoved:withEvent:))]
         fn touches_moved(&self, touches: &NSSet<UITouch>, _event: Option<&UIEvent>) {
             self.handle_touches(touches)
         }
 
-        #[method(touchesEnded:withEvent:)]
+        #[unsafe(method(touchesEnded:withEvent:))]
         fn touches_ended(&self, touches: &NSSet<UITouch>, _event: Option<&UIEvent>) {
             self.handle_touches(touches)
         }
 
-        #[method(touchesCancelled:withEvent:)]
+        #[unsafe(method(touchesCancelled:withEvent:))]
         fn touches_cancelled(&self, touches: &NSSet<UITouch>, _event: Option<&UIEvent>) {
             self.handle_touches(touches)
         }
 
-        #[method(pinchGesture:)]
+        #[unsafe(method(pinchGesture:))]
         fn pinch_gesture(&self, recognizer: &UIPinchGestureRecognizer) {
             let window = self.window().unwrap();
 
@@ -174,46 +159,40 @@ declare_class!(
                 UIGestureRecognizerState::Began => {
                     self.ivars().pinch_last_delta.set(recognizer.scale());
                     (TouchPhase::Started, 0.0)
-                }
+                },
                 UIGestureRecognizerState::Changed => {
                     let last_scale: f64 = self.ivars().pinch_last_delta.replace(recognizer.scale());
                     (TouchPhase::Moved, recognizer.scale() - last_scale)
-                }
+                },
                 UIGestureRecognizerState::Ended => {
                     let last_scale: f64 = self.ivars().pinch_last_delta.replace(0.0);
                     (TouchPhase::Moved, recognizer.scale() - last_scale)
-                }
+                },
                 UIGestureRecognizerState::Cancelled | UIGestureRecognizerState::Failed => {
                     self.ivars().rotation_last_delta.set(0.0);
                     // Pass -delta so that action is reversed
                     (TouchPhase::Cancelled, -recognizer.scale())
-                }
+                },
                 state => panic!("unexpected recognizer state: {state:?}"),
             };
 
             let gesture_event = EventWrapper::Window {
                 window_id: window.id(),
-                event: WindowEvent::PinchGesture {
-                    device_id: None,
-                    delta: delta as f64,
-                    phase,
-                },
+                event: WindowEvent::PinchGesture { device_id: None, delta: delta as f64, phase },
             };
 
             let mtm = MainThreadMarker::new().unwrap();
             app_state::handle_nonuser_event(mtm, gesture_event);
         }
 
-        #[method(doubleTapGesture:)]
+        #[unsafe(method(doubleTapGesture:))]
         fn double_tap_gesture(&self, recognizer: &UITapGestureRecognizer) {
             let window = self.window().unwrap();
 
             if recognizer.state() == UIGestureRecognizerState::Ended {
                 let gesture_event = EventWrapper::Window {
                     window_id: window.id(),
-                    event: WindowEvent::DoubleTapGesture {
-                        device_id: None,
-                    },
+                    event: WindowEvent::DoubleTapGesture { device_id: None },
                 };
 
                 let mtm = MainThreadMarker::new().unwrap();
@@ -221,7 +200,7 @@ declare_class!(
             }
         }
 
-        #[method(rotationGesture:)]
+        #[unsafe(method(rotationGesture:))]
         fn rotation_gesture(&self, recognizer: &UIRotationGestureRecognizer) {
             let window = self.window().unwrap();
 
@@ -230,23 +209,24 @@ declare_class!(
                     self.ivars().rotation_last_delta.set(0.0);
 
                     (TouchPhase::Started, 0.0)
-                }
+                },
                 UIGestureRecognizerState::Changed => {
-                    let last_rotation = self.ivars().rotation_last_delta.replace(recognizer.rotation());
+                    let last_rotation =
+                        self.ivars().rotation_last_delta.replace(recognizer.rotation());
 
                     (TouchPhase::Moved, recognizer.rotation() - last_rotation)
-                }
+                },
                 UIGestureRecognizerState::Ended => {
                     let last_rotation = self.ivars().rotation_last_delta.replace(0.0);
 
                     (TouchPhase::Ended, recognizer.rotation() - last_rotation)
-                }
+                },
                 UIGestureRecognizerState::Cancelled | UIGestureRecognizerState::Failed => {
                     self.ivars().rotation_last_delta.set(0.0);
 
                     // Pass -delta so that action is reversed
                     (TouchPhase::Cancelled, -recognizer.rotation())
-                }
+                },
                 state => panic!("unexpected recognizer state: {state:?}"),
             };
 
@@ -264,7 +244,7 @@ declare_class!(
             app_state::handle_nonuser_event(mtm, gesture_event);
         }
 
-        #[method(panGesture:)]
+        #[unsafe(method(panGesture:))]
         fn pan_gesture(&self, recognizer: &UIPanGestureRecognizer) {
             let window = self.window().unwrap();
 
@@ -275,7 +255,7 @@ declare_class!(
                     self.ivars().pan_last_delta.set(translation);
 
                     (TouchPhase::Started, 0.0, 0.0)
-                }
+                },
                 UIGestureRecognizerState::Changed => {
                     let last_pan: CGPoint = self.ivars().pan_last_delta.replace(translation);
 
@@ -283,24 +263,25 @@ declare_class!(
                     let dy = translation.y - last_pan.y;
 
                     (TouchPhase::Moved, dx, dy)
-                }
+                },
                 UIGestureRecognizerState::Ended => {
-                    let last_pan: CGPoint = self.ivars().pan_last_delta.replace(CGPoint{x:0.0, y:0.0});
+                    let last_pan: CGPoint =
+                        self.ivars().pan_last_delta.replace(CGPoint { x: 0.0, y: 0.0 });
 
                     let dx = translation.x - last_pan.x;
                     let dy = translation.y - last_pan.y;
 
                     (TouchPhase::Ended, dx, dy)
-                }
+                },
                 UIGestureRecognizerState::Cancelled | UIGestureRecognizerState::Failed => {
-                    let last_pan: CGPoint = self.ivars().pan_last_delta.replace(CGPoint{x:0.0, y:0.0});
+                    let last_pan: CGPoint =
+                        self.ivars().pan_last_delta.replace(CGPoint { x: 0.0, y: 0.0 });
 
                     // Pass -delta so that action is reversed
                     (TouchPhase::Cancelled, -last_pan.x, -last_pan.y)
-                }
+                },
                 state => panic!("unexpected recognizer state: {state:?}"),
             };
-
 
             let gesture_event = EventWrapper::Window {
                 window_id: window.id(),
@@ -315,7 +296,7 @@ declare_class!(
             app_state::handle_nonuser_event(mtm, gesture_event);
         }
 
-        #[method(canBecomeFirstResponder)]
+        #[unsafe(method(canBecomeFirstResponder))]
         fn can_become_first_responder(&self) -> bool {
             true
         }
@@ -324,27 +305,30 @@ declare_class!(
     unsafe impl NSObjectProtocol for WinitView {}
 
     unsafe impl UIGestureRecognizerDelegate for WinitView {
-        #[method(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)]
-        fn should_recognize_simultaneously(&self, _gesture_recognizer: &UIGestureRecognizer, _other_gesture_recognizer: &UIGestureRecognizer) -> bool {
+        #[unsafe(method(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:))]
+        fn should_recognize_simultaneously(
+            &self,
+            _gesture_recognizer: &UIGestureRecognizer,
+            _other_gesture_recognizer: &UIGestureRecognizer,
+        ) -> bool {
             true
         }
     }
 
-    unsafe impl UITextInputTraits for WinitView {
-    }
+    unsafe impl UITextInputTraits for WinitView {}
 
     unsafe impl UIKeyInput for WinitView {
-        #[method(hasText)]
+        #[unsafe(method(hasText))]
         fn has_text(&self) -> bool {
             true
         }
 
-        #[method(insertText:)]
+        #[unsafe(method(insertText:))]
         fn insert_text(&self, text: &NSString) {
             self.handle_insert_text(text)
         }
 
-        #[method(deleteBackward)]
+        #[unsafe(method(deleteBackward))]
         fn delete_backward(&self) {
             self.handle_delete_backward()
         }
@@ -370,7 +354,7 @@ impl WinitView {
             primary_finger: Cell::new(None),
             fingers: Cell::new(0),
         });
-        let this: Retained<Self> = unsafe { msg_send_id![super(this), initWithFrame: frame] };
+        let this: Retained<Self> = unsafe { msg_send![super(this), initWithFrame: frame] };
 
         this.setMultipleTouchEnabled(true);
 
@@ -382,8 +366,8 @@ impl WinitView {
     }
 
     fn window(&self) -> Option<Retained<WinitUIWindow>> {
-        // SAFETY: `WinitView`s are always installed in a `WinitUIWindow`
-        (**self).window().map(|window| unsafe { Retained::cast(window) })
+        // `WinitView`s should always be installed in a `WinitUIWindow`
+        (**self).window().map(|window| window.downcast().unwrap())
     }
 
     pub(crate) fn recognize_pinch_gesture(&self, should_recognize: bool) {
@@ -501,7 +485,7 @@ impl WinitView {
             } else {
                 None
             };
-            let touch_id = touch as *const UITouch as usize;
+            let touch_id = Retained::as_ptr(&touch) as usize;
             let phase = touch.phase();
             let position = {
                 let scale_factor = self.contentScaleFactor();

--- a/src/platform_impl/apple/uikit/view.rs
+++ b/src/platform_impl/apple/uikit/view.rs
@@ -3,7 +3,7 @@ use std::cell::{Cell, RefCell};
 
 use objc2::rc::Retained;
 use objc2::runtime::{NSObjectProtocol, ProtocolObject};
-use objc2::{define_class, msg_send, sel, DefinedClass, MainThreadMarker};
+use objc2::{available, define_class, msg_send, sel, DefinedClass, MainThreadMarker};
 use objc2_core_foundation::{CGFloat, CGPoint, CGRect};
 use objc2_foundation::{NSObject, NSSet, NSString};
 use objc2_ui_kit::{
@@ -462,13 +462,12 @@ impl WinitView {
     fn handle_touches(&self, touches: &NSSet<UITouch>) {
         let window = self.window().unwrap();
         let mut touch_events = Vec::new();
-        let os_supports_force = app_state::os_capabilities().force_touch;
         for touch in touches {
             let logical_location = touch.locationInView(None);
             let touch_type = touch.r#type();
             let force = if let UITouchType::Pencil = touch_type {
                 None
-            } else if os_supports_force {
+            } else if available!(ios = 9.0, tvos = 9.0, visionos = 1.0) {
                 let trait_collection = self.traitCollection();
                 let touch_capability = trait_collection.forceTouchCapability();
                 // Both the OS _and_ the device need to be checked for force touch support.

--- a/src/platform_impl/apple/uikit/view_controller.rs
+++ b/src/platform_impl/apple/uikit/view_controller.rs
@@ -1,8 +1,8 @@
 use std::cell::Cell;
 
 use objc2::rc::Retained;
-use objc2::{declare_class, msg_send_id, mutability, ClassType, DeclaredClass};
-use objc2_foundation::{MainThreadMarker, NSObject};
+use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker};
+use objc2_foundation::NSObject;
 use objc2_ui_kit::{
     UIDevice, UIInterfaceOrientationMask, UIRectEdge, UIResponder, UIStatusBarStyle,
     UIUserInterfaceIdiom, UIView, UIViewController,
@@ -20,51 +20,42 @@ pub struct ViewControllerState {
     preferred_screen_edges_deferring_system_gestures: Cell<UIRectEdge>,
 }
 
-declare_class!(
+define_class!(
+    #[unsafe(super(UIViewController, UIResponder, NSObject))]
+    #[name = "WinitUIViewController"]
+    #[ivars = ViewControllerState]
     pub(crate) struct WinitViewController;
 
-    unsafe impl ClassType for WinitViewController {
-        #[inherits(UIResponder, NSObject)]
-        type Super = UIViewController;
-        type Mutability = mutability::MainThreadOnly;
-        const NAME: &'static str = "WinitUIViewController";
-    }
-
-    impl DeclaredClass for WinitViewController {
-        type Ivars = ViewControllerState;
-    }
-
-    unsafe impl WinitViewController {
-        #[method(shouldAutorotate)]
+    /// This documentation attribute makes rustfmt work for some reason?
+    impl WinitViewController {
+        #[unsafe(method(shouldAutorotate))]
         fn should_autorotate(&self) -> bool {
             true
         }
 
-        #[method(prefersStatusBarHidden)]
+        #[unsafe(method(prefersStatusBarHidden))]
         fn prefers_status_bar_hidden(&self) -> bool {
             self.ivars().prefers_status_bar_hidden.get()
         }
 
-        #[method(preferredStatusBarStyle)]
+        #[unsafe(method(preferredStatusBarStyle))]
         fn preferred_status_bar_style(&self) -> UIStatusBarStyle {
             self.ivars().preferred_status_bar_style.get()
         }
 
-        #[method(prefersHomeIndicatorAutoHidden)]
+        #[unsafe(method(prefersHomeIndicatorAutoHidden))]
         fn prefers_home_indicator_auto_hidden(&self) -> bool {
             self.ivars().prefers_home_indicator_auto_hidden.get()
         }
 
-        #[method(supportedInterfaceOrientations)]
+        #[unsafe(method(supportedInterfaceOrientations))]
         fn supported_orientations(&self) -> UIInterfaceOrientationMask {
             self.ivars().supported_orientations.get()
         }
 
-        #[method(preferredScreenEdgesDeferringSystemGestures)]
+        #[unsafe(method(preferredScreenEdgesDeferringSystemGestures))]
         fn preferred_screen_edges_deferring_system_gestures(&self) -> UIRectEdge {
-            self.ivars()
-                .preferred_screen_edges_deferring_system_gestures
-                .get()
+            self.ivars().preferred_screen_edges_deferring_system_gestures.get()
         }
     }
 );
@@ -146,7 +137,7 @@ impl WinitViewController {
             supported_orientations: Cell::new(UIInterfaceOrientationMask::All),
             preferred_screen_edges_deferring_system_gestures: Cell::new(UIRectEdge::empty()),
         });
-        let this: Retained<Self> = unsafe { msg_send_id![super(this), init] };
+        let this: Retained<Self> = unsafe { msg_send![super(this), init] };
 
         this.set_prefers_status_bar_hidden(
             window_attributes.platform_specific.prefers_status_bar_hidden,

--- a/src/platform_impl/apple/uikit/view_controller.rs
+++ b/src/platform_impl/apple/uikit/view_controller.rs
@@ -1,14 +1,13 @@
 use std::cell::Cell;
 
 use objc2::rc::Retained;
-use objc2::{define_class, msg_send, DefinedClass, MainThreadMarker};
+use objc2::{available, define_class, msg_send, DefinedClass, MainThreadMarker};
 use objc2_foundation::NSObject;
 use objc2_ui_kit::{
     UIDevice, UIInterfaceOrientationMask, UIRectEdge, UIResponder, UIStatusBarStyle,
     UIUserInterfaceIdiom, UIView, UIViewController,
 };
 
-use super::app_state::{self};
 use crate::platform::ios::{ScreenEdge, StatusBarStyle, ValidOrientations};
 use crate::window::WindowAttributes;
 
@@ -78,11 +77,13 @@ impl WinitViewController {
 
     pub(crate) fn set_prefers_home_indicator_auto_hidden(&self, val: bool) {
         self.ivars().prefers_home_indicator_auto_hidden.set(val);
-        let os_capabilities = app_state::os_capabilities();
-        if os_capabilities.home_indicator_hidden {
+        if available!(ios = 11.0, visionos = 1.0) {
             self.setNeedsUpdateOfHomeIndicatorAutoHidden();
         } else {
-            os_capabilities.home_indicator_hidden_err_msg("ignoring")
+            tracing::warn!(
+                "`setNeedsUpdateOfHomeIndicatorAutoHidden` requires iOS 11.0+ or visionOS. \
+                 Ignoring"
+            );
         }
     }
 
@@ -92,11 +93,13 @@ impl WinitViewController {
             UIRectEdge(val.bits().into())
         };
         self.ivars().preferred_screen_edges_deferring_system_gestures.set(val);
-        let os_capabilities = app_state::os_capabilities();
-        if os_capabilities.defer_system_gestures {
+        if available!(ios = 11.0, visionos = 1.0) {
             self.setNeedsUpdateOfScreenEdgesDeferringSystemGestures();
         } else {
-            os_capabilities.defer_system_gestures_err_msg("ignoring")
+            tracing::warn!(
+                "`setNeedsUpdateOfScreenEdgesDeferringSystemGestures` requires iOS 11.0+ or \
+                 visionOS. Ignoring"
+            );
         }
     }
 

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 
 use dispatch2::MainThreadBound;
 use objc2::rc::Retained;
-use objc2::{class, define_class, msg_send, MainThreadMarker};
+use objc2::{available, class, define_class, msg_send, MainThreadMarker};
 use objc2_core_foundation::{CGFloat, CGPoint, CGRect, CGSize};
 use objc2_foundation::{NSObject, NSObjectProtocol};
 use objc2_ui_kit::{
@@ -196,8 +196,7 @@ impl Inner {
     }
 
     pub fn safe_area(&self) -> PhysicalInsets<u32> {
-        // Only available on iOS 11.0
-        let insets = if app_state::os_capabilities().safe_area {
+        let insets = if available!(ios = 11.0, tvos = 11.0, visionos = 1.0) {
             self.view.safeAreaInsets()
         } else {
             // Assume the status bar frame is the only thing that obscures the view

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -2,11 +2,11 @@
 
 use std::collections::VecDeque;
 
+use dispatch2::MainThreadBound;
 use objc2::rc::Retained;
-use objc2::{class, declare_class, msg_send, msg_send_id, mutability, ClassType, DeclaredClass};
-use objc2_foundation::{
-    CGFloat, CGPoint, CGRect, CGSize, MainThreadBound, MainThreadMarker, NSObject, NSObjectProtocol,
-};
+use objc2::{class, define_class, msg_send, MainThreadMarker};
+use objc2_core_foundation::{CGFloat, CGPoint, CGRect, CGSize};
+use objc2_foundation::{NSObject, NSObjectProtocol};
 use objc2_ui_kit::{
     UIApplication, UICoordinateSpace, UIEdgeInsets, UIResponder, UIScreen,
     UIScreenOverscanCompensation, UIViewController, UIWindow,
@@ -32,43 +32,31 @@ use crate::window::{
     WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
-declare_class!(
+define_class!(
+    #[unsafe(super(UIWindow, UIResponder, NSObject))]
+    #[name = "WinitUIWindow"]
     #[derive(Debug, PartialEq, Eq, Hash)]
     pub(crate) struct WinitUIWindow;
 
-    unsafe impl ClassType for WinitUIWindow {
-        #[inherits(UIResponder, NSObject)]
-        type Super = UIWindow;
-        type Mutability = mutability::MainThreadOnly;
-        const NAME: &'static str = "WinitUIWindow";
-    }
-
-    impl DeclaredClass for WinitUIWindow {}
-
-    unsafe impl WinitUIWindow {
-        #[method(becomeKeyWindow)]
+    /// This documentation attribute makes rustfmt work for some reason?
+    impl WinitUIWindow {
+        #[unsafe(method(becomeKeyWindow))]
         fn become_key_window(&self) {
             let mtm = MainThreadMarker::new().unwrap();
-            app_state::handle_nonuser_event(
-                mtm,
-                EventWrapper::Window {
-                    window_id: self.id(),
-                    event: WindowEvent::Focused(true),
-                },
-            );
+            app_state::handle_nonuser_event(mtm, EventWrapper::Window {
+                window_id: self.id(),
+                event: WindowEvent::Focused(true),
+            });
             let _: () = unsafe { msg_send![super(self), becomeKeyWindow] };
         }
 
-        #[method(resignKeyWindow)]
+        #[unsafe(method(resignKeyWindow))]
         fn resign_key_window(&self) {
             let mtm = MainThreadMarker::new().unwrap();
-            app_state::handle_nonuser_event(
-                mtm,
-                EventWrapper::Window {
-                    window_id: self.id(),
-                    event: WindowEvent::Focused(false),
-                },
-            );
+            app_state::handle_nonuser_event(mtm, EventWrapper::Window {
+                window_id: self.id(),
+                event: WindowEvent::Focused(false),
+            });
             let _: () = unsafe { msg_send![super(self), resignKeyWindow] };
         }
     }
@@ -86,7 +74,7 @@ impl WinitUIWindow {
         // into very confusing issues with the window not being properly activated.
         //
         // Winit ensures this by not allowing access to `ActiveEventLoop` before handling events.
-        let this: Retained<Self> = unsafe { msg_send_id![mtm.alloc(), initWithFrame: frame] };
+        let this: Retained<Self> = unsafe { msg_send![mtm.alloc(), initWithFrame: frame] };
 
         this.setRootViewController(Some(view_controller));
 

--- a/src/platform_impl/linux/wayland/seat/pointer/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/pointer/mod.rs
@@ -27,7 +27,10 @@ use sctk::seat::pointer::{
 use sctk::seat::SeatState;
 
 use crate::dpi::{LogicalPosition, PhysicalPosition};
-use crate::event::{ElementState, MouseButton, MouseScrollDelta, PointerSource, PointerKind, TouchPhase, WindowEvent};
+use crate::event::{
+    ElementState, MouseButton, MouseScrollDelta, PointerKind, PointerSource, TouchPhase,
+    WindowEvent,
+};
 
 use crate::platform_impl::wayland::state::WinitState;
 use crate::platform_impl::wayland::{self, WindowId};


### PR DESCRIPTION
This adds a few new crates that have more complete bindings than their predecessors (our `ffi` module is now a lot smaller), and uses the new `available!` macro to check for availability of APIs before using them.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
