### PR TITLE
winit-x11: fix debug mode overflow panic in `set_timestamp`

### DIFF
--- a/winit-x11/src/xdisplay.rs
+++ b/winit-x11/src/xdisplay.rs
@@ -250,9 +250,7 @@ impl XConnection {
         // Store the timestamp in the slot if it's greater than the last one.
         let mut last_timestamp = self.timestamp.load(Ordering::Relaxed);
         loop {
-            let wrapping_sub = |a: xproto::Timestamp, b: xproto::Timestamp| (a as i32) - (b as i32);
-
-            if wrapping_sub(timestamp, last_timestamp) <= 0 {
+            if (timestamp as i32).wrapping_sub(last_timestamp as i32) <= 0 {
                 break;
             }
 

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -55,3 +55,4 @@ changelog entry.
 - On Redox, handle `EINTR` when reading from `event_socket` instead of panicking.
 - On Wayland, switch from using the `ahash` hashing algorithm to `foldhash`.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.
+- On X11, fix debug mode overflow panic in `set_timestamp`.


### PR DESCRIPTION
Fixes #4484

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
