### PR TITLE
wayland: treat flush WouldBlock as recoverable back-pressure

### DIFF
--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -264,9 +264,21 @@ impl EventLoop {
             //
             // Checking for flush error is essential to perform an exit with error, since
             // once we have a protocol error, we could get stuck retrying...
-            if self.handle.connection.flush().is_err() {
-                self.set_exit_code(1);
-                return;
+            match self.handle.connection.flush() {
+                Ok(()) => {},
+                Err(sctk::reexports::client::backend::WaylandError::Io(e))
+                    if e.kind() == std::io::ErrorKind::WouldBlock =>
+                {
+                    // EAGAIN/WouldBlock from the kernel socket: SO_SNDBUF is full.
+                    // libwayland documents this as recoverable back-pressure — the
+                    // poll(POLLOUT) on the next loop iteration will drain the buffer
+                    // and we can retry. Mirrors the pattern in
+                    // calloop-wayland-source's `flush_queue`.
+                },
+                Err(_) => {
+                    self.set_exit_code(1);
+                    return;
+                },
             }
 
             if let Err(error) = self.loop_dispatch(timeout) {

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -61,3 +61,8 @@ changelog entry.
 - On Wayland, switch from using the `ahash` hashing algorithm to `foldhash`.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.
+- On Wayland, treat `wl_display.flush()` returning `WouldBlock` as
+  recoverable back-pressure rather than a fatal error. Previously the
+  event loop would exit with code 1 on transient kernel send-buffer
+  saturation; it now retries on the next loop iteration as libwayland
+  documents.


### PR DESCRIPTION
## Summary

Fix a long-standing wayland event-loop bug where any error from
`connection.flush()` is treated as fatal. `WaylandError::Io(WouldBlock)`
returned from EAGAIN on the wayland socket is recoverable
back-pressure, not a protocol error, and should be retried on the next
loop iteration rather than calling `set_exit_code(1)`.

This matches the pattern already used by
[`calloop-wayland-source`'s `flush_queue`](https://github.com/Smithay/calloop-wayland-source/blob/master/src/lib.rs)
and is consistent with [libwayland's documented contract for
`wl_display_flush`](https://wayland.freedesktop.org/docs/html/apb.html#Client-classwl__display_1ad9f0e6cab9b50da9aff10a14d5cdc59c).

## Reproducer

A client that issues many wayland requests in a tight burst — e.g.
~4000 `xdg_toplevel.set_title` / `set_size` calls within 60 ms from
multiple threads — saturates the kernel SO_SNDBUF (~208 KiB by default).
The next `wl_display.flush()` returns `WaylandError::Io(WouldBlock)`
and the event loop currently exits with code 1.

After this fix, the same workload completes cleanly: the next loop
iteration's `poll(POLLOUT)` drains the buffer and the next flush
succeeds.

## Test plan

- [x] Applied to a downstream embedder (winit consumer); the same
      stress workload that previously killed the loop in ~80 ms now
      runs 25,000 requests in under 1 s without errors.

## Notes

- Verified with `cargo +nightly fmt --check` (nightly rustfmt 1.9.0):
  the added code is fmt-clean. There is some pre-existing import-order
  drift in upstream master unrelated to this fix; not touched here to
  keep the PR focused.

## Checklist (winit PR template)

- [x] Tested on Wayland (only changes Wayland code path)
- [x] Added an entry to the `changelog` module
- [ ] Documentation updated — N/A, no API surface change
- [ ] Created or updated an example program — N/A, this is an internal
      bug fix