### PR TITLE
Add some missing Window getters

### DIFF
--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -876,7 +876,15 @@ impl CoreWindow for Window {
         PhysicalInsets::new(0, 0, 0, 0)
     }
 
+    fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        None
+    }
+
     fn set_min_surface_size(&self, _: Option<Size>) {}
+
+    fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        None
+    }
 
     fn set_max_surface_size(&self, _: Option<Size>) {}
 
@@ -888,7 +896,15 @@ impl CoreWindow for Window {
 
     fn set_title(&self, _title: &str) {}
 
+    fn is_transparent(&self) -> bool {
+        false
+    }
+
     fn set_transparent(&self, _transparent: bool) {}
+
+    fn is_blurred(&self) -> bool {
+        false
+    }
 
     fn set_blur(&self, _blur: bool) {}
 
@@ -936,7 +952,15 @@ impl CoreWindow for Window {
         true
     }
 
+    fn window_level(&self) -> WindowLevel {
+        WindowLevel::default()
+    }
+
     fn set_window_level(&self, _level: WindowLevel) {}
+
+    fn window_icon(&self) -> Option<winit_core::icon::Icon> {
+        None
+    }
 
     fn set_window_icon(&self, _window_icon: Option<winit_core::icon::Icon>) {}
 
@@ -977,6 +1001,10 @@ impl CoreWindow for Window {
 
     fn request_user_attention(&self, _request_type: Option<window::UserAttentionType>) {}
 
+    fn cursor(&self) -> Cursor {
+        Cursor::default()
+    }
+
     fn set_cursor(&self, _: Cursor) {}
 
     fn set_cursor_position(&self, _: Position) -> Result<(), RequestError> {
@@ -1008,6 +1036,10 @@ impl CoreWindow for Window {
 
     fn theme(&self) -> Option<Theme> {
         None
+    }
+
+    fn content_protected(&self) -> bool {
+        false
     }
 
     fn set_content_protected(&self, _protected: bool) {}

--- a/winit-appkit/src/window.rs
+++ b/winit-appkit/src/window.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use dispatch2::MainThreadBound;
-use dpi::{Position, Size};
+use dpi::{PhysicalSize, Position, Size};
 use objc2::rc::{autoreleasepool, Retained};
 use objc2::{define_class, MainThreadMarker, Message};
 use objc2_app_kit::{NSPanel, NSResponder, NSWindow};
@@ -141,8 +141,16 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.safe_area())
     }
 
+    fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.min_surface_size())
+    }
+
     fn set_min_surface_size(&self, min_size: Option<Size>) {
         self.maybe_wait_on_main(|delegate| delegate.set_min_surface_size(min_size))
+    }
+
+    fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.max_surface_size())
     }
 
     fn set_max_surface_size(&self, max_size: Option<Size>) {
@@ -161,8 +169,16 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.set_title(title));
     }
 
+    fn is_transparent(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_transparent())
+    }
+
     fn set_transparent(&self, transparent: bool) {
         self.maybe_wait_on_main(|delegate| delegate.set_transparent(transparent));
+    }
+
+    fn is_blurred(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_blurred())
     }
 
     fn set_blur(&self, blur: bool) {
@@ -225,8 +241,16 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.is_decorated())
     }
 
+    fn window_level(&self) -> WindowLevel {
+        self.maybe_wait_on_main(|delegate| delegate.window_level())
+    }
+
     fn set_window_level(&self, level: WindowLevel) {
         self.maybe_wait_on_main(|delegate| delegate.set_window_level(level));
+    }
+
+    fn window_icon(&self) -> Option<Icon> {
+        self.maybe_wait_on_main(|delegate| delegate.window_icon())
     }
 
     fn set_window_icon(&self, window_icon: Option<Icon>) {
@@ -261,12 +285,20 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.theme())
     }
 
