### PR TITLE
winit-win32: Fix Window focus after showing hidden maximized window

### DIFF
--- a/winit-win32/src/window_state.rs
+++ b/winit-win32/src/window_state.rs
@@ -345,12 +345,15 @@ impl WindowFlags {
         }
 
         if new.contains(WindowFlags::VISIBLE) {
-            let flag = if !self.contains(WindowFlags::MARKER_ACTIVATE) {
-                self.set(WindowFlags::MARKER_ACTIVATE, true);
-                SW_SHOWNOACTIVATE
-            } else {
-                SW_SHOW
-            };
+            let flag =
+                if new.contains(WindowFlags::MAXIMIZED) && diff.contains(WindowFlags::VISIBLE) {
+                    SW_MAXIMIZE
+                } else if !self.contains(WindowFlags::MARKER_ACTIVATE) {
+                    self.set(WindowFlags::MARKER_ACTIVATE, true);
+                    SW_SHOWNOACTIVATE
+                } else {
+                    SW_SHOW
+                };
             unsafe {
                 ShowWindow(window, flag);
             }
@@ -379,7 +382,10 @@ impl WindowFlags {
             }
         }
 
-        if diff.contains(WindowFlags::MAXIMIZED) || new.contains(WindowFlags::MAXIMIZED) {
+        if (diff.contains(WindowFlags::MAXIMIZED) || new.contains(WindowFlags::MAXIMIZED))
+            && new.contains(WindowFlags::VISIBLE)
+            && !diff.contains(WindowFlags::VISIBLE)
+        {
             unsafe {
                 ShowWindow(window, match new.contains(WindowFlags::MAXIMIZED) {
                     true => SW_MAXIMIZE,

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -67,3 +67,4 @@ changelog entry.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.
 - On macOS, fix a panic and incorrect cursor position in Ime::Preedit when the preedit string contains special characters (ie. emojis) caused by incorrect UTF-16 to UTF-8 offset conversion.
+- On Windows, fix missing focus events after showing a hidden maximized window.


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality

Fixes #4586 


Previously winit could call `ShowWindow(SW_MAXIMIZE)` while the window was still hidden. It could disturb Win32’s focus state. The fix delays the call until the window is actually shown avoiding calling it twice.