### PR TITLE
fix: add explicit closure type annotations for Rust 1.92+

### DIFF
--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -43,3 +43,6 @@ changelog entry.
 ### Fixed
 
 - On macOS, fix crash on macOS 26 by using objc2's `relax-sign-encoding` feature.
+- Fix compilation on Rust 1.92+ by adding explicit closure type annotations to
+  `Window` methods that use `maybe_wait_on_main`/`maybe_queue_on_main`.
+- On X11, fix `function_casts_as_integer` warning in IME context.

--- a/src/platform_impl/linux/x11/ime/context.rs
+++ b/src/platform_impl/linux/x11/ime/context.rs
@@ -158,7 +158,7 @@ impl PreeditCallbacks {
     pub fn new(client_data: ffi::XPointer) -> PreeditCallbacks {
         let start_callback = create_xim_callback(client_data, unsafe {
             mem::transmute::<usize, unsafe extern "C" fn(ffi::XIM, ffi::XPointer, ffi::XPointer)>(
-                preedit_start_callback as usize,
+                preedit_start_callback as *const () as usize,
             )
         });
         let done_callback = create_xim_callback(client_data, preedit_done_callback);

--- a/src/window.rs
+++ b/src/window.rs
@@ -47,12 +47,14 @@ impl Drop for Window {
     ///
     /// See [`Window`] for more details.
     fn drop(&mut self) {
-        self.window.maybe_wait_on_main(|w| {
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| {
             // If the window is in exclusive fullscreen, we must restore the desktop
             // video mode (generally this would be done on application exit, but
             // closing the window doesn't necessarily always mean application exit,
             // such as when there are multiple windows)
-            if let Some(Fullscreen::Exclusive(_)) = w.fullscreen().map(|f| f.into()) {
+            if let Some(Fullscreen::Exclusive(_)) =
+                w.fullscreen().map(|f: platform_impl::Fullscreen| f.into())
+            {
                 w.set_fullscreen(None);
             }
         })
@@ -495,7 +497,7 @@ impl Window {
     pub fn id(&self) -> WindowId {
         let _span = tracing::debug_span!("winit::Window::id",).entered();
 
-        self.window.maybe_wait_on_main(|w| WindowId(w.id()))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| WindowId(w.id()))
     }
 
     /// Returns the scale factor that can be used to map logical pixels to physical pixels, and
@@ -563,7 +565,7 @@ impl Window {
     pub fn scale_factor(&self) -> f64 {
         let _span = tracing::debug_span!("winit::Window::scale_factor",).entered();
 
-        self.window.maybe_wait_on_main(|w| w.scale_factor())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.scale_factor())
     }
 
     /// Queues a [`WindowEvent::RedrawRequested`] event to be emitted that aligns with the windowing
@@ -597,7 +599,7 @@ impl Window {
     pub fn request_redraw(&self) {
         let _span = tracing::debug_span!("winit::Window::request_redraw",).entered();
 
-        self.window.maybe_queue_on_main(|w| w.request_redraw())
+        self.window.maybe_queue_on_main(|w: &platform_impl::Window| w.request_redraw())
     }
 
     /// Notify the windowing system before presenting to the window.
@@ -636,7 +638,7 @@ impl Window {
     pub fn pre_present_notify(&self) {
         let _span = tracing::debug_span!("winit::Window::pre_present_notify",).entered();
 
-        self.window.maybe_queue_on_main(|w| w.pre_present_notify());
+        self.window.maybe_queue_on_main(|w: &platform_impl::Window| w.pre_present_notify());
     }
 
     /// Reset the dead key state of the keyboard.
@@ -654,7 +656,7 @@ impl Window {
     pub fn reset_dead_keys(&self) {
         let _span = tracing::debug_span!("winit::Window::reset_dead_keys",).entered();
 
-        self.window.maybe_queue_on_main(|w| w.reset_dead_keys())
+        self.window.maybe_queue_on_main(|w: &platform_impl::Window| w.reset_dead_keys())
     }
 }
 
@@ -678,7 +680,7 @@ impl Window {
     pub fn inner_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let _span = tracing::debug_span!("winit::Window::inner_position",).entered();
 
-        self.window.maybe_wait_on_main(|w| w.inner_position())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.inner_position())
     }
 
     /// Returns the position of the top-left hand corner of the window relative to the
@@ -701,7 +703,7 @@ impl Window {
     pub fn outer_position(&self) -> Result<PhysicalPosition<i32>, NotSupportedError> {
         let _span = tracing::debug_span!("winit::Window::outer_position",).entered();
 
-        self.window.maybe_wait_on_main(|w| w.outer_position())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.outer_position())
     }
 
     /// Modifies the position of the window.
@@ -739,7 +741,8 @@ impl Window {
         )
         .entered();
 
-        self.window.maybe_queue_on_main(move |w| w.set_outer_position(position))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.set_outer_position(position))
     }
 
     /// Returns the physical size of the window's client area.
@@ -758,7 +761,7 @@ impl Window {
     pub fn inner_size(&self) -> PhysicalSize<u32> {
         let _span = tracing::debug_span!("winit::Window::inner_size",).entered();
 
-        self.window.maybe_wait_on_main(|w| w.inner_size())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.inner_size())
     }
 
     /// Request the new size for the window.
@@ -804,7 +807,7 @@ impl Window {
             size = ?size
         )
         .entered();
-        self.window.maybe_wait_on_main(|w| w.request_inner_size(size))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.request_inner_size(size))
     }
 
     /// Returns the physical size of the entire window.
@@ -821,7 +824,7 @@ impl Window {
     #[inline]
     pub fn outer_size(&self) -> PhysicalSize<u32> {
         let _span = tracing::debug_span!("winit::Window::outer_size",).entered();
-        self.window.maybe_wait_on_main(|w| w.outer_size())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.outer_size())
     }
 
     /// Sets a minimum dimension size for the window.
@@ -849,7 +852,8 @@ impl Window {
             min_size = ?min_size
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_min_inner_size(min_size))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.set_min_inner_size(min_size))
     }
 
     /// Sets a maximum dimension size for the window.
@@ -877,7 +881,8 @@ impl Window {
             max_size = ?max_size
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_max_inner_size(max_size))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.set_max_inner_size(max_size))
     }
 
     /// Returns window resize increments if any were set.
