### PR TITLE
docs: Minor fix on v0.31 release note

### DIFF
--- a/winit/src/changelog/v0.31.md
+++ b/winit/src/changelog/v0.31.md
@@ -74,7 +74,7 @@
 - `ApplicationHandler` now uses `dyn ActiveEventLoop`.
 - On Web, let events wake up event loop immediately when using `ControlFlow::Poll`.
 - Bump MSRV from `1.70` to `1.85`.
-- Changed `ApplicationHandler::user_event` to `user_wake_up`, removing the
+- Changed `ApplicationHandler::user_event` to `proxy_wake_up`, removing the
   generic user event.
 
   Winit will now only indicate that wake up happened, you will have to pair


### PR DESCRIPTION
It says

> Changed `ApplicationHandler::user_event` to `user_wake_up`, removing the generic user event.

but I couldn't find `user_wake_up`. I guess `proxy_wake_up` is the correct one.

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
