### PR TITLE
fix: Allow unknown bit-depth on macOS

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -248,3 +248,4 @@ changelog entry.
 - On macOS, fixed the scancode conversion for audio volume keys.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
+- On macOS, don't panic on monitors with unknown bit-depths.

--- a/src/platform_impl/apple/appkit/ffi.rs
+++ b/src/platform_impl/apple/appkit/ffi.rs
@@ -11,8 +11,8 @@ use objc2_core_graphics::CGDirectDisplayID;
 
 pub const IO16BitDirectPixels: &str = "-RRRRRGGGGGBBBBB";
 pub const IO32BitDirectPixels: &str = "--------RRRRRRRRGGGGGGGGBBBBBBBB";
-
 pub const kIO30BitDirectPixels: &str = "--RRRRRRRRRRGGGGGGGGGGBBBBBBBBBB";
+pub const kIO64BitDirectPixels: &str = "-16R16G16B16";
 
 // `CGDisplayCreateUUIDFromDisplayID` comes from the `ColorSync` framework.
 // However, that framework was only introduced "publicly" in macOS 10.13.

--- a/winit-core/src/monitor.rs
+++ b/winit-core/src/monitor.rs
@@ -151,6 +151,13 @@ impl VideoMode {
     /// Returns the bit depth of this video mode, as in how many bits you have
     /// available per color. This is generally 24 bits or 32 bits on modern
     /// systems, depending on whether the alpha channel is counted or not.
+    ///
+    /// # Platform-specific
+    ///
+    /// - **macOS**: Video modes do not control the bit depth of the monitor, so this often defaults
+    ///   to 32.
+    /// - **iOS**: Always returns `None`.
+    /// - **Wayland**: Always returns `None`.
     pub fn bit_depth(&self) -> Option<NonZeroU16> {
         self.bit_depth
     }


### PR DESCRIPTION
It is unclear what values `CGDisplayModeCopyPixelEncoding` is allowed to return, so let's make sure to handle unknown cases.

Another option would be to remove it completely, and always return `None` (that'd be more in-line with what `VideoMode`s actually control on macOS nowadays). WDYT @kchibisov?

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