@@ -888,7 +893,7 @@ impl Window {
     #[inline]
     pub fn resize_increments(&self) -> Option<PhysicalSize<u32>> {
         let _span = tracing::debug_span!("winit::Window::resize_increments",).entered();
-        self.window.maybe_wait_on_main(|w| w.resize_increments())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.resize_increments())
     }
 
     /// Sets window resize increments.
@@ -910,7 +915,9 @@ impl Window {
             increments = ?increments
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_resize_increments(increments))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| {
+            w.set_resize_increments(increments)
+        })
     }
 }
 
@@ -924,7 +931,7 @@ impl Window {
     #[inline]
     pub fn set_title(&self, title: &str) {
         let _span = tracing::debug_span!("winit::Window::set_title", title).entered();
-        self.window.maybe_wait_on_main(|w| w.set_title(title))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.set_title(title))
     }
 
     /// Change the window transparency state.
@@ -945,7 +952,8 @@ impl Window {
     #[inline]
     pub fn set_transparent(&self, transparent: bool) {
         let _span = tracing::debug_span!("winit::Window::set_transparent", transparent).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_transparent(transparent))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.set_transparent(transparent))
     }
 
     /// Change the window blur state.
@@ -959,7 +967,7 @@ impl Window {
     #[inline]
     pub fn set_blur(&self, blur: bool) {
         let _span = tracing::debug_span!("winit::Window::set_blur", blur).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_blur(blur))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_blur(blur))
     }
 
     /// Modifies the window's visibility.
