### PR TITLE
winit-x11: replace XQueryKeymap with equivalent x11rb call

### DIFF
--- a/winit-x11/src/util/keys.rs
+++ b/winit-x11/src/util/keys.rs
@@ -60,12 +60,6 @@ impl Iterator for KeymapIter<'_> {
 
 impl XConnection {
     pub fn query_keymap(&self) -> Keymap {
-        // let mut keys = [0 as c_char; 32];
-
-        // unsafe {
-        //     (self.xlib.XQueryKeymap)(self.display, keys.as_mut_ptr() as *mut c_char);
-        // }
-
         let keys = self
             .xcb_connection()
             .query_keymap()


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

Don't believe this really needs any documentation changes as it's really just an implementation thing. This PR does two things:

- replaces `XQueryKeymap` with `XCBConnection::query_keymap`
- slightly optimizes the `first_bit` helper function in that same file