+    fn content_protected(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.content_protected())
+    }
+
     fn set_content_protected(&self, protected: bool) {
         self.maybe_wait_on_main(|delegate| delegate.set_content_protected(protected));
     }
 
     fn title(&self) -> String {
         self.maybe_wait_on_main(|delegate| delegate.title())
+    }
+
+    fn cursor(&self) -> Cursor {
+        self.maybe_wait_on_main(|delegate| delegate.cursor())
     }
 
     fn set_cursor(&self, cursor: Cursor) {

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -934,6 +934,10 @@ impl WindowDelegate {
         self.window().setTitle(&NSString::from_str(title))
     }
 
+    pub fn is_transparent(&self) -> bool {
+        unsafe { !self.window().isOpaque() }
+    }
+
     pub fn set_transparent(&self, transparent: bool) {
         // This is just a hint for Quartz, it doesn't actually speculate with window alpha.
         // Providing a wrong value here could result in visual artifacts, when the window is
@@ -952,6 +956,12 @@ impl WindowDelegate {
         };
 
         self.window().setBackgroundColor(Some(&color));
+    }
+
+    pub fn is_blurred(&self) -> bool {
+        // What API would we use to get this? `CGSGetWindowBackgroundBlurRadius` doesn't exist.
+        warn!("getting the background blur of the window is not supported on macOS");
+        false
     }
 
     pub fn set_blur(&self, blur: bool) {
@@ -1073,6 +1083,14 @@ impl WindowDelegate {
         None
     }
 
+    pub fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        let size = unsafe { self.window().contentMinSize() };
+        if size == NSSize::ZERO {
+            return None;
+        }
+        Some(LogicalSize::new(size.width, size.height).to_physical(self.scale_factor()))
+    }
+
     pub fn set_min_surface_size(&self, dimensions: Option<Size>) {
         let dimensions =
             dimensions.unwrap_or(Size::Logical(LogicalSize { width: 0.0, height: 0.0 }));
@@ -1090,6 +1108,15 @@ impl WindowDelegate {
             current_size.height = min_size.height;
         }
         self.window().setContentSize(current_size);
+    }
+
+    pub fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        let size = unsafe { self.window().contentMaxSize() };
+        // AppKit sets the max size to f32::MAX by default.
+        if size == NSSize::new(f32::MAX as _, f32::MAX as _) {
+            return None;
+        }
+        Some(LogicalSize::new(size.width, size.height).to_physical(self.scale_factor()))
     }
 
     pub fn set_max_surface_size(&self, dimensions: Option<Size>) {
@@ -1211,6 +1238,11 @@ impl WindowDelegate {
             buttons |= WindowButtons::CLOSE;
         }
         buttons
+    }
+
+    pub fn cursor(&self) -> Cursor {
+        warn!("getting the cursor is unimplemented on macOS");
+        Cursor::default()
     }
 
     pub fn set_cursor(&self, cursor: Cursor) {
@@ -1643,6 +1675,20 @@ impl WindowDelegate {
         self.ivars().decorations.get()
     }
 
+    pub fn window_level(&self) -> WindowLevel {
+        let level = unsafe { self.window().level() };
+        if level == kCGFloatingWindowLevel as NSWindowLevel {
+            WindowLevel::AlwaysOnTop
+        } else if level == (kCGNormalWindowLevel - 1) as NSWindowLevel {
+            WindowLevel::AlwaysOnBottom
+        } else if level == kCGNormalWindowLevel as NSWindowLevel {
+            WindowLevel::Normal
+        } else {
+            warn!(?level, "cannot determine window level, it must've been set outside of Winit");
+            WindowLevel::default()
+        }
+    }
+
     #[inline]
     pub fn set_window_level(&self, level: WindowLevel) {
         // Note: There are two different things at play here:
@@ -1660,6 +1706,11 @@ impl WindowDelegate {
             WindowLevel::Normal => kCGNormalWindowLevel as NSWindowLevel,
         };
         self.window().setLevel(level);
+    }
+
+    #[inline]
+    pub fn window_icon(&self) -> Option<Icon> {
+        None
     }
 
     #[inline]
@@ -1813,6 +1864,17 @@ impl WindowDelegate {
 
     pub fn set_theme(&self, theme: Option<Theme>) {
         unsafe { self.window().setAppearance(theme_to_appearance(theme).as_deref()) };
+    }
+
+    pub fn content_protected(&self) -> bool {
+        match unsafe { self.window().sharingType() } {
+            NSWindowSharingType::None => true,
+            NSWindowSharingType::ReadOnly => false,
+            sharing_type => {
+                warn!(?sharing_type, "unknown sharing type");
+                false
+            },
+        }
     }
 
     #[inline]

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -792,6 +792,16 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// ```
     fn safe_area(&self) -> PhysicalInsets<u32>;
 
+    /// The minimum dimensions of the window's surface if it was set.
+    ///
+    /// Getter for [`set_min_surface_size`][Window::set_min_surface_size], see that for details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Orbital:** Unsupported.
+    /// - **Web:** Unimplemented, returns `None`.
+    fn min_surface_size(&self) -> Option<PhysicalSize<u32>>;
+
     /// Sets a minimum dimensions of the window's surface.
     ///
     /// ```no_run
@@ -810,6 +820,16 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// - **iOS / Android / Orbital:** Unsupported.
     fn set_min_surface_size(&self, min_size: Option<Size>);
+
+    /// The maximum dimensions of the window's surface if it was set.
+    ///
+    /// Getter for [`set_max_surface_size`][Window::set_max_surface_size], see that for details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Orbital:** Unsupported.
+    /// - **Web:** Unimplemented, returns `None`.
+    fn max_surface_size(&self) -> Option<PhysicalSize<u32>>;
 
     /// Sets a maximum dimensions of the window's surface.
     ///
@@ -850,6 +870,16 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     fn set_surface_resize_increments(&self, increments: Option<Size>);
 
+    /// The window transparency state.
+    ///
+    /// Getter for [`set_transparent`][Window::set_transparent], see that for details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web:** Unsupported.
+    /// - **X11:** Unimplemented, returns `false`.
+    fn is_transparent(&self) -> bool;
+
     /// Change the window transparency state.
     ///
     /// This is just a hint that may not change anything about
@@ -866,6 +896,15 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **X11:** Can only be set while building the window, with
     ///   [`WindowAttributes::with_transparent`].
     fn set_transparent(&self, transparent: bool);
+
+    /// The window blur state.
+    ///
+    /// Getter for [`set_blur`][Window::set_blur], see that for details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Android / iOS / X11 / Web / Windows / macOS:** Unsupported.
+    fn is_blurred(&self) -> bool;
 
     /// Change the window blur state.
     ///
@@ -1029,12 +1068,38 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **iOS / Android / Web:** No effect.
     fn set_decorations(&self, decorations: bool);
 
+    /// The window level.
+    ///
+    /// Getter for [`set_window_level`][Window::set_window_level], see that and [`WindowLevel`] for
+    /// details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / Wayland:** Unsupported.
+    /// - **X11:** Unimplemented, returns the default window level.
+    fn window_level(&self) -> WindowLevel;
+
     /// Change the window level.
     ///
     /// This is just a hint to the OS, and the system could ignore it.
     ///
     /// See [`WindowLevel`] for details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / Wayland:** Unsupported.
     fn set_window_level(&self, level: WindowLevel);
+
+    /// The window icon, if any was set.
+    ///
+    /// Getter for [`set_window_icon`][Window::set_window_icon], see that for details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web / macOS / Orbital:** Unsupported.
+    /// - **Windows:** The icon may be different from the one set with `set_window_icon`.
+    /// - **X11 / Wayland:** Unimplemented, returns `None`.
+    fn window_icon(&self) -> Option<Icon>;
 
     /// Sets the window icon.
     ///
@@ -1043,7 +1108,7 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / / macOS / Orbital:** Unsupported.
+    /// - **iOS / Android / Web / macOS / Orbital:** Unsupported.
     ///
     /// - **Windows:** Sets `ICON_SMALL`. The base size for a window icon is 16x16, but it's
     ///   recommended to account for screen scaling and pick a multiple of that, i.e. 32x32.
@@ -1273,13 +1338,20 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     fn set_theme(&self, theme: Option<Theme>);
 
+    /// Whether the window's contents are prevented from being captured by other apps.
+    ///
+    /// Getter for [`set_content_protected`][Window::set_content_protected], see that for details.
+    ///
+    /// - **iOS / Android / X11 / Wayland / Web / Orbital:** Unsupported.
+    fn content_protected(&self) -> bool;
+
     /// Prevents the window contents from being captured by other apps.
     ///
     /// ## Platform-specific
     ///
     /// - **macOS**: if `false`, [`NSWindowSharingNone`] is used but doesn't completely prevent all
     ///   apps from reading the window content, for instance, QuickTime.
-    /// - **iOS / Android / x11 / Wayland / Web / Orbital:** Unsupported.
+    /// - **iOS / Android / X11 / Wayland / Web / Orbital:** Unsupported.
     ///
     /// [`NSWindowSharingNone`]: https://developer.apple.com/documentation/appkit/nswindowsharingtype/nswindowsharingnone
     fn set_content_protected(&self, protected: bool);
@@ -1297,6 +1369,16 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// - **iOS / Android:** Unsupported.
     fn set_title(&self, title: &str);
+
+    /// The cursor icon of the window.
+    ///
+    /// Getter for [`set_cursor`][Window::set_cursor], see that for details.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Orbital:** Unsupported.
+    /// - **macOS / X11 / Wayland / Web / Windows:** Unimplemented, returns the default cursor.
+    fn cursor(&self) -> Cursor;
 
     /// Modifies the cursor icon of the window.
     ///

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -850,13 +850,6 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     fn set_surface_resize_increments(&self, increments: Option<Size>);
 
-    /// Modifies the title of the window.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **iOS / Android:** Unsupported.
-    fn set_title(&self, title: &str);
-
     /// Change the window transparency state.
     ///
     /// This is just a hint that may not change anything about
@@ -884,15 +877,6 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **Wayland:** Only works with org_kde_kwin_blur_manager protocol.
     fn set_blur(&self, blur: bool);
 
-    /// Modifies the window's visibility.
-    ///
-    /// If `false`, this will hide the window. If `true`, this will show the window.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Android / Wayland / Web:** Unsupported.
-    fn set_visible(&self, visible: bool);
-
     /// Gets the window's current visibility state.
     ///
     /// `None` means it couldn't be determined, so it is not recommended to use this to drive your
@@ -903,6 +887,23 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **X11:** Not implemented.
     /// - **Wayland / iOS / Android / Web:** Unsupported.
     fn is_visible(&self) -> Option<bool>;
+
+    /// Modifies the window's visibility.
+    ///
+    /// If `false`, this will hide the window. If `true`, this will show the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Android / Wayland / Web:** Unsupported.
+    fn set_visible(&self, visible: bool);
+
+    /// Gets the window's current resizable state.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **X11:** Not implemented.
+    /// - **iOS / Android / Web:** Unsupported.
+    fn is_resizable(&self) -> bool;
 
     /// Sets whether the window is resizable or not.
     ///
@@ -921,22 +922,6 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// [`WindowEvent::SurfaceResized`]: crate::event::WindowEvent::SurfaceResized
     fn set_resizable(&self, resizable: bool);
 
-    /// Gets the window's current resizable state.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **X11:** Not implemented.
-    /// - **iOS / Android / Web:** Unsupported.
-    fn is_resizable(&self) -> bool;
-
-    /// Sets the enabled window buttons.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **Wayland / X11 / Orbital:** Not implemented.
-    /// - **Web / iOS / Android:** Unsupported.
-    fn set_enabled_buttons(&self, buttons: WindowButtons);
-
     /// Gets the enabled window buttons.
     ///
     /// ## Platform-specific
@@ -945,13 +930,13 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **Web / iOS / Android:** Unsupported. Always returns [`WindowButtons::all`].
     fn enabled_buttons(&self) -> WindowButtons;
 
-    /// Minimize the window, or put it back from the minimized state.
+    /// Sets the enabled window buttons.
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
-    /// - **Wayland:** Un-minimize is unsupported.
-    fn set_minimized(&self, minimized: bool);
+    /// - **Wayland / X11 / Orbital:** Not implemented.
+    /// - **Web / iOS / Android:** Unsupported.
+    fn set_enabled_buttons(&self, buttons: WindowButtons);
 
     /// Gets the window's current minimized state.
     ///
@@ -967,12 +952,13 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     fn is_minimized(&self) -> Option<bool>;
 
-    /// Sets the window to maximized or back.
+    /// Minimize the window, or put it back from the minimized state.
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web:** Unsupported.
-    fn set_maximized(&self, maximized: bool);
+    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **Wayland:** Un-minimize is unsupported.
+    fn set_minimized(&self, minimized: bool);
 
     /// Gets the window's current maximized state.
     ///
@@ -980,6 +966,22 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// - **iOS / Android / Web:** Unsupported.
     fn is_maximized(&self) -> bool;
+
+    /// Sets the window to maximized or back.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / Web:** Unsupported.
+    fn set_maximized(&self, maximized: bool);
+
+    /// Gets the window's current fullscreen state.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **Android:** Will always return `None`.
+    /// - **Orbital / Web:** Can only return `None` or `Borderless(None)`.
+    /// - **Wayland:** Can return `Borderless(None)` when there are no monitors.
+    fn fullscreen(&self) -> Option<Fullscreen>;
 
     /// Set the window's fullscreen state.
     ///
@@ -1006,14 +1008,15 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// [`VideoMode`]: crate::monitor::VideoMode
     fn set_fullscreen(&self, fullscreen: Option<Fullscreen>);
 
-    /// Gets the window's current fullscreen state.
+    /// Gets the window's current decorations state.
+    ///
+    /// Returns `true` when windows are decorated (server-side or by Winit).
+    /// Also returns `true` when no decorations are required (mobile, Web).
     ///
     /// ## Platform-specific
     ///
-    /// - **Android:** Will always return `None`.
-    /// - **Orbital / Web:** Can only return `None` or `Borderless(None)`.
-    /// - **Wayland:** Can return `Borderless(None)` when there are no monitors.
-    fn fullscreen(&self) -> Option<Fullscreen>;
+    /// - **iOS / Android / Web:** Always returns `true`.
+    fn is_decorated(&self) -> bool;
 
     /// Turn window decorations on or off.
     ///
@@ -1025,16 +1028,6 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// - **iOS / Android / Web:** No effect.
     fn set_decorations(&self, decorations: bool);
-
-    /// Gets the window's current decorations state.
-    ///
-    /// Returns `true` when windows are decorated (server-side or by Winit).
-    /// Also returns `true` when no decorations are required (mobile, Web).
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **iOS / Android / Web:** Always returns `true`.
-    fn is_decorated(&self) -> bool;
 
     /// Change the window level.
     ///
@@ -1223,6 +1216,13 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// By default IME is disabled, thus will return `None`.
     fn ime_capabilities(&self) -> Option<ImeCapabilities>;
 
+    /// Gets whether the window has keyboard focus.
+    ///
+    /// This queries the same state information as [`WindowEvent::Focused`].
+    ///
+    /// [`WindowEvent::Focused`]: crate::event::WindowEvent::Focused
+    fn has_focus(&self) -> bool;
+
     /// Brings the window to the front and sets input focus. Has no effect if the window is
     /// already in focus, minimized, or not visible.
     ///
@@ -1234,13 +1234,6 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// - **iOS / Android / Wayland / Orbital:** Unsupported.
     fn focus_window(&self);
-
-    /// Gets whether the window has keyboard focus.
-    ///
-    /// This queries the same state information as [`WindowEvent::Focused`].
-    ///
-    /// [`WindowEvent::Focused`]: crate::event::WindowEvent::Focused
-    fn has_focus(&self) -> bool;
 
     /// Requests user attention to the window, this has no effect if the application
     /// is already focused. How requesting for user attention manifests is platform dependent,
@@ -1257,6 +1250,16 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     /// - **Wayland:** Requires `xdg_activation_v1` protocol, `None` has no effect.
     fn request_user_attention(&self, request_type: Option<UserAttentionType>);
 
+    /// Returns the current window theme.
+    ///
+    /// Returns `None` if it cannot be determined on the current platform.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android / x11 / Orbital:** Unsupported.
+    /// - **Wayland:** Only returns theme overrides.
+    fn theme(&self) -> Option<Theme>;
+
     /// Set or override the window theme.
     ///
     /// Specify `None` to reset the theme to the system default.
@@ -1269,16 +1272,6 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///   will default to  [`Theme::Dark`].
     /// - **iOS / Android / Web / Orbital:** Unsupported.
     fn set_theme(&self, theme: Option<Theme>);
-
-    /// Returns the current window theme.
-    ///
-    /// Returns `None` if it cannot be determined on the current platform.
-    ///
-    /// ## Platform-specific
-    ///
-    /// - **iOS / Android / x11 / Orbital:** Unsupported.
-    /// - **Wayland:** Only returns theme overrides.
-    fn theme(&self) -> Option<Theme>;
 
     /// Prevents the window contents from being captured by other apps.
     ///
@@ -1297,6 +1290,13 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// - **iOS / Android / x11 / Wayland / Web:** Unsupported. Always returns an empty string.
     fn title(&self) -> String;
+
+    /// Modifies the title of the window.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **iOS / Android:** Unsupported.
+    fn set_title(&self, title: &str);
 
     /// Modifies the cursor icon of the window.
     ///

--- a/winit-uikit/src/window.rs
+++ b/winit-uikit/src/window.rs
@@ -122,8 +122,18 @@ impl Inner {
         debug!("`Window::set_title` is ignored on iOS")
     }
 
+    pub fn is_transparent(&self) -> bool {
+        debug!("`Window::is_transparent` is ignored on iOS");
+        false
+    }
+
     pub fn set_transparent(&self, _transparent: bool) {
         debug!("`Window::set_transparent` is ignored on iOS")
+    }
+
+    pub fn is_blurred(&self) -> bool {
+        debug!("`Window::is_blurred` is ignored on iOS");
+        false
     }
 
     pub fn set_blur(&self, _blur: bool) {
@@ -216,8 +226,18 @@ impl Inner {
         insets.to_physical(self.scale_factor())
     }
 
+    pub fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        debug!("`Window::min_surface_size` is ignored on iOS");
+        None
+    }
+
     pub fn set_min_surface_size(&self, _dimensions: Option<Size>) {
         warn!("`Window::set_min_surface_size` is ignored on iOS")
+    }
+
+    pub fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        debug!("`Window::max_surface_size` is ignored on iOS");
+        None
     }
 
     pub fn set_max_surface_size(&self, _dimensions: Option<Size>) {
@@ -255,6 +275,11 @@ impl Inner {
 
     pub fn scale_factor(&self) -> f64 {
         self.view.contentScaleFactor() as _
+    }
+
+    pub fn cursor(&self) -> Cursor {
+        warn!("`Window::cursor` is ignored on iOS");
+        Cursor::default()
     }
 
     pub fn set_cursor(&self, _cursor: Cursor) {
@@ -371,8 +396,18 @@ impl Inner {
         true
     }
 
+    pub fn window_level(&self) -> WindowLevel {
+        debug!("`Window::window_level` is ignored on iOS");
+        WindowLevel::default()
+    }
+
     pub fn set_window_level(&self, _level: WindowLevel) {
         warn!("`Window::set_window_level` is ignored on iOS")
+    }
+
+    pub fn window_icon(&self) -> Option<Icon> {
+        debug!("`Window::window_icon` is ignored on iOS");
+        None
     }
 
     pub fn set_window_icon(&self, _icon: Option<Icon>) {
@@ -462,7 +497,14 @@ impl Inner {
         None
     }
 
-    pub fn set_content_protected(&self, _protected: bool) {}
+    pub fn content_protected(&self) -> bool {
+        warn!("`Window::content_protected` is ignored on iOS");
+        false
+    }
+
+    pub fn set_content_protected(&self, _protected: bool) {
+        warn!("`Window::set_content_protected` is ignored on iOS");
+    }
 
     pub fn has_focus(&self) -> bool {
         self.window.isKeyWindow()
@@ -641,8 +683,16 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.safe_area())
     }
 
+    fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.min_surface_size())
+    }
+
     fn set_min_surface_size(&self, min_size: Option<Size>) {
         self.maybe_wait_on_main(|delegate| delegate.set_min_surface_size(min_size))
+    }
+
+    fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        self.maybe_wait_on_main(|delegate| delegate.max_surface_size())
     }
 
     fn set_max_surface_size(&self, max_size: Option<Size>) {
@@ -661,8 +711,16 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.set_title(title));
     }
 