@@ -973,7 +981,7 @@ impl Window {
     #[inline]
     pub fn set_visible(&self, visible: bool) {
         let _span = tracing::debug_span!("winit::Window::set_visible", visible).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_visible(visible))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_visible(visible))
     }
 
     /// Gets the window's current visibility state.
@@ -988,7 +996,7 @@ impl Window {
     #[inline]
     pub fn is_visible(&self) -> Option<bool> {
         let _span = tracing::debug_span!("winit::Window::is_visible",).entered();
-        self.window.maybe_wait_on_main(|w| w.is_visible())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.is_visible())
     }
 
     /// Sets whether the window is resizable or not.
@@ -1009,7 +1017,7 @@ impl Window {
     #[inline]
     pub fn set_resizable(&self, resizable: bool) {
         let _span = tracing::debug_span!("winit::Window::set_resizable", resizable).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_resizable(resizable))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_resizable(resizable))
     }
 
     /// Gets the window's current resizable state.
@@ -1021,7 +1029,7 @@ impl Window {
     #[inline]
     pub fn is_resizable(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::is_resizable",).entered();
-        self.window.maybe_wait_on_main(|w| w.is_resizable())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.is_resizable())
     }
 
     /// Sets the enabled window buttons.
@@ -1036,7 +1044,8 @@ impl Window {
             buttons = ?buttons
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_enabled_buttons(buttons))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.set_enabled_buttons(buttons))
     }
 
     /// Gets the enabled window buttons.
@@ -1047,7 +1056,7 @@ impl Window {
     /// - **Web / iOS / Android:** Unsupported. Always returns [`WindowButtons::all`].
     pub fn enabled_buttons(&self) -> WindowButtons {
         let _span = tracing::debug_span!("winit::Window::enabled_buttons",).entered();
-        self.window.maybe_wait_on_main(|w| w.enabled_buttons())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.enabled_buttons())
     }
 
     /// Sets the window to minimized or back
@@ -1059,7 +1068,7 @@ impl Window {
     #[inline]
     pub fn set_minimized(&self, minimized: bool) {
         let _span = tracing::debug_span!("winit::Window::set_minimized", minimized).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_minimized(minimized))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_minimized(minimized))
     }
 
     /// Gets the window's current minimized state.
@@ -1077,7 +1086,7 @@ impl Window {
     #[inline]
     pub fn is_minimized(&self) -> Option<bool> {
         let _span = tracing::debug_span!("winit::Window::is_minimized",).entered();
-        self.window.maybe_wait_on_main(|w| w.is_minimized())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.is_minimized())
     }
 
     /// Sets the window to maximized or back.
@@ -1088,7 +1097,7 @@ impl Window {
     #[inline]
     pub fn set_maximized(&self, maximized: bool) {
         let _span = tracing::debug_span!("winit::Window::set_maximized", maximized).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_maximized(maximized))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_maximized(maximized))
     }
 
     /// Gets the window's current maximized state.
@@ -1099,7 +1108,7 @@ impl Window {
     #[inline]
     pub fn is_maximized(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::is_maximized",).entered();
-        self.window.maybe_wait_on_main(|w| w.is_maximized())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.is_maximized())
     }
 
     /// Sets the window to fullscreen or back.
@@ -1131,7 +1140,9 @@ impl Window {
             fullscreen = ?fullscreen
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_fullscreen(fullscreen.map(|f| f.into())))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| {
+            w.set_fullscreen(fullscreen.map(|f: Fullscreen| f.into()))
+        })
     }
 
     /// Gets the window's current fullscreen state.
@@ -1145,7 +1156,9 @@ impl Window {
     #[inline]
     pub fn fullscreen(&self) -> Option<Fullscreen> {
         let _span = tracing::debug_span!("winit::Window::fullscreen",).entered();
-        self.window.maybe_wait_on_main(|w| w.fullscreen().map(|f| f.into()))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| {
+            w.fullscreen().map(|f: platform_impl::Fullscreen| f.into())
+        })
     }
 
     /// Turn window decorations on or off.
