### PR TITLE
Add 'Metal' feature for iOS/macOS uses CAMetalLayer on UIView/NSView

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,8 @@ mint = ["dpi/mint"]
 rwh_04 = ["dep:rwh_04", "ndk/rwh_04"]
 rwh_05 = ["dep:rwh_05", "ndk/rwh_05"]
 rwh_06 = ["dep:rwh_06", "ndk/rwh_06"]
+# Only works on iOS/macOS, will create a UIView/NSView with CAMetalLayer and sets gl_or_metal_backed (iOS) true
+metal = []
 
 [build-dependencies]
 cfg_aliases = "0.2.1"

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -48,6 +48,11 @@ declare_class!(
     }
 
     unsafe impl WinitView {
+        #[allow(non_snake_case)]
+        #[cfg(feature="metal")]
+        #[method(layerClass)]
+        fn layerClass() -> &'static objc2::runtime::AnyClass{ objc2::class!(CAMetalLayer) }
+
         #[method(drawRect:)]
         fn draw_rect(&self, rect: CGRect) {
             let mtm = MainThreadMarker::new().unwrap();

--- a/src/platform_impl/ios/window.rs
+++ b/src/platform_impl/ios/window.rs
@@ -522,8 +522,9 @@ impl Window {
 
         let view = WinitView::new(mtm, &window_attributes, frame);
 
-        let gl_or_metal_backed =
-            view.isKindOfClass(class!(CAMetalLayer)) || view.isKindOfClass(class!(CAEAGLLayer));
+        let gl_or_metal_backed = cfg!(feature = "metal")
+            || view.isKindOfClass(class!(CAMetalLayer))
+            || view.isKindOfClass(class!(CAEAGLLayer));
 
         let view_controller = WinitViewController::new(mtm, &window_attributes, &view);
         let window = WinitUIWindow::new(mtm, &window_attributes, frame, &view_controller);

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -804,6 +804,16 @@ impl WinitView {
         });
         let this: Retained<Self> = unsafe { msg_send_id![super(this), init] };
 
+        if cfg!(feature = "metal") {
+            unsafe {
+                let _: () = objc2::msg_send![&this, setWantsLayer: objc2::ffi::YES];
+                let metal_layer_cls = objc2::class!(CAMetalLayer);
+                let metal_layer: *mut objc2::runtime::AnyObject =
+                    objc2::msg_send![metal_layer_cls, new];
+                let _: () = objc2::msg_send![&this, setLayer: metal_layer];
+            }
+        }
+
         this.setPostsFrameChangedNotifications(true);
         let notification_center = unsafe { NSNotificationCenter::defaultCenter() };
         unsafe {


### PR DESCRIPTION
Hello winit Team :smiley:,

thank you for this awesome repository :thumbsup:

I was experimenting with macOS/iOS and [skia-safe](https://github.com/rust-skia/rust-skia/tree/master/skia-safe) with GPU Backend Metal. It was very difficult to get the Metal to work,  especially on iOS because I needed the `gl_or_metal_backed` line 525 in [platform_impl/ios/window.rs](https://github.com/rust-windowing/winit/blob/v0.30.x/src/platform_impl/ios/window.rs) to be `true`, otherwise the render with `window.request_redraw()` will not work. With the `metal` feature enabeld the UIView/NSView will automatically create a `CAMetalLayer` as its layer.

The `MetalLayer` can then be extracted as followed:
```
use raw_window_handle::RawWindowHandle;

impl ApplicationHandler for Application {

    /* Cargo.toml
    winit = { version = "0.30.11", features = ["metal"] }
    metal = "0.32"
    objc = "0.2"
    raw-window-handle = "0.6"
    */

    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
        let window = event_loop.create_window(WindowAttributes::default()).expect("Failed to create window");
        let window_handle = window.window_handle().expect("Failed to retrieve a window handle");
        let view = match window_handle.as_raw() {
            RawWindowHandle::AppKit(appkit) => appkit.ns_view.as_ptr(),
            RawWindowHandle::UiKit(uikit) => uikit.ui_view.as_ptr(),
            _ => panic!("Wrong window handle type")
        } as *mut objc::runtime::Object;

        let metal_layer = unsafe {
            let metal_layer: *mut metal::CAMetalLayer = objc::msg_send![view, layer];
            let ml = metal::MetalLayer::from_ptr(metal_layer);
            ml
        }
    }
}
```