### PR TITLE
Windows: Fix invisible gap bug in window positioning at screen edges

### DIFF
--- a/examples/topless.rs
+++ b/examples/topless.rs
@@ -26,17 +26,17 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!(
         "Topless mode (Windows only):
       − title bar         (WS_CAPTION) via with_titlebar         (false)
-      + resize border     (WS_SIZEBOX) via with_resizable        (true ) ≝
-      − top resize border              via with_top_resize_border(false)
+      + resize border@↓←→ (WS_SIZEBOX) via with_resizable        (true ) ≝
+      − resize border@↑                via with_top_resize_border(false)
         ├ not a separate WS_ window style, 'manual' removal on NonClientArea events
         └ only implemented for windows without a title bar, eg, with a custom title bar handling \
          resizing from the top
     ——————————————————————————————
     Press a key for (un)setting/querying a specific parameter (modifiers are ignored):
-                         on  off  toggle  status
-    title bar            q    w     e        r
-    resize border        a    s     d        f
-    ─ top resize border  z    x     c        v
+                         on  off  toggle  query
+    title bar            q    w     e       r
+    resize border@↓←→    a    s     d       f
+    resize border@↑      z    x     c       v
     "
     );
 

--- a/examples/topless.rs
+++ b/examples/topless.rs
@@ -1,0 +1,127 @@
+#![allow(
+    unused_imports,
+    unused_mut,
+    unused_variables,
+    dead_code,
+    unused_assignments,
+    unused_macros
+)]
+use std::error::Error;
+
+use winit::application::ApplicationHandler;
+use winit::event::WindowEvent;
+use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::window::{Window, WindowAttributes, WindowId};
+
+#[path = "util/fill.rs"]
+mod fill;
+#[path = "util/tracing.rs"]
+mod tracing;
+
+use ::tracing::info;
+#[cfg(windows_platform)]
+fn main() -> Result<(), Box<dyn Error>> {
+    tracing::init();
+
+    println!("Topless mode (Windows only):
+      − title bar         (WS_CAPTION) via with_titlebar         (false)
+      + resize border     (WS_SIZEBOX) via with_resizable        (true ) ≝
+      − top resize border              via with_top_resize_border(false)
+        ├ not a separate WS_ window style, 'manual' removal on NonClientArea events
+        └ only implemented for windows without a title bar, eg, with a custom title bar handling resizing from the top
+    ——————————————————————————————
+    Press a key for (un)setting/querying a specific parameter (modifiers are ignored):
+                         on  off  toggle  status
+    title bar            q    w     e        r
+    resize border        a    s     d        f
+    ─ top resize border  z    x     c        v
+    ");
+
+    let event_loop = EventLoop::new()?;
+
+    let app = Application::new();
+    Ok(event_loop.run_app(app)?)
+}
+
+/// Application state and event handling.
+struct Application {
+    window: Option<Box<dyn Window>>,
+}
+
+impl Application {
+    fn new() -> Self {
+        Self { window: None }
+    }
+}
+
+use winit::event::ElementState;
+use winit::keyboard::{Key, ModifiersState};
+#[cfg(windows_platform)]
+use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
+#[cfg(windows_platform)]
+use winit::platform::windows::WindowAttributesExtWindows;
+#[cfg(windows_platform)]
+use winit::platform::windows::WindowExtWindows;
+#[cfg(windows_platform)]
+impl ApplicationHandler for Application {
+    fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
+        let window_attributes =
+            WindowAttributes::default().with_title("Topless (unless you see this)!")
+            .with_decorations      (true )// decorations       ≝true
+            .with_titlebar         (false)// titlebar          ≝true
+            .with_resizable        (true )// resizable         ≝true
+            .with_top_resize_border(false)// top_resize_border ≝true
+            .with_position(dpi::Position::Logical(dpi::LogicalPosition::new(0.0,0.0)))// position: Option<Position>
+            ;
+        self.window = Some(event_loop.create_window(window_attributes).unwrap());
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &dyn ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let win = match self.window.as_ref() {
+            Some(win) => win,
+            None      => return,
+        };
+        let _modi = ModifiersState::default();
+        match event {
+            WindowEvent::KeyboardInput { event, .. } => {
+                if event.state == ElementState::Pressed && !event.repeat {
+                    match event.key_without_modifiers().as_ref() {
+                        Key::Character("q") => {win.set_titlebar(true )                                                	;info!("set_titlebar         → true")}
+                        Key::Character("w") => {win.set_titlebar(false)                                                	;info!("set_titlebar         → false")}
+                        Key::Character("e") => {let flip = !win.is_titlebar()         ; win.set_titlebar         (flip)	;info!("set_titlebar         → {flip}")}
+                        Key::Character("r") => {let is   =  win.is_titlebar()                                          	;info!("is_titlebar          = {is}")}
+                        Key::Character("a") => {win.set_resizable(true )                                               	;info!("set_resizable        → true")}
+                        Key::Character("s") => {win.set_resizable(false)                                               	;info!("set_resizable        → false")}
+                        Key::Character("d") => {let flip = !win.is_resizable()        ; win.set_resizable        (flip)	;info!("set_resizable        → {flip}")}
+                        Key::Character("f") => {let is   =  win.is_resizable()                                         	;info!("is_resizable         = {is}")}
+                        Key::Character("z") => {win.set_top_resize_border(true )                                       	;info!("set_top_resize_border→ true")}
+                        Key::Character("x") => {win.set_top_resize_border(false)                                       	;info!("set_top_resize_border→ false")}
+                        Key::Character("c") => {let flip = !win.is_top_resize_border(); win.set_top_resize_border(flip)	;info!("set_top_resize_border→ {flip}")}
+                        Key::Character("v") => {let is   =  win.is_top_resize_border()                                 	;info!("is_top_resize_border = {is}")}
+                        _ => (),
+                    }
+                }
+            },
+            WindowEvent::RedrawRequested => {
+                let window = self.window.as_ref().unwrap();
+                window.pre_present_notify();
+                fill::fill_window(window.as_ref());
+            },
+            WindowEvent::CloseRequested => {
+                event_loop.exit();
+            },
+            _ => {},
+        }
+    }
+}
+
+#[cfg(not(windows))]
+fn main() -> Result<(), Box<dyn Error>> {
+    println!("This example is only supported on Windows.");
+    Ok(())
+}

