### PR TITLE
Wayland: Use custom `Event` enum for buffered events

### DIFF
--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -15,7 +15,7 @@ use crate::application::ApplicationHandler;
 use crate::cursor::OnlyCursorImage;
 use crate::dpi::LogicalSize;
 use crate::error::{EventLoopError, OsError, RequestError};
-use crate::event::{Event, StartCause, SurfaceSizeWriter, WindowEvent};
+use crate::event::{DeviceEvent, StartCause, SurfaceSizeWriter, WindowEvent};
 use crate::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
     OwnedDisplayHandle as CoreOwnedDisplayHandle,
@@ -37,6 +37,12 @@ use super::{logical_to_physical_rounded, WindowId};
 pub use crate::event_loop::EventLoopProxy as CoreEventLoopProxy;
 
 type WaylandDispatcher = calloop::Dispatcher<'static, WaylandSource<WinitState>, WinitState>;
+
+#[derive(Debug)]
+pub(crate) enum Event {
+    WindowEvent { window_id: WindowId, event: WindowEvent },
+    DeviceEvent { event: DeviceEvent },
+}
 
 /// The Wayland event loop.
 pub struct EventLoop {
@@ -383,10 +389,9 @@ impl EventLoop {
                 Event::WindowEvent { window_id, event } => {
                     app.window_event(&self.active_event_loop, window_id, event)
                 },
-                Event::DeviceEvent { device_id, event } => {
-                    app.device_event(&self.active_event_loop, device_id, event)
+                Event::DeviceEvent { event } => {
+                    app.device_event(&self.active_event_loop, None, event)
                 },
-                _ => unreachable!("event which is neither device nor window event."),
             }
         }
 
@@ -399,10 +404,9 @@ impl EventLoop {
                 Event::WindowEvent { window_id, event } => {
                     app.window_event(&self.active_event_loop, window_id, event)
                 },
-                Event::DeviceEvent { device_id, event } => {
-                    app.device_event(&self.active_event_loop, device_id, event)
+                Event::DeviceEvent { event } => {
+                    app.device_event(&self.active_event_loop, None, event)
                 },
-                _ => unreachable!("event which is neither device nor window event."),
             }
         }
 

--- a/src/platform_impl/linux/wayland/event_loop/sink.rs
+++ b/src/platform_impl/linux/wayland/event_loop/sink.rs
@@ -2,7 +2,8 @@
 
 use std::vec::Drain;
 
-use crate::event::{DeviceEvent, Event, WindowEvent};
+use super::Event;
+use crate::event::{DeviceEvent, WindowEvent};
 use crate::window::WindowId;
 
 /// An event loop's sink to deliver events from the Wayland event callbacks
@@ -26,7 +27,7 @@ impl EventSink {
     /// Add new device event to a queue.
     #[inline]
     pub fn push_device_event(&mut self, event: DeviceEvent) {
-        self.window_events.push(Event::DeviceEvent { event, device_id: None });
+        self.window_events.push(Event::DeviceEvent { event });
     }
 
     /// Add new window event to a queue.


### PR DESCRIPTION
To avoid an unreachable case, and to allow removing the top-level `Event` enum in the future. Should be purely a refactor.