### PR TITLE
ci: fix eslint version to 9.38.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,7 +329,7 @@ jobs:
       - name: Setup NPM
         run: npm install
       - name: Run ESLint
-        run: npx eslint
+        run: npx eslint@9.38.0
 
   swc:
     name: Minimize JavaScript


### PR DESCRIPTION
9.39.0 has an issue with unified-signatures.

Links: https://github.com/eslint/eslint/issues/20272