### PR TITLE
macOS: Fix crash when reconnecting monitors

### DIFF
--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -246,7 +246,7 @@ impl MonitorHandle {
                 let modes: Vec<_> = (0..array_count)
                     .map(move |i| {
                         let mode = CFArrayGetValueAtIndex(&array, i) as *mut CGDisplayMode;
-                        CFRetained::from_raw(NonNull::new(mode).unwrap())
+                        CFRetained::retain(NonNull::new(mode).unwrap())
                     })
                     .collect();
                 modes


### PR DESCRIPTION
`CFArrayGetValueAtIndex` does not return a retained value, so we must retain ourselves.

Introduced in #4092, so didn't add a changelog entry for it.