### PR TITLE
Make "fill" module used by examples more useful + add an input tester example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 Cargo.lock
 target/
 rls/
+# pkg: Often used for temporary wasm debug builds
+pkg/
 .vscode/
 *~
 #*#

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ tracing = { version = "0.1.40", default-features = false }
 image = { version = "0.25.0", default-features = false, features = ["png"] }
 tracing = { version = "0.1.40", default-features = false, features = ["log"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+font8x8 = "0.3.1"
 
 [target.'cfg(not(target_os = "android"))'.dev-dependencies]
 softbuffer = { version = "0.4.6", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -313,6 +313,10 @@ xkbcommon-dl = "0.4.2"
 orbclient = { version = "0.3.47", default-features = false }
 redox_syscall = "0.5.7"
 
+# We want the web-time crate on non-web clients too, for examples (hence dev-dependencies)
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
+web-time = "1"
+
 # Web
 [target.'cfg(target_family = "wasm")'.dependencies]
 js-sys = "0.3.70"

--- a/examples/tester.html
+++ b/examples/tester.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+        <title>Winit Tablet Tester</title>
+        <style>
+            canvas { width: 360px; height: 250px; } * { margin: 0; padding: 0; }
+        </style>
+        <script type="module">
+            import start from '../pkg/tester.js';
+            start();
+        </script>
+    </head>
+    <body>
+    </body>
+</html>

--- a/examples/tester.rs
+++ b/examples/tester.rs
@@ -1,0 +1,242 @@
+//! Basic winit interactivity example.
+
+use std::error::Error;
+
+use font8x8::legacy::BASIC_LEGACY;
+use winit::application::ApplicationHandler;
+use winit::event::{ButtonSource, MouseButton, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, EventLoop};
+#[cfg(web_platform)]
+use winit::platform::web::WindowAttributesExtWeb;
+use winit::window::{Window, WindowAttributes, WindowId};
+
+fn draw_char(frame: &mut [u32], width: usize, x: u32, y: u32, ch: char, fg: u32, bg: u32) {
+    let x: usize = x.try_into().unwrap();
+    let y: usize = y.try_into().unwrap();
+    let glyph = BASIC_LEGACY.get(ch as usize).unwrap_or(&BASIC_LEGACY[' ' as usize]);
+    for (row, byte) in glyph.iter().enumerate() {
+        let ypart = (y + row) * width;
+        for col in 0..8 {
+            let i = ypart + (x + col);
+            if i < frame.len() && byte & (1 << col) != 0 {
+                frame[i] = fg;
+            } else {
+                frame[i] = bg;
+            }
+        }
+    }
+}
+
+fn draw_text(
+    frame: &mut [u32],
+    width: usize,
+    mut x: u32,
+    mut y: u32,
+    text: &str,
+    fg: u32,
+    bg: u32,
+) -> (u32, u32) {
+    let x_init = x;
+    let mut max_x = x;
+    let mut max_y = y;
+    for ch in text.chars() {
+        if ch == '\n' {
+            x = x_init;
+            y += 8;
+            max_y = max_y.max(y);
+        } else {
+            draw_char(frame, width, x, y, ch, fg, bg);
+            x += 8;
+            max_x = max_x.max(x);
+        }
+    }
+    (max_x + 8, max_y + 8)
+}
+
+#[path = "util/fill.rs"]
+mod fill;
+#[path = "util/tracing.rs"]
+mod tracing;
+
+#[derive(Default, Debug)]
+struct App {
+    window: Option<Box<dyn Window>>,
+    old_posx: f32,
+    old_posy: f32,
+    posx: f32,
+    posy: f32,
+    drawing: bool,
+    last_draw: Vec<[u32; 4]>,
+}
+
+impl ApplicationHandler for App {
+    fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
+        #[cfg(not(web_platform))]
+        let window_attributes = WindowAttributes::default();
+        #[cfg(web_platform)]
+        let window_attributes = WindowAttributes::default().with_append(true);
+        self.window = match event_loop.create_window(window_attributes) {
+            Ok(window) => Some(window),
+            Err(err) => {
+                eprintln!("error creating window: {err}");
+                event_loop.exit();
+                return;
+            },
+        };
+
+        let window = self.window.as_ref().unwrap();
+        window.pre_present_notify();
+        fill::fill_window_with_color(&**window, 0xff181818);
+        window.request_redraw();
+    }
+
+    fn window_event(&mut self, event_loop: &dyn ActiveEventLoop, _: WindowId, event: WindowEvent) {
+        match event {
+            WindowEvent::CloseRequested => {
+                println!("Close was requested; stopping");
+                event_loop.exit();
+            },
+            WindowEvent::SurfaceResized(_) => {
+                self.window.as_ref().expect("resize event without a window").request_redraw();
+            },
+            WindowEvent::PointerButton { position, state, button, .. } => {
+                if matches!(button, ButtonSource::Mouse(MouseButton::Left)) {
+                    self.posx = position.x as f32;
+                    self.posy = position.y as f32;
+                    self.old_posx = position.x as f32;
+                    self.old_posy = position.y as f32;
+                    self.drawing = state == winit::event::ElementState::Pressed;
+                } else {
+                    let window = self.window.as_ref().unwrap();
+                    window.pre_present_notify();
+                    fill::fill_window_with_color(&**window, 0xff181818);
+                    window.request_redraw();
+                }
+            },
+            WindowEvent::PointerMoved { position, .. } => {
+                if self.drawing {
+                    self.posx = position.x as f32;
+                    self.posy = position.y as f32;
+                }
+            },
+            WindowEvent::RedrawRequested => {
+                // Redraw the application.
+                //
+                // It's preferable for applications that do not render continuously to render in
+                // this event rather than in AboutToWait, since rendering in here allows
+                // the program to gracefully handle redraws requested by the OS.
+
+                let window = self.window.as_ref().expect("redraw request without a window");
+
+                // Notify that you're about to draw.
+                window.pre_present_notify();
+
+                let mut rects = vec![];
+                let rects_ref = &mut rects;
+                // Draw.
+                fill::fill_window_with_fn(&**window, |frame, stride, scale, frame_w, frame_h| {
+                    let extent = draw_text(
+                        frame,
+                        stride,
+                        20,
+                        50,
+                        &format!(
+                            "Input tester.\nLeft click to draw, right click to clear.\nx: {}\ny: \
+                             {}",
+                            self.posx, self.posy
+                        ),
+                        0xffffffff,
+                        0xff181818,
+                    );
+                    let rect1 = [20, 50, extent.0 - 20, extent.1 - 50];
+
+                    let mut draw_line = |xpos: f32, ypos: f32, xoff: f32, yoff: f32| {
+                        if xoff == 0.0 && yoff == 0.0 {
+                            return;
+                        }
+                        let len = (xoff * xoff + yoff * yoff).sqrt();
+                        let norm = 1.0 / xoff.abs().max(yoff.abs());
+                        let mut xo_small = xoff * norm;
+                        let mut yo_small = yoff * norm;
+                        for i in 0..=len as usize {
+                            let i = i as f32;
+
+                            let x = (xpos as f32 + xo_small * i) / scale as f32;
+                            let y = (ypos as f32 + yo_small * i) / scale as f32;
+
+                            let xpart = x.clamp(0.0, frame_w as f32 - 1.0) as usize;
+                            let ypart = y.clamp(0.0, frame_h as f32 - 1.0) as usize * stride;
+                            frame[ypart + xpart] = 0xffffffff;
+                        }
+                    };
+
+                    if self.drawing {
+                        draw_line(
+                            self.old_posx,
+                            self.old_posy,
+                            self.posx - self.old_posx,
+                            self.posy - self.old_posy,
+                        );
+                    }
+
+                    let x = self.posx.min(self.old_posx);
+                    let y = self.posy.min(self.old_posy);
+                    let w = self.posx.max(self.old_posx) - x + 1.0;
+                    let h = self.posy.max(self.old_posy) - y + 1.0;
+
+                    *rects_ref = vec![rect1, [x as u32, y as u32, w as u32, h as u32]];
+                    let mut damaged = rects_ref.clone();
+                    damaged.extend_from_slice(&self.last_draw);
+                    damaged
+                });
+
+                self.old_posx = self.posx;
+                self.old_posy = self.posy;
+
+                self.last_draw = rects;
+
+                // For contiguous redraw loop you can request a redraw from here.
+                window.request_redraw();
+                // Don't run hundreds of thousands of times per second even if the platform asks.
+                // (Can't sleep on web, so gated off there. Browsers won't ask for too much.)
+                #[cfg(not(web_platform))]
+                {
+                    std::thread::sleep(std::time::Duration::from_millis(1));
+                }
+            },
+            _ => (),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(web_platform)]
+    console_error_panic_hook::set_once();
+
+    tracing::init();
+
+    let event_loop = EventLoop::new()?;
+
+    // For alternative loop run options see `pump_events` and `run_on_demand` examples.
+    event_loop.run_app(App::default())?;
+
+    Ok(())
+}
+
+#[cfg(web_platform)]
+use wasm_bindgen::prelude::wasm_bindgen;
+#[cfg(web_platform)]
+#[wasm_bindgen(start)]
+pub fn start() -> Result<(), wasm_bindgen::JsValue> {
+    #[cfg(web_platform)]
+    console_error_panic_hook::set_once();
+
+    tracing::init();
+
+    let event_loop = EventLoop::new().unwrap();
+
+    // For alternative loop run options see `pump_events` and `run_on_demand` examples.
+    event_loop.run_app(App::default()).unwrap();
+
+    Ok(())
+}

--- a/examples/util/fill.rs
+++ b/examples/util/fill.rs
@@ -15,6 +15,8 @@ pub use platform::fill_window;
 pub use platform::fill_window_with_animated_color;
 #[allow(unused_imports)]
 pub use platform::fill_window_with_color;
+#[allow(unused_imports)]
+pub use platform::fill_window_with_fn;
 
 #[cfg(not(any(target_os = "android", target_os = "ios")))]
 mod platform {
@@ -73,6 +75,44 @@ mod platform {
         fn destroy_surface(&mut self, window: &dyn Window) {
             self.surfaces.remove(&window.id());
         }
+    }
+
+    pub fn fill_window_with_fn(
+        window: &dyn Window,
+        f: impl FnOnce(&mut [u32], usize, f64, u32, u32) -> Vec<[u32; 4]>,
+    ) {
+        GC.with(|gc| {
+            let size = window.surface_size();
+            let (Some(width), Some(height)) =
+                (NonZeroU32::new(size.width), NonZeroU32::new(size.height))
+            else {
+                return;
+            };
+
+            // Either get the last context used or create a new one.
+            let mut gc = gc.borrow_mut();
+            let surface =
+                gc.get_or_insert_with(|| GraphicsContext::new(window)).create_surface(window);
+
+            surface.resize(width, height).expect("Failed to resize the softbuffer surface");
+
+            // Run a function on the buffer.
+            let mut buffer = surface.buffer_mut().expect("Failed to get the softbuffer buffer");
+            // TODO: Figure out the correct scale factor to pass in for hidpi environments.
+            let rects = f(&mut buffer, u32::from(width) as usize, 1.0, width.into(), height.into());
+            // Collect only valid rects, and as softbuffer's expected type.
+            let rects = rects
+                .iter()
+                .filter(|r| r[2] != 0 && r[3] != 0)
+                .map(|r| softbuffer::Rect {
+                    x: r[0],
+                    y: r[1],
+                    width: r[2].try_into().unwrap(),
+                    height: r[3].try_into().unwrap(),
+                })
+                .collect::<Vec<_>>();
+            buffer.present_with_damage(&rects).expect("Failed to present the softbuffer buffer");
+        })
     }
 
     pub fn fill_window_with_color(window: &dyn Window, color: u32) {


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality

Dev-only change.

Adds a `fill_window_with_fn` function to the `fill` module (only used by examples, not winit's outward-facing API), which allows examples to graphically display real information instead of just a blank screen. However, `softbuffer`, used internally by the `fill` module, is very slow on certain platforms (web, mac os), so the usage of this new function should be limited to basic test-that-this-thing-works examples, and not used for "game" or "application" style examples. Also adds a dev dependency on `font8x8` so that examples can easily display text.

Also adds an input tester example that uses the new function. The input tester is a low-complexity scribbling/drawing application. The tester is force-aware for Touch events when Touch force is supported.

I tested the input tester tested on windows and web.

https://github.com/user-attachments/assets/d90d4ddd-be4d-4579-99d0-7c65f9e9fe73

![Screenshot_20250508-170923](https://github.com/user-attachments/assets/374a3bde-4ba2-4ae9-b7fb-7d3670b37de1)

This was inspired by a tablet tester I made for locally testing whether my tablet support fork worked (not part of this PR)

https://github.com/user-attachments/assets/f07d59ea-959f-457e-91a5-58540a445c8a

