### PR TITLE
Fix ABI mismatch in INIT_MAIN_THREAD_ID for Windows runtime

### DIFF
--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -528,9 +528,11 @@ fn main_thread_id() -> u32 {
     //
     // See: https://doc.rust-lang.org/stable/reference/abi.html#the-link_section-attribute
     #[unsafe(link_section = ".CRT$XCU")]
-    static INIT_MAIN_THREAD_ID: unsafe fn() = {
-        unsafe fn initer() {
-            unsafe { MAIN_THREAD_ID = GetCurrentThreadId() };
+    static INIT_MAIN_THREAD_ID: unsafe extern "C" fn() = {
+        unsafe extern "C" fn initer() {
+            unsafe {
+                MAIN_THREAD_ID = GetCurrentThreadId();
+            }
         }
         initer
     };


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
This PR fixes Issue #4435 by correcting the ABI used in the Windows global constructor INIT_MAIN_THREAD_ID. The function was previously declared with the Rust ABI (fn()), which is not guaranteed to match the Windows runtime expectations. It has now been updated to use the proper C ABI (extern "C" fn()), ensuring stable and correct behavior when the runtime invokes the constructor.