### PR TITLE
wayland: don't send set_buffer_scale on wl_surface below version 3

### DIFF
--- a/winit-wayland/src/window/state.rs
+++ b/winit-wayland/src/window/state.rs
@@ -814,10 +814,12 @@ impl WindowState {
                 let size = PhysicalSize::new(cursor.w, cursor.h).to_logical(scale);
                 viewport.set_destination(size.width, size.height);
                 scale
-            } else {
+            } else if surface.version() >= 3 {
                 let scale = surface.data::<SurfaceData>().unwrap().surface_data().scale_factor();
                 surface.set_buffer_scale(scale);
                 scale as f64
+            } else {
+                1.
             };
 
             surface.attach(Some(cursor.buffer.wl_buffer()), 0, 0);

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -67,3 +67,4 @@ changelog entry.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.
 - On macOS, fix a panic and incorrect cursor position in Ime::Preedit when the preedit string contains special characters (ie. emojis) caused by incorrect UTF-16 to UTF-8 offset conversion.
+- On Wayland, fix a protocol error when setting a custom cursor on compositors with `wl_surface` version below 3.


### PR DESCRIPTION
wl_surface::set_buffer_scale is available since version 3. Sending it on an older surface is a protocol error that terminates the connection. This could happen when setting a custom cursor on a compositor without wp_viewporter. The neighboring damage call already checks the version.
