### PR TITLE
win32: avoid showing hidden windows when applying window state

### DIFF
--- a/winit-win32/src/window_state.rs
+++ b/winit-win32/src/window_state.rs
@@ -344,7 +344,10 @@ impl WindowFlags {
             return;
         }
 
-        if new.contains(WindowFlags::VISIBLE) {
+        if new.contains(WindowFlags::VISIBLE)
+            && !new.contains(WindowFlags::MAXIMIZED)
+            && !new.contains(WindowFlags::MINIMIZED)
+        {
             let flag = if !self.contains(WindowFlags::MARKER_ACTIVATE) {
                 self.set(WindowFlags::MARKER_ACTIVATE, true);
                 SW_SHOWNOACTIVATE
@@ -379,7 +382,9 @@ impl WindowFlags {
             }
         }
 
-        if diff.contains(WindowFlags::MAXIMIZED) || new.contains(WindowFlags::MAXIMIZED) {
+        if new.contains(WindowFlags::VISIBLE)
+            && (diff.contains(WindowFlags::MAXIMIZED) || new.contains(WindowFlags::MAXIMIZED))
+        {
             unsafe {
                 ShowWindow(window, match new.contains(WindowFlags::MAXIMIZED) {
                     true => SW_MAXIMIZE,
@@ -389,7 +394,9 @@ impl WindowFlags {
         }
 
         // Minimize operations should execute after maximize for proper window animations
-        if diff.contains(WindowFlags::MINIMIZED) {
+        if new.contains(WindowFlags::VISIBLE)
+            && (diff.contains(WindowFlags::MINIMIZED) || new.contains(WindowFlags::MINIMIZED))
+        {
             unsafe {
                 ShowWindow(window, match new.contains(WindowFlags::MINIMIZED) {
                     true => SW_MINIMIZE,

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -61,3 +61,4 @@ changelog entry.
 - On Wayland, switch from using the `ahash` hashing algorithm to `foldhash`.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.
+- On Windows, avoid briefly showing hidden windows when applying maximized or minimized state.


### PR DESCRIPTION
On Windows, `ShowWindow(SW_MAXIMIZE)` and `ShowWindow(SW_MINIMIZE)` can make a hidden window visible.

This currently causes a problem when a window is configured while hidden. For example, eframe creates its window hidden, applies the persisted maximized state, renders the first frame, and only then shows the window. But when winit applies the maximized state, it calls `ShowWindow(SW_MAXIMIZE)` even though the target state is still hidden. The window can briefly appear before the first frame is rendered, causing a white flash.

This change avoids calling the show/maximize/minimize `ShowWindow` commands while the target window state is hidden. If the window is supposed to become visible and maximized/minimized, that state is applied when it is shown.

It also avoids doing a normal `SW_SHOW` first when the target state is maximized or minimized, so the window is shown directly in the intended state.

Tested with:

- `cargo +nightly fmt`
- `cargo check -p winit-win32`

Also tested downstream in an eframe app on Windows, where this fixes the startup flash when reopening a persisted maximized window. An example of the flicker/flash is shown in this egui issue - https://github.com/emilk/egui/issues/7746.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality