### PR TITLE
Fix 'no-decorations' in Windows.

### DIFF
--- a/winit-win32/src/window_state.rs
+++ b/winit-win32/src/window_state.rs
@@ -295,12 +295,13 @@ impl WindowFlags {
         }
         if self.contains(WindowFlags::CHILD) {
             style |= WS_CHILD; // This is incompatible with WS_POPUP if that gets added eventually.
-
-            // Remove decorations window styles for child
-            if !self.contains(WindowFlags::MARKER_DECORATIONS) {
-                style &= !(WS_CAPTION | WS_BORDER);
-                style_ex &= !WS_EX_WINDOWEDGE;
-            }
+        }
+        if !self.contains(WindowFlags::MARKER_DECORATIONS) {
+            // WS_CAPTION is equal to (WS_BORDER | WS_DLGFRAME)
+            // The former is intended for overlapped windows,
+            // the latter are for child windows.
+            style &= !(WS_CAPTION | WS_SIZEBOX);
+            style_ex &= !WS_EX_WINDOWEDGE;
         }
         if self.contains(WindowFlags::POPUP) {
             style |= WS_POPUP;

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -264,3 +264,4 @@ changelog entry.
 - On Windows, `Window::theme` will return the correct theme after setting it through `Window::set_theme`.
 - On Windows, `Window::set_theme` will change the title bar color immediately now.
 - On Windows 11, prevent incorrect shifting when dragging window onto a monitor with different DPI.
+- On Windows, `with_decoration(false)` works for overlapped (non child) windows.


### PR DESCRIPTION
In Windows, an overlapped window that used `with_decorations(false)` didn't have the proper styles.

Previously, between other flags it removed `WS_CAPTION` but only for child windows.

That doesn't actually make sense, because `WS_CAPTION` is intended for overlapped (non-child) windows only. Actually its numeric value is equal to  `WS_BORDER | WS_DLGFRAME`:
```
#define WS_CAPTION __MSABI_LONG(0x00C00000)
#define WS_BORDER __MSABI_LONG(0x00800000)
#define WS_DLGFRAME __MSABI_LONG(0x00400000)
```
That is why removing it actually removes the decoration of child windows (`WS_BORDER`).

Anyway, trying to create a secondary overlapped window without decorations doesn't work, I think because the styles are not actually removed, but the inner/outer metrics is fixed as if it were.

With this change the decorations are removed both for child and overlapped windows.

- [X] Tested on all platforms changed
- [X] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
