### PR TITLE
appkit: let `valid_attributes_for_marked_text` report winit metadata.

### DIFF
--- a/winit-appkit/src/monitor.rs
+++ b/winit-appkit/src/monitor.rs
@@ -352,8 +352,10 @@ mod tests {
 
     #[test]
     fn uuid_stable() {
-        let handle_a = MonitorHandle::new(1).unwrap();
-        let handle_b = MonitorHandle::new(1).unwrap();
+        let primary_id = CGMainDisplayID();
+
+        let handle_a = MonitorHandle::new(primary_id).unwrap();
+        let handle_b = MonitorHandle::new(primary_id).unwrap();
         assert_eq!(handle_a, handle_b);
         assert_eq!(handle_a.display_id(), handle_b.display_id());
         assert_eq!(handle_a.uuid(), handle_b.uuid());
@@ -368,8 +370,10 @@ mod tests {
     /// Test the MonitorHandle::new fallback.
     #[test]
     fn monitorhandle_from_zero() {
+        let primary_id = CGMainDisplayID();
+
         let handle0 = MonitorHandle::new(0).unwrap();
-        let handle1 = MonitorHandle::new(1).unwrap();
+        let handle1 = MonitorHandle::new(primary_id).unwrap();
         assert_eq!(handle0, handle1);
         assert_eq!(handle0.display_id(), handle1.display_id());
         assert_eq!(handle0.uuid(), handle1.uuid());

--- a/winit-wayland/src/seat/pointer/mod.rs
+++ b/winit-wayland/src/seat/pointer/mod.rs
@@ -22,19 +22,19 @@ use sctk::reexports::protocols::wp::viewporter::client::wp_viewport::WpViewport;
 
 use sctk::compositor::SurfaceData;
 use sctk::globals::GlobalData;
+use sctk::seat::SeatState;
 use sctk::seat::pointer::{
     PointerData, PointerDataExt, PointerEvent, PointerEventKind, PointerHandler,
 };
-use sctk::seat::SeatState;
 
 use dpi::{LogicalPosition, PhysicalPosition};
 use winit_core::event::{
-    ElementState, MouseButton, MouseScrollDelta, PointerKind, PointerSource, TouchPhase,
-    WindowEvent, ButtonSource,
+    ButtonSource, ElementState, MouseButton, MouseScrollDelta, PointerKind, PointerSource,
+    TouchPhase, WindowEvent,
 };
 
-use crate::state::WinitState;
 use crate::WindowId;
+use crate::state::WinitState;
 
 pub mod pointer_gesture;
 pub mod relative_pointer;

--- a/winit-wayland/src/seat/pointer/relative_pointer.rs
+++ b/winit-wayland/src/seat/pointer/relative_pointer.rs
@@ -3,8 +3,8 @@
 use std::ops::Deref;
 
 use sctk::reexports::client::globals::{BindError, GlobalList};
-use sctk::reexports::client::{delegate_dispatch, Dispatch};
 use sctk::reexports::client::{Connection, QueueHandle};
+use sctk::reexports::client::{Dispatch, delegate_dispatch};
 use sctk::reexports::protocols::wp::relative_pointer::zv1::{
     client::zwp_relative_pointer_manager_v1::ZwpRelativePointerManagerV1,
     client::zwp_relative_pointer_v1::{self, ZwpRelativePointerV1},
@@ -12,8 +12,8 @@ use sctk::reexports::protocols::wp::relative_pointer::zv1::{
 
 use sctk::globals::GlobalData;
 
-use winit_core::event::DeviceEvent;
 use crate::state::WinitState;
+use winit_core::event::DeviceEvent;
 
 /// Wrapper around the relative pointer.
 #[derive(Debug)]

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -276,6 +276,11 @@ changelog entry.
 - On macOS, fixed redundant `SurfaceResized` event at window creation.
 - On macOS, don't panic on monitors with unknown bit-depths.
 - On macOS, fixed crash when closing the window on macOS 26+.
+- On macOS, route IME key events through `NSTextInputContext::handleEvent` to avoid duplicate
+  punctuation and dead key commits produced by third-party input methods, aligning character
+  delivery with Cocoa.
+- On macOS, make AppKit monitor handle tests derive their reference display IDs from
+  `CGMainDisplayID`, preventing failures on systems where the primary monitor is not display `1`.
 - On Windows, account for mouse wheel lines per scroll setting for `WindowEvent::MouseWheel`.
 - On Windows, `Window::theme` will return the correct theme after setting it through `Window::set_theme`.
 - On Windows, `Window::set_theme` will change the title bar color immediately now.


### PR DESCRIPTION
```
- On macOS, `NSTextInputClient::validAttributesForMarkedText` now automatically attaches a value
  called `_rust_winit_\(CARGO_PKG_VERSION)`.

  This allows IME devs to identify whether `winit` is used in the IMKTextInput client.
  If identified, IME devs can introduce compatibility behaviors against such IMKTextInput client.
  InputMethodKit casts `NSTextInputClient` to `IMKTextInput`, but `validAttributesForMarkedText`
  is shared between these two protocols and can all be parsed as `Array<NSString>`.

  `validAttributesForMarkedText` specifically returns an `NSArray<NSAttributedStringKey>` which
  are plain NSString*; Apple treats custom keys as legal, so slipping harmless metadata like
  `_rust_winit_\(CARGO_PKG_VERSION)` in there is the one slot where such data is piggybackable.
```

- [ ] Tested on all platforms changed // I only tested the compilability.
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality // This requires 3rd-party input method devs to involve in after this PR gets merged.

The true reason for this PR is to allow IME devs to automatically enable their customized popup composition buffer window in lieu of preedit (inline composition buffer). This is at least better than waiting for a lot of months seeing some IME-related PR patches are not mergeable in this `winit` repository due to maintainers' concerns.

> As a 3rd-party IME dev, I would really glad to blacklist all `winit`-based IMKTextInput clients in my IME by default to save both my time and the time of the devs of such kind of IMKTextInput clients: The blacklisted clients will automatically use my popup composition buffer instead.