### PR TITLE
Add basic IME support for Android (Winit 0.31)

### DIFF
--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -152,7 +152,7 @@ pub enum WindowEvent {
     ///
     /// ## Platform-specific
     ///
-    /// - **iOS / Android / Web / Orbital:** Unsupported.
+    /// - **iOS / Web / Orbital:** Unsupported.
     Ime(Ime),
 
     /// The pointer has moved on the window.


### PR DESCRIPTION
Forward ported to Winit `master` from https://github.com/rust-windowing/winit/pull/4451

