### PR TITLE
UIKit: detect GL and Metal backing layers

### DIFF
--- a/winit-uikit/Cargo.toml
+++ b/winit-uikit/Cargo.toml
@@ -48,6 +48,7 @@ objc2-foundation = { workspace = true, features = [
 objc2-ui-kit = { workspace = true, features = [
     "std",
     "objc2-core-foundation",
+    "objc2-quartz-core",
     "UIApplication",
     "UIDevice",
     "UIEvent",

--- a/winit-uikit/src/window.rs
+++ b/winit-uikit/src/window.rs
@@ -9,6 +9,7 @@ use dpi::{
     Position, Size,
 };
 use objc2::rc::Retained;
+use objc2::runtime::AnyObject;
 use objc2::{MainThreadMarker, available, class, define_class, msg_send};
 use objc2_core_foundation::{CGFloat, CGPoint, CGRect, CGSize};
 use objc2_foundation::{NSObject, NSObjectProtocol};
@@ -535,8 +536,12 @@ impl Window {
 
         let view = WinitView::new(mtm, ios_attributes.scale_factor, frame);
 
-        let gl_or_metal_backed =
-            view.isKindOfClass(class!(CAMetalLayer)) || view.isKindOfClass(class!(CAEAGLLayer));
+        let gl_or_metal_backed = unsafe {
+            let view_layer: *mut AnyObject = msg_send![&*view, layer];
+            let metal_backed: bool = msg_send![view_layer, isKindOfClass: class!(CAMetalLayer)];
+            let gl_backed: bool = msg_send![view_layer, isKindOfClass: class!(CAEAGLLayer)];
+            metal_backed || gl_backed
+        };
 
         let view_controller = WinitViewController::new(mtm, &ios_attributes, &view);
         let window = WinitUIWindow::new(mtm, &window_attributes, frame, &view_controller);

--- a/winit-uikit/src/window.rs
+++ b/winit-uikit/src/window.rs
@@ -12,7 +12,7 @@ use objc2::rc::Retained;
 use objc2::runtime::AnyObject;
 use objc2::{MainThreadMarker, available, class, define_class, msg_send};
 use objc2_core_foundation::{CGFloat, CGPoint, CGRect, CGSize};
-use objc2_foundation::{NSObject, NSObjectProtocol};
+use objc2_foundation::NSObject;
 use objc2_ui_kit::{
     UIApplication, UICoordinateSpace, UIEdgeInsets, UIResponder, UIScreen,
     UIScreenOverscanCompensation, UIViewController, UIWindow,

--- a/winit-uikit/src/window.rs
+++ b/winit-uikit/src/window.rs
@@ -9,10 +9,9 @@ use dpi::{
     Position, Size,
 };
 use objc2::rc::Retained;
-use objc2::runtime::AnyObject;
 use objc2::{MainThreadMarker, available, class, define_class, msg_send};
 use objc2_core_foundation::{CGFloat, CGPoint, CGRect, CGSize};
-use objc2_foundation::NSObject;
+use objc2_foundation::{NSObject, NSObjectProtocol};
 use objc2_ui_kit::{
     UIApplication, UICoordinateSpace, UIEdgeInsets, UIResponder, UIScreen,
     UIScreenOverscanCompensation, UIViewController, UIWindow,
@@ -536,12 +535,9 @@ impl Window {
 
         let view = WinitView::new(mtm, ios_attributes.scale_factor, frame);
 
-        let gl_or_metal_backed = unsafe {
-            let view_layer: *mut AnyObject = msg_send![&*view, layer];
-            let metal_backed: bool = msg_send![view_layer, isKindOfClass: class!(CAMetalLayer)];
-            let gl_backed: bool = msg_send![view_layer, isKindOfClass: class!(CAEAGLLayer)];
-            metal_backed || gl_backed
-        };
+        let view_layer = view.layer();
+        let gl_or_metal_backed = view_layer.isKindOfClass(class!(CAMetalLayer))
+            || view_layer.isKindOfClass(class!(CAEAGLLayer));
 
         let view_controller = WinitViewController::new(mtm, &ios_attributes, &view);
         let window = WinitUIWindow::new(mtm, &window_attributes, frame, &view_controller);


### PR DESCRIPTION
## Summary

- detect GL/Metal-backed UIKit windows by inspecting the view's backing layer
- keep the existing redraw queue path for CAEAGLLayer/CAMetalLayer-backed views

Related: #4620 preserves queued GPU redraws while the UIKit event loop is waiting.

## Validation

- `git diff --check`
- `CARGO_TARGET_DIR=/Volumes/RustBuilds/vibe-scrap-squad/target/winit-fork-uikit-layer CARGO_INCREMENTAL=0 cargo check -p winit-uikit --target aarch64-apple-ios`