### PR TITLE
Add borderless fullscreen mode for orbital

### DIFF
--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -996,7 +996,8 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///   separate spaces are not preferred.
     ///
     ///   The dock and the menu bar are disabled in exclusive fullscreen mode.
-    /// - **Wayland:** Does not support exclusive fullscreen mode and will no-op a request.
+    /// - **Orbital / Wayland:** Does not support exclusive fullscreen mode and will no-op a
+    ///   request.
     /// - **Windows:** Screen saver is disabled in fullscreen mode.
     /// - **Web:** Passing a [`MonitorHandle`] or [`VideoMode`] that was not created with detailed
     ///   monitor permissions or calling without a [transient activation] does nothing.
@@ -1009,9 +1010,9 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// ## Platform-specific
     ///
-    /// - **Android / Orbital:** Will always return `None`.
+    /// - **Android:** Will always return `None`.
+    /// - **Orbital / Web:** Can only return `None` or `Borderless(None)`.
     /// - **Wayland:** Can return `Borderless(None)` when there are no monitors.
-    /// - **Web:** Can only return `None` or `Borderless(None)`.
     fn fullscreen(&self) -> Option<Fullscreen>;
 
     /// Turn window decorations on or off.

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -250,6 +250,7 @@ changelog entry.
 ### Fixed
 
 - On Orbital, `MonitorHandle::name()` now returns `None` instead of a dummy name.
+- On Orbital, implement `fullscreen`.
 - On iOS, fixed `SurfaceResized` and `Window::surface_size` not reporting the size of the actual surface.
 - On macOS, fixed the scancode conversion for audio volume keys.
 - On macOS, fixed the scancode conversion for `IntlBackslash`.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
