### PR TITLE
macOS: add traffic‑light inset API and demo example

### DIFF
--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -84,6 +84,7 @@ mod window_delegate;
 
 use std::os::raw::c_void;
 
+use dpi::LogicalSize;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 #[doc(inline)]
@@ -187,6 +188,10 @@ pub trait WindowExtMacOS {
 
     /// Getter for the [`WindowExtMacOS::set_unified_titlebar`].
     fn unified_titlebar(&self) -> bool;
+
+    /// Sets the offset for the window controls (traffic lights) in logical points.
+    /// Positive values move right (x) and down (y) relative to the default position.
+    fn set_traffic_light_inset(&self, inset: LogicalSize<f64>);
 }
 
 impl WindowExtMacOS for dyn Window + '_ {
@@ -297,6 +302,11 @@ impl WindowExtMacOS for dyn Window + '_ {
         let window = self.cast_ref::<AppKitWindow>().unwrap();
         window.maybe_wait_on_main(|w| w.unified_titlebar())
     }
+    fn set_traffic_light_inset(&self, inset: LogicalSize<f64>) {
+        let window = self.cast_ref::<AppKitWindow>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_traffic_light_inset(inset))
+    }
+
 }
 
 /// Corresponds to `NSApplicationActivationPolicy`.
@@ -332,6 +342,7 @@ pub struct WindowAttributesMacOS {
     pub(crate) title_hidden: bool,
     pub(crate) titlebar_hidden: bool,
     pub(crate) titlebar_buttons_hidden: bool,
+    pub(crate) traffic_light_inset: Option<LogicalSize<f64>>,
     pub(crate) fullsize_content_view: bool,
     pub(crate) disallow_hidpi: bool,
     pub(crate) has_shadow: bool,
@@ -369,6 +380,14 @@ impl WindowAttributesMacOS {
     #[inline]
     pub fn with_titlebar_buttons_hidden(mut self, titlebar_buttons_hidden: bool) -> Self {
         self.titlebar_buttons_hidden = titlebar_buttons_hidden;
+        self
+    }
+
+    /// Sets the offset for the window controls (traffic lights) in logical points.
+    /// Positive values move right (x) and down (y) relative to the default position.
+    #[inline]
+    pub fn with_traffic_light_inset(mut self, inset: LogicalSize<f64>) -> Self {
+        self.traffic_light_inset = Some(inset);
         self
     }
 
@@ -459,6 +478,7 @@ impl Default for WindowAttributesMacOS {
             title_hidden: false,
             titlebar_hidden: false,
             titlebar_buttons_hidden: false,
+            traffic_light_inset: None,
             fullsize_content_view: false,
             disallow_hidpi: false,
             has_shadow: true,

--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -191,6 +191,14 @@ pub trait WindowExtMacOS {
 
     /// Sets the offset for the window controls (traffic lights) in logical points.
     /// Positive values move right (x) and down (y) relative to the default position.
+    ///
+    /// ```no_run
+    /// # use winit::dpi::LogicalSize;
+    /// # use winit::platform::macos::WindowExtMacOS;
+    /// # fn example(window: &dyn winit::window::Window) {
+    /// window.set_traffic_light_inset(LogicalSize::new(24.0, 8.0));
+    /// # }
+    /// ```
     fn set_traffic_light_inset(&self, inset: LogicalSize<f64>);
 }
 
@@ -306,7 +314,6 @@ impl WindowExtMacOS for dyn Window + '_ {
         let window = self.cast_ref::<AppKitWindow>().unwrap();
         window.maybe_wait_on_main(move |w| w.set_traffic_light_inset(inset))
     }
-
 }
 
 /// Corresponds to `NSApplicationActivationPolicy`.
@@ -385,6 +392,16 @@ impl WindowAttributesMacOS {
 
     /// Sets the offset for the window controls (traffic lights) in logical points.
     /// Positive values move right (x) and down (y) relative to the default position.
+    ///
+    /// This applies an offset from the default position; it does not change the native
+    /// spacing between the buttons. No effect if titlebar buttons are hidden.
+    ///
+    /// ```no_run
+    /// # use winit::dpi::LogicalSize;
+    /// # use winit::platform::macos::WindowAttributesMacOS;
+    /// let attrs =
+    ///     WindowAttributesMacOS::default().with_traffic_light_inset(LogicalSize::new(24.0, 8.0));
+    /// ```
     #[inline]
     pub fn with_traffic_light_inset(mut self, inset: LogicalSize<f64>) -> Self {
         self.traffic_light_inset = Some(inset);

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -952,7 +952,6 @@ impl WindowDelegate {
         self.queue_event(WindowEvent::Moved(position));
     }
 
-
     fn apply_traffic_light_inset(&self) {
         // Nothing to do if no inset was configured.
         let Some(inset) = self.ivars().traffic_light_inset.get() else {
@@ -968,8 +967,7 @@ impl WindowDelegate {
             self.ivars().traffic_light_base.set(None);
             return;
         }
-        let Some(miniaturize) =
-            window.standardWindowButton(NSWindowButton::MiniaturizeButton)
+        let Some(miniaturize) = window.standardWindowButton(NSWindowButton::MiniaturizeButton)
         else {
             return;
         };
@@ -988,11 +986,7 @@ impl WindowDelegate {
         // Capture the current default geometry as a candidate base.
         let close_rect = close.frame();
         let spacing = miniaturize.frame().origin.x - close_rect.origin.x; // Horizontal delta between buttons.
-        let current = TrafficLightBase {
-            x: close_rect.origin.x,
-            y: close_rect.origin.y,
-            spacing,
-        };
+        let current = TrafficLightBase { x: close_rect.origin.x, y: close_rect.origin.y, spacing };
 
         // If frames no longer match cached base + inset (AppKit reset), refresh base.
         let base = match self.ivars().traffic_light_base.get() {
@@ -1008,11 +1002,11 @@ impl WindowDelegate {
                 } else {
                     base
                 }
-            }
+            },
             None => {
                 self.ivars().traffic_light_base.set(Some(current));
                 current
-            }
+            },
         };
 
         // Apply inset relative to base while preserving native spacing.

--- a/winit/examples/traffic_lights.rs
+++ b/winit/examples/traffic_lights.rs
@@ -1,4 +1,7 @@
 //! macOS traffic-light inset demo.
+//!
+//! macOS only; on other platforms this example is a no-op for insets.
+//! Arrow keys adjust the inset, Shift uses a larger step, R resets, Esc exits.
 
 use std::error::Error;
 
@@ -42,10 +45,7 @@ impl Default for App {
 
 impl App {
     fn title(&self) -> String {
-        format!(
-            "Traffic lights inset: x={:.1}, y={:.1}",
-            self.inset.width, self.inset.height
-        )
+        format!("Traffic lights inset: x={:.1}, y={:.1}", self.inset.width, self.inset.height)
     }
 
     fn apply_inset(&self) {
@@ -76,8 +76,9 @@ impl ApplicationHandler for App {
 
         #[cfg(web_platform)]
         {
-            window_attributes = window_attributes
-                .with_platform_attributes(Box::new(WindowAttributesWeb::default().with_append(true)));
+            window_attributes = window_attributes.with_platform_attributes(Box::new(
+                WindowAttributesWeb::default().with_append(true),
+            ));
         }
 
         #[cfg(macos_platform)]
@@ -100,51 +101,33 @@ impl ApplicationHandler for App {
         self.apply_inset();
     }
 
-    fn window_event(
-        &mut self,
-        event_loop: &dyn ActiveEventLoop,
-        _: WindowId,
-        event: WindowEvent,
-    ) {
+    fn window_event(&mut self, event_loop: &dyn ActiveEventLoop, _: WindowId, event: WindowEvent) {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
             WindowEvent::ModifiersChanged(modifiers) => {
                 self.modifiers = modifiers.state();
             },
             WindowEvent::KeyboardInput {
-                event:
-                    KeyEvent {
-                        state: ElementState::Pressed,
-                        key_without_modifiers: key,
-                        ..
-                    },
+                event: KeyEvent { state: ElementState::Pressed, key_without_modifiers: key, .. },
                 is_synthetic: false,
                 ..
             } => {
-                let step = if self.modifiers.shift_key() {
-                    STEP_COARSE
-                } else {
-                    STEP_FINE
-                };
+                let step = if self.modifiers.shift_key() { STEP_COARSE } else { STEP_FINE };
 
                 match key.as_ref() {
                     Key::Named(NamedKey::ArrowLeft) => self.nudge_inset(-step, 0.0),
                     Key::Named(NamedKey::ArrowRight) => self.nudge_inset(step, 0.0),
                     Key::Named(NamedKey::ArrowUp) => self.nudge_inset(0.0, -step),
                     Key::Named(NamedKey::ArrowDown) => self.nudge_inset(0.0, step),
-                    Key::Character("r") => self.set_inset(LogicalSize::new(
-                        DEFAULT_INSET_X,
-                        DEFAULT_INSET_Y,
-                    )),
+                    Key::Character("r") => {
+                        self.set_inset(LogicalSize::new(DEFAULT_INSET_X, DEFAULT_INSET_Y))
+                    },
                     Key::Named(NamedKey::Escape) => event_loop.exit(),
                     _ => (),
                 }
             },
             WindowEvent::SurfaceResized(_) => {
-                self.window
-                    .as_ref()
-                    .expect("resize event without a window")
-                    .request_redraw();
+                self.window.as_ref().expect("resize event without a window").request_redraw();
             },
             WindowEvent::RedrawRequested => {
                 let window = self.window.as_ref().expect("redraw request without a window");

--- a/winit/examples/traffic_lights.rs
+++ b/winit/examples/traffic_lights.rs
@@ -1,0 +1,172 @@
+//! macOS traffic-light inset demo.
+
+use std::error::Error;
+
+use winit::application::ApplicationHandler;
+use winit::dpi::LogicalSize;
+use winit::event::{ElementState, KeyEvent, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, EventLoop};
+use winit::keyboard::{Key, ModifiersState, NamedKey};
+#[cfg(macos_platform)]
+use winit::platform::macos::{WindowAttributesMacOS, WindowExtMacOS};
+#[cfg(web_platform)]
+use winit::platform::web::WindowAttributesWeb;
+use winit::window::{Window, WindowAttributes, WindowId};
+
+#[path = "util/fill.rs"]
+mod fill;
+#[path = "util/tracing.rs"]
+mod tracing;
+
+const DEFAULT_INSET_X: f64 = 0.0;
+const DEFAULT_INSET_Y: f64 = 0.0;
+const STEP_FINE: f64 = 1.0;
+const STEP_COARSE: f64 = 8.0;
+
+#[derive(Debug)]
+struct App {
+    window: Option<Box<dyn Window>>,
+    inset: LogicalSize<f64>,
+    modifiers: ModifiersState,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        Self {
+            window: None,
+            inset: LogicalSize::new(DEFAULT_INSET_X, DEFAULT_INSET_Y),
+            modifiers: ModifiersState::default(),
+        }
+    }
+}
+
+impl App {
+    fn title(&self) -> String {
+        format!(
+            "Traffic lights inset: x={:.1}, y={:.1}",
+            self.inset.width, self.inset.height
+        )
+    }
+
+    fn apply_inset(&self) {
+        let Some(window) = self.window.as_ref() else {
+            return;
+        };
+
+        #[cfg(macos_platform)]
+        window.set_traffic_light_inset(self.inset);
+        window.set_title(&self.title());
+    }
+
+    fn set_inset(&mut self, inset: LogicalSize<f64>) {
+        self.inset = inset;
+        self.apply_inset();
+    }
+
+    fn nudge_inset(&mut self, dx: f64, dy: f64) {
+        self.inset.width += dx;
+        self.inset.height += dy;
+        self.apply_inset();
+    }
+}
+
+impl ApplicationHandler for App {
+    fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
+        let mut window_attributes = WindowAttributes::default().with_title(self.title());
+
+        #[cfg(web_platform)]
+        {
+            window_attributes = window_attributes
+                .with_platform_attributes(Box::new(WindowAttributesWeb::default().with_append(true)));
+        }
+
+        #[cfg(macos_platform)]
+        {
+            let macos_attributes =
+                WindowAttributesMacOS::default().with_traffic_light_inset(self.inset);
+            window_attributes =
+                window_attributes.with_platform_attributes(Box::new(macos_attributes));
+        }
+
+        self.window = match event_loop.create_window(window_attributes) {
+            Ok(window) => Some(window),
+            Err(err) => {
+                eprintln!("error creating window: {err}");
+                event_loop.exit();
+                return;
+            },
+        };
+
+        self.apply_inset();
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &dyn ActiveEventLoop,
+        _: WindowId,
+        event: WindowEvent,
+    ) {
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::ModifiersChanged(modifiers) => {
+                self.modifiers = modifiers.state();
+            },
+            WindowEvent::KeyboardInput {
+                event:
+                    KeyEvent {
+                        state: ElementState::Pressed,
+                        key_without_modifiers: key,
+                        ..
+                    },
+                is_synthetic: false,
+                ..
+            } => {
+                let step = if self.modifiers.shift_key() {
+                    STEP_COARSE
+                } else {
+                    STEP_FINE
+                };
+
+                match key.as_ref() {
+                    Key::Named(NamedKey::ArrowLeft) => self.nudge_inset(-step, 0.0),
+                    Key::Named(NamedKey::ArrowRight) => self.nudge_inset(step, 0.0),
+                    Key::Named(NamedKey::ArrowUp) => self.nudge_inset(0.0, -step),
+                    Key::Named(NamedKey::ArrowDown) => self.nudge_inset(0.0, step),
+                    Key::Character("r") => self.set_inset(LogicalSize::new(
+                        DEFAULT_INSET_X,
+                        DEFAULT_INSET_Y,
+                    )),
+                    Key::Named(NamedKey::Escape) => event_loop.exit(),
+                    _ => (),
+                }
+            },
+            WindowEvent::SurfaceResized(_) => {
+                self.window
+                    .as_ref()
+                    .expect("resize event without a window")
+                    .request_redraw();
+            },
+            WindowEvent::RedrawRequested => {
+                let window = self.window.as_ref().expect("redraw request without a window");
+                window.pre_present_notify();
+                fill::fill_window(window.as_ref());
+            },
+            _ => (),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    #[cfg(web_platform)]
+    console_error_panic_hook::set_once();
+
+    tracing::init();
+
+    println!("Traffic-light inset demo (macOS only).");
+    println!("Arrow keys adjust X/Y. Shift = coarse step.");
+    println!("R resets. Esc closes.");
+
+    let event_loop = EventLoop::new()?;
+    event_loop.run_app(App::default())?;
+    Ok(())
+}

--- a/winit/examples/traffic_lights.rs
+++ b/winit/examples/traffic_lights.rs
@@ -72,22 +72,14 @@ impl App {
 
 impl ApplicationHandler for App {
     fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
-        let mut window_attributes = WindowAttributes::default().with_title(self.title());
-
+        let window_attributes = WindowAttributes::default().with_title(self.title());
         #[cfg(web_platform)]
-        {
-            window_attributes = window_attributes.with_platform_attributes(Box::new(
-                WindowAttributesWeb::default().with_append(true),
-            ));
-        }
-
+        let window_attributes = window_attributes
+            .with_platform_attributes(Box::new(WindowAttributesWeb::default().with_append(true)));
         #[cfg(macos_platform)]
-        {
-            let macos_attributes =
-                WindowAttributesMacOS::default().with_traffic_light_inset(self.inset);
-            window_attributes =
-                window_attributes.with_platform_attributes(Box::new(macos_attributes));
-        }
+        let window_attributes = window_attributes.with_platform_attributes(Box::new(
+            WindowAttributesMacOS::default().with_traffic_light_inset(self.inset),
+        ));
 
         self.window = match event_loop.create_window(window_attributes) {
             Ok(window) => Some(window),

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -43,6 +43,8 @@ changelog entry.
 ### Added
 
 - Add `keyboard` support for OpenHarmony.
+- On macOS, add `WindowAttributesMacOS::with_traffic_light_inset` and
+  `WindowExtMacOS::set_traffic_light_inset`.
 
 ### Fixed
 


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [X] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality

Description:
- Adds `WindowAttributesMacOS::with_traffic_light_inset` and `WindowExtMacOS::set_traffic_light_inset` to offset the traffic‑light buttons in logical points.
- Applies the inset reliably across title changes, resizes, and fullscreen transitions; no effect when titlebar buttons are hidden.
- Adds `traffic_lights` example for interactive adjustment (arrow keys, Shift for coarse, R reset, Esc exit).
- Adds changelog entry in `winit/src/changelog/unreleased.md`.

Fixes #4436

Tests:
- `cargo check -p winit-appkit`
- `cargo check -p winit --example traffic_lights`