### PR TITLE
wayland: Implement xdg_toplevel_icon_v1 protocol

### DIFF
--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -1041,18 +1041,20 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
 
     /// Sets the window icon.
     ///
-    /// On Windows and X11, this is typically the small icon in the top-left
+    /// On Windows, Wayland and X11, this is typically the small icon in the top-left
     /// corner of the titlebar.
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Wayland / macOS / Orbital:** Unsupported.
+    /// - **iOS / Android / Web / / macOS / Orbital:** Unsupported.
     ///
     /// - **Windows:** Sets `ICON_SMALL`. The base size for a window icon is 16x16, but it's
     ///   recommended to account for screen scaling and pick a multiple of that, i.e. 32x32.
     ///
     /// - **X11:** Has no universal guidelines for icon sizes, so you're at the whims of the WM.
     ///   That said, it's usually in the same ballpark as on Windows.
+    ///
+    /// - **Wayland:** The default scale is set to `1`
     fn set_window_icon(&self, window_icon: Option<Icon>);
 
     /// Set the IME cursor editing area, where the `position` is the top left corner of that area

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -32,6 +32,7 @@ use crate::types::kwin_blur::KWinBlurManager;
 use crate::types::wp_fractional_scaling::FractionalScalingManager;
 use crate::types::wp_viewporter::ViewporterState;
 use crate::types::xdg_activation::XdgActivationState;
+use crate::types::xdg_toplevel_icon_manager::XdgToplevelIconManagerState;
 use crate::window::{WindowRequests, WindowState};
 use crate::WindowId;
 
