### PR TITLE
Windows: fix window resizing with decorations disabled

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -245,3 +245,4 @@ changelog entry.
 - On macos, `WindowExtMacOS::set_simple_fullscreen` now honors `WindowExtMacOS::set_borderless_game`
 - On X11 and Wayland, fixed pump_events with `Some(Duration::Zero)` blocking with `Wait` polling mode
 - On macOS, fixed `run_app_on_demand` returning without closing open windows.
+- On Windows, fixed window resizing with decorated shadow disabled.

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -1096,7 +1096,7 @@ unsafe fn public_window_callback_inner(
                 if let Ok(monitor_info) = monitor::get_monitor_info(monitor) {
                     params.rgrc[0] = monitor_info.monitorInfo.rcWork;
                 }
-            } else if window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW) {
+            } else if !window_flags.contains(WindowFlags::MARKER_DECORATIONS) || window_flags.contains(WindowFlags::MARKER_UNDECORATED_SHADOW) {
                 // Extend the client area to cover the whole non-client area.
                 // https://docs.microsoft.com/en-us/windows/win32/winmsg/wm-nccalcsize#remarks
                 //
@@ -1109,7 +1109,9 @@ unsafe fn public_window_callback_inner(
                 // ahead of the window surface. Currently, there seems no option to achieve this
                 // with the Windows API.
                 params.rgrc[0].top += 1;
-                params.rgrc[0].bottom += 1;
+                params.rgrc[0].bottom -= 9;
+                params.rgrc[0].left += 9;
+                params.rgrc[0].right -= 9;
             }
 
             result = ProcResult::Value(0);


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/4186

This fixes the client area preventing the window to be resized while decorations are disabled.
This is still not perfect, the top border of the window has a resize area shorter than normal windows because of the titlebar that needs to be hidden.

```rust
let window_attributes = WindowAttributes::default()
     .with_decorations(false)
     .with_resizable(true)
```

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
