### PR TITLE
chore: Move event loop recreation check into backends themselves

### DIFF
--- a/src/platform_impl/web/event_loop/mod.rs
+++ b/src/platform_impl/web/event_loop/mod.rs
@@ -27,6 +27,7 @@ static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
 impl EventLoop {
     pub(crate) fn new(_: &PlatformSpecificEventLoopAttributes) -> Result<Self, EventLoopError> {
         if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
+            // For better cross-platformness.
             return Err(EventLoopError::RecreationAttempt);
         }
 

--- a/src/platform_impl/web/event_loop/runner.rs
+++ b/src/platform_impl/web/event_loop/runner.rs
@@ -22,7 +22,7 @@ use super::super::main_thread::MainThreadMarker;
 use super::super::monitor::MonitorHandler;
 use super::proxy::EventLoopProxy;
 use super::state::State;
-use super::{backend, ActiveEventLoop};
+use super::{backend, ActiveEventLoop, EventLoop};
 use crate::platform::web::{PollStrategy, WaitUntilStrategy};
 use crate::platform_impl::platform::backend::{EventListenerHandle, SafeAreaHandle};
 use crate::platform_impl::platform::r#async::DispatchRunner;
@@ -773,7 +773,7 @@ impl Shared {
         //     * The `register_redraw_request` closure.
         //     * The `destroy_fn` closure.
         if self.0.event_loop_recreation.get() {
-            crate::event_loop::EventLoopBuilder::allow_event_loop_recreation();
+            EventLoop::allow_event_loop_recreation();
         }
     }
 

--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -128,6 +128,11 @@ const GLOBAL_WINDOW: WindowId = WindowId::from_raw(0);
 
 impl EventLoop {
     pub fn new(attributes: &PlatformSpecificEventLoopAttributes) -> Result<Self, EventLoopError> {
+        static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
+        if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
+            return Err(EventLoopError::RecreationAttempt);
+        }
+
         let android_app = attributes.android_app.as_ref().expect(
             "An `AndroidApp` as passed to android_main() is required to create an `EventLoop` on \
              Android",

--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -130,6 +130,7 @@ impl EventLoop {
     pub fn new(attributes: &PlatformSpecificEventLoopAttributes) -> Result<Self, EventLoopError> {
         static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
         if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
+            // For better cross-platformness.
             return Err(EventLoopError::RecreationAttempt);
         }
 

--- a/winit-appkit/src/app_state.rs
+++ b/winit-appkit/src/app_state.rs
@@ -58,7 +58,7 @@ impl AppState {
         activation_policy: Option<NSApplicationActivationPolicy>,
         default_menu: bool,
         activate_ignoring_other_apps: bool,
-    ) -> Rc<Self> {
+    ) -> Option<Rc<Self>> {
         let event_loop_proxy = Arc::new(EventLoopProxy::new(mtm, move || {
             Self::get(mtm).with_handler(|app, event_loop| app.proxy_wake_up(event_loop));
         }));
@@ -85,8 +85,7 @@ impl AppState {
             pending_redraw: RefCell::new(vec![]),
         });
 
-        GLOBAL.get(mtm).set(this.clone()).expect("application state can only be set once");
-        this
+        GLOBAL.get(mtm).set(this.clone()).ok().and(Some(this))
     }
 
     pub fn get(mtm: MainThreadMarker) -> Rc<Self> {

--- a/winit-appkit/src/event_loop.rs
+++ b/winit-appkit/src/event_loop.rs
@@ -182,7 +182,8 @@ impl EventLoop {
             activation_policy,
             attributes.default_menu,
             attributes.activate_ignoring_other_apps,
-        );
+        )
+        .ok_or_else(|| EventLoopError::RecreationAttempt)?;
 
         // Initialize the application (if it has not already been).
         let app = NSApplication::sharedApplication(mtm);

--- a/winit-core/src/error.rs
+++ b/winit-core/src/error.rs
@@ -19,7 +19,13 @@ pub enum EventLoopError {
 impl fmt::Display for EventLoopError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::RecreationAttempt => write!(f, "EventLoop can't be recreated"),
+            Self::RecreationAttempt => {
+                write!(
+                    f,
+                    "EventLoop can't be recreated, only a single instance of it is supported (for \
+                     cross-platform compatibility)"
+                )
+            },
             Self::Os(err) => err.fmt(f),
             Self::ExitFailure(status) => write!(f, "Exit Failure: {status}"),
             Self::NotSupported(err) => err.fmt(f),

--- a/winit-orbital/src/event_loop.rs
+++ b/winit-orbital/src/event_loop.rs
@@ -283,6 +283,7 @@ impl EventLoop {
     pub fn new(_: &PlatformSpecificEventLoopAttributes) -> Result<Self, EventLoopError> {
         static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
         if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
+            // For better cross-platformness.
             return Err(EventLoopError::RecreationAttempt);
         }
 

--- a/winit-uikit/src/event_loop.rs
+++ b/winit-uikit/src/event_loop.rs
@@ -149,6 +149,7 @@ impl EventLoop {
         static mut SINGLETON_INIT: bool = false;
         unsafe {
             if SINGLETON_INIT {
+                // Required, AppState is global state, and event loop can only be run once.
                 return Err(EventLoopError::RecreationAttempt);
             }
             SINGLETON_INIT = true;

--- a/winit-uikit/src/event_loop.rs
+++ b/winit-uikit/src/event_loop.rs
@@ -148,10 +148,9 @@ impl EventLoop {
 
         static mut SINGLETON_INIT: bool = false;
         unsafe {
-            assert!(
-                !SINGLETON_INIT,
-                "Only one `EventLoop` is supported on iOS. `EventLoopProxy` might be helpful"
-            );
+            if SINGLETON_INIT {
+                return Err(EventLoopError::RecreationAttempt);
+            }
             SINGLETON_INIT = true;
         }
 

--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -82,6 +82,7 @@ impl EventLoop {
     pub fn new() -> Result<EventLoop, EventLoopError> {
         static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
         if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
+            // For better cross-platformness.
             return Err(EventLoopError::RecreationAttempt);
         }
 

--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -5,7 +5,7 @@ use std::io::Result as IOResult;
 use std::mem;
 use std::os::fd::OwnedFd;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
-use std::sync::atomic::Ordering;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};

--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -80,6 +80,11 @@ pub struct EventLoop {
 
 impl EventLoop {
     pub fn new() -> Result<EventLoop, EventLoopError> {
+        static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
+        if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
+            return Err(EventLoopError::RecreationAttempt);
+        }
+
         let connection = Connection::connect_to_env().map_err(|err| os_error!(err))?;
 
         let (globals, mut event_queue) =

--- a/winit-x11/src/event_loop.rs
+++ b/winit-x11/src/event_loop.rs
@@ -210,6 +210,7 @@ impl EventLoop {
     pub fn new() -> Result<EventLoop, EventLoopError> {
         static EVENT_LOOP_CREATED: AtomicBool = AtomicBool::new(false);
         if EVENT_LOOP_CREATED.swap(true, Ordering::Relaxed) {
+            // Required?
             return Err(EventLoopError::RecreationAttempt);
         }
 


### PR DESCRIPTION
This check was introduced in https://github.com/rust-windowing/winit/pull/2344 to fix https://github.com/rust-windowing/winit/issues/2166, and later relaxed on Web in https://github.com/rust-windowing/winit/pull/2720.

We need to move the check into the backends themselves though to finish https://github.com/rust-windowing/winit/pull/4249, so that is what this PR does. On a few platforms (AppKit and UIKit), I've opted to implement this using existing checks instead of a new `static`.