### PR TITLE
macOS: fix crash due during window drop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "winit"
-version = "0.30.12"
+version = "0.30.13"
 authors = [
     "The winit contributors",
     "Pierre Krieger <pierre.krieger1708@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ```toml
 [dependencies]
-winit = "0.30.12"
+winit = "0.30.13"
 ```
 
 ## [Documentation](https://docs.rs/winit)

--- a/src/changelog/v0.30.md
+++ b/src/changelog/v0.30.md
@@ -1,3 +1,9 @@
+## 0.30.13
+
+### Fixed
+
+- On macOS, fixed crash when closing the window on macOS 26+.
+
 ## 0.30.12
 
 ### Fixed

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -62,7 +62,7 @@
 //! If your application is currently based on `NativeActivity` via the `ndk-glue` crate and building
 //! with `cargo apk`, then the minimal changes would be:
 //! 1. Remove `ndk-glue` from your `Cargo.toml`
-//! 2. Enable the `"android-native-activity"` feature for Winit: `winit = { version = "0.30.12",
+//! 2. Enable the `"android-native-activity"` feature for Winit: `winit = { version = "0.30.13",
 //!    features = [ "android-native-activity" ] }`
 //! 3. Add an `android_main` entrypoint (as above), instead of using the '`[ndk_glue::main]` proc
 //!    macro from `ndk-macros` (optionally add a dependency on `android_logger` and initialize

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -81,7 +81,7 @@ extern "C" fn preedit_draw_callback(
         call_data.chg_first as usize..(call_data.chg_first + call_data.chg_length) as usize;
     if chg_range.start > client_data.text.len() || chg_range.end > client_data.text.len() {
         tracing::warn!(
-            "invalid chg range: buffer length={}, but chg_first={} chg_lengthg={}",
+            "invalid chg range: buffer length={}, but chg_first={} chg_length={}",
             client_data.text.len(),
             call_data.chg_first,
             call_data.chg_length

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -379,7 +379,6 @@ declare_class!(
             let Some(window) = (**self).window() else {
                 return CGRect::ZERO;
             };
-            
             let rect = NSRect::new(
                 self.ivars().ime_position.get(),
                 self.ivars().ime_size.get()

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -11,9 +11,9 @@ use objc2_app_kit::{
     NSTrackingRectTag, NSView, NSViewFrameDidChangeNotification,
 };
 use objc2_foundation::{
-    MainThreadMarker, NSArray, NSAttributedString, NSAttributedStringKey, NSCopying,
+    CGRect, MainThreadMarker, NSArray, NSAttributedString, NSAttributedStringKey, NSCopying,
     NSMutableAttributedString, NSNotFound, NSNotificationCenter, NSObject, NSObjectProtocol,
-    NSPoint, NSRange, NSRect, NSSize, NSString, NSUInteger, CGRect,
+    NSPoint, NSRange, NSRect, NSSize, NSString, NSUInteger,
 };
 
 use super::app_state::ApplicationDelegate;

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -10,6 +10,7 @@ use objc2_app_kit::{
     NSApplication, NSCursor, NSEvent, NSEventPhase, NSResponder, NSTextInputClient,
     NSTrackingRectTag, NSView, NSViewFrameDidChangeNotification,
 };
+use objc2_core_foundation::CGRect;
 use objc2_foundation::{
     MainThreadMarker, NSArray, NSAttributedString, NSAttributedStringKey, NSCopying,
     NSMutableAttributedString, NSNotFound, NSNotificationCenter, NSObject, NSObjectProtocol,
@@ -374,13 +375,18 @@ declare_class!(
             _actual_range: *mut NSRange,
         ) -> NSRect {
             trace_scope!("firstRectForCharacterRange:actualRange:");
+            // Guard when the view is no longer in a window during teardown.
+            let Some(window) = (**self).window() else {
+                return CGRect::ZERO;
+            };
+            
             let rect = NSRect::new(
                 self.ivars().ime_position.get(),
                 self.ivars().ime_size.get()
             );
             // Return value is expected to be in screen coordinates, so we need a conversion here
-            self.window()
-                .convertRectToScreen(self.convertRect_toView(rect, None))
+            window.convertRectToScreen(
+                self.convertRect_toView(rect, None))
         }
 
         #[method(insertText:replacementRange:)]

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -10,11 +10,10 @@ use objc2_app_kit::{
     NSApplication, NSCursor, NSEvent, NSEventPhase, NSResponder, NSTextInputClient,
     NSTrackingRectTag, NSView, NSViewFrameDidChangeNotification,
 };
-use objc2_core_foundation::CGRect;
 use objc2_foundation::{
     MainThreadMarker, NSArray, NSAttributedString, NSAttributedStringKey, NSCopying,
     NSMutableAttributedString, NSNotFound, NSNotificationCenter, NSObject, NSObjectProtocol,
-    NSPoint, NSRange, NSRect, NSSize, NSString, NSUInteger,
+    NSPoint, NSRange, NSRect, NSSize, NSString, NSUInteger, CGRect,
 };
 
 use super::app_state::ApplicationDelegate;


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

On macOS 26+ the window drop was leading to unwrap, since
events were coming after the window was already destroyed,
while it sounds rather strange, guard against such things just
in case.

Backport changes for v0.30.x release

Merged to Master
- #4334
Fixes 
- https://github.com/rust-windowing/winit/issues/4333.
