### PR TITLE
feature(macOS) add option to treat control clicks as right (secondary) clicks

### DIFF
--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -173,6 +173,12 @@ pub trait WindowExtMacOS {
     /// Getter for the [`WindowExtMacOS::set_option_as_alt`].
     fn option_as_alt(&self) -> OptionAsAlt;
 
+    /// Set whether a left click with control held should be treated as a right (secondary) click
+    fn set_ctrl_click_to_secondary(&self, ctrl_click_to_secondary: bool);
+
+    /// Getter for the [`WindowExtMacOS::set_ctrl_click_to_secondary`]
+    fn ctrl_click_to_secondary(&self) -> bool;
+
     /// Disable the Menu Bar and Dock in Simple or Borderless Fullscreen mode. Useful for games.
     /// The effect is applied when [`WindowExtMacOS::set_simple_fullscreen`] or
     /// [`Window::set_fullscreen`] is called.
@@ -275,6 +281,18 @@ impl WindowExtMacOS for dyn Window + '_ {
     }
 
     #[inline]
+    fn set_ctrl_click_to_secondary(&self, ctrl_click_to_secondary: bool) {
+        let window = self.cast_ref::<AppKitWindow>().unwrap();
+        window.maybe_wait_on_main(move |w| w.set_ctrl_click_to_secondary(ctrl_click_to_secondary));
+    }
+
+    #[inline]
+    fn ctrl_click_to_secondary(&self) -> bool {
+        let window = self.cast_ref::<AppKitWindow>().unwrap();
+        window.maybe_wait_on_main(|w| w.ctrl_click_to_secondary())
+    }
+
+    #[inline]
     fn set_borderless_game(&self, borderless_game: bool) {
         let window = self.cast_ref::<AppKitWindow>().unwrap();
         window.maybe_wait_on_main(|w| w.set_borderless_game(borderless_game))
@@ -338,6 +356,7 @@ pub struct WindowAttributesMacOS {
     pub(crate) accepts_first_mouse: bool,
     pub(crate) tabbing_identifier: Option<String>,
     pub(crate) option_as_alt: OptionAsAlt,
+    pub(crate) ctrl_click_to_secondary: bool,
     pub(crate) borderless_game: bool,
     pub(crate) unified_titlebar: bool,
     pub(crate) panel: bool,
@@ -423,6 +442,13 @@ impl WindowAttributesMacOS {
         self
     }
 
+    /// Set whether a left click with control held should be remapped to a right (secondary) click
+    #[inline]
+    pub fn with_ctrl_click_to_secondary(mut self, ctrl_click_to_secondary: bool) -> Self {
+        self.ctrl_click_to_secondary = ctrl_click_to_secondary;
+        self
+    }
+
     /// See [`WindowExtMacOS::set_borderless_game`] for details on what this means if set.
     #[inline]
     pub fn with_borderless_game(mut self, borderless_game: bool) -> Self {
@@ -465,6 +491,7 @@ impl Default for WindowAttributesMacOS {
             accepts_first_mouse: true,
             tabbing_identifier: None,
             option_as_alt: Default::default(),
+            ctrl_click_to_secondary: false,
             borderless_game: false,
             unified_titlebar: false,
             panel: false,

--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -137,6 +137,12 @@ pub struct ViewState {
 
     /// The state of the `Option` as `Alt`.
     option_as_alt: Cell<OptionAsAlt>,
+
+    /// Whether to treat a left click while control is held as a right (secondary) click
+    ctrl_click_to_secondary: Cell<bool>,
+    /// Whether the next LMB release should be treated as a right click because it was initiated as
+    /// a secondary click (see above)
+    lmb_press_is_secondary: Cell<bool>,
 }
 
 define_class!(
@@ -799,6 +805,7 @@ impl WinitView {
         app_state: &Rc<AppState>,
         accepts_first_mouse: bool,
         option_as_alt: OptionAsAlt,
+        ctrl_click_to_secondary: bool,
         mtm: MainThreadMarker,
     ) -> Retained<Self> {
         let this = mtm.alloc().set_ivars(ViewState {
@@ -814,8 +821,10 @@ impl WinitView {
             ime_capabilities: Default::default(),
             forward_key_to_app: Default::default(),
             marked_text: Default::default(),
+            lmb_press_is_secondary: Default::default(),
             accepts_first_mouse,
             option_as_alt: Cell::new(option_as_alt),
+            ctrl_click_to_secondary: Cell::new(ctrl_click_to_secondary),
         });
         let this: Retained<Self> = unsafe { msg_send![super(this), init] };
 
@@ -926,6 +935,14 @@ impl WinitView {
 
     pub(super) fn option_as_alt(&self) -> OptionAsAlt {
         self.ivars().option_as_alt.get()
+    }
+
+    pub(super) fn set_ctrl_click_to_secondary(&self, ctrl_click_to_secondary: bool) {
+        self.ivars().ctrl_click_to_secondary.set(ctrl_click_to_secondary);
+    }
+
+    pub(super) fn ctrl_click_to_secondary(&self) -> bool {
+        self.ivars().ctrl_click_to_secondary.get()
     }
 
     /// Update modifiers if `event` has something different
@@ -1056,7 +1073,24 @@ impl WinitView {
 
     fn mouse_click(&self, event: &NSEvent, button_state: ElementState) {
         let position = self.mouse_view_point(event).to_physical(self.scale_factor());
-        let button = mouse_button(event);
+        let mut button = mouse_button(event);
+
+        if self.ivars().ctrl_click_to_secondary.get() && button == MouseButton::Left {
+            match button_state {
+                ElementState::Pressed => {
+                    let modifiers = self.ivars().modifiers.get().state();
+                    if modifiers.contains(ModifiersState::CONTROL) {
+                        self.ivars().lmb_press_is_secondary.set(true);
+                        button = MouseButton::Right;
+                    }
+                },
+                ElementState::Released => {
+                    if self.ivars().lmb_press_is_secondary.take() {
+                        button = MouseButton::Right;
+                    }
+                },
+            }
+        }
 
         self.update_modifiers(event, false);
 

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -711,6 +711,7 @@ fn new_window(
             app_state,
             macos_attrs.accepts_first_mouse,
             macos_attrs.option_as_alt,
+            macos_attrs.ctrl_click_to_secondary,
             mtm,
         );
 
@@ -2002,6 +2003,14 @@ impl WindowExtMacOS for WindowDelegate {
 
     fn option_as_alt(&self) -> OptionAsAlt {
         self.view().option_as_alt()
+    }
+
+    fn set_ctrl_click_to_secondary(&self, ctrl_click_to_secondary: bool) {
+        self.view().set_ctrl_click_to_secondary(ctrl_click_to_secondary);
+    }
+
+    fn ctrl_click_to_secondary(&self) -> bool {
+        self.view().ctrl_click_to_secondary()
     }
 
     fn set_borderless_game(&self, borderless_game: bool) {

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -44,6 +44,7 @@ changelog entry.
 
 - Add `keyboard` support for OpenHarmony.
 - On iOS, add Apple Pencil support with force, altitude, and azimuth data.
+- On macOS, add off-by-default `ctrl_click_to_secondary` window attribute to treat left clicks as right clicks while `CONTROL` is held.
 
 ### Changed
 


### PR DESCRIPTION
Provides an option that resolves #4469.
- [x] Tested on all platforms changed
- [X] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
