### PR TITLE
Use next `objc2` version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,13 +104,13 @@ ndk = { version = "0.9.0", features = ["rwh_06"], default-features = false }
 
 # AppKit or UIKit
 [target.'cfg(target_vendor = "apple")'.dependencies]
-block2 = "0.6.0"
-dispatch2 = { version = "0.2.0", default-features = false, features = ["std", "objc2"] }
-objc2 = "0.6.0"
+block2 = "0.6.1"
+dispatch2 = { version = "0.3.0", default-features = false, features = ["std", "objc2"] }
+objc2 = "0.6.1"
 
 # AppKit
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3.0", default-features = false, features = [
+objc2-app-kit = { version = "0.3.1", default-features = false, features = [
     "std",
     "objc2-core-foundation",
     "NSAppearance",
@@ -142,7 +142,7 @@ objc2-app-kit = { version = "0.3.0", default-features = false, features = [
     "NSWindowScripting",
     "NSWindowTabGroup",
 ] }
-objc2-core-foundation = { version = "0.3.0", default-features = false, features = [
+objc2-core-foundation = { version = "0.3.1", default-features = false, features = [
     "std",
     "block2",
     "CFBase",
@@ -152,7 +152,7 @@ objc2-core-foundation = { version = "0.3.0", default-features = false, features 
     "CFString",
     "CFUUID",
 ] }
-objc2-core-graphics = { version = "0.3.0", default-features = false, features = [
+objc2-core-graphics = { version = "0.3.1", default-features = false, features = [
     "std",
     "libc",
     "CGDirectDisplay",
@@ -162,14 +162,14 @@ objc2-core-graphics = { version = "0.3.0", default-features = false, features = 
     "CGRemoteOperation",
     "CGWindowLevel",
 ] }
-objc2-core-video = { version = "0.3.0", default-features = false, features = [
+objc2-core-video = { version = "0.3.1", default-features = false, features = [
     "std",
     "objc2-core-graphics",
     "CVBase",
     "CVReturn",
     "CVDisplayLink",
 ] }
-objc2-foundation = { version = "0.3.0", default-features = false, features = [
+objc2-foundation = { version = "0.3.1", default-features = false, features = [
     "std",
     "block2",
     "objc2-core-foundation",
@@ -194,14 +194,14 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = [
 
 # UIKit
 [target.'cfg(all(target_vendor = "apple", not(target_os = "macos")))'.dependencies]
-objc2-core-foundation = { version = "0.3.0", default-features = false, features = [
+objc2-core-foundation = { version = "0.3.1", default-features = false, features = [
     "std",
     "CFCGTypes",
     "CFBase",
     "CFRunLoop",
     "CFString",
 ] }
-objc2-foundation = { version = "0.3.0", default-features = false, features = [
+objc2-foundation = { version = "0.3.1", default-features = false, features = [
     "std",
     "block2",
     "objc2-core-foundation",
@@ -214,7 +214,7 @@ objc2-foundation = { version = "0.3.0", default-features = false, features = [
     "NSThread",
     "NSSet",
 ] }
-objc2-ui-kit = { version = "0.3.0", default-features = false, features = [
+objc2-ui-kit = { version = "0.3.1", default-features = false, features = [
     "std",
     "objc2-core-foundation",
     "UIApplication",

--- a/src/platform_impl/apple/appkit/event.rs
+++ b/src/platform_impl/apple/appkit/event.rs
@@ -3,7 +3,7 @@ use std::ptr::NonNull;
 use dispatch2::run_on_main;
 use objc2::rc::Retained;
 use objc2_app_kit::{NSEvent, NSEventModifierFlags, NSEventSubtype, NSEventType};
-use objc2_core_foundation::{CFData, CFDataGetBytePtr, CFRetained};
+use objc2_core_foundation::{CFData, CFRetained};
 use objc2_foundation::NSPoint;
 use smol_str::SmolStr;
 
@@ -30,7 +30,7 @@ pub fn get_modifierless_char(scancode: u16) -> Key {
         return Key::Unidentified(NativeKey::MacOS(scancode));
     };
 
-    let layout = unsafe { CFDataGetBytePtr(layout_data).cast() };
+    let layout = layout_data.byte_ptr().cast();
     let keyboard_type = run_on_main(|_mtm| unsafe { ffi::LMGetKbdType() });
 
     let mut result_len = 0;

--- a/src/platform_impl/apple/appkit/ffi.rs
+++ b/src/platform_impl/apple/appkit/ffi.rs
@@ -1,6 +1,6 @@
 // TODO: Upstream these
 
-#![allow(dead_code, non_snake_case, non_upper_case_globals)]
+#![allow(non_upper_case_globals)]
 
 use std::ffi::c_void;
 
@@ -9,27 +9,10 @@ use objc2::runtime::AnyObject;
 use objc2_core_foundation::{cf_type, CFString, CFUUID};
 use objc2_core_graphics::CGDirectDisplayID;
 
-pub const kCGDisplayBlendNormal: f32 = 0.0;
-pub const kCGDisplayBlendSolidColor: f32 = 1.0;
-
-pub type CGDisplayFadeReservationToken = u32;
-pub const kCGDisplayFadeReservationInvalidToken: CGDisplayFadeReservationToken = 0;
-
-pub const IO1BitIndexedPixels: &str = "P";
-pub const IO2BitIndexedPixels: &str = "PP";
-pub const IO4BitIndexedPixels: &str = "PPPP";
-pub const IO8BitIndexedPixels: &str = "PPPPPPPP";
 pub const IO16BitDirectPixels: &str = "-RRRRRGGGGGBBBBB";
 pub const IO32BitDirectPixels: &str = "--------RRRRRRRRGGGGGGGGBBBBBBBB";
 
 pub const kIO30BitDirectPixels: &str = "--RRRRRRRRRRGGGGGGGGGGBBBBBBBBBB";
-pub const kIO64BitDirectPixels: &str = "-16R16G16B16";
-
-pub const kIO16BitFloatPixels: &str = "-16FR16FG16FB16";
-pub const kIO32BitFloatPixels: &str = "-32FR32FG32FB32";
-
-pub const IOYUV422Pixels: &str = "Y4U2V2";
-pub const IO8BitOverlayPixels: &str = "O8";
 
 // `CGDisplayCreateUUIDFromDisplayID` comes from the `ColorSync` framework.
 // However, that framework was only introduced "publicly" in macOS 10.13.
@@ -58,7 +41,6 @@ extern "C" {
 pub struct TISInputSource(std::ffi::c_void);
 
 cf_type!(
-    #[encoding_name = "__TISInputSource"]
     unsafe impl TISInputSource {}
 );
 
@@ -103,45 +85,3 @@ extern "C" {
         unicodeString: *mut UniChar,
     ) -> OSStatus;
 }
-
-// CGWindowLevel.h
-//
-// Note: There are two different things at play in this header:
-// `CGWindowLevel` and `CGWindowLevelKey`.
-//
-// It seems like there was a push towards using "key" values instead of the
-// raw window level values, and then you were supposed to use
-// `CGWindowLevelForKey` to get the actual level.
-//
-// But the values that `NSWindowLevel` has are compiled in, and as such has
-// to remain ABI compatible, so they're safe for us to hardcode as well.
-#[allow(dead_code, non_upper_case_globals)]
-mod window_level {
-    const kCGNumReservedWindowLevels: i32 = 16;
-    const kCGNumReservedBaseWindowLevels: i32 = 5;
-
-    pub const kCGBaseWindowLevel: i32 = i32::MIN;
-    pub const kCGMinimumWindowLevel: i32 = kCGBaseWindowLevel + kCGNumReservedBaseWindowLevels;
-    pub const kCGMaximumWindowLevel: i32 = i32::MAX - kCGNumReservedWindowLevels;
-
-    pub const kCGDesktopWindowLevel: i32 = kCGMinimumWindowLevel + 20;
-    pub const kCGDesktopIconWindowLevel: i32 = kCGDesktopWindowLevel + 20;
-    pub const kCGBackstopMenuLevel: i32 = -20;
-    pub const kCGNormalWindowLevel: i32 = 0;
-    pub const kCGFloatingWindowLevel: i32 = 3;
-    pub const kCGTornOffMenuWindowLevel: i32 = 3;
-    pub const kCGModalPanelWindowLevel: i32 = 8;
-    pub const kCGUtilityWindowLevel: i32 = 19;
-    pub const kCGDockWindowLevel: i32 = 20;
-    pub const kCGMainMenuWindowLevel: i32 = 24;
-    pub const kCGStatusWindowLevel: i32 = 25;
-    pub const kCGPopUpMenuWindowLevel: i32 = 101;
-    pub const kCGOverlayWindowLevel: i32 = 102;
-    pub const kCGHelpWindowLevel: i32 = 200;
-    pub const kCGDraggingWindowLevel: i32 = 500;
-    pub const kCGScreenSaverWindowLevel: i32 = 1000;
-    pub const kCGAssistiveTechHighWindowLevel: i32 = 1500;
-    pub const kCGCursorWindowLevel: i32 = kCGMaximumWindowLevel - 1;
-}
-
-pub use window_level::*;

--- a/src/platform_impl/apple/event_loop_proxy.rs
+++ b/src/platform_impl/apple/event_loop_proxy.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 
 use objc2::MainThreadMarker;
 use objc2_core_foundation::{
-    kCFRunLoopCommonModes, CFIndex, CFRetained, CFRunLoop, CFRunLoopAddSource, CFRunLoopGetMain,
-    CFRunLoopSource, CFRunLoopSourceContext, CFRunLoopSourceCreate, CFRunLoopSourceInvalidate,
-    CFRunLoopSourceSignal, CFRunLoopWakeUp,
+    kCFRunLoopCommonModes, CFIndex, CFRetained, CFRunLoop, CFRunLoopSource, CFRunLoopSourceContext,
 };
 
 use crate::event_loop::EventLoopProxyProvider;
@@ -90,12 +88,12 @@ impl EventLoopProxy {
         // Keeping the closure alive beyond this scope is fine, because `F: 'static`.
         let source = unsafe {
             let _ = mtm;
-            CFRunLoopSourceCreate(None, order, &mut context).unwrap()
+            CFRunLoopSource::new(None, order, &mut context).unwrap()
         };
 
         // Register the source to be performed on the main thread.
-        let main_loop = unsafe { CFRunLoopGetMain() }.unwrap();
-        unsafe { CFRunLoopAddSource(&main_loop, Some(&source), kCFRunLoopCommonModes) };
+        let main_loop = CFRunLoop::main().unwrap();
+        unsafe { main_loop.add_source(Some(&source), kCFRunLoopCommonModes) };
 
         Self { source, main_loop }
     }
@@ -106,7 +104,7 @@ impl EventLoopProxy {
     pub(crate) fn invalidate(&self) {
         // NOTE: We do NOT fire this on `Drop`, since we want the proxy to be cloneable, such that
         // we only need to register a single source even if there's multiple proxies in use.
-        unsafe { CFRunLoopSourceInvalidate(&self.source) };
+        self.source.invalidate();
     }
 }
 
@@ -115,12 +113,12 @@ impl EventLoopProxyProvider for EventLoopProxy {
         // Signal the source, which ends up later invoking `perform` on the main thread.
         //
         // Multiple signals in quick succession are automatically coalesced into a single signal.
-        unsafe { CFRunLoopSourceSignal(&self.source) };
+        self.source.signal();
 
         // Let the main thread know there's a new event.
         //
         // This is required since we may be (probably are) running on a different thread, and the
         // main loop may be sleeping (and `CFRunLoopSourceSignal` won't wake it).
-        unsafe { CFRunLoopWakeUp(&self.main_loop) };
+        self.main_loop.wake_up();
     }
 }

--- a/src/platform_impl/apple/uikit/app_state.rs
+++ b/src/platform_impl/apple/uikit/app_state.rs
@@ -11,9 +11,8 @@ use dispatch2::MainThreadBound;
 use objc2::rc::Retained;
 use objc2::MainThreadMarker;
 use objc2_core_foundation::{
-    kCFRunLoopCommonModes, CFAbsoluteTimeGetCurrent, CFRetained, CFRunLoop, CFRunLoopAddTimer,
-    CFRunLoopGetMain, CFRunLoopTimer, CFRunLoopTimerCreate, CFRunLoopTimerInvalidate,
-    CFRunLoopTimerSetNextFireDate, CGRect, CGSize,
+    kCFRunLoopCommonModes, CFAbsoluteTimeGetCurrent, CFRetained, CFRunLoop, CFRunLoopTimer, CGRect,
+    CGSize,
 };
 use objc2_ui_kit::{UIApplication, UICoordinateSpace, UIView};
 
@@ -115,7 +114,7 @@ impl AppState {
             #[inline(never)]
             #[cold]
             fn init_guard(guard: &mut RefMut<'static, Option<AppState>>, mtm: MainThreadMarker) {
-                let waker = EventLoopWaker::new(unsafe { CFRunLoopGetMain().unwrap() });
+                let waker = EventLoopWaker::new(CFRunLoop::main().unwrap());
                 let event_loop_proxy = Arc::new(EventLoopProxy::new(mtm, move || {
                     get_handler(mtm).handle(|app| app.proxy_wake_up(&ActiveEventLoop { mtm }));
                 }));
@@ -305,7 +304,11 @@ pub(crate) fn queue_gl_or_metal_redraw(mtm: MainThreadMarker, window: Retained<W
     }
 }
 
-pub(crate) fn launch(mtm: MainThreadMarker, app: impl ApplicationHandler, run: impl FnOnce()) {
+pub(crate) fn launch<R>(
+    mtm: MainThreadMarker,
+    app: impl ApplicationHandler,
+    run: impl FnOnce() -> R,
+) -> R {
     get_handler(mtm).set(Box::new(app), run)
 }
 
@@ -544,9 +547,7 @@ struct EventLoopWaker {
 
 impl Drop for EventLoopWaker {
     fn drop(&mut self) {
-        unsafe {
-            CFRunLoopTimerInvalidate(&self.timer);
-        }
+        self.timer.invalidate();
     }
 }
 
@@ -557,7 +558,7 @@ impl EventLoopWaker {
             // Create a timer with a 0.1µs interval (1ns does not work) to mimic polling.
             // It is initially setup with a first fire time really far into the
             // future, but that gets changed to fire immediately in did_finish_launching
-            let timer = CFRunLoopTimerCreate(
+            let timer = CFRunLoopTimer::new(
                 None,
                 f64::MAX,
                 0.000_000_1,
@@ -567,18 +568,18 @@ impl EventLoopWaker {
                 ptr::null_mut(),
             )
             .unwrap();
-            CFRunLoopAddTimer(&rl, Some(&timer), kCFRunLoopCommonModes);
+            rl.add_timer(Some(&timer), kCFRunLoopCommonModes);
 
             EventLoopWaker { timer }
         }
     }
 
     fn stop(&mut self) {
-        unsafe { CFRunLoopTimerSetNextFireDate(&self.timer, f64::MAX) }
+        self.timer.set_next_fire_date(f64::MAX);
     }
 
     fn start(&mut self) {
-        unsafe { CFRunLoopTimerSetNextFireDate(&self.timer, f64::MIN) }
+        self.timer.set_next_fire_date(f64::MIN);
     }
 
     fn start_at(&mut self, instant: Instant) {
@@ -586,13 +587,11 @@ impl EventLoopWaker {
         if now >= instant {
             self.start();
         } else {
-            unsafe {
-                let current = CFAbsoluteTimeGetCurrent();
-                let duration = instant - now;
-                let fsecs =
-                    duration.subsec_nanos() as f64 / 1_000_000_000.0 + duration.as_secs() as f64;
-                CFRunLoopTimerSetNextFireDate(&self.timer, current + fsecs);
-            }
+            let current = CFAbsoluteTimeGetCurrent();
+            let duration = instant - now;
+            let fsecs =
+                duration.subsec_nanos() as f64 / 1_000_000_000.0 + duration.as_secs() as f64;
+            self.timer.set_next_fire_date(current + fsecs);
         }
     }
 }


### PR DESCRIPTION
A lot of CoreFoundation methods have been marked safe, and converted into methods. Note that the old functions are still available, just deprecated.

- [x] Tested on all platforms changed
  - Tested on macOS and Mac Catalyst.
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
  - This is a minor version bump, not interesting.
