### PR TITLE
iOS: Support starting  EventLoop from already running UIApplication

### DIFF
--- a/winit-uikit/Cargo.toml
+++ b/winit-uikit/Cargo.toml
@@ -68,6 +68,8 @@ objc2-ui-kit = { workspace = true, features = [
     "UIView",
     "UIViewController",
     "UIWindow",
+    "UIScene",
+    "UIWindowScene"
 ] }
 winit-common = { workspace = true, features = ["core-foundation", "event-handler"] }
 

--- a/winit-uikit/src/app_state.rs
+++ b/winit-uikit/src/app_state.rs
@@ -451,10 +451,14 @@ fn handle_hidpi_proxy(mtm: MainThreadMarker, event: ScaleFactorChanged) {
     let ScaleFactorChanged { suggested_size, scale_factor, window } = event;
     let new_surface_size = Arc::new(Mutex::new(suggested_size));
     get_handler(mtm).handle(|app| {
-        app.window_event(&ActiveEventLoop { mtm }, window.id(), WindowEvent::ScaleFactorChanged {
-            scale_factor,
-            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),
-        });
+        app.window_event(
+            &ActiveEventLoop { mtm },
+            window.id(),
+            WindowEvent::ScaleFactorChanged {
+                scale_factor,
+                surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),
+            },
+        );
     });
     let (view, screen_frame) = get_view_and_screen_frame(&window);
     let physical_size = *new_surface_size.lock().unwrap();

--- a/winit-uikit/src/event_loop.rs
+++ b/winit-uikit/src/event_loop.rs
@@ -139,13 +139,12 @@ pub struct EventLoop {
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct PlatformSpecificEventLoopAttributes {}
+pub struct PlatformSpecificEventLoopAttributes {
+    pub mtm: Option<MainThreadMarker>,
+}
 
 impl EventLoop {
-    pub fn new(_: &PlatformSpecificEventLoopAttributes) -> Result<EventLoop, EventLoopError> {
-        let mtm = MainThreadMarker::new()
-            .expect("On iOS, `EventLoop` must be created on the main thread");
-
+    pub fn new_with_mtm(mtm: MainThreadMarker) -> Result<EventLoop, EventLoopError> {
         if !AppState::setup_global(mtm) {
             // Required, AppState is global state, and event loop can only be run once.
             return Err(EventLoopError::RecreationAttempt);
@@ -238,17 +237,36 @@ impl EventLoop {
         })
     }
 
+    pub fn new(
+        attributes: &PlatformSpecificEventLoopAttributes,
+    ) -> Result<EventLoop, EventLoopError> {
+        // if the user provided a MainThreadMarker, use it; otherwise, create one
+        let mtm = match attributes.mtm {
+            Some(mtm) => mtm,
+            None => MainThreadMarker::new()
+                .expect("On iOS, `EventLoop` must be created on the main thread"),
+        };
+
+        EventLoop::new_with_mtm(mtm)
+    }
+
     // Require `'static` for correctness, we won't be able to `Drop` the user's state otherwise.
     pub fn run_app_never_return<A: ApplicationHandler + 'static>(self, app: A) -> ! {
         let application: Option<Retained<UIApplication>> =
             unsafe { msg_send![UIApplication::class(), sharedApplication] };
-        assert!(
-            application.is_none(),
-            "\
-                `EventLoop` cannot be `run` after a call to `UIApplicationMain` on iOS\nNote: \
-             `EventLoop::run_app` calls `UIApplicationMain` on iOS",
-        );
+        if let Some(_) = application {
+            // launch without calling `UIApplicationMain`, then park the thread forever
+            // it would probably be better to turn this into a `register_app`-style function
+            // and just return immediately
+            app_state::launch(self.mtm, app, || {
+                loop {
+                    std::thread::park();
+                }
+            });
 
+            // manually call did_finish_launching(mtm);
+            app_state::did_finish_launching(self.mtm);
+        }
         // We intentionally override neither the application nor the delegate,
         // to allow the user to do so themselves!
         //

--- a/winit-uikit/src/lib.rs
+++ b/winit-uikit/src/lib.rs
@@ -110,6 +110,8 @@ mod window;
 
 use std::os::raw::c_void;
 
+pub use objc2;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use winit_core::monitor::{MonitorHandle, VideoMode};
@@ -292,6 +294,12 @@ impl WindowExtIOS for dyn Window + '_ {
         let window = self.cast_ref::<UIKitWindow>().unwrap();
         window.maybe_wait_on_main(move |w| w.recognize_rotation_gesture(should_recognize));
     }
+}
+
+pub trait EventLoopBuilderExtIOS {
+    /// Sets the main thread marker to be used by the event loop.
+    fn with_main_thread_marker(&mut self, main_thread_marker: objc2::MainThreadMarker)
+    -> &mut Self;
 }
 
 /// Ios specific window attributes.

--- a/winit/src/event_loop.rs
+++ b/winit/src/event_loop.rs
@@ -383,6 +383,14 @@ impl winit_android::EventLoopBuilderExtAndroid for EventLoopBuilder {
     }
 }
 
+#[cfg(ios_platform)]
+impl winit_uikit::EventLoopBuilderExtIOS for EventLoopBuilder {
+    fn with_main_thread_marker(&mut self, mtm: winit_uikit::objc2::MainThreadMarker) -> &mut Self {
+        self.platform_specific.mtm = Some(mtm);
+        self
+    }
+}
+
 #[cfg(macos_platform)]
 impl winit_appkit::EventLoopBuilderExtMacOS for EventLoopBuilder {
     #[inline]


### PR DESCRIPTION
These are the minimal code changes I could get away with to enable starting a  `EventLoop` with an already-running `UIApplication`. The use case would be running `winit`-based apps inside any sort of already-running app on iOS, either from a native SwiftUI/Objective-C application or via Python/PyO3. Basically any case were you can't/don't want to control when `UIApplicationMain` is called.

**Please treat this as a starting point for discussion! Feedback is very welcome.**

There are some major limitations at the moment:
1. Currently, `run_app` blocks indefinitely by parking the calling thread. This is obviously not great for several reasons, and it also means you can't create the `EventLoop` on the main thread.
2. You need to provide your own (unchecked) `MainThreadMarker`. In my testing this did not cause problems (as the callbacks that contain the code that calls into UIKit still run on the main thread), but it is massively unsafe and likely invites potential unsoundness.
3. There is no good way to return from an `EventLoop`. I'm actually not sure what the best approach is here. One could either:
 (a) Adopt a web-style `register_app` that returns immediately and then provide a way to signal that the app has finished running, or (b) provide a `run_app` that blocks for the duration of the app and then returns. The latter would obviously require calling it from a new thread.
4. I believe you can't run multiple `winit` instances simultaneously because they name custom Objective-C classes the same way. Not problem when you can't run more  than one `EventLoop` per `UIApplication`, but problematic once you lift that restriction. This could potentially be addressed by generating unique names at runtime (?).

Please let me know what you think!

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