--- a/examples/topless.rs
+++ b/examples/topless.rs
@@ -23,19 +23,22 @@ use ::tracing::info;
 fn main() -> Result<(), Box<dyn Error>> {
     tracing::init();
 
-    println!("Topless mode (Windows only):
+    println!(
+        "Topless mode (Windows only):
       − title bar         (WS_CAPTION) via with_titlebar         (false)
       + resize border     (WS_SIZEBOX) via with_resizable        (true ) ≝
       − top resize border              via with_top_resize_border(false)
         ├ not a separate WS_ window style, 'manual' removal on NonClientArea events
-        └ only implemented for windows without a title bar, eg, with a custom title bar handling resizing from the top
+        └ only implemented for windows without a title bar, eg, with a custom title bar handling \
+         resizing from the top
     ——————————————————————————————
     Press a key for (un)setting/querying a specific parameter (modifiers are ignored):
                          on  off  toggle  status
     title bar            q    w     e        r
     resize border        a    s     d        f
     ─ top resize border  z    x     c        v
-    ");
+    "
+    );
 
     let event_loop = EventLoop::new()?;
 
@@ -65,14 +68,13 @@ use winit::platform::windows::WindowExtWindows;
 #[cfg(windows_platform)]
 impl ApplicationHandler for Application {
     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-        let window_attributes =
-            WindowAttributes::default().with_title("Topless (unless you see this)!")
-            .with_decorations      (true )// decorations       ≝true
-            .with_titlebar         (false)// titlebar          ≝true
-            .with_resizable        (true )// resizable         ≝true
-            .with_top_resize_border(false)// top_resize_border ≝true
-            .with_position(dpi::Position::Logical(dpi::LogicalPosition::new(0.0,0.0)))// position: Option<Position>
-            ;
+        let window_attributes = WindowAttributes::default()
+            .with_title("Topless (unless you see this)!")
+            .with_decorations(true) //       decorations       ≝true
+            .with_titlebar(false) //         titlebar          ≝true
+            .with_resizable(true) //         resizable         ≝true
+            .with_top_resize_border(false) // top_resize_border ≝true
+            .with_position(dpi::Position::Logical(dpi::LogicalPosition::new(0.0, 0.0)));
         self.window = Some(event_loop.create_window(window_attributes).unwrap());
     }
 
@@ -84,25 +86,64 @@ impl ApplicationHandler for Application {
     ) {
         let win = match self.window.as_ref() {
             Some(win) => win,
-            None      => return,
+            None => return,
         };
         let _modi = ModifiersState::default();
         match event {
             WindowEvent::KeyboardInput { event, .. } => {
                 if event.state == ElementState::Pressed && !event.repeat {
                     match event.key_without_modifiers().as_ref() {
-                        Key::Character("q") => {win.set_titlebar(true )                                                	;info!("set_titlebar         → true")}
-                        Key::Character("w") => {win.set_titlebar(false)                                                	;info!("set_titlebar         → false")}
-                        Key::Character("e") => {let flip = !win.is_titlebar()         ; win.set_titlebar         (flip)	;info!("set_titlebar         → {flip}")}
-                        Key::Character("r") => {let is   =  win.is_titlebar()                                          	;info!("is_titlebar          = {is}")}
-                        Key::Character("a") => {win.set_resizable(true )                                               	;info!("set_resizable        → true")}
-                        Key::Character("s") => {win.set_resizable(false)                                               	;info!("set_resizable        → false")}
-                        Key::Character("d") => {let flip = !win.is_resizable()        ; win.set_resizable        (flip)	;info!("set_resizable        → {flip}")}
-                        Key::Character("f") => {let is   =  win.is_resizable()                                         	;info!("is_resizable         = {is}")}
-                        Key::Character("z") => {win.set_top_resize_border(true )                                       	;info!("set_top_resize_border→ true")}
-                        Key::Character("x") => {win.set_top_resize_border(false)                                       	;info!("set_top_resize_border→ false")}
-                        Key::Character("c") => {let flip = !win.is_top_resize_border(); win.set_top_resize_border(flip)	;info!("set_top_resize_border→ {flip}")}
-                        Key::Character("v") => {let is   =  win.is_top_resize_border()                                 	;info!("is_top_resize_border = {is}")}
+                        Key::Character("q") => {
+                            win.set_titlebar(true);
+                            info!("set_titlebar         → true")
+                        },
+                        Key::Character("w") => {
+                            win.set_titlebar(false);
+                            info!("set_titlebar         → false")
+                        },
+                        Key::Character("e") => {
+                            let flip = !win.is_titlebar();
+                            win.set_titlebar(flip);
+                            info!("set_titlebar         → {flip}")
+                        },
+                        Key::Character("r") => {
+                            let is = win.is_titlebar();
+                            info!("is_titlebar          = {is}")
+                        },
+                        Key::Character("a") => {
+                            win.set_resizable(true);
+                            info!("set_resizable        → true")
+                        },
+                        Key::Character("s") => {
+                            win.set_resizable(false);
+                            info!("set_resizable        → false")
+                        },
+                        Key::Character("d") => {
+                            let flip = !win.is_resizable();
+                            win.set_resizable(flip);
+                            info!("set_resizable        → {flip}")
+                        },
+                        Key::Character("f") => {
+                            let is = win.is_resizable();
+                            info!("is_resizable         = {is}")
+                        },
+                        Key::Character("z") => {
+                            win.set_top_resize_border(true);
+                            info!("set_top_resize_border→ true")
+                        },
+                        Key::Character("x") => {
+                            win.set_top_resize_border(false);
+                            info!("set_top_resize_border→ false")
+                        },
+                        Key::Character("c") => {
+                            let flip = !win.is_top_resize_border();
+                            win.set_top_resize_border(flip);
+                            info!("set_top_resize_border→ {flip}")
+                        },
+                        Key::Character("v") => {
+                            let is = win.is_top_resize_border();
+                            info!("is_top_resize_border = {is}")
+                        },
                         _ => (),
                     }
                 }

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -37,6 +37,10 @@ with it, the migration guide should be added below the entry, like:
 
 ```
 
+```md
+- (WindowsOS) Fixed (removed) an invisible gap between the screen border and the window's visible border at 0 `x`/`y` coordinates due to the fact that window's invisible resize borders are considered part of a window box for positioning win32 APIs (`SetWindowPos`). Now an invisible resize border is treated the same as a shadow and `with_position` and `set_position` APIs are updated to offset the coordinates before communicating with win32 APIs. In some cases (when a window has no title bar, but does have resize borders), the top resize border becomes visible, but it's still ignored for consistency.
+```
+
 The migration guide could reference other migration examples in the current
 changelog entry.
 

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -17,6 +17,7 @@ on how to add them:
 - On Wayland, add `Window::common_api`.
 - On Windows, add `Window::some_rare_api`.
 - On Windows, add `WindowAttributesExtWindows::with_titlebar`, `Window::set_titlebar` to allow enabling/disabling titlebar separately from the resize border (currently combined in decorations).
+- On Windows, add `WindowAttributesExtWindows::is_top_resize_border`, `Window::set_top_resize_border` to allow enabling/disabling the top resize border when title bar is disabled. Allows implementing custom title bars that should handle the top resizing themselves.
 ```
 
 When the change requires non-trivial amount of work for users to comply

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -16,6 +16,7 @@ on how to add them:
 - On X11, add `Window::even_more_rare_api`.
 - On Wayland, add `Window::common_api`.
 - On Windows, add `Window::some_rare_api`.
+- On Windows, add `WindowAttributesExtWindows::with_titlebar`, `Window::set_titlebar` to allow enabling/disabling titlebar separately from the resize border (currently combined in decorations).
 ```
 
 When the change requires non-trivial amount of work for users to comply

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -291,6 +291,15 @@ pub trait WindowExtWindows {
     /// Returns `true` when windows have a titlebar (server-side or by Winit).
     fn is_titlebar(&self) -> bool;
 
+    /// Turn window top resize border on or off (for windows without a title bar).
+    /// By default this is enabled.
+    fn set_top_resize_border(&self, top_resize_border: bool);
+
+    /// Gets the window's current top resize border state (for windows without a title bar).
+    ///
+    /// Returns `true` when windows have a top resize border.
+    fn is_top_resize_border(&self) -> bool;
+
     /// Sets the preferred style of the window corners.
     ///
     /// Supported starting with Windows 11 Build 22000.
@@ -416,6 +425,18 @@ impl WindowExtWindows for dyn Window + '_ {
     }
 
     #[inline]
+    fn set_top_resize_border(&self, top_resize_border: bool) {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_top_resize_border(top_resize_border)
+    }
+
+    #[inline]
+    fn is_top_resize_border(&self) -> bool {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.is_top_resize_border()
+    }
+
+    #[inline]
     fn set_corner_preference(&self, preference: CornerPreference) {
         let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_corner_preference(preference)
@@ -508,6 +529,10 @@ pub trait WindowAttributesExtWindows {
     /// Enables/disables the window titlebar by setting `WS_CAPTION`.
     fn with_titlebar(self, titlebar: bool) -> Self;
 
+    /// Enables/disables the window's top resize border by setting its height to 0.
+    /// Only for windows without a title bar.
+    fn with_top_resize_border(self, top_resize_border: bool) -> Self;
+
     /// Enables or disables drag and drop support (enabled by default). Will interfere with other
     /// crates that use multi-threaded COM API (`CoInitializeEx` with `COINIT_MULTITHREADED`
     /// instead of `COINIT_APARTMENTTHREADED`) on the same thread. Note that winit may still
@@ -585,6 +610,12 @@ impl WindowAttributesExtWindows for WindowAttributes {
     #[inline]
     fn with_titlebar(mut self, titlebar: bool) -> Self {
         self.platform_specific.titlebar = titlebar;
+        self
+    }
+
+    #[inline]
+    fn with_top_resize_border(mut self, top_resize_border: bool) -> Self {
+        self.platform_specific.top_resize_border = top_resize_border;
         self
     }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -281,6 +281,16 @@ pub trait WindowExtWindows {
     /// Supported starting with Windows 11 Build 22000.
     fn set_title_text_color(&self, color: Color);
 
+    /// Turn window title bar on or off by setting `WS_CAPTION`.
+    /// By default this is enabled. Note that fullscreen windows
+    /// naturally do not have title bar.
+    fn set_titlebar(&self, titlebar: bool);
+
+    /// Gets the window's current titlebar state.
+    ///
+    /// Returns `true` when windows have a titlebar (server-side or by Winit).
+    fn is_titlebar(&self) -> bool;
+
     /// Sets the preferred style of the window corners.
     ///
     /// Supported starting with Windows 11 Build 22000.
@@ -394,6 +404,18 @@ impl WindowExtWindows for dyn Window + '_ {
     }
 
     #[inline]
+    fn set_titlebar(&self, titlebar: bool) {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.set_titlebar(titlebar)
+    }
+
+    #[inline]
+    fn is_titlebar(&self) -> bool {
+        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        window.is_titlebar()
+    }
+
+    #[inline]
     fn set_corner_preference(&self, preference: CornerPreference) {
         let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_corner_preference(preference)
@@ -483,6 +505,9 @@ pub trait WindowAttributesExtWindows {
     /// This sets `WS_EX_NOREDIRECTIONBITMAP`.
     fn with_no_redirection_bitmap(self, flag: bool) -> Self;
 
+    /// Enables/disables the window titlebar by setting `WS_CAPTION`.
+    fn with_titlebar(self, titlebar: bool) -> Self;
+
     /// Enables or disables drag and drop support (enabled by default). Will interfere with other
     /// crates that use multi-threaded COM API (`CoInitializeEx` with `COINIT_MULTITHREADED`
     /// instead of `COINIT_APARTMENTTHREADED`) on the same thread. Note that winit may still
@@ -554,6 +579,12 @@ impl WindowAttributesExtWindows for WindowAttributes {
     #[inline]
     fn with_no_redirection_bitmap(mut self, flag: bool) -> Self {
         self.platform_specific.no_redirection_bitmap = flag;
+        self
+    }
+
+    #[inline]
+    fn with_titlebar(mut self, titlebar: bool) -> Self {
+        self.platform_specific.titlebar = titlebar;
         self
     }
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1094,7 +1094,7 @@ unsafe fn public_window_callback_inner(
     window: HWND,
     msg: u32,
     wparam: WPARAM,
-    lparam: LPARAM,
+    mut lparam: LPARAM,
     userdata: &WindowData,
 ) -> LRESULT {
     let mut result = ProcResult::DefWindowProc(wparam);
@@ -2281,6 +2281,12 @@ unsafe fn public_window_callback_inner(
         },
 
         WM_NCACTIVATE => {
+            let window_flags = userdata.window_state_lock().window_flags;
+            if   !window_flags.contains(WindowFlags::TITLE_BAR)
+              && !window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
+              &&  window_flags.contains(WindowFlags::RESIZABLE) {
+                lparam = -1;
+            }
             let is_active = wparam != false.into();
             let active_focus_changed = userdata.window_state_lock().set_active(is_active);
             if active_focus_changed {

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1138,12 +1138,15 @@ unsafe fn public_window_callback_inner(
     let callback = || match msg {
         WM_NCCALCSIZE => {
             let window_flags = userdata.window_state_lock().window_flags;
-            // Remove top resize border from an untitled window t to free up area for, eg, a custom title bar, which should then handle resizing events itself
+            // Remove top resize border from an untitled window t to free up area for, eg, a custom
+            // title bar, which should then handle resizing events itself
             if wparam != 0
-              && !window_flags.contains(WindowFlags::TITLE_BAR)
-              && !window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
-              &&  window_flags.contains(WindowFlags::RESIZABLE)
-              && !util::is_maximized(window) { // maximized wins have no borders
+                && !window_flags.contains(WindowFlags::TITLE_BAR)
+                && !window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
+                && window_flags.contains(WindowFlags::RESIZABLE)
+                && !util::is_maximized(window)
+            {
+                // maximized wins have no borders
                 result = ProcResult::DefWindowProc(wparam);
                 let rect = unsafe { &mut *(lparam as *mut RECT) };
                 let adj_rect = userdata
@@ -2282,9 +2285,10 @@ unsafe fn public_window_callback_inner(
 
         WM_NCACTIVATE => {
             let window_flags = userdata.window_state_lock().window_flags;
-            if   !window_flags.contains(WindowFlags::TITLE_BAR)
-              && !window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
-              &&  window_flags.contains(WindowFlags::RESIZABLE) {
+            if !window_flags.contains(WindowFlags::TITLE_BAR)
+                && !window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
+                && window_flags.contains(WindowFlags::RESIZABLE)
+            {
                 lparam = -1;
             }
             let is_active = wparam != false.into();

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1138,6 +1138,24 @@ unsafe fn public_window_callback_inner(
     let callback = || match msg {
         WM_NCCALCSIZE => {
             let window_flags = userdata.window_state_lock().window_flags;
+            // Remove top resize border from an untitled window t to free up area for, eg, a custom title bar, which should then handle resizing events itself
+            if wparam != 0
+              && !window_flags.contains(WindowFlags::TITLE_BAR)
+              && !window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
+              &&  window_flags.contains(WindowFlags::RESIZABLE)
+              && !util::is_maximized(window) { // maximized wins have no borders
+                result = ProcResult::DefWindowProc(wparam);
+                let rect = unsafe { &mut *(lparam as *mut RECT) };
+                let adj_rect = userdata
+                    .window_state_lock()
+                    .window_flags
+                    .adjust_rect(window, *rect)
+                    .unwrap_or(*rect);
+                let border_top = rect.top - adj_rect.top;
+                let params = unsafe { &mut *(lparam as *mut NCCALCSIZE_PARAMS) };
+                params.rgrc[0].top -= border_top;
+                return;
+            }
             if wparam == 0 || window_flags.contains(WindowFlags::MARKER_DECORATIONS) {
                 result = ProcResult::DefWindowProc(wparam);
                 return;

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1144,7 +1144,8 @@ unsafe fn public_window_callback_inner(
                 && !window_flags.contains(WindowFlags::TITLE_BAR)
                 && !window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
                 && window_flags.contains(WindowFlags::RESIZABLE)
-                && !util::is_maximized(window) // max wins have no borders
+                && !util::is_maximized(window)
+            // max wins have no borders
             {
                 result = ProcResult::DefWindowProc(wparam);
                 let rect = unsafe { &mut *(lparam as *mut RECT) };

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1138,15 +1138,14 @@ unsafe fn public_window_callback_inner(
     let callback = || match msg {
         WM_NCCALCSIZE => {
             let window_flags = userdata.window_state_lock().window_flags;
-            // Remove top resize border from an untitled window t to free up area for, eg, a custom
+            // Remove top resize border from an untitled window to free up area for, eg, a custom
             // title bar, which should then handle resizing events itself
             if wparam != 0
                 && !window_flags.contains(WindowFlags::TITLE_BAR)
                 && !window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
                 && window_flags.contains(WindowFlags::RESIZABLE)
-                && !util::is_maximized(window)
+                && !util::is_maximized(window) // max wins have no borders
             {
-                // maximized wins have no borders
                 result = ProcResult::DefWindowProc(wparam);
                 let rect = unsafe { &mut *(lparam as *mut RECT) };
                 let adj_rect = userdata

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -32,6 +32,7 @@ pub struct PlatformSpecificWindowAttributes {
     pub title_text_color: Option<Color>,
     pub corner_preference: Option<CornerPreference>,
     pub titlebar: bool,
+    pub top_resize_border: bool,
 }
 
 impl Default for PlatformSpecificWindowAttributes {
@@ -52,6 +53,7 @@ impl Default for PlatformSpecificWindowAttributes {
             title_text_color: None,
             corner_preference: None,
             titlebar: true,
+            top_resize_border: true,
         }
     }
 }

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -31,6 +31,7 @@ pub struct PlatformSpecificWindowAttributes {
     pub title_background_color: Option<Color>,
     pub title_text_color: Option<Color>,
     pub corner_preference: Option<CornerPreference>,
+    pub titlebar: bool,
 }
 
 impl Default for PlatformSpecificWindowAttributes {
@@ -50,6 +51,7 @@ impl Default for PlatformSpecificWindowAttributes {
             title_background_color: None,
             title_text_color: None,
             corner_preference: None,
+            titlebar: true,
         }
     }
 }

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -16,11 +16,11 @@ use windows_sys::Win32::UI::HiDpi::{
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::GetActiveWindow;
 use windows_sys::Win32::UI::Input::Pointer::{POINTER_INFO, POINTER_TOUCH_INFO};
 use windows_sys::Win32::UI::WindowsAndMessaging::{
-    ClipCursor, GetClientRect, GetClipCursor, GetSystemMetrics, GetWindowPlacement, GetWindowRect,
-    IsIconic, ShowCursor, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM,
-    IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_WAIT,
-    SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SW_MAXIMIZE,
-    WINDOWPLACEMENT, GWL_STYLE, GetWindowLongW,
+    ClipCursor, GetClientRect, GetClipCursor, GetSystemMetrics, GetWindowLongW, GetWindowPlacement,
+    GetWindowRect, IsIconic, ShowCursor, GWL_STYLE, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS,
+    IDC_HAND, IDC_HELP, IDC_IBEAM, IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE,
+    IDC_SIZEWE, IDC_WAIT, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN,
+    SM_YVIRTUALSCREEN, SW_MAXIMIZE, WINDOWPLACEMENT,
 };
 
 use crate::utils::Lazy;
@@ -82,69 +82,97 @@ impl WindowArea {
     }
 }
 
-use windows_sys::Win32::UI::WindowsAndMessaging::{
-    AdjustWindowRectEx, WS_BORDER, WS_CLIPSIBLINGS, WS_EX_WINDOWEDGE, WS_EX_ACCEPTFILES, WS_SIZEBOX, WS_CAPTION, WS_SYSMENU, WS_DLGFRAME,
-};
 use windows_sys::Win32::Foundation::FALSE;
+use windows_sys::Win32::UI::WindowsAndMessaging::{
+    AdjustWindowRectEx, WS_BORDER, WS_CAPTION, WS_CLIPSIBLINGS, WS_DLGFRAME, WS_EX_ACCEPTFILES,
+    WS_EX_WINDOWEDGE, WS_SIZEBOX, WS_SYSMENU,
+};
 
 /// Get sizes for the invisible resize (`sizing`=`true`) or visible thin borders without having to
 /// carefully adjust the actual styles of a real window (since, e.g., removing a single `WS_BORDER`
-/// style may lead to other style changes being applied automatically depending on the style combinations,
-/// thus resulting in an incorrect estimate for the thin border that `WS_BORDER` sets)
+/// style may lead to other style changes being applied automatically depending on the style
+/// combinations, thus resulting in an incorrect estimate for the thin border that `WS_BORDER` sets)
 /// `hwnd` is only used for DPI adjustment.
 pub fn get_border_size(hwnd: HWND, sizing: bool) -> Result<dpi::PhysicalUnit<i32>, io::Error> {
-    let style    = if sizing { WS_SIZEBOX | WS_BORDER | WS_CLIPSIBLINGS | WS_SYSMENU
-    } else {                                WS_BORDER | WS_CLIPSIBLINGS | WS_SYSMENU};
-    let style_no = if sizing {              WS_BORDER | WS_CLIPSIBLINGS | WS_SYSMENU
-    } else {                                            WS_CLIPSIBLINGS | WS_SYSMENU};
+    let style = if sizing {
+        WS_SIZEBOX | WS_BORDER | WS_CLIPSIBLINGS | WS_SYSMENU
+    } else {
+        WS_BORDER | WS_CLIPSIBLINGS | WS_SYSMENU
+    };
+    let style_no = if sizing {
+        WS_BORDER | WS_CLIPSIBLINGS | WS_SYSMENU
+    } else {
+        WS_CLIPSIBLINGS | WS_SYSMENU
+    };
     let style_ex = WS_EX_WINDOWEDGE | WS_EX_ACCEPTFILES;
-    let mut rect_style   : RECT = unsafe{mem::zeroed()};
-    let mut rect_style_no: RECT = unsafe{mem::zeroed()};
-    win_to_err(unsafe{
+    let mut rect_style: RECT = unsafe { mem::zeroed() };
+    let mut rect_style_no: RECT = unsafe { mem::zeroed() };
+    win_to_err(unsafe {
         if let (Some(get_dpi_for_window), Some(adjust_window_rect_ex_for_dpi)) =
             (*GET_DPI_FOR_WINDOW, *ADJUST_WINDOW_RECT_EX_FOR_DPI)
-        {  let dpi = {get_dpi_for_window(hwnd)};
-            adjust_window_rect_ex_for_dpi(&mut rect_style   , style   , FALSE, style_ex, dpi);
+        {
+            let dpi = { get_dpi_for_window(hwnd) };
+            adjust_window_rect_ex_for_dpi(&mut rect_style, style, FALSE, style_ex, dpi);
             adjust_window_rect_ex_for_dpi(&mut rect_style_no, style_no, FALSE, style_ex, dpi)
         } else {
-            AdjustWindowRectEx           (&mut rect_style   , style   , FALSE, style_ex     );
-            AdjustWindowRectEx           (&mut rect_style_no, style_no, FALSE, style_ex     )
+            AdjustWindowRectEx(&mut rect_style, style, FALSE, style_ex);
+            AdjustWindowRectEx(&mut rect_style_no, style_no, FALSE, style_ex)
         }
     })?;
     Ok(dpi::PhysicalUnit(rect_style_no.left - rect_style.left))
 }
 
 use crate::platform_impl::windows::window_state::WindowFlags;
-/// Get the size of the resize borders as an offset in physical coordinates. Takes into account various
-/// window styles to only return offset if it would prevent placing a 0,0 window in the screen's corner
-pub fn get_offset_resize_border(hwnd: HWND, win_flags: WindowFlags) -> Result<dpi::PhysicalInsets<i32>, io::Error> {
+/// Get the size of the resize borders as an offset in physical coordinates. Takes into account
+/// various window styles to only return offset if it would prevent placing a 0,0 window in the
+/// screen's corner
+pub fn get_offset_resize_border(
+    hwnd: HWND,
+    win_flags: WindowFlags,
+) -> Result<dpi::PhysicalInsets<i32>, io::Error> {
     let mut offset = dpi::PhysicalInsets::new(0, 0, 0, 0);
-    if !is_maximized(hwnd) {                           // resize borders not pushed off-screen
-        let style = unsafe{GetWindowLongW(hwnd, GWL_STYLE) as u32};
-        if style & WS_SIZEBOX == WS_SIZEBOX {          // ...actually exist
-            if !win_flags.contains(WindowFlags::RESIZABLE) {tracing::warn!("Window has resize borders, but is configured not to have them");}
+    if !is_maximized(hwnd) {
+        // resize borders not pushed off-screen
+        let style = unsafe { GetWindowLongW(hwnd, GWL_STYLE) as u32 };
+        if style & WS_SIZEBOX == WS_SIZEBOX {
+            // ...actually exist
+            if !win_flags.contains(WindowFlags::RESIZABLE) {
+                tracing::warn!("Window has resize borders, but is configured not to have them");
+            }
             let border_sizing = get_border_size(hwnd, true)?;
             offset.left = border_sizing.0; // ←left: always offset
 
-            if style & WS_CAPTION != WS_CAPTION {            // no caption (≝title+border) exists
-                if win_flags.contains(WindowFlags::TITLE_BAR) {tracing::warn!("Window has no title bar, but is configured to have it");}
-                if win_flags.contains(WindowFlags::TOP_RESIZE_BORDER) { // top resize border is NOT removed "manually"
-                    offset.top  = border_sizing.0  ; // ↑top: offset if no title bar (border is now visible)
+            if style & WS_CAPTION != WS_CAPTION {
+                // no caption (≝title+border) exists
+                if win_flags.contains(WindowFlags::TITLE_BAR) {
+                    tracing::warn!("Window has no title bar, but is configured to have it");
+                }
+                if win_flags.contains(WindowFlags::TOP_RESIZE_BORDER) {
+                    // top resize border is NOT removed "manually"
+                    offset.top = border_sizing.0; // ↑top: offset if no title bar (border is now
+                                                  // visible)
                 }
             }
-        } else if style & WS_DLGFRAME == WS_DLGFRAME { // or is substituted by dlgFrame in win32's window box, which is an invisible border that does nothing
+        } else if style & WS_DLGFRAME == WS_DLGFRAME {
+            // or is substituted by dlgFrame in win32's window box, which is an invisible border
+            // that does nothing
             let border_sizing = get_border_size(hwnd, true)?;
             offset.left = border_sizing.0; // ←left: always offset
 
-            if style & WS_CAPTION != WS_CAPTION {            // no caption (≝title+border) exists
-                if win_flags.contains(WindowFlags::TITLE_BAR) {tracing::warn!("Window has no title bar, but is configured to have it");}
-                if win_flags.contains(WindowFlags::TOP_RESIZE_BORDER) { // top resize border is NOT removed "manually"
-                    offset.top  = border_sizing.0  ; // ↑top: offset if no title bar (border is now visible)
+            if style & WS_CAPTION != WS_CAPTION {
+                // no caption (≝title+border) exists
+                if win_flags.contains(WindowFlags::TITLE_BAR) {
+                    tracing::warn!("Window has no title bar, but is configured to have it");
+                }
+                if win_flags.contains(WindowFlags::TOP_RESIZE_BORDER) {
+                    // top resize border is NOT removed "manually"
+                    offset.top = border_sizing.0; // ↑top: offset if no title bar (border is now
+                                                  // visible)
                 }
             }
         }
     }
-    offset.right  = offset.left; // resize borders are the same
+    offset.right = offset.left; // resize borders are the same
     offset.bottom = offset.left;
     Ok(offset)
 }

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -137,7 +137,7 @@ pub fn get_offset_resize_border(
         if style & WS_SIZEBOX == WS_SIZEBOX {
             // ...actually exist
             if !win_flags.contains(WindowFlags::RESIZABLE) {
-                tracing::warn!("Window has resize borders, but is configured not to have them");
+                tracing::debug!("Window has resize borders, but is configured not to have them");
             }
             let border_sizing = get_border_size(hwnd, true)?;
             offset.left = border_sizing.0; // ←left: always offset
@@ -145,7 +145,7 @@ pub fn get_offset_resize_border(
             if style & WS_CAPTION != WS_CAPTION {
                 // no caption (≝title+border) exists
                 if win_flags.contains(WindowFlags::TITLE_BAR) {
-                    tracing::warn!("Window has no title bar, but is configured to have it");
+                    tracing::debug!("Window has no title bar, but is configured to have it");
                 }
                 if win_flags.contains(WindowFlags::TOP_RESIZE_BORDER) {
                     // top resize border is NOT removed "manually"
@@ -162,7 +162,7 @@ pub fn get_offset_resize_border(
             if style & WS_CAPTION != WS_CAPTION {
                 // no caption (≝title+border) exists
                 if win_flags.contains(WindowFlags::TITLE_BAR) {
-                    tracing::warn!("Window has no title bar, but is configured to have it");
+                    tracing::debug!("Window has no title bar, but is configured to have it");
                 }
                 if win_flags.contains(WindowFlags::TOP_RESIZE_BORDER) {
                     // top resize border is NOT removed "manually"

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -319,6 +319,25 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_titlebar(&self, titlebar: bool) {
+        let window = self.window;
+        let window_state = Arc::clone(&self.window_state);
+
+        self.thread_executor.execute_in_thread(move || {
+            let _ = &window;
+            WindowState::set_window_flags(window_state.lock().unwrap(), window, |f| {
+                f.set(WindowFlags::TITLE_BAR, titlebar)
+            });
+        });
+    }
+
+    #[inline]
+    pub fn is_titlebar(&self) -> bool {
+        let window_state = self.window_state_lock();
+        window_state.window_flags.contains(WindowFlags::TITLE_BAR)
+    }
+
+    #[inline]
     pub fn set_corner_preference(&self, preference: CornerPreference) {
         unsafe {
             DwmSetWindowAttribute(
@@ -1259,6 +1278,7 @@ unsafe fn init(
 
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
+    window_flags.set(WindowFlags::TITLE_BAR, attributes.platform_specific.titlebar);
     window_flags.set(
         WindowFlags::MARKER_UNDECORATED_SHADOW,
         attributes.platform_specific.decoration_shadow,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -42,7 +42,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     HTTOPLEFT, HTTOPRIGHT, MENU_ITEM_STATE, MFS_DISABLED, MFS_ENABLED, MF_BYCOMMAND, NID_READY,
     PM_NOREMOVE, SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_MOVE, SC_RESTORE, SC_SIZE, SM_DIGITIZER,
     SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, TPM_LEFTALIGN, TPM_RETURNCMD,
-    WDA_EXCLUDEFROMCAPTURE, WDA_NONE, WM_NCLBUTTONDOWN, WM_SYSCOMMAND, WNDCLASSEXW,
+    WDA_EXCLUDEFROMCAPTURE, WDA_NONE, WM_NCLBUTTONDOWN, WM_SYSCOMMAND, WNDCLASSEXW
 };
 
 use crate::cursor::Cursor;
@@ -447,7 +447,13 @@ impl CoreWindow for Window {
     fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
         util::WindowArea::Outer
             .get_rect(self.hwnd())
-            .map(|rect| Ok(PhysicalPosition::new(rect.left, rect.top)))
+            .map(|rect| {
+                if let Ok(offset) = util::get_offset_resize_border(self.hwnd(), self.window_state_lock().window_flags) {
+                    Ok(PhysicalPosition::new(rect.left + offset.left, rect.top + offset.top))
+                } else {
+                    Ok(PhysicalPosition::new(rect.left              , rect.top             ))
+                }
+            })
             .expect(
                 "Unexpected GetWindowRect failure; please report this error to \
                  rust-windowing/winit",
@@ -467,6 +473,11 @@ impl CoreWindow for Window {
 
     fn set_outer_position(&self, position: Position) {
         let (x, y): (i32, i32) = position.to_physical::<i32>(self.scale_factor()).into();
+        let (x_off, y_off) = if let Ok(offset) = util::get_offset_resize_border(self.hwnd(), self.window_state_lock().window_flags) {
+            (offset.left, offset.top)
+        } else {
+            (0,0)
+        };
 
         let window_state = Arc::clone(&self.window_state);
         let window = self.window;
@@ -481,8 +492,8 @@ impl CoreWindow for Window {
             SetWindowPos(
                 self.hwnd(),
                 0,
-                x,
-                y,
+                x - x_off,
+                y - y_off,
                 0,
                 0,
                 SWP_ASYNCWINDOWPOS | SWP_NOZORDER | SWP_NOSIZE | SWP_NOACTIVATE,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -1298,7 +1298,8 @@ unsafe fn init(
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
     window_flags.set(WindowFlags::TITLE_BAR, attributes.platform_specific.titlebar);
-    window_flags.set(WindowFlags::TOP_RESIZE_BORDER, attributes.platform_specific.top_resize_border);
+    window_flags
+        .set(WindowFlags::TOP_RESIZE_BORDER, attributes.platform_specific.top_resize_border);
     window_flags.set(
         WindowFlags::MARKER_UNDECORATED_SHADOW,
         attributes.platform_specific.decoration_shadow,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -42,7 +42,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     HTTOPLEFT, HTTOPRIGHT, MENU_ITEM_STATE, MFS_DISABLED, MFS_ENABLED, MF_BYCOMMAND, NID_READY,
     PM_NOREMOVE, SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_MOVE, SC_RESTORE, SC_SIZE, SM_DIGITIZER,
     SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, TPM_LEFTALIGN, TPM_RETURNCMD,
-    WDA_EXCLUDEFROMCAPTURE, WDA_NONE, WM_NCLBUTTONDOWN, WM_SYSCOMMAND, WNDCLASSEXW
+    WDA_EXCLUDEFROMCAPTURE, WDA_NONE, WM_NCLBUTTONDOWN, WM_SYSCOMMAND, WNDCLASSEXW,
 };
 
 use crate::cursor::Cursor;
@@ -449,10 +449,13 @@ impl CoreWindow for Window {
         util::WindowArea::Outer
             .get_rect(self.hwnd())
             .map(|rect| {
-                if let Ok(offset) = util::get_offset_resize_border(self.hwnd(), self.window_state_lock().window_flags) {
+                if let Ok(offset) = util::get_offset_resize_border(
+                    self.hwnd(),
+                    self.window_state_lock().window_flags,
+                ) {
                     Ok(PhysicalPosition::new(rect.left + offset.left, rect.top + offset.top))
                 } else {
-                    Ok(PhysicalPosition::new(rect.left              , rect.top             ))
+                    Ok(PhysicalPosition::new(rect.left, rect.top))
                 }
             })
             .expect(
@@ -475,10 +478,12 @@ impl CoreWindow for Window {
     // TODO: limit to Windows 10 (and maybe 11?)
     fn set_outer_position(&self, position: Position) {
         let (x, y): (i32, i32) = position.to_physical::<i32>(self.scale_factor()).into();
-        let (x_off, y_off) = if let Ok(offset) = util::get_offset_resize_border(self.hwnd(), self.window_state_lock().window_flags) {
+        let (x_off, y_off) = if let Ok(offset) =
+            util::get_offset_resize_border(self.hwnd(), self.window_state_lock().window_flags)
+        {
             (offset.left, offset.top)
         } else {
-            (0,0)
+            (0, 0)
         };
 
         let window_state = Arc::clone(&self.window_state);

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -444,6 +444,7 @@ impl CoreWindow for Window {
 
     fn pre_present_notify(&self) {}
 
+    // TODO: limit to Windows 10 (and maybe 11?)
     fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
         util::WindowArea::Outer
             .get_rect(self.hwnd())
@@ -471,6 +472,7 @@ impl CoreWindow for Window {
         PhysicalPosition::new(rect.left, rect.top)
     }
 
+    // TODO: limit to Windows 10 (and maybe 11?)
     fn set_outer_position(&self, position: Position) {
         let (x, y): (i32, i32) = position.to_physical::<i32>(self.scale_factor()).into();
         let (x_off, y_off) = if let Ok(offset) = util::get_offset_resize_border(self.hwnd(), self.window_state_lock().window_flags) {

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -338,6 +338,25 @@ impl Window {
     }
 
     #[inline]
+    pub fn set_top_resize_border(&self, top_resize_border: bool) {
+        let window = self.window;
+        let window_state = Arc::clone(&self.window_state);
+
+        self.thread_executor.execute_in_thread(move || {
+            let _ = &window;
+            WindowState::set_window_flags(window_state.lock().unwrap(), window, |f| {
+                f.set(WindowFlags::TOP_RESIZE_BORDER, top_resize_border)
+            });
+        });
+    }
+
+    #[inline]
+    pub fn is_top_resize_border(&self) -> bool {
+        let window_state = self.window_state_lock();
+        window_state.window_flags.contains(WindowFlags::TOP_RESIZE_BORDER)
+    }
+
+    #[inline]
     pub fn set_corner_preference(&self, preference: CornerPreference) {
         unsafe {
             DwmSetWindowAttribute(
@@ -1279,6 +1298,7 @@ unsafe fn init(
     let mut window_flags = WindowFlags::empty();
     window_flags.set(WindowFlags::MARKER_DECORATIONS, attributes.decorations);
     window_flags.set(WindowFlags::TITLE_BAR, attributes.platform_specific.titlebar);
+    window_flags.set(WindowFlags::TOP_RESIZE_BORDER, attributes.platform_specific.top_resize_border);
     window_flags.set(
         WindowFlags::MARKER_UNDECORATED_SHADOW,
         attributes.platform_specific.decoration_shadow,

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -125,6 +125,8 @@ bitflags! {
 
         const CLIP_CHILDREN = 1 << 22;
 
+        const TITLE_BAR = 1 << 23; //0x__800000 on Windows sets WS_CAPTION (0x__C00000)
+
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits();
     }
 }
@@ -288,6 +290,9 @@ impl WindowFlags {
                 style &= !(WS_CAPTION | WS_BORDER);
                 style_ex &= !WS_EX_WINDOWEDGE;
             }
+            if !self.contains(WindowFlags::TITLE_BAR) {
+                style &= !WS_CAPTION;
+            }
         }
         if self.contains(WindowFlags::POPUP) {
             style |= WS_POPUP;
@@ -303,6 +308,11 @@ impl WindowFlags {
         }
         if self.contains(WindowFlags::CLIP_CHILDREN) {
             style |= WS_CLIPCHILDREN;
+        }
+        if self.contains(WindowFlags::TITLE_BAR) {
+            style |= WS_CAPTION;
+        } else {
+            style &= !WS_CAPTION;
         }
 
         if self.intersects(
@@ -435,6 +445,9 @@ impl WindowFlags {
             // `WM_NCCALCSIZE`.
             if !self.contains(WindowFlags::MARKER_DECORATIONS) {
                 style &= !(WS_CAPTION | WS_SIZEBOX);
+            }
+            if !self.contains(WindowFlags::TITLE_BAR) {
+                style &= !WS_CAPTION;
             }
 
             util::win_to_err({

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -127,6 +127,10 @@ bitflags! {
 
         const TITLE_BAR = 1 << 23; //0x__800000 on Windows sets WS_CAPTION (0x__C00000)
 
+        /// Unset to signal that a window without a title bar, eg, with a custom one,
+        /// does not need a ~6px resize border at the top. No effect on a titled window.
+        const TOP_RESIZE_BORDER = 1 << 24; //0x_1000000
+
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits();
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -616,8 +616,8 @@ pub trait Window: AsAny + Send + Sync {
     /// ## Platform-specific
     ///
     /// - **Web:** Returns the top-left coordinates relative to the viewport.
-    /// - **Windows:** Ignores the invisible resize borders (as well as the top visible resize border
-    ///   that appears when if a window has no title bar) on Windows 10.
+    /// - **Windows:** Ignores the invisible resize borders (as well as the top visible resize
+    ///   border that appears when if a window has no title bar) on Windows 10.
     /// - **Android / Wayland:** Always returns [`RequestError::NotSupported`].
     // TODO: document Windows 11 if it's also part of the limit?
     fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError>;

--- a/src/window.rs
+++ b/src/window.rs
@@ -188,6 +188,7 @@ impl WindowAttributes {
     ///   that appears when a window has no title bar) on Windows 10.
     /// - **X11:** The top left corner of the window, the window's "outer" position.
     /// - **Others:** Ignored.
+    // TODO: document Windows 11 if it's also part of the limit?
     #[inline]
     pub fn with_position<P: Into<Position>>(mut self, position: P) -> Self {
         self.position = Some(position.into());
@@ -618,6 +619,7 @@ pub trait Window: AsAny + Send + Sync {
     /// - **Windows:** Ignores the invisible resize borders (as well as the top visible resize border
     ///   that appears when if a window has no title bar) on Windows 10.
     /// - **Android / Wayland:** Always returns [`RequestError::NotSupported`].
+    // TODO: document Windows 11 if it's also part of the limit?
     fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError>;
 
     /// Sets the position of the window on the desktop.

--- a/src/window.rs
+++ b/src/window.rs
@@ -185,7 +185,8 @@ impl WindowAttributes {
     ///   [`Window::set_outer_position`] after creating the window.
     /// - **Windows:** The top left corner position of the window title bar, the window's "outer"
     ///   position. Ignores the invisible resize borders (as well as the top visible resize border
-    ///   that appears when a window has no title bar) on Windows 10.
+    ///   that appears if a window has no title bar) on Windows 10. Thin borders are not ignored,
+    ///   though they may also be invisible (and if resize borders exist, also resize).
     /// - **X11:** The top left corner of the window, the window's "outer" position.
     /// - **Others:** Ignored.
     // TODO: document Windows 11 if it's also part of the limit?
@@ -617,7 +618,8 @@ pub trait Window: AsAny + Send + Sync {
     ///
     /// - **Web:** Returns the top-left coordinates relative to the viewport.
     /// - **Windows:** Ignores the invisible resize borders (as well as the top visible resize
-    ///   border that appears when if a window has no title bar) on Windows 10.
+    ///   border that appears if a window has no title bar) on Windows 10. Thin borders are
+    ///   not ignored, though they may also be invisible (and if resize borders exist, also resize).
     /// - **Android / Wayland:** Always returns [`RequestError::NotSupported`].
     // TODO: document Windows 11 if it's also part of the limit?
     fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError>;

--- a/src/window.rs
+++ b/src/window.rs
@@ -184,8 +184,8 @@ impl WindowAttributes {
     ///   position the top left corner of the whole window you have to use
     ///   [`Window::set_outer_position`] after creating the window.
     /// - **Windows:** The top left corner position of the window title bar, the window's "outer"
-    ///   position. There may be a small gap between this position and the window due to the
-    ///   specifics of the Window Manager.
+    ///   position. Ignores the invisible resize borders (as well as the top visible resize border
+    ///   that appears when a window has no title bar) on Windows 10.
     /// - **X11:** The top left corner of the window, the window's "outer" position.
     /// - **Others:** Ignored.
     #[inline]
@@ -615,6 +615,8 @@ pub trait Window: AsAny + Send + Sync {
     /// ## Platform-specific
     ///
     /// - **Web:** Returns the top-left coordinates relative to the viewport.
+    /// - **Windows:** Ignores the invisible resize borders (as well as the top visible resize border
+    ///   that appears when if a window has no title bar) on Windows 10.
     /// - **Android / Wayland:** Always returns [`RequestError::NotSupported`].
     fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError>;
 


### PR DESCRIPTION
Removes invisible gaps between the screen border and window border that is comprized of an invisible resize border that win32 APIs consider to be part of the outer window box, so when winit uses `0,0` position, this applies to the invisible left window resize border, not the visible window border

(without a caption, the top resize border becomes visible, but is treated the same for consistency)

this is on top of https://github.com/rust-windowing/winit/pull/4100 to test interactions with the border-removing functionality introduced there

**Question**:
- how to make this border adjustment only work in a specific Windows version? My guess is this should work **incorrectly** in Windows 7 since those windows had **visible** resize borders, only Win10 introduced **invisible** resize borders 
- as an alternative fix: is there a way to simply determine which border pixels for a given window are transparent? Then this could resolve the Win version, but also improve the API itself to reflect the base desire to move the **visible** window and have no gaps

**Before**: Gap = RegularBorder + ResizeBorder
<img width="100" alt="ToplessBefore Gap = RegularBorder + ResizeBorder" src="https://github.com/user-attachments/assets/2904e1fb-558d-483e-9f4d-0059d54d4ec2" />
<img width="100" alt="ToplessAfter Gap = RegularBorder" src="https://github.com/user-attachments/assets/4303fdf8-c005-482b-bfde-f29b237e73c6" />
**After**: Gap = RegularBorder (in this case it's transparent, but for some other windows it's not, this PR doesn't touch it because it can't determine which case it is)

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality. The example from the previous PR should suffice

closes https://github.com/rust-windowing/winit/issues/4107

