### PR TITLE
icon: refactor `Icon` to be `dyn`

### DIFF
--- a/examples/application.rs
+++ b/examples/application.rs
@@ -20,6 +20,7 @@ use winit::dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use winit::error::RequestError;
 use winit::event::{DeviceEvent, DeviceId, Ime, MouseButton, MouseScrollDelta, WindowEvent};
 use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::icon::RgbaIcon;
 use winit::keyboard::{Key, ModifiersState};
 use winit::monitor::Fullscreen;
 #[cfg(macos_platform)]
@@ -1156,7 +1157,7 @@ fn load_icon(bytes: &[u8]) -> Icon {
         let rgba = image.into_raw();
         (rgba, width, height)
     };
-    Icon::from_rgba(icon_rgba, icon_width, icon_height).expect("Failed to open icon")
+    RgbaIcon::new(icon_rgba, icon_width, icon_height).expect("Failed to open icon").into()
 }
 
 fn modifiers_to_string(mods: ModifiersState) -> String {

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -76,6 +76,8 @@ changelog entry.
 - On X11, set an "area" attribute on XIM input connection to convey the cursor area.
 - Implement `CustomCursorProvider` for `CustomCursor` to access cursor API.
 - Add `CustomCursorSource::Url`, `CustomCursorSource::from_animation`.
+- Implement `CustomIconProvider` for `RgbaIcon`.
+- Add `icon` module that exposes winit's icon API.
 
 ### Changed
 
@@ -196,6 +198,7 @@ changelog entry.
 - Move `window::Fullscreen` to `monitor::Fullscreen`.
 - Renamed "super" key to "meta", to match the naming in the W3C specification.
   `NamedKey::Super` still exists, but it's non-functional and deprecated, `NamedKey::Meta` should be used instead.
+- Move `IconExtWindows` into `WinIcon`.
 
 ### Removed
 
@@ -230,9 +233,10 @@ changelog entry.
 - Remove `Window::inner_position`, use the new `Window::surface_position` instead.
 - Remove `CustomCursorExtWeb`, use the `CustomCursorSource`.
 - Remove `CustomCursor::from_rgba`, use `CustomCursorSource` instead.
-- Removed `ApplicationHandler::exited`, the event loop being shut down can now be listened to in
+- Remove `ApplicationHandler::exited`, the event loop being shut down can now be listened to in
   the `Drop` impl on the application handler.
-- Removed `NamedKey::Space`, match on `Key::Character(" ")` instead.
+- Remove `NamedKey::Space`, match on `Key::Character(" ")` instead.
+- Remove `PartialEq` impl for `WindowAttributes`.
 
 ### Fixed
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,7 +302,7 @@ pub mod error;
 mod cursor;
 pub mod event;
 pub mod event_loop;
-mod icon;
+pub mod icon;
 pub mod keyboard;
 pub mod monitor;
 mod platform_impl;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,6 +288,8 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg_hide), doc(cfg_hide(doc, docsrs)))]
 #![allow(clippy::missing_safety_doc)]
 #![warn(clippy::uninlined_format_args)]
+// TODO: wasm-binding needs to be updated for that to be resolved, for now just silence it.
+#![cfg_attr(web_platform, allow(unknown_lints, wasm_c_abi))]
 
 // Re-export DPI types so that users don't have to put it in Cargo.toml.
 #[doc(inline)]

