### PR TITLE
winit: silence wasm on nightly

### DIFF
--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -282,7 +282,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![warn(clippy::uninlined_format_args)]
 // TODO: wasm-binding needs to be updated for that to be resolved, for now just silence it.
-#![cfg_attr(web_platform, allow(unknown_lints, wasm_c_abi))]
+#![cfg_attr(web_platform, allow(unknown_lints, renamed_and_removed_lints, wasm_c_abi))]
 
 // Re-export DPI types so that users don't have to put it in Cargo.toml.
 #[doc(inline)]


### PR DESCRIPTION
The lint is needed for stable, but is no longer present on nightly, so silence it for the time being.

