### PR TITLE
chore: appease clippy

### DIFF
--- a/winit-x11/src/ime/inner.rs
+++ b/winit-x11/src/ime/inner.rs
@@ -50,8 +50,13 @@ impl ImeInner {
     }
 
     pub unsafe fn close_im_if_necessary(&self) -> Result<bool, XError> {
-        if !self.is_destroyed && self.im.is_some() {
-            unsafe { close_im(&self.xconn, self.im.as_ref().unwrap().im) }.map(|_| true)
+        if !self.is_destroyed {
+            if let Some(im) = &self.im {
+                unsafe { close_im(&self.xconn, im.im) }?;
+                Ok(true)
+            } else {
+                Ok(false)
+            }
         } else {
             Ok(false)
         }


### PR DESCRIPTION
To fix CI, currently fails with:
```
error: called `unwrap` on `self.im` after checking its variant with `is_some`
  --> winit-x11/src/ime/inner.rs:54:44
   |
53 |         if !self.is_destroyed && self.im.is_some() {
   |                                  ----------------- the check is happening here
54 |             unsafe { close_im(&self.xconn, self.im.as_ref().unwrap().im) }.map(|_| true)
   |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: try using `match`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.93.0/index.html#unnecessary_unwrap
   = note: `-D clippy::unnecessary-unwrap` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::unnecessary_unwrap)]`
```