### PR TITLE
Implement set_window_icon for macOS

### DIFF
--- a/winit-appkit/Cargo.toml
+++ b/winit-appkit/Cargo.toml
@@ -28,6 +28,7 @@ objc2.workspace = true
 objc2-app-kit = { workspace = true, features = [
     "std",
     "objc2-core-foundation",
+    "objc2-core-graphics",
     "NSAppearance",
     "NSApplication",
     "NSBitmapImageRep",
@@ -70,6 +71,8 @@ objc2-core-foundation = { workspace = true, features = [
 objc2-core-graphics = { workspace = true, features = [
     "std",
     "libc",
+    "CGColorSpace",
+    "CGDataProvider",
     "CGDirectDisplay",
     "CGDisplayConfiguration",
     "CGDisplayFade",

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -1050,7 +1050,9 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / / macOS / Orbital:** Unsupported.
+    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    ///
+    /// - **macOS:** Sets the application icon (NSApplication.applicationIconImage).
     ///
     /// - **Windows:** Sets `ICON_SMALL`. The base size for a window icon is 16x16, but it's
     ///   recommended to account for screen scaling and pick a multiple of that, i.e. 32x32.

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -88,6 +88,7 @@ changelog entry.
 - Add more `ImePurpose` values.
 - Add `ImeHints` to request particular IME behaviour.
 - Add Pen input support on Wayland, Windows, and Web via new Pointer event.
+- On macOS, added implementation for `Window::set_window_icon`
 
 ### Changed
 


### PR DESCRIPTION
- [ x ] Tested on all platforms changed
  - `cargo run --example application`
- [ x ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ x ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior

Implemented set_window_icon for macOS by setting the application icon. Yes it's not technically the same as a window icon, but it's close enough.

Closes https://github.com/rust-windowing/winit/issues/3398
