### PR TITLE
fix(macOS) "fix" toggling IME on appkit backend

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -872,24 +872,33 @@ impl WinitView {
             false
         }
     }
+    pub(super) fn enable_ime(&self, capabilities: ImeCapabilities) {
+        // This seems reasonable but the prior behavior of `set_ime_allowed` doesn't do this
+        // (it was also broken but let's not break things worse)
 
-    pub(super) fn set_ime_allowed(&self, capabilities: Option<ImeCapabilities>) {
-        if self.ivars().ime_capabilities.get().is_some() {
-            return;
-        }
-        self.ivars().ime_capabilities.set(capabilities);
+        // if self.ivars().ime_capabilities.get().is_none() {
+        //     self.ivars().ime_state.set(ImeState::Ground);
+        // }
 
-        if capabilities.is_some() {
-            return;
-        }
-
-        // Clear markedText
-        *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
-
+        // why are we disabling things in an enable fn? who knows. it's what the previous one did
+        // though
         if self.ivars().ime_state.get() != ImeState::Disabled {
             self.ivars().ime_state.set(ImeState::Disabled);
             self.queue_event(WindowEvent::Ime(Ime::Disabled));
         }
+        self.ivars().ime_capabilities.set(Some(capabilities));
+        *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
+    }
+    pub(super) fn disable_ime(&self) {
+        // see above
+        self.ivars().ime_capabilities.set(None);
+        if self.ivars().ime_state.get() != ImeState::Disabled {
+            self.ivars().ime_state.set(ImeState::Disabled);
+            self.queue_event(WindowEvent::Ime(Ime::Disabled));
+        }
+        // we probably don't need to do this, but again this mirrors the prior behavior of
+        // `set_ime_allowed`
+        *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
     }
 
     pub(super) fn ime_capabilities(&self) -> Option<ImeCapabilities> {

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -1686,7 +1686,7 @@ impl WindowDelegate {
                 if current_caps.is_some() {
                     return Err(ImeRequestError::AlreadyEnabled);
                 }
-                self.view().set_ime_allowed(Some(capabilities));
+                self.view().enable_ime(capabilities);
                 request_data
             },
             ImeRequest::Update(request_data) => {
@@ -1696,7 +1696,7 @@ impl WindowDelegate {
                 request_data
             },
             ImeRequest::Disable => {
-                self.view().set_ime_allowed(None);
+                self.view().disable_ime();
                 return Ok(());
             },
         };

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -58,3 +58,4 @@ changelog entry.
 - On Windows, fix `WM_IME_SETCONTEXT` IME UI flag masking on `lParam`.
 - On macOS, fix crash in `set_marked_text` when native Pinyin IME sends out-of-bounds `selected_range`.
 - On X11, fix debug mode overflow panic in `set_timestamp`.
+- On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.


### PR DESCRIPTION
- [X] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [N/A] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [N/A] Created or updated an example program if it would help users understand this functionality

Fixes #4432, although there are still countless other bugs in the implementation. For context, I'm planning on experimenting with a rewrite of the appkit IME backend, based loosely on Chromium's workarounds, and this makes the internal api a bit nicer for that. It's also an easy "harm reduction" fix for a simple bug (unlike the rest of the NSTextInputClient related issues).
