### PR TITLE
macOS: Close windows automatically when exiting

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -240,3 +240,4 @@ changelog entry.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
 - On Windows, fixed ~500 ms pause when clicking the title bar during continuous redraw.
 - On macos, `WindowExtMacOS::set_simple_fullscreen` now honors `WindowExtMacOS::set_borderless_game`
+- On macOS, fixed `run_app_on_demand` returning without closing open windows.

--- a/src/platform_impl/apple/appkit/event_loop.rs
+++ b/src/platform_impl/apple/appkit/event_loop.rs
@@ -407,6 +407,22 @@ pub(super) fn stop_app_immediately(app: &NSApplication) {
     });
 }
 
+/// Tell all windows to close.
+///
+/// This will synchronously trigger `WindowEvent::Destroyed` within
+/// `windowWillClose:`, giving the application one last chance to handle
+/// those events. It doesn't matter if the user also ends up closing the
+/// windows in `Window`'s `Drop` impl, once a window has been closed once, it
+/// stays closed.
+///
+/// This ensures that no windows linger on after the event loop has exited,
+/// see <https://github.com/rust-windowing/winit/issues/4135>.
+pub(super) fn notify_windows_of_exit(app: &NSApplication) {
+    for window in app.windows() {
+        window.close();
+    }
+}
+
 /// Catches panics that happen inside `f` and when a panic
 /// happens, stops the `sharedApplication`
 #[inline]


### PR DESCRIPTION
This disallows carrying over open windows between calls of `run_app_on_demand` (which wasn't intended to be supported anyhow). Wasn't nearly as hard as I feared. Fixes https://github.com/rust-windowing/winit/issues/4135.

I looked a bit back, seems this was noted in https://github.com/rust-windowing/winit/pull/2767#pullrequestreview-1498222334 too, but never resolved.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
