### PR TITLE
winit-web: skip_recreation_check added

### DIFF
--- a/winit-web/src/event_loop/window_target.rs
+++ b/winit-web/src/event_loop/window_target.rs
@@ -56,8 +56,7 @@ impl ActiveEventLoop {
         Self { runner: runner::Shared::new(), modifiers: ModifiersShared::default() }
     }
 
-    pub(crate) fn run(&self, app: Box<dyn ApplicationHandler>, event_loop_recreation: bool) {
-        self.runner.event_loop_recreation(event_loop_recreation);
+    pub(crate) fn run(&self, app: Box<dyn ApplicationHandler>) {
         self.runner.start(app, self.clone());
     }
 

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -205,6 +205,9 @@ changelog entry.
 - Move `EventLoopExtRunOnDemand` from platform module to `winit::event_loop::run_on_demand`.
 - Use `NamedKey`, `Code` and `Location` from the `keyboard-types` v0.8 crate.
 - Deprecate `Window::set_ime_allowed`, `Window::set_ime_cursor_area`, and `Window::set_ime_purpose`.
+- On Web, added the option when directly using `winit_web::event_loop::EventLoop` to bypass the recreation check.
+  Running multiple `EventLoop`s concurrently work on Web, but it's a niche usage and not expected when using the
+  normal `winit::event_loop::EventLoop` path.
 
 ### Removed
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Tested locally against a web app with two separate Canvases with their own winit+wgpu contexts in a Dioxus web app and unmounting+remounting the components (destroying and recreating everything in the process).