### PR TITLE
wayland/fix: crash due consequent calls to set_cursor_grab

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -249,3 +249,4 @@ changelog entry.
 - On macos, `WindowExtMacOS::set_simple_fullscreen` now honors `WindowExtMacOS::set_borderless_game`
 - On X11 and Wayland, fixed pump_events with `Some(Duration::Zero)` blocking with `Wait` polling mode
 - On macOS, fixed `run_app_on_demand` returning without closing open windows.
+- On Wayland, fixed a crash when consequently calling `set_cursor_grab` without pointer focus.


### PR DESCRIPTION
Only mark that the grab was applied when it actually got applied. Previously there was an issue with grab being marked as applied without a pointer over the window, when in reality it wasn't.

Fixes #4073.


--

Could you test this, @Jupeyy? It's a bit different approach, but should also solve it.
