### PR TITLE
Have WindowExtMacOS::set_simple_fullscreen honor WindowExtMacOS::set_borderless_game

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -236,3 +236,4 @@ changelog entry.
 - On macOS, fixed the scancode conversion for audio volume keys.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
+- On macos, `WindowExtMacOS::set_simple_fullscreen` now honors `WindowExtMacOS::set_borderless_game`

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -151,7 +151,9 @@ pub trait WindowExtMacOS {
     /// Getter for the [`WindowExtMacOS::set_option_as_alt`].
     fn option_as_alt(&self) -> OptionAsAlt;
 
-    /// Disable the Menu Bar and Dock in Borderless Fullscreen mode. Useful for games.
+    /// Disable the Menu Bar and Dock in Simple or Borderless Fullscreen mode. Useful for games.
+    /// The effect is applied when [`WindowExtMacOS::set_simple_fullscreen`] or
+    /// [`Window::set_fullscreen`] is called.
     fn set_borderless_game(&self, borderless_game: bool);
 
     /// Getter for the [`WindowExtMacOS::set_borderless_game`].

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1874,8 +1874,13 @@ impl WindowExtMacOS for WindowDelegate {
             self.ivars().is_simple_fullscreen.set(true);
 
             // Simulate pre-Lion fullscreen by hiding the dock and menu bar
-            let presentation_options = NSApplicationPresentationOptions::AutoHideDock
-                | NSApplicationPresentationOptions::AutoHideMenuBar;
+            let presentation_options = if self.is_borderless_game() {
+                NSApplicationPresentationOptions::HideDock
+                    | NSApplicationPresentationOptions::HideMenuBar
+            } else {
+                NSApplicationPresentationOptions::AutoHideDock
+                    | NSApplicationPresentationOptions::AutoHideMenuBar
+            };
             app.setPresentationOptions(presentation_options);
 
             // Hide the titlebar

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1896,7 +1896,6 @@ impl WindowExtMacOS for WindowDelegate {
             self.window().setMovable(false);
         } else {
             let new_mask = self.saved_style();
-            self.set_style_mask(new_mask);
             self.ivars().is_simple_fullscreen.set(false);
 
             let save_presentation_opts = self.ivars().save_presentation_opts.get();
@@ -1919,6 +1918,7 @@ impl WindowExtMacOS for WindowDelegate {
 
             self.window().setFrame_display(frame, true);
             self.window().setMovable(true);
+            self.set_style_mask(new_mask);
         }
 
         true


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation 


Also fixes a panic when leaving simple fullscreen. 

