### PR TITLE
On Windows, add window cloaking support via DWMWA_CLOAK

### DIFF
--- a/winit-win32/src/lib.rs
+++ b/winit-win32/src/lib.rs
@@ -249,6 +249,12 @@ pub trait WindowExtWindows {
     /// and <https://docs.microsoft.com/en-us/windows/win32/winmsg/window-features#disabled-windows>
     fn set_enable(&self, enabled: bool);
 
+    /// Cloaks the window such that it is not visible to the user. The window is still composed by
+    /// DWM.
+    ///
+    /// Not supported on Windows 7 and earlier.
+    fn set_cloaked(&self, cloaked: bool);
+
     /// This sets `ICON_BIG`. A good ceiling here is 256x256.
     fn set_taskbar_icon(&self, taskbar_icon: Option<Icon>);
 
@@ -412,6 +418,12 @@ impl WindowExtWindows for dyn CoreWindow + '_ {
         window.set_use_system_scroll_speed(should_use)
     }
 
+    #[inline]
+    fn set_cloaked(&self, cloaked: bool) {
+        let window = self.cast_ref::<Window>().unwrap();
+        window.set_cloaked(cloaked)
+    }
+
     unsafe fn window_handle_any_thread(
         &self,
     ) -> Result<rwh_06::WindowHandle<'_>, rwh_06::HandleError> {
@@ -474,6 +486,7 @@ pub struct WindowAttributesWindows {
     pub(crate) title_text_color: Option<Color>,
     pub(crate) corner_preference: Option<CornerPreference>,
     pub(crate) use_system_wheel_speed: bool,
+    pub(crate) cloaked: bool,
 }
 
 impl Default for WindowAttributesWindows {
@@ -494,6 +507,7 @@ impl Default for WindowAttributesWindows {
             title_text_color: None,
             corner_preference: None,
             use_system_wheel_speed: true,
+            cloaked: false,
         }
     }
 }
@@ -624,6 +638,15 @@ impl WindowAttributesWindows {
     /// Supported starting with Windows 11 Build 22000.
     pub fn with_corner_preference(mut self, corners: CornerPreference) -> Self {
         self.corner_preference = Some(corners);
+        self
+    }
+
+    /// Cloaks the window such that it is not visible to the user. The window is still composed by
+    /// DWM.
+    ///
+    /// Not supported on Windows 7 and earlier.
+    pub fn with_cloaked(mut self, cloaked: bool) -> Self {
+        self.cloaked = cloaked;
         self
     }
 

--- a/winit-win32/src/window.rs
+++ b/winit-win32/src/window.rs
@@ -14,7 +14,7 @@ use windows_sys::Win32::Foundation::{
 };
 use windows_sys::Win32::Graphics::Dwm::{
     DWM_BB_BLURREGION, DWM_BB_ENABLE, DWM_BLURBEHIND, DWM_SYSTEMBACKDROP_TYPE,
-    DWM_WINDOW_CORNER_PREFERENCE, DWMWA_BORDER_COLOR, DWMWA_CAPTION_COLOR,
+    DWM_WINDOW_CORNER_PREFERENCE, DWMWA_BORDER_COLOR, DWMWA_CAPTION_COLOR, DWMWA_CLOAK,
     DWMWA_SYSTEMBACKDROP_TYPE, DWMWA_TEXT_COLOR, DWMWA_WINDOW_CORNER_PREFERENCE,
     DwmEnableBlurBehindWindow, DwmSetWindowAttribute,
 };
@@ -382,6 +382,17 @@ impl Window {
         match icon_type {
             IconType::Small => self.window_state_lock().window_icon = None,
             IconType::Big => self.window_state_lock().taskbar_icon = None,
+        }
+    }
+
+    pub fn set_cloaked(&self, cloaked: bool) {
+        unsafe {
+            DwmSetWindowAttribute(
+                self.hwnd(),
+                DWMWA_CLOAK.try_into().unwrap(),
+                &cloaked as *const bool as *const _,
+                mem::size_of::<bool>() as u32,
+            );
         }
     }
 }
@@ -1349,6 +1360,9 @@ impl InitData<'_> {
         }
         if let Some(corner) = self.win_attributes.corner_preference {
             win.set_corner_preference(corner);
+        }
+        if self.win_attributes.cloaked {
+            win.set_cloaked(true);
         }
     }
 }

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -50,6 +50,8 @@ changelog entry.
 - On Android, added scancode conversions for more obscure key codes.
 - On Wayland, added `HoldGesture` event for multi-finger hold gestures
 - On Wayland, added ext-background-effect-v1 support.
+- On Windows, add `WindowExtWindows::set_cloaked` and
+  `WindowAttributesWindows::with_cloaked` to cloak a window via `DWMWA_CLOAK`.
 
 ### Changed
 


### PR DESCRIPTION
### Summary

Adds Windows window cloaking support via the [`DWMWA_CLOAK`](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute) DWM attribute. Cloaking hides a window from the user while it is still composed by DWM (unlike hiding/minimizing), which is useful for things like off-screen rendering, thumbnails, and smooth show/hide without flicker.

### API

- `WindowExtWindows::set_cloaked(&self, cloaked: bool)` — toggle cloaking on an existing window.
- `WindowAttributesWindows::with_cloaked(self, cloaked: bool)` — request cloaking at creation time.

Not supported on Windows 7 and earlier.

Needed this for one of my projects - would be nice to get it merged to upstream.
