### PR TITLE
Upgrade `windows-sys` dependency to 0.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ objc2-ui-kit = { version = "0.3.2", default-features = false }
 
 # Windows dependencies.
 unicode-segmentation = "1.7.1"
-windows-sys = "0.59.0"
+windows-sys = "0.61"
 
 # Linux dependencies.
 ahash = { version = "0.8.7", features = ["no-rng"] }

--- a/winit-win32/src/dark_mode.rs
+++ b/winit-win32/src/dark_mode.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 /// which is inspired by the solution in https://github.com/ysc3839/win32-darkmode
 use std::{ffi::c_void, ptr};
 
-use windows_sys::Win32::Foundation::{BOOL, HWND, LPARAM, S_OK, WPARAM};
+use windows_sys::Win32::Foundation::{HWND, LPARAM, S_OK, WPARAM};
 use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 use windows_sys::Win32::UI::Accessibility::{HCF_HIGHCONTRASTON, HIGHCONTRASTA};
 use windows_sys::Win32::UI::Controls::SetWindowTheme;
@@ -11,7 +11,7 @@ use windows_sys::Win32::UI::Input::KeyboardAndMouse::GetActiveWindow;
 use windows_sys::Win32::UI::WindowsAndMessaging::{
     DefWindowProcW, SPI_GETHIGHCONTRAST, SystemParametersInfoA, WM_NCACTIVATE,
 };
-use windows_sys::core::{PCSTR, PCWSTR};
+use windows_sys::core::{BOOL, PCSTR, PCWSTR};
 use windows_sys::w;
 use winit_core::window::Theme;
 

--- a/winit-win32/src/definitions.rs
+++ b/winit-win32/src/definitions.rs
@@ -3,9 +3,9 @@
 
 use std::ffi::c_void;
 
-use windows_sys::Win32::Foundation::{BOOL, HWND, POINTL};
+use windows_sys::Win32::Foundation::{HWND, POINTL};
 use windows_sys::Win32::System::Com::{FORMATETC, STGMEDIUM};
-use windows_sys::core::{GUID, HRESULT};
+use windows_sys::core::{BOOL, GUID, HRESULT};
 
 pub type IUnknown = *mut c_void;
 pub type IAdviseSink = *mut c_void;

--- a/winit-win32/src/monitor.rs
+++ b/winit-win32/src/monitor.rs
@@ -4,13 +4,14 @@ use std::num::{NonZeroU16, NonZeroU32};
 use std::{io, iter, mem, ptr};
 
 use dpi::{PhysicalPosition, PhysicalSize};
-use windows_sys::Win32::Foundation::{BOOL, HWND, LPARAM, POINT, RECT};
+use windows_sys::Win32::Foundation::{HWND, LPARAM, POINT, RECT};
 use windows_sys::Win32::Graphics::Gdi::{
     DEVMODEW, DM_BITSPERPEL, DM_DISPLAYFREQUENCY, DM_PELSHEIGHT, DM_PELSWIDTH,
     ENUM_CURRENT_SETTINGS, EnumDisplayMonitors, EnumDisplaySettingsExW, GetMonitorInfoW, HDC,
     HMONITOR, MONITOR_DEFAULTTONEAREST, MONITOR_DEFAULTTOPRIMARY, MONITORINFO, MONITORINFOEXW,
     MonitorFromPoint, MonitorFromWindow,
 };
+use windows_sys::core::BOOL;
 use winit_core::monitor::{MonitorHandleProvider, VideoMode};
 
 use super::util::decode_wide;

--- a/winit-win32/src/util.rs
+++ b/winit-win32/src/util.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::{io, mem, ptr};
 
-use windows_sys::Win32::Foundation::{BOOL, HANDLE, HMODULE, HWND, NTSTATUS, POINT, RECT};
+use windows_sys::Win32::Foundation::{HANDLE, HMODULE, HWND, NTSTATUS, POINT, RECT};
 use windows_sys::Win32::Graphics::Gdi::{ClientToScreen, HMONITOR};
 use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
@@ -23,7 +23,7 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN, SW_MAXIMIZE,
     ShowCursor, WINDOW_LONG_PTR_INDEX, WINDOWPLACEMENT,
 };
-use windows_sys::core::{HRESULT, PCWSTR};
+use windows_sys::core::{BOOL, HRESULT, PCWSTR};
 use winit_core::cursor::CursorIcon;
 use winit_core::event::DeviceId;
 

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -44,6 +44,10 @@ changelog entry.
 
 - Add `keyboard` support for OpenHarmony.
 
+### Changed
+
+- Updated `windows-sys` to `v0.61`.
+
 ### Fixed
 
 - On X11, fix `set_hittest` not working on some window managers.


### PR DESCRIPTION
`windows-sys` 0.61.x consistently uses `raw-dylib` for importing APIs from Windows DLLs. This makes a huge difference when using non-MSVC toolchains to build Windows binaries, e.g. `x86_64-pc-windows-gnullvm`.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality