### PR TITLE
Implement Display, Error for ImeSurroundingTextError

### DIFF
--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -1691,6 +1691,22 @@ pub enum ImeSurroundingTextError {
     AnchorBadPosition,
 }
 
+impl fmt::Display for ImeSurroundingTextError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ImeSurroundingTextError::TextTooLong => write!(f, "text exceeds maximum length"),
+            ImeSurroundingTextError::CursorBadPosition => {
+                write!(f, "cursor is not at a valid text index")
+            },
+            ImeSurroundingTextError::AnchorBadPosition => {
+                write!(f, "anchor is not at a valid text index")
+            },
+        }
+    }
+}
+
+impl std::error::Error for ImeSurroundingTextError {}
+
 /// Defines the text surrounding the caret
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

@kchibisov 

I would also move these to `error.rs` but I'm leaning towards moving all IME stuff into an `ime` module when addressing #4412.