### PR TITLE
Improve example IME messages

### DIFF
--- a/examples/application.rs
+++ b/examples/application.rs
@@ -515,13 +515,13 @@ impl ApplicationHandler for Application {
             WindowEvent::Ime(event) => match event {
                 Ime::Enabled => info!("IME enabled for Window={window_id:?}"),
                 Ime::Preedit(text, caret_pos) => {
-                    info!("Preedit: {}, with caret at {:?}", text, caret_pos);
+                    info!("IME Preedit: {}, with caret at {:?}", text, caret_pos);
                 },
                 Ime::Commit(text) => {
                     window.text_field_contents.0.push_str(&text);
                     window.text_field_contents.1 += text.len();
 
-                    info!("Committed: {}", text);
+                    info!("IME Committed: {}", text);
                     let request_data = window.get_ime_update();
                     window.window.request_ime_update(ImeRequest::Update(request_data)).unwrap();
                 },


### PR DESCRIPTION
I am trying to debug an IME issue with Wayland and I want to be able to grep for "IME" to see all the IME events. This changes makes that possible.

I'm planning to file an issue later. This change makes it simpler to demonstrate the issue and easier for other people to debug it.

I don't think it is necessary to test this change on multiple platforms or update the documentation.

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
