### PR TITLE
AppKit: Expose native transition state

### DIFF
--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -105,6 +105,9 @@ pub trait WindowExtMacOS {
     /// or AppKit is running an equivalent native resize transition.
     fn is_live_resizing(&self) -> bool;
 
+    /// Returns whether AppKit is currently entering or exiting native fullscreen.
+    fn is_fullscreen_transition(&self) -> bool;
+
     /// Returns whether or not the window is in simple fullscreen mode.
     fn simple_fullscreen(&self) -> bool;
 
@@ -218,6 +221,12 @@ impl WindowExtMacOS for dyn Window + '_ {
     fn is_live_resizing(&self) -> bool {
         let window = self.cast_ref::<AppKitWindow>().unwrap();
         window.maybe_wait_on_main(|w| w.is_live_resizing())
+    }
+
+    #[inline]
+    fn is_fullscreen_transition(&self) -> bool {
+        let window = self.cast_ref::<AppKitWindow>().unwrap();
+        window.maybe_wait_on_main(|w| w.is_fullscreen_transition())
     }
 
     #[inline]

--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -101,6 +101,10 @@ use self::window::Window as AppKitWindow;
 
 /// Additional methods on [`Window`] that are specific to MacOS.
 pub trait WindowExtMacOS {
+    /// This is `true` only while the user is interactively resizing the window
+    /// or AppKit is running an equivalent native resize transition.
+    fn is_live_resizing(&self) -> bool;
+
     /// Returns whether or not the window is in simple fullscreen mode.
     fn simple_fullscreen(&self) -> bool;
 
@@ -210,6 +214,12 @@ pub trait WindowExtMacOS {
 }
 
 impl WindowExtMacOS for dyn Window + '_ {
+    #[inline]
+    fn is_live_resizing(&self) -> bool {
+        let window = self.cast_ref::<AppKitWindow>().unwrap();
+        window.maybe_wait_on_main(|w| w.is_live_resizing())
+    }
+
     #[inline]
     fn simple_fullscreen(&self) -> bool {
         let window = self.cast_ref::<AppKitWindow>().unwrap();

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -1530,6 +1530,10 @@ impl WindowDelegate {
         Err(NotSupportedError::new("drag_resize_window is not supported"))
     }
 
+    pub fn is_live_resizing(&self) -> bool {
+        self.window().inLiveResize()
+    }
+
     #[inline]
     pub fn show_window_menu(&self, _position: Position) {}
 
@@ -2085,6 +2089,11 @@ fn restore_and_release_display(monitor: &MonitorHandle) {
 }
 
 impl WindowExtMacOS for WindowDelegate {
+    #[inline]
+    fn is_live_resizing(&self) -> bool {
+        WindowDelegate::is_live_resizing(self)
+    }
+
     #[inline]
     fn simple_fullscreen(&self) -> bool {
         self.ivars().is_simple_fullscreen.get()

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -147,6 +147,7 @@ define_class!(
         #[unsafe(method(windowDidResize:))]
         fn window_did_resize(&self, _: Option<&AnyObject>) {
             let _entered = debug_span!("windowDidResize:").entered();
+            self.refresh_maximized();
             // NOTE: WindowEvent::SurfaceResized is reported using NSViewFrameDidChangeNotification.
             self.emit_move_event();
         }
@@ -162,6 +163,7 @@ define_class!(
         #[unsafe(method(windowDidEndLiveResize:))]
         fn window_did_end_live_resize(&self, _: Option<&AnyObject>) {
             let _entered = debug_span!("windowDidEndLiveResize:").entered();
+            self.refresh_maximized();
             self.set_resize_increments_inner(NSSize::new(1., 1.));
         }
 
@@ -279,6 +281,7 @@ define_class!(
             let _entered = debug_span!("windowDidEnterFullScreen:").entered();
             self.ivars().initial_fullscreen.set(false);
             self.ivars().in_fullscreen_transition.set(false);
+            self.request_redraw();
             if let Some(target_fullscreen) = self.ivars().target_fullscreen.take() {
                 self.set_fullscreen(target_fullscreen);
             }
@@ -291,6 +294,7 @@ define_class!(
 
             self.restore_state_from_fullscreen();
             self.ivars().in_fullscreen_transition.set(false);
+            self.request_redraw();
             if let Some(target_fullscreen) = self.ivars().target_fullscreen.take() {
                 self.set_fullscreen(target_fullscreen);
             }
@@ -1187,6 +1191,10 @@ impl WindowDelegate {
         self.ivars().app_state.queue_redraw(window_id(self.window()));
     }
 
+    fn refresh_maximized(&self) {
+        self.ivars().maximized.set(self.is_zoomed());
+    }
+
     #[inline]
     pub fn pre_present_notify(&self) {}
 
@@ -1522,6 +1530,7 @@ impl WindowDelegate {
         let event =
             NSApplication::sharedApplication(mtm).currentEvent().ok_or(RequestError::Ignored)?;
         self.window().performWindowDragWithEvent(&event);
+        self.refresh_maximized();
         Ok(())
     }
 
@@ -1532,6 +1541,10 @@ impl WindowDelegate {
 
     pub fn is_live_resizing(&self) -> bool {
         self.window().inLiveResize()
+    }
+
+    pub fn is_fullscreen_transition(&self) -> bool {
+        self.ivars().in_fullscreen_transition.get()
     }
 
     #[inline]
@@ -1610,6 +1623,7 @@ impl WindowDelegate {
         let mtm = MainThreadMarker::from(self);
         let is_zoomed = self.is_zoomed();
         if is_zoomed == maximized {
+            self.ivars().maximized.set(maximized);
             return;
         };
 
@@ -1647,7 +1661,7 @@ impl WindowDelegate {
 
     #[inline]
     pub fn is_maximized(&self) -> bool {
-        self.is_zoomed()
+        self.ivars().maximized.get()
     }
 
     #[inline]
@@ -2092,6 +2106,11 @@ impl WindowExtMacOS for WindowDelegate {
     #[inline]
     fn is_live_resizing(&self) -> bool {
         WindowDelegate::is_live_resizing(self)
+    }
+
+    #[inline]
+    fn is_fullscreen_transition(&self) -> bool {
+        WindowDelegate::is_fullscreen_transition(self)
     }
 
     #[inline]

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -48,7 +48,8 @@ changelog entry.
 - On Redox, add support for `EventLoopExtPumpEvents::pump_app_events`.
 - Implement `Send` and `Sync` for `OwnedDisplayHandle`.
 - Use new macOS 15 cursors for resize icons.
-- On macOS, add `WindowExtMacOS::is_live_resizing`.
+- On macOS, add `WindowExtMacOS::is_live_resizing` and
+  `WindowExtMacOS::is_fullscreen_transition`.
 - On Android, added scancode conversions for more obscure key codes.
 - On Wayland, added `HoldGesture` event for multi-finger hold gestures
 - On Wayland, added ext-background-effect-v1 support.
@@ -79,3 +80,4 @@ changelog entry.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.
 - On macOS, fix a panic and incorrect cursor position in Ime::Preedit when the preedit string contains special characters (ie. emojis) caused by incorrect UTF-16 to UTF-8 offset conversion.
 - On Wayland, fix a protocol error when setting a custom cursor on compositors with `wl_surface` version below 3.
+- On macOS, avoid querying AppKit's zoom state from `Window::is_maximized`.

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -48,6 +48,7 @@ changelog entry.
 - On Redox, add support for `EventLoopExtPumpEvents::pump_app_events`.
 - Implement `Send` and `Sync` for `OwnedDisplayHandle`.
 - Use new macOS 15 cursors for resize icons.
+- On macOS, add `WindowExtMacOS::is_live_resizing`.
 - On Android, added scancode conversions for more obscure key codes.
 - On Wayland, added `HoldGesture` event for multi-finger hold gestures
 - On Wayland, added ext-background-effect-v1 support.


### PR DESCRIPTION
## Summary

This exposes AppKit native transition state through `WindowExtMacOS`:

- `WindowExtMacOS::is_live_resizing()` for AppKit live-resize transitions.
- `WindowExtMacOS::is_fullscreen_transition()` for native fullscreen enter/exit transitions.

It also keeps macOS maximized state cached so callers can poll `Window::is_maximized()` without forcing `NSWindow.isZoomed` to [temporarily mutate window style masks](https://github.com/yay/winit/blob/086c209e87bcb52132ac40e49dd1950c95fe0d3f/winit-appkit/src/window_delegate.rs#L1333-L1349), and requests a final redraw when AppKit completes native fullscreen transitions.

## Motivation

Renderer integrations need to know when AppKit is driving native window transitions so they can synchronize surface presentation and avoid stale or stretched frames during live resize and fullscreen animations.

For a specific example see this egui PR https://github.com/emilk/egui/pull/8280 that depends on this winit PR.

## Checks

- `cargo +nightly fmt --check`
- `cargo check -p winit --all-features`