+    fn is_transparent(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_transparent())
+    }
+
     fn set_transparent(&self, transparent: bool) {
         self.maybe_wait_on_main(|delegate| delegate.set_transparent(transparent));
+    }
+
+    fn is_blurred(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.is_blurred())
     }
 
     fn set_blur(&self, blur: bool) {
@@ -725,8 +783,16 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.is_decorated())
     }
 
+    fn window_level(&self) -> WindowLevel {
+        self.maybe_wait_on_main(|delegate| delegate.window_level())
+    }
+
     fn set_window_level(&self, level: WindowLevel) {
         self.maybe_wait_on_main(|delegate| delegate.set_window_level(level));
+    }
+
+    fn window_icon(&self) -> Option<Icon> {
+        self.maybe_wait_on_main(|delegate| delegate.window_icon())
     }
 
     fn set_window_icon(&self, window_icon: Option<Icon>) {
@@ -761,12 +827,20 @@ impl CoreWindow for Window {
         self.maybe_wait_on_main(|delegate| delegate.theme())
     }
 
+    fn content_protected(&self) -> bool {
+        self.maybe_wait_on_main(|delegate| delegate.content_protected())
+    }
+
     fn set_content_protected(&self, protected: bool) {
         self.maybe_wait_on_main(|delegate| delegate.set_content_protected(protected));
     }
 
     fn title(&self) -> String {
         self.maybe_wait_on_main(|delegate| delegate.title())
+    }
+
+    fn cursor(&self) -> Cursor {
+        self.maybe_wait_on_main(|delegate| delegate.cursor())
     }
 
     fn set_cursor(&self, cursor: Cursor) {

--- a/winit-wayland/src/window/mod.rs
+++ b/winit-wayland/src/window/mod.rs
@@ -351,12 +351,22 @@ impl CoreWindow for Window {
         PhysicalInsets::new(0, 0, 0, 0)
     }
 
+    fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        let size = self.window_state.lock().unwrap().min_surface_size();
+        size.map(|size| size.to_physical(self.scale_factor()))
+    }
+
     fn set_min_surface_size(&self, min_size: Option<Size>) {
         let scale_factor = self.scale_factor();
         let min_size = min_size.map(|size| size.to_logical(scale_factor));
         self.window_state.lock().unwrap().set_min_surface_size(min_size);
         // NOTE: Requires commit to be applied.
         self.request_redraw();
+    }
+
+    fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        let size = self.window_state.lock().unwrap().max_surface_size();
+        size.map(|size| size.to_physical(self.scale_factor()))
     }
 
     /// Set the maximum surface size for the window.
