### PR TITLE
Add `as_inner` helper method on trait objects

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -76,8 +76,8 @@ changelog entry.
 
 ### Changed
 
-- Change `ActiveEventLoop` and `Window` to be traits, and added `as_inner` methods to extract the
-  backend type from those.
+- Change `ActiveEventLoop` and `Window` to be traits, and added `as_inner`/`as_inner_mut` methods
+  to extract the backend type from those.
 - `ActiveEventLoop::create_window` now returns `Box<dyn Window>`.
 - `ApplicationHandler` now uses `dyn ActiveEventLoop`.
 - On Web, let events wake up event loop immediately when using `ControlFlow::Poll`.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -76,8 +76,8 @@ changelog entry.
 
 ### Changed
 
-- Change `ActiveEventLoop` and `Window` to be traits, and added `as_inner`/`as_inner_mut` methods
-  to extract the backend type from those.
+- Change `ActiveEventLoop` and `Window` to be traits, and added `as_inner`/`as_inner_mut`/`into_inner`
+  methods to extract the backend type from those.
 - `ActiveEventLoop::create_window` now returns `Box<dyn Window>`.
 - `ApplicationHandler` now uses `dyn ActiveEventLoop`.
 - On Web, let events wake up event loop immediately when using `ControlFlow::Poll`.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -76,7 +76,7 @@ changelog entry.
 
 ### Changed
 
-- Change `ActiveEventLoop` and `Window` to be traits, and added `as_inner`/`as_inner_mut`/`into_inner`
+- Change `ActiveEventLoop` and `Window` to be traits, and added `cast_ref`/`cast_mut`/`cast`
   methods to extract the backend type from those.
 - `ActiveEventLoop::create_window` now returns `Box<dyn Window>`.
 - `ApplicationHandler` now uses `dyn ActiveEventLoop`.

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -76,8 +76,8 @@ changelog entry.
 
 ### Changed
 
-- Change `ActiveEventLoop` to be a trait.
-- Change `Window` to be a trait.
+- Change `ActiveEventLoop` and `Window` to be traits, and added `as_inner` methods to extract the
+  backend type from those.
 - `ActiveEventLoop::create_window` now returns `Box<dyn Window>`.
 - `ApplicationHandler` now uses `dyn ActiveEventLoop`.
 - On Web, let events wake up event loop immediately when using `ControlFlow::Poll`.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -411,7 +411,7 @@ impl dyn ActiveEventLoop + '_ {
     /// Downcast to the backend active event loop type.
     ///
     /// Returns `None` if the active event loop was not from that backend.
-    pub fn as_inner<T: ActiveEventLoop>(&self) -> Option<&T> {
+    pub fn cast_ref<T: ActiveEventLoop>(&self) -> Option<&T> {
         let this: &dyn Any = self.__as_any();
         this.downcast_ref::<T>()
     }
@@ -419,7 +419,7 @@ impl dyn ActiveEventLoop + '_ {
     /// Mutable downcast to the backend active event loop type.
     ///
     /// Returns `None` if the active event loop was not from that backend.
-    pub fn as_inner_mut<T: ActiveEventLoop>(&mut self) -> Option<&mut T> {
+    pub fn cast_mut<T: ActiveEventLoop>(&mut self) -> Option<&mut T> {
         let this: &mut dyn Any = self.__as_any_mut();
         this.downcast_mut::<T>()
     }
@@ -427,7 +427,7 @@ impl dyn ActiveEventLoop + '_ {
     /// Owned downcast to the backend active event loop type.
     ///
     /// Returns `Err` with `self` if the active event loop was not from that backend.
-    pub fn into_inner<T: ActiveEventLoop>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+    pub fn cast<T: ActiveEventLoop>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
         let reference: &dyn Any = self.__as_any();
         if reference.is::<T>() {
             let this: Box<dyn Any> = self.__into_any();

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -8,6 +8,7 @@
 //!
 //! See the root-level documentation for information on how to create and use an event loop to
 //! handle events.
+use std::any::Any;
 use std::fmt;
 use std::marker::PhantomData;
 #[cfg(any(x11_platform, wayland_platform))]
@@ -403,6 +404,16 @@ pub trait ActiveEventLoop: AsAny + fmt::Debug {
 impl HasDisplayHandle for dyn ActiveEventLoop + '_ {
     fn display_handle(&self) -> Result<DisplayHandle<'_>, HandleError> {
         self.rwh_06_handle().display_handle()
+    }
+}
+
+impl dyn ActiveEventLoop + '_ {
+    /// Downcast to the backend active event loop type.
+    ///
+    /// Returns `None` if the active event loop was not from that backend.
+    pub fn as_inner<T: ActiveEventLoop>(&self) -> Option<&T> {
+        let this: &dyn Any = self.as_any();
+        this.downcast_ref::<T>()
     }
 }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -25,7 +25,7 @@ use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, RequestError};
 use crate::monitor::MonitorHandle;
 use crate::platform_impl;
-use crate::utils::{AsAny, OpaqueObject};
+use crate::utils::{impl_dyn_casting, AsAny};
 use crate::window::{CustomCursor, CustomCursorSource, Theme, Window, WindowAttributes};
 
 /// Provides a way to retrieve events from the system and from the windows that were registered to
@@ -406,7 +406,7 @@ impl HasDisplayHandle for dyn ActiveEventLoop + '_ {
     }
 }
 
-impl OpaqueObject for dyn ActiveEventLoop + '_ {}
+impl_dyn_casting!(ActiveEventLoop);
 
 /// A proxy for the underlying display handle.
 ///

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -415,6 +415,14 @@ impl dyn ActiveEventLoop + '_ {
         let this: &dyn Any = self.as_any();
         this.downcast_ref::<T>()
     }
+
+    /// Mutable downcast to the backend active event loop type.
+    ///
+    /// Returns `None` if the active event loop was not from that backend.
+    pub fn as_inner_mut<T: ActiveEventLoop>(&mut self) -> Option<&mut T> {
+        let this: &mut dyn Any = self.as_any_mut();
+        this.downcast_mut::<T>()
+    }
 }
 
 /// A proxy for the underlying display handle.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -412,7 +412,7 @@ impl dyn ActiveEventLoop + '_ {
     ///
     /// Returns `None` if the active event loop was not from that backend.
     pub fn as_inner<T: ActiveEventLoop>(&self) -> Option<&T> {
-        let this: &dyn Any = self.as_any();
+        let this: &dyn Any = self.__as_any();
         this.downcast_ref::<T>()
     }
 
@@ -420,7 +420,7 @@ impl dyn ActiveEventLoop + '_ {
     ///
     /// Returns `None` if the active event loop was not from that backend.
     pub fn as_inner_mut<T: ActiveEventLoop>(&mut self) -> Option<&mut T> {
-        let this: &mut dyn Any = self.as_any_mut();
+        let this: &mut dyn Any = self.__as_any_mut();
         this.downcast_mut::<T>()
     }
 
@@ -428,9 +428,9 @@ impl dyn ActiveEventLoop + '_ {
     ///
     /// Returns `Err` with `self` if the active event loop was not from that backend.
     pub fn into_inner<T: ActiveEventLoop>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        let reference: &dyn Any = self.as_any();
+        let reference: &dyn Any = self.__as_any();
         if reference.is::<T>() {
-            let this: Box<dyn Any> = self.into_any();
+            let this: Box<dyn Any> = self.__into_any();
             // Unwrap is okay, we just checked the type of `self` is `T`.
             Ok(this.downcast::<T>().unwrap())
         } else {

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -423,6 +423,20 @@ impl dyn ActiveEventLoop + '_ {
         let this: &mut dyn Any = self.as_any_mut();
         this.downcast_mut::<T>()
     }
+
+    /// Owned downcast to the backend active event loop type.
+    ///
+    /// Returns `Err` with `self` if the active event loop was not from that backend.
+    pub fn into_inner<T: ActiveEventLoop>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+        let reference: &dyn Any = self.as_any();
+        if reference.is::<T>() {
+            let this: Box<dyn Any> = self.into_any();
+            // Unwrap is okay, we just checked the type of `self` is `T`.
+            Ok(this.downcast::<T>().unwrap())
+        } else {
+            Err(self)
+        }
+    }
 }
 
 /// A proxy for the underlying display handle.

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -8,7 +8,6 @@
 //!
 //! See the root-level documentation for information on how to create and use an event loop to
 //! handle events.
-use std::any::Any;
 use std::fmt;
 use std::marker::PhantomData;
 #[cfg(any(x11_platform, wayland_platform))]
@@ -26,7 +25,7 @@ use crate::application::ApplicationHandler;
 use crate::error::{EventLoopError, RequestError};
 use crate::monitor::MonitorHandle;
 use crate::platform_impl;
-use crate::utils::AsAny;
+use crate::utils::{AsAny, OpaqueObject};
 use crate::window::{CustomCursor, CustomCursorSource, Theme, Window, WindowAttributes};
 
 /// Provides a way to retrieve events from the system and from the windows that were registered to
@@ -407,37 +406,7 @@ impl HasDisplayHandle for dyn ActiveEventLoop + '_ {
     }
 }
 
-impl dyn ActiveEventLoop + '_ {
-    /// Downcast to the backend active event loop type.
-    ///
-    /// Returns `None` if the active event loop was not from that backend.
-    pub fn cast_ref<T: ActiveEventLoop>(&self) -> Option<&T> {
-        let this: &dyn Any = self.__as_any();
-        this.downcast_ref::<T>()
-    }
-
-    /// Mutable downcast to the backend active event loop type.
-    ///
-    /// Returns `None` if the active event loop was not from that backend.
-    pub fn cast_mut<T: ActiveEventLoop>(&mut self) -> Option<&mut T> {
-        let this: &mut dyn Any = self.__as_any_mut();
-        this.downcast_mut::<T>()
-    }
-
-    /// Owned downcast to the backend active event loop type.
-    ///
-    /// Returns `Err` with `self` if the active event loop was not from that backend.
-    pub fn cast<T: ActiveEventLoop>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        let reference: &dyn Any = self.__as_any();
-        if reference.is::<T>() {
-            let this: Box<dyn Any> = self.__into_any();
-            // Unwrap is okay, we just checked the type of `self` is `T`.
-            Ok(this.downcast::<T>().unwrap())
-        } else {
-            Err(self)
-        }
-    }
-}
+impl OpaqueObject for dyn ActiveEventLoop + '_ {}
 
 /// A proxy for the underlying display handle.
 ///

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -157,6 +157,14 @@ impl dyn MonitorHandleProvider + '_ {
         let this: &dyn Any = self.as_any();
         this.downcast_ref::<T>()
     }
