### PR TITLE
macOS: Feature-gate `CGSSetWindowBackgroundBlurRadius`

### DIFF
--- a/winit-appkit/Cargo.toml
+++ b/winit-appkit/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [features]
+private-apple-apis = []
 serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]
 
 [dependencies]

--- a/winit-appkit/src/ffi.rs
+++ b/winit-appkit/src/ffi.rs
@@ -4,8 +4,6 @@
 
 use std::ffi::c_void;
 
-use objc2::ffi::NSInteger;
-use objc2::runtime::AnyObject;
 use objc2_core_foundation::{CFString, CFUUID, cf_type};
 use objc2_core_graphics::CGDirectDisplayID;
 
@@ -26,17 +24,6 @@ unsafe extern "C" {
     pub fn CGDisplayCreateUUIDFromDisplayID(display: CGDirectDisplayID) -> *mut CFUUID;
 
     pub fn CGDisplayGetDisplayIDFromUUID(uuid: &CFUUID) -> CGDirectDisplayID;
-}
-
-#[link(name = "CoreGraphics", kind = "framework")]
-unsafe extern "C" {
-    // Wildly used private APIs; Apple uses them for their Terminal.app.
-    pub fn CGSMainConnectionID() -> *mut AnyObject;
-    pub fn CGSSetWindowBackgroundBlurRadius(
-        connection_id: *mut AnyObject,
-        window_id: NSInteger,
-        radius: i64,
-    ) -> i32;
 }
 
 #[repr(transparent)]

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -57,7 +57,6 @@ use winit_core::window::{
 
 use super::app_state::AppState;
 use super::cursor::{CustomCursor, cursor_from_icon};
-use super::ffi;
 use super::monitor::{self, MonitorHandle, flip_window_screen_coordinates, get_display_id};
 use super::util::cgerr;
 use super::view::WinitView;
@@ -1101,17 +1100,30 @@ impl WindowDelegate {
     }
 
     pub fn set_blur(&self, blur: bool) {
-        // NOTE: in general we want to specify the blur radius, but the choice of 80
-        // should be a reasonable default.
-        let radius = if blur { 80 } else { 0 };
-        let window_number = self.window().windowNumber();
-        unsafe {
-            ffi::CGSSetWindowBackgroundBlurRadius(
-                ffi::CGSMainConnectionID(),
-                window_number,
-                radius,
-            );
+        #[cfg(feature = "private-apple-apis")]
+        {
+            #[link(name = "CoreGraphics", kind = "framework")]
+            unsafe extern "C" {
+                // Wildly used private APIs; Apple uses them for their Terminal.app.
+                pub fn CGSMainConnectionID() -> *mut objc2::runtime::AnyObject;
+                pub fn CGSSetWindowBackgroundBlurRadius(
+                    connection_id: *mut objc2::runtime::AnyObject,
+                    window_id: objc2_foundation::NSInteger,
+                    radius: i64,
+                ) -> i32;
+            }
+
+            // NOTE: in general we want to specify the blur radius, but the choice of 80
+            // should be a reasonable default.
+            let radius = if blur { 80 } else { 0 };
+            let window_number = self.window().windowNumber();
+            unsafe {
+                CGSSetWindowBackgroundBlurRadius(CGSMainConnectionID(), window_number, radius)
+            };
         }
+
+        // TODO: Implement blur using public methods somehow?
+        let _ = blur;
     }
 
     pub fn set_visible(&self, visible: bool) {

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -879,6 +879,7 @@ pub trait Window: AsAny + Send + Sync + fmt::Debug {
     ///
     /// ## Platform-specific
     ///
+    /// - **macOS**: Must enable the `private-apple-apis` Cargo feature.
     /// - **Android / iOS / X11 / Web / Windows:** Unsupported.
     /// - **Wayland:** Only works with `org_kde_kwin_blur_manager` or
     ///   `ext_background_effect_manager_v1` protocol.

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -44,6 +44,7 @@ default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 android-game-activity = ["winit-android/game-activity"]
 android-native-activity = ["winit-android/native-activity"]
 mint = ["dpi/mint"]
+private-apple-apis = ["winit-appkit/private-apple-apis"]
 serde = [
     "dep:serde",
     "cursor-icon/serde",

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -56,6 +56,7 @@ changelog entry.
 
 - Updated `windows-sys` to `v0.61`.
 - On older macOS versions (tested up to 12.7.6), applications now receive mouse movement events for unfocused windows, matching the behavior on other platforms.
+- On macOS, using the private API `CGSSetWindowBackgroundBlurRadius` for `Window::set_blur` is now disabled by default. It can be re-enabled using the Cargo feature `private-apple-apis`.
 
 ### Fixed
 

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -195,6 +195,9 @@
 //! * `rwh_06`: Implement `raw-window-handle v0.6` traits.
 //! * `serde`: Enables serialization/deserialization of certain types with [Serde](https://crates.io/crates/serde).
 //! * `mint`: Enables mint (math interoperability standard types) conversions.
+//! * `private-apple-apis`: Enables private APIs whose usage might cause rejections from the App
+//!   Store. Currently enables the use of `CGSSetWindowBackgroundBlurRadius`, commonly used for
+//!   terminal emulators.
 //!
 //! See the [`platform`] module for documentation on platform-specific cargo
 //! features.


### PR DESCRIPTION
Feature-gate `CGSSetWindowBackgroundBlurRadius` behind the Cargo feature `private-apple-apis`.

Fixes https://github.com/rust-windowing/winit/issues/4205.

- [x] Tested on all platforms changed
  - We don't really have an example to test it properly (since all our examples render something static), but calling `set_blur(true)` works both with and without the feature enabled.
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
