### PR TITLE
fix(android): Populate `KeyEvent.text` via `Key::to_text()`

### DIFF
--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -473,16 +473,23 @@ impl EventLoop {
                             &mut self.combining_accent,
                         );
 
+                        let logical_key = keycodes::to_logical(key_char, keycode);
+                        let text = if state == event::ElementState::Pressed {
+                            logical_key.to_text().map(smol_str::SmolStr::new)
+                        } else {
+                            None
+                        };
+
                         let event = event::WindowEvent::KeyboardInput {
                             device_id: Some(DeviceId::from_raw(key.device_id() as i64)),
                             event: event::KeyEvent {
                                 state,
                                 physical_key: keycodes::to_physical_key(keycode),
-                                logical_key: keycodes::to_logical(key_char, keycode),
+                                logical_key,
                                 location: keycodes::to_location(keycode),
                                 repeat: key.repeat_count() > 0,
-                                text: None,
-                                text_with_all_modifiers: None,
+                                text: text.clone(),
+                                text_with_all_modifiers: text,
                                 key_without_modifiers: keycodes::to_logical(key_char, keycode),
                             },
                             is_synthetic: false,

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -791,7 +791,7 @@ pub struct KeyEvent {
     ///
     /// ## Platform-specific
     ///
-    /// - **Android:** Unimplemented, this field is always the same value as `text`.
+    /// - **Android:** This field is always the same value as `text`.
     /// - **iOS:** Unimplemented, this field is always the same value as `text`.
     /// - **Web:** Unsupported, this field is always the same value as `text`.
     pub text_with_all_modifiers: Option<SmolStr>,

--- a/winit/src/changelog/v0.31.md
+++ b/winit/src/changelog/v0.31.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Fixed panic when calling `Window::set_ime_allowed`.
+- On Android, populate `KeyEvent::text` and `KeyEvent::text_with_all_modifiers` via `Key::to_text()`
 
 ## 0.31.0-beta.1
 


### PR DESCRIPTION
The `text` field on `KeyEvent` was hardcoded to `None` on Android, making it impossible for custom `NativeActivity` subclasses that show the IME to receive functional text input using *for example* the existing `winit-egui` crate which relies on this field being set.

Use `Key::to_text()` on press events to derive `text` from `logical_key`, matching the convention used by the Windows and macOS backends.

Supposedly that doesn't include all kinds of special virtual unicode keys, but at least the basics work this way.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] ~Created or updated an example program if it would help users understand this functionality~ N/A