### PR TITLE
Fix a pause in the event loop when clicking the title bar on windows

### DIFF
--- a/examples/application.rs
+++ b/examples/application.rs
@@ -42,6 +42,9 @@ use winit::window::{
 #[path = "util/tracing.rs"]
 mod tracing;
 
+#[path = "util/fill.rs"]
+mod fill;
+
 /// The amount of points to around the window for drag resize direction calculations.
 const BORDER_SIZE: f64 = 20.;
 
@@ -314,6 +317,13 @@ impl Application {
                 self.sender.send(Action::Message).unwrap();
                 event_loop.create_proxy().wake_up();
             },
+            Action::ToggleAnimatedFillColor => {
+                window.animated_fill_color = !window.animated_fill_color;
+            },
+            Action::ToggleContinuousRedraw => {
+                window.continuous_redraw = !window.continuous_redraw;
+                window.window.request_redraw();
+            },
         }
     }
 
@@ -440,6 +450,9 @@ impl ApplicationHandler for Application {
             WindowEvent::RedrawRequested => {
                 if let Err(err) = window.draw() {
                     error!("Error drawing window: {err}");
+                }
+                if window.continuous_redraw {
+                    window.window.request_redraw();
                 }
             },
             WindowEvent::Occluded(occluded) => {
@@ -616,6 +629,13 @@ struct WindowState {
     window: Arc<dyn Window>,
     /// The window theme we're drawing with.
     theme: Theme,
+    /// Fill the window with animated color
+    animated_fill_color: bool,
+    /// The application start time. Used for color fill animation
+    #[cfg(not(android_platform))]
+    start_time: std::time::Instant,
+    /// Redraw continuously
+    continuous_redraw: bool,
     /// Cursor position over the window.
     cursor_position: Option<PhysicalPosition<f64>>,
     /// Window modifiers state.
@@ -669,6 +689,10 @@ impl WindowState {
             surface,
             window,
             theme,
+            animated_fill_color: false,
+            continuous_redraw: false,
+            #[cfg(not(android_platform))]
+            start_time: std::time::Instant::now(),
             ime,
             cursor_position: Default::default(),
             cursor_hidden: Default::default(),
@@ -947,6 +971,11 @@ impl WindowState {
             return Ok(());
         }
 
+        if self.animated_fill_color {
+            fill::fill_window_with_animated_color(&*self.window, self.start_time);
+            return Ok(());
+        }
+
         let mut buffer = self.surface.buffer_mut()?;
 
         // Draw a different color inside the safe area
@@ -1038,6 +1067,8 @@ enum Action {
     RequestResize,
     DumpMonitors,
     Message,
+    ToggleAnimatedFillColor,
+    ToggleContinuousRedraw,
 }
 
 impl Action {
@@ -1082,6 +1113,8 @@ impl Action {
                  information"
             },
             Action::Message => "Prints a message through a user wake up",
+            Action::ToggleAnimatedFillColor => "Toggle animated fill color",
+            Action::ToggleContinuousRedraw => "Toggle continuous redraw",
         }
     }
 }
@@ -1196,6 +1229,7 @@ const CURSORS: &[CursorIcon] = &[
 const KEY_BINDINGS: &[Binding<&'static str>] = &[
     Binding::new("Q", ModifiersState::CONTROL, Action::CloseWindow),
     Binding::new("H", ModifiersState::CONTROL, Action::PrintHelp),
+    Binding::new("F", ModifiersState::SHIFT, Action::ToggleAnimatedFillColor),
     Binding::new("F", ModifiersState::CONTROL, Action::ToggleFullscreen),
     #[cfg(macos_platform)]
     Binding::new("F", ModifiersState::ALT, Action::ToggleSimpleFullscreen),
@@ -1205,6 +1239,7 @@ const KEY_BINDINGS: &[Binding<&'static str>] = &[
     Binding::new("P", ModifiersState::CONTROL, Action::ToggleResizeIncrements),
     Binding::new("R", ModifiersState::CONTROL, Action::ToggleResizable),
     Binding::new("R", ModifiersState::ALT, Action::RequestResize),
+    Binding::new("R", ModifiersState::SHIFT, Action::ToggleContinuousRedraw),
     // M.
     Binding::new("M", ModifiersState::CONTROL.union(ModifiersState::ALT), Action::DumpMonitors),
     Binding::new("M", ModifiersState::CONTROL, Action::ToggleMaximize),

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -127,6 +127,7 @@ mod platform {
 
 #[cfg(any(target_os = "android", target_os = "ios"))]
 mod platform {
+    #[allow(dead_code)]
     pub fn fill_window(_window: &dyn winit::window::Window) {
         // No-op on mobile platforms.
     }

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -12,6 +12,8 @@ pub use platform::cleanup_window;
 #[allow(unused_imports)]
 pub use platform::fill_window;
 #[allow(unused_imports)]
+pub use platform::fill_window_with_animated_color;
+#[allow(unused_imports)]
 pub use platform::fill_window_with_color;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
@@ -103,6 +105,16 @@ mod platform {
     }
 
     #[allow(dead_code)]
+    pub fn fill_window_with_animated_color(window: &dyn Window, start: std::time::Instant) {
+        let time = start.elapsed().as_secs_f32() * 1.5;
+        let blue = (time.sin() * 255.0) as u32;
+        let green = ((time.cos() * 255.0) as u32) << 8;
+        let red = ((1.0 - time.sin() * 255.0) as u32) << 16;
+        let color = red | green | blue;
+        fill_window_with_color(window, color);
+    }
+
+    #[allow(dead_code)]
     pub fn cleanup_window(window: &dyn Window) {
         GC.with(|gc| {
             let mut gc = gc.borrow_mut();
@@ -121,6 +133,14 @@ mod platform {
 
     #[allow(dead_code)]
     pub fn fill_window_with_color(_window: &dyn winit::window::Window, _color: u32) {
+        // No-op on mobile platforms.
+    }
+
+    #[allow(dead_code)]
+    pub fn fill_window_with_animated_color(
+        _window: &dyn winit::window::Window,
+        _start: std::time::Instant,
+    ) {
         // No-op on mobile platforms.
     }
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -12,9 +12,17 @@ use winit::window::{Window, WindowAttributes, WindowId};
 #[path = "util/fill.rs"]
 mod fill;
 
-#[derive(Default, Debug)]
+#[derive(Debug)]
 struct App {
     window: Option<Box<dyn Window>>,
+    start_time: std::time::Instant,
+    continuous_redraw: bool,
+}
+
+impl App {
+    fn new(continuous_redraw: bool) -> App {
+        App { window: None, start_time: std::time::Instant::now(), continuous_redraw }
+    }
 }
 
 impl ApplicationHandler for App {
@@ -55,11 +63,18 @@ impl ApplicationHandler for App {
                 // Notify that you're about to draw.
                 window.pre_present_notify();
 
-                // Draw.
-                fill::fill_window(window.as_ref());
+                if self.continuous_redraw {
+                    // Animate the fill color. This may be used to demonstrate smooth window
+                    // resizing and movement when interacting with the window
+                    // frame or title bar.
+                    fill::fill_window_with_animated_color(window.as_ref(), self.start_time);
 
-                // For contiguous redraw loop you can request a redraw from here.
-                // window.request_redraw();
+                    // For contiguous redraw loop you can request a redraw from here.
+                    window.request_redraw();
+                } else {
+                    // Draw.
+                    fill::fill_window(window.as_ref());
+                }
             },
             _ => (),
         }
@@ -71,7 +86,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     console_error_panic_hook::set_once();
 
     let event_loop = EventLoop::new()?;
-    let mut app = App::default();
+
+    // Set to true to continuously redraw the window which will also animate the fill color.
+    let continuous_redraw = false;
+
+    let mut app = App::new(continuous_redraw);
 
     // For alternative loop run options see `pump_events` and `run_on_demand` examples.
     event_loop.run_app(&mut app).map_err(Into::into)

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -12,17 +12,9 @@ use winit::window::{Window, WindowAttributes, WindowId};
 #[path = "util/fill.rs"]
 mod fill;
 
-#[derive(Debug)]
+#[derive(Default, Debug)]
 struct App {
     window: Option<Box<dyn Window>>,
-    start_time: std::time::Instant,
-    continuous_redraw: bool,
-}
-
-impl App {
-    fn new(continuous_redraw: bool) -> App {
-        App { window: None, start_time: std::time::Instant::now(), continuous_redraw }
-    }
 }
 
 impl ApplicationHandler for App {
@@ -63,18 +55,11 @@ impl ApplicationHandler for App {
                 // Notify that you're about to draw.
                 window.pre_present_notify();
 
-                if self.continuous_redraw {
-                    // Animate the fill color. This may be used to demonstrate smooth window
-                    // resizing and movement when interacting with the window
-                    // frame or title bar.
-                    fill::fill_window_with_animated_color(window.as_ref(), self.start_time);
+                // Draw.
+                fill::fill_window(window.as_ref());
 
-                    // For contiguous redraw loop you can request a redraw from here.
-                    window.request_redraw();
-                } else {
-                    // Draw.
-                    fill::fill_window(window.as_ref());
-                }
+                // For contiguous redraw loop you can request a redraw from here.
+                // window.request_redraw();
             },
             _ => (),
         }
@@ -86,11 +71,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     console_error_panic_hook::set_once();
 
     let event_loop = EventLoop::new()?;
-
-    // Set to true to continuously redraw the window which will also animate the fill color.
-    let continuous_redraw = false;
-
-    let mut app = App::new(continuous_redraw);
+    let mut app = App::default();
 
     // For alternative loop run options see `pump_events` and `run_on_demand` examples.
     event_loop.run_app(&mut app).map_err(Into::into)

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -236,3 +236,4 @@ changelog entry.
 - On macOS, fixed the scancode conversion for audio volume keys.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
+- On Windows, fixed ~500 ms pause when clicking the title bar during continuous redraw.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1135,6 +1135,8 @@ unsafe fn public_window_callback_inner(
 
         WM_NCLBUTTONDOWN => {
             if wparam == HTCAPTION as _ {
+                // lparam must be zero to prevent the pause when clicking the title bar to drag
+                let lparam = 0;
                 unsafe { PostMessageW(window, WM_MOUSEMOVE, 0, lparam) };
             }
             result = ProcResult::DefWindowProc(wparam);

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1158,7 +1158,7 @@ unsafe fn public_window_callback_inner(
                 //
                 // When right-click the title bar, the system window menu is presented to the user,
                 // and the modal event loop begins. This dummy event does *not* prevent the freeze
-                // in the main event loop imposed caused by that popup menu.
+                // in the main event loop caused by that popup menu.
                 let lparam = 0;
                 unsafe { PostMessageW(window, WM_MOUSEMOVE, 0, lparam) };
             }

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1135,7 +1135,30 @@ unsafe fn public_window_callback_inner(
 
         WM_NCLBUTTONDOWN => {
             if wparam == HTCAPTION as _ {
-                // lparam must be zero to prevent the pause when clicking the title bar to drag
+                // Prevent the user event loop from pausing when left clicking the title bar.
+                //
+                // When the user interacts with the title bar, Windows enters the modal event
+                // loop. Currently, a left click causes a pause for about 500ms. Sending a dummy
+                // mouse-move event seems to cancel the modal loop early, preventing the pause.
+                // The application will never see this dummy event.
+                //
+                // The mouse coordinates are encoded into the lparam value, however the WM_MOUSEMOVE
+                // event is not using the same coordinate system of the WM_NCLBUTTONDOWN event.
+                // One uses client-area coordinates and the other is screen-coordinates. In any
+                // case, passing the lparam as-is with the dummy event does not seem the cancel
+                // the modal loop.
+                //
+                // However, passing in a value of 0 has been observed to always cancel the pause.
+                //
+                // Other notes:
+                //
+                // For some unknown reason, the cursor will blink when clicking the title bar.
+                // Cancelling the modal loop early causes the blink to happen *immediately*.
+                // Otherwise, the blank happens *after* the pause.
+                //
+                // When right-click the title bar, the system window menu is presented to the user,
+                // and the modal event loop begins. This dummy event does *not* prevent the freeze
+                // in the main event loop imposed caused by that popup menu.
                 let lparam = 0;
                 unsafe { PostMessageW(window, WM_MOUSEMOVE, 0, lparam) };
             }


### PR DESCRIPTION
When clicking the title bar on Windows, to drag the window, there is a noticeable ~500ms pause in continuous redraw requests. This was fixed in #839 and then regressed in #1852. The cursor blinks in both cases and is unrelated. The regression made the blink happen after the pause instead of immediately.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users