+
+    /// Mutable downcast to the backend monitor handle type.
+    ///
+    /// Returns `None` if the monitor handle was not from that backend.
+    pub fn as_inner_mut<T: MonitorHandleProvider>(&mut self) -> Option<&mut T> {
+        let this: &mut dyn Any = self.as_any_mut();
+        this.downcast_mut::<T>()
+    }
 }
 
 /// Describes a fullscreen video mode of a monitor.

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::utils::{AsAny, OpaqueObject};
+use crate::utils::{impl_dyn_casting, AsAny};
 
 /// Handle to a monitor.
 ///
@@ -148,7 +148,7 @@ impl PartialEq for dyn MonitorHandleProvider + '_ {
 
 impl Eq for dyn MonitorHandleProvider + '_ {}
 
-impl OpaqueObject for dyn MonitorHandleProvider + '_ {}
+impl_dyn_casting!(MonitorHandleProvider);
 
 /// Describes a fullscreen video mode of a monitor.
 ///

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -5,7 +5,6 @@
 //! methods, which return an iterator of [`MonitorHandle`]:
 //! - [`ActiveEventLoop::available_monitors`][crate::event_loop::ActiveEventLoop::available_monitors].
 //! - [`Window::available_monitors`][crate::window::Window::available_monitors].
-use std::any::Any;
 use std::borrow::Cow;
 use std::fmt;
 use std::num::{NonZeroU16, NonZeroU32};
@@ -13,7 +12,7 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 use crate::dpi::{PhysicalPosition, PhysicalSize};
-use crate::utils::AsAny;
+use crate::utils::{AsAny, OpaqueObject};
 
 /// Handle to a monitor.
 ///
@@ -149,37 +148,7 @@ impl PartialEq for dyn MonitorHandleProvider + '_ {
 
 impl Eq for dyn MonitorHandleProvider + '_ {}
 
-impl dyn MonitorHandleProvider + '_ {
-    /// Downcast to the backend monitor handle type.
-    ///
-    /// Returns `None` if the monitor handle was not from that backend.
-    pub fn cast_ref<T: MonitorHandleProvider>(&self) -> Option<&T> {
-        let this: &dyn Any = self.__as_any();
-        this.downcast_ref::<T>()
-    }
-
-    /// Mutable downcast to the backend monitor handle type.
-    ///
-    /// Returns `None` if the monitor handle was not from that backend.
-    pub fn cast_mut<T: MonitorHandleProvider>(&mut self) -> Option<&mut T> {
-        let this: &mut dyn Any = self.__as_any_mut();
-        this.downcast_mut::<T>()
-    }
-
-    /// Owned downcast to the backend monitor handle type.
-    ///
-    /// Returns `Err` with `self` if the monitor handle was not from that backend.
-    pub fn cast<T: MonitorHandleProvider>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        let reference: &dyn Any = self.__as_any();
-        if reference.is::<T>() {
-            let this: Box<dyn Any> = self.__into_any();
-            // Unwrap is okay, we just checked the type of `self` is `T`.
-            Ok(this.downcast::<T>().unwrap())
-        } else {
-            Err(self)
-        }
-    }
-}
+impl OpaqueObject for dyn MonitorHandleProvider + '_ {}
 
 /// Describes a fullscreen video mode of a monitor.
 ///

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -154,7 +154,7 @@ impl dyn MonitorHandleProvider + '_ {
     ///
     /// Returns `None` if the monitor handle was not from that backend.
     pub fn as_inner<T: MonitorHandleProvider>(&self) -> Option<&T> {
-        let this: &dyn Any = self.as_any();
+        let this: &dyn Any = self.__as_any();
         this.downcast_ref::<T>()
     }
 
@@ -162,7 +162,7 @@ impl dyn MonitorHandleProvider + '_ {
     ///
     /// Returns `None` if the monitor handle was not from that backend.
     pub fn as_inner_mut<T: MonitorHandleProvider>(&mut self) -> Option<&mut T> {
-        let this: &mut dyn Any = self.as_any_mut();
+        let this: &mut dyn Any = self.__as_any_mut();
         this.downcast_mut::<T>()
     }
 
@@ -170,9 +170,9 @@ impl dyn MonitorHandleProvider + '_ {
     ///
     /// Returns `Err` with `self` if the monitor handle was not from that backend.
     pub fn into_inner<T: MonitorHandleProvider>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        let reference: &dyn Any = self.as_any();
+        let reference: &dyn Any = self.__as_any();
         if reference.is::<T>() {
-            let this: Box<dyn Any> = self.into_any();
+            let this: Box<dyn Any> = self.__into_any();
             // Unwrap is okay, we just checked the type of `self` is `T`.
             Ok(this.downcast::<T>().unwrap())
         } else {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -153,7 +153,7 @@ impl dyn MonitorHandleProvider + '_ {
     /// Downcast to the backend monitor handle type.
     ///
     /// Returns `None` if the monitor handle was not from that backend.
-    pub fn as_inner<T: MonitorHandleProvider>(&self) -> Option<&T> {
+    pub fn cast_ref<T: MonitorHandleProvider>(&self) -> Option<&T> {
         let this: &dyn Any = self.__as_any();
         this.downcast_ref::<T>()
     }
@@ -161,7 +161,7 @@ impl dyn MonitorHandleProvider + '_ {
     /// Mutable downcast to the backend monitor handle type.
     ///
     /// Returns `None` if the monitor handle was not from that backend.
-    pub fn as_inner_mut<T: MonitorHandleProvider>(&mut self) -> Option<&mut T> {
+    pub fn cast_mut<T: MonitorHandleProvider>(&mut self) -> Option<&mut T> {
         let this: &mut dyn Any = self.__as_any_mut();
         this.downcast_mut::<T>()
     }
@@ -169,7 +169,7 @@ impl dyn MonitorHandleProvider + '_ {
     /// Owned downcast to the backend monitor handle type.
     ///
     /// Returns `Err` with `self` if the monitor handle was not from that backend.
-    pub fn into_inner<T: MonitorHandleProvider>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+    pub fn cast<T: MonitorHandleProvider>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
         let reference: &dyn Any = self.__as_any();
         if reference.is::<T>() {
             let this: Box<dyn Any> = self.__into_any();

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -5,6 +5,7 @@
 //! methods, which return an iterator of [`MonitorHandle`]:
 //! - [`ActiveEventLoop::available_monitors`][crate::event_loop::ActiveEventLoop::available_monitors].
 //! - [`Window::available_monitors`][crate::window::Window::available_monitors].
+use std::any::Any;
 use std::borrow::Cow;
 use std::fmt;
 use std::num::{NonZeroU16, NonZeroU32};
@@ -147,6 +148,16 @@ impl PartialEq for dyn MonitorHandleProvider + '_ {
 }
 
 impl Eq for dyn MonitorHandleProvider + '_ {}
+
+impl dyn MonitorHandleProvider + '_ {
+    /// Downcast to the backend monitor handle type.
+    ///
+    /// Returns `None` if the monitor handle was not from that backend.
+    pub fn as_inner<T: MonitorHandleProvider>(&self) -> Option<&T> {
+        let this: &dyn Any = self.as_any();
+        this.downcast_ref::<T>()
+    }
+}
 
 /// Describes a fullscreen video mode of a monitor.
 ///

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -165,6 +165,20 @@ impl dyn MonitorHandleProvider + '_ {
         let this: &mut dyn Any = self.as_any_mut();
         this.downcast_mut::<T>()
     }
+
+    /// Owned downcast to the backend monitor handle type.
+    ///
+    /// Returns `Err` with `self` if the monitor handle was not from that backend.
+    pub fn into_inner<T: MonitorHandleProvider>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+        let reference: &dyn Any = self.as_any();
+        if reference.is::<T>() {
+            let this: Box<dyn Any> = self.into_any();
+            // Unwrap is okay, we just checked the type of `self` is `T`.
+            Ok(this.downcast::<T>().unwrap())
+        } else {
+            Err(self)
+        }
+    }
 }
 
 /// Describes a fullscreen video mode of a monitor.

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -101,19 +101,19 @@ pub trait WindowExtAndroid {
 
 impl WindowExtAndroid for dyn Window + '_ {
     fn content_rect(&self) -> Rect {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.content_rect()
     }
 
     fn config(&self) -> ConfigurationRef {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.config()
     }
 }
 
 impl ActiveEventLoopExtAndroid for dyn ActiveEventLoop + '_ {
     fn android_app(&self) -> &AndroidApp {
-        let event_loop = self.as_inner::<crate::platform_impl::ActiveEventLoop>().unwrap();
+        let event_loop = self.cast_ref::<crate::platform_impl::ActiveEventLoop>().unwrap();
         &event_loop.app
     }
 }

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -72,7 +72,6 @@
 
 use self::activity::{AndroidApp, ConfigurationRef, Rect};
 use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
-use crate::utils::OpaqueObject;
 use crate::window::{Window, WindowAttributes};
 
 /// Additional methods on [`EventLoop`] that are specific to Android.

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -72,6 +72,7 @@
 
 use self::activity::{AndroidApp, ConfigurationRef, Rect};
 use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
+use crate::utils::OpaqueObject;
 use crate::window::{Window, WindowAttributes};
 
 /// Additional methods on [`EventLoop`] that are specific to Android.

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -101,20 +101,19 @@ pub trait WindowExtAndroid {
 
 impl WindowExtAndroid for dyn Window + '_ {
     fn content_rect(&self) -> Rect {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.content_rect()
     }
 
     fn config(&self) -> ConfigurationRef {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.config()
     }
 }
 
 impl ActiveEventLoopExtAndroid for dyn ActiveEventLoop + '_ {
     fn android_app(&self) -> &AndroidApp {
-        let event_loop =
-            self.as_any().downcast_ref::<crate::platform_impl::ActiveEventLoop>().unwrap();
+        let event_loop = self.as_inner::<crate::platform_impl::ActiveEventLoop>().unwrap();
         &event_loop.app
     }
 }

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -214,25 +214,25 @@ pub trait WindowExtIOS {
 impl WindowExtIOS for dyn Window + '_ {
     #[inline]
     fn set_scale_factor(&self, scale_factor: f64) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_scale_factor(scale_factor));
     }
 
     #[inline]
     fn set_valid_orientations(&self, valid_orientations: ValidOrientations) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_valid_orientations(valid_orientations));
     }
 
     #[inline]
     fn set_prefers_home_indicator_hidden(&self, hidden: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_prefers_home_indicator_hidden(hidden));
     }
 
     #[inline]
     fn set_preferred_screen_edges_deferring_system_gestures(&self, edges: ScreenEdge) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| {
             w.set_preferred_screen_edges_deferring_system_gestures(edges)
         });
