### PR TITLE
macOS: Fix monitors connected via certain Thunderbolt hubs

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -256,3 +256,4 @@ changelog entry.
 - On Wayland, apply fractional scaling to custom cursors.
 - On macOS, fixed `VideoMode::refresh_rate_millihertz` for fractional refresh rates.
 - On macOS, store monitor handle to avoid panics after going in/out of sleep.
+- On macOS, allow certain invalid monitor handles and return `None` instead of panicking.

--- a/src/platform_impl/apple/appkit/window_delegate.rs
+++ b/src/platform_impl/apple/appkit/window_delegate.rs
@@ -1756,8 +1756,14 @@ impl WindowDelegate {
     // Allow directly accessing the current monitor internally without unwrapping.
     pub(crate) fn current_monitor_inner(&self) -> Option<MonitorHandle> {
         let display_id = get_display_id(&*self.window().screen()?);
-        // Display ID just fetched from live NSScreen, should be fine to unwrap.
-        Some(MonitorHandle::new(display_id).expect("invalid display ID"))
+        if let Some(monitor) = MonitorHandle::new(display_id) {
+            Some(monitor)
+        } else {
+            // NOTE: Display ID was just fetched from live NSScreen, but can still result in `None`
+            // with certain Thunderbolt docked monitors.
+            warn!(display_id, "got screen with invalid display ID");
+            None
+        }
     }
 
     #[inline]


### PR DESCRIPTION
Instead of panicking, raise a warning and return `None` or similar.

Redo of https://github.com/rust-windowing/winit/pull/4171, but for the `master` branch, and with an extra fix for `Window::current_monitor` (which could easily exhibit similar issues).

Fixes https://github.com/bevyengine/bevy/issues/17827.

- [x] Tested on all platforms changed
  - Tested in https://github.com/rust-windowing/winit/pull/4171.
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
