### PR TITLE
Emit `destroy_surfaces()` consistently on all platforms

### DIFF
--- a/winit-appkit/src/event_loop.rs
+++ b/winit-appkit/src/event_loop.rs
@@ -357,6 +357,7 @@ impl EventLoop {
 
                 if self.app_state.exiting() {
                     self.app_state.internal_exit();
+                    app.destroy_surfaces(&self.window_target);
                     PumpStatus::Exit(0)
                 } else {
                     PumpStatus::Continue

--- a/winit-core/src/application/mod.rs
+++ b/winit-core/src/application/mod.rs
@@ -72,8 +72,9 @@ pub trait ApplicationHandler {
     /// applications to create a render surface until that point.
     ///
     /// For consistency, all platforms call this method even if they don't themselves have a formal
-    /// surface destroy/create lifecycle. For systems without a surface destroy/create lifecycle the
-    /// [`can_create_surfaces()`] event is always emitted after the [`StartCause::Init`] event.
+    /// surface create/destroy lifecycle. For systems without a surface create/destrory lifecycle
+    /// the [`can_create_surfaces()`] event is always emitted after the [`StartCause::Init`]
+    /// event.
     ///
     /// Applications should be able to gracefully handle back-to-back [`can_create_surfaces()`] and
     /// [`destroy_surfaces()`] calls.
@@ -275,6 +276,21 @@ pub trait ApplicationHandler {
     ///
     /// See [`can_create_surfaces()`] for more details.
     ///
+    /// ## Portability
+    ///
+    /// It's recommended that applications should only destroy their render surfaces after the
+    /// [`destroy_surfaces()`] method is called. Some systems (specifically Android) won't allow
+    /// applications to use the render surface after that point.
+    ///
+    /// For consistency, all platforms call this method even if they don't themselves have a formal
+    /// surface create/destroy lifecycle. For systems without a surface create/destroy lifecycle the
+    /// [`destroy_surfaces()`] event is always emitted before [`PumpStatus::Exit`] is returned.
+    ///
+    /// Applications should be able to gracefully handle back-to-back [`can_create_surfaces()`] and
+    /// [`destroy_surfaces()`] calls.
+    ///
+    /// [`PumpStatus::Exit`]: crate::event_loop::pump_events::PumpStatus::Exit
+    ///
     /// ## Platform-specific
     ///
     /// ### Android
@@ -297,10 +313,6 @@ pub trait ApplicationHandler {
     /// [`onStop`]: https://developer.android.com/reference/android/app/Activity#onStop()
     /// [`VkSurfaceKHR`]: https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkSurfaceKHR.html
     /// [`wgpu::Surface`]: https://docs.rs/wgpu/latest/wgpu/struct.Surface.html
-    ///
-    /// ### Others
-    ///
-    /// - **iOS / macOS / Orbital / Wayland / Web / Windows / X11:** Unsupported.
     ///
     /// [`can_create_surfaces()`]: Self::can_create_surfaces()
     /// [`destroy_surfaces()`]: Self::destroy_surfaces()

--- a/winit-orbital/src/event_loop.rs
+++ b/winit-orbital/src/event_loop.rs
@@ -681,6 +681,8 @@ impl EventLoop {
             }
         }
 
+        app.destroy_surfaces(&self.window_target);
+
         Ok(())
     }
 

--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -218,6 +218,8 @@ impl EventLoop {
         if let Some(code) = self.exit_code() {
             self.loop_running = false;
 
+            app.destroy_surfaces(&self.active_event_loop);
+
             PumpStatus::Exit(code)
         } else {
             // NOTE: spawn a wake-up thread, thus if we have code reading the wayland connection

--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -303,6 +303,9 @@ impl EventLoop {
             // Immediately reset the internal state for the loop to allow
             // the loop to be run more than once.
             self.runner.reset_runner();
+
+            app.destroy_surfaces(ActiveEventLoop::from_ref(&self.runner));
+
             PumpStatus::Exit(code)
         } else {
             self.runner.prepare_wait();

--- a/winit-win32/src/event_loop/runner.rs
+++ b/winit-win32/src/event_loop/runner.rs
@@ -287,9 +287,9 @@ impl EventLoopRunner {
         }
     }
 
-    /// Dispatch control flow events (`NewEvents`, `AboutToWait`, and
-    /// `LoopExiting`) as necessary to bring the internal `RunnerState` to the
-    /// new runner state.
+    /// Dispatch control flow events ([`ApplicationHandler::new_events()`] and
+    /// [`ApplicationHandler::about_to_wait()`]) as necessary to bring the internal [`RunnerState`]
+    /// to the new runner state.
     ///
     /// The state transitions are defined as follows:
     ///

--- a/winit-x11/src/event_loop.rs
+++ b/winit-x11/src/event_loop.rs
@@ -479,6 +479,8 @@ impl EventLoop {
         if let Some(code) = self.exit_code() {
             self.loop_running = false;
 
+            app.destroy_surfaces(&self.event_processor.target);
+
             PumpStatus::Exit(code)
         } else {
             PumpStatus::Continue

--- a/winit/src/changelog/v0.31.md
+++ b/winit/src/changelog/v0.31.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Changed
+
+- `destroy_surfaces()` is now emitted on all platforms for behaviour-parity.
+
 ## 0.31.0-beta.2
 
 ### Added
@@ -86,8 +92,8 @@
 - `ApplicationHandler::can_create|destroy_surfaces()` was split off from
   `ApplicationHandler::resumed/suspended()`.
 
-  `ApplicationHandler::can_create_surfaces()` should, for portability reasons
-  to Android, be the only place to create render surfaces.
+  `ApplicationHandler::can_create_surfaces()` and `ApplicationHandler::destroy_surfaces()` should,
+  for portability reasons to Android, be the only place to create and destroy render surfaces respectively.
 
   `ApplicationHandler::resumed/suspended()` are now only emitted by iOS, Web
   and Android, and now signify actually resuming/suspending the application.

--- a/winit/src/event_loop.rs
+++ b/winit/src/event_loop.rs
@@ -165,6 +165,8 @@ impl EventLoop {
     ///     start_cause = event_loop.wait_if_necessary();
     /// }
     ///
+    /// app.destroy_surfaces(event_loop);
+    ///
     /// // Finished running, drop application state.
     /// drop(app);
     /// ```


### PR DESCRIPTION
Fixes https://github.com/rust-windowing/winit/issues/3206

Surface creation and destruction events exist "specifically" for Android which has diverging lifetimes for its `Surface` structure compared to other platforms; specifically Vulkan `VkSurfaceKHR` or `EGLSurface` objects need to be destroyed and recreated.

Commit 6cdb3179 ("Consistently deliver a Resumed event on all platforms") made sure to consistently call `can_create_surfaces()` (`Event::Resumed` back then) on all platforms directly after startup so that users don't have to have platform-specific surface creation behaviour in two disjoint places, but we forgot about `destroy_surfaces()` (back then `Event::Suspended`) leading to applications still having to handle this destruction in two different places.

Solve that by calling the callback on all those platforms, directly before returning `PumpStatus::Exit` from `fn single_iteration()` or `fn pump_app_events()` (on Appkit).

Tested on:
- [ ] ~Android~ this was already supported before this PR, of course; but would be useful to check/assert that Android (the two backends `android-activity` hosts currently) consistently emit this event before exiting the loop however.
- [x] Wayland
- [x] X11
- [ ] Appkit
- [ ] UIkit: code missing, should be in `CFRunLoopActivity::Exit`?
- [ ] Win32
- [ ] Web (TODO: Not yet added)
- [ ] Orbital

> [!IMPORTANT]
> Draft because this is entirely untested and may not even compile on all platforms. The samples likely still need to be updated to match the new behaviour too.

In a distant future (before Winit 0.31 perhaps) these events should perhaps be moved to `WindowEvent`, as outlined in https://github.com/rust-windowing/winit/issues/4420.