@@ -1160,7 +1173,8 @@ impl Window {
     #[inline]
     pub fn set_decorations(&self, decorations: bool) {
         let _span = tracing::debug_span!("winit::Window::set_decorations", decorations).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_decorations(decorations))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.set_decorations(decorations))
     }
 
     /// Gets the window's current decorations state.
@@ -1174,7 +1188,7 @@ impl Window {
     #[inline]
     pub fn is_decorated(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::is_decorated",).entered();
-        self.window.maybe_wait_on_main(|w| w.is_decorated())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.is_decorated())
     }
 
     /// Change the window level.
@@ -1188,7 +1202,7 @@ impl Window {
             level = ?level
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_window_level(level))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_window_level(level))
     }
 
     /// Sets the window icon.
@@ -1208,7 +1222,8 @@ impl Window {
     #[inline]
     pub fn set_window_icon(&self, window_icon: Option<Icon>) {
         let _span = tracing::debug_span!("winit::Window::set_window_icon",).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_window_icon(window_icon))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.set_window_icon(window_icon))
     }
 
     /// Set the IME cursor editing area, where the `position` is the top left corner of that area
@@ -1255,7 +1270,9 @@ impl Window {
             size = ?size,
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_ime_cursor_area(position, size))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| {
+            w.set_ime_cursor_area(position, size)
+        })
     }
 
     /// Sets whether the window should get IME events
@@ -1283,7 +1300,7 @@ impl Window {
     #[inline]
     pub fn set_ime_allowed(&self, allowed: bool) {
         let _span = tracing::debug_span!("winit::Window::set_ime_allowed", allowed).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_ime_allowed(allowed))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_ime_allowed(allowed))
     }
 
     /// Sets the IME purpose for the window using [`ImePurpose`].
@@ -1298,7 +1315,7 @@ impl Window {
             purpose = ?purpose
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_ime_purpose(purpose))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_ime_purpose(purpose))
     }
 
     /// Brings the window to the front and sets input focus. Has no effect if the window is
@@ -1314,7 +1331,7 @@ impl Window {
     #[inline]
     pub fn focus_window(&self) {
         let _span = tracing::debug_span!("winit::Window::focus_window",).entered();
-        self.window.maybe_queue_on_main(|w| w.focus_window())
+        self.window.maybe_queue_on_main(|w: &platform_impl::Window| w.focus_window())
     }
 
     /// Gets whether the window has keyboard focus.
@@ -1325,7 +1342,7 @@ impl Window {
     #[inline]
     pub fn has_focus(&self) -> bool {
         let _span = tracing::debug_span!("winit::Window::has_focus",).entered();
-        self.window.maybe_wait_on_main(|w| w.has_focus())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.has_focus())
     }
 
     /// Requests user attention to the window, this has no effect if the application
@@ -1348,7 +1365,9 @@ impl Window {
             request_type = ?request_type
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.request_user_attention(request_type))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| {
+            w.request_user_attention(request_type)
+        })
     }
 
     /// Set or override the window theme.
@@ -1369,7 +1388,7 @@ impl Window {
             theme = ?theme
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.set_theme(theme))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_theme(theme))
     }
 
     /// Returns the current window theme.
@@ -1383,7 +1402,7 @@ impl Window {
     #[inline]
     pub fn theme(&self) -> Option<Theme> {
         let _span = tracing::debug_span!("winit::Window::theme",).entered();
-        self.window.maybe_wait_on_main(|w| w.theme())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.theme())
     }
 
     /// Prevents the window contents from being captured by other apps.
@@ -1398,7 +1417,9 @@ impl Window {
     pub fn set_content_protected(&self, protected: bool) {
         let _span =
             tracing::debug_span!("winit::Window::set_content_protected", protected).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_content_protected(protected))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| {
+            w.set_content_protected(protected)
+        })
     }
 
     /// Gets the current title of the window.
