### PR TITLE
AppKit: Add tablet tool support

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -8,8 +8,8 @@ use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Sel};
 use objc2::{AnyThread, DefinedClass, MainThreadMarker, define_class, msg_send};
 use objc2_app_kit::{
-    NSApplication, NSCursor, NSEvent, NSEventPhase, NSResponder, NSTextInputClient, NSTrackingArea,
-    NSTrackingAreaOptions, NSView, NSWindow,
+    NSApplication, NSCursor, NSEvent, NSEventPhase, NSEventSubtype, NSPointingDeviceType,
+    NSResponder, NSTextInputClient, NSTrackingArea, NSTrackingAreaOptions, NSView, NSWindow,
 };
 use objc2_core_foundation::CGRect;
 use objc2_foundation::{
@@ -18,8 +18,9 @@ use objc2_foundation::{
 };
 use tracing::{debug_span, trace_span};
 use winit_core::event::{
-    DeviceEvent, ElementState, Ime, KeyEvent, Modifiers, MouseButton, MouseScrollDelta,
-    PointerKind, PointerSource, TouchPhase, WindowEvent,
+    ButtonSource, DeviceEvent, ElementState, Force, Ime, KeyEvent, Modifiers, MouseButton,
+    MouseScrollDelta, PointerKind, PointerSource, TabletToolButton, TabletToolData, TabletToolKind,
+    TabletToolTilt, TouchPhase, WindowEvent,
 };
 use winit_core::keyboard::{Key, KeyCode, KeyLocation, ModifiersState, NamedKey};
 use winit_core::window::ImeCapabilities;
@@ -135,6 +136,13 @@ pub struct ViewState {
 
     /// The state of the `Option` as `Alt`.
     option_as_alt: Cell<OptionAsAlt>,
+
+    /// The tablet tool currently in proximity, if any.
+    ///
+    /// AppKit only reports the tool type on proximity events; tablet-point events always
+    /// report `Unknown`, so the tool announced at proximity time is cached here for use
+    /// by subsequent point and enter/exit events.
+    tablet_tool: Cell<Option<TabletToolKind>>,
 }
 
 define_class!(
@@ -633,7 +641,7 @@ define_class!(
                 device_id: None,
                 primary: true,
                 position,
-                kind: PointerKind::Mouse,
+                kind: self.current_pointer_kind(),
             });
         }
 
@@ -647,8 +655,15 @@ define_class!(
                 device_id: None,
                 primary: true,
                 position: Some(position),
-                kind: PointerKind::Mouse,
+                kind: self.current_pointer_kind(),
             });
+        }
+
+        #[unsafe(method(tabletProximity:))]
+        fn tablet_proximity(&self, event: &NSEvent) {
+            let _entered = debug_span!("tabletProximity:").entered();
+
+            self.update_tablet_tool(event);
         }
 
         #[unsafe(method(scrollWheel:))]
@@ -792,6 +807,7 @@ impl WinitView {
             marked_text: Default::default(),
             accepts_first_mouse,
             option_as_alt: Cell::new(option_as_alt),
+            tablet_tool: Cell::new(None),
         });
         let this: Retained<Self> = unsafe { msg_send![super(this), init] };
         *this.ivars().input_source.borrow_mut() = this.current_input_source();
@@ -1074,6 +1090,7 @@ impl WinitView {
     }
 
     fn mouse_click(&self, event: &NSEvent, button_state: ElementState) {
+        let tablet = self.tablet_event_data(event);
         let position = self.mouse_view_point(event).to_physical(self.scale_factor());
         let button = mouse_button(event);
 
@@ -1084,11 +1101,27 @@ impl WinitView {
             primary: true,
             state: button_state,
             position,
-            button: button.into(),
+            button: match tablet {
+                Some((kind, data)) => ButtonSource::TabletTool {
+                    kind,
+                    button: match button {
+                        // Mirror winit-core's `TabletToolButton` to `MouseButton` conversion table.
+                        MouseButton::Left => TabletToolButton::Contact,
+                        MouseButton::Right => TabletToolButton::Barrel,
+                        MouseButton::Middle => TabletToolButton::Other(1),
+                        MouseButton::Back => TabletToolButton::Other(3),
+                        MouseButton::Forward => TabletToolButton::Other(4),
+                        other => TabletToolButton::Other(other as u16),
+                    },
+                    data,
+                },
+                None => button.into(),
+            },
         });
     }
 
     fn mouse_motion(&self, event: &NSEvent) {
+        let tablet = self.tablet_event_data(event);
         let view_point = self.mouse_view_point(event);
         let frame = self.frame();
 
@@ -1110,8 +1143,51 @@ impl WinitView {
             device_id: None,
             primary: true,
             position: view_point.to_physical(self.scale_factor()),
-            source: PointerSource::Mouse,
+            source: match tablet {
+                Some((kind, data)) => PointerSource::TabletTool { kind, data },
+                None => PointerSource::Mouse,
+            },
         });