@@ -380,6 +390,10 @@ impl CoreWindow for Window {
     fn set_title(&self, title: &str) {
         let new_title = title.to_string();
         self.window_state.lock().unwrap().set_title(new_title);
+    }
+
+    fn is_transparent(&self) -> bool {
+        self.window_state.lock().unwrap().is_transparent()
     }
 
     #[inline]
@@ -487,6 +501,10 @@ impl CoreWindow for Window {
         self.window_state.lock().unwrap().scale_factor()
     }
 
+    fn is_blurred(&self) -> bool {
+        self.window_state.lock().unwrap().is_blurred()
+    }
+
     #[inline]
     fn set_blur(&self, blur: bool) {
         self.window_state.lock().unwrap().set_blur(blur);
@@ -502,7 +520,15 @@ impl CoreWindow for Window {
         self.window_state.lock().unwrap().is_decorated()
     }
 
+    fn window_level(&self) -> WindowLevel {
+        WindowLevel::default()
+    }
+
     fn set_window_level(&self, _level: WindowLevel) {}
+
+    fn window_icon(&self) -> Option<winit_core::icon::Icon> {
+        self.window_state.lock().unwrap().window_icon()
+    }
 
     fn set_window_icon(&self, window_icon: Option<winit_core::icon::Icon>) {
         self.window_state.lock().unwrap().set_window_icon(window_icon)
@@ -566,7 +592,16 @@ impl CoreWindow for Window {
         self.window_state.lock().unwrap().theme()
     }
 
+    fn content_protected(&self) -> bool {
+        false
+    }
+
     fn set_content_protected(&self, _protected: bool) {}
+
+    fn cursor(&self) -> Cursor {
+        warn!("getting the cursor is unimplemented on Wayland");
+        Cursor::default()
+    }
 
     fn set_cursor(&self, cursor: Cursor) {
         let window_state = &mut self.window_state.lock().unwrap();

--- a/winit-wayland/src/window/state.rs
+++ b/winit-wayland/src/window/state.rs
@@ -780,6 +780,10 @@ impl WindowState {
         });
     }
 
+    pub fn min_surface_size(&self) -> Option<LogicalSize<u32>> {
+        self.min_surface_size
+    }
+
     /// Set maximum inner window size.
     pub fn set_min_surface_size(&mut self, size: Option<LogicalSize<u32>>) {
         // Ensure that the window has the right minimum size.
@@ -796,6 +800,10 @@ impl WindowState {
 
         self.min_surface_size = size;
         self.window.set_min_size(Some(size.into()));
+    }
+
+    pub fn max_surface_size(&self) -> Option<LogicalSize<u32>> {
+        self.max_surface_size
     }
 
     /// Set maximum inner window size.
@@ -1059,6 +1067,10 @@ impl WindowState {
         }
     }
 
+    pub fn is_blurred(&self) -> bool {
+        self.blur.is_some()
+    }
+
     /// Make window background blurred
     #[inline]
     pub fn set_blur(&mut self, blurred: bool) {
@@ -1099,6 +1111,11 @@ impl WindowState {
         self.title = title;
     }
 
+    pub fn window_icon(&self) -> Option<winit_core::icon::Icon> {
+        warn!("getting the window icon is unimplemented on Wayland");
+        None
+    }
+
     /// Set the window's icon
     pub fn set_window_icon(&mut self, window_icon: Option<winit_core::icon::Icon>) {
         let xdg_toplevel_icon_manager = match self.xdg_toplevel_icon_manager.as_ref() {
@@ -1136,6 +1153,10 @@ impl WindowState {
         if let Some(xdg_toplevel_icon) = xdg_toplevel_icon {
             xdg_toplevel_icon.destroy();
         }
+    }
+
+    pub fn is_transparent(&self) -> bool {
+        self.transparent
     }
 
     /// Mark the window as transparent.

--- a/winit-web/src/window.rs
+++ b/winit-web/src/window.rs
@@ -6,6 +6,7 @@ use dpi::{
     LogicalInsets, LogicalPosition, LogicalSize, PhysicalInsets, PhysicalPosition, PhysicalSize,
     Position, Size,
 };
+use tracing::warn;
 use web_sys::HtmlCanvasElement;
 use winit_core::cursor::Cursor;
 use winit_core::error::{NotSupportedError, RequestError};
@@ -192,6 +193,11 @@ impl RootWindow for Window {
         })
     }
 
+    fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        warn!("min_surface_size is not implemented on Web");
+        None
+    }
+
     fn set_min_surface_size(&self, min_size: Option<Size>) {
         self.inner.dispatch(move |inner| {
             let dimensions = min_size.map(|min_size| min_size.to_logical(inner.scale_factor()));
@@ -202,6 +208,11 @@ impl RootWindow for Window {
                 dimensions,
             )
         })
+    }
+
+    fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        warn!("max_surface_size is not implemented on Web");
+        None
     }
 
     fn set_max_surface_size(&self, max_size: Option<Size>) {
@@ -228,7 +239,15 @@ impl RootWindow for Window {
         self.inner.queue(|inner| inner.canvas.set_attribute("alt", title))
     }
 
+    fn is_transparent(&self) -> bool {
+        false
+    }
+
     fn set_transparent(&self, _: bool) {}
+
+    fn is_blurred(&self) -> bool {
+        false
+    }
 
     fn set_blur(&self, _: bool) {}
 
@@ -300,8 +319,16 @@ impl RootWindow for Window {
         true
     }
 
+    fn window_level(&self) -> WindowLevel {
+        WindowLevel::default()
+    }
+
     fn set_window_level(&self, _: WindowLevel) {
         // Intentionally a no-op, no window ordering
+    }
+
+    fn window_icon(&self) -> Option<Icon> {
+        None
     }
 
     fn set_window_icon(&self, _: Option<Icon>) {
@@ -344,10 +371,19 @@ impl RootWindow for Window {
         })
     }
 
+    fn content_protected(&self) -> bool {
+        false
+    }
+
     fn set_content_protected(&self, _: bool) {}
 
     fn title(&self) -> String {
         String::new()
+    }
+
+    fn cursor(&self) -> Cursor {
+        warn!("getting the cursor is not implemented on Web");
+        Cursor::default()
     }
 
     fn set_cursor(&self, cursor: Cursor) {

--- a/winit-x11/src/window.rs
+++ b/winit-x11/src/window.rs
@@ -115,8 +115,16 @@ impl CoreWindow for Window {
         self.0.safe_area()
     }
 
+    fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        self.0.min_surface_size()
+    }
+
     fn set_min_surface_size(&self, min_size: Option<Size>) {
         self.0.set_min_surface_size(min_size)
+    }
+
+    fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        self.0.max_surface_size()
     }
 
     fn set_max_surface_size(&self, max_size: Option<Size>) {
@@ -135,8 +143,16 @@ impl CoreWindow for Window {
         self.0.set_title(title);
     }
 
+    fn is_transparent(&self) -> bool {
+        self.0.is_transparent()
+    }
+
     fn set_transparent(&self, transparent: bool) {
         self.0.set_transparent(transparent);
+    }
+
+    fn is_blurred(&self) -> bool {
+        self.0.is_blurred()
     }
 
     fn set_blur(&self, blur: bool) {
@@ -199,8 +215,17 @@ impl CoreWindow for Window {
         self.0.is_decorated()
     }
 
+    fn window_level(&self) -> WindowLevel {
+        self.0.window_level()
+    }
+
     fn set_window_level(&self, level: WindowLevel) {
         self.0.set_window_level(level);
+    }
+
+    fn window_icon(&self) -> Option<winit_core::icon::Icon> {
+        warn!("getting the window icon is unimplemented on X11");
+        None
     }
 
     fn set_window_icon(&self, window_icon: Option<winit_core::icon::Icon>) {
@@ -239,12 +264,20 @@ impl CoreWindow for Window {
         self.0.theme()
     }
 
+    fn content_protected(&self) -> bool {
+        self.0.content_protected()
+    }
+
     fn set_content_protected(&self, protected: bool) {
         self.0.set_content_protected(protected);
     }
 
     fn title(&self) -> String {
         self.0.title()
+    }
+
+    fn cursor(&self) -> Cursor {
+        self.0.cursor()
     }
 
     fn set_cursor(&self, cursor: Cursor) {
@@ -1357,8 +1390,17 @@ impl UnownedWindow {
         self.xconn.flush_requests().expect("Failed to set window title");
     }
 
+    fn is_transparent(&self) -> bool {
+        warn!("getting transparency state is unimplemented on X11");
+        false
+    }
+
     #[inline]
     pub fn set_transparent(&self, _transparent: bool) {}
+
+    fn is_blurred(&self) -> bool {
+        false
+    }
 
     #[inline]
     pub fn set_blur(&self, _blur: bool) {}
@@ -1402,6 +1444,11 @@ impl UnownedWindow {
     fn set_window_level_inner(&self, level: WindowLevel) -> Result<VoidCookie<'_>, X11Error> {
         self.toggle_atom(_NET_WM_STATE_ABOVE, level == WindowLevel::AlwaysOnTop)?.ignore_error();
         self.toggle_atom(_NET_WM_STATE_BELOW, level == WindowLevel::AlwaysOnBottom)
+    }
+
+    fn window_level(&self) -> WindowLevel {
+        warn!("getting the window level is unimplemented on X11");
+        WindowLevel::default()
     }
 
     #[inline]
@@ -1665,6 +1712,11 @@ impl UnownedWindow {
         .expect("Failed to call `XSetWMNormalHints`");
     }
 
+    fn min_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        let size = self.shared_state_lock().min_surface_size;
+        size.map(|size| size.to_physical(self.scale_factor()))
+    }
+
     #[inline]
     pub fn set_min_surface_size(&self, dimensions: Option<Size>) {
         self.shared_state_lock().min_surface_size = dimensions;
@@ -1679,6 +1731,11 @@ impl UnownedWindow {
                 dimensions.map(|(w, h)| (cast_dimension_to_hint(w), cast_dimension_to_hint(h)))
         })
         .expect("Failed to call `XSetWMNormalHints`");
+    }
+
+    fn max_surface_size(&self) -> Option<PhysicalSize<u32>> {
+        let size = self.shared_state_lock().max_surface_size;
+        size.map(|size| size.to_physical(self.scale_factor()))
     }
 
     #[inline]
@@ -1797,6 +1854,12 @@ impl UnownedWindow {
     #[inline]
     pub fn xlib_window(&self) -> c_ulong {
         self.xwindow as ffi::Window
+    }
+
+    #[inline]
+    pub fn cursor(&self) -> Cursor {
+        warn!("getting the cursor is unimplemented on X11");
+        Cursor::default()
     }
 
     #[inline]
@@ -2253,6 +2316,10 @@ impl UnownedWindow {
     #[inline]
     pub fn theme(&self) -> Option<Theme> {
         None
+    }
+
+    pub fn content_protected(&self) -> bool {
+        false
     }
 
     pub fn set_content_protected(&self, _protected: bool) {}

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -69,6 +69,14 @@ changelog entry.
 - Add `DeviceId::into_raw()` and `from_raw()`.
 - Added `Window::surface_position`, which is the position of the surface inside the window.
 - Added `Window::safe_area`, which describes the area of the surface that is unobstructed.
+- Added `Window::min_surface_size`.
+- Added `Window::max_surface_size`.
+- Added `Window::is_transparent`.
+- Added `Window::is_blurred`.
+- Added `Window::window_level`.
+- Added `Window::window_icon`.
+- Added `Window::content_protected`.
+- Added `Window::cursor`.
 - On X11, Wayland, Windows and macOS, improved scancode conversions for more obscure key codes.
 - Add ability to make non-activating window on macOS using `NSPanel` with `NSWindowStyleMask::NonactivatingPanel`.
 - Implement `MonitorHandleProvider` for `MonitorHandle` to access common monitor API.


### PR DESCRIPTION
Add the following methods to `Window`:
- `min_surface_size`.
- `max_surface_size`.
- `is_transparent`.
- `is_blurred`.
- `window_level`.
- `window_icon`.
- `content_protected`.
- `cursor`.

Related to https://github.com/rust-windowing/winit/issues/1295 and https://github.com/rust-windowing/winit/issues/3690.

- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
