### PR TITLE
windows: fix freeze on keyboard layout switch (Punto Switcher)

### DIFF
--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -51,12 +51,12 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     SystemParametersInfoW, TranslateMessage, WHEEL_DELTA, WINDOWPOS, WM_CAPTURECHANGED, WM_CLOSE,
     WM_CREATE, WM_DESTROY, WM_DPICHANGED, WM_ENTERSIZEMOVE, WM_EXITSIZEMOVE, WM_GETMINMAXINFO,
     WM_IME_COMPOSITION, WM_IME_ENDCOMPOSITION, WM_IME_SETCONTEXT, WM_IME_STARTCOMPOSITION,
-    WM_INPUT, WM_KEYDOWN, WM_KEYUP, WM_KILLFOCUS, WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN,
-    WM_MBUTTONUP, WM_MENUCHAR, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL, WM_NCACTIVATE,
-    WM_NCCALCSIZE, WM_NCCREATE, WM_NCDESTROY, WM_NCLBUTTONDOWN, WM_PAINT, WM_POINTERDOWN,
-    WM_POINTERUP, WM_POINTERUPDATE, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR, WM_SETFOCUS,
-    WM_SETTINGCHANGE, WM_SIZE, WM_SIZING, WM_SYSCOMMAND, WM_SYSKEYDOWN, WM_SYSKEYUP, WM_TOUCH,
-    WM_WINDOWPOSCHANGED, WM_WINDOWPOSCHANGING, WM_XBUTTONDOWN, WM_XBUTTONUP, WMSZ_BOTTOM,
+    WM_INPUT, WM_INPUTLANGCHANGE, WM_KEYDOWN, WM_KEYUP, WM_KILLFOCUS, WM_LBUTTONDOWN, WM_LBUTTONUP,
+    WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MENUCHAR, WM_MOUSEHWHEEL, WM_MOUSEMOVE, WM_MOUSEWHEEL,
+    WM_NCACTIVATE, WM_NCCALCSIZE, WM_NCCREATE, WM_NCDESTROY, WM_NCLBUTTONDOWN, WM_PAINT,
+    WM_POINTERDOWN, WM_POINTERUP, WM_POINTERUPDATE, WM_RBUTTONDOWN, WM_RBUTTONUP, WM_SETCURSOR,
+    WM_SETFOCUS, WM_SETTINGCHANGE, WM_SIZE, WM_SIZING, WM_SYSCOMMAND, WM_SYSKEYDOWN, WM_SYSKEYUP,
+    WM_TOUCH, WM_WINDOWPOSCHANGED, WM_WINDOWPOSCHANGING, WM_XBUTTONDOWN, WM_XBUTTONUP, WMSZ_BOTTOM,
     WMSZ_BOTTOMLEFT, WMSZ_BOTTOMRIGHT, WMSZ_LEFT, WMSZ_RIGHT, WMSZ_TOP, WMSZ_TOPLEFT,
     WMSZ_TOPRIGHT, WNDCLASSEXW, WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW,
     WS_EX_TRANSPARENT, WS_OVERLAPPED, WS_POPUP, WS_VISIBLE,
@@ -1506,6 +1506,21 @@ unsafe fn public_window_callback_inner(
             // IME UI visibility flags are in lparam.
             let lparam = lparam & !(ISC_SHOWUICOMPOSITIONWINDOW as isize);
             result = ProcResult::Value(unsafe { DefWindowProcW(window, msg, wparam, lparam) });
+        },
+
+        WM_INPUTLANGCHANGE => {
+            // Refresh the cached keyboard layout for the newly activated input
+            // language. This message is sent (by Windows or by layout switchers
+            // such as Punto Switcher) after the layout changes. Refreshing the
+            // cache here prevents a freeze that otherwise occurs when switching
+            // layout via such tools. We still defer to `DefWindowProc` so the
+            // message keeps propagating to first-level child windows, as the
+            // Win32 documentation requires.
+            {
+                let mut layouts = LAYOUT_CACHE.lock().unwrap();
+                layouts.get_current_layout();
+            }
+            result = ProcResult::DefWindowProc(wparam);
         },
 
         // this is necessary for us to maintain minimize/restore state

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -57,6 +57,10 @@ changelog entry.
 
 ### Fixed
 
