### PR TITLE
Windows: Increase border size in undecorated shadow mode for better grip

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -194,6 +194,7 @@ changelog entry.
 - Removed `KeyEventExtModifierSupplement`, and made the fields `text_with_all_modifiers` and
   `key_without_modifiers` public on `KeyEvent` instead.
 - Move `window::Fullscreen` to `monitor::Fullscreen`.
+- On Windows, adjusted the border size in undecorated shadow mode to improve gripability.
 
 ### Removed
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1108,8 +1108,10 @@ unsafe fn public_window_callback_inner(
                 // Unfortunately this results in janky resize behavior, where the compositor is
                 // ahead of the window surface. Currently, there seems no option to achieve this
                 // with the Windows API.
-                params.rgrc[0].top += 1;
-                params.rgrc[0].bottom += 1;
+
+                params.rgrc[0].bottom -= 2;
+                params.rgrc[0].left += 2;
+                params.rgrc[0].right -= 2;
             }
 
             result = ProcResult::Value(0);


### PR DESCRIPTION
After enabling undecorated shadow on Windows, the borders, except for the top, become very thin, making dragging the window difficult.

I have modified the border size to make it easier to grab and drag. However, I've realized that this might not be the best solution.

- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
