### PR TITLE
Drop application handler on run loop exit

### DIFF
--- a/examples/application.rs
+++ b/examples/application.rs
@@ -592,15 +592,15 @@ impl ApplicationHandler for Application {
         }
     }
 
-    #[cfg(not(android_platform))]
-    fn exiting(&mut self, _event_loop: &dyn ActiveEventLoop) {
-        // We must drop the context here.
-        self.context = None;
-    }
-
     #[cfg(target_os = "macos")]
     fn macos_handler(&mut self) -> Option<&mut dyn ApplicationHandlerExtMacOS> {
         Some(self)
+    }
+}
+
+impl Drop for Application {
+    fn drop(&mut self) {
+        info!("Application exited");
     }
 }
 

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -11,6 +11,8 @@ use winit::window::{Window, WindowAttributes, WindowId};
 
 #[path = "util/fill.rs"]
 mod fill;
+#[path = "util/tracing.rs"]
+mod tracing;
 
 #[derive(Default, Debug)]
 struct App {
@@ -70,9 +72,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     #[cfg(web_platform)]
     console_error_panic_hook::set_once();
 
+    tracing::init();
+
     let event_loop = EventLoop::new()?;
-    let mut app = App::default();
 
     // For alternative loop run options see `pump_events` and `run_on_demand` examples.
-    event_loop.run_app(&mut app).map_err(Into::into)
+    event_loop.run_app(App::default())?;
+
+    Ok(())
 }

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -228,6 +228,8 @@ changelog entry.
 - Remove `Window::inner_position`, use the new `Window::surface_position` instead.
 - Remove `CustomCursorExtWeb`, use the `CustomCursorSource`.
 - Remove `CustomCursor::from_rgba`, use `CustomCursorSource` instead.
+- Removed `ApplicationHandler::exited`, the event loop being shut down can now be listened to in
+  the `Drop` impl on the application handler.
 
 ### Fixed
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,39 +1,4 @@
 //! The event enums and assorted supporting types.
-//!
-//! These are sent to the closure given to [`EventLoop::run_app(...)`], where they get
-//! processed and used to modify the program state. For more details, see the root-level
-//! documentation.
-//!
-//! Some of these events represent different "parts" of a traditional event-handling loop. You could
-//! approximate the basic ordering loop of [`EventLoop::run_app(...)`] like this:
-//!
-//! ```rust,ignore
-//! let mut start_cause = StartCause::Init;
-//!
-//! while !elwt.exiting() {
-//!     app.new_events(event_loop, start_cause);
-//!
-//!     for event in (window events, user events, device events) {
-//!         // This will pick the right method on the application based on the event.
-//!         app.handle_event(event_loop, event);
-//!     }
-//!
-//!     for window_id in (redraw windows) {
-//!         app.window_event(event_loop, window_id, RedrawRequested);
-//!     }
-//!
-//!     app.about_to_wait(event_loop);
-//!     start_cause = wait_if_necessary();
-//! }
-//!
-//! app.exiting(event_loop);
-//! ```
-//!
-//! This leaves out timing details like [`ControlFlow::WaitUntil`] but hopefully
-//! describes what happens in what order.
-//!
-//! [`EventLoop::run_app(...)`]: crate::event_loop::EventLoop::run_app
-//! [`ControlFlow::WaitUntil`]: crate::event_loop::ControlFlow::WaitUntil
 use std::path::PathBuf;
 use std::sync::{Mutex, Weak};
 #[cfg(not(web_platform))]
