### PR TITLE
Add with_simple_fullscreen to WindowAttributesMacOS

### DIFF
--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -341,6 +341,7 @@ pub struct WindowAttributesMacOS {
     pub(crate) borderless_game: bool,
     pub(crate) unified_titlebar: bool,
     pub(crate) panel: bool,
+    pub(crate) simple_fullscreen: bool,
 }
 
 impl WindowAttributesMacOS {
@@ -437,6 +438,12 @@ impl WindowAttributesMacOS {
         self
     }
 
+    /// See [`WindowExtMacOS::set_simple_fullscreen`] for details on what this means if set.
+    pub fn with_simple_fullscreen(mut self, simple_fullscreen: bool) -> Self {
+        self.simple_fullscreen = simple_fullscreen;
+        self
+    }
+
     /// Use [`NSPanel`] window with [`NonactivatingPanel`] window style mask instead of
     /// [`NSWindow`].
     ///
@@ -468,6 +475,7 @@ impl Default for WindowAttributesMacOS {
             borderless_game: false,
             unified_titlebar: false,
             panel: false,
+            simple_fullscreen: false,
         }
     }
 }

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -847,6 +847,8 @@ impl WindowDelegate {
         // Set fullscreen mode after we setup everything
         delegate.set_fullscreen(attrs.fullscreen);
 
+        delegate.set_simple_fullscreen(macos_attrs.simple_fullscreen);
+
         // Setting the window as key has to happen *after* we set the fullscreen
         // state, since otherwise we'll briefly see the window at normal size
         // before it transitions.

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -16,6 +16,7 @@ on how to add them:
 - On X11, add `Window::even_more_rare_api`.
 - On Wayland, add `Window::common_api`.
 - On Windows, add `Window::some_rare_api`.
+- On macOS, add `WindowAttributesMacOS::with_simple_fullscreen`.
 ```
 
 When the change requires non-trivial amount of work for users to comply


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
