### PR TITLE
Account for mouse wheel speed settings on Windows

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -249,3 +249,4 @@ changelog entry.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
 - On macOS, don't panic on monitors with unknown bit-depths.
+- On Windows, account for mouse wheel lines per scroll setting for `WindowEvent::MouseWheel`.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

Fix `WindowEvent::MouseWheel` doesn't account for mouse wheel speed settings

Reference docs: https://learn.microsoft.com/en-us/windows/win32/inputdev/about-mouse-input#determining-the-number-of-scroll-lines
Reference tao PR: https://github.com/tauri-apps/tao/pull/1119