### PR TITLE
Remove self from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,13 +14,13 @@
 /winit-wayland                      @kchibisov
 
 # X11
-/winit-x11                          @kchibisov @notgull
+/winit-x11                          @kchibisov
 
 # Web
 /winit-web                          @daxpedda
 
-# Windows (Win32)
-/winit-win32                        @notgull
+# Windows (Win32) (UNOWNED)
+#/winit-win32                       
 
 # Orbital (Redox OS)
 /winit-orbital                      @jackpot51


### PR DESCRIPTION
This is making official what's basically been the
case for the past few months at this point. I no
longer have the capacity to effectively review
and merge PRs for the Windows and X11 backends.

Thanks again for having me.
