### PR TITLE
x11:wayland: fix pump_events blocking with `Wait`

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -238,3 +238,4 @@ changelog entry.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
 - On Windows, fixed ~500 ms pause when clicking the title bar during continuous redraw.
 - On macos, `WindowExtMacOS::set_simple_fullscreen` now honors `WindowExtMacOS::set_borderless_game`
+- On X11 and Wayland, fixed pump_events with `Some(Duration::Zero)` blocking with `Wait` polling mode

--- a/src/platform_impl/linux/wayland/event_loop/mod.rs
+++ b/src/platform_impl/linux/wayland/event_loop/mod.rs
@@ -273,7 +273,10 @@ impl EventLoop {
 
             // Reduce spurious wake-ups.
             let dispatched_events = self.with_state(|state| state.dispatched_events);
-            if matches!(cause, StartCause::WaitCancelled { .. }) && !dispatched_events {
+            if matches!(cause, StartCause::WaitCancelled { .. })
+                && !dispatched_events
+                && timeout.is_none()
+            {
                 continue;
             }
 

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -570,6 +570,7 @@ impl EventLoop {
         // If we don't have any pending `_receiver`
         if !self.has_pending()
             && !matches!(&cause, StartCause::ResumeTimeReached { .. } | StartCause::Poll)
+            && timeout.is_none()
         {
             return;
         }


### PR DESCRIPTION
Using `Duration::Zero` with `Wait` polling mode was still blocking until the event was actually delivered. Thus when `pump_events` API is used, ensure that it's not happening.

Fixes #4130.
