### PR TITLE
input method: Prevent adding caps from breaking backward-compatibility

### DIFF
--- a/examples/application.rs
+++ b/examples/application.rs
@@ -669,7 +669,11 @@ impl WindowState {
         let request_data = ImeRequestData::default()
             .with_purpose(ImePurpose::Normal)
             .with_cursor_area(LogicalPosition { x: 0, y: 0 }.into(), IME_CURSOR_SIZE.into());
-        let enable_request = ImeEnableRequest::new(ImeCapabilities::all(), request_data).unwrap();
+        let enable_request = ImeEnableRequest::new(
+            ImeCapabilities::new().with_purpose().with_cursor_area(),
+            request_data,
+        )
+        .unwrap();
         let enable_ime = ImeRequest::Enable(enable_request);
 
         // Initial update
@@ -714,8 +718,11 @@ impl WindowState {
                 .unwrap_or(LogicalPosition { x: 0, y: 0 }.into());
             let request_data =
                 ImeRequestData::default().with_cursor_area(cursor_pos, IME_CURSOR_SIZE.into());
-            let enable_request =
-                ImeEnableRequest::new(ImeCapabilities::all(), request_data).unwrap();
+            let enable_request = ImeEnableRequest::new(
+                ImeCapabilities::new().with_purpose().with_cursor_area(),
+                request_data,
+            )
+            .unwrap();
             self.window.request_ime_update(ImeRequest::Enable(enable_request)).unwrap();
         };
 

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -1698,7 +1698,7 @@ impl WindowDelegate {
         };
 
         if let Some((spot, size)) = request_data.cursor_area {
-            if self.view().ime_capabilities().unwrap().contains(ImeCapabilities::CURSOR_AREA) {
+            if self.view().ime_capabilities().unwrap().cursor_area() {
                 let scale_factor = self.scale_factor();
                 let logical_spot = spot.to_logical(scale_factor);
                 let logical_spot = NSPoint::new(logical_spot.x, logical_spot.y);

--- a/winit-wayland/src/seat/text_input/mod.rs
+++ b/winit-wayland/src/seat/text_input/mod.rs
@@ -261,7 +261,7 @@ impl ClientState {
     /// Updates the fields of the state which are present in update_fields.
     pub fn update(&mut self, request_data: ImeRequestData, scale_factor: f64) {
         if let Some(purpose) = request_data.purpose {
-            if self.capabilities.contains(ImeCapabilities::PURPOSE) {
+            if self.capabilities.purpose() {
                 self.content_type = purpose.into();
             } else {
                 warn!("discarding ImePurpose update without capability enabled.");
@@ -269,7 +269,7 @@ impl ClientState {
         }
 
         if let Some((position, size)) = request_data.cursor_area {
-            if self.capabilities.contains(ImeCapabilities::CURSOR_AREA) {
+            if self.capabilities.cursor_area() {
                 let position: LogicalPosition<u32> = position.to_logical(scale_factor);
                 let size: LogicalSize<u32> = size.to_logical(scale_factor);
                 self.cursor_area = (position, size);
@@ -280,11 +280,11 @@ impl ClientState {
     }
 
     pub fn content_type(&self) -> Option<ContentType> {
-        self.capabilities.contains(ImeCapabilities::PURPOSE).then_some(self.content_type)
+        self.capabilities.purpose().then_some(self.content_type)
     }
 
     pub fn cursor_area(&self) -> Option<(LogicalPosition<u32>, LogicalSize<u32>)> {
-        self.capabilities.contains(ImeCapabilities::CURSOR_AREA).then_some(self.cursor_area)
+        self.capabilities.cursor_area().then_some(self.cursor_area)
     }
 }
 

--- a/winit-win32/src/window.rs
+++ b/winit-win32/src/window.rs
@@ -1051,7 +1051,7 @@ impl CoreWindow for Window {
             };
 
             if let Some((spot, size)) = request_data.cursor_area {
-                if capabilities.contains(ImeCapabilities::CURSOR_AREA) {
+                if capabilities.cursor_area() {
                     let scale_factor = state.scale_factor;
                     ImeContext::current(window.hwnd()).set_ime_cursor_area(
                         spot,

--- a/winit-x11/src/window.rs
+++ b/winit-x11/src/window.rs
@@ -2112,7 +2112,7 @@ impl UnownedWindow {
         };
 
         if let Some((position, size)) = state.cursor_area {
-            if capabilities.contains(ImeCapabilities::CURSOR_AREA) {
+            if capabilities.cursor_area() {
                 self.set_ime_cursor_area(position, size);
             } else {
                 warn!("discarding IME cursor area update without capability enabled.");


### PR DESCRIPTION
When the API is shaped so that the API user can enable capabilities from a future version of the API, e.g. with Capabilities.all(), the API user still can't supply them. The new version of the backend may reject them, causing a breakage on upgrade.

This change prevents the API user from enabling capabilities they don't know about.

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

* * *

I thought that winit doesn't want to have to bump the major version just because new features are added in this area.

@kchibisov 