### PR TITLE
On Windows, don't confine cursor to center of window when grabbed and hidden

### DIFF
--- a/winit-win32/src/window_state.rs
+++ b/winit-win32/src/window_state.rs
@@ -516,13 +516,6 @@ impl CursorFlags {
                             let cy = (client_rect.top + client_rect.bottom) / 2;
                             Some(RECT { left: cx, right: cx + 1, top: cy, bottom: cy + 1 })
                         }
-                    } else if self.contains(CursorFlags::HIDDEN) {
-                        // Confine the cursor to the center of the window if the cursor is hidden.
-                        // This avoids problems with the cursor activating
-                        // the taskbar if the window borders or overlaps that.
-                        let cx = (client_rect.left + client_rect.right) / 2;
-                        let cy = (client_rect.top + client_rect.bottom) / 2;
-                        Some(RECT { left: cx, right: cx + 1, top: cy, bottom: cy + 1 })
                     } else {
                         Some(client_rect)
                     }

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -212,6 +212,7 @@ changelog entry.
 - Use `NamedKey`, `Code` and `Location` from the `keyboard-types` v0.8 crate.
 - Deprecate `Window::set_ime_allowed`, `Window::set_ime_cursor_area`, and `Window::set_ime_purpose`.
 - `Force::normalized()` now takes a `Option<ToolAngle>` to calculate the perpendicular force.
+- On Windows, don't confine cursor to center of window when grabbed and hidden.
 
 ### Removed
 


### PR DESCRIPTION
This PR undoes the change from https://github.com/rust-windowing/winit/commit/ba10c35240a91aed38f5c2c3a94d31233263bc5f. Fixes #3987.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
