### PR TITLE
CI: fix typos

### DIFF
--- a/winit-win32/src/keyboard.rs
+++ b/winit-win32/src/keyboard.rs
@@ -463,7 +463,7 @@ enum PartialText {
 
 enum PartialLogicalKey {
     /// Use the text provided by the WM_CHAR messages and report that as a `Character` variant. If
-    /// the text consists of multiple grapheme clusters (user-precieved characters) that means that
+    /// the text consists of multiple grapheme clusters (user-perceived characters) that means that
     /// dead key could not be combined with the second input, and in that case we should fall back
     /// to using what would have without a dead-key input.
     TextOr(Key),

--- a/winit/src/changelog/v0.29.md
+++ b/winit/src/changelog/v0.29.md
@@ -250,7 +250,7 @@
 - On Web, fix some `WindowBuilder` methods doing nothing.
 - On Web, fix some `Window` methods using incorrect HTML attributes instead of CSS properties.
 - On Web, fix the bfcache by not using the `beforeunload` event and map bfcache loading/unloading to `Suspended`/`Resumed` events.
-- On Web, fix touch input not gaining or loosing focus.
+- On Web, fix touch input not gaining or losing focus.
 - On Web, fix touch location to be as accurate as mouse position.
 - On Web, handle coalesced pointer events, which increases the resolution of pointer inputs.
 - On Web, implement `Window::focus_window()`.


### PR DESCRIPTION
The typos action was updated on a remote host, breaking all existing CI pipelines.

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

* * *

Seems that CI is set up in such a way that changes in other projects can break the pipelines here.
I made them happy again.