### PR TITLE
Web: Use touch events instead of pointer events for touch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,7 +319,7 @@ pin-project = "1"
 wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.43"
 web-time = "1"
-web_sys = { package = "web-sys", version = "0.3.70", features = [
+web-sys = { version = "0.3.70", features = [
     "AbortController",
     "AbortSignal",
     "Blob",
@@ -365,6 +365,9 @@ web_sys = { package = "web-sys", version = "0.3.70", features = [
     "ResizeObserverSize",
     "Screen",
     "ScreenOrientation",
+    "Touch",
+    "TouchEvent",
+    "TouchList",
     "Url",
     "VisibilityState",
     "WheelEvent",

--- a/src/platform_impl/web/event_loop/window_target.rs
+++ b/src/platform_impl/web/event_loop/window_target.rs
@@ -239,6 +239,28 @@ impl ActiveEventLoop {
                 })))
             }
         });
+        
+        canvas.on_touch_move(
+            {
+                let runner = self.runner.clone();
+
+                move |device_id, events| {
+                    runner.send_events(events.into_iter().map(
+                        |(position, pointer_source)| {
+                            Event::WindowEvent {
+                                window_id,
+                                event: WindowEvent::PointerMoved {
+                                    device_id,
+                                    position,
+                                    primary: false, // TODO: find out when this should be true
+                                    source: pointer_source,
+                                }
+                            }
+                        },
+                    ));
+                }
+            },
+        );
 
         canvas.on_pointer_move(
             {

--- a/src/platform_impl/web/web_sys/canvas.rs
+++ b/src/platform_impl/web/web_sys/canvas.rs
@@ -391,6 +391,21 @@ impl Canvas {
             Rc::clone(&self.prevent_default),
         )
     }
+    
+    pub fn on_touch_move<C>(&self, cursor_handler: C)
+    where
+        C: 'static
+        + FnMut(
+            Option<DeviceId>,
+            Vec<(PhysicalPosition<f64>, PointerSource)> // TODO: change to &mut dyn Iterator
+        ),
+    {
+        self.handlers.borrow_mut().pointer_handler.on_touch_move(
+            &self.common,
+            cursor_handler,
+            Rc::clone(&self.prevent_default),
+        )
+    }
 
     pub fn on_mouse_wheel<F>(&self, mut handler: F)
     where

--- a/src/platform_impl/web/web_sys/mod.rs
+++ b/src/platform_impl/web/web_sys/mod.rs
@@ -6,6 +6,7 @@ mod fullscreen;
 mod intersection_handle;
 mod media_query_handle;
 mod pointer;
+mod touch;
 mod resize_scaling;
 mod safe_area;
 mod schedule;

--- a/src/platform_impl/web/web_sys/pointer.rs
+++ b/src/platform_impl/web/web_sys/pointer.rs
@@ -1,13 +1,13 @@
 use std::cell::Cell;
 use std::rc::Rc;
-
-use web_sys::PointerEvent;
-
+use tracing::{error, info};
+use web_sys::{PointerEvent, TouchEvent};
+use dpi::LogicalPosition;
 use super::canvas::Common;
 use super::event;
 use super::event_handle::EventListenerHandle;
 use crate::dpi::PhysicalPosition;
-use crate::event::{ButtonSource, DeviceId, ElementState, Force, PointerKind, PointerSource};
+use crate::event::{ButtonSource, DeviceId, ElementState, FingerId, Force, PointerKind, PointerSource};
 use crate::keyboard::ModifiersState;
 use crate::platform_impl::web::event::mkdid;
 
@@ -19,6 +19,7 @@ pub(super) struct PointerHandler {
     on_pointer_press: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
     on_pointer_release: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
     on_touch_cancel: Option<EventListenerHandle<dyn FnMut(PointerEvent)>>,
+    on_touch_move: Option<EventListenerHandle<dyn FnMut(TouchEvent)>>,
 }
 
 impl PointerHandler {
@@ -30,6 +31,7 @@ impl PointerHandler {
             on_pointer_press: None,
             on_pointer_release: None,
             on_touch_cancel: None,
+            on_touch_move: None,
         }
     }
 
@@ -186,6 +188,11 @@ impl PointerHandler {
                 let pointer_id = event.pointer_id();
                 let device_id = mkdid(pointer_id);
                 let kind = event::pointer_type(&event, pointer_id);
+                if let PointerKind::Touch(_) = kind {
+                    return; // We handle touch events with touchmove
+                    // TODO: Perhaps this should be a toggleable option. 
+                    // If not, then remove the touch related code below
+                }
                 let primary = event.is_primary();
 
                 // chorded button event
@@ -252,6 +259,56 @@ impl PointerHandler {
                             },
                         )
                     }),
