### PR TITLE
macOS: Fix Korean composing text commit key handling

### DIFF
--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -54,3 +54,4 @@ changelog entry.
 - On X11, fix `set_hittest` not working on some window managers.
 - On Redox, handle `EINTR` when reading from `event_socket` instead of panicking.
 - On Wayland, switch from using the `ahash` hashing algorithm to `foldhash`.
+- On macOS, fix double space input and key loss when committing Korean IME composition.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

## Summary

A minimal fix that addresses a major pain point in macOS Korean IME handling.

Fixes two interrelated bugs reported downstream in Alacritty:

  1. **Double space input**: With Korean IME active and no text being composed, pressing `Space` once inserts two spaces
    alacritty/alacritty#8079
  2. **Key loss**: After committing composed text, trigger keys of ASCII characters were silently dropped.
    alacritty/alacritty#6942

## Root Cause

### Bug 1: Double Space

When Space is pressed with Korean IME active but no active composition, macOS calls `setMarkedText(" ")` followed by `insertText` twice within the same `interpretKeyEvents`. The first `insertText` call set `ImeState::Committed` but did not clear `marked_text`. The second call still saw `hasMarkedText() == true` and emitted a duplicate `Ime::Commit(" ")`.

### Bug 2: Key Loss

`doCommandBySelector` had a blanket early-return guard when `ImeState == Committed`:

```rust
if self.ivars().ime_state.get() == ImeState::Committed {
    return;
}
```

This was originally added to prevent `Enter` from being sent twice when used to confirm IME input. However, it was too aggressive — it swallowed ASCII key commands after a commit, preventing `forward_key_to_app` from being set. This caused trigger keys to be silently dropped.

## Fix

**In `insertText`:**
- Clear `marked_text` immediately after committing, so subsequent `insertText` calls within the same `interpretKeyEvents` no longer see stale preedit state.
- Add an `else if Committed` branch that sets `forward_key_to_app = true` for post-commit characters, forwarding them as regular key events instead of duplicate IME commits.

**In `doCommandBySelector`:**
- Remove the `Committed` early-return guard. With `marked_text` properly cleared in `insertText`, the double-input issue this guard was meant to prevent no longer occurs.

## Test Results (Korean IME)

Tested with the `ime` example (`cargo run --example ime`). Below are before/after comparisons for each Korean IME scenario.

### Space on empty field (Bug 1: double space)

<table>
<tr><th>Before (🔴 double space)</th><th>After (✅ single space)</th></tr>
<tr><td>

```
Preedit:  , caret Some((1, 1))
Preedit: , caret None
 |                          ← 1st space
Preedit: , caret None
  |                         ← 2nd space
                             (duplicate!)
```

</td><td>

```
Preedit:  , caret Some((1, 1))
Preedit: , caret None
 |                          ← 1 space only ✓
```

</td></tr>
</table>

### "한" + Space commit (already worked)

<table>
<tr><th>Before (✅)</th><th>After (✅)</th></tr>
<tr><td>

```
Preedit: ㅎ, caret Some((3, 3))
Preedit: 하, caret Some((3, 3))
Preedit: 한, caret Some((3, 3))
Preedit: 한 , caret Some((4, 4))
Preedit: , caret None
한 |
```

</td><td>

```
Preedit: ㅎ, caret Some((3, 3))
Preedit: 하, caret Some((3, 3))
Preedit: 한, caret Some((3, 3))
Preedit: 한 , caret Some((4, 4))
Preedit: , caret None
한 |
```

</td></tr>
</table>

### "한" + Enter commit (already worked)

<table>
<tr><th>Before (✅)</th><th>After (✅)</th></tr>
<tr><td>

```
Preedit: ㅎ, caret Some((3, 3))
Preedit: 하, caret Some((3, 3))
Preedit: 한, caret Some((3, 3))
Preedit: , caret None
한|
한                          ← newline ✓
```

</td><td>

```
Preedit: ㅎ, caret Some((3, 3))
Preedit: 하, caret Some((3, 3))
Preedit: 한, caret Some((3, 3))
Preedit: , caret None
한|
한                          ← newline ✓
```

</td></tr>
</table>

### "한" + digit (Bug 2: key loss)

<table>
<tr><th>Before (🔴 digit dropped)</th><th>After (✅ digit forwarded)</th></tr>
<tr><td>

```
Preedit: ㅎ, caret Some((3, 3))
Preedit: 하, caret Some((3, 3))
Preedit: 한, caret Some((3, 3))
Preedit: , caret None
한|                     ← "5" silently dropped!
Preedit: , caret None
```

</td><td>

```
Preedit: ㅎ, caret Some((3, 3))
Preedit: 하, caret Some((3, 3))
Preedit: 한, caret Some((3, 3))
Preedit: , caret None
한|
한5|                    ← digit forwarded ✓
```

</td></tr>
</table>

### "한" + ASCII (Bug 2: key loss)

<table>
<tr><th>Before (🔴 ASCII dropped)</th><th>After (✅ ASCII forwarded)</th></tr>
<tr><td>

```
Preedit: ㅎ, caret Some((3, 3))
Preedit: 하, caret Some((3, 3))
Preedit: 한, caret Some((3, 3))
Preedit: , caret None
한|                     ← ";" silently dropped!
Preedit: , caret None
```

</td><td>

```
Preedit: ㅎ, caret Some((3, 3))
Preedit: 하, caret Some((3, 3))
Preedit: 한, caret Some((3, 3))
Preedit: , caret None
한|
한;|                    ← ASCII forwarded ✓
```

</td></tr>
</table>

## Impact on Other CJK IMEs

These changes only affect the Korean IME code path. Japanese and Chinese IMEs are not affected because:

- Japanese/Chinese IMEs consume confirmation keys (Enter/Space) internally — they never reach `doCommandBySelector` or trigger a second `insertText` within the same `interpretKeyEvents` call.
- The `Committed` state is reset to `Ground` at the end of each `keyDown`, so the next keypress always starts from `Ground` regardless of IME.

Japanese and Chinese IMEs were tested and confirmed no regression (nihon→にほん, nihao→你好, emoji selection, etc.).