### PR TITLE
Add windows-only attribute to enable WS_EX_NOACTIVATE

### DIFF
--- a/winit-win32/src/lib.rs
+++ b/winit-win32/src/lib.rs
@@ -474,6 +474,7 @@ pub struct WindowAttributesWindows {
     pub(crate) title_text_color: Option<Color>,
     pub(crate) corner_preference: Option<CornerPreference>,
     pub(crate) use_system_wheel_speed: bool,
+    pub(crate) no_activate: bool,
 }
 
 impl Default for WindowAttributesWindows {
@@ -494,6 +495,7 @@ impl Default for WindowAttributesWindows {
             title_text_color: None,
             corner_preference: None,
             use_system_wheel_speed: true,
+            no_activate: false,
         }
     }
 }
@@ -636,6 +638,13 @@ impl WindowAttributesWindows {
     /// The default is `true`.
     pub fn with_use_system_scroll_speed(mut self, should_use: bool) -> Self {
         self.use_system_wheel_speed = should_use;
+        self
+    }
+
+    /// This sets or removes the WS_EX_NOACTIVATE flag
+    /// The default is `false`
+    pub fn with_no_activate(mut self, no_activate: bool) -> Self {
+        self.no_activate = no_activate;
         self
     }
 }

--- a/winit-win32/src/window.rs
+++ b/winit-win32/src/window.rs
@@ -1383,6 +1383,7 @@ unsafe fn init(
     // so the diffing later can work.
     window_flags.set(WindowFlags::CLOSABLE, true);
     window_flags.set(WindowFlags::CLIP_CHILDREN, win_attributes.clip_children);
+    window_flags.set(WindowFlags::NO_ACTIVATE, win_attributes.no_activate);
 
     let mut fallback_parent = || match win_attributes.owner {
         Some(parent) => {

--- a/winit-win32/src/window_state.rs
+++ b/winit-win32/src/window_state.rs
@@ -13,9 +13,9 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     SWP_NOREPOSITION, SWP_NOSIZE, SWP_NOZORDER, SendMessageW, SetWindowLongW, SetWindowPos,
     ShowWindow, WINDOW_EX_STYLE, WINDOW_STYLE, WINDOWPLACEMENT, WS_BORDER, WS_CAPTION, WS_CHILD,
     WS_CLIPCHILDREN, WS_CLIPSIBLINGS, WS_EX_ACCEPTFILES, WS_EX_APPWINDOW, WS_EX_LAYERED,
-    WS_EX_NOREDIRECTIONBITMAP, WS_EX_TOPMOST, WS_EX_TRANSPARENT, WS_EX_WINDOWEDGE, WS_MAXIMIZE,
-    WS_MAXIMIZEBOX, WS_MINIMIZE, WS_MINIMIZEBOX, WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SIZEBOX,
-    WS_SYSMENU, WS_VISIBLE,
+    WS_EX_NOACTIVATE, WS_EX_NOREDIRECTIONBITMAP, WS_EX_TOPMOST, WS_EX_TRANSPARENT,
+    WS_EX_WINDOWEDGE, WS_MAXIMIZE, WS_MAXIMIZEBOX, WS_MINIMIZE, WS_MINIMIZEBOX,
+    WS_OVERLAPPEDWINDOW, WS_POPUP, WS_SIZEBOX, WS_SYSMENU, WS_VISIBLE,
 };
 use winit_core::icon::Icon;
 use winit_core::keyboard::ModifiersState;
@@ -139,6 +139,8 @@ bitflags! {
         const MARKER_ACTIVATE = 1 << 21;
 
         const CLIP_CHILDREN = 1 << 22;
+
+        const NO_ACTIVATE = 1 << 23;
 
         const EXCLUSIVE_FULLSCREEN_OR_MASK = WindowFlags::ALWAYS_ON_TOP.bits();
     }
@@ -322,6 +324,9 @@ impl WindowFlags {
         }
         if self.contains(WindowFlags::CLIP_CHILDREN) {
             style |= WS_CLIPCHILDREN;
+        }
+        if self.contains(WindowFlags::NO_ACTIVATE) {
+            style_ex |= WS_EX_NOACTIVATE;
         }
 
         if self.intersects(

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -49,6 +49,7 @@ changelog entry.
 - Use new macOS 15 cursors for resize icons.
 - On Android, added scancode conversions for more obscure key codes.
 - On Wayland, added ext-background-effect-v1 support.
+- On Windows, add WindowAttributesWindows::no_activate for WS_EX_NOACTIVATE flag
 
 ### Changed
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

This PR adds a way to set Windows-specific flag WS_EX_NOACTIVATE, which prevents the created window from becoming the foreground from user interaction.