+                );
+            }));
+    }
+    
+    pub fn on_touch_move<C>(
+        &mut self,
+        canvas_common: &Common,
+        mut cursor_handler: C,
+        prevent_default: Rc<Cell<bool>>,
+    ) where
+        C: 'static
+        + FnMut(
+            Option<DeviceId>,
+            Vec<(PhysicalPosition<f64>, PointerSource)> // TODO: change to &mut dyn Iterator
+        ),
+    {
+        let window = canvas_common.window.clone();
+        let canvas = canvas_common.raw().clone();
+        self.on_touch_move =
+            Some(canvas_common.add_event("touchmove", move |event: TouchEvent| {
+                if prevent_default.get() {
+                    // prevent text selection
+                    event.prevent_default();
+                    // but still focus element
+                    let _ = canvas.focus();
+                }
+                let mut i = 0;
+                let mut event_items = vec![];
+                let mut device_id = None;
+                loop {
+                    if let Some(touch) = event.changed_touches().get(i) {
+                        i += 1;
+                        let position = LogicalPosition::new(
+                            touch.client_x() as f64,
+                            touch.client_y() as f64,
+                        ).to_physical(super::scale_factor(&window));
+                        let source = PointerSource::Touch { 
+                            finger_id: FingerId(touch.identifier() as usize), 
+                            force: Some(Force::Normalized(touch.force() as f64)) 
+                        };
+                        device_id = mkdid(touch.identifier());
+                        error!("Hello sailor!");
+                        event_items.push((position, source));
+                    } else {
+                        break;
+                    }
+                }
+                cursor_handler(
+                    device_id, // TODO: Not sure how to get the device ID
+                    event_items
                 );
             }));
     }