--- a/src/platform/pump_events.rs
+++ b/src/platform/pump_events.rs
@@ -47,19 +47,19 @@ pub trait EventLoopExtPumpEvents {
     /// buffered and handled outside of Winit include:
     /// - `RedrawRequested` events, used to schedule rendering.
     ///
-    ///     macOS for example uses a `drawRect` callback to drive rendering
-    ///     within applications and expects rendering to be finished before
-    ///     the `drawRect` callback returns.
+    ///   macOS for example uses a `drawRect` callback to drive rendering
+    ///   within applications and expects rendering to be finished before
+    ///   the `drawRect` callback returns.
     ///
-    ///     For portability it's strongly recommended that applications should
-    ///     keep their rendering inside the closure provided to Winit.
+    ///   For portability it's strongly recommended that applications should
+    ///   keep their rendering inside the closure provided to Winit.
     /// - Any lifecycle events, such as `Suspended` / `Resumed`.
     ///
-    ///     The handling of these events needs to be synchronized with the
-    ///     operating system and it would never be appropriate to buffer a
-    ///     notification that your application has been suspended or resumed and
-    ///     then handled that later since there would always be a chance that
-    ///     other lifecycle events occur while the event is buffered.
+    ///   The handling of these events needs to be synchronized with the
+    ///   operating system and it would never be appropriate to buffer a
+    ///   notification that your application has been suspended or resumed and
+    ///   then handled that later since there would always be a chance that
+    ///   other lifecycle events occur while the event is buffered.
     ///
     /// ## Supported Platforms
     ///

--- a/src/platform_impl/android/mod.rs
+++ b/src/platform_impl/android/mod.rs
@@ -20,7 +20,6 @@ use crate::event_loop::{
     EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider,
     OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
-pub(crate) use crate::icon::NoIcon as PlatformIcon;
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
 use crate::platform::pump_events::PumpStatus;
 use crate::window::{

--- a/src/platform_impl/apple/appkit/mod.rs
+++ b/src/platform_impl/apple/appkit/mod.rs
@@ -21,4 +21,3 @@ pub(crate) use self::event_loop::{
 pub(crate) use self::monitor::MonitorHandle;
 pub(crate) use self::window::Window;
 pub(crate) use self::window_delegate::PlatformSpecificWindowAttributes;
-pub(crate) use crate::icon::NoIcon as PlatformIcon;

--- a/src/platform_impl/apple/uikit/app_state.rs
+++ b/src/platform_impl/apple/uikit/app_state.rs
@@ -298,7 +298,7 @@ pub(crate) fn queue_gl_or_metal_redraw(mtm: MainThreadMarker, window: Retained<W
         },
         s @ &mut AppStateImpl::ProcessingRedraws { .. }
         | s @ &mut AppStateImpl::Waiting { .. }
-        | s @ &mut AppStateImpl::PollFinished { .. } => bug!("unexpected state {:?}", s),
+        | s @ &mut AppStateImpl::PollFinished => bug!("unexpected state {:?}", s),
         &mut AppStateImpl::Terminated => {
             panic!("Attempt to create a `Window` after the app has terminated")
         },

--- a/src/platform_impl/apple/uikit/mod.rs
+++ b/src/platform_impl/apple/uikit/mod.rs
@@ -14,7 +14,6 @@ pub(crate) use self::event_loop::{
 };
 pub(crate) use self::monitor::MonitorHandle;
 pub(crate) use self::window::{PlatformSpecificWindowAttributes, Window};
-pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 #[derive(Debug)]
 pub enum OsError {}

--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -13,7 +13,6 @@ use crate::application::ApplicationHandler;
 use crate::dpi::Size;
 use crate::error::{EventLoopError, NotSupportedError};
 use crate::event_loop::ActiveEventLoop;
-pub(crate) use crate::icon::RgbaIcon as PlatformIcon;
 use crate::platform::pump_events::PumpStatus;
 #[cfg(x11_platform)]
 use crate::platform::x11::WindowType as XWindowType;

--- a/src/platform_impl/orbital/mod.rs
+++ b/src/platform_impl/orbital/mod.rs
@@ -4,7 +4,6 @@ use std::{fmt, str};
 
 pub(crate) use self::event_loop::{ActiveEventLoop, EventLoop};
 pub use self::window::Window;
-pub(crate) use crate::icon::NoIcon as PlatformIcon;
 
 mod event_loop;
 mod window;

--- a/src/platform_impl/web/mod.rs
+++ b/src/platform_impl/web/mod.rs
@@ -42,4 +42,3 @@ pub(crate) use self::monitor::{
 };
 use self::web_sys as backend;
 pub use self::window::{PlatformSpecificWindowAttributes, Window};
-pub(crate) use crate::icon::NoIcon as PlatformIcon;

--- a/src/platform_impl/windows/icon.rs
+++ b/src/platform_impl/windows/icon.rs
@@ -5,13 +5,12 @@ use std::{fmt, io, mem, ptr};
 
 use cursor_icon::CursorIcon;
 use windows_sys::core::PCWSTR;
-use windows_sys::Win32::Foundation::HWND;
 use windows_sys::Win32::Graphics::Gdi::{
     CreateBitmap, CreateCompatibleBitmap, DeleteObject, GetDC, ReleaseDC, SetBitmapBits,
 };
 use windows_sys::Win32::UI::WindowsAndMessaging::{
-    CreateIcon, CreateIconIndirect, DestroyCursor, DestroyIcon, LoadImageW, SendMessageW, HCURSOR,
-    HICON, ICONINFO, ICON_BIG, ICON_SMALL, IMAGE_ICON, LR_DEFAULTSIZE, LR_LOADFROMFILE, WM_SETICON,
+    CreateIcon, CreateIconIndirect, DestroyCursor, DestroyIcon, LoadImageW, HCURSOR, HICON,
+    ICONINFO, ICON_BIG, ICON_SMALL, IMAGE_ICON, LR_DEFAULTSIZE, LR_LOADFROMFILE,
 };
 
 use super::util;
@@ -19,71 +18,12 @@ use crate::cursor::{CursorImage, CustomCursorProvider};
 use crate::dpi::PhysicalSize;
 use crate::error::RequestError;
 use crate::icon::*;
-
-impl Pixel {
-    fn convert_to_bgra(&mut self) {
-        mem::swap(&mut self.r, &mut self.b);
-    }
-}
-
-impl RgbaIcon {
-    fn into_windows_icon(self) -> Result<WinIcon, BadIcon> {
-        let rgba = self.rgba;
-        let pixel_count = rgba.len() / PIXEL_SIZE;
-        let mut and_mask = Vec::with_capacity(pixel_count);
-        let pixels =
-            unsafe { std::slice::from_raw_parts_mut(rgba.as_ptr() as *mut Pixel, pixel_count) };
-        for pixel in pixels {
-            and_mask.push(pixel.a.wrapping_sub(u8::MAX)); // invert alpha channel
-            pixel.convert_to_bgra();
-        }
-        assert_eq!(and_mask.len(), pixel_count);
-        let handle = unsafe {
-            CreateIcon(
-                ptr::null_mut(),
-                self.width as i32,
-                self.height as i32,
-                1,
-                (PIXEL_SIZE * 8) as u8,
-                and_mask.as_ptr(),
-                rgba.as_ptr(),
-            )
-        };
-        if !handle.is_null() {
-            Ok(WinIcon::from_handle(handle))
-        } else {
-            Err(BadIcon::OsError(io::Error::last_os_error()))
-        }
-    }
-}
-
-#[derive(Debug)]
-pub enum IconType {
-    Small = ICON_SMALL as isize,
-    Big = ICON_BIG as isize,
-}
-
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct RaiiIcon {
-    handle: HICON,
-}
-
-unsafe impl Send for RaiiIcon {}
-unsafe impl Sync for RaiiIcon {}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct WinIcon {
-    inner: Arc<RaiiIcon>,
-}
+use crate::platform::windows::WinIcon;
 
 unsafe impl Send for WinIcon {}
 
 impl WinIcon {
-    pub fn as_raw_handle(&self) -> HICON {
-        self.inner.handle
-    }
-
-    pub fn from_path<P: AsRef<Path>>(
+    pub(crate) fn from_path_impl<P: AsRef<Path>>(
         path: P,
         size: Option<PhysicalSize<u32>>,
     ) -> Result<Self, BadIcon> {
@@ -109,14 +49,14 @@ impl WinIcon {
         }
     }
 
-    pub fn from_resource(
+    pub(crate) fn from_resource_impl(
         resource_id: u16,
         size: Option<PhysicalSize<u32>>,
     ) -> Result<Self, BadIcon> {
         Self::from_resource_ptr(resource_id as PCWSTR, size)
     }
 
-    pub fn from_resource_name(
+    pub(crate) fn from_resource_name_impl(
         resource_name: &str,
         size: Option<PhysicalSize<u32>>,
     ) -> Result<Self, BadIcon> {
@@ -147,14 +87,36 @@ impl WinIcon {
         }
     }
 
-    pub fn from_rgba(rgba: Vec<u8>, width: u32, height: u32) -> Result<Self, BadIcon> {
-        let rgba_icon = RgbaIcon::from_rgba(rgba, width, height)?;
-        rgba_icon.into_windows_icon()
+    pub(crate) fn as_raw_handle(&self) -> HICON {
+        self.inner.handle
     }
 
-    pub fn set_for_window(&self, hwnd: HWND, icon_type: IconType) {
-        unsafe {
-            SendMessageW(hwnd, WM_SETICON, icon_type as usize, self.as_raw_handle() as isize);
+    pub(crate) fn from_rgba(rgba: &RgbaIcon) -> Result<Self, BadIcon> {
+        let pixel_count = rgba.rgba.len() / PIXEL_SIZE;
+        let mut and_mask = Vec::with_capacity(pixel_count);
+        let pixels = unsafe {
+            std::slice::from_raw_parts_mut(rgba.rgba.as_ptr() as *mut Pixel, pixel_count)
+        };
+        for pixel in pixels {
+            and_mask.push(pixel.a.wrapping_sub(u8::MAX)); // invert alpha channel
+            pixel.convert_to_bgra();
+        }
+        assert_eq!(and_mask.len(), pixel_count);
+        let handle = unsafe {
+            CreateIcon(
+                ptr::null_mut(),
+                rgba.width as i32,
+                rgba.height as i32,
+                1,
+                (PIXEL_SIZE * 8) as u8,
+                and_mask.as_ptr(),
+                rgba.rgba.as_ptr(),
+            )
+        };
+        if !handle.is_null() {
+            Ok(WinIcon::from_handle(handle))
+        } else {
+            Err(BadIcon::OsError(io::Error::last_os_error()))
         }
     }
 
@@ -163,11 +125,7 @@ impl WinIcon {
     }
 }
 
-impl Drop for RaiiIcon {
-    fn drop(&mut self) {
-        unsafe { DestroyIcon(self.handle) };
-    }
-}
+impl IconProvider for WinIcon {}
 
 impl fmt::Debug for WinIcon {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
@@ -175,9 +133,29 @@ impl fmt::Debug for WinIcon {
     }
 }
 
-pub fn unset_for_window(hwnd: HWND, icon_type: IconType) {
-    unsafe {
-        SendMessageW(hwnd, WM_SETICON, icon_type as usize, 0);
+impl Pixel {
+    fn convert_to_bgra(&mut self) {
+        mem::swap(&mut self.r, &mut self.b);
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum IconType {
+    Small = ICON_SMALL as isize,
+    Big = ICON_BIG as isize,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub(crate) struct RaiiIcon {
+    handle: HICON,
+}
+
+unsafe impl Send for RaiiIcon {}
+unsafe impl Sync for RaiiIcon {}
+
+impl Drop for RaiiIcon {
+    fn drop(&mut self) {
+        unsafe { DestroyIcon(self.handle) };
     }
 }
 

--- a/src/platform_impl/windows/mod.rs
+++ b/src/platform_impl/windows/mod.rs
@@ -2,7 +2,7 @@ use windows_sys::Win32::Foundation::HWND;
 use windows_sys::Win32::UI::WindowsAndMessaging::{HMENU, WINDOW_LONG_PTR_INDEX};
 
 pub(crate) use self::event_loop::{EventLoop, PlatformSpecificEventLoopAttributes};
-pub(crate) use self::icon::{SelectedCursor, WinIcon as PlatformIcon, WinIcon};
+pub(crate) use self::icon::{RaiiIcon, SelectedCursor};
 pub(crate) use self::keyboard::{physicalkey_to_scancode, scancode_to_physicalkey};
 pub(crate) use self::monitor::MonitorHandle;
 pub(crate) use self::window::Window;
@@ -10,7 +10,7 @@ use crate::event::DeviceId;
 use crate::icon::Icon;
 use crate::platform::windows::{BackdropType, Color, CornerPreference};
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct PlatformSpecificWindowAttributes {
     pub owner: Option<HWND>,
     pub menu: Option<HMENU>,

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -37,14 +37,15 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     CreateWindowExW, EnableMenuItem, FlashWindowEx, GetClientRect, GetCursorPos,
     GetForegroundWindow, GetSystemMenu, GetSystemMetrics, GetWindowPlacement, GetWindowTextLengthW,
     GetWindowTextW, IsWindowVisible, LoadCursorW, PeekMessageW, PostMessageW, RegisterClassExW,
-    SetCursor, SetCursorPos, SetForegroundWindow, SetMenuDefaultItem, SetWindowDisplayAffinity,
-    SetWindowPlacement, SetWindowPos, SetWindowTextW, TrackPopupMenu, CS_HREDRAW, CS_VREDRAW,
-    CW_USEDEFAULT, FLASHWINFO, FLASHW_ALL, FLASHW_STOP, FLASHW_TIMERNOFG, FLASHW_TRAY,
-    GWLP_HINSTANCE, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTLEFT, HTRIGHT, HTTOP,
-    HTTOPLEFT, HTTOPRIGHT, MENU_ITEM_STATE, MFS_DISABLED, MFS_ENABLED, MF_BYCOMMAND, NID_READY,
-    PM_NOREMOVE, SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_MOVE, SC_RESTORE, SC_SIZE, SM_DIGITIZER,
-    SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, TPM_LEFTALIGN, TPM_RETURNCMD,
-    WDA_EXCLUDEFROMCAPTURE, WDA_NONE, WM_NCLBUTTONDOWN, WM_SYSCOMMAND, WNDCLASSEXW,
+    SendMessageW, SetCursor, SetCursorPos, SetForegroundWindow, SetMenuDefaultItem,
+    SetWindowDisplayAffinity, SetWindowPlacement, SetWindowPos, SetWindowTextW, TrackPopupMenu,
+    CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, FLASHWINFO, FLASHW_ALL, FLASHW_STOP, FLASHW_TIMERNOFG,
+    FLASHW_TRAY, GWLP_HINSTANCE, HTBOTTOM, HTBOTTOMLEFT, HTBOTTOMRIGHT, HTCAPTION, HTLEFT, HTRIGHT,
+    HTTOP, HTTOPLEFT, HTTOPRIGHT, MENU_ITEM_STATE, MFS_DISABLED, MFS_ENABLED, MF_BYCOMMAND,
+    NID_READY, PM_NOREMOVE, SC_CLOSE, SC_MAXIMIZE, SC_MINIMIZE, SC_MOVE, SC_RESTORE, SC_SIZE,
+    SM_DIGITIZER, SWP_ASYNCWINDOWPOS, SWP_NOACTIVATE, SWP_NOSIZE, SWP_NOZORDER, TPM_LEFTALIGN,
+    TPM_RETURNCMD, WDA_EXCLUDEFROMCAPTURE, WDA_NONE, WM_NCLBUTTONDOWN, WM_SETICON, WM_SYSCOMMAND,
+    WNDCLASSEXW,
 };
 
 use super::icon::WinCursor;
@@ -52,9 +53,9 @@ use super::MonitorHandle;
 use crate::cursor::Cursor;
 use crate::dpi::{PhysicalInsets, PhysicalPosition, PhysicalSize, Position, Size};
 use crate::error::{NotSupportedError, RequestError};
-use crate::icon::Icon;
+use crate::icon::{Icon, RgbaIcon};
 use crate::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle, MonitorHandleProvider};
-use crate::platform::windows::{BackdropType, Color, CornerPreference};
+use crate::platform::windows::{BackdropType, Color, CornerPreference, WinIcon};
 use crate::platform_impl::platform::dark_mode::try_theme;
 use crate::platform_impl::platform::definitions::{
     CLSID_TaskbarList, IID_ITaskbarList, IID_ITaskbarList2, ITaskbarList, ITaskbarList2,
@@ -66,7 +67,7 @@ use crate::platform_impl::platform::drop_handler::FileDropHandler;
 use crate::platform_impl::platform::event_loop::{
     self, ActiveEventLoop, Event, EventLoopRunner, DESTROY_MSG_ID,
 };
-use crate::platform_impl::platform::icon::{self, IconType};
+use crate::platform_impl::platform::icon::IconType;
 use crate::platform_impl::platform::ime::ImeContext;
 use crate::platform_impl::platform::keyboard::KeyEventBuilder;
 use crate::platform_impl::platform::window_state::{
@@ -189,12 +190,11 @@ impl Window {
     }
 
     pub fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>) {
-        if let Some(ref taskbar_icon) = taskbar_icon {
-            taskbar_icon.inner.set_for_window(self.hwnd(), IconType::Big);
+        if let Some(taskbar_icon) = taskbar_icon {
+            self.set_icon(taskbar_icon, IconType::Big);
         } else {
-            icon::unset_for_window(self.hwnd(), IconType::Big);
+            self.unset_icon(IconType::Big);
         }
-        self.window_state_lock().taskbar_icon = taskbar_icon;
     }
 
     unsafe fn handle_os_dragging(&self, wparam: WPARAM) {
@@ -347,6 +347,45 @@ impl Window {
                 &(preference as DWM_WINDOW_CORNER_PREFERENCE) as *const _ as _,
                 mem::size_of::<DWM_WINDOW_CORNER_PREFERENCE>() as _,
             );
+        }
+    }
+
+    fn set_icon(&self, mut new_icon: Icon, icon_type: IconType) {
+        if let Some(icon) = new_icon.0.cast_ref::<RgbaIcon>() {
+            let icon = match WinIcon::from_rgba(icon) {
+                Ok(icon) => icon,
+                Err(err) => {
+                    warn!("{}", err);
+                    return;
+                },
+            };
+            new_icon = Icon(Arc::new(icon));
+        }
+
+        if let Some(icon) = new_icon.0.cast_ref::<WinIcon>() {
+            unsafe {
+                SendMessageW(
+                    self.hwnd(),
+                    WM_SETICON,
+                    icon_type as usize,
+                    icon.as_raw_handle() as isize,
+                );
+            }
+
+            match icon_type {
+                IconType::Small => self.window_state_lock().window_icon = Some(new_icon),
+                IconType::Big => self.window_state_lock().taskbar_icon = Some(new_icon),
+            }
+        }
+    }
+
+    fn unset_icon(&self, icon_type: IconType) {
+        unsafe {
+            SendMessageW(self.hwnd(), WM_SETICON, icon_type as usize, 0);
+        }
+        match icon_type {
+            IconType::Small => self.window_state_lock().window_icon = None,
+            IconType::Big => self.window_state_lock().taskbar_icon = None,
         }
     }
 }
@@ -974,12 +1013,11 @@ impl CoreWindow for Window {
     }
 
     fn set_window_icon(&self, window_icon: Option<Icon>) {
-        if let Some(ref window_icon) = window_icon {
-            window_icon.inner.set_for_window(self.hwnd(), IconType::Small);
+        if let Some(window_icon) = window_icon {
+            self.set_icon(window_icon, IconType::Small);
         } else {
-            icon::unset_for_window(self.hwnd(), IconType::Small);
+            self.unset_icon(IconType::Small);
         }
-        self.window_state_lock().window_icon = window_icon;
     }
 
     fn set_ime_cursor_area(&self, spot: Position, size: Size) {

--- a/src/window.rs
+++ b/src/window.rs
@@ -46,7 +46,7 @@ impl fmt::Debug for WindowId {
 }
 
 /// Attributes used when creating a window.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct WindowAttributes {
     pub surface_size: Option<Size>,
     pub min_surface_size: Option<Size>,


### PR DESCRIPTION
Same as for `CustomCursor`. However, the API uses `dyn` stuff only because of `Windows` backend at the time of writing, generally, platforms should just have a separate method that deals with all of that, and e.g. top-level winit only guarantees `Rgba`.

Part of https://github.com/rust-windowing/winit/issues/3433.

- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