@@ -1409,7 +1430,7 @@ impl Window {
     #[inline]
     pub fn title(&self) -> String {
         let _span = tracing::debug_span!("winit::Window::title",).entered();
-        self.window.maybe_wait_on_main(|w| w.title())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.title())
     }
 }
 
@@ -1426,7 +1447,7 @@ impl Window {
     pub fn set_cursor(&self, cursor: impl Into<Cursor>) {
         let cursor = cursor.into();
         let _span = tracing::debug_span!("winit::Window::set_cursor",).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_cursor(cursor))
+        self.window.maybe_queue_on_main(move |w: &platform_impl::Window| w.set_cursor(cursor))
     }
 
     /// Deprecated! Use [`Window::set_cursor()`] instead.
@@ -1462,7 +1483,7 @@ impl Window {
             position = ?position
         )
         .entered();
-        self.window.maybe_wait_on_main(|w| w.set_cursor_position(position))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.set_cursor_position(position))
     }
 
     /// Set grabbing [mode][CursorGrabMode] on the cursor preventing it from leaving the window.
@@ -1487,7 +1508,7 @@ impl Window {
             mode = ?mode
         )
         .entered();
-        self.window.maybe_wait_on_main(|w| w.set_cursor_grab(mode))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.set_cursor_grab(mode))
     }
 
     /// Modifies the cursor's visibility.
@@ -1505,7 +1526,8 @@ impl Window {
     #[inline]
     pub fn set_cursor_visible(&self, visible: bool) {
         let _span = tracing::debug_span!("winit::Window::set_cursor_visible", visible).entered();
-        self.window.maybe_queue_on_main(move |w| w.set_cursor_visible(visible))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.set_cursor_visible(visible))
     }
 
     /// Moves the window with the left mouse button until the button is released.
@@ -1522,7 +1544,7 @@ impl Window {
     #[inline]
     pub fn drag_window(&self) -> Result<(), ExternalError> {
         let _span = tracing::debug_span!("winit::Window::drag_window",).entered();
-        self.window.maybe_wait_on_main(|w| w.drag_window())
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.drag_window())
     }
 
     /// Resizes the window with the left mouse button until the button is released.
@@ -1541,7 +1563,7 @@ impl Window {
             direction = ?direction
         )
         .entered();
-        self.window.maybe_wait_on_main(|w| w.drag_resize_window(direction))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.drag_resize_window(direction))
     }
 
     /// Show [window menu] at a specified position .
@@ -1560,7 +1582,8 @@ impl Window {
             position = ?position
         )
         .entered();
-        self.window.maybe_queue_on_main(move |w| w.show_window_menu(position))
+        self.window
+            .maybe_queue_on_main(move |w: &platform_impl::Window| w.show_window_menu(position))
     }
 
     /// Modifies whether the window catches cursor events.
@@ -1575,7 +1598,7 @@ impl Window {
     #[inline]
     pub fn set_cursor_hittest(&self, hittest: bool) -> Result<(), ExternalError> {
         let _span = tracing::debug_span!("winit::Window::set_cursor_hittest", hittest).entered();
-        self.window.maybe_wait_on_main(|w| w.set_cursor_hittest(hittest))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| w.set_cursor_hittest(hittest))
     }
 }
 
@@ -1587,7 +1610,9 @@ impl Window {
     #[inline]
     pub fn current_monitor(&self) -> Option<MonitorHandle> {
         let _span = tracing::debug_span!("winit::Window::current_monitor",).entered();
-        self.window.maybe_wait_on_main(|w| w.current_monitor().map(|inner| MonitorHandle { inner }))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| {
+            w.current_monitor().map(|inner| MonitorHandle { inner })
+        })
     }
 
     /// Returns the list of all the monitors available on the system.