--- a/src/platform_impl/web/web_sys/touch.rs
+++ b/src/platform_impl/web/web_sys/touch.rs
@@ -1,0 +1,146 @@
+use super::canvas::Common;
+use super::event;
+use super::event_handle::EventListenerHandle;
+use crate::dpi::PhysicalPosition;
+use crate::event::{DeviceId, FingerId, Force};
+use std::cell::Cell;
+use std::rc::Rc;
+use web_sys::TouchEvent;
+
+#[allow(dead_code)]
+pub(super) struct TouchHandler {
+    on_touch_start: Option<EventListenerHandle<dyn FnMut(TouchEvent)>>,
+    on_touch_end: Option<EventListenerHandle<dyn FnMut(TouchEvent)>>,
+    on_touch_move: Option<EventListenerHandle<dyn FnMut(TouchEvent)>>,
+    on_touch_cancel: Option<EventListenerHandle<dyn FnMut(TouchEvent)>>,
+}
+
+impl TouchHandler {
+    pub fn new() -> Self {
+        Self {
+            on_touch_start: None,
+            on_touch_end: None,
+            on_touch_move: None,
+            on_touch_cancel: None,
+        }
+    }
+
+    pub fn on_touch_end<T>(&mut self, canvas_common: &Common, mut handler: T)
+    where
+        T: 'static
+        + FnMut(Option<DeviceId>, bool, PhysicalPosition<f64>, FingerId),
+    {
+        let window = canvas_common.window.clone();
+        self.on_touch_end =
+            Some(canvas_common.add_event("touchend", move |event: TouchEvent| {
+                let changed_touches = event::changed_touches(event);
+                for touch in changed_touches {
+                    handler(
+                        None, // TODO: how to get device ID?
+                        touch.identifier() == 0, // TODO: this is probably not an accurate way to check if it's the primary finger
+                        event::finger_position(&touch).to_physical(super::scale_factor(&window)),
+                        event::finger_id(&touch),
+                    )
+                }
+            }));
+    }
+
+    pub fn on_touch_start<T>(
+        &mut self,
+        canvas_common: &Common,
+        mut handler: T,
+        prevent_default: Rc<Cell<bool>>,
+    ) where
+        T: 'static
+        + FnMut(Option<DeviceId>, bool, PhysicalPosition<f64>, FingerId, Option<Force>),
+    {
+        let window = canvas_common.window.clone();
+        let canvas = canvas_common.raw().clone();
+        self.on_touch_start =
+            Some(canvas_common.add_event("touchdown", move |event: TouchEvent| {
+                if prevent_default.get() {
+                    // prevent text selection
+                    event.prevent_default();
+                    // but still focus element
+                    let _ = canvas.focus();
+                }
+                for touch in event::changed_touches(event) {
+                    handler(
+                        None, // TODO: how to get device ID?
+                        touch.identifier() == 0, // TODO: this is probably not an accurate way to check if it's the primary finger
+                        event::finger_position(&touch).to_physical(super::scale_factor(&window)),
+                        event::finger_id(&touch),
+                        event::finger_force(&touch),
+                    )
+                }
+            }));
+    }
+
+    pub fn on_touch_move<T>(
+        &mut self,
+        canvas_common: &Common,
+        mut handler: T,
+        prevent_default: Rc<Cell<bool>>,
+    ) where
+        T: 'static
+        + FnMut(Option<DeviceId>, bool, PhysicalPosition<f64>, FingerId, Option<Force>),
+    {
+        let window = canvas_common.window.clone();
+        let canvas = canvas_common.raw().clone();
+        self.on_touch_move =
+            Some(canvas_common.add_event("touchmove", move |event: TouchEvent| {
+                if prevent_default.get() {
+                    // prevent text selection
+                    event.prevent_default();
+                    // but still focus element
+                    let _ = canvas.focus();
+                }
+                for touch in event::changed_touches(event) {
+                    handler(
+                        None, // TODO: how to get device ID?
+                        touch.identifier() == 0, // TODO: this is probably not an accurate way to check if it's the primary finger
+                        event::finger_position(&touch).to_physical(super::scale_factor(&window)),
+                        event::finger_id(&touch),
+                        event::finger_force(&touch),
+                    )
+                }
+            }));
+    }
+    
+    pub fn on_touch_cancel<T>(
+        &mut self,
+        canvas_common: &Common,
+        mut handler: T,
+        prevent_default: Rc<Cell<bool>>,
+    ) where
+        T: 'static
+        + FnMut(Option<DeviceId>, bool, PhysicalPosition<f64>, FingerId),
+    {
+        let window = canvas_common.window.clone();
+        let canvas = canvas_common.raw().clone();
+        self.on_touch_cancel =
+            Some(canvas_common.add_event("touchcancel", move |event: TouchEvent| {
+                if prevent_default.get() {
+                    // prevent text selection
+                    event.prevent_default();
+                    // but still focus element
+                    let _ = canvas.focus();
+                }
+                for touch in event::changed_touches(event) {
+                    handler(
+                        None, // TODO: how to get device ID?
+                        touch.identifier() == 0, // TODO: this is probably not an accurate way to check if it's the primary finger
+                        event::finger_position(&touch).to_physical(super::scale_factor(&window)),
+                        event::finger_id(&touch),
+                    )
+                }
+            }));
+    }
+    
+    pub fn remove_listeners(&mut self) {
+        self.on_touch_move = None;
+        self.on_touch_end = None;
+        self.on_touch_start = None;
+        self.on_touch_cancel = None;
+    }
+}


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
