### PR TITLE
macOS: Store UUID in MonitorHandle instead of CGDirectDisplayID

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -248,10 +248,11 @@ changelog entry.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
 - On Windows, fixed ~500 ms pause when clicking the title bar during continuous redraw.
-- On macos, `WindowExtMacOS::set_simple_fullscreen` now honors `WindowExtMacOS::set_borderless_game`
+- On macOS, `WindowExtMacOS::set_simple_fullscreen` now honors `WindowExtMacOS::set_borderless_game`
 - On X11 and Wayland, fixed pump_events with `Some(Duration::Zero)` blocking with `Wait` polling mode
 - On macOS, fixed `run_app_on_demand` returning without closing open windows.
 - On Wayland, fixed a crash when consequently calling `set_cursor_grab` without pointer focus.
 - On Wayland, ensure that external event loop is woken-up when using pump_events and integrating via `FD`.
 - On Wayland, apply fractional scaling to custom cursors.
 - On macOS, fixed `VideoMode::refresh_rate_millihertz` for fractional refresh rates.
+- On macOS, store monitor handle to avoid panics after going in/out of sleep.

--- a/src/platform_impl/apple/appkit/ffi.rs
+++ b/src/platform_impl/apple/appkit/ffi.rs
@@ -24,6 +24,8 @@ pub const kIO30BitDirectPixels: &str = "--RRRRRRRRRRGGGGGGGGGGBBBBBBBBBB";
 #[link(name = "ApplicationServices", kind = "framework")]
 extern "C" {
     pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> *mut CFUUID;
+
+    pub fn CGDisplayGetDisplayIDFromUUID(uuid: &CFUUID) -> CGDirectDisplayID;
 }
 
 #[link(name = "CoreGraphics", kind = "framework")]

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1756,7 +1756,8 @@ impl WindowDelegate {
     // Allow directly accessing the current monitor internally without unwrapping.
     pub(crate) fn current_monitor_inner(&self) -> Option<MonitorHandle> {
         let display_id = get_display_id(&*self.window().screen()?);
-        Some(MonitorHandle::new(display_id))
+        // Display ID just fetched from live NSScreen, should be fine to unwrap.
+        Some(MonitorHandle::new(display_id).expect("invalid display ID"))
     }
 
     #[inline]


### PR DESCRIPTION
The monitor UUID is what actually represents the monitor, `CGDirectDisplayID` is closer in correspondence to a configured framebuffer. We've already been doing comparisons on the UUID for [a while](https://github.com/rust-windowing/winit/pull/925), let's finish this by also storing the UUID.

Fixes #4166.

I have created a branch for backporting this onto v0.30 [here](https://github.com/rust-windowing/winit/tree/madsmtm/macos-monitor-handle-uuid-v0.30.x).

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
