### PR TITLE
fix: #4333 Main Thread Panic triggered by ime during view teardown

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -364,7 +364,7 @@ define_class!(
             trace_scope!("firstRectForCharacterRange:actualRange:");
 
             // guard when the view is no longer in a window during teardown.
-             let Some(win) = self.window_optional() else {
+            let Some(win) = self.window_optional() else {
                 return CGRect::ZERO; // safe fallback
             };
 

--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -363,15 +363,15 @@ define_class!(
         ) -> NSRect {
             trace_scope!("firstRectForCharacterRange:actualRange:");
 
-            // guard when the view is no longer in a window during teardown.
-            let Some(win) = self.window_optional() else {
-                return CGRect::ZERO; // safe fallback
+            // Guard when the view is no longer in a window during teardown.
+            let Some(window) = self.window_optional() else {
+                return CGRect::ZERO;
             };
 
             // Return value is expected to be in screen coordinates, so we need a conversion
             let rect = NSRect::new(self.ivars().ime_position.get(), self.ivars().ime_size.get());
             let view_rect = self.convertRect_toView(rect, None);
-            win.convertRectToScreen(view_rect)
+            window.convertRectToScreen(view_rect)
         }
 
         #[unsafe(method(insertText:replacementRange:))]

--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -361,11 +361,13 @@ define_class!(
             _actual_range: *mut NSRange,
         ) -> NSRect {
             trace_scope!("firstRectForCharacterRange:actualRange:");
-            
+
             // NEW: guard when the view is no longer in a window during teardown.
-            if let Some(win) = self.window_optional() { // e.g., helper that returns Option<NSWindow>
-                let rect = NSRect::new(self.ivars().ime_position.get(), self.ivars().ime_size.get());
-                // Return value is expected to be in screen coordinates, so we need a conversion here
+            if let Some(win) = self.window_optional() {
+                // e.g., helper that returns Option<NSWindow>
+                let rect =
+                    NSRect::new(self.ivars().ime_position.get(), self.ivars().ime_size.get());
+                // Return value is expected to be in screen coordinates, so we need a conversion
                 win.convertRectToScreen(self.convertRect_toView(rect, None))
             } else {
                 NSZeroRect // safe fallback; places candidate UI offscreen / default

--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -362,9 +362,9 @@ define_class!(
         ) -> NSRect {
             trace_scope!("firstRectForCharacterRange:actualRange:");
             let rect = NSRect::new(self.ivars().ime_position.get(), self.ivars().ime_size.get());
-            // Return value is expected to be in screen coordinates, so we need a conversion here
+                // Return value is expected to be in screen coordinates, so we need a conversion here
             self.window().convertRectToScreen(self.convertRect_toView(rect, None))
-        }
+                    }
 
         #[unsafe(method(insertText:replacementRange:))]
         fn insert_text(&self, string: &NSObject, _replacement_range: NSRange) {
@@ -813,6 +813,10 @@ impl WinitView {
 
     fn window(&self) -> Retained<NSWindow> {
         (**self).window().expect("view must be installed in a window")
+    }
+
+    fn window_optional(&self) -> Option<Retained<NSWindow>> {
+        (**self).window()
     }
 
     fn queue_event(&self, event: WindowEvent) {

--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -364,7 +364,7 @@ define_class!(
             trace_scope!("firstRectForCharacterRange:actualRange:");
 
             // Guard when the view is no longer in a window during teardown.
-            let Some(window) = self.window_optional() else {
+            let Some(window) = (**self).window() else {
                 return CGRect::ZERO;
             };
 
@@ -821,10 +821,6 @@ impl WinitView {
 
     fn window(&self) -> Retained<NSWindow> {
         (**self).window().expect("view must be installed in a window")
-    }
-
-    fn window_optional(&self) -> Option<Retained<NSWindow>> {
-        (**self).window()
     }
 
     fn queue_event(&self, event: WindowEvent) {

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -254,4 +254,4 @@ changelog entry.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
 - On macOS, don't panic on monitors with unknown bit-depths.
-- On macOS, fixed `View::first_rect_for_character_range()` to not panic when window is nil during teardown.
+- On macOS, fixed crash when closing the window on macOS 26+.

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -254,3 +254,4 @@ changelog entry.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
 - On macOS, don't panic on monitors with unknown bit-depths.
+- On macOS, fixed `View::first_rect_for_character_range()` to not panic when window is nil during teardown.


### PR DESCRIPTION
Fixes Main Thread Panic from IME during window/view teardown


- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
