### PR TITLE
Implement an atomic input method API

### DIFF
--- a/winit-appkit/src/window.rs
+++ b/winit-appkit/src/window.rs
@@ -13,8 +13,8 @@ use winit_core::error::RequestError;
 use winit_core::icon::Icon;
 use winit_core::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
 use winit_core::window::{
-    ImePurpose, Theme, UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons,
-    WindowId, WindowLevel,
+    ImeCapabilities, ImeRequest, ImeRequestError, Theme, UserAttentionType, Window as CoreWindow,
+    WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
 use super::event_loop::ActiveEventLoop;
@@ -233,16 +233,12 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.set_window_icon(window_icon));
     }
 
-    fn set_ime_cursor_area(&self, position: Position, size: Size) {
-        self.maybe_wait_on_main(|delegate| delegate.set_ime_cursor_area(position, size));
+    fn request_ime_update(&self, request: ImeRequest) -> Result<(), ImeRequestError> {
+        self.maybe_wait_on_main(|delegate| delegate.request_ime_update(request))
     }
 
-    fn set_ime_allowed(&self, allowed: bool) {
-        self.maybe_wait_on_main(|delegate| delegate.set_ime_allowed(allowed));
-    }
-
-    fn set_ime_purpose(&self, purpose: ImePurpose) {
-        self.maybe_wait_on_main(|delegate| delegate.set_ime_purpose(purpose));
+    fn ime_capabilities(&self) -> Option<ImeCapabilities> {
+        self.maybe_wait_on_main(|delegate| delegate.ime_capabilities())
     }
 
     fn focus_window(&self) {

--- a/winit-orbital/src/window.rs
+++ b/winit-orbital/src/window.rs
@@ -6,7 +6,7 @@ use dpi::{PhysicalInsets, PhysicalPosition, PhysicalSize, Position, Size};
 use winit_core::cursor::Cursor;
 use winit_core::error::{NotSupportedError, RequestError};
 use winit_core::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
-use winit_core::window::{self, ImePurpose, Window as CoreWindow, WindowId};
+use winit_core::window::{self, Window as CoreWindow, WindowId};
 
 use crate::event_loop::{ActiveEventLoop, EventLoopProxy};
 use crate::{RedoxSocket, WindowProperties};
@@ -159,6 +159,10 @@ impl Window {
 impl CoreWindow for Window {
     fn id(&self) -> WindowId {
         WindowId::from_raw(self.window_socket.fd)
+    }
+
+    fn ime_capabilities(&self) -> Option<window::ImeCapabilities> {
+        None
     }
 
     #[inline]
@@ -354,14 +358,9 @@ impl CoreWindow for Window {
     #[inline]
     fn set_window_icon(&self, _window_icon: Option<winit_core::icon::Icon>) {}
 
-    #[inline]
-    fn set_ime_cursor_area(&self, _position: Position, _size: Size) {}
-
-    #[inline]
-    fn set_ime_allowed(&self, _allowed: bool) {}
-
-    #[inline]
-    fn set_ime_purpose(&self, _purpose: ImePurpose) {}
+    fn request_ime_update(&self, _: window::ImeRequest) -> Result<(), window::ImeRequestError> {
+        Err(window::ImeRequestError::NotSupported)
+    }
 
     #[inline]
     fn focus_window(&self) {}

--- a/winit-wayland/src/seat/mod.rs
+++ b/winit-wayland/src/seat/mod.rs
@@ -26,8 +26,10 @@ use keyboard::{KeyboardData, KeyboardState};
 pub use pointer::relative_pointer::RelativePointerState;
 pub use pointer::{PointerConstraintsState, WinitPointerData, WinitPointerDataExt};
 use text_input::TextInputData;
-pub use text_input::{TextInputState, ZwpTextInputV3Ext};
+pub use text_input::{ClientState as TextInputClientState, TextInputState};
 use touch::TouchPoint;
+
+pub(crate) use crate::seat::text_input::ZwpTextInputV3Ext;
 
 #[derive(Debug, Default)]
 pub struct WinitSeatState {

--- a/winit-wayland/src/window/mod.rs
+++ b/winit-wayland/src/window/mod.rs
@@ -20,8 +20,9 @@ use winit_core::event::{Ime, WindowEvent};
 use winit_core::event_loop::AsyncRequestSerial;
 use winit_core::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
 use winit_core::window::{
-    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
-    WindowAttributes, WindowButtons, WindowId, WindowLevel,
+    CursorGrabMode, ImeCapabilities, ImeRequest, ImeRequestError, ResizeDirection, Theme,
+    UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
+    WindowLevel,
 };
 
 use super::event_loop::sink::EventSink;
@@ -508,30 +509,21 @@ impl CoreWindow for Window {
     }
 
     #[inline]
-    fn set_ime_cursor_area(&self, position: Position, size: Size) {
-        let window_state = self.window_state.lock().unwrap();
-        if window_state.ime_allowed() {
-            let scale_factor = window_state.scale_factor();
-            let position = position.to_logical(scale_factor);
-            let size = size.to_logical(scale_factor);
-            window_state.set_ime_cursor_area(position, size);
-        }
-    }
+    fn request_ime_update(&self, request: ImeRequest) -> Result<(), ImeRequestError> {
+        let state_changed = self.window_state.lock().unwrap().request_ime_update(request)?;
 
-    #[inline]
-    fn set_ime_allowed(&self, allowed: bool) {
-        let mut window_state = self.window_state.lock().unwrap();
-
-        if window_state.ime_allowed() != allowed && window_state.set_ime_allowed(allowed) {
+        if let Some(allowed) = state_changed {
             let event = WindowEvent::Ime(if allowed { Ime::Enabled } else { Ime::Disabled });
             self.window_events_sink.lock().unwrap().push_window_event(event, self.window_id);
             self.event_loop_awakener.ping();
         }
+
+        Ok(())
     }
 
     #[inline]
-    fn set_ime_purpose(&self, purpose: ImePurpose) {
-        self.window_state.lock().unwrap().set_ime_purpose(purpose);
+    fn ime_capabilities(&self) -> Option<ImeCapabilities> {
+        self.window_state.lock().unwrap().ime_allowed()
     }
 
     fn focus_window(&self) {}

--- a/winit-web/src/window.rs
+++ b/winit-web/src/window.rs
@@ -12,8 +12,8 @@ use winit_core::error::{NotSupportedError, RequestError};
 use winit_core::icon::Icon;
 use winit_core::monitor::{Fullscreen, MonitorHandle as CoremMonitorHandle};
 use winit_core::window::{
-    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as RootWindow,
-    WindowAttributes, WindowButtons, WindowId, WindowLevel,
+    CursorGrabMode, ImeRequestError, ResizeDirection, Theme, UserAttentionType,
+    Window as RootWindow, WindowAttributes, WindowButtons, WindowId, WindowLevel,
 };
 
 use crate::event_loop::ActiveEventLoop;
@@ -308,16 +308,12 @@ impl RootWindow for Window {
         // Currently an intentional no-op
     }
 
-    fn set_ime_cursor_area(&self, _: Position, _: Size) {
-        // Currently not implemented
+    fn ime_capabilities(&self) -> Option<winit_core::window::ImeCapabilities> {
+        None
     }
 
-    fn set_ime_allowed(&self, _: bool) {
-        // Currently not implemented
-    }
-
-    fn set_ime_purpose(&self, _: ImePurpose) {
-        // Currently not implemented
+    fn request_ime_update(&self, _: winit_core::window::ImeRequest) -> Result<(), ImeRequestError> {
+        Err(ImeRequestError::NotSupported)
     }
 
     fn focus_window(&self) {

--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -1416,7 +1416,7 @@ unsafe fn public_window_callback_inner(
         },
 
         WM_IME_STARTCOMPOSITION => {
-            let ime_allowed = userdata.window_state_lock().ime_allowed;
+            let ime_allowed = userdata.window_state_lock().ime_capabilities.is_some();
             if ime_allowed {
                 userdata.window_state_lock().ime_state = ImeState::Enabled;
 
@@ -1429,7 +1429,7 @@ unsafe fn public_window_callback_inner(
         WM_IME_COMPOSITION => {
             let ime_allowed_and_composing = {
                 let w = userdata.window_state_lock();
-                w.ime_allowed && w.ime_state != ImeState::Disabled
+                w.ime_capabilities.is_some() && w.ime_state != ImeState::Disabled
             };
             // Windows Hangul IME sends WM_IME_COMPOSITION after WM_IME_ENDCOMPOSITION, so
             // check whether composing.
@@ -1480,7 +1480,7 @@ unsafe fn public_window_callback_inner(
         WM_IME_ENDCOMPOSITION => {
             let ime_allowed_or_composing = {
                 let w = userdata.window_state_lock();
-                w.ime_allowed || w.ime_state != ImeState::Disabled
+                w.ime_capabilities.is_some() || w.ime_state != ImeState::Disabled
             };
             if ime_allowed_or_composing {
                 if userdata.window_state_lock().ime_state == ImeState::Preedit {

--- a/winit-win32/src/ime.rs
+++ b/winit-win32/src/ime.rs
@@ -149,7 +149,7 @@ impl ImeContext {
         }
     }
 
-    unsafe fn system_has_ime() -> bool {
+    pub unsafe fn system_has_ime() -> bool {
         unsafe { GetSystemMetrics(SM_IMMENABLED) != 0 }
     }
 }

--- a/winit-win32/src/window.rs
+++ b/winit-win32/src/window.rs
@@ -51,8 +51,9 @@ use winit_core::error::RequestError;
 use winit_core::icon::{Icon, RgbaIcon};
 use winit_core::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle, MonitorHandleProvider};
 use winit_core::window::{
-    CursorGrabMode, ImePurpose, ResizeDirection, Theme, UserAttentionType, Window as CoreWindow,
-    WindowAttributes, WindowButtons, WindowId, WindowLevel,
+    CursorGrabMode, ImeCapabilities, ImeRequest, ImeRequestError, ResizeDirection, Theme,
+    UserAttentionType, Window as CoreWindow, WindowAttributes, WindowButtons, WindowId,
+    WindowLevel,
 };
 
 use crate::dark_mode::try_theme;
@@ -1008,25 +1009,63 @@ impl CoreWindow for Window {
         }
     }
 
-    fn set_ime_cursor_area(&self, spot: Position, size: Size) {
+    fn ime_capabilities(&self) -> Option<ImeCapabilities> {
+        self.window_state.lock().unwrap().ime_capabilities
+    }
+
+    fn request_ime_update(&self, request: ImeRequest) -> Result<(), ImeRequestError> {
+        // NOTE: this is racy way of doing this, but unless we remove the `Send` from the `Window`
+        // we can not do much about that.
+        let cap = self.window_state.lock().unwrap().ime_capabilities;
+        match &request {
+            ImeRequest::Enable(..) if cap.is_some() => return Err(ImeRequestError::AlreadyEnabled),
+            ImeRequest::Update(_) if cap.is_none() => return Err(ImeRequestError::NotEnabled),
+            _ => (),
+        }
+
         let window = self.window;
         let state = self.window_state.clone();
         self.thread_executor.execute_in_thread(move || unsafe {
-            let scale_factor = state.lock().unwrap().scale_factor;
-            ImeContext::current(window.hwnd()).set_ime_cursor_area(spot, size, scale_factor);
+            let hwnd = window.hwnd();
+            let mut state = state.lock().unwrap();
+            let (capabilities, request_data) = match &request {
+                ImeRequest::Enable(enable) => {
+                    let capabilities = *enable.capabilities();
+                    state.ime_capabilities = Some(capabilities);
+                    ImeContext::set_ime_allowed(hwnd, true);
+                    (capabilities, enable.request_data())
+                },
+                ImeRequest::Update(request_data) => {
+                    if let Some(capabilities) = state.ime_capabilities {
+                        (capabilities, request_data)
+                    } else {
+                        warn!("ime update without IME enabled.");
+                        return;
+                    }
+                },
+                ImeRequest::Disable => {
+                    state.ime_capabilities = None;
+                    ImeContext::set_ime_allowed(window.hwnd(), false);
+                    return;
+                },
+            };
+
+            if let Some((spot, size)) = request_data.cursor_area {
+                if capabilities.contains(ImeCapabilities::CURSOR_AREA) {
+                    let scale_factor = state.scale_factor;
+                    ImeContext::current(window.hwnd()).set_ime_cursor_area(
+                        spot,
+                        size,
+                        scale_factor,
+                    );
+                } else {
+                    warn!("discarding IME cursor area update without capability enabled.");
+                }
+            }
         });
-    }
 
-    fn set_ime_allowed(&self, allowed: bool) {
-        let window = self.window;
-        let state = self.window_state.clone();
-        self.thread_executor.execute_in_thread(move || unsafe {
-            state.lock().unwrap().ime_allowed = allowed;
-            ImeContext::set_ime_allowed(window.hwnd(), allowed);
-        })
+        Ok(())
     }
-
-    fn set_ime_purpose(&self, _purpose: ImePurpose) {}
 
     fn request_user_attention(&self, request_type: Option<UserAttentionType>) {
         let window = self.window;

--- a/winit-win32/src/window_state.rs
+++ b/winit-win32/src/window_state.rs
@@ -19,7 +19,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 use winit_core::icon::Icon;
 use winit_core::keyboard::ModifiersState;
 use winit_core::monitor::Fullscreen;
-use winit_core::window::{Theme, WindowAttributes};
+use winit_core::window::{ImeCapabilities, Theme, WindowAttributes};
 
 use crate::{event_loop, util, SelectedCursor};
 
@@ -48,7 +48,7 @@ pub(crate) struct WindowState {
     pub window_flags: WindowFlags,
 
     pub ime_state: ImeState,
-    pub ime_allowed: bool,
+    pub ime_capabilities: Option<ImeCapabilities>,
 
     // Used by WM_NCACTIVATE, WM_SETFOCUS and WM_KILLFOCUS
     pub is_active: bool,
@@ -178,7 +178,7 @@ impl WindowState {
             window_flags: WindowFlags::empty(),
 
             ime_state: ImeState::Disabled,
-            ime_allowed: false,
+            ime_capabilities: None,
 
             is_active: false,
             is_focused: false,

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -82,6 +82,7 @@ changelog entry.
 - `ActivationToken::as_raw` to get a ref to raw token.
 - Each platform now has corresponding `WindowAttributes` struct instead of trait extension.
 - On Wayland, added implementation for `Window::set_window_icon`
+- Add `Window::request_ime_update` to atomically apply set of IME changes.
 
 ### Changed
 
@@ -203,6 +204,7 @@ changelog entry.
 - Move `EventLoopExtPumpEvents` and `PumpStatus` from platform module to `winit::event_loop::pump_events`.
 - Move `EventLoopExtRunOnDemand` from platform module to `winit::event_loop::run_on_demand`.
 - Use `NamedKey`, `Code` and `Location` from the `keyboard-types` v0.8 crate.
+- Deprecate `Window::set_ime_allowed`, `Window::set_ime_cursor_area`, and `Window::set_ime_purpose`.
 
 ### Removed
 


### PR DESCRIPTION
This is based on the Wayland text-input procotol, where changes are grouped into sets and applied with .commit or .done, depending on the direction.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality