### PR TITLE
Emit Android joystick axes as device motion events

### DIFF
--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -5,7 +5,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use android_activity::input::{InputEvent, KeyAction, Keycode, MotionAction};
+use android_activity::input::{Axis, InputEvent, KeyAction, Keycode, MotionAction, Source};
 use android_activity::{
     AndroidApp, AndroidAppWaker, ConfigurationRef, InputStatus, MainEvent, Rect,
 };
@@ -323,6 +323,12 @@ impl EventLoop {
             InputEvent::MotionEvent(motion_event) => {
                 let device_id = Some(DeviceId::from_raw(motion_event.device_id() as i64));
                 let action = motion_event.action();
+                let source = motion_event.source();
+
+                if source.is_joystick_class() || matches!(source, Source::Gamepad) {
+                    self.dispatch_joystick_axes(motion_event, device_id, app);
+                    return input_status;
+                }
 
                 let pointers: Option<
                     Box<dyn Iterator<Item = android_activity::input::Pointer<'_>>>,
@@ -507,6 +513,35 @@ impl EventLoop {
         input_status
     }
 
+    fn dispatch_joystick_axes<A: ApplicationHandler>(
+        &self,
+        motion_event: &android_activity::input::MotionEvent<'_>,
+        device_id: Option<DeviceId>,
+        app: &mut A,
+    ) {
+        if !matches!(
+            motion_event.action(),
+            MotionAction::Move
+                | MotionAction::Down
+                | MotionAction::Up
+                | MotionAction::Cancel
+                | MotionAction::ButtonPress
+                | MotionAction::ButtonRelease
+        ) {
+            return;
+        }
+
+        for pointer in motion_event.pointers() {
+            for axis in ANDROID_GAMEPAD_AXES {
+                let event = event::DeviceEvent::Motion {
+                    axis: Into::<u32>::into(axis),
+                    value: pointer.axis_value(axis) as f64,
+                };
+                app.device_event(&self.window_target, device_id, event);
+            }
+        }
+    }
+
     pub fn run_app_on_demand<A: ApplicationHandler>(
         &mut self,
         mut app: A,
@@ -641,6 +676,21 @@ impl EventLoop {
         self.window_target.exiting()
     }
 }
+
+const ANDROID_GAMEPAD_AXES: [Axis; 12] = [
+    Axis::X,
+    Axis::Y,
+    Axis::Z,
+    Axis::Rx,
+    Axis::Ry,
+    Axis::Rz,
+    Axis::HatX,
+    Axis::HatY,
+    Axis::Ltrigger,
+    Axis::Rtrigger,
+    Axis::Gas,
+    Axis::Brake,
+];
 
 pub struct EventLoopProxy {
     wake_up: AtomicBool,

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -668,6 +668,18 @@ pub enum DeviceEvent {
         delta: (f64, f64),
     },
 
+    /// Change in value of a device-specific analog axis.
+    ///
+    /// The axis identifier is platform-specific. Applications that need to understand controller
+    /// layouts should pair this with platform/device metadata or their own mapping layer.
+    Motion {
+        /// The device-specific axis identifier.
+        axis: AxisId,
+
+        /// The current axis value.
+        value: f64,
+    },
+
     /// Physical scroll event
     MouseWheel {
         delta: MouseScrollDelta,


### PR DESCRIPTION
## Summary

- add a raw `DeviceEvent::Motion { axis, value }` event for device-specific analog axes
- route Android joystick/gamepad `MotionEvent` samples before the touch path
- emit motion values for common joystick, hat and analog trigger axes

This lets Android gamepad sticks, D-pad hats and analog triggers reach applications without being dropped as touch input. The Android backend reports the raw Android axis IDs so applications can map controller layouts themselves.

## Validation

- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/RustBuilds/vibe-scrap-squad/target/winit-fork-master CARGO_INCREMENTAL=0 cargo check -p winit --target aarch64-linux-android --features android-native-activity`

Note: `cargo fmt --check` requires this repository's nightly rustfmt configuration. This machine only has stable installed, and stable rustfmt reports unrelated repository-wide formatting diffs when reading the upstream config.