@@ -240,19 +240,19 @@ impl WindowExtIOS for dyn Window + '_ {
 
     #[inline]
     fn set_prefers_status_bar_hidden(&self, hidden: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_prefers_status_bar_hidden(hidden));
     }
 
     #[inline]
     fn set_preferred_status_bar_style(&self, status_bar_style: StatusBarStyle) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_preferred_status_bar_style(status_bar_style))
     }
 
     #[inline]
     fn recognize_pinch_gesture(&self, should_recognize: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.recognize_pinch_gesture(should_recognize));
     }
 
@@ -263,7 +263,7 @@ impl WindowExtIOS for dyn Window + '_ {
         minimum_number_of_touches: u8,
         maximum_number_of_touches: u8,
     ) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| {
             w.recognize_pan_gesture(
                 should_recognize,
@@ -275,13 +275,13 @@ impl WindowExtIOS for dyn Window + '_ {
 
     #[inline]
     fn recognize_doubletap_gesture(&self, should_recognize: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.recognize_doubletap_gesture(should_recognize));
     }
 
     #[inline]
     fn recognize_rotation_gesture(&self, should_recognize: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.recognize_rotation_gesture(should_recognize));
     }
 }
@@ -398,13 +398,13 @@ impl MonitorHandleExtIOS for MonitorHandle {
     fn ui_screen(&self) -> *mut c_void {
         // SAFETY: The marker is only used to get the pointer of the screen
         let mtm = unsafe { objc2::MainThreadMarker::new_unchecked() };
-        let monitor = self.as_inner::<IosMonitorHandle>().unwrap();
+        let monitor = self.cast_ref::<IosMonitorHandle>().unwrap();
         objc2::rc::Retained::as_ptr(monitor.ui_screen(mtm)) as *mut c_void
     }
 
     #[inline]
     fn preferred_video_mode(&self) -> VideoMode {
-        let monitor = self.as_inner::<IosMonitorHandle>().unwrap();
+        let monitor = self.cast_ref::<IosMonitorHandle>().unwrap();
         monitor.preferred_video_mode()
     }
 }

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -109,7 +109,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::monitor::{MonitorHandle, VideoMode};
 use crate::platform_impl::MonitorHandle as IosMonitorHandle;
-use crate::utils::OpaqueObject;
 use crate::window::{Window, WindowAttributes};
 
 /// Additional methods on [`Window`] that are specific to iOS.

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -109,6 +109,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::monitor::{MonitorHandle, VideoMode};
 use crate::platform_impl::MonitorHandle as IosMonitorHandle;
+use crate::utils::OpaqueObject;
 use crate::window::{Window, WindowAttributes};
 
 /// Additional methods on [`Window`] that are specific to iOS.

--- a/src/platform/ios.rs
+++ b/src/platform/ios.rs
@@ -214,25 +214,25 @@ pub trait WindowExtIOS {
 impl WindowExtIOS for dyn Window + '_ {
     #[inline]
     fn set_scale_factor(&self, scale_factor: f64) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_scale_factor(scale_factor));
     }
 
     #[inline]
     fn set_valid_orientations(&self, valid_orientations: ValidOrientations) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_valid_orientations(valid_orientations));
     }
 
     #[inline]
     fn set_prefers_home_indicator_hidden(&self, hidden: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_prefers_home_indicator_hidden(hidden));
     }
 
     #[inline]
     fn set_preferred_screen_edges_deferring_system_gestures(&self, edges: ScreenEdge) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| {
             w.set_preferred_screen_edges_deferring_system_gestures(edges)
         });
@@ -240,19 +240,19 @@ impl WindowExtIOS for dyn Window + '_ {
 
     #[inline]
     fn set_prefers_status_bar_hidden(&self, hidden: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_prefers_status_bar_hidden(hidden));
     }
 
     #[inline]
     fn set_preferred_status_bar_style(&self, status_bar_style: StatusBarStyle) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_preferred_status_bar_style(status_bar_style))
     }
 
     #[inline]
     fn recognize_pinch_gesture(&self, should_recognize: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.recognize_pinch_gesture(should_recognize));
     }
 
@@ -263,7 +263,7 @@ impl WindowExtIOS for dyn Window + '_ {
         minimum_number_of_touches: u8,
         maximum_number_of_touches: u8,
     ) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| {
             w.recognize_pan_gesture(
                 should_recognize,
@@ -275,13 +275,13 @@ impl WindowExtIOS for dyn Window + '_ {
 
     #[inline]
     fn recognize_doubletap_gesture(&self, should_recognize: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.recognize_doubletap_gesture(should_recognize));
     }
 
     #[inline]
     fn recognize_rotation_gesture(&self, should_recognize: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.recognize_rotation_gesture(should_recognize));
     }
 }
@@ -398,13 +398,13 @@ impl MonitorHandleExtIOS for MonitorHandle {
     fn ui_screen(&self) -> *mut c_void {
         // SAFETY: The marker is only used to get the pointer of the screen
         let mtm = unsafe { objc2::MainThreadMarker::new_unchecked() };
-        let monitor = self.as_any().downcast_ref::<IosMonitorHandle>().unwrap();
+        let monitor = self.as_inner::<IosMonitorHandle>().unwrap();
         objc2::rc::Retained::as_ptr(monitor.ui_screen(mtm)) as *mut c_void
     }
 
     #[inline]
     fn preferred_video_mode(&self) -> VideoMode {
-        let monitor = self.as_any().downcast_ref::<IosMonitorHandle>().unwrap();
+        let monitor = self.as_inner::<IosMonitorHandle>().unwrap();
         monitor.preferred_video_mode()
     }
 }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -168,109 +168,109 @@ pub trait WindowExtMacOS {
 impl WindowExtMacOS for dyn Window + '_ {
     #[inline]
     fn simple_fullscreen(&self) -> bool {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.simple_fullscreen())
     }
 
     #[inline]
     fn set_simple_fullscreen(&self, fullscreen: bool) -> bool {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_simple_fullscreen(fullscreen))
     }
 
     #[inline]
     fn has_shadow(&self) -> bool {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.has_shadow())
     }
 
     #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_has_shadow(has_shadow));
     }
 
     #[inline]
     fn set_tabbing_identifier(&self, identifier: &str) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.set_tabbing_identifier(identifier))
     }
 
     #[inline]
     fn tabbing_identifier(&self) -> String {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.tabbing_identifier())
     }
 
     #[inline]
     fn select_next_tab(&self) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.select_next_tab());
     }
 
     #[inline]
     fn select_previous_tab(&self) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.select_previous_tab());
     }
 
     #[inline]
     fn select_tab_at_index(&self, index: usize) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.select_tab_at_index(index));
     }
 
     #[inline]
     fn num_tabs(&self) -> usize {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.num_tabs())
     }
 
     #[inline]
     fn is_document_edited(&self) -> bool {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.is_document_edited())
     }
 
     #[inline]
     fn set_document_edited(&self, edited: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_document_edited(edited));
     }
 
     #[inline]
     fn set_option_as_alt(&self, option_as_alt: OptionAsAlt) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_option_as_alt(option_as_alt));
     }
 
     #[inline]
     fn option_as_alt(&self) -> OptionAsAlt {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.option_as_alt())
     }
 
     #[inline]
     fn set_borderless_game(&self, borderless_game: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.set_borderless_game(borderless_game))
     }
 
     #[inline]
     fn is_borderless_game(&self) -> bool {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.is_borderless_game())
     }
 
     #[inline]
     fn set_unified_titlebar(&self, unified_titlebar: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.set_unified_titlebar(unified_titlebar))
     }
 
     #[inline]
     fn unified_titlebar(&self) -> bool {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.unified_titlebar())
     }
 }
@@ -506,7 +506,7 @@ pub trait MonitorHandleExtMacOS {
 
 impl MonitorHandleExtMacOS for MonitorHandle {
     fn ns_screen(&self) -> Option<*mut c_void> {
-        let monitor = self.as_any().downcast_ref::<MacOsMonitorHandle>().unwrap();
+        let monitor = self.as_inner::<MacOsMonitorHandle>().unwrap();
         // SAFETY: We only use the marker to get a pointer
         let mtm = unsafe { objc2::MainThreadMarker::new_unchecked() };
         monitor.ns_screen(mtm).map(|s| objc2::rc::Retained::as_ptr(&s) as _)
@@ -532,32 +532,28 @@ pub trait ActiveEventLoopExtMacOS {
 impl ActiveEventLoopExtMacOS for dyn ActiveEventLoop + '_ {
     fn hide_application(&self) {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non macOS event loop on macOS");
         event_loop.hide_application()
     }
 
     fn hide_other_applications(&self) {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non macOS event loop on macOS");
         event_loop.hide_other_applications()
     }
 
     fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non macOS event loop on macOS");
         event_loop.set_allows_automatic_window_tabbing(enabled);
     }
 
     fn allows_automatic_window_tabbing(&self) -> bool {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non macOS event loop on macOS");
         event_loop.allows_automatic_window_tabbing()
     }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -168,109 +168,109 @@ pub trait WindowExtMacOS {
 impl WindowExtMacOS for dyn Window + '_ {
     #[inline]
     fn simple_fullscreen(&self) -> bool {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.simple_fullscreen())
     }
 
     #[inline]
     fn set_simple_fullscreen(&self, fullscreen: bool) -> bool {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_simple_fullscreen(fullscreen))
     }
 
     #[inline]
     fn has_shadow(&self) -> bool {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.has_shadow())
     }
 
     #[inline]
     fn set_has_shadow(&self, has_shadow: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_has_shadow(has_shadow));
     }
 
     #[inline]
     fn set_tabbing_identifier(&self, identifier: &str) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.set_tabbing_identifier(identifier))
     }
 
     #[inline]
     fn tabbing_identifier(&self) -> String {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.tabbing_identifier())
     }
 
     #[inline]
     fn select_next_tab(&self) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.select_next_tab());
     }
 
     #[inline]
     fn select_previous_tab(&self) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.select_previous_tab());
     }
 
     #[inline]
     fn select_tab_at_index(&self, index: usize) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.select_tab_at_index(index));
     }
 
     #[inline]
     fn num_tabs(&self) -> usize {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.num_tabs())
     }
 
     #[inline]
     fn is_document_edited(&self) -> bool {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.is_document_edited())
     }
 
     #[inline]
     fn set_document_edited(&self, edited: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_document_edited(edited));
     }
 
     #[inline]
     fn set_option_as_alt(&self, option_as_alt: OptionAsAlt) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_option_as_alt(option_as_alt));
     }
 
     #[inline]
     fn option_as_alt(&self) -> OptionAsAlt {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.option_as_alt())
     }
 
     #[inline]
     fn set_borderless_game(&self, borderless_game: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.set_borderless_game(borderless_game))
     }
 
     #[inline]
     fn is_borderless_game(&self) -> bool {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.is_borderless_game())
     }
 
     #[inline]
     fn set_unified_titlebar(&self, unified_titlebar: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.set_unified_titlebar(unified_titlebar))
     }
 
     #[inline]
     fn unified_titlebar(&self) -> bool {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.maybe_wait_on_main(|w| w.unified_titlebar())
     }
 }
