### PR TITLE
winit-orbital: Fix i586 build

### DIFF
--- a/winit-orbital/src/event_loop.rs
+++ b/winit-orbital/src/event_loop.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 use std::collections::VecDeque;
+use std::os::raw::c_long;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Instant;
@@ -642,7 +643,7 @@ impl EventLoop {
 
                 if let Some(duration) = instant.checked_duration_since(start) {
                     time.tv_sec += duration.as_secs() as i64;
-                    time.tv_nsec += duration.subsec_nanos() as i64;
+                    time.tv_nsec += duration.subsec_nanos() as c_long;
                     // Normalize timespec so tv_nsec is not greater than one second.
                     while time.tv_nsec >= 1_000_000_000 {
                         time.tv_sec += 1;


### PR DESCRIPTION
`timespec.tv_nsec` is `c_long`. In `i586-unknown-redox` it's `i32`, so the type mismatch here causes compilation fail for the platform.

References: 
- [`timespec.tv_nsec`](https://github.com/rust-lang/libc/blob/59e4578dae5a78f116b8448da829d9fd249e64e1/src/unix/mod.rs#L82)

- [X] Tested on all platforms changed
- [X] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [X] Created or updated an example program if it would help users understand this functionality

