### PR TITLE
Android: implement `Window::safe_area`

### DIFF
--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -6,9 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use android_activity::input::{InputEvent, KeyAction, Keycode, MotionAction};
-use android_activity::{
-    AndroidApp, AndroidAppWaker, ConfigurationRef, InputStatus, MainEvent, Rect,
-};
+use android_activity::{AndroidApp, AndroidAppWaker, ConfigurationRef, InputStatus, MainEvent};
 use dpi::{PhysicalInsets, PhysicalPosition, PhysicalSize, Position, Size};
 use tracing::{debug, trace, warn};
 use winit_core::application::ApplicationHandler;
@@ -193,9 +191,7 @@ impl EventLoop {
                 },
                 MainEvent::WindowResized { .. } => resized = true,
                 MainEvent::RedrawNeeded { .. } => pending_redraw = true,
-                MainEvent::ContentRectChanged { .. } => {
-                    warn!("TODO: find a way to notify application of content rect change");
-                },
+                MainEvent::ContentRectChanged { .. } => pending_redraw = true,
                 MainEvent::GainedFocus => {
                     HAS_FOCUS.store(true, Ordering::Relaxed);
                     let event = event::WindowEvent::Focused(true);
@@ -784,10 +780,6 @@ impl Window {
         self.app.config()
     }
 
-    pub(crate) fn content_rect(&self) -> Rect {
-        self.app.content_rect()
-    }
-
     // Allow the usage of HasRawWindowHandle inside this function
     #[allow(deprecated)]
     fn raw_window_handle_rwh_06(&self) -> Result<rwh_06::RawWindowHandle, rwh_06::HandleError> {
@@ -852,7 +844,7 @@ impl CoreWindow for Window {
     fn pre_present_notify(&self) {}
 
     fn surface_position(&self) -> PhysicalPosition<i32> {
-        (0, 0).into()
+        (0.0, 0.0).into()
     }
 
     fn outer_position(&self) -> Result<PhysicalPosition<i32>, RequestError> {
@@ -876,7 +868,14 @@ impl CoreWindow for Window {
     }
 
     fn safe_area(&self) -> PhysicalInsets<u32> {
-        PhysicalInsets::new(0, 0, 0, 0)
+        let insets = self.app.content_rect();
+        let outer_size = self.outer_size();
+        PhysicalInsets {
+            top: insets.top as u32,
+            left: insets.left as u32,
+            bottom: outer_size.height.saturating_sub(insets.bottom as u32),
+            right: outer_size.width.saturating_sub(insets.right as u32),
+        }
     }
 
     fn set_min_surface_size(&self, _: Option<Size>) {}

--- a/winit-android/src/lib.rs
+++ b/winit-android/src/lib.rs
@@ -77,7 +77,7 @@ mod keycodes;
 use winit_core::event_loop::ActiveEventLoop as CoreActiveEventLoop;
 use winit_core::window::Window as CoreWindow;
 
-use self::activity::{AndroidApp, ConfigurationRef, Rect};
+use self::activity::{AndroidApp, ConfigurationRef};
 pub use crate::event_loop::{
     ActiveEventLoop, EventLoop, EventLoopProxy, PlatformSpecificEventLoopAttributes,
     PlatformSpecificWindowAttributes, Window,
@@ -97,17 +97,10 @@ pub trait ActiveEventLoopExtAndroid {
 
 /// Additional methods on [`Window`] that are specific to Android.
 pub trait WindowExtAndroid {
-    fn content_rect(&self) -> Rect;
-
     fn config(&self) -> ConfigurationRef;
 }
 
 impl WindowExtAndroid for dyn CoreWindow + '_ {
-    fn content_rect(&self) -> Rect {
-        let window = self.cast_ref::<Window>().unwrap();
-        window.content_rect()
-    }
-
     fn config(&self) -> ConfigurationRef {
         let window = self.cast_ref::<Window>().unwrap();
         window.config()

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -768,7 +768,7 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// ## Platform-specific
     ///
-    /// - **Android / Orbital / Wayland / Windows / X11:** Unimplemented, returns `(0, 0, 0, 0)`.
+    /// - **Orbital / Wayland / Windows / X11:** Unimplemented, returns `(0, 0, 0, 0)`.
     ///
     /// ## Example
     ///

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -44,6 +44,7 @@ changelog entry.
 
 - Add `keyboard` support for OpenHarmony.
 - On iOS, add Apple Pencil support with force, altitude, and azimuth data.
+- On Android, implement `Window::safe_area`. This replaces `WindowExtAndroid::content_rect` which has been removed.
 
 ### Changed
 


### PR DESCRIPTION
Implements `Window::safe_area` for Android. This replaces the platform-specific `WindowExtAndroid::content_rect` method.

Android provides the `top` and `right` coordinates as offsets from the top left (0, 0) point rather than as insets from the nearest side. So these are subtracted from the outer size to normalize them according the existing semantics of `Window::safe_area`.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
