### PR TITLE
Draft: text input: Add surrounding text to frontend

### DIFF
--- a/examples/application.rs
+++ b/examples/application.rs
@@ -40,7 +40,7 @@ use winit::platform::web::{ActiveEventLoopExtWeb, WindowAttributesWeb};
 #[cfg(x11_platform)]
 use winit::platform::x11::{ActiveEventLoopExtX11, WindowAttributesX11};
 use winit::window::{
-    CursorGrabMode, ImeCapabilities, ImeEnableRequest, ImePurpose, ImeRequestData, ResizeDirection,
+    CursorGrabMode, ImeCapabilities, ImeEnableRequest, ImePurpose, ImeRequestData, ImeSurroundingText, ResizeDirection,
     Theme, Window, WindowAttributes, WindowId,
 };
 use winit_core::application::macos::ApplicationHandlerExtMacOS;
@@ -611,6 +611,9 @@ impl ApplicationHandlerExtMacOS for Application {
 /// State of the window.
 struct WindowState {
     ime_enabled: bool,
+    /// The contents of the emulated text field for IME purposes (not displayed).
+    /// (text, cursor position in bytes).
+    text_field_contents: (String, usize),
     /// Render surface.
     ///
     /// NOTE: This surface must be dropped before the `Window`.
@@ -668,9 +671,12 @@ impl WindowState {
         // Allow IME out of the box.
         let request_data = ImeRequestData::default()
             .with_purpose(ImePurpose::Normal)
-            .with_cursor_area(LogicalPosition { x: 0, y: 0 }.into(), IME_CURSOR_SIZE.into());
+            .with_cursor_area(LogicalPosition { x: 0, y: 0 }.into(), IME_CURSOR_SIZE.into())
+            .with_surrounding_text(
+                ImeSurroundingText::new(String::new(), 0, 0).unwrap()
+             );
         let enable_request = ImeEnableRequest::new(
-            ImeCapabilities::new().with_purpose().with_cursor_area(),
+            ImeCapabilities::new().with_purpose().with_cursor_area().with_surrounding_text(),
             request_data,
         )
         .unwrap();
@@ -695,6 +701,7 @@ impl WindowState {
             #[cfg(not(android_platform))]
             start_time: Instant::now(),
             ime_enabled: true,
+            text_field_contents: (String::new(), 0),
             cursor_position: Default::default(),
             cursor_hidden: Default::default(),
             modifiers: Default::default(),
@@ -716,10 +723,26 @@ impl WindowState {
                 .cursor_position
                 .map(Into::into)
                 .unwrap_or(LogicalPosition { x: 0, y: 0 }.into());
+            // Limit text field size to 4000 bytes
+            let (text, cursor) = &self.text_field_contents;
+            let minimal_offset = cursor / 4000 * 4000;
+            let first_char_boundary = (minimal_offset..*cursor)
+                .find(|off| text.is_char_boundary(*off))
+                .unwrap_or(*cursor);
+            let last_char_boundary = (*cursor..(first_char_boundary+4000))
+                .rev()
+                .find(|off| text.is_char_boundary(*off))
+                .unwrap_or(*cursor);
+            let surrounding_text = &text[first_char_boundary..last_char_boundary];
+            let relative_cursor = cursor - first_char_boundary;
+            let surrounding_text = ImeSurroundingText::new(surrounding_text.into(), relative_cursor, relative_cursor)
+                .expect("Bug in example: bad byte calculations");
             let request_data =
-                ImeRequestData::default().with_cursor_area(cursor_pos, IME_CURSOR_SIZE.into());
+                ImeRequestData::default()
+                .with_cursor_area(cursor_pos, IME_CURSOR_SIZE.into())
+                .with_surrounding_text(surrounding_text);
             let enable_request = ImeEnableRequest::new(
-                ImeCapabilities::new().with_purpose().with_cursor_area(),
+                ImeCapabilities::new().with_purpose().with_cursor_area().with_surrounding_text(),
                 request_data,
             )
             .unwrap();

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -1623,6 +1623,73 @@ impl Default for ImePurpose {
     }
 }
 
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum ImeSurroundingTextError {
+    /// Text exceeds 4000 bytes
+    TextTooLong,
+    /// Cursor not on a code point boundary, or past the end of text.
+    CursorBadPosition,
+    /// Anchor not on a code point boundary, or past the end of text.
+    AnchorBadPosition,
+}
+
+/// Defines the text surrounding the caret
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub struct ImeSurroundingText {
+    /// An excerpt of the text present in the text input field, excluding preedit.
+    text: String,
+    /// The position of the caret, in bytes from the beginning of the string
+    cursor: usize,
+    /// The position of the other end of selection, in bytes.
+    /// With no selection, it should be the same as the cursor.
+    anchor: usize,
+}
+
+impl ImeSurroundingText {
+    /// Defines the text surroundng the cursor and the selection within it.
+    ///
+    /// `text`: An excerpt of the text present in the text input field, excluding preedit.
+    /// It must be limited to 4000 bytes due to backend constraints.
+    /// `cursor`: The position of the caret, in bytes from the beginning of the string.
+    /// `anchor: The position of the other end of selection, in bytes.
+    /// With no selection, it should be the same as the cursor.
+    ///
+    /// This may fail if the byte indices don't fall on code point boundaries,
+    /// or if the text is too long.
+    ///
+    /// ## Examples:
+    ///
+    /// A text field containing `foo|bar` where `|` denotes the caret would correspond to a value obtained by:
+    ///
+    /// ```
+    /// # use winit_core::window::ImeSurroundingText;
+    /// let sur = ImeSurroundingText::new("foobar".into(), 3, 3).unwrap();
+    /// ```
+    ///
+    /// Because preedit is excluded from the text string, a text field containing `foo[baz|]bar` where `|` denotes the caret and [baz|] is the preedit would be created in exactly the same way.
+    pub fn new(text: String, cursor: usize, anchor: usize) -> Result<Self, ImeSurroundingTextError> {
+        let text = if text.len() < 4000 {
+            text
+        } else {
+            return Err(ImeSurroundingTextError::TextTooLong);
+        };
+        
+        let cursor = if text.is_char_boundary(cursor) && cursor <= text.len() {
+            cursor
+        } else {
+            return Err(ImeSurroundingTextError::CursorBadPosition);
+        };
+        
+        let anchor = if text.is_char_boundary(anchor) && anchor <= text.len() {
+            anchor
+        } else {
+            return Err(ImeSurroundingTextError::AnchorBadPosition);
+        };
+        
+        Ok(Self { text, cursor, anchor })
+    }
+}
+
 /// Request to send to IME.
 #[derive(Debug, PartialEq, Clone)]
 pub enum ImeRequest {
@@ -1658,7 +1725,7 @@ impl ImeEnableRequest {
     ///
     /// This will return [`None`] if some capability was requested but its initial value was not
     /// set by the user or value was set by the user, but capability not requested.
-    pub const fn new(capabilities: ImeCapabilities, request_data: ImeRequestData) -> Option<Self> {
+    pub fn new(capabilities: ImeCapabilities, request_data: ImeRequestData) -> Option<Self> {
         if capabilities.cursor_area() ^ request_data.cursor_area.is_some() {
             return None;
         }
@@ -1667,6 +1734,9 @@ impl ImeEnableRequest {
             return None;
         }
 
+        if capabilities.surrounding_text() ^ request_data.surrounding_text.is_some() {
+            return None;
+        }
         Some(Self { capabilities, request_data })
     }
 
@@ -1681,7 +1751,7 @@ impl ImeEnableRequest {
     }
 
     /// Destruct [`ImeEnableRequest`]  into its raw parts.
-    pub const fn into_raw(self) -> (ImeCapabilities, ImeRequestData) {
+    pub fn into_raw(self) -> (ImeCapabilities, ImeRequestData) {
         (self.capabilities, self.request_data)
     }
 }
@@ -1728,6 +1798,18 @@ impl ImeCapabilities {
     pub const fn cursor_area(&self) -> bool {
         self.0.contains(ImeCapabilitiesFlags::CURSOR_AREA)
     }
+    
+    /// Marks `surrounding_text` as supported.
+    ///
+    /// For more details see [`ImeRequestData::with_surrounding_text`].
+    pub const fn with_surrounding_text(self) -> Self {
+        Self(self.0.union(ImeCapabilitiesFlags::SURROUNDING_TEXT))
+    }
+
+    /// Returns `true` if `surrounding_text` is supported.
+    pub const fn surrounding_text(&self) -> bool {
+        self.0.contains(ImeCapabilitiesFlags::SURROUNDING_TEXT)
+    }
 }
 
 bitflags! {
@@ -1738,6 +1820,8 @@ bitflags! {
         /// Client supports reporting cursor area for IME popup to
         /// appear.
         const CURSOR_AREA = 1 << 1;
+        /// Client supports reporting the text around the caret
+        const SURROUNDING_TEXT = 1 << 2;
     }
 }
 
@@ -1758,6 +1842,10 @@ pub struct ImeRequestData {
     ///
     /// To support updating it, enable [`ImeCapabilities::CURSOR_AREA`].
     pub cursor_area: Option<(Position, Size)>,
+    /// The text surrounding the caret
+    ///
+    /// To support updating it, enable [`ImeCapabilities::SURROUNDING_TEXT`].
+    pub surrounding_text: Option<ImeSurroundingText>,
 }
 
 impl ImeRequestData {
@@ -1809,6 +1897,13 @@ impl ImeRequestData {
     /// [japanese]: https://support.apple.com/guide/japanese-input-method/use-the-candidate-window-jpim10262/6.3/mac/12.0
     pub fn with_cursor_area(self, position: Position, size: Size) -> Self {
         Self { cursor_area: Some((position, size)), ..self }
+    }
+
+    /// Describes the text surrounding the caret.
+    ///
+    /// The IME can then continue providing suggestions for the continuation of the existing text, as well as can erase text more accurately, for example glyphs composed of multiple code points.
+    pub fn with_surrounding_text(self, surrounding_text: ImeSurroundingText) -> Self {
+        Self { surrounding_text: Some(surrounding_text), ..self}
     }
 }
 
@@ -1876,7 +1971,7 @@ mod tests {
 
     use dpi::{LogicalPosition, LogicalSize, Position, Size};
 
-    use super::{ImeCapabilities, ImeEnableRequest, ImeRequestData};
+    use super::{ImeCapabilities, ImeEnableRequest, ImeRequestData, ImeSurroundingText, ImeSurroundingTextError};
     use crate::window::ImePurpose;
 
     #[test]
@@ -1930,5 +2025,22 @@ mod tests {
                 .with_cursor_area(position, size)
         )
         .is_some());
+        
+        let text: &[u8] = ['a' as u8; 8000].as_slice();
+        let text = std::str::from_utf8(text).unwrap();
+        assert_eq!(
+            ImeSurroundingText::new(text.into(), 0, 0), 
+            Err(ImeSurroundingTextError::TextTooLong),
+        );
+
+        assert_eq!(
+            ImeSurroundingText::new("short".into(), 110, 0),
+            Err(ImeSurroundingTextError::CursorBadPosition),
+        );
+
+        assert_eq!(
+            ImeSurroundingText::new("граница".into(), 1, 0),
+            Err(ImeSurroundingTextError::CursorBadPosition),
+        );
     }
 }


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

This adds the surrounding_text input method API inspired by the Wayland implementation.

One controversial idea is how to count text offsets. The Wayland backend uses bytes. It's reasonable that winit should expose code points instead, at a linear runtime cost per IME update.

Another controversial idea is the text size limit leaking from the backend to the frontend API. I imagine most other APIs also impose some kind of a limit, so what we need is the lowest common value. But I haven't found clear answers about what other APIs do here.
Checking at the frontend is simpler to reason about compared to failing when applying, but it potentially excludes some expressivity other backends could allow.

For now, there's no backend code involved.