### PR TITLE
Fix runtime crash in macOS 26 Tahoe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ ndk = { version = "0.9.0", default-features = false }
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 block2 = "0.5.1"
 core-foundation = "0.9.3"
-objc2 = "0.5.2"
+objc2 = { version = "0.5.2", features = ["relax-sign-encoding"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-graphics = "0.23.1"


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

fixes #4299 by including the feature "relax-sign-encoding"
rust and obj-c are not the same about enforcing a number type

see https://github.com/madsmtm/objc2/issues/765 for more information