### PR TITLE
macOS/iOS: Implement wake-ups using system mechanisms

### DIFF
--- a/src/platform_impl/apple/event_loop_proxy.rs
+++ b/src/platform_impl/apple/event_loop_proxy.rs
@@ -1,0 +1,126 @@
+use std::os::raw::c_void;
+use std::sync::Arc;
+
+use objc2::MainThreadMarker;
+use objc2_core_foundation::{
+    kCFRunLoopCommonModes, CFIndex, CFRetained, CFRunLoop, CFRunLoopAddSource, CFRunLoopGetMain,
+    CFRunLoopSource, CFRunLoopSourceContext, CFRunLoopSourceCreate, CFRunLoopSourceInvalidate,
+    CFRunLoopSourceSignal, CFRunLoopWakeUp,
+};
+
+use crate::event_loop::EventLoopProxyProvider;
+
+/// A waker that signals a `CFRunLoopSource` on the main thread.
+///
+/// We use this to integrate with the system as cleanly as possible (instead of e.g. keeping an
+/// atomic around that we check on each iteration of the event loop).
+///
+/// See <https://developer.apple.com/documentation/corefoundation/cfrunloopsource?language=objc>.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct EventLoopProxy {
+    source: CFRetained<CFRunLoopSource>,
+    /// Cached value of `CFRunLoopGetMain`.
+    main_loop: CFRetained<CFRunLoop>,
+}
+
+// FIXME(madsmtm): Mark `CFRunLoopSource` + `CFRunLoop` as `Send` + `Sync`.
+unsafe impl Send for EventLoopProxy {}
+unsafe impl Sync for EventLoopProxy {}
+
+impl EventLoopProxy {
+    /// Create a new proxy, registering it to be performed on the main thread.
+    ///
+    /// The provided closure should call `proxy_wake_up` on the application.
+    pub(crate) fn new<F: Fn() + 'static>(mtm: MainThreadMarker, signaller: F) -> Self {
+        // We use an `Arc` here to make sure that the reference-counting of the signal container is
+        // atomic (`Retained`/`CFRetained` would be valid alternatives too).
+        let signaller = Arc::new(signaller);
+
+        unsafe extern "C-unwind" fn retain<F>(info: *const c_void) -> *const c_void {
+            // SAFETY: The pointer was passed to `CFRunLoopSourceContext.info` below.
+            unsafe { Arc::increment_strong_count(info.cast::<F>()) };
+            info
+        }
+        unsafe extern "C-unwind" fn release<F>(info: *const c_void) {
+            // SAFETY: The pointer was passed to `CFRunLoopSourceContext.info` below.
+            unsafe { Arc::decrement_strong_count(info.cast::<F>()) };
+        }
+
+        // Pointer equality / hashing.
+        extern "C-unwind" fn equal(info1: *const c_void, info2: *const c_void) -> u8 {
+            (info1 == info2) as u8
+        }
+        extern "C-unwind" fn hash(info: *const c_void) -> usize {
+            info as usize
+        }
+
+        // Call the provided closure.
+        unsafe extern "C-unwind" fn perform<F: Fn()>(info: *mut c_void) {
+            // SAFETY: The pointer was passed to `CFRunLoopSourceContext.info` below.
+            let signaller = unsafe { &*info.cast::<F>() };
+            (signaller)();
+        }
+
+        // Fire last.
+        let order = CFIndex::MAX - 1;
+
+        // This is marked `mut` to match the signature of `CFRunLoopSourceCreate`, but the
+        // information is copied, and not actually mutated.
+        let mut context = CFRunLoopSourceContext {
+            version: 0,
+            // This is retained on creation.
+            info: Arc::as_ptr(&signaller) as *mut c_void,
+            retain: Some(retain::<F>),
+            release: Some(release::<F>),
+            copyDescription: None,
+            equal: Some(equal),
+            hash: Some(hash),
+            schedule: None,
+            cancel: None,
+            perform: Some(perform::<F>),
+        };
+
+        // SAFETY: The normal callbacks are thread-safe (`retain`/`release` use atomics, and
+        // `equal`/`hash` only access a pointer).
+        //
+        // Note that the `perform` callback isn't thread-safe (we don't have `F: Send + Sync`), but
+        // that's okay, since we are on the main thread, and the source is only added to the main
+        // run loop (below), and hence only performed there.
+        //
+        // Keeping the closure alive beyond this scope is fine, because `F: 'static`.
+        let source = unsafe {
+            let _ = mtm;
+            CFRunLoopSourceCreate(None, order, &mut context).unwrap()
+        };
+
+        // Register the source to be performed on the main thread.
+        let main_loop = unsafe { CFRunLoopGetMain() }.unwrap();
+        unsafe { CFRunLoopAddSource(&main_loop, Some(&source), kCFRunLoopCommonModes) };
+
+        Self { source, main_loop }
+    }
+
+    // FIXME(madsmtm): Use this on macOS too.
+    // More difficult there, since the user can re-start the event loop.
+    #[cfg_attr(target_os = "macos", allow(dead_code))]
+    pub(crate) fn invalidate(&self) {
+        // NOTE: We do NOT fire this on `Drop`, since we want the proxy to be cloneable, such that
+        // we only need to register a single source even if there's multiple proxies in use.
+        unsafe { CFRunLoopSourceInvalidate(&self.source) };
+    }
+}
+
+impl EventLoopProxyProvider for EventLoopProxy {
+    fn wake_up(&self) {
+        // Signal the source, which ends up later invoking `perform` on the main thread.
+        //
+        // Multiple signals in quick succession are automatically coalesced into a single signal.
+        unsafe { CFRunLoopSourceSignal(&self.source) };
+
+        // Let the main thread know there's a new event.
+        //
+        // This is required since we may be (probably are) running on a different thread, and the
+        // main loop may be sleeping (and `CFRunLoopSourceSignal` won't wake it).
+        unsafe { CFRunLoopWakeUp(&self.main_loop) };
+    }
+}

--- a/src/platform_impl/apple/mod.rs
+++ b/src/platform_impl/apple/mod.rs
@@ -3,6 +3,7 @@
 #[cfg(target_os = "macos")]
 mod appkit;
 mod event_handler;
+mod event_loop_proxy;
 mod notification_center;
 #[cfg(not(target_os = "macos"))]
 mod uikit;

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -10,7 +10,7 @@ mod window;
 use std::fmt;
 
 pub(crate) use self::event_loop::{
-    ActiveEventLoop, EventLoop, EventLoopProxy, PlatformSpecificEventLoopAttributes,
+    ActiveEventLoop, EventLoop, PlatformSpecificEventLoopAttributes,
 };
 pub(crate) use self::monitor::MonitorHandle;
 pub(crate) use self::window::{PlatformSpecificWindowAttributes, Window};


### PR DESCRIPTION
Setting an atomic in `wake_up` and relying on it being propagated by the time the run loop wakes up is brittle, the proper way of using [`CFRunLoopSource`](https://developer.apple.com/documentation/corefoundation/cfrunloopsource?language=objc) is to do your work inside the `perform` callback. This also automatically handles coalescing multiple events, and frees us from having to manually check an atomic on each iteration of the run loop.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
  - I decided not to, the real change is in https://github.com/rust-windowing/winit/pull/3694.

Part of https://github.com/rust-windowing/winit/issues/1029.