### PR TITLE
Add basic IME support for Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -376,3 +376,6 @@ edition = "2021"
 [workspace.dependencies]
 serde = { version = "1", features = ["serde_derive"] }
 mint = "0.5.6"
+
+[patch.crates-io]
+android-activity = { git = "https://github.com/rust-mobile/android-activity.git", branch = "rib/stack/ime-support" }

--- a/src/changelog/v0.30.md
+++ b/src/changelog/v0.30.md
@@ -1,3 +1,10 @@
+
+## 0.30.13
+
+### Added
+
+- On Android, added support for Ime events, for soft keyboard input.
+
 ## 0.30.12
 
 ### Fixed

--- a/src/event.rs
+++ b/src/event.rs
@@ -227,7 +227,7 @@ pub enum WindowEvent {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS / Web / Orbital:** Unsupported.
     Ime(Ime),
 
     /// The cursor has moved on the window.

--- a/src/platform_impl/android/keycodes.rs
+++ b/src/platform_impl/android/keycodes.rs
@@ -169,6 +169,12 @@ pub fn character_map_and_combine_key(
 ) -> Option<KeyMapChar> {
     let device_id = key_event.device_id();
 
+    // A device ID of 0 indicates a non-physical device (e.g. software keyboard)
+    // which we don't expect to have an associated KeyCharacterMap
+    if device_id == 0 {
+        return None;
+    }
+
     let key_map = match app.device_key_character_map(device_id) {
         Ok(key_map) => key_map,
         Err(err) => {


### PR DESCRIPTION
This adds basic support for Ime events to the Android backend.

Note that this will only work when running with the game-activity backend, which uses AGDK GameText to forward Android IME events:

https://developer.android.com/games/agdk/add-support-for-text-input

Normally on Android, input methods track three things:
- Surrounding text
- A compose region
- A selection

Since Winit doesn't track surrounding text and therefore also wouldn't be able to handle orthogonal compose + selection regions within some surrounding text, we can treat the whole text region that we edit as the "preedit" string, and we can then treat the compose region as the optional selection within the preedit string.

This is limited for now because there's no reliable event for committing the input via the "Done" key for a soft keyboard, but it's still usable without this for now.

I've tested this with Egui 0.33

**Note: I've opened this as a draft against the v0.30.x branch since that's what I've tested with.** I might get a chance to forward port to master but it looks like a lot has changed and I don't have anything convenient to test with currently.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- ~[ ] Created or updated an example program if it would help users understand this functionality~
