### PR TITLE
Bump version of unicode-segmentation crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,7 +241,7 @@ objc2-ui-kit = { version = "0.3.0", default-features = false, features = [
 
 # Windows
 [target.'cfg(target_os = "windows")'.dependencies]
-unicode-segmentation = "1.7.1"
+unicode-segmentation = "1.12.0"
 windows-sys = { version = "0.52.0", features = [
     "Win32_Devices_HumanInterfaceDevice",
     "Win32_Foundation",

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -185,6 +185,7 @@ changelog entry.
   whilst files are being dragged over the window. It doesn't contain any file paths, just the
   pointer position.
 - Updated `objc2` to `v0.6`.
+- Updated `unicode-segmentation` to `1.12.0`
 
 ### Removed
 


### PR DESCRIPTION
Bump Up `unicode-segmentation` crate to latest version for almost 40% performance speed and been able to use with `eframe ` create together with package `text-splitter` v.0.13.1

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [n/a] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [n/a] Created or updated an example program if it would help users understand this functionality
