### PR TITLE
winit-appkit: commit even if marked text is nothing.

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -390,9 +390,12 @@ define_class!(
 
             let is_control = string.chars().next().is_some_and(|c| c.is_control());
 
-            // Commit only if we have marked text.
-            if self.hasMarkedText() && self.is_ime_enabled() && !is_control {
-                self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
+            if self.is_ime_enabled() && !string.is_empty() && !is_control {
+                // Some IMEs (e.g. Sogou/WeChat) skip marked text and commit directly.
+                if self.hasMarkedText() {
+                    self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
+                }
+
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                 self.ivars().ime_state.set(ImeState::Committed);
             }

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -197,6 +197,11 @@ changelog entry.
   The `WindowEvent::DragMoved` event is entirely new, and is emitted whenever the pointer moves
   whilst files are being dragged over the window. It doesn't contain any file paths, just the
   pointer position.
+- On macOS, NSTextInputClient protocol implementation now accepts commits even though the marked text is empty.
+
+  Most Sogou-style pinyin IME were designed to not use marked text feature when directly committing
+  punctuations. That's why this patch is necessary, allowing them to input punctuations correctly
+  without committing the character hardcoded in the base ukelele keylayout used by the input method.
 - Updated `objc2` to `v0.6`.
 - Updated `windows-sys` to `v0.59`.
   - To match the corresponding changes in `windows-sys`, the `HWND`, `HMONITOR`, and `HMENU` types


### PR DESCRIPTION
- Most Sogou-style pinyin IME were designed to not use marked text feature when directly committing punctuations. That's why this patch is necessary, allowing them to input punctuations correctly without committing the character hardcoded in the base ukelele keylayout used by the input method.

- [ ] Tested on all platforms changed // I need to test this in Alacritty, but I'm not familiar with Cargo. I need someone else to help me compile a copy of Alacritty so I can do the test.
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
