### PR TITLE
prevent incorrect resizing/shifting of window when dragging onto monitor with different DPI

### DIFF
--- a/winit-win32/src/dark_mode.rs
+++ b/winit-win32/src/dark_mode.rs
@@ -5,9 +5,8 @@ use std::{ffi::c_void, ptr};
 
 use windows_sys::core::{PCSTR, PCWSTR};
 use windows_sys::w;
-use windows_sys::Win32::Foundation::{BOOL, HWND, LPARAM, NTSTATUS, S_OK, WPARAM};
+use windows_sys::Win32::Foundation::{BOOL, HWND, LPARAM, S_OK, WPARAM};
 use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
-use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
 use windows_sys::Win32::UI::Accessibility::{HCF_HIGHCONTRASTON, HIGHCONTRASTA};
 use windows_sys::Win32::UI::Controls::SetWindowTheme;
 use windows_sys::Win32::UI::Input::KeyboardAndMouse::GetActiveWindow;
@@ -17,39 +16,10 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
 use winit_core::window::Theme;
 
 use super::util;
-
-static WIN10_BUILD_VERSION: LazyLock<Option<u32>> = LazyLock::new(|| {
-    type RtlGetVersion = unsafe extern "system" fn(*mut OSVERSIONINFOW) -> NTSTATUS;
-    let handle = get_function!("ntdll.dll", RtlGetVersion);
-
-    if let Some(rtl_get_version) = handle {
-        unsafe {
-            let mut vi = OSVERSIONINFOW {
-                dwOSVersionInfoSize: 0,
-                dwMajorVersion: 0,
-                dwMinorVersion: 0,
-                dwBuildNumber: 0,
-                dwPlatformId: 0,
-                szCSDVersion: [0; 128],
-            };
-
-            let status = (rtl_get_version)(&mut vi);
-
-            if status >= 0 && vi.dwMajorVersion == 10 && vi.dwMinorVersion == 0 {
-                Some(vi.dwBuildNumber)
-            } else {
-                None
-            }
-        }
-    } else {
-        None
-    }
-});
-
 static DARK_MODE_SUPPORTED: LazyLock<bool> = LazyLock::new(|| {
     // We won't try to do anything for windows versions < 17763
     // (Windows 10 October 2018 update)
-    match *WIN10_BUILD_VERSION {
+    match *util::WIN10_BUILD_VERSION {
         Some(v) => v >= 17763,
         None => false,
     }

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -259,3 +259,4 @@ changelog entry.
 - On Windows, account for mouse wheel lines per scroll setting for `WindowEvent::MouseWheel`.
 - On Windows, `Window::theme` will return the correct theme after setting it through `Window::set_theme`.
 - On Windows, `Window::set_theme` will change the title bar color immediately now.
+- On Windows 11, prevent incorrect shifting when dragging window onto a monitor with different DPI.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] ~~Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
- [ ] ~~Created or updated an example program if it would help users understand this functionality~~

The original [PR 4119](https://github.com/rust-windowing/winit/pull/4119) appears to be abandoned. This PR aims to recreate the fix, following the project guidelines.

> This PR fixes this issue: https://github.com/rust-windowing/winit/issues/4041
> 
> The code I deleted has a validation to check if the new window bounds which Windows is suggesting to move the monitor to is actually on the monitor which triggered the WM_DPI_CHANGED event. If that validation fails, it tried to move the window such that it will be on the monitor which triggered the WM_DPI_CHANGED event. However, this validation was buggy and was actually causing this bug. It was moving the window off of the intended monitor. It seems this is no longer necessary. For example, [Chromium's DPI changed handler](https://github.com/chromium/chromium/blob/2b7390111f4987f8ab6781cebed91172d2b56464/ui/views/win/hwnd_message_handler.cc#L1904) does not contain an analogous check.
> 
> Before
> https://www.loom.com/share/aefc5dc1027a42fc8f462c23621ce9a5
> 
> After
> https://www.loom.com/share/81351dcb5938463c8bb60a66b2a0641b

> I've created a similar fix for TAO but kept the logic conditionally for Windows 10 (build < 22000) just to be safe. But I'm not sure if it is worth to keep that much logic just for minimal positioning optimizations, especially now that Windows 10 will soon reach EOL.
> 
> Related PR and issues (TAO seems still uses the same logic since it was forked from winit, so I think they are relevant):
> 
> https://github.com/tauri-apps/tao/pull/1056
> https://github.com/tauri-apps/tao/issues/1053
> https://github.com/tauri-apps/tauri/issues/10263
> https://github.com/tauri-apps/tauri/issues/12626