### PR TITLE
x11: fix crash with uim

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -227,3 +227,4 @@ changelog entry.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
 - On Windows, fixed the event loop not waking on accessibility requests.
 - On X11, fixed cursor grab mode state tracking on error.
+- On X11, fixed crash with uim

--- a/src/platform_impl/linux/x11/ime/callbacks.rs
+++ b/src/platform_impl/linux/x11/ime/callbacks.rs
@@ -122,19 +122,15 @@ unsafe fn replace_im(inner: *mut ImeInner) -> Result<(), ReplaceImError> {
         let is_allowed =
             old_context.as_ref().map(|old_context| old_context.is_allowed()).unwrap_or_default();
 
-        // We can't use the style from the old context here, since it may change on reload, so
-        // pick style from the new XIM based on the old state.
-        let style = if is_allowed { new_im.preedit_style } else { new_im.none_style };
-
         let new_context = {
             let result = unsafe {
                 ImeContext::new(
                     xconn,
-                    new_im.im,
-                    style,
+                    &new_im,
                     *window,
                     spot,
                     (*inner).event_sender.clone(),
+                    is_allowed,
                 )
             };
             if result.is_err() {

--- a/src/platform_impl/linux/x11/ime/input_method.rs
+++ b/src/platform_impl/linux/x11/ime/input_method.rs
@@ -82,9 +82,7 @@ impl InputMethod {
         }
 
         let preedit_style = preedit_style.unwrap_or_else(|| none_style.unwrap());
-        // Always initialize none style even when it's not advertised, since it seems to work
-        // regardless...
-        let none_style = none_style.unwrap_or(Style::None(XIM_NONE_STYLE));
+        let none_style = none_style.unwrap_or(preedit_style);
 
         Some(InputMethod { im, _name: name, preedit_style, none_style })
     }


### PR DESCRIPTION
Let's just not forward events to the IME once the user requested that it should be disabled, though, still try to change its state explicitly.

Fixes #4082.

