### PR TITLE
Use a shared version number for all winit-* crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,21 +8,22 @@ edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/rust-windowing/winit"
 rust-version = "1.80"
+version = "0.30.11"
 
 [workspace.dependencies]
 # Workspace dependencies.
 # `winit` has no version here to allow using it in dev deps for docs.
 winit = { path = "winit" }
-winit-android = { version = "0.0.0", path = "winit-android" }
-winit-appkit = { version = "0.0.0", path = "winit-appkit" }
-winit-common = { version = "0.0.0", path = "winit-common" }
-winit-core = { version = "0.0.0", path = "winit-core" }
-winit-orbital = { version = "0.0.0", path = "winit-orbital" }
-winit-uikit = { version = "0.0.0", path = "winit-uikit" }
-winit-wayland = { version = "0.0.0", path = "winit-wayland", default-features = false }
-winit-web = { version = "0.0.0", path = "winit-web" }
-winit-win32 = { version = "0.0.0", path = "winit-win32" }
-winit-x11 = { version = "0.0.0", path = "winit-x11" }
+winit-android = { version = "0.30.11", path = "winit-android" }
+winit-appkit = { version = "0.30.11", path = "winit-appkit" }
+winit-common = { version = "0.30.11", path = "winit-common" }
+winit-core = { version = "0.30.11", path = "winit-core" }
+winit-orbital = { version = "0.30.11", path = "winit-orbital" }
+winit-uikit = { version = "0.30.11", path = "winit-uikit" }
+winit-wayland = { version = "0.30.11", path = "winit-wayland", default-features = false }
+winit-web = { version = "0.30.11", path = "winit-web" }
+winit-win32 = { version = "0.30.11", path = "winit-win32" }
+winit-x11 = { version = "0.30.11", path = "winit-x11" }
 
 # Core dependencies.
 bitflags = "2"

--- a/winit-android/Cargo.toml
+++ b/winit-android/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 name = "winit-android"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 game-activity = ["android-activity/game-activity"]

--- a/winit-appkit/Cargo.toml
+++ b/winit-appkit/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 name = "winit-appkit"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]

--- a/winit-common/Cargo.toml
+++ b/winit-common/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 name = "winit-common"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 # Event Handler

--- a/winit-core/Cargo.toml
+++ b/winit-core/Cargo.toml
@@ -10,7 +10,7 @@ name = "winit-core"
 readme = "README.md"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 serde = [

--- a/winit-orbital/Cargo.toml
+++ b/winit-orbital/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 name = "winit-orbital"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]

--- a/winit-uikit/Cargo.toml
+++ b/winit-uikit/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 name = "winit-uikit"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]

--- a/winit-wayland/Cargo.toml
+++ b/winit-wayland/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 name = "winit-wayland"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 default = ["dlopen", "csd-adwaita"]

--- a/winit-web/Cargo.toml
+++ b/winit-web/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 name = "winit-web"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]

--- a/winit-win32/Cargo.toml
+++ b/winit-win32/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 name = "winit-win32"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde", "winit-core/serde"]

--- a/winit-x11/Cargo.toml
+++ b/winit-x11/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 name = "winit-x11"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.0.0"
+version.workspace = true
 
 [features]
 serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 name = "winit"
 repository.workspace = true
 rust-version.workspace = true
-version = "0.30.11"
+version.workspace = true
 
 [package.metadata.docs.rs]
 features = [


### PR DESCRIPTION
There are basically two ways we can do versioning of the `winit-*` crates:
1. Distinct versioning for each crate.
2. A single shared version for all the crates.

There are many benefits to the first approach, including that we don't need to re-release unchanged crates for patch releases that only affect few crates, and that we might be able to re-use Winit crates between breaking changes of other crates (e.g. if `winit-core` becomes very stable).

But the maintenance cost for us is also just quite high (there's a lot more combinations to test), and it makes it confusing for consumers to find the "mapping" between the main `winit` crate version and the platform-specific crate versions.

We discussed it [in our recent meeting](https://hackmd.io/@winit-meetings/Hy4iCnAzlg), and came to the conclusion that we should go with a shared versioning scheme for simplicity for now, and only later have versions diverge if there's a concrete need.

Part of https://github.com/rust-windowing/winit/issues/3433.