### PR TITLE
Add PartialEq for RgbaIcon

### DIFF
--- a/winit-core/src/icon.rs
+++ b/winit-core/src/icon.rs
@@ -60,7 +60,7 @@ impl fmt::Display for BadIcon {
 
 impl Error for BadIcon {}
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RgbaIcon {
     pub(crate) width: u32,
     pub(crate) height: u32,


### PR DESCRIPTION
Will simplify implementing reactive window icons in Xilem.
