### PR TITLE
macOS: resample deferred surface resize events

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use dpi::{LogicalPosition, PhysicalSize};
 use objc2::rc::Retained;
 use objc2::runtime::{AnyObject, Sel};
-use objc2::{AnyThread, DefinedClass, MainThreadMarker, define_class, msg_send};
+use objc2::{AnyThread, DefinedClass, MainThreadMarker, Message, define_class, msg_send};
 use objc2_app_kit::{
     NSApplication, NSCursor, NSDragOperation, NSDraggingSession, NSEvent, NSEventPhase,
     NSResponder, NSTextInputClient, NSTrackingArea, NSTrackingAreaOptions, NSView,
@@ -876,13 +876,14 @@ impl WinitView {
         });
     }
 
-    fn surface_resized(&self) {
+    pub(super) fn surface_resized(&self) {
         let Some(window) = (**self).window() else {
             return;
         };
-        let size = self.surface_size();
         let window_id = window_id(&window);
+        let view = self.retain();
         self.ivars().app_state.maybe_queue_with_handler(move |app, event_loop| {
+            let size = view.surface_size();
             app.window_event(event_loop, window_id, WindowEvent::SurfaceResized(size));
         });
     }

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -1057,7 +1057,7 @@ impl WindowDelegate {
             let size = NSSize::new(logical_size.width, logical_size.height);
             window.setContentSize(size);
         }
-        self.queue_event(WindowEvent::SurfaceResized(physical_size));
+        self.view().surface_resized();
     }
 
     fn emit_move_event(&self) {

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -68,4 +68,6 @@ changelog entry.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.
 - On macOS, fix a panic and incorrect cursor position in Ime::Preedit when the preedit string contains special characters (ie. emojis) caused by incorrect UTF-16 to UTF-8 offset conversion.
+- On macOS, prevent an older deferred surface resize from overriding newer sizes after AppKit
+  transitions.
 - On Wayland, fix a protocol error when setting a custom cursor on compositors with `wl_surface` version below 3.


### PR DESCRIPTION
## Issue

Notice 20pt-wide black bars. These can show up on egui app launch, if the app was previously open on a bigger screen, got closed, and is now launching on a smaller screen, where the app window has to size down to fit.

<img width="1604" height="1036" alt="black-bars" src="https://github.com/user-attachments/assets/fbcd9fac-8c49-4ee9-a9ed-e906d0f810f8" />

## Summary

Re-sample an AppKit view's backing size when a deferred `SurfaceResized` callback is delivered,
rather than emitting the size captured when the callback was queued.

This remains a draft while the fix undergoes a downstream soak.

## Root cause

AppKit can synchronously resize a view while Winit is already handling an application event. Winit
cannot re-enter the application handler, so `WinitView::surface_resized` defers its callback to the
default run-loop mode.

AppKit may then continue a live-resize transition in event-tracking mode. Those newer resize events
can be delivered before the default-mode callback resumes. Because the deferred callback captured
its size eagerly, it could subsequently emit an older size and overwrite the renderer's correct
surface configuration.

In the reproduced failure:

- A `4096x2254` resize was deferred while the window became visible.
- AppKit continued resizing the surface to `4056x2214`.
- WGPU correctly configured `4056x2214`.
- The older deferred callback then reconfigured WGPU back to `4096x2254`.
- The AppKit view and Metal layer remained `2028x1107` points at a 2x backing scale, leaving
  20-point black bars at the right and bottom edges.

Repainting or changing appearance did not reconfigure the surface, while a manual window resize
did and immediately removed the bars.

## Reproduction

1. Set an Apple Studio Display to `2560x1440 (Default)`.
2. Size the window so it almost fills the desktop and close the application.
3. Change the display resolution to `2048x1152`.
4. Relaunch the application so AppKit constrains the restored window during its first show.

The failure is timing-sensitive, but this sequence makes it substantially easier to reproduce.

## Fix

- Retain the `WinitView` in the deferred callback and read `surface_size()` when that callback is
  actually delivered.
- Route the resize following `ScaleFactorChanged` through the same helper, preserving
  `SurfaceSizeWriter` requests while reporting AppKit's authoritative final backing size.