@@ -641,10 +606,12 @@ impl FingerId {
 ///
 /// Useful for interactions that diverge significantly from a conventional 2D GUI, such as 3D camera
 /// or first-person game controls. Many physical actions, such as mouse movement, can produce both
-/// device and window events. Because window events typically arise from virtual devices
+/// device and [window events]. Because window events typically arise from virtual devices
 /// (corresponding to GUI pointers and keyboard focus) the device IDs may not match.
 ///
 /// Note that these events are delivered regardless of input focus.
+///
+/// [window events]: WindowEvent
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum DeviceEvent {
     /// Change in physical position of a pointing device.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -186,7 +186,56 @@ impl EventLoop {
 impl EventLoop {
     /// Run the application with the event loop on the calling thread.
     ///
-    /// See the [`set_control_flow()`] docs on how to change the event loop's behavior.
+    /// ## Event loop flow
+    ///
+    /// This function internally handles the different parts of a traditional event-handling loop.
+    /// You can imagine this method as being implemented like this:
+    ///
+    /// ```rust,ignore
+    /// let mut start_cause = StartCause::Init;
+    ///
+    /// // Run the event loop.
+    /// while !event_loop.exiting() {
+    ///     // Wake up.
+    ///     app.new_events(event_loop, start_cause);
+    ///
+    ///     // Indicate that surfaces can now safely be created.
+    ///     if start_cause == StartCause::Init {
+    ///         app.can_create_surfaces(event_loop);
+    ///     }
+    ///
+    ///     // Handle proxy wake-up event.
+    ///     if event_loop.proxy_wake_up_set() {
+    ///         event_loop.proxy_wake_up_clear();
+    ///         app.proxy_wake_up(event_loop);
+    ///     }
+    ///
+    ///     // Handle actions done by the user / system such as moving the cursor, resizing the
+    ///     // window, changing the window theme, etc.
+    ///     for event in event_loop.events() {
+    ///         match event {
+    ///             window event => app.window_event(event_loop, window_id, event),
+    ///             device event => app.device_event(event_loop, device_id, event),
+    ///         }
+    ///     }
+    ///
+    ///     // Handle redraws.
+    ///     for window_id in event_loop.pending_redraws() {
+    ///         app.window_event(event_loop, window_id, WindowEvent::RedrawRequested);
+    ///     }
+    ///
+    ///     // Done handling events, wait until we're woken up again.
+    ///     app.about_to_wait(event_loop);
+    ///     start_cause = event_loop.wait_if_necessary();
+    /// }
+    ///
+    /// // Finished running, drop application state.
+    /// drop(app);
+    /// ```
+    ///
+    /// This is of course a very coarse-grained overview, and leaves out timing details like
+    /// [`ControlFlow::WaitUntil`] and life-cycle methods like [`ApplicationHandler::resumed`], but
+    /// it should give you an idea of how things fit together.
     ///
     /// ## Platform-specific
     ///
@@ -381,14 +430,21 @@ pub trait ActiveEventLoop: AsAny + fmt::Debug {
     /// Gets the current [`ControlFlow`].
     fn control_flow(&self) -> ControlFlow;
 
-    /// This exits the event loop.
+    /// Stop the event loop.
     ///
-    /// See [`exiting`][crate::application::ApplicationHandler::exiting].
+    /// ## Platform-specific
+    ///
+    /// ### iOS
+    ///
+    /// It is not possible to programmatically exit/quit an application on iOS, so this function is
+    /// a no-op there. See also [this technical Q&A][qa1561].
+    ///
+    /// [qa1561]: https://developer.apple.com/library/archive/qa/qa1561/_index.html
     fn exit(&self);
 
-    /// Returns if the [`EventLoop`] is about to stop.
+    /// Returns whether the [`EventLoop`] is about to stop.
     ///
-    /// See [`exit()`][Self::exit].
+    /// Set by [`exit()`][Self::exit].
     fn exiting(&self) -> bool;
 
     /// Gets a persistent reference to the underlying platform display.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,8 @@
 //! Some user activity, like mouse movement, can generate both a [`WindowEvent`] *and* a
 //! [`DeviceEvent`].
 //!
-//! You can retrieve events by calling [`EventLoop::run_app()`]. This function will
-//! dispatch events for every [`Window`] that was created with that particular [`EventLoop`], and
-//! will run until [`exit()`] is used, at which point [`exiting()`] is called.
+//! You can retrieve events by calling [`EventLoop::run_app()`]. This function will dispatch events
+//! for every [`Window`] that was created with that particular [`EventLoop`].
 //!
 //! Winit no longer uses a `EventLoop::poll_events() -> impl Iterator<Event>`-based event loop
 //! model, since that can't be implemented properly on some platforms (e.g Web, iOS) and works
@@ -58,10 +57,19 @@
 //!
 //! impl ApplicationHandler for App {
 //!     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
+//!         // The event loop has launched, and we can initialize our UI state.
+//!
+//!         // Create a simple window with default attributes.
 //!         self.window = Some(event_loop.create_window(WindowAttributes::default()).unwrap());
 //!     }
 //!
-//!     fn window_event(&mut self, event_loop: &dyn ActiveEventLoop, id: WindowId, event: WindowEvent) {
+//!     fn window_event(
+//!         &mut self,
+//!         event_loop: &dyn ActiveEventLoop,
+//!         id: WindowId,
+//!         event: WindowEvent,
+//!     ) {
+//!         // Called by `EventLoop::run_app` when a new event happens on the window.
 //!         match event {
 //!             WindowEvent::CloseRequested => {
 //!                 println!("The close button was pressed; stopping");
@@ -82,15 +90,18 @@
 //!                 // applications which do not always need to. Applications that redraw continuously
 //!                 // can render here instead.
 //!                 self.window.as_ref().unwrap().request_redraw();
-//!             }
+//!             },
 //!             _ => (),
 //!         }
 //!     }
 //! }
 //!
 //! # // Intentionally use `fn main` for clarity
-//! fn main() {
-//!     let event_loop = EventLoop::new().unwrap();
+//! fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     // Create a new event loop.
+//!     let event_loop = EventLoop::new()?;
+//!
+//!     // Configure settings before launching.
 //!
 //!     // ControlFlow::Poll continuously runs the event loop, even if the OS hasn't
 //!     // dispatched any events. This is ideal for games and similar applications.
@@ -101,8 +112,10 @@
 //!     // input, and uses significantly less power/CPU time than ControlFlow::Poll.
 //!     event_loop.set_control_flow(ControlFlow::Wait);
 //!
-//!     let mut app = App::default();
-//!     event_loop.run_app(&mut app);
+//!     // Launch and begin running the event loop.
+//!     event_loop.run_app(App::default())?;
+//!
+//!     Ok(())
 //! }
 //! ```
 //!
@@ -261,7 +274,6 @@
 //! [`Window::id()`]: window::Window::id
 //! [`WindowEvent`]: event::WindowEvent
 //! [`DeviceEvent`]: event::DeviceEvent
-//! [`exiting()`]: crate::application::ApplicationHandler::exiting
 //! [`raw_window_handle`]: ./window/struct.Window.html#method.raw_window_handle
 //! [`raw_display_handle`]: ./window/struct.Window.html#method.raw_display_handle
 //! [^1]: `EventLoopExtPumpEvents::pump_app_events()` is only available on Windows, macOS, Android, X11 and Wayland.

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -85,12 +85,9 @@
 //!
 //!  - applicationDidBecomeActive is Resumed
 //!  - applicationWillResignActive is Suspended
-//!  - applicationWillTerminate is LoopExiting
+//!  - applicationWillTerminate corresponds to `Drop`ping the application handler.
 //!
-//! Keep in mind that after LoopExiting event is received every attempt to draw with
-//! opengl will result in segfault.
-//!
-//! Also note that app may not receive the LoopExiting event if suspended; it might be SIGKILL'ed.
+//! Note that an app may not receive the `Drop` event if suspended; it might be SIGKILL'ed.
 //!
 //! ## Custom `UIApplicationDelegate`
 //!

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -546,8 +546,6 @@ impl EventLoop {
         if self.exiting() {
             self.loop_running = false;
 
-            app.exiting(&self.window_target);
-
             PumpStatus::Exit(0)
         } else {
             PumpStatus::Continue

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -285,10 +285,10 @@ impl EventLoop {
     // redundant wake ups.
     pub fn run_app_on_demand<A: ApplicationHandler>(
         &mut self,
-        mut app: A,
+        app: A,
     ) -> Result<(), EventLoopError> {
         self.app_state.clear_exit();
-        self.app_state.set_event_handler(&mut app, || {
+        self.app_state.set_event_handler(app, || {
             autoreleasepool(|_| {
                 // clear / normalize pump_events state
                 self.app_state.set_wait_timeout(None);
@@ -324,9 +324,9 @@ impl EventLoop {
     pub fn pump_app_events<A: ApplicationHandler>(
         &mut self,
         timeout: Option<Duration>,
-        mut app: A,
+        app: A,
     ) -> PumpStatus {
-        self.app_state.set_event_handler(&mut app, || {
+        self.app_state.set_event_handler(app, || {
             autoreleasepool(|_| {
                 // As a special case, if the application hasn't been launched yet then we at least
                 // run the loop until it has fully launched.

--- a/src/platform_impl/apple/uikit/event_loop.rs
+++ b/src/platform_impl/apple/uikit/event_loop.rs
@@ -243,7 +243,7 @@ impl EventLoop {
         })
     }
 
-    pub fn run_app<A: ApplicationHandler>(self, mut app: A) -> ! {
+    pub fn run_app<A: ApplicationHandler>(self, app: A) -> ! {
         let application: Option<Retained<UIApplication>> =
             unsafe { msg_send![UIApplication::class(), sharedApplication] };
         assert!(
@@ -259,7 +259,7 @@ impl EventLoop {
             fn _NSGetArgv() -> *mut *mut *mut c_char;
         }
 
-        app_state::launch(self.mtm, &mut app, || unsafe {
+        app_state::launch(self.mtm, app, || unsafe {
             UIApplicationMain(
                 *_NSGetArgc(),
                 NonNull::new(*_NSGetArgv()).unwrap(),

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -203,10 +203,9 @@ impl EventLoop {
         if !self.exiting() {
             self.poll_events_with_timeout(timeout, &mut app);
         }
+
         if let Some(code) = self.exit_code() {
             self.loop_running = false;
-
-            app.exiting(&self.active_event_loop);
 
             PumpStatus::Exit(code)
         } else {

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -498,8 +498,6 @@ impl EventLoop {
         if let Some(code) = self.exit_code() {
             self.loop_running = false;
 
-            app.exiting(self.window_target());
-
             PumpStatus::Exit(code)
         } else {
             PumpStatus::Continue

--- a/src/platform_impl/orbital/event_loop.rs
+++ b/src/platform_impl/orbital/event_loop.rs
@@ -650,8 +650,6 @@ impl EventLoop {
             }
         }
 
-        app.exiting(&self.window_target);
-
         Ok(())
     }
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -158,7 +158,6 @@ impl Runner {
             Event::Resumed => self.app.resumed(&self.event_loop),
             Event::CreateSurfaces => self.app.can_create_surfaces(&self.event_loop),
             Event::AboutToWait => self.app.about_to_wait(&self.event_loop),
-            Event::LoopExiting => self.app.exiting(&self.event_loop),
         }
     }
 }
@@ -639,7 +638,9 @@ impl Shared {
         self.apply_control_flow();
         // We don't call `handle_loop_destroyed` here because we don't need to
         // perform cleanup when the Web browser is going to destroy the page.
-        self.handle_event(Event::LoopExiting);
+        //
+        // We do want to run the application handler's `Drop` impl.
+        *self.0.runner.borrow_mut() = RunnerEnum::Destroyed;
     }
 
     // handle_event takes in events and either queues them or applies a callback
@@ -737,7 +738,6 @@ impl Shared {
     }
 
     fn handle_loop_destroyed(&self) {
-        self.handle_event(Event::LoopExiting);
         let all_canvases = std::mem::take(&mut *self.0.all_canvases.borrow_mut());
         *self.0.page_transition_event_handle.borrow_mut() = None;
         *self.0.on_mouse_move.borrow_mut() = None;
@@ -879,6 +879,5 @@ pub(crate) enum Event {
     CreateSurfaces,
     Resumed,
     AboutToWait,
-    LoopExiting,
     UserWakeUp,
 }

--- a/src/platform_impl/windows/event_loop/runner.rs
+++ b/src/platform_impl/windows/event_loop/runner.rs
@@ -333,7 +333,6 @@ impl EventLoopRunner {
                 self.call_new_events(true);
                 self.call_event_handler(|app, event_loop| app.about_to_wait(event_loop));
                 self.last_events_cleared.set(Instant::now());
-                self.call_event_handler(|app, event_loop| app.exiting(event_loop));
             },
             (_, Uninitialized) => panic!("cannot move state to Uninitialized"),
 
@@ -341,9 +340,7 @@ impl EventLoopRunner {
             (Idle, HandlingMainEvents) => {
                 self.call_new_events(false);
             },
-            (Idle, Destroyed) => {
-                self.call_event_handler(|app, event_loop| app.exiting(event_loop));
-            },
+            (Idle, Destroyed) => {},
 
             (HandlingMainEvents, Idle) => {
                 // This is always the last event we dispatch before waiting for new events
@@ -353,7 +350,6 @@ impl EventLoopRunner {
             (HandlingMainEvents, Destroyed) => {
                 self.call_event_handler(|app, event_loop| app.about_to_wait(event_loop));
                 self.last_events_cleared.set(Instant::now());
-                self.call_event_handler(|app, event_loop| app.exiting(event_loop));
             },
 
             (Destroyed, _) => panic!("cannot move state from Destroyed"),


### PR DESCRIPTION
Part of https://github.com/rust-windowing/winit/issues/2903, split out from https://github.com/rust-windowing/winit/pull/3895. This is the motivation for doing https://github.com/rust-windowing/winit/pull/3721.

Calling the `Drop` impl of the user's `ApplicationHandler` is important on macOS, iOS and Web, since they don't necessarily return from `EventLoop::run_app`. This PR fixes that.

And now that we reliably call `Drop`, the `ApplicationHandler::exited` event/callback is unnecessary; using `Drop` composes much better (open files etc. stored in the app state will be automatically flushed), and prevents weirdness like attempting to create a new window while exiting. So this PR also removes that method.

- [x] Tested on all platforms changed
  - [x] macOS
  - [x] iOS
  - [x] Web
  - [x] Wayland/X11/Windows/Android are trivial
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
