### PR TITLE
wayland: Handle `axis_value120` scroll events

### DIFF
--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -268,3 +268,4 @@ changelog entry.
 - On Windows, `Window::set_theme` will change the title bar color immediately now.
 - On Windows 11, prevent incorrect shifting when dragging window onto a monitor with different DPI.
 - On Web, device events are emitted regardless of cursor type.
+- On Wayland, `axis_value120` scroll events now generate `MouseScrollDelta::LineDelta`


### PR DESCRIPTION
This can be tested with the `application` example, looking at the events shown for mouse wheel movement.

`wl_pointer::axis_discrete` isn't sent in version 8 or higher of `wl_pointer`. And `sctk` doesn't convert the `value120` events, so on compositors advertising version 8, only pixel scroll events were being sent.

This sends `MouseScrollDelta::LineDelta` with a fractional value, without doing any accumulation. Given `LineDelta` contains `f32` values, this presumably is expected?

Though it might be good to change the definition of `MouseScrollDelta` to include both discrete and pixel values, when the compositor sends both. I'm not familiar with how this works on non-Wayland backends though.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
