### PR TITLE
X11: Fix deadlock in request_ime_update

### DIFF
--- a/winit-x11/src/window.rs
+++ b/winit-x11/src/window.rs
@@ -2097,6 +2097,7 @@ impl UnownedWindow {
             },
             CoreImeRequest::Update(state) => {
                 if let Some(capabilities) = shared_state.ime_capabilities {
+                    drop(shared_state);
                     (capabilities, state)
                 } else {
                     // The IME was not yet enabled, so discard the update.


### PR DESCRIPTION
The `set_ime_cursor_area` called later in this function also requests a lock for `shared_state`

- [X] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
