### PR TITLE
Windows: Fix Incorrect cursor_range Calculation in Ime::Preedit

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -256,3 +256,4 @@ changelog entry.
 - On Wayland, apply fractional scaling to custom cursors.
 - On macOS, fixed `VideoMode::refresh_rate_millihertz` for fractional refresh rates.
 - On macOS, store monitor handle to avoid panics after going in/out of sleep.
+- On Windows, fixed `Ime::Preedit` cursor offset calculation.

--- a/src/platform_impl/windows/ime.rs
+++ b/src/platform_impl/windows/ime.rs
@@ -31,32 +31,27 @@ impl ImeContext {
         let text = unsafe { self.get_composition_string(GCS_COMPSTR) }?;
         let attrs = unsafe { self.get_composition_data(GCS_COMPATTR) }.unwrap_or_default();
 
-        // text is UTF-8, and attrs is UTF-16, so we need to convert the UTF-8 index to UTF-16 for
-        // processing.
-        let utf16_to_utf8 = {
-            let mut utf16_to_utf8 = Vec::new();
-            let mut utf8_offset = 0;
-
-            for chr in text.chars() {
-                let utf16_len = chr.len_utf16();
-                utf16_to_utf8.extend(std::iter::repeat(utf8_offset).take(utf16_len));
-                utf8_offset += chr.len_utf8();
-            }
-            utf16_to_utf8
-        };
-
         let mut first = None;
         let mut last = None;
+        let mut boundary_before_char = 0;
+        let mut attr_idx = 0;
 
-        for (utf16_idx, &attr) in attrs.iter().enumerate() {
+        for chr in text.chars() {
+            let Some(attr) = attrs.get(attr_idx).copied() else {
+                break;
+            };
+
             let char_is_targeted =
                 attr as u32 == ATTR_TARGET_CONVERTED || attr as u32 == ATTR_TARGET_NOTCONVERTED;
-            let utf8_idx = *utf16_to_utf8.get(utf16_idx).unwrap_or(&text.len());
+
             if first.is_none() && char_is_targeted {
-                first = Some(utf8_idx);
+                first = Some(boundary_before_char);
             } else if first.is_some() && last.is_none() && !char_is_targeted {
-                last = Some(utf8_idx);
+                last = Some(boundary_before_char);
             }
+
+            boundary_before_char += chr.len_utf8();
+            attr_idx += chr.len_utf16();
         }
 
         if first.is_some() && last.is_none() {


### PR DESCRIPTION
This pull request resolves the Ime::Preedit issue reported in #3967.
The issue arises because text is based on UTF-8 while attribute is based on UTF-16, leading to misalignment in cursor positioning.

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
