### PR TITLE
macOS: default menu uses bundle name

### DIFF
--- a/winit-appkit/src/menu.rs
+++ b/winit-appkit/src/menu.rs
@@ -2,7 +2,7 @@ use objc2::rc::Retained;
 use objc2::runtime::Sel;
 use objc2::{sel, MainThreadMarker};
 use objc2_app_kit::{NSApplication, NSEventModifierFlags, NSMenu, NSMenuItem};
-use objc2_foundation::{ns_string, NSProcessInfo, NSString};
+use objc2_foundation::{ns_string, NSBundle, NSProcessInfo, NSString};
 
 struct KeyEquivalent<'a> {
     key: &'a NSString,
@@ -16,7 +16,10 @@ pub fn initialize(app: &NSApplication) {
     menubar.addItem(&app_menu_item);
 
     let app_menu = NSMenu::new(mtm);
-    let process_name = NSProcessInfo::processInfo().processName();
+    let process_name = match NSBundle::mainBundle().name() {
+        Some(bundle_name) => bundle_name,
+        None => NSProcessInfo::processInfo().processName(),
+    };
 
     // About menu item
     let about_item_title = ns_string!("About ").stringByAppendingString(&process_name);

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -174,6 +174,7 @@ changelog entry.
 - Rename `VideoModeHandle` to `VideoMode`, now it only stores plain data.
 - Make `Fullscreen::Exclusive` contain `(MonitorHandle, VideoMode)`.
 - Reworked the file drag-and-drop API.
+- On macOS, the default menu uses the bundle name or falls back to the process name as before.
 
   The `WindowEvent::DroppedFile`, `WindowEvent::HoveredFile` and `WindowEvent::HoveredFileCancelled`
   events have been removed, and replaced with `WindowEvent::DragEntered`, `WindowEvent::DragMoved`,


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Use the bundle name in the default menu or fall back to using the process name as before. Using the bundle name is the convention on macOS. If the app doesn't provide a bundle name, fall back to using the process name. Note in the image that the bundle name is capitalized and matches the name of the menu, the process name does not.

<img width="994" height="485" alt="bundle_name" src="https://github.com/user-attachments/assets/3a1369a1-098b-445f-bd07-f851368def02" />