+    }
+
+    /// The kind of pointer currently driving the cursor.
+    ///
+    /// Enter/exit events carry no tablet information (`NSEvent::subtype` raises on them),
+    /// so the kind is derived from the cached proximity state instead.
+    fn current_pointer_kind(&self) -> PointerKind {
+        match self.ivars().tablet_tool.get() {
+            Some(kind) => PointerKind::TabletTool(kind),
+            None => PointerKind::Mouse,
+        }
+    }
+
+    /// Update the cached tablet tool from a proximity event.
+    ///
+    /// The caller must ensure `event` is a `TabletProximity` event or a mouse event with
+    /// the `TabletProximity` subtype: the proximity accessors (`pointingDeviceType`,
+    /// `isEnteringProximity`) raise on other events.
+    fn update_tablet_tool(&self, event: &NSEvent) {
+        let tool = event.isEnteringProximity().then(|| tablet_tool_kind(event));
+        self.ivars().tablet_tool.set(tool);
+    }
+
+    /// Handle the tablet parts of a mouse event: update the cached tool on proximity
+    /// transitions and return the tool and its data for tablet-point events.
+    fn tablet_event_data(&self, event: &NSEvent) -> Option<(TabletToolKind, TabletToolData)> {
+        match event.subtype() {
+            NSEventSubtype::TabletPoint => {
+                // The tool kind is only announced at proximity time; if no proximity event
+                // was seen (e.g. the tool was already on the tablet at startup), assume the
+                // most common tool, a pen.
+                let kind = self.ivars().tablet_tool.get().unwrap_or(TabletToolKind::Pen);
+                Some((kind, tablet_tool_data(event)))
+            },
+            NSEventSubtype::TabletProximity => {
+                self.update_tablet_tool(event);
+                None
+            },
+            _ => None,
+        }
     }
 
     fn mouse_view_point(&self, event: &NSEvent) -> LogicalPosition<f64> {
@@ -1134,6 +1210,44 @@ fn mouse_button(event: &NSEvent) -> MouseButton {
         .ok()
         .and_then(MouseButton::try_from_u8)
         .expect("expected MacOS button number in the range 0..=31")
+}
+
+/// Map a tablet proximity `NSEvent`'s pointing device type to a [`TabletToolKind`].
+///
+/// The caller must ensure `event` is a proximity event (type `TabletProximity` or a mouse
+/// event with that subtype): the device type is only reported at proximity time —
+/// tablet-point events always report `Unknown`.
+fn tablet_tool_kind(event: &NSEvent) -> TabletToolKind {
+    let device = event.pointingDeviceType();
+    if device == NSPointingDeviceType::Eraser {
+        TabletToolKind::Eraser
+    } else if device == NSPointingDeviceType::Cursor {
+        // AppKit's `Cursor` is the tablet puck; winit's closest tool kind is `Mouse`.
+        TabletToolKind::Mouse
+    } else {
+        // `Pen` and `Unknown` both map to a pen; it is the most common tool and a
+        // reasonable default for hardware that does not report a specific type.
+        TabletToolKind::Pen
+    }
+}
+
+/// Collect tablet tool data (pressure, barrel pressure, twist, tilt) from a tablet `NSEvent`.
+///
+/// The caller must ensure `event` originates from a tablet (subtype `TabletPoint`): the
+/// tablet-specific accessors (`tilt`, `rotation`, `tangentialPressure`) raise on
+/// non-tablet events.
+fn tablet_tool_data(event: &NSEvent) -> TabletToolData {
+    // `NSEvent::tilt` reports each axis in [-1, 1]; winit expects degrees in [-90, 90].
+    // AppKit's y-up orientation means positive y tilts away from the user, while winit
+    // documents positive y as towards the user, so negate y.
+    let tilt = event.tilt();
+    TabletToolData {
+        force: Some(Force::Normalized(event.pressure() as f64)),
+        tangential_force: Some(event.tangentialPressure()),
+        twist: Some(event.rotation().rem_euclid(360.0) as u16),
+        tilt: Some(TabletToolTilt { x: (tilt.x * 90.0) as i8, y: (-tilt.y * 90.0) as i8 }),
+        angle: None,
+    }
 }
 
 // NOTE: to get option as alt working we need to rewrite events

--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -637,11 +637,16 @@ define_class!(
 
             let position = self.mouse_view_point(event).to_physical(self.scale_factor());
 
+            // Enter/exit events carry no tablet information (`NSEvent::subtype` raises on
+            // them), so the device that crossed the boundary cannot be determined. Report
+            // `Unknown` rather than guessing.
+            // The actual tool and its data are still delivered on the subsequent move and
+            // button events.
             self.queue_event(WindowEvent::PointerEntered {
                 device_id: None,
                 primary: true,
                 position,
-                kind: self.current_pointer_kind(),
+                kind: PointerKind::Unknown,
             });
         }
 
@@ -651,11 +656,13 @@ define_class!(
 
             let position = self.mouse_view_point(event).to_physical(self.scale_factor());
 
+            // See `mouseEntered:` above: enter/exit events cannot identify the device, so
+            // `Unknown` is reported here too.
             self.queue_event(WindowEvent::PointerLeft {
                 device_id: None,
                 primary: true,
                 position: Some(position),
-                kind: self.current_pointer_kind(),
+                kind: PointerKind::Unknown,
             });
         }
 
@@ -1102,18 +1109,8 @@ impl WinitView {
             state: button_state,
             position,
             button: match tablet {
-                Some((kind, data)) => ButtonSource::TabletTool {
-                    kind,
-                    button: match button {
-                        // Mirror winit-core's `TabletToolButton` to `MouseButton` conversion table.
-                        MouseButton::Left => TabletToolButton::Contact,
-                        MouseButton::Right => TabletToolButton::Barrel,
-                        MouseButton::Middle => TabletToolButton::Other(1),
-                        MouseButton::Back => TabletToolButton::Other(3),
-                        MouseButton::Forward => TabletToolButton::Other(4),
-                        other => TabletToolButton::Other(other as u16),
-                    },
-                    data,
+                Some((kind, data)) => {
+                    ButtonSource::TabletTool { kind, button: tablet_button(button), data }
                 },
                 None => button.into(),
             },
@@ -1148,17 +1145,6 @@ impl WinitView {
                 None => PointerSource::Mouse,
             },
         });
-    }
-
-    /// The kind of pointer currently driving the cursor.
-    ///
-    /// Enter/exit events carry no tablet information (`NSEvent::subtype` raises on them),
-    /// so the kind is derived from the cached proximity state instead.
-    fn current_pointer_kind(&self) -> PointerKind {
-        match self.ivars().tablet_tool.get() {
-            Some(kind) => PointerKind::TabletTool(kind),
-            None => PointerKind::Mouse,
-        }
     }
 
     /// Update the cached tablet tool from a proximity event.
