### PR TITLE
macOS:IME prefer insertText over keyDown when ime is enabled

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -390,9 +390,11 @@ define_class!(
 
             let is_control = string.chars().next().is_some_and(|c| c.is_control());
 
-            // Commit only if we have marked text.
-            if self.hasMarkedText() && self.is_ime_enabled() && !is_control {
-                self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
+            if self.ivars().ime_capabilities.get().is_some() && !is_control {
+                if self.hasMarkedText() {
+                    // clear preedit only if we have marked text.
+                    self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
+                }
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                 self.ivars().ime_state.set(ImeState::Committed);
             }


### PR DESCRIPTION
Fixes #3342

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

This makes it so that if IME is enabled, events will be sent as IME::Commit instead of using keyDown. This is necessary because for input such as emoji, you cannot rely on any previous state to signify that the text will be handled by a keyDown. 
