### PR TITLE
Preventing repositioning logic in `WM_DPICHANGED` from during a `Window::set_fullscreen()` call

### DIFF
--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2299,17 +2299,19 @@ unsafe fn public_window_callback_inner(
                 };
             }
 
-            unsafe {
-                SetWindowPos(
-                    window,
-                    0,
-                    new_outer_rect.left,
-                    new_outer_rect.top,
-                    new_outer_rect.right - new_outer_rect.left,
-                    new_outer_rect.bottom - new_outer_rect.top,
-                    SWP_NOZORDER | SWP_NOACTIVATE,
-                )
-            };
+            if !userdata.window_state_lock().currently_repositioning {
+                unsafe {
+                    SetWindowPos(
+                        window,
+                        0,
+                        new_outer_rect.left,
+                        new_outer_rect.top,
+                        new_outer_rect.right - new_outer_rect.left,
+                        new_outer_rect.bottom - new_outer_rect.top,
+                        SWP_NOZORDER | SWP_NOACTIVATE,
+                    )
+                };
+            }
 
             result = ProcResult::Value(0);
         },

--- a/src/platform_impl/windows/window.rs
+++ b/src/platform_impl/windows/window.rs
@@ -823,6 +823,7 @@ impl Window {
                     let position: (i32, i32) = monitor.position().into();
                     let size: (u32, u32) = monitor.size().into();
 
+                    window_state.lock().unwrap().currently_repositioning = true;
                     unsafe {
                         SetWindowPos(
                             window,
@@ -835,6 +836,7 @@ impl Window {
                         );
                         InvalidateRgn(window, 0, false.into());
                     }
+                    window_state.lock().unwrap().currently_repositioning = false;
                 },
                 None => {
                     let mut window_state_lock = window_state.lock().unwrap();

--- a/src/platform_impl/windows/window_state.rs
+++ b/src/platform_impl/windows/window_state.rs
@@ -56,6 +56,8 @@ pub(crate) struct WindowState {
     pub dragging: bool,
 
     pub skip_taskbar: bool,
+
+    pub currently_repositioning: bool
 }
 
 #[derive(Clone)]
@@ -176,6 +178,8 @@ impl WindowState {
             dragging: false,
 
             skip_taskbar: false,
+
+            currently_repositioning: false
         }
     }
 


### PR DESCRIPTION
This might not be the best fix, and it should probably be extended to cover cases where a window is repositioned beyond `Window::set_fullscreen()`

Feel free to reject this if there is a better way to go!