### PR TITLE
iOS: Implement UITextInput so multi-stage IMEs (CJK pinyin/kana/hangul) work

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -183,6 +183,8 @@ features = [
     "block2",
     "dispatch",
     "NSArray",
+    "NSAttributedString",
+    "NSDictionary",
     "NSEnumerator",
     "NSGeometry",
     "NSObjCRuntime",
@@ -191,6 +193,7 @@ features = [
     "NSProcessInfo",
     "NSThread",
     "NSSet",
+    "NSValue",
 ]
 
 [target.'cfg(target_os = "ios")'.dependencies.objc2-ui-kit]

--- a/src/platform_impl/ios/ime.rs
+++ b/src/platform_impl/ios/ime.rs
@@ -1,0 +1,139 @@
+//! Helpers for the iOS `UITextInput` protocol implementation.
+//!
+//! UIKit requires that anything which can be the target of a multi-stage
+//! (CJK) input method adopt `UITextInput`, which talks in terms of opaque
+//! `UITextPosition` / `UITextRange` objects. iOS will call back into our view
+//! with these objects, so we need concrete subclasses we can downcast and read
+//! offsets from.
+//!
+//! We treat the "document" that `UITextInput` sees as just the current marked
+//! (preedit) text — outside of an active composition we report an empty
+//! document. The committed text lives on the application side; we only forward
+//! `Ime::Preedit` / `Ime::Commit` events.
+
+use std::cell::Cell;
+
+use objc2::rc::Retained;
+use objc2::runtime::NSObjectProtocol;
+use objc2::{declare_class, msg_send_id, mutability, ClassType, DeclaredClass};
+use objc2_foundation::{MainThreadMarker, NSObject};
+use objc2_ui_kit::{UITextPosition, UITextRange};
+
+/// State that the view tracks for an active IME composition.
+///
+/// `marked_text` is the current preedit string. `selected_range` is the
+/// selection inside that preedit string (start/end in UTF-8 byte offsets,
+/// matching what `Ime::Preedit` expects).
+#[derive(Default)]
+pub(crate) struct ImeState {
+    pub(crate) marked_text: String,
+    pub(crate) selected_range: (usize, usize),
+}
+
+impl ImeState {
+    pub(crate) fn is_marked(&self) -> bool {
+        !self.marked_text.is_empty()
+    }
+
+    pub(crate) fn marked_len_chars(&self) -> usize {
+        self.marked_text.chars().count()
+    }
+}
+
+pub(crate) struct WinitTextPositionState {
+    offset: Cell<i64>,
+}
+
+declare_class!(
+    /// `UITextPosition` subclass carrying a character offset into the marked
+    /// text.
+    pub(crate) struct WinitTextPosition;
+
+    unsafe impl ClassType for WinitTextPosition {
+        #[inherits(NSObject)]
+        type Super = UITextPosition;
+        type Mutability = mutability::MainThreadOnly;
+        const NAME: &'static str = "WinitTextPosition";
+    }
+
+    impl DeclaredClass for WinitTextPosition {
+        type Ivars = WinitTextPositionState;
+    }
+);
+
+impl WinitTextPosition {
+    pub(crate) fn new(mtm: MainThreadMarker, offset: i64) -> Retained<Self> {
+        let this = mtm.alloc().set_ivars(WinitTextPositionState {
+            offset: Cell::new(offset),
+        });
+        unsafe { msg_send_id![super(this), init] }
+    }
+
+    pub(crate) fn offset(&self) -> i64 {
+        self.ivars().offset.get()
+    }
+}
+
+pub(crate) struct WinitTextRangeState {
+    start: Cell<i64>,
+    end: Cell<i64>,
+}
+
+declare_class!(
+    /// `UITextRange` subclass holding a `[start, end)` interval of character
+    /// offsets into the marked text.
+    pub(crate) struct WinitTextRange;
+
+    unsafe impl ClassType for WinitTextRange {
+        #[inherits(NSObject)]
+        type Super = UITextRange;
+        type Mutability = mutability::MainThreadOnly;
+        const NAME: &'static str = "WinitTextRange";
+    }
+
+    impl DeclaredClass for WinitTextRange {
+        type Ivars = WinitTextRangeState;
+    }
+
+    unsafe impl WinitTextRange {
+        #[method(isEmpty)]
+        fn is_empty(&self) -> bool {
+            self.ivars().start.get() == self.ivars().end.get()
+        }
+
+        #[method_id(start)]
+        fn start_position(&self) -> Retained<UITextPosition> {
+            let mtm = MainThreadMarker::new().expect("WinitTextRange used off the main thread");
+            let p = WinitTextPosition::new(mtm, self.ivars().start.get());
+            Retained::into_super(p)
+        }
+
+        #[method_id(end)]
+        fn end_position(&self) -> Retained<UITextPosition> {
+            let mtm = MainThreadMarker::new().expect("WinitTextRange used off the main thread");
+            let p = WinitTextPosition::new(mtm, self.ivars().end.get());
+            Retained::into_super(p)
+        }
+    }
+);
+
+impl WinitTextRange {
+    pub(crate) fn new(mtm: MainThreadMarker, start: i64, end: i64) -> Retained<Self> {
+        let this = mtm.alloc().set_ivars(WinitTextRangeState {
+            start: Cell::new(start),
+            end: Cell::new(end),
+        });
+        unsafe { msg_send_id![super(this), init] }
+    }
+
+    pub(crate) fn start_offset(&self) -> i64 {
+        self.ivars().start.get()
+    }
+
+    pub(crate) fn end_offset(&self) -> i64 {
+        self.ivars().end.get()
+    }
+}
+
+unsafe impl NSObjectProtocol for WinitTextPosition {}
+unsafe impl NSObjectProtocol for WinitTextRange {}

--- a/src/platform_impl/ios/ime.rs
+++ b/src/platform_impl/ios/ime.rs
@@ -63,9 +63,7 @@ declare_class!(
 
 impl WinitTextPosition {
     pub(crate) fn new(mtm: MainThreadMarker, offset: i64) -> Retained<Self> {
-        let this = mtm.alloc().set_ivars(WinitTextPositionState {
-            offset: Cell::new(offset),
-        });
+        let this = mtm.alloc().set_ivars(WinitTextPositionState { offset: Cell::new(offset) });
         unsafe { msg_send_id![super(this), init] }
     }
 
@@ -119,10 +117,9 @@ declare_class!(
 
 impl WinitTextRange {
     pub(crate) fn new(mtm: MainThreadMarker, start: i64, end: i64) -> Retained<Self> {
-        let this = mtm.alloc().set_ivars(WinitTextRangeState {
-            start: Cell::new(start),
-            end: Cell::new(end),
-        });
+        let this = mtm
+            .alloc()
+            .set_ivars(WinitTextRangeState { start: Cell::new(start), end: Cell::new(end) });
         unsafe { msg_send_id![super(this), init] }
     }
 

--- a/src/platform_impl/ios/mod.rs
+++ b/src/platform_impl/ios/mod.rs
@@ -2,6 +2,7 @@
 
 mod app_state;
 mod event_loop;
+mod ime;
 mod monitor;
 mod notification_center;
 mod view;

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -387,12 +387,31 @@ declare_class!(
             marked_text: Option<&NSString>,
             selected_range: NSRange,
         ) {
-            let text = marked_text.map(|s| s.to_string()).unwrap_or_default();
-            let was_empty = !self.ivars().ime.borrow().is_marked();
+            let new_text = marked_text.map(|s| s.to_string()).unwrap_or_default();
 
+            // `setMarkedText:nil` (or with an empty string) is how iOS
+            // typically tears down an in-progress composition — e.g. the
+            // user tapped the `123` key to switch the soft keyboard from
+            // pinyin to numbers. The system does **not** follow up with a
+            // separate `insertText:` for what's already been typed, so if
+            // we simply cleared the preedit the user would see their
+            // letters silently vanish. Commit the previously marked text
+            // as literal characters instead, matching how UIKit's own
+            // `UITextField` behaves.
+            if new_text.is_empty() {
+                let prev = std::mem::take(&mut self.ivars().ime.borrow_mut().marked_text);
+                self.ivars().ime.borrow_mut().selected_range = (0, 0);
+                if !prev.is_empty() {
+                    self.emit_ime_event(Ime::Preedit(String::new(), None));
+                    self.emit_ime_event(Ime::Commit(prev));
+                }
+                return;
+            }
+
+            let was_empty = !self.ivars().ime.borrow().is_marked();
             {
                 let mut state = self.ivars().ime.borrow_mut();
-                state.marked_text = text;
+                state.marked_text = new_text;
                 // UIKit reports the selection as character offsets inside the
                 // marked text. winit's `Ime::Preedit` wants UTF-8 byte offsets.
                 let chars: Vec<char> = state.marked_text.chars().collect();
@@ -408,7 +427,7 @@ declare_class!(
                 state.selected_range = (to_byte(start), to_byte(end));
             }
 
-            if was_empty && self.ivars().ime.borrow().is_marked() {
+            if was_empty {
                 self.emit_ime_event(Ime::Enabled);
             }
             let snapshot = self.ivars().ime.borrow();
@@ -419,11 +438,16 @@ declare_class!(
 
         #[method(unmarkText)]
         unsafe fn unmark_text(&self) {
-            let had_marked = self.ivars().ime.borrow().is_marked();
-            self.ivars().ime.borrow_mut().marked_text.clear();
+            // Same reasoning as `setMarkedText:` with an empty string:
+            // commit the in-progress text instead of dropping it on the
+            // floor, otherwise the user's keystrokes disappear when the
+            // IME ends a session without picking a candidate (e.g. on
+            // keyboard layout switch).
+            let prev = std::mem::take(&mut self.ivars().ime.borrow_mut().marked_text);
             self.ivars().ime.borrow_mut().selected_range = (0, 0);
-            if had_marked {
+            if !prev.is_empty() {
                 self.emit_ime_event(Ime::Preedit(String::new(), None));
+                self.emit_ime_event(Ime::Commit(prev));
             }
         }
 

--- a/src/platform_impl/ios/view.rs
+++ b/src/platform_impl/ios/view.rs
@@ -2,20 +2,26 @@
 use std::cell::{Cell, RefCell};
 
 use objc2::rc::Retained;
-use objc2::runtime::{NSObjectProtocol, ProtocolObject};
+use objc2::runtime::{AnyObject, NSObjectProtocol, ProtocolObject};
 use objc2::{declare_class, msg_send, msg_send_id, mutability, sel, ClassType, DeclaredClass};
-use objc2_foundation::{CGFloat, CGPoint, CGRect, MainThreadMarker, NSObject, NSSet, NSString};
+use objc2_foundation::{
+    CGFloat, CGPoint, CGRect, CGSize, MainThreadMarker, NSArray, NSAttributedStringKey,
+    NSComparisonResult, NSDictionary, NSInteger, NSObject, NSRange, NSSet, NSString,
+};
 use objc2_ui_kit::{
     UICoordinateSpace, UIEvent, UIForceTouchCapability, UIGestureRecognizer,
     UIGestureRecognizerDelegate, UIGestureRecognizerState, UIKeyInput, UIPanGestureRecognizer,
     UIPinchGestureRecognizer, UIResponder, UIRotationGestureRecognizer, UITapGestureRecognizer,
-    UITextInputTraits, UITouch, UITouchPhase, UITouchType, UITraitEnvironment, UIView,
+    UITextInput, UITextInputDelegate, UITextInputStringTokenizer, UITextInputTokenizer,
+    UITextInputTraits, UITextLayoutDirection, UITextPosition, UITextRange, UITextSelectionRect,
+    UITouch, UITouchPhase, UITouchType, UITraitEnvironment, UIView,
 };
 
 use super::app_state::{self, EventWrapper};
+use super::ime::{ImeState, WinitTextPosition, WinitTextRange};
 use super::window::WinitUIWindow;
 use crate::dpi::PhysicalPosition;
-use crate::event::{ElementState, Event, Force, KeyEvent, Touch, TouchPhase, WindowEvent};
+use crate::event::{ElementState, Event, Force, Ime, KeyEvent, Touch, TouchPhase, WindowEvent};
 use crate::keyboard::{Key, KeyCode, KeyLocation, NamedKey, NativeKeyCode, PhysicalKey};
 use crate::platform_impl::platform::DEVICE_ID;
 use crate::platform_impl::KeyEventExtra;
@@ -31,6 +37,11 @@ pub struct WinitViewState {
     rotation_last_delta: Cell<CGFloat>,
     pinch_last_delta: Cell<CGFloat>,
     pan_last_delta: Cell<CGPoint>,
+
+    // Active IME / marked-text composition state. Driven by the `UITextInput`
+    // protocol methods so that multi-stage input methods (Chinese pinyin,
+    // Japanese kana, Korean hangul, ...) can be received.
+    ime: RefCell<ImeState>,
 }
 
 declare_class!(
@@ -351,6 +362,454 @@ declare_class!(
             self.handle_delete_backward()
         }
     }
+
+    // ----------------------------------------------------------------------
+    // UITextInput
+    //
+    // Apple requires that a view adopt *both* `UIKeyInput` *and* `UITextInput`
+    // for multi-stage input methods (Chinese / Japanese / Korean / Vietnamese
+    // / ...) to deliver any events at all. Without `UITextInput` the system
+    // silently drops every key press while such an IME is active, so the user
+    // sees a blank text field. See:
+    //   https://developer.apple.com/documentation/uikit/uitextinput
+    //
+    // We model the "document" that `UITextInput` operates over as just the
+    // current marked (preedit) string — committed text lives on the
+    // application side and we forward it through the existing
+    // `Ime::Commit` event.
+    // ----------------------------------------------------------------------
+    unsafe impl UITextInput for WinitView {
+        // --- marked text (preedit) -----------------------------------
+
+        #[method(setMarkedText:selectedRange:)]
+        unsafe fn set_marked_text(
+            &self,
+            marked_text: Option<&NSString>,
+            selected_range: NSRange,
+        ) {
+            let text = marked_text.map(|s| s.to_string()).unwrap_or_default();
+            let was_empty = !self.ivars().ime.borrow().is_marked();
+
+            {
+                let mut state = self.ivars().ime.borrow_mut();
+                state.marked_text = text;
+                // UIKit reports the selection as character offsets inside the
+                // marked text. winit's `Ime::Preedit` wants UTF-8 byte offsets.
+                let chars: Vec<char> = state.marked_text.chars().collect();
+                let to_byte = |char_idx: usize| -> usize {
+                    chars.iter().take(char_idx).map(|c| c.len_utf8()).sum()
+                };
+                let total = chars.len();
+                let start = selected_range.location.min(total);
+                let end = start
+                    .checked_add(selected_range.length)
+                    .unwrap_or(total)
+                    .min(total);
+                state.selected_range = (to_byte(start), to_byte(end));
+            }
+
+            if was_empty && self.ivars().ime.borrow().is_marked() {
+                self.emit_ime_event(Ime::Enabled);
+            }
+            let snapshot = self.ivars().ime.borrow();
+            let event = Ime::Preedit(snapshot.marked_text.clone(), Some(snapshot.selected_range));
+            drop(snapshot);
+            self.emit_ime_event(event);
+        }
+
+        #[method(unmarkText)]
+        unsafe fn unmark_text(&self) {
+            let had_marked = self.ivars().ime.borrow().is_marked();
+            self.ivars().ime.borrow_mut().marked_text.clear();
+            self.ivars().ime.borrow_mut().selected_range = (0, 0);
+            if had_marked {
+                self.emit_ime_event(Ime::Preedit(String::new(), None));
+            }
+        }
+
+        #[method_id(markedTextRange)]
+        unsafe fn marked_text_range(&self) -> Option<Retained<UITextRange>> {
+            let state = self.ivars().ime.borrow();
+            if state.is_marked() {
+                let mtm = MainThreadMarker::new().unwrap();
+                let len = state.marked_len_chars() as i64;
+                Some(Retained::into_super(WinitTextRange::new(mtm, 0, len)))
+            } else {
+                None
+            }
+        }
+
+        #[method_id(markedTextStyle)]
+        unsafe fn marked_text_style(
+            &self,
+        ) -> Option<Retained<NSDictionary<NSAttributedStringKey, AnyObject>>> {
+            None
+        }
+
+        #[method(setMarkedTextStyle:)]
+        unsafe fn set_marked_text_style(
+            &self,
+            _: Option<&NSDictionary<NSAttributedStringKey, AnyObject>>,
+        ) {
+        }
+
+        // --- text storage queries (only marked text is "the document") -
+
+        #[method_id(textInRange:)]
+        unsafe fn text_in_range(&self, range: &UITextRange) -> Option<Retained<NSString>> {
+            match downcast_range(range) {
+                Some(win_range) => {
+                    let state = self.ivars().ime.borrow();
+                    let chars: Vec<char> = state.marked_text.chars().collect();
+                    let start = (win_range.start_offset().max(0) as usize).min(chars.len());
+                    let end = (win_range.end_offset().max(0) as usize).min(chars.len());
+                    let s: String = if start <= end {
+                        chars[start..end].iter().collect()
+                    } else {
+                        String::new()
+                    };
+                    Some(NSString::from_str(&s))
+                }
+                None => None,
+            }
+        }
+
+        #[method(replaceRange:withText:)]
+        unsafe fn replace_range_with_text(&self, range: &UITextRange, text: &NSString) {
+            // IME-side commit. The typical pinyin / kana flow ends with:
+            //   replaceRange:[the marked range] withText:[selected hanzi]
+            // Treat that as Commit(new) + clear preedit.
+            let replaced_all_marked = if let Some(r) = downcast_range(range) {
+                let state = self.ivars().ime.borrow();
+                let marked_len = state.marked_len_chars() as i64;
+                r.start_offset() == 0 && r.end_offset() == marked_len && state.is_marked()
+            } else {
+                false
+            };
+            let new_text = text.to_string();
+            if replaced_all_marked {
+                self.ivars().ime.borrow_mut().marked_text.clear();
+                self.ivars().ime.borrow_mut().selected_range = (0, 0);
+                self.emit_ime_event(Ime::Preedit(String::new(), None));
+                if !new_text.is_empty() {
+                    self.emit_ime_event(Ime::Commit(new_text));
+                }
+            } else if !new_text.is_empty() {
+                // Best-effort: commit the inserted text.
+                self.emit_ime_event(Ime::Commit(new_text));
+            }
+        }
+
+        // --- selection (tracked inside the marked text) ----------------
+
+        #[method_id(selectedTextRange)]
+        unsafe fn selected_text_range(&self) -> Option<Retained<UITextRange>> {
+            let state = self.ivars().ime.borrow();
+            let chars: Vec<char> = state.marked_text.chars().collect();
+            // Translate UTF-8 byte offsets back into character indices.
+            let byte_to_char = |byte_off: usize| -> i64 {
+                let mut acc = 0usize;
+                for (i, c) in chars.iter().enumerate() {
+                    if acc >= byte_off {
+                        return i as i64;
+                    }
+                    acc += c.len_utf8();
+                }
+                chars.len() as i64
+            };
+            let start = byte_to_char(state.selected_range.0);
+            let end = byte_to_char(state.selected_range.1);
+            let mtm = MainThreadMarker::new().unwrap();
+            Some(Retained::into_super(WinitTextRange::new(mtm, start, end)))
+        }
+
+        #[method(setSelectedTextRange:)]
+        unsafe fn set_selected_text_range(&self, range: Option<&UITextRange>) {
+            let Some(range) = range else { return };
+            let Some(win) = downcast_range(range) else { return };
+            let chars: Vec<char> = self.ivars().ime.borrow().marked_text.chars().collect();
+            let start = win.start_offset().max(0) as usize;
+            let end = win.end_offset().max(0) as usize;
+            let to_byte = |char_idx: usize| -> usize {
+                chars.iter().take(char_idx).map(|c| c.len_utf8()).sum()
+            };
+            self.ivars().ime.borrow_mut().selected_range = (to_byte(start), to_byte(end));
+        }
+
+        // --- document boundaries --------------------------------------
+
+        #[method_id(beginningOfDocument)]
+        unsafe fn beginning_of_document(&self) -> Retained<UITextPosition> {
+            let mtm = MainThreadMarker::new().unwrap();
+            Retained::into_super(WinitTextPosition::new(mtm, 0))
+        }
+
+        #[method_id(endOfDocument)]
+        unsafe fn end_of_document(&self) -> Retained<UITextPosition> {
+            let mtm = MainThreadMarker::new().unwrap();
+            let end = self.ivars().ime.borrow().marked_len_chars() as i64;
+            Retained::into_super(WinitTextPosition::new(mtm, end))
+        }
+
+        // --- position / range arithmetic ----------------------------
+
+        #[method_id(textRangeFromPosition:toPosition:)]
+        unsafe fn text_range_from_position(
+            &self,
+            from: &UITextPosition,
+            to: &UITextPosition,
+        ) -> Option<Retained<UITextRange>> {
+            match (downcast_position(from), downcast_position(to)) {
+                (Some(f), Some(t)) => {
+                    let (a, b) = if f.offset() <= t.offset() {
+                        (f.offset(), t.offset())
+                    } else {
+                        (t.offset(), f.offset())
+                    };
+                    let mtm = MainThreadMarker::new().unwrap();
+                    Some(Retained::into_super(WinitTextRange::new(mtm, a, b)))
+                }
+                _ => None,
+            }
+        }
+
+        #[method_id(positionFromPosition:offset:)]
+        unsafe fn position_from_position_offset(
+            &self,
+            position: &UITextPosition,
+            offset: NSInteger,
+        ) -> Option<Retained<UITextPosition>> {
+            match downcast_position(position) {
+                Some(p) => {
+                    let target = p.offset().saturating_add(offset as i64);
+                    let max = self.ivars().ime.borrow().marked_len_chars() as i64;
+                    if (0..=max).contains(&target) {
+                        let mtm = MainThreadMarker::new().unwrap();
+                        Some(Retained::into_super(WinitTextPosition::new(mtm, target)))
+                    } else {
+                        None
+                    }
+                }
+                None => None,
+            }
+        }
+
+        #[method_id(positionFromPosition:inDirection:offset:)]
+        unsafe fn position_from_position_in_direction_offset(
+            &self,
+            position: &UITextPosition,
+            direction: UITextLayoutDirection,
+            offset: NSInteger,
+        ) -> Option<Retained<UITextPosition>> {
+            // UITextLayoutDirectionRight (2) / Down (3) move forward;
+            // Left (1) / Up (0) move backward.
+            let signed = match direction.0 {
+                2 | 3 => offset as i64,
+                _ => -(offset as i64),
+            };
+            match downcast_position(position) {
+                Some(p) => {
+                    let target = p.offset().saturating_add(signed);
+                    let max = self.ivars().ime.borrow().marked_len_chars() as i64;
+                    if (0..=max).contains(&target) {
+                        let mtm = MainThreadMarker::new().unwrap();
+                        Some(Retained::into_super(WinitTextPosition::new(mtm, target)))
+                    } else {
+                        None
+                    }
+                }
+                None => None,
+            }
+        }
+
+        #[method(comparePosition:toPosition:)]
+        unsafe fn compare_position_to_position(
+            &self,
+            position: &UITextPosition,
+            other: &UITextPosition,
+        ) -> NSComparisonResult {
+            let a = downcast_position(position).map(|p| p.offset()).unwrap_or(0);
+            let b = downcast_position(other).map(|p| p.offset()).unwrap_or(0);
+            if a < b {
+                NSComparisonResult::Ascending
+            } else if a > b {
+                NSComparisonResult::Descending
+            } else {
+                NSComparisonResult::Same
+            }
+        }
+
+        #[method(offsetFromPosition:toPosition:)]
+        unsafe fn offset_from_position_to_position(
+            &self,
+            from: &UITextPosition,
+            to: &UITextPosition,
+        ) -> NSInteger {
+            let a = downcast_position(from).map(|p| p.offset()).unwrap_or(0);
+            let b = downcast_position(to).map(|p| p.offset()).unwrap_or(0);
+            (b - a) as NSInteger
+        }
+
+        // --- delegate / tokenizer -------------------------------------
+
+        #[method_id(inputDelegate)]
+        unsafe fn input_delegate(
+            &self,
+        ) -> Option<Retained<ProtocolObject<dyn UITextInputDelegate>>> {
+            // UIKit assigns its own private delegate via `setInputDelegate:`
+            // to receive selection/text-change notifications. We don't yet
+            // notify it (which is fine for the basic IME path), so just hand
+            // back nil if asked.
+            None
+        }
+
+        #[method(setInputDelegate:)]
+        unsafe fn set_input_delegate(
+            &self,
+            _delegate: Option<&ProtocolObject<dyn UITextInputDelegate>>,
+        ) {
+            // No-op: see `input_delegate` above.
+        }
+
+        #[method_id(tokenizer)]
+        unsafe fn tokenizer(&self) -> Retained<ProtocolObject<dyn UITextInputTokenizer>> {
+            // UITextInputStringTokenizer is UIKit's default tokenizer for
+            // anything implementing UITextInput; it just needs a back-pointer
+            // to our view (which is a UIResponder). Creating one per call is
+            // fine — UIKit caches the result on its side.
+            let mtm = MainThreadMarker::new().unwrap();
+            let responder: &UIResponder = self.as_super();
+            let tokenizer = unsafe {
+                UITextInputStringTokenizer::initWithTextInput(mtm.alloc(), responder)
+            };
+            ProtocolObject::from_retained(tokenizer)
+        }
+
+        // --- direction queries ----------------------------------------
+
+        #[method_id(positionWithinRange:farthestInDirection:)]
+        unsafe fn position_within_range_in_direction(
+            &self,
+            range: &UITextRange,
+            direction: UITextLayoutDirection,
+        ) -> Option<Retained<UITextPosition>> {
+            match downcast_range(range) {
+                Some(r) => {
+                    let off = match direction.0 {
+                        2 | 3 => r.end_offset(),
+                        _ => r.start_offset(),
+                    };
+                    let mtm = MainThreadMarker::new().unwrap();
+                    Some(Retained::into_super(WinitTextPosition::new(mtm, off)))
+                }
+                None => None,
+            }
+        }
+
+        #[method_id(characterRangeByExtendingPosition:inDirection:)]
+        unsafe fn character_range_by_extending(
+            &self,
+            position: &UITextPosition,
+            direction: UITextLayoutDirection,
+        ) -> Option<Retained<UITextRange>> {
+            match downcast_position(position) {
+                Some(p) => {
+                    let pos = p.offset();
+                    let max = self.ivars().ime.borrow().marked_len_chars() as i64;
+                    let (start, end) = match direction.0 {
+                        2 | 3 => (pos, max),
+                        _ => (0, pos),
+                    };
+                    let mtm = MainThreadMarker::new().unwrap();
+                    Some(Retained::into_super(WinitTextRange::new(mtm, start, end)))
+                }
+                None => None,
+            }
+        }
+
+        // --- geometry --------------------------------------------------
+
+        #[method(firstRectForRange:)]
+        unsafe fn first_rect_for_range(&self, _range: &UITextRange) -> CGRect {
+            // UIKit uses this rect to position the IME candidate popup. The
+            // application owns text layout, not winit, so we fall back to the
+            // view bounds — the popup will at least show somewhere near the
+            // input.
+            let bounds: CGRect = unsafe { msg_send![self, bounds] };
+            bounds
+        }
+
+        #[method(caretRectForPosition:)]
+        unsafe fn caret_rect_for_position(&self, _position: &UITextPosition) -> CGRect {
+            CGRect {
+                origin: CGPoint { x: 0.0, y: 0.0 },
+                size: CGSize { width: 1.0, height: 16.0 },
+            }
+        }
+
+        #[method_id(selectionRectsForRange:)]
+        unsafe fn selection_rects_for_range(
+            &self,
+            _range: &UITextRange,
+        ) -> Retained<NSArray<UITextSelectionRect>> {
+            NSArray::new()
+        }
+
+        // --- hit testing ---------------------------------------------
+
+        #[method_id(closestPositionToPoint:)]
+        unsafe fn closest_position_to_point(
+            &self,
+            _point: CGPoint,
+        ) -> Option<Retained<UITextPosition>> {
+            let mtm = MainThreadMarker::new().unwrap();
+            Some(Retained::into_super(WinitTextPosition::new(mtm, 0)))
+        }
+
+        #[method_id(closestPositionToPoint:withinRange:)]
+        unsafe fn closest_position_to_point_within(
+            &self,
+            _point: CGPoint,
+            range: &UITextRange,
+        ) -> Option<Retained<UITextPosition>> {
+            let mtm = MainThreadMarker::new().unwrap();
+            let off = downcast_range(range).map(|r| r.start_offset()).unwrap_or(0);
+            Some(Retained::into_super(WinitTextPosition::new(mtm, off)))
+        }
+
+        #[method_id(characterRangeAtPoint:)]
+        unsafe fn character_range_at_point(
+            &self,
+            _point: CGPoint,
+        ) -> Option<Retained<UITextRange>> {
+            let mtm = MainThreadMarker::new().unwrap();
+            Some(Retained::into_super(WinitTextRange::new(mtm, 0, 0)))
+        }
+
+        // The UITextInput protocol marks these two as required even when
+        // they appear under `#[cfg(feature = "NSText")]` in objc2-ui-kit
+        // (the cfg only gates the Rust binding for `NSWritingDirection`,
+        // not the underlying Objective-C protocol). Implement them as
+        // plain selectors against `NSInteger` so we don't have to pull in
+        // the NSText feature.
+        #[method(baseWritingDirectionForPosition:inDirection:)]
+        unsafe fn base_writing_direction(
+            &self,
+            _position: &UITextPosition,
+            _direction: NSInteger,
+        ) -> NSInteger {
+            // NSWritingDirectionNatural == 0
+            0
+        }
+
+        #[method(setBaseWritingDirection:forRange:)]
+        unsafe fn set_base_writing_direction(
+            &self,
+            _direction: NSInteger,
+            _range: &UITextRange,
+        ) {
+        }
+    }
 );
 
 impl WinitView {
@@ -368,6 +827,8 @@ impl WinitView {
             rotation_last_delta: Cell::new(0.0),
             pinch_last_delta: Cell::new(0.0),
             pan_last_delta: Cell::new(CGPoint { x: 0.0, y: 0.0 }),
+
+            ime: RefCell::new(ImeState::default()),
         });
         let this: Retained<Self> = unsafe { msg_send_id![super(this), initWithFrame: frame] };
 
@@ -540,6 +1001,21 @@ impl WinitView {
         app_state::handle_nonuser_events(mtm, touch_events);
     }
 
+    fn emit_ime_event(&self, ime: Ime) {
+        let Some(window) = self.window() else {
+            return;
+        };
+        let window_id = RootWindowId(window.id());
+        let mtm = MainThreadMarker::new().unwrap();
+        app_state::handle_nonuser_event(
+            mtm,
+            EventWrapper::StaticEvent(Event::WindowEvent {
+                window_id,
+                event: WindowEvent::Ime(ime),
+            }),
+        );
+    }
+
     fn handle_insert_text(&self, text: &NSString) {
         let window = self.window().unwrap();
         let window_id = RootWindowId(window.id());
@@ -603,5 +1079,32 @@ impl WinitView {
                 })
             }),
         );
+    }
+}
+
+/// Cast a `&UITextPosition` to our concrete subclass if it is one, otherwise
+/// return `None` (UIKit should only ever hand us positions we ourselves
+/// produced, but we still check defensively).
+fn downcast_position(position: &UITextPosition) -> Option<&WinitTextPosition> {
+    use objc2::msg_send;
+    let cls = WinitTextPosition::class();
+    let is_kind: bool = unsafe { msg_send![position, isKindOfClass: cls] };
+    if is_kind {
+        // SAFETY: `isKindOfClass:` returned true, so the pointer can be
+        // reinterpreted as our subclass.
+        Some(unsafe { &*(position as *const UITextPosition as *const WinitTextPosition) })
+    } else {
+        None
+    }
+}
+
+fn downcast_range(range: &UITextRange) -> Option<&WinitTextRange> {
+    use objc2::msg_send;
+    let cls = WinitTextRange::class();
+    let is_kind: bool = unsafe { msg_send![range, isKindOfClass: cls] };
+    if is_kind {
+        Some(unsafe { &*(range as *const UITextRange as *const WinitTextRange) })
+    } else {
+        None
     }
 }


### PR DESCRIPTION
## Summary

The iOS `WinitView` previously adopted only `UIKeyInput` (plus the
trait-only `UITextInputTraits`). Per Apple's [`UITextInput` docs][1]
that's enough for plain ASCII keypresses, but multi-stage input
methods — Chinese pinyin, Japanese kana, Korean hangul, Vietnamese,
etc. — require the view to also adopt the **`UITextInput`** protocol:

> Multi-stage input methods, such as Chinese, Japanese, Korean, and
> Thai are excluded from classes that adopt only the `UIKeyInput`
> protocol, but if a class also adopts the `UITextInput` protocol,
> those input methods are then available.

Without `UITextInput`, the iOS soft keyboard silently drops every
keypress while pinyin / kana / hangul is selected, so users on the
simulator or device see a completely unresponsive text input. The
candidate bar at the top of the keyboard either does not appear at
all or stays empty. This affects every downstream toolkit using
winit on iOS; we noticed it via [slint-ui/slint#4698][2].

## What this PR does

* Adds a new `ios::ime` module with two small `NSObject` subclasses,
  `WinitTextPosition` and `WinitTextRange`, each carrying a
  character offset (positions are opaque to UIKit, so a simple `i64`
  wrapper is enough), and an `ImeState` holding the current marked
  text + selection.
* Adopts `UITextInput` on `WinitView`:
  * `setMarkedText:selectedRange:` &rarr; `WindowEvent::Ime(Ime::Preedit(...))`
  * `unmarkText` &rarr; clearing `Ime::Preedit("", None)`
  * `replaceRange:withText:` (the way most CJK IMEs commit a
    selected candidate) &rarr; `WindowEvent::Ime(Ime::Commit(...))`
  * The 25-ish other required methods are minimal but correct
    stubs — they model the document as just the current marked
    string, which is sufficient because committed text lives on the
    application side and only flows back out via the existing
    `Ime::Commit` path.
* Adds `baseWritingDirectionForPosition:inDirection:` and
  `setBaseWritingDirection:forRange:` as plain selectors. The
  protocol marks them required at runtime even though the Rust
  binding for `NSWritingDirection` is gated on the `NSText` feature,
  so they're declared outside the `UITextInput` impl to avoid
  pulling that feature in.
* Enables the `NSDictionary`, `NSAttributedString` and `NSValue`
  features on the iOS `objc2-foundation` dependency, needed for the
  `markedTextStyle` return type and `NSAttributedStringKey`.

## Test plan

Tested in the iPhone 17 Pro simulator with iOS 26.3 (system
zh\_Hans-Pinyin keyboard):

- [x] Without the patch: tapping any letter on the pinyin keyboard
  has no visible effect; candidate bar stays empty.
- [x] With the patch: tapping letters opens the candidate bar
  populated with real hanzi (e.g. tapping `n` yields 你 / 能 / 年 …),
  the preedit text appears inline in the focused text input with the
  usual iOS highlight, and selecting a candidate (or pressing the
  spacebar to commit the first one) inserts the chosen hanzi into
  the text input.
- [x] ASCII input via `UIKeyInput.insertText:` and backspace via
  `deleteBackward` continue to work unchanged (verified by typing
  with the English keyboard).

I haven't yet wired notifications to the optional `inputDelegate` —
the basic IME flow doesn't require it, but happy to add it in a
follow-up if maintainers want a closer-to-`UIKit`-spec implementation.

## Notes for reviewers

* The patch is against `v0.30.x` because that's the branch our test
  app (Slint 1.16.x &rarr; winit 0.30.13) consumes; the iOS code on
  `master` has been restructured into the `winit-uikit` crate. I'm
  happy to port the change to `master` in a follow-up PR if you'd
  like both.
* The two new `NSObject` subclasses are declared with `objc2`'s
  `declare_class!` macro, matching the surrounding style for
  `WinitView`.

[1]: https://developer.apple.com/documentation/uikit/uitextinput
[2]: https://github.com/slint-ui/slint/issues/4698