### PR TITLE
macOS: fix CJK punctuation dropped when insertText: called without hasMarkedText()

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -371,9 +371,24 @@ define_class!(
 
             let is_control = string.chars().next().is_some_and(|c| c.is_control());
 
-            // Commit only if we have marked text.
-            if self.hasMarkedText() && self.is_ime_enabled() && !is_control {
-                self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
+            // Commit the text whenever the IME is enabled and the string is
+            // not a control character.  The original guard `hasMarkedText()`
+            // was too strict: some input methods (e.g. macOS Chinese
+            // Simplified Pinyin) convert punctuation keys by calling
+            // `insertText:` *without* a prior `setMarkedText:`, so
+            // `hasMarkedText()` is `false` even though the text is the
+            // IME-converted result (e.g. `,` → `，`).
+            //
+            // Without this change winit silently drops the converted
+            // character and the raw ASCII key from `NSEvent.characters`
+            // reaches the application instead.
+            //
+            // When `hasMarkedText()` is `true` we still clear the preedit
+            // first, preserving the existing preedit-then-commit sequence.
+            if self.is_ime_enabled() && !is_control {
+                if self.hasMarkedText() {
+                    self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
+                }
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                 self.ivars().ime_state.set(ImeState::Committed);
             }

--- a/winit-x11/src/event_processor.rs
+++ b/winit-x11/src/event_processor.rs
@@ -1757,7 +1757,7 @@ impl EventProcessor {
                 .find(|prev_monitor| prev_monitor.name == new_monitor.name)
                 .map(|prev_monitor| prev_monitor.scale_factor);
             if Some(new_monitor.scale_factor) != maybe_prev_scale_factor {
-                for window in self.target.windows.borrow().iter().filter_map(|(_, w)| w.upgrade()) {
+                for window in self.target.windows.borrow().values().filter_map(|w| w.upgrade()) {
                     window.refresh_dpi_for_monitor(
                         &new_monitor,
                         maybe_prev_scale_factor,

--- a/winit/src/changelog/v0.31.md
+++ b/winit/src/changelog/v0.31.md
@@ -1,6 +1,14 @@
 ## 0.31.0-beta.2
 
-### Added
+### Fixed
+
+- On macOS, `insertText:replacementRange:` now always emits `Ime::Commit`
+  when the IME is enabled, even when `hasMarkedText()` is `false`. This
+  fixes Chinese (and potentially other CJK) punctuation input: the macOS
+  Chinese Simplified Pinyin IME converts punctuation keys (e.g. `,` →
+  `，`) via a direct `insertText:` call without a prior `setMarkedText:`,
+  causing the converted character to be silently dropped and the raw ASCII
+  key to reach the application instead.
 
 - Add `EventLoopExtRegister::register_app` for being explicit about how the event loop runs on Web.
 - Add `EventLoopExtNeverReturn::run_app_never_return` for being explicit about how the event loop runs on iOS.


### PR DESCRIPTION
## Summary

The macOS Chinese Simplified Pinyin IME (and likely other CJK input methods) converts punctuation keys by calling `insertText:replacementRange:` **without** a prior `setMarkedText:` call. Because `hasMarkedText()` is `false` at that point, the previous code silently dropped the converted character and the raw ASCII key from `NSEvent.characters` reached the application.

**Example**: pressing `,` in Chinese input mode should produce `，` (Chinese comma), but the application received `,` (ASCII) because `，` was never emitted as `Ime::Commit`.

This affects at least:
- Chinese Simplified Pinyin (confirmed): all punctuation keys — `，` `。` `？` `！` `；` `：` `「` `」` etc.
- Likely other CJK IMEs that use direct `insertText:` for non-composition keys.

## Root Cause

```rust
// Before: Commit only if we have marked text.
if self.hasMarkedText() && self.is_ime_enabled() && !is_control {
    ...emit Commit...
}
// Otherwise: silently dropped!
```

When an IME converts a key directly (no preedit), `hasMarkedText()` is `false`, so the committed text was dropped. The `keyDown:` callback then generated `KeyboardInput` with the raw `NSEvent.characters` (ASCII).

## Fix

Emit `Ime::Commit` whenever `is_ime_enabled()` is true, regardless of `hasMarkedText()`:

```rust
if self.is_ime_enabled() && !is_control {
    if self.hasMarkedText() {
        // Preserve existing preedit-clear-before-commit behaviour.
        self.queue_event(Ime::Preedit(String::new(), None));
    }
    self.queue_event(Ime::Commit(string));
    self.ivars().ime_state.set(ImeState::Committed);
}
```

`ImeState::Committed` is set in both paths, so `keyDown:` treats the key as handled (`had_ime_input = true`) and does **not** generate a duplicate `KeyboardInput` event with the raw ASCII character.

## Testing

- [x] Chinese Simplified Pinyin: punctuation (`，` `。` `？` `！` `；` `：`), full-width ASCII (`ｆｏｒ`), and composed characters (`nihao` → `你好`) all work correctly.
- [x] No duplicate ASCII character emitted alongside `Ime::Commit`.
- [x] Standard preedit-then-commit sequence (setMarkedText → insertText) unchanged.
- [ ] Japanese IME — needs testing (architecture similar to Chinese, expected no regression)
- [ ] Korean IME — needs testing (see also #4478 which touches related code)

## Relation to #4478

PR #4478 fixes Korean-specific double-input and key-loss bugs. This PR is orthogonal: it fixes the case where `insertText:` is called without any prior `setMarkedText:`, which the Korean PR does not address.