### PR TITLE
Wayland: seal xdg-activation tokens with the last pointer-press serial

### DIFF
--- a/winit-wayland/src/window/mod.rs
+++ b/winit-wayland/src/window/mod.rs
@@ -248,6 +248,11 @@ impl Window {
 
         let data = XdgActivationTokenData::Obtain((self.window_id, serial));
         let xdg_activation_token = xdg_activation.get_activation_token(&self.queue_handle, data);
+        // Seal the token with the latest input serial, otherwise compositors
+        // enforcing focus-stealing prevention refuse the ensuing activation.
+        if let Some((seat, serial)) = self.window_state.lock().unwrap().latest_seat_serial() {
+            xdg_activation_token.set_serial(serial, &seat);
+        }
         xdg_activation_token.set_surface(self.surface());
         xdg_activation_token.commit();
 
@@ -566,6 +571,11 @@ impl CoreWindow for Window {
             Arc::downgrade(&self.attention_requested),
         ));
         let xdg_activation_token = xdg_activation.get_activation_token(&self.queue_handle, data);
+        // Seal the token with the latest input serial, otherwise compositors
+        // enforcing focus-stealing prevention refuse the ensuing activation.
+        if let Some((seat, serial)) = self.window_state.lock().unwrap().latest_seat_serial() {
+            xdg_activation_token.set_serial(serial, &seat);
+        }
         xdg_activation_token.set_surface(&surface);
         xdg_activation_token.commit();
     }

--- a/winit-wayland/src/window/state.rs
+++ b/winit-wayland/src/window/state.rs
@@ -254,6 +254,18 @@ impl WindowState {
         })
     }
 
+    /// The `(seat, serial)` of the latest pointer button event observed on
+    /// this window, if any. Used to seal xdg-activation tokens with
+    /// `set_serial(...)`.
+    pub fn latest_seat_serial(&self) -> Option<(WlSeat, u32)> {
+        // TODO(kchibisov) handle touch serials.
+        let mut found = None;
+        self.apply_on_pointer(|_, data| {
+            found = Some((data.seat().clone(), data.latest_button_serial()));
+        });
+        found
+    }
+
     /// Get the current state of the frame callback.
     pub fn frame_callback_state(&self) -> FrameCallbackState {
         self.frame_callback_state

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -64,6 +64,12 @@ changelog entry.
   `DefWindowProc` for normal propagation.
 - On Redox, handle `EINTR` when reading from `event_socket` instead of panicking.
 - On Wayland, switch from using the `ahash` hashing algorithm to `foldhash`.
+- On Wayland, seal xdg-activation tokens with the latest pointer button
+  serial. Tokens issued by `Window::request_activation_token` /
+  user-attention requests previously carried no input-event serial, so
+  compositors enforcing focus-stealing prevention (mutter, kwin, niri)
+  refused the ensuing activation and the launched application's window
+  opened without focus.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.
 - On macOS, fix a panic and incorrect cursor position in Ime::Preedit when the preedit string contains special characters (ie. emojis) caused by incorrect UTF-16 to UTF-8 offset conversion.


### PR DESCRIPTION
## Problem

`Window::request_activation_token()` (and the xdg-activation path of `request_user_attention`) builds its `xdg_activation_token_v1` request with `set_surface` + `commit`, but never calls `set_serial`.

The protocol marks `set_serial` as optional, but adds:

> Some compositors might refuse to activate toplevels when the token doesn't have a valid and recent enough event serial.

In practice, compositors enforcing focus-stealing prevention (mutter, KWin, niri in strict mode) validate the token's serial against the pointer's **grab serial** and silently refuse the ensuing `activate()` when it's absent. On mutter the minted token string ends in `_TIME0` and the activation degrades to demands-attention at best. Net effect: an app that requests a token on user click and hands it to a child process via `XDG_ACTIVATION_TOKEN` sees the child's window open **without focus** — defeating the exact purpose of the API.

This mirrors what GTK4/GDK and Qt do internally (both seal launch tokens with the serial of the triggering input event), and is the missing piece behind several "launched app opens behind the launcher on GNOME Wayland" reports across the ecosystem (e.g. wezterm/wezterm#3619, ghostty-org/ghostty#5812 discuss the same compositor behavior).

## Fix

- Record the `(WlSeat, serial)` of the last pointer button **press** on the window's `WindowState` (recorded in the pointer handler, which already locks that state).
- Seal both token issuers (`request_activation_token`, `request_user_attention`) with it via `set_serial(serial, &seat)` before `commit`.

**Why press only:** compositors update the pointer grab serial exclusively on button press (mutter `meta-wayland-pointer.c`). UI toolkits fire click actions on *release*, so recording the release serial too would always overwrite the press serial with one the compositor doesn't recognize — we hit exactly this during testing (token still refused when sealed with the release serial; accepted with the press serial).

Storing per-`WindowState` (rather than globally) also keeps the serial and the `set_surface` target referring to the same surface, which matches how compositors validate the pair, and avoids growing the platform `Window` enum.

If the window has never seen a button press, behavior is unchanged (token issued without serial, best-effort as before).

## Testing

Tested on a GNOME 46 / mutter Wayland cabinet setup (winit-based launcher app, fullscreen):

1. Launcher requests a token on user click, receives it via `ActivationTokenDone`, and passes it in `XDG_ACTIVATION_TOKEN` to a spawned process.
2. **Before:** token sealed without serial → mutter refuses activation → child window opens unfocused. Confirmed via mutter source (46.0 `meta-wayland-activation.c`: `token_can_activate` → `meta_wayland_seat_get_grab_info`).
3. **After:** spawning `gnome-text-editor` (GTK4, reference consumer of `XDG_ACTIVATION_TOKEN`) with the sealed token transfers keyboard focus reliably (3/3 runs, including >30 s after launcher startup, i.e. long past any startup token's validity).
4. Instrumented traces confirmed the press serial is captured and applied at `set_serial` time.

`cargo +nightly fmt`, `cargo clippy -p winit-wayland` and `cargo test -p winit-wayland` are clean; the change is confined to `winit-wayland`.

## Future work

Keyboard (`wl_keyboard.key`) and touch (`wl_touch.down`) serials can be recorded the same way for apps driven without a pointer; this PR keeps the scope to the pointer path.