### PR TITLE
wayland IME: Discard completed delete request

### DIFF
--- a/winit-wayland/src/seat/text_input/mod.rs
+++ b/winit-wayland/src/seat/text_input/mod.rs
@@ -150,7 +150,7 @@ impl Dispatch<ZwpTextInputV3, TextInputData, WinitState> for TextInputState {
                 // 6. Place cursor inside preedit text.
 
                 if let Some(DeleteSurroundingText { before, after }) =
-                    text_input_data.pending_delete
+                    text_input_data.pending_delete.take()
                 {
                     state.events_sink.push_window_event(
                         WindowEvent::Ime(Ime::DeleteSurrounding {


### PR DESCRIPTION
This is a fix. The deletion request would repeat until the next deletion request.

It makes me wonder if `Option::take()` on every value separately is the right choice here. It goes completely unnoticed when missing. Perhaps there should be a .reset() at the end, resetting all the values to default instead.

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
