### PR TITLE
docs: clarify how to create windows from ActiveEventLoop

### DIFF
--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -15,7 +15,10 @@
 //! }
 //! ```
 //!
-//! Then you create a [`Window`] with [`create_window`].
+//! Then you launch the event loop with [`EventLoop::run_app()`], which gives your
+//! [`ApplicationHandler`] callbacks an [`ActiveEventLoop`]. Use that active event loop to create a
+//! [`Window`] with [`create_window`]; the example below does this in
+//! [`ApplicationHandler::can_create_surfaces`], after the platform is ready for surface creation.
 //!
 //! # Event handling
 //!
@@ -258,6 +261,9 @@
 //! [`EventLoop`]: event_loop::EventLoop
 //! [`EventLoop::new()`]: event_loop::EventLoop::new
 //! [`EventLoop::run_app()`]: event_loop::EventLoop::run_app
+//! [`ActiveEventLoop`]: event_loop::ActiveEventLoop
+//! [`ApplicationHandler`]: application::ApplicationHandler
+//! [`ApplicationHandler::can_create_surfaces`]: application::ApplicationHandler::can_create_surfaces
 //! [`exit()`]: event_loop::ActiveEventLoop::exit
 //! [`Window`]: window::Window
 //! [`WindowId`]: window::WindowId


### PR DESCRIPTION
Fixes #3877.

## Reproduction

The crate-level "Building windows" documentation currently shows creating an
`EventLoop`, then immediately says to create a `Window` with `create_window`.
That skips the step where users obtain an `ActiveEventLoop`, which is the value
that actually exposes `create_window`.

## Why this is a small fix

The existing example already creates the window from an `ApplicationHandler`
callback. This PR only adds the missing explanation: `EventLoop::run_app()`
launches the loop and passes an `ActiveEventLoop` to the handler callbacks, and
that active event loop should be used to create the window.

## Backward compatibility

This is documentation-only. No API, behavior, examples, or runtime code are
changed.

## Checks

* `cargo check -p winit` passed
* `cargo test -p winit --doc` passed
* `cargo fmt --check` fails due to existing formatting / rustfmt configuration unrelated to this docs-only change