@@ -506,7 +506,7 @@ pub trait MonitorHandleExtMacOS {
 
 impl MonitorHandleExtMacOS for MonitorHandle {
     fn ns_screen(&self) -> Option<*mut c_void> {
-        let monitor = self.as_inner::<MacOsMonitorHandle>().unwrap();
+        let monitor = self.cast_ref::<MacOsMonitorHandle>().unwrap();
         // SAFETY: We only use the marker to get a pointer
         let mtm = unsafe { objc2::MainThreadMarker::new_unchecked() };
         monitor.ns_screen(mtm).map(|s| objc2::rc::Retained::as_ptr(&s) as _)
@@ -532,28 +532,28 @@ pub trait ActiveEventLoopExtMacOS {
 impl ActiveEventLoopExtMacOS for dyn ActiveEventLoop + '_ {
     fn hide_application(&self) {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non macOS event loop on macOS");
         event_loop.hide_application()
     }
 
     fn hide_other_applications(&self) {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non macOS event loop on macOS");
         event_loop.hide_other_applications()
     }
 
     fn set_allows_automatic_window_tabbing(&self, enabled: bool) {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non macOS event loop on macOS");
         event_loop.set_allows_automatic_window_tabbing(enabled);
     }
 
     fn allows_automatic_window_tabbing(&self) -> bool {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non macOS event loop on macOS");
         event_loop.allows_automatic_window_tabbing()
     }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -74,6 +74,7 @@ use crate::application::ApplicationHandler;
 use crate::event_loop::{ActiveEventLoop, EventLoopBuilder};
 use crate::monitor::MonitorHandle;
 use crate::platform_impl::MonitorHandle as MacOsMonitorHandle;
+use crate::utils::OpaqueObject;
 use crate::window::{Window, WindowAttributes, WindowId};
 
 /// Additional methods on [`Window`] that are specific to MacOS.

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -74,7 +74,6 @@ use crate::application::ApplicationHandler;
 use crate::event_loop::{ActiveEventLoop, EventLoopBuilder};
 use crate::monitor::MonitorHandle;
 use crate::platform_impl::MonitorHandle as MacOsMonitorHandle;
-use crate::utils::OpaqueObject;
 use crate::window::{Window, WindowAttributes, WindowId};
 
 /// Additional methods on [`Window`] that are specific to MacOS.

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -75,15 +75,12 @@ impl EventLoopExtStartupNotify for dyn ActiveEventLoop + '_ {
 impl WindowExtStartupNotify for dyn Window + '_ {
     fn request_activation_token(&self) -> Result<AsyncRequestSerial, RequestError> {
         #[cfg(wayland_platform)]
-        if let Some(window) = self.as_any().downcast_ref::<crate::platform_impl::wayland::Window>()
-        {
+        if let Some(window) = self.as_inner::<crate::platform_impl::wayland::Window>() {
             return window.request_activation_token();
         }
 
         #[cfg(x11_platform)]
-        if let Some(window) =
-            self.as_any().downcast_ref::<crate::platform_impl::x11::window::Window>()
-        {
+        if let Some(window) = self.as_inner::<crate::platform_impl::x11::window::Window>() {
             return window.request_activation_token();
         }
 

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -75,12 +75,12 @@ impl EventLoopExtStartupNotify for dyn ActiveEventLoop + '_ {
 impl WindowExtStartupNotify for dyn Window + '_ {
     fn request_activation_token(&self) -> Result<AsyncRequestSerial, RequestError> {
         #[cfg(wayland_platform)]
-        if let Some(window) = self.as_inner::<crate::platform_impl::wayland::Window>() {
+        if let Some(window) = self.cast_ref::<crate::platform_impl::wayland::Window>() {
             return window.request_activation_token();
         }
 
         #[cfg(x11_platform)]
-        if let Some(window) = self.as_inner::<crate::platform_impl::x11::window::Window>() {
+        if let Some(window) = self.cast_ref::<crate::platform_impl::x11::window::Window>() {
             return window.request_activation_token();
         }
 

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -27,6 +27,7 @@ use crate::error::{NotSupportedError, RequestError};
 use crate::event_loop::{ActiveEventLoop, AsyncRequestSerial};
 #[cfg(wayland_platform)]
 use crate::platform::wayland::ActiveEventLoopExtWayland;
+use crate::utils::OpaqueObject;
 use crate::window::{ActivationToken, Window, WindowAttributes};
 
 /// The variable which is used mostly on X11.

--- a/src/platform/startup_notify.rs
+++ b/src/platform/startup_notify.rs
@@ -27,7 +27,6 @@ use crate::error::{NotSupportedError, RequestError};
 use crate::event_loop::{ActiveEventLoop, AsyncRequestSerial};
 #[cfg(wayland_platform)]
 use crate::platform::wayland::ActiveEventLoopExtWayland;
-use crate::utils::OpaqueObject;
 use crate::window::{ActivationToken, Window, WindowAttributes};
 
 /// The variable which is used mostly on X11.

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -14,7 +14,6 @@
 //! * `wayland-csd-adwaita-crossfont`.
 //! * `wayland-csd-adwaita-notitle`.
 use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
-use crate::utils::OpaqueObject;
 pub use crate::window::Theme;
 use crate::window::{Window as CoreWindow, WindowAttributes};
 

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -26,7 +26,7 @@ pub trait ActiveEventLoopExtWayland {
 impl ActiveEventLoopExtWayland for dyn ActiveEventLoop + '_ {
     #[inline]
     fn is_wayland(&self) -> bool {
-        self.as_inner::<crate::platform_impl::wayland::ActiveEventLoop>().is_some()
+        self.cast_ref::<crate::platform_impl::wayland::ActiveEventLoop>().is_some()
     }
 }
 

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -26,7 +26,7 @@ pub trait ActiveEventLoopExtWayland {
 impl ActiveEventLoopExtWayland for dyn ActiveEventLoop + '_ {
     #[inline]
     fn is_wayland(&self) -> bool {
-        self.as_any().downcast_ref::<crate::platform_impl::wayland::ActiveEventLoop>().is_some()
+        self.as_inner::<crate::platform_impl::wayland::ActiveEventLoop>().is_some()
     }
 }
 

--- a/src/platform/wayland.rs
+++ b/src/platform/wayland.rs
@@ -14,6 +14,7 @@
 //! * `wayland-csd-adwaita-crossfont`.
 //! * `wayland-csd-adwaita-notitle`.
 use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
+use crate::utils::OpaqueObject;
 pub use crate::window::Theme;
 use crate::window::{Window as CoreWindow, WindowAttributes};
 

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -67,6 +67,7 @@ use crate::platform_impl::{
     OrientationLockFuture as PlatformOrientationLockFuture,
 };
 use crate::platform_impl::{MonitorHandle as WebMonitorHandle, PlatformCustomCursorSource};
+use crate::utils::OpaqueObject;
 use crate::window::{CustomCursor, Window, WindowAttributes};
 
 #[cfg(not(web_platform))]

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -105,23 +105,23 @@ pub trait WindowExtWeb {
 impl WindowExtWeb for dyn Window + '_ {
     #[inline]
     fn canvas(&self) -> Option<Ref<'_, HtmlCanvasElement>> {
-        self.as_inner::<crate::platform_impl::Window>().expect("non Web window on Web").canvas()
+        self.cast_ref::<crate::platform_impl::Window>().expect("non Web window on Web").canvas()
     }
 
     fn prevent_default(&self) -> bool {
-        self.as_inner::<crate::platform_impl::Window>()
+        self.cast_ref::<crate::platform_impl::Window>()
             .expect("non Web window on Web")
             .prevent_default()
     }
 
     fn set_prevent_default(&self, prevent_default: bool) {
-        self.as_inner::<crate::platform_impl::Window>()
+        self.cast_ref::<crate::platform_impl::Window>()
             .expect("non Web window on Web")
             .set_prevent_default(prevent_default)
     }
 
     fn is_cursor_lock_raw(&self) -> bool {
-        self.as_inner::<crate::platform_impl::Window>()
+        self.cast_ref::<crate::platform_impl::Window>()
             .expect("non Web window on Web")
             .is_cursor_lock_raw()
     }
@@ -365,7 +365,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn create_custom_cursor_async(&self, source: CustomCursorSource) -> CustomCursorFuture {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.create_custom_cursor_async(source)
     }
@@ -373,7 +373,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn set_poll_strategy(&self, strategy: PollStrategy) {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.set_poll_strategy(strategy);
     }
@@ -381,7 +381,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn poll_strategy(&self) -> PollStrategy {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.poll_strategy()
     }
@@ -389,7 +389,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn set_wait_until_strategy(&self, strategy: WaitUntilStrategy) {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.set_wait_until_strategy(strategy);
     }
@@ -397,7 +397,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn wait_until_strategy(&self) -> WaitUntilStrategy {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.wait_until_strategy()
     }
@@ -405,7 +405,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn is_cursor_lock_raw(&self) -> bool {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.is_cursor_lock_raw()
     }
@@ -413,7 +413,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn has_multiple_screens(&self) -> Result<bool, NotSupportedError> {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.has_multiple_screens()
     }
@@ -421,7 +421,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn request_detailed_monitor_permission(&self) -> MonitorPermissionFuture {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         MonitorPermissionFuture(event_loop.request_detailed_monitor_permission())
     }
@@ -429,7 +429,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn has_detailed_monitor_permission(&self) -> bool {
         let event_loop = self
-            .as_inner::<crate::platform_impl::ActiveEventLoop>()
+            .cast_ref::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.has_detailed_monitor_permission()
     }
@@ -681,24 +681,24 @@ pub trait MonitorHandleExtWeb {
 
 impl MonitorHandleExtWeb for dyn MonitorHandleProvider + '_ {
     fn is_internal(&self) -> Option<bool> {
-        self.as_inner::<WebMonitorHandle>().unwrap().is_internal()
+        self.cast_ref::<WebMonitorHandle>().unwrap().is_internal()
     }
 
     fn orientation(&self) -> OrientationData {
-        self.as_inner::<WebMonitorHandle>().unwrap().orientation()
+        self.cast_ref::<WebMonitorHandle>().unwrap().orientation()
     }
 
     fn request_lock(&self, orientation_lock: OrientationLock) -> OrientationLockFuture {
-        let future = self.as_inner::<WebMonitorHandle>().unwrap().request_lock(orientation_lock);
+        let future = self.cast_ref::<WebMonitorHandle>().unwrap().request_lock(orientation_lock);
         OrientationLockFuture(future)
     }
 
     fn unlock(&self) -> Result<(), OrientationLockError> {
-        self.as_inner::<WebMonitorHandle>().unwrap().unlock()
+        self.cast_ref::<WebMonitorHandle>().unwrap().unlock()
     }
 
     fn is_detailed(&self) -> bool {
-        self.as_inner::<WebMonitorHandle>().unwrap().is_detailed()
+        self.cast_ref::<WebMonitorHandle>().unwrap().is_detailed()
     }
 }
 

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -67,7 +67,6 @@ use crate::platform_impl::{
     OrientationLockFuture as PlatformOrientationLockFuture,
 };
 use crate::platform_impl::{MonitorHandle as WebMonitorHandle, PlatformCustomCursorSource};
-use crate::utils::OpaqueObject;
 use crate::window::{CustomCursor, Window, WindowAttributes};
 
 #[cfg(not(web_platform))]

--- a/src/platform/web.rs
+++ b/src/platform/web.rs
@@ -105,29 +105,23 @@ pub trait WindowExtWeb {
 impl WindowExtWeb for dyn Window + '_ {
     #[inline]
     fn canvas(&self) -> Option<Ref<'_, HtmlCanvasElement>> {
-        self.as_any()
-            .downcast_ref::<crate::platform_impl::Window>()
-            .expect("non Web window on Web")
-            .canvas()
+        self.as_inner::<crate::platform_impl::Window>().expect("non Web window on Web").canvas()
     }
 
     fn prevent_default(&self) -> bool {
-        self.as_any()
-            .downcast_ref::<crate::platform_impl::Window>()
+        self.as_inner::<crate::platform_impl::Window>()
             .expect("non Web window on Web")
             .prevent_default()
     }
 
     fn set_prevent_default(&self, prevent_default: bool) {
-        self.as_any()
-            .downcast_ref::<crate::platform_impl::Window>()
+        self.as_inner::<crate::platform_impl::Window>()
             .expect("non Web window on Web")
             .set_prevent_default(prevent_default)
     }
 
     fn is_cursor_lock_raw(&self) -> bool {
-        self.as_any()
-            .downcast_ref::<crate::platform_impl::Window>()
+        self.as_inner::<crate::platform_impl::Window>()
             .expect("non Web window on Web")
             .is_cursor_lock_raw()
     }
@@ -371,8 +365,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn create_custom_cursor_async(&self, source: CustomCursorSource) -> CustomCursorFuture {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.create_custom_cursor_async(source)
     }
@@ -380,8 +373,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn set_poll_strategy(&self, strategy: PollStrategy) {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.set_poll_strategy(strategy);
     }
@@ -389,8 +381,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn poll_strategy(&self) -> PollStrategy {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.poll_strategy()
     }
@@ -398,8 +389,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn set_wait_until_strategy(&self, strategy: WaitUntilStrategy) {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.set_wait_until_strategy(strategy);
     }
@@ -407,8 +397,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn wait_until_strategy(&self) -> WaitUntilStrategy {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.wait_until_strategy()
     }
@@ -416,8 +405,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn is_cursor_lock_raw(&self) -> bool {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.is_cursor_lock_raw()
     }
@@ -425,8 +413,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn has_multiple_screens(&self) -> Result<bool, NotSupportedError> {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.has_multiple_screens()
     }
@@ -434,8 +421,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn request_detailed_monitor_permission(&self) -> MonitorPermissionFuture {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         MonitorPermissionFuture(event_loop.request_detailed_monitor_permission())
     }
@@ -443,8 +429,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
     #[inline]
     fn has_detailed_monitor_permission(&self) -> bool {
         let event_loop = self
-            .as_any()
-            .downcast_ref::<crate::platform_impl::ActiveEventLoop>()
+            .as_inner::<crate::platform_impl::ActiveEventLoop>()
             .expect("non Web event loop on Web");
         event_loop.has_detailed_monitor_permission()
     }
@@ -696,28 +681,24 @@ pub trait MonitorHandleExtWeb {
 
 impl MonitorHandleExtWeb for dyn MonitorHandleProvider + '_ {
     fn is_internal(&self) -> Option<bool> {
-        self.as_any().downcast_ref::<WebMonitorHandle>().unwrap().is_internal()
+        self.as_inner::<WebMonitorHandle>().unwrap().is_internal()
     }
 
     fn orientation(&self) -> OrientationData {
-        self.as_any().downcast_ref::<WebMonitorHandle>().unwrap().orientation()
+        self.as_inner::<WebMonitorHandle>().unwrap().orientation()
     }
 
     fn request_lock(&self, orientation_lock: OrientationLock) -> OrientationLockFuture {
-        let future = self
-            .as_any()
-            .downcast_ref::<WebMonitorHandle>()
-            .unwrap()
-            .request_lock(orientation_lock);
+        let future = self.as_inner::<WebMonitorHandle>().unwrap().request_lock(orientation_lock);
         OrientationLockFuture(future)
     }
 
     fn unlock(&self) -> Result<(), OrientationLockError> {
-        self.as_any().downcast_ref::<WebMonitorHandle>().unwrap().unlock()
+        self.as_inner::<WebMonitorHandle>().unwrap().unlock()
     }
 
     fn is_detailed(&self) -> bool {
-        self.as_any().downcast_ref::<WebMonitorHandle>().unwrap().is_detailed()
+        self.as_inner::<WebMonitorHandle>().unwrap().is_detailed()
     }
 }
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -343,37 +343,37 @@ pub trait WindowExtWindows {
 impl WindowExtWindows for dyn Window + '_ {
     #[inline]
     fn set_enable(&self, enabled: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_enable(enabled)
     }
 
     #[inline]
     fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_taskbar_icon(taskbar_icon)
     }
 
     #[inline]
     fn set_skip_taskbar(&self, skip: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_skip_taskbar(skip)
     }
 
     #[inline]
     fn set_undecorated_shadow(&self, shadow: bool) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_undecorated_shadow(shadow)
     }
 
     #[inline]
     fn set_system_backdrop(&self, backdrop_type: BackdropType) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_system_backdrop(backdrop_type)
     }
 
     #[inline]
     fn set_border_color(&self, color: Option<Color>) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_border_color(color.unwrap_or(Color::NONE))
     }
 
@@ -382,26 +382,26 @@ impl WindowExtWindows for dyn Window + '_ {
         // The windows docs don't mention NONE as a valid options but it works in practice and is
         // useful to circumvent the Windows option "Show accent color on title bars and
         // window borders"
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_title_background_color(color.unwrap_or(Color::NONE))
     }
 
     #[inline]
     fn set_title_text_color(&self, color: Color) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_title_text_color(color)
     }
 
     #[inline]
     fn set_corner_preference(&self, preference: CornerPreference) {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         window.set_corner_preference(preference)
     }
 
     unsafe fn window_handle_any_thread(
         &self,
     ) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
-        let window = self.as_any().downcast_ref::<crate::platform_impl::Window>().unwrap();
+        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
         unsafe {
             let handle = window.rwh_06_no_thread_check()?;
 

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -15,7 +15,6 @@ use windows_sys::Win32::Foundation::HANDLE;
 use crate::dpi::PhysicalSize;
 use crate::event::DeviceId;
 use crate::event_loop::EventLoopBuilder;
-use crate::utils::OpaqueObject;
 use crate::window::{BadIcon, Icon, Window, WindowAttributes};
 
 /// Window Handle type used by Win32 API

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -15,6 +15,7 @@ use windows_sys::Win32::Foundation::HANDLE;
 use crate::dpi::PhysicalSize;
 use crate::event::DeviceId;
 use crate::event_loop::EventLoopBuilder;
+use crate::utils::OpaqueObject;
 use crate::window::{BadIcon, Icon, Window, WindowAttributes};
 
 /// Window Handle type used by Win32 API

--- a/src/platform/windows.rs
+++ b/src/platform/windows.rs
@@ -343,37 +343,37 @@ pub trait WindowExtWindows {
 impl WindowExtWindows for dyn Window + '_ {
     #[inline]
     fn set_enable(&self, enabled: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_enable(enabled)
     }
 
     #[inline]
     fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_taskbar_icon(taskbar_icon)
     }
 
     #[inline]
     fn set_skip_taskbar(&self, skip: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_skip_taskbar(skip)
     }
 
     #[inline]
     fn set_undecorated_shadow(&self, shadow: bool) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_undecorated_shadow(shadow)
     }
 
     #[inline]
     fn set_system_backdrop(&self, backdrop_type: BackdropType) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_system_backdrop(backdrop_type)
     }
 
     #[inline]
     fn set_border_color(&self, color: Option<Color>) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_border_color(color.unwrap_or(Color::NONE))
     }
 
@@ -382,26 +382,26 @@ impl WindowExtWindows for dyn Window + '_ {
         // The windows docs don't mention NONE as a valid options but it works in practice and is
         // useful to circumvent the Windows option "Show accent color on title bars and
         // window borders"
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_title_background_color(color.unwrap_or(Color::NONE))
     }
 
     #[inline]
     fn set_title_text_color(&self, color: Color) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_title_text_color(color)
     }
 
     #[inline]
     fn set_corner_preference(&self, preference: CornerPreference) {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         window.set_corner_preference(preference)
     }
 
     unsafe fn window_handle_any_thread(
         &self,
     ) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
-        let window = self.as_inner::<crate::platform_impl::Window>().unwrap();
+        let window = self.cast_ref::<crate::platform_impl::Window>().unwrap();
         unsafe {
             let handle = window.rwh_06_no_thread_check()?;
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::dpi::Size;
 use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
-use crate::utils::OpaqueObject;
 use crate::window::{Window as CoreWindow, WindowAttributes};
 
 /// X window type. Maps directly to

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -91,7 +91,7 @@ pub trait ActiveEventLoopExtX11 {
 impl ActiveEventLoopExtX11 for dyn ActiveEventLoop + '_ {
     #[inline]
     fn is_x11(&self) -> bool {
-        self.as_inner::<crate::platform_impl::x11::ActiveEventLoop>().is_some()
+        self.cast_ref::<crate::platform_impl::x11::ActiveEventLoop>().is_some()
     }
 }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -91,7 +91,7 @@ pub trait ActiveEventLoopExtX11 {
 impl ActiveEventLoopExtX11 for dyn ActiveEventLoop + '_ {
     #[inline]
     fn is_x11(&self) -> bool {
-        self.as_any().downcast_ref::<crate::platform_impl::x11::ActiveEventLoop>().is_some()
+        self.as_inner::<crate::platform_impl::x11::ActiveEventLoop>().is_some()
     }
 }
 

--- a/src/platform/x11.rs
+++ b/src/platform/x11.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::dpi::Size;
 use crate::event_loop::{ActiveEventLoop, EventLoop, EventLoopBuilder};
+use crate::utils::OpaqueObject;
 use crate::window::{Window as CoreWindow, WindowAttributes};
 
 /// X window type. Maps directly to

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -556,7 +556,7 @@ fn new_window(
         let screen = match attrs.fullscreen.clone() {
             Some(Fullscreen::Borderless(Some(monitor)))
             | Some(Fullscreen::Exclusive(monitor, _)) => {
-                let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                 monitor.ns_screen(mtm).or_else(|| NSScreen::mainScreen(mtm))
             },
             Some(Fullscreen::Borderless(None)) => NSScreen::mainScreen(mtm),
@@ -1460,7 +1460,7 @@ impl WindowDelegate {
         if let Some(ref fullscreen) = fullscreen {
             let new_screen = match fullscreen {
                 Fullscreen::Borderless(Some(monitor)) | Fullscreen::Exclusive(monitor, _) => {
-                    let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                    let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                     monitor.ns_screen(mtm)
                 },
                 Fullscreen::Borderless(None) => {
@@ -1519,7 +1519,7 @@ impl WindowDelegate {
                 cgerr(CGDisplayCapture(display_id)).unwrap();
             }
 
-            let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+            let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
             let video_mode =
                 match monitor.video_mode_handles().find(|mode| &mode.mode == video_mode) {
                     Some(video_mode) => video_mode,
@@ -1587,7 +1587,7 @@ impl WindowDelegate {
                 toggle_fullscreen(self.window());
             },
             (Some(Fullscreen::Exclusive(monitor, _)), None) => {
-                let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                 restore_and_release_display(monitor);
                 toggle_fullscreen(self.window());
             },
@@ -1618,7 +1618,7 @@ impl WindowDelegate {
                 );
                 app.setPresentationOptions(presentation_options);
 
-                let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                 restore_and_release_display(monitor);
 
                 // Restore the normal window level following the Borderless fullscreen

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -51,7 +51,6 @@ use crate::error::{NotSupportedError, RequestError};
 use crate::event::{SurfaceSizeWriter, WindowEvent};
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle, MonitorHandleProvider};
 use crate::platform::macos::{OptionAsAlt, WindowExtMacOS};
-use crate::utils::OpaqueObject;
 use crate::window::{
     Cursor, CursorGrabMode, Icon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -51,6 +51,7 @@ use crate::error::{NotSupportedError, RequestError};
 use crate::event::{SurfaceSizeWriter, WindowEvent};
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle, MonitorHandleProvider};
 use crate::platform::macos::{OptionAsAlt, WindowExtMacOS};
+use crate::utils::OpaqueObject;
 use crate::window::{
     Cursor, CursorGrabMode, Icon, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -556,7 +556,7 @@ fn new_window(
         let screen = match attrs.fullscreen.clone() {
             Some(Fullscreen::Borderless(Some(monitor)))
             | Some(Fullscreen::Exclusive(monitor, _)) => {
-                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                 monitor.ns_screen(mtm).or_else(|| NSScreen::mainScreen(mtm))
             },
             Some(Fullscreen::Borderless(None)) => NSScreen::mainScreen(mtm),
@@ -1460,7 +1460,7 @@ impl WindowDelegate {
         if let Some(ref fullscreen) = fullscreen {
             let new_screen = match fullscreen {
                 Fullscreen::Borderless(Some(monitor)) | Fullscreen::Exclusive(monitor, _) => {
-                    let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                    let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                     monitor.ns_screen(mtm)
                 },
                 Fullscreen::Borderless(None) => {
@@ -1519,7 +1519,7 @@ impl WindowDelegate {
                 cgerr(CGDisplayCapture(display_id)).unwrap();
             }
 
-            let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+            let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
             let video_mode =
                 match monitor.video_mode_handles().find(|mode| &mode.mode == video_mode) {
                     Some(video_mode) => video_mode,
@@ -1587,7 +1587,7 @@ impl WindowDelegate {
                 toggle_fullscreen(self.window());
             },
             (Some(Fullscreen::Exclusive(monitor, _)), None) => {
-                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                 restore_and_release_display(monitor);
                 toggle_fullscreen(self.window());
             },
@@ -1618,7 +1618,7 @@ impl WindowDelegate {
                 );
                 app.setPresentationOptions(presentation_options);
 
-                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                 restore_and_release_display(monitor);
 
                 // Restore the normal window level following the Borderless fullscreen

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -81,7 +81,7 @@ impl WinitUIWindow {
 
         match window_attributes.fullscreen.clone() {
             Some(Fullscreen::Exclusive(monitor, ref video_mode)) => {
-                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                 let screen = monitor.ui_screen(mtm);
                 if let Some(video_mode) =
                     monitor.video_modes_handles().find(|mode| &mode.mode == video_mode)
@@ -91,7 +91,7 @@ impl WinitUIWindow {
                 this.setScreen(screen);
             },
             Some(Fullscreen::Borderless(Some(ref monitor))) => {
-                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                 let screen = monitor.ui_screen(mtm);
                 this.setScreen(screen);
             },
@@ -306,7 +306,7 @@ impl Inner {
         let mtm = MainThreadMarker::new().unwrap();
         let uiscreen = match &monitor {
             Some(Fullscreen::Exclusive(monitor, video_mode)) => {
-                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                 let uiscreen = monitor.ui_screen(mtm);
                 if let Some(video_mode) =
                     monitor.video_modes_handles().find(|mode| &mode.mode == video_mode)
@@ -316,7 +316,7 @@ impl Inner {
                 uiscreen.clone()
             },
             Some(Fullscreen::Borderless(Some(monitor))) => {
-                monitor.as_inner::<MonitorHandle>().unwrap().ui_screen(mtm).clone()
+                monitor.cast_ref::<MonitorHandle>().unwrap().ui_screen(mtm).clone()
             },
             Some(Fullscreen::Borderless(None)) => {
                 self.current_monitor_inner().ui_screen(mtm).clone()
@@ -492,7 +492,7 @@ impl Window {
         let screen = match fullscreen {
             Some(Fullscreen::Exclusive(ref monitor, _))
             | Some(Fullscreen::Borderless(Some(ref monitor))) => {
-                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                 monitor.ui_screen(mtm)
             },
             Some(Fullscreen::Borderless(None)) | None => &main_screen,

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -28,7 +28,6 @@ use crate::event::WindowEvent;
 use crate::icon::Icon;
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
 use crate::platform::ios::{ScreenEdge, StatusBarStyle, ValidOrientations};
-use crate::utils::OpaqueObject;
 use crate::window::{
     CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -81,7 +81,7 @@ impl WinitUIWindow {
 
         match window_attributes.fullscreen.clone() {
             Some(Fullscreen::Exclusive(monitor, ref video_mode)) => {
-                let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                 let screen = monitor.ui_screen(mtm);
                 if let Some(video_mode) =
                     monitor.video_modes_handles().find(|mode| &mode.mode == video_mode)
@@ -91,7 +91,7 @@ impl WinitUIWindow {
                 this.setScreen(screen);
             },
             Some(Fullscreen::Borderless(Some(ref monitor))) => {
-                let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                 let screen = monitor.ui_screen(mtm);
                 this.setScreen(screen);
             },
@@ -306,7 +306,7 @@ impl Inner {
         let mtm = MainThreadMarker::new().unwrap();
         let uiscreen = match &monitor {
             Some(Fullscreen::Exclusive(monitor, video_mode)) => {
-                let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                 let uiscreen = monitor.ui_screen(mtm);
                 if let Some(video_mode) =
                     monitor.video_modes_handles().find(|mode| &mode.mode == video_mode)
@@ -316,7 +316,7 @@ impl Inner {
                 uiscreen.clone()
             },
             Some(Fullscreen::Borderless(Some(monitor))) => {
-                monitor.as_any().downcast_ref::<MonitorHandle>().unwrap().ui_screen(mtm).clone()
+                monitor.as_inner::<MonitorHandle>().unwrap().ui_screen(mtm).clone()
             },
             Some(Fullscreen::Borderless(None)) => {
                 self.current_monitor_inner().ui_screen(mtm).clone()
@@ -492,7 +492,7 @@ impl Window {
         let screen = match fullscreen {
             Some(Fullscreen::Exclusive(ref monitor, _))
             | Some(Fullscreen::Borderless(Some(ref monitor))) => {
-                let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                 monitor.ui_screen(mtm)
             },
             Some(Fullscreen::Borderless(None)) | None => &main_screen,

--- a/src/platform_impl/apple/uikit/window.rs
+++ b/src/platform_impl/apple/uikit/window.rs
@@ -28,6 +28,7 @@ use crate::event::WindowEvent;
 use crate::icon::Icon;
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
 use crate::platform::ios::{ScreenEdge, StatusBarStyle, ValidOrientations};
+use crate::utils::OpaqueObject;
 use crate::window::{
     CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -23,7 +23,6 @@ use crate::event::{Ime, WindowEvent};
 use crate::event_loop::AsyncRequestSerial;
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
 use crate::platform_impl::wayland::output;
-use crate::utils::AsAny;
 use crate::window::{
     Cursor, CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     Window as CoreWindow, WindowAttributes, WindowButtons, WindowId, WindowLevel,
@@ -146,10 +145,7 @@ impl Window {
             #[cfg_attr(not(x11_platform), allow(clippy::bind_instead_of_map))]
             Some(Fullscreen::Borderless(monitor)) => {
                 let output = monitor.as_ref().and_then(|monitor| {
-                    monitor
-                        .as_any()
-                        .downcast_ref::<output::MonitorHandle>()
-                        .map(|handle| &handle.proxy)
+                    monitor.as_inner::<output::MonitorHandle>().map(|handle| &handle.proxy)
                 });
 
                 window.set_fullscreen(output)
@@ -446,10 +442,7 @@ impl CoreWindow for Window {
             #[cfg_attr(not(x11_platform), allow(clippy::bind_instead_of_map))]
             Some(Fullscreen::Borderless(monitor)) => {
                 let output = monitor.as_ref().and_then(|monitor| {
-                    monitor
-                        .as_any()
-                        .downcast_ref::<output::MonitorHandle>()
-                        .map(|handle| &handle.proxy)
+                    monitor.as_inner::<output::MonitorHandle>().map(|handle| &handle.proxy)
                 });
 
                 self.window.set_fullscreen(output)

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -23,7 +23,6 @@ use crate::event::{Ime, WindowEvent};
 use crate::event_loop::AsyncRequestSerial;
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
 use crate::platform_impl::wayland::output;
-use crate::utils::OpaqueObject;
 use crate::window::{
     Cursor, CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     Window as CoreWindow, WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -23,6 +23,7 @@ use crate::event::{Ime, WindowEvent};
 use crate::event_loop::AsyncRequestSerial;
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
 use crate::platform_impl::wayland::output;
+use crate::utils::OpaqueObject;
 use crate::window::{
     Cursor, CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType,
     Window as CoreWindow, WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/linux/wayland/window/mod.rs
+++ b/src/platform_impl/linux/wayland/window/mod.rs
@@ -145,7 +145,7 @@ impl Window {
             #[cfg_attr(not(x11_platform), allow(clippy::bind_instead_of_map))]
             Some(Fullscreen::Borderless(monitor)) => {
                 let output = monitor.as_ref().and_then(|monitor| {
-                    monitor.as_inner::<output::MonitorHandle>().map(|handle| &handle.proxy)
+                    monitor.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy)
                 });
 
                 window.set_fullscreen(output)
@@ -442,7 +442,7 @@ impl CoreWindow for Window {
             #[cfg_attr(not(x11_platform), allow(clippy::bind_instead_of_map))]
             Some(Fullscreen::Borderless(monitor)) => {
                 let output = monitor.as_ref().and_then(|monitor| {
-                    monitor.as_inner::<output::MonitorHandle>().map(|handle| &handle.proxy)
+                    monitor.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy)
                 });
 
                 self.window.set_fullscreen(output)

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1067,11 +1067,11 @@ impl UnownedWindow {
                 let (monitor, video_mode): (Cow<'_, X11MonitorHandle>, Option<&VideoMode>) =
                     match &fullscreen {
                         Fullscreen::Exclusive(monitor, video_mode) => {
-                            let monitor = monitor.as_inner::<X11MonitorHandle>().unwrap();
+                            let monitor = monitor.cast_ref::<X11MonitorHandle>().unwrap();
                             (Cow::Borrowed(monitor), Some(video_mode))
                         },
                         Fullscreen::Borderless(Some(monitor)) => {
-                            let monitor = monitor.as_inner::<X11MonitorHandle>().unwrap();
+                            let monitor = monitor.cast_ref::<X11MonitorHandle>().unwrap();
                             (Cow::Borrowed(monitor), None)
                         },
                         Fullscreen::Borderless(None) => {

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -36,6 +36,7 @@ use crate::platform_impl::x11::{
     xinput_fp1616_to_float, MonitorHandle as X11MonitorHandle, WakeSender, X11Error,
 };
 use crate::platform_impl::{common, PlatformCustomCursor, PlatformIcon};
+use crate::utils::OpaqueObject;
 use crate::window::{
     CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -36,7 +36,6 @@ use crate::platform_impl::x11::{
     xinput_fp1616_to_float, MonitorHandle as X11MonitorHandle, WakeSender, X11Error,
 };
 use crate::platform_impl::{common, PlatformCustomCursor, PlatformIcon};
-use crate::utils::OpaqueObject;
 use crate::window::{
     CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1067,13 +1067,11 @@ impl UnownedWindow {
                 let (monitor, video_mode): (Cow<'_, X11MonitorHandle>, Option<&VideoMode>) =
                     match &fullscreen {
                         Fullscreen::Exclusive(monitor, video_mode) => {
-                            let monitor =
-                                monitor.as_any().downcast_ref::<X11MonitorHandle>().unwrap();
+                            let monitor = monitor.as_inner::<X11MonitorHandle>().unwrap();
                             (Cow::Borrowed(monitor), Some(video_mode))
                         },
                         Fullscreen::Borderless(Some(monitor)) => {
-                            let monitor =
-                                monitor.as_any().downcast_ref::<X11MonitorHandle>().unwrap();
+                            let monitor = monitor.as_inner::<X11MonitorHandle>().unwrap();
                             (Cow::Borrowed(monitor), None)
                         },
                         Fullscreen::Borderless(None) => {

--- a/src/platform_impl/web/web_sys/fullscreen.rs
+++ b/src/platform_impl/web/web_sys/fullscreen.rs
@@ -11,6 +11,7 @@ use super::super::main_thread::MainThreadMarker;
 use super::super::monitor::{self, ScreenDetailed};
 use crate::monitor::Fullscreen;
 use crate::platform_impl::MonitorHandle;
+use crate::utils::OpaqueObject;
 
 pub(crate) fn request_fullscreen(
     main_thread: MainThreadMarker,

--- a/src/platform_impl/web/web_sys/fullscreen.rs
+++ b/src/platform_impl/web/web_sys/fullscreen.rs
@@ -65,7 +65,7 @@ pub(crate) fn request_fullscreen(
                 return;
             }
 
-            let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+            let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
 
             if let Some(monitor) = monitor.detailed(main_thread) {
                 let options: FullscreenOptions = Object::new().unchecked_into();

--- a/src/platform_impl/web/web_sys/fullscreen.rs
+++ b/src/platform_impl/web/web_sys/fullscreen.rs
@@ -65,7 +65,7 @@ pub(crate) fn request_fullscreen(
                 return;
             }
 
-            let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+            let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
 
             if let Some(monitor) = monitor.detailed(main_thread) {
                 let options: FullscreenOptions = Object::new().unchecked_into();

--- a/src/platform_impl/web/web_sys/fullscreen.rs
+++ b/src/platform_impl/web/web_sys/fullscreen.rs
@@ -11,7 +11,6 @@ use super::super::main_thread::MainThreadMarker;
 use super::super::monitor::{self, ScreenDetailed};
 use crate::monitor::Fullscreen;
 use crate::platform_impl::MonitorHandle;
-use crate::utils::OpaqueObject;
 
 pub(crate) fn request_fullscreen(
     main_thread: MainThreadMarker,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -72,7 +72,6 @@ use crate::platform_impl::platform::window_state::{
     CursorFlags, SavedWindow, WindowFlags, WindowState,
 };
 use crate::platform_impl::platform::{monitor, util, SelectedCursor};
-use crate::utils::OpaqueObject;
 use crate::window::{
     CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -790,7 +790,7 @@ impl CoreWindow for Window {
             // fullscreen
             match (&old_fullscreen, &fullscreen) {
                 (_, Some(Fullscreen::Exclusive(monitor, video_mode))) => {
-                    let monitor = monitor.as_any().downcast_ref::<MonitorHandle>().unwrap();
+                    let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
                     let video_mode =
                         match monitor.video_mode_handles().find(|mode| &mode.mode == video_mode) {
                             Some(monitor) => monitor,
@@ -882,9 +882,9 @@ impl CoreWindow for Window {
 
                     let monitor = match &fullscreen {
                         Fullscreen::Exclusive(monitor, _)
-                        | Fullscreen::Borderless(Some(monitor)) => Some(Cow::Borrowed(
-                            monitor.as_any().downcast_ref::<MonitorHandle>().unwrap(),
-                        )),
+                        | Fullscreen::Borderless(Some(monitor)) => {
+                            Some(Cow::Borrowed(monitor.as_inner::<MonitorHandle>().unwrap()))
+                        },
                         Fullscreen::Borderless(None) => None,
                     };
 

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -72,6 +72,7 @@ use crate::platform_impl::platform::window_state::{
     CursorFlags, SavedWindow, WindowFlags, WindowState,
 };
 use crate::platform_impl::platform::{monitor, util, SelectedCursor};
+use crate::utils::OpaqueObject;
 use crate::window::{
     CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
     WindowAttributes, WindowButtons, WindowId, WindowLevel,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -790,7 +790,7 @@ impl CoreWindow for Window {
             // fullscreen
             match (&old_fullscreen, &fullscreen) {
                 (_, Some(Fullscreen::Exclusive(monitor, video_mode))) => {
-                    let monitor = monitor.as_inner::<MonitorHandle>().unwrap();
+                    let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                     let video_mode =
                         match monitor.video_mode_handles().find(|mode| &mode.mode == video_mode) {
                             Some(monitor) => monitor,
@@ -883,7 +883,7 @@ impl CoreWindow for Window {
                     let monitor = match &fullscreen {
                         Fullscreen::Exclusive(monitor, _)
                         | Fullscreen::Borderless(Some(monitor)) => {
-                            Some(Cow::Borrowed(monitor.as_inner::<MonitorHandle>().unwrap()))
+                            Some(Cow::Borrowed(monitor.cast_ref::<MonitorHandle>().unwrap()))
                         },
                         Fullscreen::Borderless(None) => None,
                     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,7 +28,8 @@ impl<T> Deref for Lazy<T> {
     }
 }
 
-pub trait AsAny {
+// FIXME: Remove and replace with a coercion once rust-lang/rust#65991 is in MSRV (1.86).
+pub trait AsAny: Any {
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,3 +58,39 @@ impl<T: Any> AsAny for T {
         self
     }
 }
+
+/// Marker for top-level traits to bring in more type safe casting methods.
+pub trait OpaqueObject
+where
+    Self: 'static + AsAny,
+{
+    /// Downcast to the backend concrete type.
+    ///
+    /// Returns `None` if the object was not from that backend.
+    fn cast_ref<T: 'static>(&self) -> Option<&T> {
+        let this: &dyn Any = self.__as_any();
+        this.downcast_ref::<T>()
+    }
+
+    /// Mutable downcast to the backend concrete type.
+    ///
+    /// Returns `None` if the window was not from that backend.
+    fn cast_mut<T: 'static>(&mut self) -> Option<&mut T> {
+        let this: &mut dyn Any = self.__as_any_mut();
+        this.downcast_mut::<T>()
+    }
+
+    /// Owned downcast to the backend concrete type.
+    ///
+    /// Returns `Err` with `self` if the concrete was not from that backend.
+    fn cast<T: 'static>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+        let reference: &dyn Any = self.__as_any();
+        if reference.is::<T>() {
+            let this: Box<dyn Any> = self.__into_any();
+            // Unwrap is okay, we just checked the type of `self` is `T`.
+            Ok(this.downcast::<T>().unwrap())
+        } else {
+            Err(self)
+        }
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -33,6 +33,7 @@ impl<T> Deref for Lazy<T> {
 pub trait AsAny: Any {
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
+    fn into_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
 impl<T: Any> AsAny for T {
@@ -43,6 +44,11 @@ impl<T: Any> AsAny for T {
 
     #[inline(always)]
     fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    #[inline(always)]
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -72,7 +72,7 @@ macro_rules! impl_dyn_casting {
 
             /// Mutable downcast to the backend concrete type.
             ///
-            /// Returns `None` if the window was not from that backend.
+            /// Returns `None` if the object was not from that backend.
             pub fn cast_mut<T: $trait>(&mut self) -> Option<&mut T> {
                 let this: &mut dyn std::any::Any = self.__as_any_mut();
                 this.downcast_mut::<T>()
@@ -80,7 +80,7 @@ macro_rules! impl_dyn_casting {
 
             /// Owned downcast to the backend concrete type.
             ///
-            /// Returns `Err` with `self` if the concrete was not from that backend.
+            /// Returns `Err` with `self` if the object was not from that backend.
             pub fn cast<T: $trait>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
                 let reference: &dyn std::any::Any = self.__as_any();
                 if reference.is::<T>() {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -29,26 +29,32 @@ impl<T> Deref for Lazy<T> {
 }
 
 // NOTE: This is `pub`, but isn't actually exposed outside the crate.
+// NOTE: Marked as `#[doc(hidden)]` and underscored, because they can be quite difficult to use
+// correctly, see discussion in #4160.
 // FIXME: Remove and replace with a coercion once rust-lang/rust#65991 is in MSRV (1.86).
+#[doc(hidden)]
 pub trait AsAny: Any {
-    fn as_any(&self) -> &dyn Any;
-    fn as_any_mut(&mut self) -> &mut dyn Any;
-    fn into_any(self: Box<Self>) -> Box<dyn Any>;
+    #[doc(hidden)]
+    fn __as_any(&self) -> &dyn Any;
+    #[doc(hidden)]
+    fn __as_any_mut(&mut self) -> &mut dyn Any;
+    #[doc(hidden)]
+    fn __into_any(self: Box<Self>) -> Box<dyn Any>;
 }
 
 impl<T: Any> AsAny for T {
     #[inline(always)]
-    fn as_any(&self) -> &dyn Any {
+    fn __as_any(&self) -> &dyn Any {
         self
     }
 
     #[inline(always)]
-    fn as_any_mut(&mut self) -> &mut dyn Any {
+    fn __as_any_mut(&mut self) -> &mut dyn Any {
         self
     }
 
     #[inline(always)]
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+    fn __into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,6 +28,7 @@ impl<T> Deref for Lazy<T> {
     }
 }
 
+// NOTE: This is `pub`, but isn't actually exposed outside the crate.
 // FIXME: Remove and replace with a coercion once rust-lang/rust#65991 is in MSRV (1.86).
 pub trait AsAny: Any {
     fn as_any(&self) -> &dyn Any;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1350,6 +1350,14 @@ impl dyn Window + '_ {
         let this: &dyn Any = self.as_any();
         this.downcast_ref::<T>()
     }
+
+    /// Mutable downcast to the backend window type.
+    ///
+    /// Returns `None` if the window was not from that backend.
+    pub fn as_inner_mut<T: Window>(&mut self) -> Option<&mut T> {
+        let this: &mut dyn Any = self.as_any_mut();
+        this.downcast_mut::<T>()
+    }
 }
 
 impl PartialEq for dyn Window + '_ {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,5 +1,4 @@
 //! The [`Window`] struct and associated types.
-use std::any::Any;
 use std::fmt;
 
 #[doc(inline)]
@@ -13,7 +12,7 @@ use crate::error::RequestError;
 pub use crate::icon::{BadIcon, Icon};
 use crate::monitor::{Fullscreen, MonitorHandle};
 use crate::platform_impl::PlatformSpecificWindowAttributes;
-use crate::utils::AsAny;
+use crate::utils::{AsAny, OpaqueObject};
 
 /// Identifier of a window. Unique for each window.
 ///
@@ -1342,37 +1341,9 @@ impl dyn Window + '_ {
     pub fn default_attributes() -> WindowAttributes {
         WindowAttributes::default()
     }
-
-    /// Downcast to the backend window type.
-    ///
-    /// Returns `None` if the window was not from that backend.
-    pub fn cast_ref<T: Window>(&self) -> Option<&T> {
-        let this: &dyn Any = self.__as_any();
-        this.downcast_ref::<T>()
-    }
-
-    /// Mutable downcast to the backend window type.
-    ///
-    /// Returns `None` if the window was not from that backend.
-    pub fn cast_mut<T: Window>(&mut self) -> Option<&mut T> {
-        let this: &mut dyn Any = self.__as_any_mut();
-        this.downcast_mut::<T>()
-    }
-
-    /// Owned downcast to the backend window type.
-    ///
-    /// Returns `Err` with `self` if the window was not from that backend.
-    pub fn cast<T: Window>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        let reference: &dyn Any = self.__as_any();
-        if reference.is::<T>() {
-            let this: Box<dyn Any> = self.__into_any();
-            // Unwrap is okay, we just checked the type of `self` is `T`.
-            Ok(this.downcast::<T>().unwrap())
-        } else {
-            Err(self)
-        }
-    }
 }
+
+impl OpaqueObject for dyn Window + '_ {}
 
 impl PartialEq for dyn Window + '_ {
     fn eq(&self, other: &dyn Window) -> bool {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1358,6 +1358,20 @@ impl dyn Window + '_ {
         let this: &mut dyn Any = self.as_any_mut();
         this.downcast_mut::<T>()
     }
+
+    /// Owned downcast to the backend window type.
+    ///
+    /// Returns `Err` with `self` if the window was not from that backend.
+    pub fn into_inner<T: Window>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+        let reference: &dyn Any = self.as_any();
+        if reference.is::<T>() {
+            let this: Box<dyn Any> = self.into_any();
+            // Unwrap is okay, we just checked the type of `self` is `T`.
+            Ok(this.downcast::<T>().unwrap())
+        } else {
+            Err(self)
+        }
+    }
 }
 
 impl PartialEq for dyn Window + '_ {

--- a/src/window.rs
+++ b/src/window.rs
@@ -1,4 +1,5 @@
 //! The [`Window`] struct and associated types.
+use std::any::Any;
 use std::fmt;
 
 #[doc(inline)]
@@ -1335,11 +1336,19 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     fn rwh_06_window_handle(&self) -> &dyn rwh_06::HasWindowHandle;
 }
 
-impl dyn Window {
+impl dyn Window + '_ {
     /// Create a new [`WindowAttributes`] which allows modifying the window's attributes before
     /// creation.
     pub fn default_attributes() -> WindowAttributes {
         WindowAttributes::default()
+    }
+
+    /// Downcast to the backend window type.
+    ///
+    /// Returns `None` if the window was not from that backend.
+    pub fn as_inner<T: Window>(&self) -> Option<&T> {
+        let this: &dyn Any = self.as_any();
+        this.downcast_ref::<T>()
     }
 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -1346,7 +1346,7 @@ impl dyn Window + '_ {
     /// Downcast to the backend window type.
     ///
     /// Returns `None` if the window was not from that backend.
-    pub fn as_inner<T: Window>(&self) -> Option<&T> {
+    pub fn cast_ref<T: Window>(&self) -> Option<&T> {
         let this: &dyn Any = self.__as_any();
         this.downcast_ref::<T>()
     }
@@ -1354,7 +1354,7 @@ impl dyn Window + '_ {
     /// Mutable downcast to the backend window type.
     ///
     /// Returns `None` if the window was not from that backend.
-    pub fn as_inner_mut<T: Window>(&mut self) -> Option<&mut T> {
+    pub fn cast_mut<T: Window>(&mut self) -> Option<&mut T> {
         let this: &mut dyn Any = self.__as_any_mut();
         this.downcast_mut::<T>()
     }
@@ -1362,7 +1362,7 @@ impl dyn Window + '_ {
     /// Owned downcast to the backend window type.
     ///
     /// Returns `Err` with `self` if the window was not from that backend.
-    pub fn into_inner<T: Window>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+    pub fn cast<T: Window>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
         let reference: &dyn Any = self.__as_any();
         if reference.is::<T>() {
             let this: Box<dyn Any> = self.__into_any();

--- a/src/window.rs
+++ b/src/window.rs
@@ -1347,7 +1347,7 @@ impl dyn Window + '_ {
     ///
     /// Returns `None` if the window was not from that backend.
     pub fn as_inner<T: Window>(&self) -> Option<&T> {
-        let this: &dyn Any = self.as_any();
+        let this: &dyn Any = self.__as_any();
         this.downcast_ref::<T>()
     }
 
@@ -1355,7 +1355,7 @@ impl dyn Window + '_ {
     ///
     /// Returns `None` if the window was not from that backend.
     pub fn as_inner_mut<T: Window>(&mut self) -> Option<&mut T> {
-        let this: &mut dyn Any = self.as_any_mut();
+        let this: &mut dyn Any = self.__as_any_mut();
         this.downcast_mut::<T>()
     }
 
@@ -1363,9 +1363,9 @@ impl dyn Window + '_ {
     ///
     /// Returns `Err` with `self` if the window was not from that backend.
     pub fn into_inner<T: Window>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
-        let reference: &dyn Any = self.as_any();
+        let reference: &dyn Any = self.__as_any();
         if reference.is::<T>() {
-            let this: Box<dyn Any> = self.into_any();
+            let this: Box<dyn Any> = self.__into_any();
             // Unwrap is okay, we just checked the type of `self` is `T`.
             Ok(this.downcast::<T>().unwrap())
         } else {

--- a/src/window.rs
+++ b/src/window.rs
@@ -12,7 +12,7 @@ use crate::error::RequestError;
 pub use crate::icon::{BadIcon, Icon};
 use crate::monitor::{Fullscreen, MonitorHandle};
 use crate::platform_impl::PlatformSpecificWindowAttributes;
-use crate::utils::{AsAny, OpaqueObject};
+use crate::utils::{impl_dyn_casting, AsAny};
 
 /// Identifier of a window. Unique for each window.
 ///
@@ -1343,7 +1343,7 @@ impl dyn Window + '_ {
     }
 }
 
-impl OpaqueObject for dyn Window + '_ {}
+impl_dyn_casting!(Window);
 
 impl PartialEq for dyn Window + '_ {
     fn eq(&self, other: &dyn Window) -> bool {


### PR DESCRIPTION
Avoids issues with calling `.as_any().downcast_ref()` on smart pointers, and makes it simpler to convert into the backend type, and clearer which kind of conversion we support. Alternative to https://github.com/rust-windowing/winit/pull/4157.

We should also be able to completely remove `AsAny` once we have MSRV 1.86, which is why I've added `Any` as a supertrait of that.

It's actually a miracle that `crate::monitor::MonitorHandle` -> `dyn crate::monitor::MonitorHandleProvider` -> `.as_any` -> `platform_impl::MonitorHandle` path that we use currently works at all (which it only does because all method calls do an implicit deref).

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
  - Not yet, backend types aren't yet exposed.