@@ -92,6 +93,12 @@ pub struct WinitState {
 
     /// Xdg activation.
     pub xdg_activation: Option<XdgActivationState>,
+
+    /// Xdg toplevel icon manager
+    pub xdg_toplevel_icon_manager: Option<XdgToplevelIconManagerState>,
+
+    /// The pool where icons are allocated
+    pub icon_pool: Arc<Mutex<SlotPool>>,
 
     /// Relative pointer.
     pub relative_pointer: Option<RelativePointerState>,
@@ -159,6 +166,7 @@ impl WinitState {
 
         let shm = Shm::bind(globals, queue_handle).map_err(|err| os_error!(err))?;
         let custom_cursor_pool = Arc::new(Mutex::new(SlotPool::new(2, &shm).unwrap()));
+        let icon_pool = Arc::new(Mutex::new(SlotPool::new(2, &shm).unwrap()));
 
         Ok(Self {
             registry_state,
@@ -171,6 +179,10 @@ impl WinitState {
 
             xdg_shell: XdgShell::bind(globals, queue_handle).map_err(|err| os_error!(err))?,
             xdg_activation: XdgActivationState::bind(globals, queue_handle).ok(),
+
+            xdg_toplevel_icon_manager: XdgToplevelIconManagerState::bind(globals, queue_handle)
+                .ok(),
+            icon_pool,
 
             windows: Default::default(),
             window_requests: Default::default(),

--- a/winit-wayland/src/types/mod.rs
+++ b/winit-wayland/src/types/mod.rs
@@ -5,3 +5,4 @@ pub mod kwin_blur;
 pub mod wp_fractional_scaling;
 pub mod wp_viewporter;
 pub mod xdg_activation;
+pub mod xdg_toplevel_icon_manager;

--- a/winit-wayland/src/types/xdg_toplevel_icon_manager.rs
+++ b/winit-wayland/src/types/xdg_toplevel_icon_manager.rs
@@ -1,0 +1,110 @@
+//! Handling of xdg toplevel icon manager, which is used for icon setting requests.
+
+use crate::state::WinitState;
+use sctk::globals::GlobalData;
+use sctk::shm::slot::{Buffer, SlotPool};
+use tracing::warn;
+use wayland_client::globals::{BindError, GlobalList};
+use wayland_client::protocol::wl_shm::Format;
+use wayland_client::{delegate_dispatch, Connection, Dispatch, Proxy, QueueHandle};
+use wayland_protocols::xdg::toplevel_icon::v1::client::xdg_toplevel_icon_manager_v1::XdgToplevelIconManagerV1;
+use wayland_protocols::xdg::toplevel_icon::v1::client::xdg_toplevel_icon_v1::XdgToplevelIconV1;
+use winit_core::icon::{Icon, RgbaIcon};
+
+#[derive(Debug)]
+pub struct XdgToplevelIconManagerState {
+    xdg_toplevel_icon_manager: XdgToplevelIconManagerV1,
+}
+
+impl XdgToplevelIconManagerState {
+    pub fn bind(
+        globals: &GlobalList,
+        queue_handle: &QueueHandle<WinitState>,
+    ) -> Result<Self, BindError> {
+        let xdg_toplevel_icon_manager = globals.bind(queue_handle, 1..=1, GlobalData)?;
+        Ok(Self { xdg_toplevel_icon_manager })
+    }
+
+    pub fn global(&self) -> &XdgToplevelIconManagerV1 {
+        &self.xdg_toplevel_icon_manager
+    }
+}
+
+impl Dispatch<XdgToplevelIconManagerV1, GlobalData, WinitState> for XdgToplevelIconManagerState {
+    fn event(
+        _state: &mut WinitState,
+        _proxy: &XdgToplevelIconManagerV1,
+        _event: <XdgToplevelIconManagerV1 as Proxy>::Event,
+        _data: &GlobalData,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<WinitState>,
+    ) {
+    }
+}
+
+#[derive(Debug)]
+pub enum ToplevelIconError {
+    InvalidBuffer,
+    Immutable,
+    NoBuffer,
+}
+
+#[derive(Debug)]
+pub struct ToplevelIcon {
+    buffer: Buffer,
+}
+
+impl ToplevelIcon {
+    pub fn new(icon: Icon, pool: &mut SlotPool) -> Result<Self, ToplevelIconError> {
+        let buffer: Buffer;
+        let canvas: &mut [u8];
+        if let Some(icon) = icon.cast_ref::<RgbaIcon>() {
+            (buffer, canvas) = pool
+                .create_buffer(
+                    icon.width() as i32,
+                    icon.height() as i32,
+                    4 * (icon.width() as i32),
+                    Format::Argb8888,
+                )
+                .unwrap();
+
+            for (canvas_chunk, rgba) in
+                canvas.chunks_exact_mut(4).zip(icon.buffer().chunks_exact(4))
+            {
+                // Alpha in buffer is premultiplied.
+                let alpha = rgba[3] as f32 / 255.;
+                let r = (rgba[0] as f32 * alpha) as u32;
+                let g = (rgba[1] as f32 * alpha) as u32;
+                let b = (rgba[2] as f32 * alpha) as u32;
+                let color = ((rgba[3] as u32) << 24) + (r << 16) + (g << 8) + b;
+                let array: &mut [u8; 4] = canvas_chunk.try_into().unwrap();
+                *array = color.to_le_bytes();
+            }
+        } else {
+            warn!("invalid icon");
+            return Err(ToplevelIconError::InvalidBuffer);
+        }
+
+        Ok(Self { buffer })
+    }
+
+    pub fn add_buffer(&self, xdg_toplevel_icon: &XdgToplevelIconV1) {
+        xdg_toplevel_icon.add_buffer(self.buffer.wl_buffer(), 1);
+    }
+}
+
+impl Dispatch<XdgToplevelIconV1, GlobalData, WinitState> for XdgToplevelIconManagerState {
+    fn event(
+        _state: &mut WinitState,
+        _proxy: &XdgToplevelIconV1,
+        _event: <XdgToplevelIconV1 as Proxy>::Event,
+        _data: &GlobalData,
+        _conn: &Connection,
+        _qhandle: &QueueHandle<WinitState>,
+    ) {
+        // No events
+    }
+}
+
+delegate_dispatch!(WinitState: [XdgToplevelIconManagerV1: GlobalData] => XdgToplevelIconManagerState);
+delegate_dispatch!(WinitState: [XdgToplevelIconV1: GlobalData] => XdgToplevelIconManagerState);

--- a/winit-wayland/src/window/state.rs
+++ b/winit-wayland/src/window/state.rs
@@ -40,6 +40,7 @@ use crate::seat::{
 use crate::state::{WindowCompositorUpdate, WinitState};
 use crate::types::cursor::{CustomCursor, SelectedCursor, WaylandCustomCursor};
 use crate::types::kwin_blur::KWinBlurManager;
+use crate::types::xdg_toplevel_icon_manager::ToplevelIcon;
 
 #[cfg(feature = "sctk-adwaita")]
 pub type WinitFrame = sctk_adwaita::AdwaitaFrame<WinitState>;
@@ -83,6 +84,12 @@ pub struct WindowState {
 
     /// The current window title.
     title: String,
+
+    /// The current window toplevel icon
+    pub(crate) toplevel_icon: Option<ToplevelIcon>,
+
+    /// A shared pool where to allocate icons
+    pub(crate) icon_pool: Arc<Mutex<SlotPool>>,
 
     /// Whether the frame is resizable.
     resizable: bool,
@@ -181,6 +188,7 @@ impl WindowState {
             .map(|fsm| fsm.fractional_scaling(window.wl_surface(), queue_handle));
 
         Self {
+            toplevel_icon: None,
             blur: None,
             blur_manager: winit_state.kwin_blur_manager.clone(),
             compositor,
@@ -207,6 +215,7 @@ impl WindowState {
             scale_factor: 1.,
             shm: winit_state.shm.wl_shm().clone(),
             custom_cursor_pool: winit_state.custom_cursor_pool.clone(),
+            icon_pool: winit_state.icon_pool.clone(),
             size: initial_size.to_logical(1.),
             stateless_size: initial_size.to_logical(1.),
             initial_size: Some(initial_size),

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -59,8 +59,10 @@ changelog entry.
 - Implement `Clone`, `Copy`, `Debug`, `Deserialize`, `Eq`, `Hash`, `Ord`, `PartialEq`, `PartialOrd`
   and `Serialize` on many types.
 - Add `MonitorHandle::current_video_mode()`.
-- Add `ApplicationHandlerExtMacOS` trait, and a `macos_handler` method to `ApplicationHandler` which returns a `dyn ApplicationHandlerExtMacOS` which allows for macOS specific extensions to winit.
-- Add a `standard_key_binding` method to the `ApplicationHandlerExtMacOS` trait. This allows handling of standard keybindings such as "go to end of line" on macOS.
+- Add `ApplicationHandlerExtMacOS` trait, and a `macos_handler` method to `ApplicationHandler` which returns a
+  `dyn ApplicationHandlerExtMacOS` which allows for macOS specific extensions to winit.
+- Add a `standard_key_binding` method to the `ApplicationHandlerExtMacOS` trait. This allows handling of standard
+  keybindings such as "go to end of line" on macOS.
 - On macOS, add `WindowExtMacOS::set_unified_titlebar` and `WindowAttributesMacOS::with_unified_titlebar`
   to use a larger style of titlebar.
 - Add `WindowId::into_raw()` and `from_raw()`.
@@ -73,6 +75,7 @@ changelog entry.
 - Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`.
 - Implement `MonitorHandleProvider` for `MonitorHandle` to access common monitor API.
 - On X11, set an "area" attribute on XIM input connection to convey the cursor area.
+- On Wayland, added implementation for xdg_toplevel_icon_v1 protocol
 - Implement `CustomCursorProvider` for `CustomCursor` to access cursor API.
 - Add `CustomCursorSource::Url`, `CustomCursorSource::from_animation`.
 - Implement `CustomIconProvider` for `RgbaIcon`.
@@ -122,20 +125,20 @@ changelog entry.
   application delegate yourself.
 - On X11, remove our dependency on libXcursor. (#3749)
 - Renamed the following APIs to make it clearer that the sizes apply to the underlying surface:
-  - `WindowEvent::Resized` to `SurfaceResized`.
-  - `InnerSizeWriter` to `SurfaceSizeWriter`.
-  - `WindowAttributes.inner_size` to `surface_size`.
-  - `WindowAttributes.min_inner_size` to `min_surface_size`.
-  - `WindowAttributes.max_inner_size` to `max_surface_size`.
-  - `WindowAttributes.resize_increments` to `surface_resize_increments`.
-  - `WindowAttributes::with_inner_size` to `with_surface_size`.
-  - `WindowAttributes::with_min_inner_size` to `with_min_surface_size`.
-  - `WindowAttributes::with_max_inner_size` to `with_max_surface_size`.
-  - `WindowAttributes::with_resize_increments` to `with_surface_resize_increments`.
-  - `Window::inner_size` to `surface_size`.
-  - `Window::request_inner_size` to `request_surface_size`.
-  - `Window::set_min_inner_size` to `set_min_surface_size`.
-  - `Window::set_max_inner_size` to `set_max_surface_size`.
+    - `WindowEvent::Resized` to `SurfaceResized`.
+    - `InnerSizeWriter` to `SurfaceSizeWriter`.
+    - `WindowAttributes.inner_size` to `surface_size`.
+    - `WindowAttributes.min_inner_size` to `min_surface_size`.
+    - `WindowAttributes.max_inner_size` to `max_surface_size`.
+    - `WindowAttributes.resize_increments` to `surface_resize_increments`.
+    - `WindowAttributes::with_inner_size` to `with_surface_size`.
+    - `WindowAttributes::with_min_inner_size` to `with_min_surface_size`.
+    - `WindowAttributes::with_max_inner_size` to `with_max_surface_size`.
+    - `WindowAttributes::with_resize_increments` to `with_surface_resize_increments`.
+    - `Window::inner_size` to `surface_size`.
+    - `Window::request_inner_size` to `request_surface_size`.
+    - `Window::set_min_inner_size` to `set_min_surface_size`.
+    - `Window::set_max_inner_size` to `set_max_surface_size`.
 
   To migrate, you can probably just replace all instances of `inner_size` with `surface_size` in your codebase.
 - Every event carrying a `DeviceId` now uses `Option<DeviceId>` instead. A `None` value signifies that the
@@ -143,26 +146,26 @@ changelog entry.
 - Pointer `WindowEvent`s were overhauled. The new events can handle any type of pointer, serving as
   a single pointer input source. Now your application can handle any pointer type without having to
   explicitly handle e.g. `Touch`:
-  - Rename `CursorMoved` to `PointerMoved`.
-  - Rename `CursorEntered` to `PointerEntered`.
-  - Rename `CursorLeft` to `PointerLeft`.
-  - Rename `MouseInput` to `PointerButton`.
-  - Add `primary` to every `PointerEvent` as a way to identify discard non-primary pointers in a
-    multi-touch interaction.
-  - Add `position` to every `PointerEvent`.
-  - `PointerMoved` is **not sent** after `PointerEntered` anymore.
-  - Remove `Touch`, which is folded into the `Pointer*` events.
-  - New `PointerKind` added to `PointerEntered` and `PointerLeft`, signifying which pointer type is
-    the source of this event.
-  - New `PointerSource` added to `PointerMoved`, similar to `PointerKind` but holding additional
-    data.
-  - New `ButtonSource` added to `PointerButton`, similar to `PointerKind` but holding pointer type
-    specific buttons. Use `ButtonSource::mouse_button()` to easily normalize any pointer button
-    type to a generic mouse button.
-  - New `FingerId` added to `PointerKind::Touch` and `PointerSource::Touch` able to uniquely
-    identify a finger in a multi-touch interaction. Replaces the old `Touch::id`.
-  - In the same spirit rename `DeviceEvent::MouseMotion` to `PointerMotion`.
-  - Remove `Force::Calibrated::altitude_angle`.
+    - Rename `CursorMoved` to `PointerMoved`.
+    - Rename `CursorEntered` to `PointerEntered`.
+    - Rename `CursorLeft` to `PointerLeft`.
+    - Rename `MouseInput` to `PointerButton`.
+    - Add `primary` to every `PointerEvent` as a way to identify discard non-primary pointers in a
+      multi-touch interaction.
+    - Add `position` to every `PointerEvent`.
+    - `PointerMoved` is **not sent** after `PointerEntered` anymore.
+    - Remove `Touch`, which is folded into the `Pointer*` events.
+    - New `PointerKind` added to `PointerEntered` and `PointerLeft`, signifying which pointer type is
+      the source of this event.
+    - New `PointerSource` added to `PointerMoved`, similar to `PointerKind` but holding additional
+      data.
+    - New `ButtonSource` added to `PointerButton`, similar to `PointerKind` but holding pointer type
+      specific buttons. Use `ButtonSource::mouse_button()` to easily normalize any pointer button
+      type to a generic mouse button.
+    - New `FingerId` added to `PointerKind::Touch` and `PointerSource::Touch` able to uniquely
+      identify a finger in a multi-touch interaction. Replaces the old `Touch::id`.
+    - In the same spirit rename `DeviceEvent::MouseMotion` to `PointerMotion`.
+    - Remove `Force::Calibrated::altitude_angle`.
 - On X11, use bottom-right corner for IME hotspot in `Window::set_ime_cursor_area`.
 - On macOS and iOS, no longer emit `ScaleFactorChanged` upon window creation.
 - On macOS, no longer emit `Focused` upon window creation.
@@ -182,17 +185,17 @@ changelog entry.
   pointer position.
 
   The rough correspondence is:
-  - `WindowEvent::HoveredFile` -> `WindowEvent::DragEntered`
-  - `WindowEvent::DroppedFile` -> `WindowEvent::DragDropped`
-  - `WindowEvent::HoveredFileCancelled` -> `WindowEvent::DragLeft`
+    - `WindowEvent::HoveredFile` -> `WindowEvent::DragEntered`
+    - `WindowEvent::DroppedFile` -> `WindowEvent::DragDropped`
+    - `WindowEvent::HoveredFileCancelled` -> `WindowEvent::DragLeft`
 
   The `WindowEvent::DragMoved` event is entirely new, and is emitted whenever the pointer moves
   whilst files are being dragged over the window. It doesn't contain any file paths, just the
   pointer position.
 - Updated `objc2` to `v0.6`.
 - Updated `windows-sys` to `v0.59`.
-  - To match the corresponding changes in `windows-sys`, the `HWND`, `HMONITOR`, and `HMENU` types
-    now alias to `*mut c_void` instead of `isize`.
+    - To match the corresponding changes in `windows-sys`, the `HWND`, `HMONITOR`, and `HMENU` types
+      now alias to `*mut c_void` instead of `isize`.
 - Removed `KeyEventExtModifierSupplement`, and made the fields `text_with_all_modifiers` and
   `key_without_modifiers` public on `KeyEvent` instead.
 - Move `window::Fullscreen` to `monitor::Fullscreen`.
@@ -207,14 +210,14 @@ changelog entry.
 
 - Remove `Event`.
 - Remove already deprecated APIs:
-  - `EventLoop::create_window()`
-  - `EventLoop::run`.
-  - `EventLoopBuilder::new()`
-  - `EventLoopExtPumpEvents::pump_events`.
-  - `EventLoopExtRunOnDemand::run_on_demand`.
-  - `VideoMode`
-  - `WindowAttributes::new()`
-  - `Window::set_cursor_icon()`
+    - `EventLoop::create_window()`
+    - `EventLoop::run`.
+    - `EventLoopBuilder::new()`
+    - `EventLoopExtPumpEvents::pump_events`.
+    - `EventLoopExtRunOnDemand::run_on_demand`.
+    - `VideoMode`
+    - `WindowAttributes::new()`
+    - `Window::set_cursor_icon()`
 - On iOS, remove `platform::ios::EventLoopExtIOS` and related `platform::ios::Idiom` type.
 
   This feature was incomplete, and the equivalent functionality can be trivially achieved outside
@@ -231,7 +234,7 @@ changelog entry.
   `WindowId::into_raw()` and `from_raw()`.
 - Remove `dummy()` from `WindowId` and `DeviceId`.
 - Remove `WindowEvent::Touch` and `Touch` in favor of the new `PointerKind`, `PointerSource` and
- `ButtonSource` as part of the new pointer event overhaul.
+  `ButtonSource` as part of the new pointer event overhaul.
 - Remove `Force::altitude_angle`.
 - Remove `Window::inner_position`, use the new `Window::surface_position` instead.
 - Remove `CustomCursorExtWeb`, use the `CustomCursorSource`.


### PR DESCRIPTION
Added implementation for [xdg_toplevel_icon_v1](https://wayland.app/protocols/xdg-toplevel-icon-v1)

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
