### PR TITLE
x11: implement set_override_redirect

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -71,6 +71,7 @@ changelog entry.
 - Added `Window::safe_area`, which describes the area of the surface that is unobstructed.
 - On X11, Wayland, Windows and macOS, improved scancode conversions for more obscure key codes.
 - Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`.
+- Add ability to set `override_redirect` on X11 windows after creation with `WindowExtX11::set_override_redirect`.
 - On Windows, add `IconExtWindows::from_resource_name`.
 - Implement `MonitorHandleProvider` for `MonitorHandle` to access common monitor API.
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -137,9 +137,18 @@ impl EventLoopBuilderExtX11 for EventLoopBuilder {
 /// Additional methods on [`Window`] that are specific to X11.
 ///
 /// [`Window`]: crate::window::Window
-pub trait WindowExtX11 {}
+pub trait WindowExtX11 {
+    /// Modify override-redirect flag.
+    fn set_override_redirect(&self, value: bool);
+}
 
-impl WindowExtX11 for dyn CoreWindow {}
+impl WindowExtX11 for dyn CoreWindow {
+    fn set_override_redirect(&self, value: bool) {
+        let window =
+            self.as_any().downcast_ref::<crate::platform_impl::x11::window::Window>().unwrap();
+        window.set_override_redirect(value);
+    }
+}
 
 /// Additional methods on [`WindowAttributes`] that are specific to X11.
 pub trait WindowAttributesExtX11 {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -14,7 +14,7 @@ use x11rb::properties::{WmHints, WmSizeHints, WmSizeHintsSpecification};
 use x11rb::protocol::shape::SK;
 use x11rb::protocol::sync::{ConnectionExt as _, Int64};
 use x11rb::protocol::xfixes::{ConnectionExt, RegionWrapper};
-use x11rb::protocol::xproto::{self, ConnectionExt as _, Rectangle};
+use x11rb::protocol::xproto::{self, ChangeWindowAttributesAux, ConnectionExt as _, Rectangle};
 use x11rb::protocol::{randr, xinput};
 
 use super::util::{self, SelectedCursor};
@@ -1824,6 +1824,20 @@ impl UnownedWindow {
             Cursor::Custom(RootCustomCursor { inner: PlatformCustomCursor::Wayland(_) }) => {
                 tracing::error!("passed a Wayland cursor to X11 backend")
             },
+        }
+    }
+
+    #[inline]
+    pub fn set_override_redirect(&self, value: bool) {
+        let mut swa = ChangeWindowAttributesAux::new();
+        swa.override_redirect = Some(value as u32);
+        if let Err(err) = self
+            .xconn
+            .xcb_connection()
+            .change_window_attributes(self.xwindow, &swa)
+            .map(|cookie| cookie.ignore_error())
+        {
+            tracing::error!("failed to set override-redirect: {err}");
         }
     }
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

implements `window.set_override_redirect()` for x11 so it can be updated after the window is created
(Note: I just ported this from my 0.30 branch to master without retesting and I'm not sure on the WindowExtX11 downcast)