+- On Windows, fix a freeze that occurs when the keyboard layout is switched by
+  tools such as Punto Switcher. The `WM_INPUTLANGCHANGE` message is now handled
+  to refresh the cached keyboard layout, while still deferring to
+  `DefWindowProc` for normal propagation.
 - On Redox, handle `EINTR` when reading from `event_socket` instead of panicking.
 - On Wayland, switch from using the `ahash` hashing algorithm to `foldhash`.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.


### PR DESCRIPTION
## Summary

Fixes a freeze that affects any winit application on Windows when the keyboard
layout is switched by tools such as **Punto Switcher** (a popular auto layout
switcher). The window stops responding until the process is killed.

This was originally found and fixed in Warp's winit fork
([warpdotdev/winit#15](https://github.com/warpdotdev/winit/pull/15)); this PR
ports the same change to upstream.

## Root cause (from a minidump of the frozen process)

A full dump was taken with procdump on the frozen window (original, unpatched
code) and analyzed with `minidump-stackwalk` using symbols generated from the
local system DLLs (so x64 unwind/CFI is exact).

Reliable top of the main thread:

```
0  win32u.dll!NtUserMsgWaitForMultipleObjectsEx        (instruction pointer)
1  winit::...::event_loop::wait_for_messages_impl       (Found by: call frame info)
2  user32.dll!CallNextHookEx
3  user32.dll!...
```

- The thread is blocked in **`MsgWaitForMultipleObjectsEx`** — winit's
  event-loop wait (`wait_for_messages_impl`) — **re-entered** during message
  dispatch.
- **`pshook64.dll`** (Punto Switcher's global hook) is injected into the process
  and present on the stack (`CallNextHookEx`), i.e. it runs on our thread during
  dispatch.
- **No mutex / `LAYOUT_CACHE` / `WaitOnAddress` frames anywhere.**

So this is a **re-entrant Win32 message-loop wait** mediated by the layout
switcher's hook, not a Rust mutex self-deadlock.

## Fix

Handle `WM_INPUTLANGCHANGE` to refresh the cached keyboard layout, then defer to
`DefWindowProc` (kept, per the
[Win32 docs](https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-inputlangchange),
so the message still propagates to first-level child windows).

```rust
WM_INPUTLANGCHANGE => {
    { let mut layouts = LAYOUT_CACHE.lock().unwrap(); layouts.get_current_layout(); }
    result = ProcResult::DefWindowProc(wparam);
}
```

## Testing (Windows 11 + Punto Switcher)

Built the winit test app for `x86_64-pc-windows-gnu` and exercised real Punto
Switcher layout switches (English ↔ Russian, confirmed by alphabet changes in
the key log). Isolation variants:

| Variant | `WM_INPUTLANGCHANGE` handler | Result |
|---|---|---|
| original (no handler) | — | **freezes** (dump captured) |
| refresh + `update_modifiers` + `Value(1)` (swallow) | skips DefWindowProc | no freeze |
| **refresh + `DefWindowProc`** (this PR) | keeps DefWindowProc | **no freeze** |
| refresh only + `DefWindowProc`, no `update_modifiers` | keeps DefWindowProc | no freeze |

So the **layout-cache refresh** is the minimal change that stops the freeze;
swallowing the message and `update_modifiers` are not needed.

**Known limitation:** the operative change was isolated empirically, and we have
proven what it is *not* (a mutex deadlock), but the precise reason a cache
refresh prevents the re-entrant wait is not fully traced — Punto Switcher's hook
is closed-source, and the dump shows no layout-loading frames at the freeze
point.

## Related issues

Closes #4584 (standalone bug report with the minidump evidence).

- #1907 — "No way to handle keyboard layout change events" (this PR handles the `WM_INPUTLANGCHANGE` message)
- #2678 — "API for keyboard layouts"

- [x] Tested on all platforms changed (Windows, the only platform changed)
- [x] Added an entry to the `changelog` module
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

