### PR TITLE
custom cursor fractional scale support for wayland platform

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -253,3 +253,4 @@ changelog entry.
 - On macOS, fixed `run_app_on_demand` returning without closing open windows.
 - On Wayland, fixed a crash when consequently calling `set_cursor_grab` without pointer focus.
 - On Wayland, ensure that external event loop is woken-up when using pump_events and integrating via `FD`.
+- On Wayland, apply fractional scaling to custom cursors.

--- a/src/platform_impl/linux/wayland/seat/mod.rs
+++ b/src/platform_impl/linux/wayland/seat/mod.rs
@@ -96,8 +96,12 @@ impl SeatHandler for WinitState {
             },
             SeatCapability::Pointer if seat_state.pointer.is_none() => {
                 let surface = self.compositor_state.create_surface(queue_handle);
+                let viewport = self
+                    .viewporter_state
+                    .as_ref()
+                    .map(|state| state.get_viewport(&surface, queue_handle));
                 let surface_id = surface.id();
-                let pointer_data = WinitPointerData::new(seat.clone());
+                let pointer_data = WinitPointerData::new(seat.clone(), viewport);
                 let themed_pointer = self
                     .seat_state
                     .get_pointer_with_theme_and_data(


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Currently, winit uses an integer surface scale for custom cursor icons on the Wayland platform. When a monitor uses fractional scaling, this results in the cursor appearing slightly smaller than expected.

For example, if the desktop scale factor is 1.5, winit sets the scale factor to 2. The compositor then downscales from 2 to 1.5, while users expect the icon displayed as provided.

This change applies a fractional scale using a viewport for the custom cursor, avoiding the issue above.