### PR TITLE
fix: Support fractional refresh rates in video modes on macOS

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -254,3 +254,4 @@ changelog entry.
 - On Wayland, fixed a crash when consequently calling `set_cursor_grab` without pointer focus.
 - On Wayland, ensure that external event loop is woken-up when using pump_events and integrating via `FD`.
 - On Wayland, apply fractional scaling to custom cursors.
+- On macOS, fixed `VideoMode::refresh_rate_millihertz` for fractional refresh rates.

--- a/src/platform_impl/apple/appkit/monitor.rs
+++ b/src/platform_impl/apple/appkit/monitor.rs
@@ -126,13 +126,12 @@ impl MonitorHandle {
         let modes = unsafe { CFRetained::cast_unchecked::<CFArray<CGDisplayMode>>(array) };
 
         modes.into_iter().map(move |mode| {
-            let cg_refresh_rate_hertz =
-                unsafe { CGDisplayMode::refresh_rate(Some(&mode)) }.round() as i64;
+            let cg_refresh_rate_hertz = unsafe { CGDisplayMode::refresh_rate(Some(&mode)) };
 
             // CGDisplayModeGetRefreshRate returns 0.0 for any display that
             // isn't a CRT
-            let refresh_rate_millihertz = if cg_refresh_rate_hertz > 0 {
-                NonZeroU32::new((cg_refresh_rate_hertz * 1000) as u32)
+            let refresh_rate_millihertz = if cg_refresh_rate_hertz > 0.0 {
+                NonZeroU32::new((cg_refresh_rate_hertz * 1000.0).round() as u32)
             } else {
                 refresh_rate_millihertz
             };


### PR DESCRIPTION
Do not round the refresh rate until _after_ it has been converted to millihertz.

This was introduced in https://github.com/rust-windowing/winit/pull/2352, before that PR, fractional refresh rates weren't a thing in Winit. But after that, we still rounded the refresh rate on macOS. See also https://github.com/rust-windowing/winit/pull/3254#discussion_r1412133048.

The `application.rs` example now outputs the expected values:

<img width="616" alt="screenshot" src="https://github.com/user-attachments/assets/f5ef1ccd-0bf2-49ee-91ed-d48dbd2bac7b" />

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