@@ -1212,22 +1198,33 @@ fn mouse_button(event: &NSEvent) -> MouseButton {
         .expect("expected MacOS button number in the range 0..=31")
 }
 
+/// Map a [`MouseButton`] reported by a tablet event to its [`TabletToolButton`].
+///
+/// Mirrors winit-core's `TabletToolButton` to `MouseButton` conversion table.
+fn tablet_button(button: MouseButton) -> TabletToolButton {
+    match button {
+        MouseButton::Left => TabletToolButton::Contact,
+        MouseButton::Right => TabletToolButton::Barrel,
+        MouseButton::Middle => TabletToolButton::Other(1),
+        MouseButton::Back => TabletToolButton::Other(3),
+        MouseButton::Forward => TabletToolButton::Other(4),
+        other => TabletToolButton::Other(other as u16),
+    }
+}
+
 /// Map a tablet proximity `NSEvent`'s pointing device type to a [`TabletToolKind`].
 ///
 /// The caller must ensure `event` is a proximity event (type `TabletProximity` or a mouse
 /// event with that subtype): the device type is only reported at proximity time —
 /// tablet-point events always report `Unknown`.
 fn tablet_tool_kind(event: &NSEvent) -> TabletToolKind {
-    let device = event.pointingDeviceType();
-    if device == NSPointingDeviceType::Eraser {
-        TabletToolKind::Eraser
-    } else if device == NSPointingDeviceType::Cursor {
+    match event.pointingDeviceType() {
+        NSPointingDeviceType::Eraser => TabletToolKind::Eraser,
         // AppKit's `Cursor` is the tablet puck; winit's closest tool kind is `Mouse`.
-        TabletToolKind::Mouse
-    } else {
+        NSPointingDeviceType::Cursor => TabletToolKind::Mouse,
         // `Pen` and `Unknown` both map to a pen; it is the most common tool and a
         // reasonable default for hardware that does not report a specific type.
-        TabletToolKind::Pen
+        _ => TabletToolKind::Pen,
     }
 }
 

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -1085,6 +1085,13 @@ pub enum TabletToolKind {
     Lens,
 }
 
+/// Data describing how a tablet tool is held and used.
+///
+/// ## Platform-specific
+///
+/// **macOS:** `angle` is always [`None`]; orientation is reported through `tilt` instead.
+/// Sensor support is not detected, so all other fields are always [`Some`], and tools
+/// lacking a given sensor report zero.
 #[derive(Default, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct TabletToolData {

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -44,6 +44,7 @@ changelog entry.
 
 - Add `keyboard` support for OpenHarmony.
 - On iOS, add Apple Pencil support with force, altitude, and azimuth data.
+- On macOS, add tablet tool support with tool type (pen/eraser), pressure, tilt, twist, and barrel pressure data.
 - On Redox, add support for missing keyboard scancodes.
 - Implement `Send` and `Sync` for `OwnedDisplayHandle`.
 - Use new macOS 15 cursors for resize icons.


### PR DESCRIPTION
Add support to winit-appkit for tablet tools (pen/eraser) with rich inputs like pressure and tilt.

/begin Edit: (explain the issues with accessing data )

Apple's implementation has two difficulties we need to work around. The first is limited acccess to information about whether the event is from a tablet or a mouse (`NSEvent.subtype`), and the second is limited access information about kind of pointer tool created the event (`NSEvent.pointingdevicetype`).

1. [subtype: whether this is a mouse or tablet or just "tablet proximity" kind of event](https://developer.apple.com/documentation/appkit/nsevent/subtype) is not available (trying to access it throws an exception) on mouse_enter/mouse_exit.
<img width="640" height="565" alt="Screenshot 2026-07-06 at 12 56 51 PM" src="https://github.com/user-attachments/assets/f97305a7-5fdc-4795-a356-88afdbbe7a9e" />

So mouse_enter and mouse_exit have to be `unknown` pointer type in appkit.

2. [pointingdevicetype: which kind of "pointer" tool (mouse, pen, erasor, ...) ](https://developer.apple.com/documentation/appkit/nsevent/pointingdevicetype-swift.property) that information is only available on the "proximity type" events for that device that happen when a pen tablet sense the pen is "entering nearby" or "exiting the sensible area" so relatively a pre-start-drawing and post-end-drawing kind of event.

<img width="660" height="542" alt="Screenshot 2026-07-06 at 12 28 10 PM" src="https://github.com/user-attachments/assets/a7b7bf06-a1eb-439e-9250-8bd0d12a9c56" />

So we keep that information cached in the ViewState.

/end edit

Tilt gets converted from -1,1 to -90,90. `y` is negated, since AppKit is y-up and winit documents positive y as toward the user.

- [x] Tested on all platforms changed
Tested with a toy app that tracks a Wacom tablet pressure (sphere size) and tilt (the vector)

<img width="1162" height="274" alt="Screenshot 2026-06-09 at 8 41 47 PM" src="https://github.com/user-attachments/assets/57d76eff-ee82-4280-bc66-92fe00e8e3a9" />

- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
