### PR TITLE
add CursorGrabMode::Locked for windows

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -11,6 +11,7 @@ on how to add them:
 ```md
 ### Added
 
+- On Windows, add `CursorGrabMode::Locked`.
 - Add `Window::turbo()`, implemented on X11, Wayland, and Web.
 - On X11, add `Window::some_rare_api`.
 - On X11, add `Window::even_more_rare_api`.

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -6,8 +6,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io, mem, ptr};
 
 use crate::utils::Lazy;
-use windows_sys::{core::{HRESULT, PCWSTR}, Win32::{Foundation::POINT, UI::WindowsAndMessaging::GetCursorPos}};
-use windows_sys::Win32::Foundation::{BOOL, HANDLE, HMODULE, HWND, RECT};
+use windows_sys::core::{HRESULT, PCWSTR};
+use windows_sys::Win32::Foundation::{BOOL, HANDLE, HMODULE, HWND, POINT, RECT};
 use windows_sys::Win32::Graphics::Gdi::{ClientToScreen, HMONITOR};
 use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 use windows_sys::Win32::System::SystemServices::IMAGE_DOS_HEADER;
@@ -17,9 +17,9 @@ use windows_sys::Win32::UI::HiDpi::{
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::GetActiveWindow;
 use windows_sys::Win32::UI::Input::Pointer::{POINTER_INFO, POINTER_PEN_INFO, POINTER_TOUCH_INFO};
 use windows_sys::Win32::UI::WindowsAndMessaging::{
-    ClipCursor, GetClientRect, GetClipCursor, GetSystemMetrics, GetWindowPlacement, GetWindowRect,
-    IsIconic, ShowCursor, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP, IDC_IBEAM,
-    IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_WAIT,
+    ClipCursor, GetClientRect, GetClipCursor, GetCursorPos, GetSystemMetrics, GetWindowPlacement,
+    GetWindowRect, IsIconic, ShowCursor, IDC_APPSTARTING, IDC_ARROW, IDC_CROSS, IDC_HAND, IDC_HELP,
+    IDC_IBEAM, IDC_NO, IDC_SIZEALL, IDC_SIZENESW, IDC_SIZENS, IDC_SIZENWSE, IDC_SIZEWE, IDC_WAIT,
     SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SW_MAXIMIZE,
     WINDOWPLACEMENT,
 };

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -6,7 +6,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io, mem, ptr};
 
 use crate::utils::Lazy;
-use windows_sys::core::{HRESULT, PCWSTR};
+use windows_sys::{core::{HRESULT, PCWSTR}, Win32::{Foundation::POINT, UI::WindowsAndMessaging::GetCursorPos}};
 use windows_sys::Win32::Foundation::{BOOL, HANDLE, HMODULE, HWND, RECT};
 use windows_sys::Win32::Graphics::Gdi::{ClientToScreen, HMONITOR};
 use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
@@ -96,6 +96,13 @@ pub fn set_cursor_hidden(hidden: bool) {
     let changed = HIDDEN.swap(hidden, Ordering::SeqCst) ^ hidden;
     if changed {
         unsafe { ShowCursor(BOOL::from(!hidden)) };
+    }
+}
+
+pub fn get_cursor_position() -> Result<POINT, io::Error> {
+    unsafe {
+        let mut point: POINT = mem::zeroed();
+        win_to_err(GetCursorPos(&mut point)).map(|_| point)
     }
 }
 

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -488,10 +488,15 @@ impl CursorFlags {
                 true => {
                     if self.contains(CursorFlags::LOCKED) {
                         if let Ok(pos) = util::get_cursor_position() {
-                            Some(RECT { left: pos.x, right: pos.x + 1, top: pos.y, bottom: pos.y + 1})
+                            Some(RECT { 
+                                left: pos.x, 
+                                right: pos.x + 1, 
+                                top: pos.y, 
+                                bottom: pos.y + 1,
+                            })
                         } else {
-                            // If lock is applied while the cursor is not available, lock it to the middle 
-                            // of the window.
+                            // If lock is applied while the cursor is not available, lock it to the 
+                            // middle of the window.
                             let cx = (client_rect.left + client_rect.right) / 2;
                             let cy = (client_rect.top + client_rect.bottom) / 2;
                             Some(RECT { left: cx, right: cx + 1, top: cy, bottom: cy + 1 })

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -488,7 +488,7 @@ impl CursorFlags {
                 true => {
                     if self.contains(CursorFlags::LOCKED) {
                         if let Ok(pos) = util::get_cursor_position() {
-                            Some(RECT { 
+                            Some(RECT {
                                 left: pos.x,
                                 right: pos.x + 1,
                                 top: pos.y,

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -77,6 +77,7 @@ bitflags! {
         const GRABBED   = 1 << 0;
         const HIDDEN    = 1 << 1;
         const IN_WINDOW = 1 << 2;
+        const LOCKED    = 1 << 3;
     }
 }
 bitflags! {
@@ -485,7 +486,17 @@ impl CursorFlags {
         if util::is_focused(window) {
             let cursor_clip = match self.contains(CursorFlags::GRABBED) {
                 true => {
-                    if self.contains(CursorFlags::HIDDEN) {
+                    if self.contains(CursorFlags::LOCKED) {
+                        if let Ok(pos) = util::get_cursor_position() {
+                            Some(RECT { left: pos.x, right: pos.x + 1, top: pos.y, bottom: pos.y + 1})
+                        } else {
+                            // If lock is applied while the cursor is not available, lock it to the middle 
+                            // of the window.
+                            let cx = (client_rect.left + client_rect.right) / 2;
+                            let cy = (client_rect.top + client_rect.bottom) / 2;
+                            Some(RECT { left: cx, right: cx + 1, top: cy, bottom: cy + 1 })
+                        }
+                    } else if self.contains(CursorFlags::HIDDEN) {
                         // Confine the cursor to the center of the window if the cursor is hidden.
                         // This avoids problems with the cursor activating
                         // the taskbar if the window borders or overlaps that.

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -489,13 +489,13 @@ impl CursorFlags {
                     if self.contains(CursorFlags::LOCKED) {
                         if let Ok(pos) = util::get_cursor_position() {
                             Some(RECT { 
-                                left: pos.x, 
-                                right: pos.x + 1, 
-                                top: pos.y, 
+                                left: pos.x,
+                                right: pos.x + 1,
+                                top: pos.y,
                                 bottom: pos.y + 1,
                             })
                         } else {
-                            // If lock is applied while the cursor is not available, lock it to the 
+                            // If lock is applied while the cursor is not available, lock it to the
                             // middle of the window.
                             let cx = (client_rect.left + client_rect.right) / 2;
                             let cy = (client_rect.top + client_rect.bottom) / 2;

--- a/src/window.rs
+++ b/src/window.rs
@@ -1707,8 +1707,7 @@ pub enum CursorGrabMode {
     ///
     /// ## Platform-specific
     ///
-    /// - **X11:** Not implemented. Always returns [`ExternalError::NotSupported`] for
-    ///   now.
+    /// - **X11:** Not implemented. Always returns [`ExternalError::NotSupported`] for now.
     /// - **iOS / Android:** Always returns an [`ExternalError::NotSupported`].
     Locked,
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -1707,7 +1707,7 @@ pub enum CursorGrabMode {
     ///
     /// ## Platform-specific
     ///
-    /// - **X11 / Windows:** Not implemented. Always returns [`ExternalError::NotSupported`] for
+    /// - **X11:** Not implemented. Always returns [`ExternalError::NotSupported`] for
     ///   now.
     /// - **iOS / Android:** Always returns an [`ExternalError::NotSupported`].
     Locked,


### PR DESCRIPTION
adds support for CursorGrabMode::Locked on windows platform.

i targetted the 0.30.x branch since that's the easiest way for me to test. hope that's ok.

separately - how would people feel about a flag to disable the "`GRABBED & HIDDEN` -> confine to centre of window" behaviour? i find it suprising, since i may still want to use the cursor position even if i've hidden it.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [-] Created or updated an example program if it would help users understand this functionality