@@ -1599,7 +1624,7 @@ impl Window {
     #[inline]
     pub fn available_monitors(&self) -> impl Iterator<Item = MonitorHandle> {
         let _span = tracing::debug_span!("winit::Window::available_monitors",).entered();
-        self.window.maybe_wait_on_main(|w| {
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| {
             w.available_monitors().into_iter().map(|inner| MonitorHandle { inner })
         })
     }
@@ -1618,7 +1643,9 @@ impl Window {
     #[inline]
     pub fn primary_monitor(&self) -> Option<MonitorHandle> {
         let _span = tracing::debug_span!("winit::Window::primary_monitor",).entered();
-        self.window.maybe_wait_on_main(|w| w.primary_monitor().map(|inner| MonitorHandle { inner }))
+        self.window.maybe_wait_on_main(|w: &platform_impl::Window| {
+            w.primary_monitor().map(|inner| MonitorHandle { inner })
+        })
     }
 }
 
@@ -1658,7 +1685,11 @@ unsafe impl<T> Send for UnsafeSendWrapper<T> {}
 #[cfg(feature = "rwh_05")]
 unsafe impl rwh_05::HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> rwh_05::RawWindowHandle {
-        self.window.maybe_wait_on_main(|w| UnsafeSendWrapper(w.raw_window_handle_rwh_05())).0
+        self.window
+            .maybe_wait_on_main(|w: &platform_impl::Window| {
+                UnsafeSendWrapper(w.raw_window_handle_rwh_05())
+            })
+            .0
     }
 }
 
@@ -1669,14 +1700,22 @@ unsafe impl rwh_05::HasRawDisplayHandle for Window {
     ///
     /// [`EventLoop`]: crate::event_loop::EventLoop
     fn raw_display_handle(&self) -> rwh_05::RawDisplayHandle {
-        self.window.maybe_wait_on_main(|w| UnsafeSendWrapper(w.raw_display_handle_rwh_05())).0
+        self.window
+            .maybe_wait_on_main(|w: &platform_impl::Window| {
+                UnsafeSendWrapper(w.raw_display_handle_rwh_05())
+            })
+            .0
     }
 }
 
 #[cfg(feature = "rwh_04")]
 unsafe impl rwh_04::HasRawWindowHandle for Window {
     fn raw_window_handle(&self) -> rwh_04::RawWindowHandle {
-        self.window.maybe_wait_on_main(|w| UnsafeSendWrapper(w.raw_window_handle_rwh_04())).0
+        self.window
+            .maybe_wait_on_main(|w: &platform_impl::Window| {
+                UnsafeSendWrapper(w.raw_window_handle_rwh_04())
+            })
+            .0
     }
 }
 


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

## Summary

Starting with Rust 1.92, the compiler can no longer infer types for closure
parameters passed to `maybe_wait_on_main` and `maybe_queue_on_main` in
`src/window.rs`. This causes 59 `E0282` errors when building winit 0.30.12 on
any Rust version from 1.92 onward — including **stable 1.93.1**.

## Changes

- Add `|w: &platform_impl::Window|` type annotations to all 59 closures in
  `src/window.rs` that use `maybe_wait_on_main`/`maybe_queue_on_main`
- Add `Fullscreen` type annotations to 3 inner `.map()` closures that call
  `.into()` on fullscreen state
- Fix `function_casts_as_integer` warning in X11 IME `context.rs` by casting
  through `*const ()` first
- Add changelog entries

## Tested on

All versions failed with 59-63 `E0282` errors **before** this patch and
compile cleanly **after**:

- nightly-2026-02-14 (rustc 1.95.0)
- nightly-2026-02-10 (rustc 1.95.0)
- nightly-2026-02-05 (rustc 1.95.0)
- nightly-2026-01-15 (rustc 1.94.0)
- nightly-2025-12-01 (rustc 1.93.0)
- nightly-2025-10-01 (rustc 1.92.0)
- stable 1.93.1

Fixes #4486