### PR TITLE
Use the MSRV-aware resolver instead of pinning versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
 
     - name: Generate lockfile
       # Also updates the crates.io index
-      run: cargo generate-lockfile && cargo update -p smol_str --precise 0.3.2 && cargo update -p unicode-segmentation --precise 1.12.0 && cargo update -p wayland-protocols --precise 0.32.12
+      run: cargo generate-lockfile
 
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 default-members = ["winit"]
 members = ["dpi", "winit*"]
-resolver = "2"
+resolver = "3"
 
 [workspace.package]
 edition = "2024"


### PR DESCRIPTION
Resolver 3 skips dependency versions whose rust-version is above ours, so the CI lockfile step no longer needs --precise pins that must be maintained by hand.
This is also more reliable as more crate are release with higher MSRV