### PR TITLE
docs: Fix some over-indentation

### DIFF
--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -47,19 +47,19 @@ pub trait EventLoopExtPumpEvents {
     /// buffered and handled outside of Winit include:
     /// - `RedrawRequested` events, used to schedule rendering.
     ///
-    ///     macOS for example uses a `drawRect` callback to drive rendering
-    ///     within applications and expects rendering to be finished before
-    ///     the `drawRect` callback returns.
+    ///   macOS for example uses a `drawRect` callback to drive rendering
+    ///   within applications and expects rendering to be finished before
+    ///   the `drawRect` callback returns.
     ///
-    ///     For portability it's strongly recommended that applications should
-    ///     keep their rendering inside the closure provided to Winit.
+    ///   For portability it's strongly recommended that applications should
+    ///   keep their rendering inside the closure provided to Winit.
     /// - Any lifecycle events, such as `Suspended` / `Resumed`.
     ///
-    ///     The handling of these events needs to be synchronized with the
-    ///     operating system and it would never be appropriate to buffer a
-    ///     notification that your application has been suspended or resumed and
-    ///     then handled that later since there would always be a chance that
-    ///     other lifecycle events occur while the event is buffered.
+    ///   The handling of these events needs to be synchronized with the
+    ///   operating system and it would never be appropriate to buffer a
+    ///   notification that your application has been suspended or resumed and
+    ///   then handled that later since there would always be a chance that
+    ///   other lifecycle events occur while the event is buffered.
     ///
     /// ## Supported Platforms
     ///


### PR DESCRIPTION
This fixes a new `clippy::doc_overindented_list_items` lint on nightly.

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
