### PR TITLE
IME: Add delete_surrounding_text

### DIFF
--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -879,6 +879,8 @@ impl From<ModifiersState> for Modifiers {
 
 /// Describes [input method](https://en.wikipedia.org/wiki/Input_method) events.
 ///
+/// The `Ime` events must be applied in the order they arrive.
+///
 /// This is also called a "composition event".
 ///
 /// Most keypresses using a latin-like keyboard layout simply generate a
@@ -935,13 +937,27 @@ pub enum Ime {
     /// position. When it's `None`, the cursor should be hidden. When `String` is an empty string
     /// this indicates that preedit was cleared.
     ///
-    /// The cursor position is byte-wise indexed.
+    /// The cursor position is byte-wise indexed, assuming UTF-8.
     Preedit(String, Option<(usize, usize)>),
 
     /// Notifies when text should be inserted into the editor widget.
     ///
     /// Right before this event winit will send empty [`Self::Preedit`] event.
     Commit(String),
+
+    /// Delete text surrounding the cursor or selection.
+    ///
+    /// This event does not affect either the pre-edit string.
+    /// This means that the application must first remove the pre-edit,
+    /// then execute the deletion, then insert the removed text back.
+    ///
+    /// This event assumes text is stored in UTF-8.
+    DeleteSurrounding {
+        /// Bytes to remove before the selection
+        before_bytes: usize,
+        /// Bytes to remove after the selection
+        after_bytes: usize,
+    },
 
     /// Notifies when the IME was disabled.
     ///

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -83,6 +83,7 @@ changelog entry.
 - Each platform now has corresponding `WindowAttributes` struct instead of trait extension.
 - On Wayland, added implementation for `Window::set_window_icon`
 - Add `Window::request_ime_update` to atomically apply set of IME changes.
+- Add `Ime::DeleteSurrounding` to let the input method delete text.
 
 ### Changed
 


### PR DESCRIPTION
This completes the basic Wayland IME compatibility.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

This should work with any compatible input method, but I tested on my development versions:

Anvil: https://github.com/dcz-self/smithay/tree/im_popup_v3 `cargo run -- --winit`
Stiwri: https://codeberg.org/dcz/stiwri/src/branch/popup `WAYLAND_DISPLAY=wayland-1 cargo run --bin t9`

Because the test application doesn't actually display text, you have to track the events in its console. A delete request will get sent by the IME when the pre-edit is empty, so you need to press the red X button twice. Best try out the IME on a regular application first.