### PR TITLE
Fix runtime crash on macos26 "type code 'q', but found 'Q'"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ ndk = { version = "0.9.0", features = ["rwh_06"], default-features = false }
 # Apple dependencies.
 block2 = "0.6.1"
 dispatch2 = { version = "0.3.0", default-features = false, features = ["std", "objc2"] }
-objc2 = "0.6.1"
+objc2 = { version = "0.6.1", features = ["relax-sign-encoding"] }
 objc2-app-kit = { version = "0.3.1", default-features = false }
 objc2-core-foundation = { version = "0.3.1", default-features = false }
 objc2-core-graphics = { version = "0.3.1", default-features = false }

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -205,6 +205,8 @@ changelog entry.
 - Move `EventLoopExtRunOnDemand` from platform module to `winit::event_loop::run_on_demand`.
 - Use `NamedKey`, `Code` and `Location` from the `keyboard-types` v0.8 crate.
 - Deprecate `Window::set_ime_allowed`, `Window::set_ime_cursor_area`, and `Window::set_ime_purpose`.
+- On macOS, use the objc2 feature `relax-sign-encoding` to fix a runtime crash #4299
+  in macOS 26 with objc type checking.
 
 ### Removed
 


### PR DESCRIPTION
> thread 'main' panicked at /Users/robert/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/objc2-foundation-0.2.2/src/generated/NSEnumerator.rs:7:1:
> invalid message send to -[_TtGCs23_ContiguousArrayStorageCSo8NSScreen_$ countByEnumeratingWithState:objects:count:]: expected return to have type code 'q', but found 'Q'
> note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

fixes #4299
uses suggested fix from https://github.com/madsmtm/objc2/issues/765

- [ ] Tested on all platforms changed
  - [x] macOS 26 M3
  - [x] iOS 26 iPhone 16
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
