### PR TITLE
Bump version on master

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ name = "winit"
 readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.30.7"
+version = "0.30.9"
 
 [package.metadata.docs.rs]
 features = [

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```toml
 [dependencies]
-winit = "0.30.7"
+winit = "0.30.9"
 ```
 
 ## [Documentation](https://docs.rs/winit)

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -71,8 +71,6 @@ changelog entry.
 - Added `Window::safe_area`, which describes the area of the surface that is unobstructed.
 - On X11, Wayland, Windows and macOS, improved scancode conversions for more obscure key codes.
 - Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`.
-- `ActivationToken::from_raw` and `ActivationToken::into_raw`.
-- On X11, add a workaround for disabling IME on GNOME.
 
 ### Changed
 
@@ -164,7 +162,6 @@ changelog entry.
 - Update `smol_str` to version `0.3`
 - Rename `VideoModeHandle` to `VideoMode`, now it only stores plain data.
 - Make `Fullscreen::Exclusive` contain `(MonitorHandle, VideoMode)`.
-- On Wayland, no longer send an explicit clearing `Ime::Preedit` just prior to a new `Ime::Preedit`.
 - Reworked the file drag-and-drop API.
 
   The `WindowEvent::DroppedFile`, `WindowEvent::HoveredFile` and `WindowEvent::HoveredFileCancelled`
@@ -225,7 +222,3 @@ changelog entry.
 - On macOS, fixed the scancode conversion for audio volume keys.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
-- On Windows, fixed the event loop not waking on accessibility requests.
-- On X11, fixed cursor grab mode state tracking on error.
-- On X11, fixed crash with uim
-- On iOS, maybe fixed high CPU usage even when using `ControlFlow::Wait`.

--- a/src/changelog/v0.30.md
+++ b/src/changelog/v0.30.md
@@ -1,3 +1,27 @@
+## 0.30.9
+
+### Changed
+
+- On Wayland, no longer send an explicit clearing `Ime::Preedit` just prior to a new `Ime::Preedit`.
+
+### Fixed
+
+- On X11, fix crash with uim.
+- On X11, fix modifiers for keys that were sent by the same X11 request.
+- On iOS, fix high CPU usage even when using `ControlFlow::Wait`.
+
+## 0.30.8
+
+### Added
+
+- `ActivationToken::from_raw` and `ActivationToken::into_raw`.
+- On X11, add a workaround for disabling IME on GNOME.
+
+### Fixed
+
+- On Windows, fixed the event loop not waking on accessibility requests.
+- On X11, fixed cursor grab mode state tracking on error.
+
 ## 0.30.7
 
 ### Fixed

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -62,7 +62,7 @@
 //! If your application is currently based on `NativeActivity` via the `ndk-glue` crate and building
 //! with `cargo apk`, then the minimal changes would be:
 //! 1. Remove `ndk-glue` from your `Cargo.toml`
-//! 2. Enable the `"android-native-activity"` feature for Winit: `winit = { version = "0.30.7",
+//! 2. Enable the `"android-native-activity"` feature for Winit: `winit = { version = "0.30.9",
 //!    features = [ "android-native-activity" ] }`
 //! 3. Add an `android_main` entrypoint (as above), instead of using the '`[ndk_glue::main]` proc
 //!    macro from `ndk-macros` (optionally add a dependency on `android_logger` and initialize


### PR DESCRIPTION
This commit does not represent a release and only synchronizes CHANGELOG from the latest release.

This also includes 0.30.8 sync, since it was forgotten.


--

Will merge once the 0.30.9 is out.