### PR TITLE
ci: pin log to 0.4.29 so the 1.70 MSRV jobs build again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,11 @@ jobs:
            cargo update -p gethostname@1.1.0 --precise 1.0.2
            cargo update -p unicode-ident --precise 1.0.10
            cargo update -p syn --precise 2.0.114
+           # `log >= 0.4.30` bumped its MSRV to 1.71, which breaks the
+           # Test 1.70.0 matrix jobs. Pin to the last 1.70-compatible
+           # release (`0.4.29`, rust_version = 1.68) until winit bumps
+           # its own MSRV.
+           cargo update -p log --precise 0.4.29
 
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')


### PR DESCRIPTION
The Test 1.70.0 jobs on \`v0.30.x\` have been failing for a couple of
weeks with:

\`\`\`
error: package \`log v0.4.32\` cannot be built because it requires
rustc 1.71.0 or newer, while the currently active rustc version is
1.70.0
\`\`\`

\`log >= 0.4.30\` bumped its MSRV to 1.71. winit's declared MSRV on
this branch is still 1.70, so the lockfile generated fresh by CI
includes a \`log\` version that won't build. Latest baseline run on
\`v0.30.x\`: [#26613381849](https://github.com/rust-windowing/winit/actions/runs/26613381849)
— every \`Test 1.70.0\` job red with the same error.

This change adds one more \`cargo update -p log --precise 0.4.29\` to
the existing \"Generate lockfile\" step that already pins ahash /
bumpalo / softbuffer / etc. \`0.4.29\` is the last release with
\`rust_version = 1.68\`, so it builds cleanly on 1.70.

Strictly a CI hygiene fix — no source changes, and nothing here
forces consumers off newer \`log\` versions; this only affects what
the CI workflow generates into \`Cargo.lock\` before running
\`cargo test\`.

Discovered while investigating CI on #4592.