### PR TITLE
Add `no_std` support specifically for `wasm32v1-none`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
           - { name: 'iOS x86_64',         target: x86_64-apple-ios,         os: macos-latest,    }
           - { name: 'iOS Aarch64',        target: aarch64-apple-ios,        os: macos-latest,    }
           - { name: 'Web',                target: wasm32-unknown-unknown,   os: ubuntu-latest,   }
+          - name: 'Web (no_std)'
+            target: wasm32v1-none
+            os: ubuntu-latest
+            options: >-
+              --config patch.crates-io.web-time.git="https://github.com/daxpedda/web-time"
         exclude:
               # Web on nightly needs extra arguments
 
@@ -211,7 +216,7 @@ jobs:
       run: cargo $CMD test -p winit-uikit $OPTIONS --no-run
 
     - name: Test winit Web
-      if: contains(matrix.platform.target, 'wasm')
+      if: contains(matrix.platform.target, 'wasm') && !contains(matrix.platform.target, 'wasm32v1-none')
       run: cargo $CMD test -p winit-web $OPTIONS --no-run
 
     - name: Test winit Win32
@@ -242,6 +247,7 @@ jobs:
     - name: Build tests
       if: >
         !contains(matrix.platform.target, 'redox') &&
+        !contains(matrix.platform.target, 'wasm32v1-none') &&
         matrix.toolchain != '1.86'
       run: cargo $CMD test --no-run $OPTIONS
 
@@ -251,16 +257,21 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         (!contains(matrix.platform.target, 'wasm32') || matrix.toolchain == 'nightly') &&
         !contains(matrix.platform.target, 'redox') &&
+        !contains(matrix.platform.target, 'wasm32v1-none') &&
         matrix.toolchain != '1.86'
       run: cargo $CMD test $OPTIONS
 
     - name: Lint with clippy
-      if: (matrix.toolchain == 'stable') && !contains(matrix.platform.options, '--no-default-features')
+      if: >
+        (matrix.toolchain == 'stable') &&
+        !contains(matrix.platform.target, 'wasm32v1-none') &&
+        !contains(matrix.platform.options, '--no-default-features')
       run: cargo clippy --all-targets $OPTIONS $TEST_OPTIONS -- -Dwarnings
 
     - name: Build tests with serde enabled
       if: >
         !contains(matrix.platform.target, 'redox') &&
+        !contains(matrix.platform.target, 'wasm32v1-none') &&
         matrix.toolchain != '1.86'
       run: cargo $CMD test --no-run $OPTIONS $TEST_OPTIONS --features serde
 
@@ -270,11 +281,12 @@ jobs:
         !contains(matrix.platform.target, 'ios') &&
         (!contains(matrix.platform.target, 'wasm32') || matrix.toolchain == 'nightly') &&
         !contains(matrix.platform.target, 'redox') &&
+        !contains(matrix.platform.target, 'wasm32v1-none') &&
         matrix.toolchain != '1.86'
       run: cargo $CMD test $OPTIONS $TEST_OPTIONS --features serde
 
     - name: Check docs.rs documentation
-      if: matrix.toolchain == 'nightly'
+      if: matrix.toolchain == 'nightly' && !contains(matrix.platform.target, 'wasm32v1-none')
       run: cargo doc --no-deps $OPTIONS --features=serde,mint,android-native-activity
       env:
         RUSTDOCFLAGS: '--deny=warnings ${{ matrix.platform.rustflags }} --cfg=docsrs --cfg=unreleased_changelogs'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ winit = { path = "winit" }
 winit-android = { version = "=0.31.0-beta.2", path = "winit-android" }
 winit-appkit = { version = "=0.31.0-beta.2", path = "winit-appkit" }
 winit-common = { version = "=0.31.0-beta.2", path = "winit-common" }
-winit-core = { version = "=0.31.0-beta.2", path = "winit-core" }
+winit-core = { version = "=0.31.0-beta.2", path = "winit-core", default-features = false }
 winit-orbital = { version = "=0.31.0-beta.2", path = "winit-orbital" }
 winit-uikit = { version = "=0.31.0-beta.2", path = "winit-uikit" }
 winit-wayland = { version = "=0.31.0-beta.2", path = "winit-wayland", default-features = false }
@@ -89,11 +89,11 @@ redox_event = { package = "redox_event", version = "0.4.8" }
 atomic-waker = "1"
 concurrent-queue = { version = "2", default-features = false }
 console_error_panic_hook = "0.1"
-js-sys = "0.3.70"
+js-sys = { version = "0.3.70", default-features = false }
 pin-project = "1"
 tracing-web = "0.1"
-wasm-bindgen = "0.2.93"
-wasm-bindgen-futures = "0.4.43"
+wasm-bindgen = { version = "0.2.93", default-features = false }
+wasm-bindgen-futures = { version = "0.4.43", default-features = false }
 wasm-bindgen-test = "0.3"
 web-time = { version = "1", default-features = false }
-web_sys = { package = "web-sys", version = "0.3.70" }
+web_sys = { package = "web-sys", version = "0.3.70", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,15 +28,15 @@ winit-x11 = { version = "=0.31.0-beta.2", path = "winit-x11" }
 # Core dependencies.
 bitflags = "2"
 cfg_aliases = "0.2.2"
-cursor-icon = "1.1.0"
-dpi = { version = "0.1.2", path = "dpi" }
-keyboard-types = "0.8.0"
+cursor-icon = { version = "1.1.0", default-features = false }
+dpi = { version = "0.1.2", path = "dpi", default-features = false }
+keyboard-types = { version = "0.8.0", default-features = false }
 mint = "0.5.6"
-rwh_06 = { package = "raw-window-handle", version = "0.6", features = ["std"] }
-serde = { version = "1", features = ["serde_derive"] }
-smol_str = "0.3"
+rwh_06 = { package = "raw-window-handle", version = "0.6", default-features = false }
+serde = { version = "1", default-features = false, features = ["serde_derive", "alloc"] }
+smol_str = { version = "0.3", default-features = false }
 tracing = { version = "0.1.40", default-features = false }
-url = "2"
+url = { version = "2", default-features = false }
 
 # Dev dependencies.
 image = { version = "0.25.0", default-features = false }
@@ -94,5 +94,5 @@ tracing-web = "0.1"
 wasm-bindgen = "0.2.93"
 wasm-bindgen-futures = "0.4.43"
 wasm-bindgen-test = "0.3"
-web-time = "1"
+web-time = { version = "1", default-features = false }
 web_sys = { package = "web-sys", version = "0.3.70" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ atomic-waker = "1"
 concurrent-queue = { version = "2", default-features = false }
 console_error_panic_hook = "0.1"
 js-sys = { version = "0.3.70", default-features = false }
+once_cell = { version = "1", default-features = false }
 pin-project = "1"
 tracing-web = "0.1"
 wasm-bindgen = { version = "0.2.93", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ cfg_aliases = "0.2.2"
 cursor-icon = { version = "1.1.0", default-features = false }
 dpi = { version = "0.1.2", path = "dpi", default-features = false }
 keyboard-types = { version = "0.8.0", default-features = false }
+libm = { version = "0.2" }
 mint = "0.5.6"
 rwh_06 = { package = "raw-window-handle", version = "0.6", default-features = false }
 serde = { version = "1", default-features = false, features = ["serde_derive", "alloc"] }

--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -210,11 +210,10 @@ impl EventLoop {
                     let old_scale_factor = scale_factor(&self.android_app);
                     let scale_factor = scale_factor(&self.android_app);
                     if (scale_factor - old_scale_factor).abs() < f64::EPSILON {
-                        let new_surface_size = Arc::new(Mutex::new(screen_size(&self.android_app)));
+                        let (surface_size_writer, _) =
+                            SurfaceSizeWriter::new(screen_size(&self.android_app));
                         let event = event::WindowEvent::ScaleFactorChanged {
-                            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(
-                                &new_surface_size,
-                            )),
+                            surface_size_writer,
                             scale_factor,
                         };
 

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 use std::ffi::c_void;
 use std::ptr;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use dispatch2::MainThreadBound;
 use dpi::{
@@ -1080,13 +1080,9 @@ impl WindowDelegate {
         let window = self.window();
 
         let suggested_size = self.view().surface_size();
-        let new_surface_size = Arc::new(Mutex::new(suggested_size));
-        self.queue_event(WindowEvent::ScaleFactorChanged {
-            scale_factor,
-            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),
-        });
-        let physical_size = *new_surface_size.lock().unwrap();
-        drop(new_surface_size);
+        let (surface_size_writer, new_surface_size) = SurfaceSizeWriter::new(suggested_size);
+        self.queue_event(WindowEvent::ScaleFactorChanged { scale_factor, surface_size_writer });
+        let physical_size = new_surface_size.take();
 
         if physical_size != suggested_size {
             let logical_size = physical_size.to_logical(scale_factor);

--- a/winit-core/Cargo.toml
+++ b/winit-core/Cargo.toml
@@ -36,6 +36,9 @@ url = { workspace = true, default-features = false }
 [target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
 web-time = { workspace = true, default-features = false }
 
+[target.'cfg(all(target_family = "wasm", target_os = "none"))'.dependencies]
+libm.workspace = true
+
 [target.'cfg(not(all(target_family = "wasm", target_os = "none")))'.dependencies]
 url = { workspace = true, default-features = false, features = ["std"] }
 

--- a/winit-core/Cargo.toml
+++ b/winit-core/Cargo.toml
@@ -24,17 +24,20 @@ serde = [
 
 [dependencies]
 bitflags.workspace = true
-cursor-icon.workspace = true
-dpi.workspace = true
-keyboard-types.workspace = true
-rwh_06.workspace = true
-serde = { workspace = true, optional = true }
-smol_str.workspace = true
-url.workspace = true
+cursor-icon = { workspace = true, default-features = false }
+dpi = { workspace = true, default-features = false }
+keyboard-types = { workspace = true, default-features = false }
+rwh_06 = { workspace = true, default-features = false }
+serde = { workspace = true, default-features = false, optional = true }
+smol_str = { workspace = true, default-features = false }
+url = { workspace = true, default-features = false }
 
 # `wasm32-unknown-unknown` and `wasm32-none`, but not `wasm32-wasi`.
 [target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
-web-time.workspace = true
+web-time = { workspace = true, default-features = false }
+
+[target.'cfg(not(all(target_family = "wasm", target_os = "none")))'.dependencies]
+url = { workspace = true, default-features = false, features = ["std"] }
 
 [dev-dependencies]
 winit.workspace = true

--- a/winit-core/src/application/mod.rs
+++ b/winit-core/src/application/mod.rs
@@ -1,5 +1,7 @@
 //! End user application handling.
 
+use alloc::boxed::Box;
+
 use crate::event::{DeviceEvent, DeviceId, StartCause, WindowEvent};
 use crate::event_loop::ActiveEventLoop;
 use crate::window::WindowId;

--- a/winit-core/src/as_any.rs
+++ b/winit-core/src/as_any.rs
@@ -1,4 +1,5 @@
-use std::any::Any;
+use alloc::boxed::Box;
+use core::any::Any;
 
 // NOTE: This is `pub`, but isn't actually exposed outside the crate.
 // NOTE: Marked as `#[doc(hidden)]` and underscored, because they can be quite difficult to use
@@ -39,7 +40,7 @@ macro_rules! impl_dyn_casting {
             ///
             /// Returns `None` if the object was not from that backend.
             pub fn cast_ref<T: $trait>(&self) -> Option<&T> {
-                let this: &dyn std::any::Any = self.__as_any();
+                let this: &dyn core::any::Any = self.__as_any();
                 this.downcast_ref::<T>()
             }
 
@@ -47,16 +48,18 @@ macro_rules! impl_dyn_casting {
             ///
             /// Returns `None` if the object was not from that backend.
             pub fn cast_mut<T: $trait>(&mut self) -> Option<&mut T> {
-                let this: &mut dyn std::any::Any = self.__as_any_mut();
+                let this: &mut dyn core::any::Any = self.__as_any_mut();
                 this.downcast_mut::<T>()
             }
 
             /// Owned downcast to the backend concrete type.
             ///
             /// Returns `Err` with `self` if the object was not from that backend.
-            pub fn cast<T: $trait>(self: Box<Self>) -> Result<Box<T>, Box<Self>> {
+            pub fn cast<T: $trait>(
+                self: alloc::boxed::Box<Self>,
+            ) -> Result<alloc::boxed::Box<T>, alloc::boxed::Box<Self>> {
                 if self.cast_ref::<T>().is_some() {
-                    let this: Box<dyn std::any::Any> = self.__into_any();
+                    let this: alloc::boxed::Box<dyn core::any::Any> = self.__into_any();
                     // Unwrap is okay, we just checked the type of `self` is `T`.
                     Ok(this.downcast::<T>().unwrap())
                 } else {
@@ -71,6 +74,8 @@ pub use impl_dyn_casting;
 
 #[cfg(test)]
 mod tests {
+    use alloc::boxed::Box;
+
     use super::AsAny;
 
     struct Foo;

--- a/winit-core/src/cursor.rs
+++ b/winit-core/src/cursor.rs
@@ -1,9 +1,11 @@
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::error::Error;
 use core::fmt;
-use std::error::Error;
-use std::hash::Hash;
-use std::ops::Deref;
-use std::sync::Arc;
-use std::time::Duration;
+use core::hash::Hash;
+use core::ops::Deref;
+use core::time::Duration;
 
 #[doc(inline)]
 pub use cursor_icon::CursorIcon;
@@ -92,7 +94,7 @@ impl PartialEq for CustomCursor {
 impl Eq for CustomCursor {}
 
 impl Hash for CustomCursor {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         Arc::as_ptr(&self.0).hash(state);
     }
 }

--- a/winit-core/src/data_transfer.rs
+++ b/winit-core/src/data_transfer.rs
@@ -99,9 +99,13 @@
 
 #![warn(missing_docs)]
 
-use std::ops::ControlFlow;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
+use core::ops::ControlFlow;
+use std::io;
 use std::path::{Path, PathBuf};
-use std::{fmt, io};
 
 use crate::as_any::AsAny;
 
@@ -319,7 +323,7 @@ pub trait TypedData: AsAny + fmt::Debug + Send + Sync {
 // basis.
 impl PartialEq for dyn TypedData {
     fn eq(&self, other: &Self) -> bool {
-        std::ptr::addr_eq(self, other)
+        core::ptr::addr_eq(self, other)
     }
 }
 
@@ -394,11 +398,12 @@ pub enum SendData {
     Uris(Vec<String>),
     /// String
     ///
-    /// This can also be constructed with the [`From<String>`](std::string::String) implementation.
+    /// This can also be constructed with the [`From<String>`](alloc::string::String)
+    /// implementation.
     String(String),
     /// Binary blob
     ///
-    /// This can also be constructed with the [`From<Vec<u8>>`](std::vec::Vec) implementation.
+    /// This can also be constructed with the [`From<Vec<u8>>`](alloc::vec::Vec) implementation.
     Bytes(Vec<u8>),
 }
 

--- a/winit-core/src/data_transfer.rs
+++ b/winit-core/src/data_transfer.rs
@@ -104,8 +104,16 @@ use alloc::string::String;
 use alloc::vec::Vec;
 use core::fmt;
 use core::ops::ControlFlow;
+// FIXME: alloc::io is a nightly only feature as of writing
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
 use std::io;
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
+#[allow(unused_imports, reason = "TypedData not yet supported on no_std")]
 use std::path::{Path, PathBuf};
+
+#[cfg(all(target_family = "wasm", target_os = "none"))]
+#[allow(unused_imports, reason = "TypedData not yet supported on no_std")]
+use {alloc::string::String as PathBuf, core::primitive::str as Path};
 
 use crate::as_any::AsAny;
 
@@ -222,6 +230,7 @@ impl TransferType for TypeHint {
 impl_dyn_casting!(TransferType);
 
 // Replicates the cfg for `url::Url::parse`
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
 #[cfg(any(unix, windows, target_os = "redox", target_os = "wasi", target_os = "hermit"))]
 fn default_try_as_file_paths<T: TypedData + ?Sized>(data: &T) -> io::Result<Vec<PathBuf>> {
     data.try_as_uris().and_then(|uris| {
@@ -240,6 +249,7 @@ fn default_try_as_file_paths<T: TypedData + ?Sized>(data: &T) -> io::Result<Vec<
 //
 // It doesn't matter that this is unimplemented on the web, as we don't currently support
 // drag-and-drop for web targets and the web platform can't directly access paths anyway.
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
 #[cfg(not(any(unix, windows, target_os = "redox", target_os = "wasi", target_os = "hermit")))]
 fn default_try_as_file_paths<T: TypedData + ?Sized>(_: &T) -> io::Result<Vec<PathBuf>> {
     Err(io::ErrorKind::Unsupported.into())
@@ -254,6 +264,7 @@ fn default_try_as_file_paths<T: TypedData + ?Sized>(_: &T) -> io::Result<Vec<Pat
 /// error with [`io::ErrorKind::Deadlock`]. For now, the only way to access the data is via blocking
 /// on the event loop, so simply retrying the next time an event is received that references the
 /// data transfer should be enough to ensure that the data is accessible.
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
 pub trait TypedData: AsAny + fmt::Debug + Send + Sync {
     /// The type of this `TypedData`.
     fn type_(&self) -> &dyn TransferType;
@@ -321,12 +332,14 @@ pub trait TypedData: AsAny + fmt::Debug + Send + Sync {
 
 // Required for `WindowEvent` to implement `PartialEq` - we just implement this on a best-effort
 // basis.
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
 impl PartialEq for dyn TypedData {
     fn eq(&self, other: &Self) -> bool {
         core::ptr::addr_eq(self, other)
     }
 }
 
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
 impl_dyn_casting!(TypedData);
 
 /// Metadata about a data transfer. This does not allow actually receiving data, as that is an

--- a/winit-core/src/error.rs
+++ b/winit-core/src/error.rs
@@ -1,5 +1,6 @@
-use std::error::Error;
-use std::fmt::{self, Display};
+use alloc::boxed::Box;
+use core::error::Error;
+use core::fmt::{self, Display};
 
 /// A general error that may occur while running or creating
 /// the event loop.

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -11,7 +11,6 @@ use dpi::{PhysicalPosition, PhysicalSize};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
-use crate::Instant;
 use crate::data_transfer::DataTransferId;
 #[cfg(not(all(target_family = "wasm", target_os = "none")))]
 use crate::data_transfer::TypedData;
@@ -21,6 +20,7 @@ use crate::keyboard::{self, ModifiersKeyState, ModifiersKeys, ModifiersState};
 #[cfg(doc)]
 use crate::window::Window;
 use crate::window::{ActivationToken, Theme};
+use crate::{Instant, libm};
 
 /// Describes the reason the event loop is resuming.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -1143,7 +1143,7 @@ impl Force {
         match self {
             Force::Calibrated { force, max_possible_force } => {
                 let force = match angle {
-                    Some(TabletToolAngle { altitude, .. }) => force / altitude.sin(),
+                    Some(TabletToolAngle { altitude, .. }) => force / libm::sin(altitude),
                     None => *force,
                 };
                 force / max_possible_force
@@ -1300,7 +1300,7 @@ impl TabletToolTilt {
             azimuth = 0.;
         } else {
             // Non-boundary case: neither tiltX nor tiltY is equal to 0 or +-90
-            azimuth = f64::atan2(y.tan(), x.tan());
+            azimuth = libm::atan2(libm::tan(*y), libm::tan(*x));
 
             if azimuth < 0. {
                 azimuth += PI_2;
@@ -1317,7 +1317,7 @@ impl TabletToolTilt {
             altitude = PI_0_5 - x.abs();
         } else {
             // Non-boundary case: neither tiltX nor tiltY is equal to 0 or +-90
-            altitude = f64::atan(1. / f64::sqrt(x.tan().powi(2) + y.tan().powi(2)));
+            altitude = libm::atan(1. / libm::hypot(libm::tan(*x), libm::tan(*y)));
         }
 
         TabletToolAngle { altitude, azimuth }
@@ -1403,13 +1403,16 @@ impl TabletToolAngle {
         }
 
         if self.altitude != 0. {
-            let altitude = self.altitude.tan();
+            let altitude = libm::tan(self.altitude);
 
-            x = f64::atan(f64::cos(self.azimuth) / altitude);
-            y = f64::atan(f64::sin(self.azimuth) / altitude);
+            x = libm::atan(libm::cos(self.azimuth) / altitude);
+            y = libm::atan(libm::sin(self.azimuth) / altitude);
         }
 
-        TabletToolTilt { x: x.to_degrees().round() as i8, y: y.to_degrees().round() as i8 }
+        TabletToolTilt {
+            x: libm::round(x.to_degrees()) as i8,
+            y: libm::round(y.to_degrees()) as i8,
+        }
     }
 }
 

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -12,7 +12,9 @@ use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
 use crate::Instant;
-use crate::data_transfer::{DataTransferId, TypedData};
+use crate::data_transfer::DataTransferId;
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
+use crate::data_transfer::TypedData;
 use crate::error::RequestError;
 use crate::event_loop::{AsyncRequestSerial, DndAction};
 use crate::keyboard::{self, ModifiersKeyState, ModifiersKeys, ModifiersState};
@@ -45,6 +47,7 @@ pub enum StartCause {
 }
 
 /// Describes an event from a [`Window`].
+#[cfg_attr(not(all(target_family = "wasm", target_os = "none")), non_exhaustive)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum WindowEvent {
     /// The activation token was delivered back and now could be used.
@@ -149,6 +152,7 @@ pub enum WindowEvent {
     /// cases, winit may dispatch the event to all  windows that have access to the data
     /// transfer. If your application should only process this event once per data transfer, the
     /// `serial` field can be used to deduplicate it.
+    #[cfg(not(all(target_family = "wasm", target_os = "none")))]
     DataTransferReceived {
         /// ID of the data transfer object, see
         /// [`crate::event_loop::ActiveEventLoop::data_transfer`].
@@ -1800,24 +1804,24 @@ mod tests {
         const TILT_TO_ANGLE: &[(TabletToolTilt, TabletToolAngle)] = &[
             (TabletToolTilt { x: 0, y: 0 }, TabletToolAngle { altitude: FRAC_PI_2, azimuth: 0. }),
             (TabletToolTilt { x: 0, y: 90 }, TabletToolAngle { altitude: 0., azimuth: FRAC_PI_2 }),
-            (
-                TabletToolTilt { x: 0, y: -90 },
-                TabletToolAngle { altitude: 0., azimuth: 3. * FRAC_PI_2 },
-            ),
+            (TabletToolTilt { x: 0, y: -90 }, TabletToolAngle {
+                altitude: 0.,
+                azimuth: 3. * FRAC_PI_2,
+            }),
             (TabletToolTilt { x: 90, y: 0 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
             (TabletToolTilt { x: 90, y: 90 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
             (TabletToolTilt { x: 90, y: -90 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
             (TabletToolTilt { x: -90, y: 0 }, TabletToolAngle { altitude: 0., azimuth: PI }),
             (TabletToolTilt { x: -90, y: 90 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
             (TabletToolTilt { x: -90, y: -90 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
-            (
-                TabletToolTilt { x: 0, y: 45 },
-                TabletToolAngle { altitude: FRAC_PI_4, azimuth: FRAC_PI_2 },
-            ),
-            (
-                TabletToolTilt { x: 0, y: -45 },
-                TabletToolAngle { altitude: FRAC_PI_4, azimuth: 3. * FRAC_PI_2 },
-            ),
+            (TabletToolTilt { x: 0, y: 45 }, TabletToolAngle {
+                altitude: FRAC_PI_4,
+                azimuth: FRAC_PI_2,
+            }),
+            (TabletToolTilt { x: 0, y: -45 }, TabletToolAngle {
+                altitude: FRAC_PI_4,
+                azimuth: 3. * FRAC_PI_2,
+            }),
             (TabletToolTilt { x: 45, y: 0 }, TabletToolAngle { altitude: FRAC_PI_4, azimuth: 0. }),
             (TabletToolTilt { x: -45, y: 0 }, TabletToolAngle { altitude: FRAC_PI_4, azimuth: PI }),
         ];
@@ -1832,20 +1836,20 @@ mod tests {
             (TabletToolAngle { altitude: FRAC_PI_4, azimuth: 0. }, TabletToolTilt { x: 45, y: 0 }),
             (TabletToolAngle { altitude: FRAC_PI_2, azimuth: 0. }, TabletToolTilt { x: 0, y: 0 }),
             (TabletToolAngle { altitude: 0., azimuth: FRAC_PI_2 }, TabletToolTilt { x: 0, y: 90 }),
-            (
-                TabletToolAngle { altitude: FRAC_PI_4, azimuth: FRAC_PI_2 },
-                TabletToolTilt { x: 0, y: 45 },
-            ),
+            (TabletToolAngle { altitude: FRAC_PI_4, azimuth: FRAC_PI_2 }, TabletToolTilt {
+                x: 0,
+                y: 45,
+            }),
             (TabletToolAngle { altitude: 0., azimuth: PI }, TabletToolTilt { x: -90, y: 0 }),
             (TabletToolAngle { altitude: FRAC_PI_4, azimuth: PI }, TabletToolTilt { x: -45, y: 0 }),
-            (
-                TabletToolAngle { altitude: 0., azimuth: 3. * FRAC_PI_2 },
-                TabletToolTilt { x: 0, y: -90 },
-            ),
-            (
-                TabletToolAngle { altitude: FRAC_PI_4, azimuth: 3. * FRAC_PI_2 },
-                TabletToolTilt { x: 0, y: -45 },
-            ),
+            (TabletToolAngle { altitude: 0., azimuth: 3. * FRAC_PI_2 }, TabletToolTilt {
+                x: 0,
+                y: -90,
+            }),
+            (TabletToolAngle { altitude: FRAC_PI_4, azimuth: 3. * FRAC_PI_2 }, TabletToolTilt {
+                x: 0,
+                y: -45,
+            }),
         ];
 
         for (angle, tilt) in ANGLE_TO_TILT {

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -4,7 +4,7 @@ use alloc::sync::{Arc, Weak};
 use core::cell::LazyCell;
 use core::cmp::Ordering;
 use core::f64;
-use std::sync::Mutex;
+use core::sync::atomic::{self, AtomicU32};
 
 use dpi::{PhysicalPosition, PhysicalSize};
 #[cfg(feature = "serde")]
@@ -1583,15 +1583,61 @@ pub enum MouseScrollDelta {
     PixelDelta(PhysicalPosition<f64>),
 }
 
+/// A handle which can retrieve a [surface size](PhysicalSize<u32>) from a [`SurfaceSizeWriter`].
+pub struct SurfaceSizeWriterHandle {
+    inner: Arc<SharedSurfaceSize>,
+}
+
+impl SurfaceSizeWriterHandle {
+    /// Consume this handle and retrieve the new [surface size](PhysicalSize<u32>).
+    pub fn take(self) -> PhysicalSize<u32> {
+        self.inner.get()
+    }
+
+    fn new(strong: Arc<SharedSurfaceSize>) -> Self {
+        Self { inner: strong }
+    }
+}
+
+#[derive(Debug)]
+struct SharedSurfaceSize {
+    inner: PhysicalSize<AtomicU32>,
+}
+
+impl SharedSurfaceSize {
+    fn get(&self) -> PhysicalSize<u32> {
+        PhysicalSize {
+            width: self.inner.width.load(atomic::Ordering::Acquire),
+            height: self.inner.height.load(atomic::Ordering::Acquire),
+        }
+    }
+
+    fn set(&self, size: PhysicalSize<u32>) {
+        self.inner.width.store(size.width, atomic::Ordering::Release);
+        self.inner.height.store(size.height, atomic::Ordering::Release);
+    }
+
+    fn new(size: PhysicalSize<u32>) -> Self {
+        Self {
+            inner: PhysicalSize {
+                width: AtomicU32::new(size.width),
+                height: AtomicU32::new(size.height),
+            },
+        }
+    }
+}
+
 /// Handle to synchronously change the size of the window from the [`WindowEvent`].
 #[derive(Debug, Clone)]
 pub struct SurfaceSizeWriter {
-    pub(crate) new_surface_size: Weak<Mutex<PhysicalSize<u32>>>,
+    new_surface_size: Weak<SharedSurfaceSize>,
 }
 
 impl SurfaceSizeWriter {
-    pub fn new(new_surface_size: Weak<Mutex<PhysicalSize<u32>>>) -> Self {
-        Self { new_surface_size }
+    pub fn new(new_surface_size: PhysicalSize<u32>) -> (Self, SurfaceSizeWriterHandle) {
+        let strong = Arc::new(SharedSurfaceSize::new(new_surface_size));
+        let weak = Arc::downgrade(&strong);
+        (Self { new_surface_size: weak }, SurfaceSizeWriterHandle::new(strong))
     }
 
     /// Try to request surface size which will be set synchronously on the window.
@@ -1600,7 +1646,7 @@ impl SurfaceSizeWriter {
         new_surface_size: PhysicalSize<u32>,
     ) -> Result<(), RequestError> {
         if let Some(inner) = self.new_surface_size.upgrade() {
-            *inner.lock().unwrap() = new_surface_size;
+            inner.set(new_surface_size);
             Ok(())
         } else {
             Err(RequestError::Ignored)
@@ -1610,7 +1656,7 @@ impl SurfaceSizeWriter {
     /// Get the currently stashed surface size.
     pub fn surface_size(&self) -> Result<PhysicalSize<u32>, RequestError> {
         if let Some(inner) = self.new_surface_size.upgrade() {
-            Ok(*inner.lock().unwrap())
+            Ok(inner.get())
         } else {
             Err(RequestError::Ignored)
         }

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -1,8 +1,10 @@
 //! The event enums and assorted supporting types.
-use std::cell::LazyCell;
-use std::cmp::Ordering;
-use std::f64;
-use std::sync::{Arc, Mutex, Weak};
+use alloc::string::String;
+use alloc::sync::{Arc, Weak};
+use core::cell::LazyCell;
+use core::cmp::Ordering;
+use core::f64;
+use std::sync::Mutex;
 
 use dpi::{PhysicalPosition, PhysicalSize};
 #[cfg(feature = "serde")]
@@ -1268,7 +1270,7 @@ impl TabletToolTilt {
     pub fn angle(self) -> TabletToolAngle {
         // See <https://www.w3.org/TR/2024/WD-pointerevents3-20240326/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle>.
 
-        use std::f64::consts::*;
+        use core::f64::consts::*;
 
         const PI_0_5: f64 = FRAC_PI_2;
         const PI_1_5: f64 = 3. * FRAC_PI_2;
@@ -1363,7 +1365,7 @@ impl TabletToolAngle {
     pub fn tilt(self) -> TabletToolTilt {
         // See <https://www.w3.org/TR/2024/WD-pointerevents3-20240326/#converting-between-tiltx-tilty-and-altitudeangle-azimuthangle>.
 
-        use std::f64::consts::*;
+        use core::f64::consts::*;
 
         const PI_0_5: f64 = FRAC_PI_2;
         const PI_1_5: f64 = 3. * FRAC_PI_2;
@@ -1625,7 +1627,8 @@ impl Eq for SurfaceSizeWriter {}
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeSet, HashSet};
+    use alloc::collections::BTreeSet;
+    use std::collections::HashSet;
 
     use dpi::PhysicalPosition;
 
@@ -1743,7 +1746,7 @@ mod tests {
 
     #[test]
     fn test_tilt_angle_conversions() {
-        use std::f64::consts::*;
+        use core::f64::consts::*;
 
         use event::{TabletToolAngle, TabletToolTilt};
 
@@ -1751,24 +1754,24 @@ mod tests {
         const TILT_TO_ANGLE: &[(TabletToolTilt, TabletToolAngle)] = &[
             (TabletToolTilt { x: 0, y: 0 }, TabletToolAngle { altitude: FRAC_PI_2, azimuth: 0. }),
             (TabletToolTilt { x: 0, y: 90 }, TabletToolAngle { altitude: 0., azimuth: FRAC_PI_2 }),
-            (TabletToolTilt { x: 0, y: -90 }, TabletToolAngle {
-                altitude: 0.,
-                azimuth: 3. * FRAC_PI_2,
-            }),
+            (
+                TabletToolTilt { x: 0, y: -90 },
+                TabletToolAngle { altitude: 0., azimuth: 3. * FRAC_PI_2 },
+            ),
             (TabletToolTilt { x: 90, y: 0 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
             (TabletToolTilt { x: 90, y: 90 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
             (TabletToolTilt { x: 90, y: -90 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
             (TabletToolTilt { x: -90, y: 0 }, TabletToolAngle { altitude: 0., azimuth: PI }),
             (TabletToolTilt { x: -90, y: 90 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
             (TabletToolTilt { x: -90, y: -90 }, TabletToolAngle { altitude: 0., azimuth: 0. }),
-            (TabletToolTilt { x: 0, y: 45 }, TabletToolAngle {
-                altitude: FRAC_PI_4,
-                azimuth: FRAC_PI_2,
-            }),
-            (TabletToolTilt { x: 0, y: -45 }, TabletToolAngle {
-                altitude: FRAC_PI_4,
-                azimuth: 3. * FRAC_PI_2,
-            }),
+            (
+                TabletToolTilt { x: 0, y: 45 },
+                TabletToolAngle { altitude: FRAC_PI_4, azimuth: FRAC_PI_2 },
+            ),
+            (
+                TabletToolTilt { x: 0, y: -45 },
+                TabletToolAngle { altitude: FRAC_PI_4, azimuth: 3. * FRAC_PI_2 },
+            ),
             (TabletToolTilt { x: 45, y: 0 }, TabletToolAngle { altitude: FRAC_PI_4, azimuth: 0. }),
             (TabletToolTilt { x: -45, y: 0 }, TabletToolAngle { altitude: FRAC_PI_4, azimuth: PI }),
         ];
@@ -1783,20 +1786,20 @@ mod tests {
             (TabletToolAngle { altitude: FRAC_PI_4, azimuth: 0. }, TabletToolTilt { x: 45, y: 0 }),
             (TabletToolAngle { altitude: FRAC_PI_2, azimuth: 0. }, TabletToolTilt { x: 0, y: 0 }),
             (TabletToolAngle { altitude: 0., azimuth: FRAC_PI_2 }, TabletToolTilt { x: 0, y: 90 }),
-            (TabletToolAngle { altitude: FRAC_PI_4, azimuth: FRAC_PI_2 }, TabletToolTilt {
-                x: 0,
-                y: 45,
-            }),
+            (
+                TabletToolAngle { altitude: FRAC_PI_4, azimuth: FRAC_PI_2 },
+                TabletToolTilt { x: 0, y: 45 },
+            ),
             (TabletToolAngle { altitude: 0., azimuth: PI }, TabletToolTilt { x: -90, y: 0 }),
             (TabletToolAngle { altitude: FRAC_PI_4, azimuth: PI }, TabletToolTilt { x: -45, y: 0 }),
-            (TabletToolAngle { altitude: 0., azimuth: 3. * FRAC_PI_2 }, TabletToolTilt {
-                x: 0,
-                y: -90,
-            }),
-            (TabletToolAngle { altitude: FRAC_PI_4, azimuth: 3. * FRAC_PI_2 }, TabletToolTilt {
-                x: 0,
-                y: -45,
-            }),
+            (
+                TabletToolAngle { altitude: 0., azimuth: 3. * FRAC_PI_2 },
+                TabletToolTilt { x: 0, y: -90 },
+            ),
+            (
+                TabletToolAngle { altitude: FRAC_PI_4, azimuth: 3. * FRAC_PI_2 },
+                TabletToolTilt { x: 0, y: -45 },
+            ),
         ];
 
         for (angle, tilt) in ANGLE_TO_TILT {
@@ -1815,7 +1818,7 @@ mod tests {
         let force3 = event::Force::Calibrated { force: 5.0, max_possible_force: 2.5 };
         assert_eq!(
             force3.normalized(Some(event::TabletToolAngle {
-                altitude: std::f64::consts::PI / 2.0,
+                altitude: core::f64::consts::PI / 2.0,
                 azimuth: 0.
             })),
             2.0

--- a/winit-core/src/event_loop/mod.rs
+++ b/winit-core/src/event_loop/mod.rs
@@ -3,10 +3,11 @@ pub mod pump_events;
 pub mod register;
 pub mod run_on_demand;
 
-use std::fmt::{self, Debug};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::fmt::{self, Debug};
+use core::sync::atomic::{AtomicUsize, Ordering};
+use core::time::Duration;
 
 use rwh_06::{DisplayHandle, HandleError, HasDisplayHandle};
 

--- a/winit-core/src/event_loop/pump_events.rs
+++ b/winit-core/src/event_loop/pump_events.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use core::time::Duration;
 
 use crate::application::ApplicationHandler;
 

--- a/winit-core/src/icon.rs
+++ b/winit-core/src/icon.rs
@@ -3,6 +3,7 @@ use alloc::vec::Vec;
 use core::error::Error;
 use core::ops::Deref;
 use core::{fmt, mem};
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
 use std::io;
 
 use crate::as_any::AsAny;
@@ -27,6 +28,7 @@ impl Deref for Icon {
 impl_dyn_casting!(IconProvider);
 
 #[derive(Debug)]
+#[cfg_attr(all(target_family = "wasm", target_os = "none"), non_exhaustive)]
 /// An error produced when using [`RgbaIcon::new`] with invalid arguments.
 pub enum BadIcon {
     /// Produced when the length of the `rgba` argument isn't divisible by 4, thus `rgba` can't be
@@ -36,6 +38,7 @@ pub enum BadIcon {
     /// At least one of your arguments is incorrect.
     DimensionsVsPixelCount { width: u32, height: u32, width_x_height: usize, pixel_count: usize },
     /// Produced when underlying OS functionality failed to create the icon
+    #[cfg(not(all(target_family = "wasm", target_os = "none")))]
     OsError(io::Error),
 }
 
@@ -55,6 +58,7 @@ impl fmt::Display for BadIcon {
                      dimensions, the expected pixel count is {width_x_height:?}.",
                 )
             },
+            #[cfg(not(all(target_family = "wasm", target_os = "none")))]
             BadIcon::OsError(e) => write!(f, "OS error when instantiating the icon: {e:?}"),
         }
     }

--- a/winit-core/src/icon.rs
+++ b/winit-core/src/icon.rs
@@ -1,7 +1,9 @@
-use std::error::Error;
-use std::ops::Deref;
-use std::sync::Arc;
-use std::{fmt, io, mem};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::error::Error;
+use core::ops::Deref;
+use core::{fmt, mem};
+use std::io;
 
 use crate::as_any::AsAny;
 

--- a/winit-core/src/keyboard.rs
+++ b/winit-core/src/keyboard.rs
@@ -33,8 +33,8 @@ pub enum NativeKeyCode {
     Ohos(u32),
 }
 
-impl std::fmt::Debug for NativeKeyCode {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NativeKeyCode {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use NativeKeyCode::{Android, MacOS, Ohos, Unidentified, Windows, Xkb};
         let mut debug_tuple;
         match self {
@@ -95,8 +95,8 @@ pub enum NativeKey {
     Ohos(u32),
 }
 
-impl std::fmt::Debug for NativeKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for NativeKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         use NativeKey::{Android, MacOS, Ohos, Unidentified, Web, Windows, Xkb};
         let mut debug_tuple;
         match self {

--- a/winit-core/src/lib.rs
+++ b/winit-core/src/lib.rs
@@ -11,6 +11,8 @@
 
 #[macro_use]
 extern crate alloc;
+
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
 extern crate std;
 
 #[macro_use]
@@ -27,10 +29,15 @@ pub mod keyboard;
 pub mod monitor;
 pub mod window;
 
-// `Instant` is not actually available on `wasm32-unknown-unknown`, the `std` implementation there
-// is a stub. And `wasm32-none` doesn't even have `std`. Instead, we use `web_time::Instant`.
+#[cfg(not(all(target_family = "wasm", target_os = "none")))]
+pub(crate) mod libm;
+// `Instant` is not actually available on `wasm32-unknown-unknown`, the `std` implementation
+// there is a stub. And `wasm32-none` doesn't even have `std`. Instead, we use
+// `web_time::Instant`.
 #[cfg(not(all(target_family = "wasm", any(target_os = "unknown", target_os = "none"))))]
 pub(crate) use std::time::Instant;
 
+#[cfg(all(target_family = "wasm", target_os = "none"))]
+pub(crate) use ::libm;
 #[cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))]
 pub(crate) use web_time::Instant;

--- a/winit-core/src/lib.rs
+++ b/winit-core/src/lib.rs
@@ -6,6 +6,12 @@
 //! See the [`winit`] crate for the full user-facing API.
 //!
 //! [`winit`]: https://docs.rs/winit
+#![warn(clippy::std_instead_of_core, clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate std;
 
 #[macro_use]
 pub mod as_any;

--- a/winit-core/src/libm.rs
+++ b/winit-core/src/libm.rs
@@ -1,0 +1,27 @@
+pub fn round(x: f64) -> f64 {
+    f64::round(x)
+}
+
+pub fn sin(x: f64) -> f64 {
+    f64::sin(x)
+}
+
+pub fn atan2(y: f64, x: f64) -> f64 {
+    f64::atan2(y, x)
+}
+
+pub fn tan(x: f64) -> f64 {
+    f64::tan(x)
+}
+
+pub fn atan(x: f64) -> f64 {
+    f64::atan(x)
+}
+
+pub fn hypot(x: f64, y: f64) -> f64 {
+    f64::hypot(x, y)
+}
+
+pub fn cos(x: f64) -> f64 {
+    f64::cos(x)
+}

--- a/winit-core/src/monitor.rs
+++ b/winit-core/src/monitor.rs
@@ -5,11 +5,12 @@
 //! methods, which return an iterator of [`MonitorHandle`]:
 //! - [`ActiveEventLoop::available_monitors`][crate::event_loop::ActiveEventLoop::available_monitors].
 //! - [`Window::available_monitors`][crate::window::Window::available_monitors].
-use std::borrow::Cow;
-use std::fmt;
-use std::num::{NonZeroU16, NonZeroU32};
-use std::ops::Deref;
-use std::sync::Arc;
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use core::fmt;
+use core::num::{NonZeroU16, NonZeroU32};
+use core::ops::Deref;
 
 use dpi::{PhysicalPosition, PhysicalSize};
 

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -1,5 +1,7 @@
 //! The [`Window`] trait and associated types.
-use std::fmt;
+use alloc::boxed::Box;
+use alloc::string::String;
+use core::fmt;
 
 use bitflags::bitflags;
 use cursor_icon::CursorIcon;
@@ -513,7 +515,7 @@ pub(crate) struct SendSyncRawWindowHandle(pub(crate) rwh_06::RawWindowHandle);
 unsafe impl Send for SendSyncRawWindowHandle {}
 unsafe impl Sync for SendSyncRawWindowHandle {}
 
-pub trait PlatformWindowAttributes: AsAny + std::fmt::Debug + Send + Sync {
+pub trait PlatformWindowAttributes: AsAny + core::fmt::Debug + Send + Sync {
     fn box_clone(&self) -> Box<dyn PlatformWindowAttributes>;
 }
 
@@ -1521,8 +1523,8 @@ impl PartialEq for dyn Window + '_ {
 
 impl Eq for dyn Window + '_ {}
 
-impl std::hash::Hash for dyn Window + '_ {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for dyn Window + '_ {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.id().hash(state);
     }
 }
@@ -1779,7 +1781,7 @@ impl fmt::Display for ImeSurroundingTextError {
     }
 }
 
-impl std::error::Error for ImeSurroundingTextError {}
+impl core::error::Error for ImeSurroundingTextError {}
 
 /// Defines the text surrounding the caret
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
@@ -2129,7 +2131,7 @@ impl fmt::Display for ImeRequestError {
     }
 }
 
-impl std::error::Error for ImeRequestError {}
+impl core::error::Error for ImeRequestError {}
 
 /// An opaque token used to activate the [`Window`].
 ///
@@ -2243,7 +2245,7 @@ mod tests {
         );
 
         let text: &[u8] = ['a' as u8; 8000].as_slice();
-        let text = std::str::from_utf8(text).unwrap();
+        let text = core::str::from_utf8(text).unwrap();
         assert_eq!(
             ImeSurroundingText::new(text.into(), 0, 0),
             Err(ImeSurroundingTextError::TextTooLong),

--- a/winit-uikit/src/app_state.rs
+++ b/winit-uikit/src/app_state.rs
@@ -3,7 +3,7 @@
 use std::cell::{Cell, OnceCell};
 use std::collections::HashSet;
 use std::os::raw::c_void;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
 use std::{fmt, ptr};
 
@@ -449,16 +449,15 @@ fn handle_wrapped_event(mtm: MainThreadMarker, event: EventWrapper) {
 
 fn handle_hidpi_proxy(mtm: MainThreadMarker, event: ScaleFactorChanged) {
     let ScaleFactorChanged { suggested_size, scale_factor, window } = event;
-    let new_surface_size = Arc::new(Mutex::new(suggested_size));
+    let (surface_size_writer, new_surface_size) = SurfaceSizeWriter::new(suggested_size);
     get_handler(mtm).handle(|app| {
         app.window_event(&ActiveEventLoop { mtm }, window.id(), WindowEvent::ScaleFactorChanged {
             scale_factor,
-            surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),
+            surface_size_writer,
         });
     });
     let (view, screen_frame) = get_view_and_screen_frame(&window);
-    let physical_size = *new_surface_size.lock().unwrap();
-    drop(new_surface_size);
+    let physical_size = new_surface_size.take();
     let logical_size = physical_size.to_logical(scale_factor);
     let size = CGSize::new(logical_size.width, logical_size.height);
     let new_frame: CGRect = CGRect::new(screen_frame.origin, size);

--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -392,16 +392,12 @@ impl EventLoop {
                 // Stash the old window size.
                 let old_physical_size = physical_size;
 
-                let new_surface_size = Arc::new(Mutex::new(physical_size));
-                let event = WindowEvent::ScaleFactorChanged {
-                    scale_factor,
-                    surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),
-                };
+                let (surface_size_writer, new_surface_size) = SurfaceSizeWriter::new(physical_size);
+                let event = WindowEvent::ScaleFactorChanged { scale_factor, surface_size_writer };
 
                 app.window_event(&self.active_event_loop, window_id, event);
 
-                let physical_size = *new_surface_size.lock().unwrap();
-                drop(new_surface_size);
+                let physical_size = new_surface_size.take();
 
                 // Resize the window when user altered the size.
                 if old_physical_size != physical_size {

--- a/winit-web/Cargo.toml
+++ b/winit-web/Cargo.toml
@@ -19,21 +19,21 @@ serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]
 
 [dependencies]
 bitflags.workspace = true
-cursor-icon.workspace = true
-dpi.workspace = true
-rwh_06.workspace = true
-serde = { workspace = true, optional = true }
-smol_str.workspace = true
+cursor-icon = { workspace = true, default-features = false }
+dpi = { workspace = true, default-features = false }
+rwh_06 = { workspace = true, default-features = false }
+serde = { workspace = true, default-features = false, optional = true }
+smol_str = { workspace = true, default-features = false }
 tracing.workspace = true
-winit-core.workspace = true
+winit-core = { workspace = true, default-features = false }
 
 # Platform-specific
-js-sys.workspace = true
+js-sys = { workspace = true, default-features = false }
 pin-project.workspace = true
-wasm-bindgen.workspace = true
-wasm-bindgen-futures.workspace = true
-web-time.workspace = true
-web_sys = { workspace = true, features = [
+wasm-bindgen = { workspace = true, default-features = false }
+wasm-bindgen-futures = { workspace = true, default-features = false }
+web-time = { workspace = true, default-features = false }
+web_sys = { workspace = true, default-features = false, features = [
     "AbortController",
     "AbortSignal",
     "Blob",

--- a/winit-web/Cargo.toml
+++ b/winit-web/Cargo.toml
@@ -21,6 +21,7 @@ serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]
 bitflags.workspace = true
 cursor-icon = { workspace = true, default-features = false }
 dpi = { workspace = true, default-features = false }
+once_cell = { workspace = true, default-features = false, features = ["race", "alloc"] }
 rwh_06 = { workspace = true, default-features = false }
 serde = { workspace = true, default-features = false, optional = true }
 smol_str = { workspace = true, default-features = false }

--- a/winit-web/src/async/abortable.rs
+++ b/winit-web/src/async/abortable.rs
@@ -1,10 +1,10 @@
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::task::{Context, Poll};
+use alloc::sync::Arc;
+use core::error::Error;
+use core::fmt::{self, Display, Formatter};
+use core::future::Future;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::{Context, Poll};
 
 use pin_project::pin_project;
 

--- a/winit-web/src/async/atomic_waker.rs
+++ b/winit-web/src/async/atomic_waker.rs
@@ -1,6 +1,6 @@
-use std::cell::RefCell;
-use std::ops::Deref;
-use std::task::Waker;
+use core::cell::RefCell;
+use core::ops::Deref;
+use core::task::Waker;
 
 #[derive(Debug)]
 pub struct AtomicWaker(RefCell<Option<Waker>>);

--- a/winit-web/src/async/channel.rs
+++ b/winit-web/src/async/channel.rs
@@ -1,8 +1,8 @@
-use std::future;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use alloc::sync::Arc;
+use core::future;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
 use std::sync::mpsc::{self, RecvError, SendError, TryRecvError};
-use std::task::Poll;
 
 use super::AtomicWaker;
 

--- a/winit-web/src/async/channel.rs
+++ b/winit-web/src/async/channel.rs
@@ -1,29 +1,34 @@
 use alloc::sync::Arc;
-use core::future;
+use core::error::Error;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::task::Poll;
-use std::sync::mpsc::{self, RecvError, SendError, TryRecvError};
+use core::{fmt, future};
 
-use super::AtomicWaker;
+use super::{AtomicWaker, ConcurrentQueue, PopError, PushError};
 
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
-    let (sender, receiver) = mpsc::channel();
-    let shared = Arc::new(Shared { closed: AtomicBool::new(false), waker: AtomicWaker::new() });
+    let queue = ConcurrentQueue::unbounded();
+    let shared =
+        Arc::new(Shared { closed: AtomicBool::new(false), waker: AtomicWaker::new(), queue });
 
-    let sender = Sender { sender, shared: Arc::clone(&shared) };
-    let receiver = Receiver { receiver, shared };
+    let sender = Sender { shared: Arc::clone(&shared) };
+    let receiver = Receiver { shared };
 
     (sender, receiver)
 }
 
 pub struct Sender<T> {
-    sender: mpsc::Sender<T>,
-    shared: Arc<Shared>,
+    shared: Arc<Shared<T>>,
 }
 
 impl<T> Sender<T> {
     pub fn send(&self, event: T) -> Result<(), SendError<T>> {
-        self.sender.send(event)?;
+        if let Err(PushError::Closed(event) | PushError::Full(event)) =
+            self.shared.queue.push(event)
+        {
+            return Err(SendError(event));
+        }
+
         self.shared.waker.wake();
 
         Ok(())
@@ -38,44 +43,76 @@ impl<T> Drop for Sender<T> {
 }
 
 pub struct Receiver<T> {
-    receiver: mpsc::Receiver<T>,
-    shared: Arc<Shared>,
+    shared: Arc<Shared<T>>,
 }
 
 impl<T> Receiver<T> {
     pub async fn next(&self) -> Result<T, RecvError> {
-        future::poll_fn(|cx| match self.receiver.try_recv() {
+        future::poll_fn(|cx| match self.shared.queue.pop() {
             Ok(event) => Poll::Ready(Ok(event)),
-            Err(TryRecvError::Empty) => {
+            Err(PopError::Empty) => {
                 self.shared.waker.register(cx.waker());
 
-                match self.receiver.try_recv() {
+                match self.shared.queue.pop() {
                     Ok(event) => Poll::Ready(Ok(event)),
-                    Err(TryRecvError::Empty) => {
+                    Err(PopError::Empty) => {
                         if self.shared.closed.load(Ordering::Relaxed) {
                             Poll::Ready(Err(RecvError))
                         } else {
                             Poll::Pending
                         }
                     },
-                    Err(TryRecvError::Disconnected) => Poll::Ready(Err(RecvError)),
+                    Err(PopError::Closed) => Poll::Ready(Err(RecvError)),
                 }
             },
-            Err(TryRecvError::Disconnected) => Poll::Ready(Err(RecvError)),
+            Err(PopError::Closed) => Poll::Ready(Err(RecvError)),
         })
         .await
     }
 
     pub fn try_recv(&self) -> Result<Option<T>, RecvError> {
-        match self.receiver.try_recv() {
+        match self.shared.queue.pop() {
             Ok(value) => Ok(Some(value)),
-            Err(TryRecvError::Empty) => Ok(None),
-            Err(TryRecvError::Disconnected) => Err(RecvError),
+            Err(PopError::Empty) => Ok(None),
+            Err(PopError::Closed) => Err(RecvError),
         }
     }
 }
 
-struct Shared {
+struct Shared<T> {
     closed: AtomicBool,
     waker: AtomicWaker,
+    queue: ConcurrentQueue<T>,
 }
+
+/// An error returned from the [`Sender::send`] function on **channel**s.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub struct SendError<T>(pub T);
+
+impl<T> fmt::Debug for SendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SendError").finish_non_exhaustive()
+    }
+}
+
+impl<T> fmt::Display for SendError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "sending on a closed channel".fmt(f)
+    }
+}
+
+impl<T> Error for SendError<T> {}
+
+/// An error returned from the [`try_recv`] function on a [`Receiver`].
+///
+/// [`try_recv`]: Receiver::try_recv
+#[derive(PartialEq, Eq, Clone, Copy, Debug)]
+pub struct RecvError;
+
+impl fmt::Display for RecvError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        "receiving on a closed channel".fmt(f)
+    }
+}
+
+impl Error for RecvError {}

--- a/winit-web/src/async/concurrent_queue.rs
+++ b/winit-web/src/async/concurrent_queue.rs
@@ -1,4 +1,5 @@
-use std::cell::{Cell, RefCell};
+use alloc::vec::Vec;
+use core::cell::{Cell, RefCell};
 
 #[derive(Debug)]
 pub struct ConcurrentQueue<T> {

--- a/winit-web/src/async/dispatcher.rs
+++ b/winit-web/src/async/dispatcher.rs
@@ -1,9 +1,11 @@
-use std::cell::Ref;
-use std::cmp::Ordering;
-use std::fmt::{self, Debug, Formatter};
-use std::hash::{Hash, Hasher};
-use std::rc::Rc;
-use std::sync::{Arc, Condvar, Mutex};
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use core::cell::Ref;
+use core::cmp::Ordering;
+use core::fmt::{self, Debug, Formatter};
+use core::hash::{Hash, Hasher};
+use std::sync::{Condvar, Mutex};
 
 use super::super::main_thread::MainThreadMarker;
 use super::{Receiver, Sender, Wrapper, channel};
@@ -112,7 +114,7 @@ impl<T> Dispatcher<T> {
             // safe because this function won't return until `f` has finished executing. See
             // `Self::new()`.
             let closure = Closure(unsafe {
-                std::mem::transmute::<
+                core::mem::transmute::<
                     Box<dyn FnOnce(&T) + Send>,
                     Box<dyn FnOnce(&T) + Send + 'static>,
                 >(closure)

--- a/winit-web/src/async/dispatcher.rs
+++ b/winit-web/src/async/dispatcher.rs
@@ -5,7 +5,6 @@ use core::cell::Ref;
 use core::cmp::Ordering;
 use core::fmt::{self, Debug, Formatter};
 use core::hash::{Hash, Hasher};
-use std::sync::{Condvar, Mutex};
 
 use super::super::main_thread::MainThreadMarker;
 use super::{Receiver, Sender, Wrapper, channel};
@@ -102,12 +101,10 @@ impl<T> Dispatcher<T> {
         if let Some(main_thread) = MainThreadMarker::new() {
             f(&self.0.value(main_thread))
         } else {
-            let pair = Arc::new((Mutex::new(None), Condvar::new()));
+            let (sender, receiver) = channel::<R>();
             let closure = Box::new({
-                let pair = pair.clone();
                 move |value: &T| {
-                    *pair.0.lock().unwrap() = Some(f(value));
-                    pair.1.notify_one();
+                    let _ = sender.send(f(value));
                 }
             }) as Box<dyn FnOnce(&T) + Send>;
             // SAFETY: The `transmute` is necessary because `Closure` requires `'static`. This is
@@ -122,13 +119,12 @@ impl<T> Dispatcher<T> {
 
             self.0.send(closure);
 
-            let mut started = pair.0.lock().unwrap();
-
-            while started.is_none() {
-                started = pair.1.wait(started).unwrap();
+            loop {
+                match receiver.try_recv() {
+                    Ok(Some(value)) => break value,
+                    _ => core::hint::spin_loop(),
+                }
             }
-
-            started.take().unwrap()
         }
     }
 }

--- a/winit-web/src/async/mod.rs
+++ b/winit-web/src/async/mod.rs
@@ -9,7 +9,7 @@ mod notifier;
 mod wrapper;
 
 pub(crate) use atomic_waker::AtomicWaker;
-use concurrent_queue::{ConcurrentQueue, PushError};
+use concurrent_queue::{ConcurrentQueue, PopError, PushError};
 
 pub use self::abortable::{AbortHandle, Abortable, DropAbortHandle};
 pub use self::channel::{Receiver, Sender, channel};

--- a/winit-web/src/async/notifier.rs
+++ b/winit-web/src/async/notifier.rs
@@ -1,7 +1,8 @@
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::{Arc, OnceLock};
-use std::task::{Context, Poll, Waker};
+use alloc::sync::Arc;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker};
+use std::sync::OnceLock;
 
 use super::{ConcurrentQueue, PushError};
 

--- a/winit-web/src/async/notifier.rs
+++ b/winit-web/src/async/notifier.rs
@@ -1,8 +1,10 @@
+use alloc::boxed::Box;
 use alloc::sync::Arc;
 use core::future::Future;
 use core::pin::Pin;
 use core::task::{Context, Poll, Waker};
-use std::sync::OnceLock;
+
+use once_cell::race::OnceBox;
 
 use super::{ConcurrentQueue, PushError};
 
@@ -11,11 +13,11 @@ pub struct Notifier<T: Clone>(Arc<Inner<T>>);
 
 impl<T: Clone> Notifier<T> {
     pub fn new() -> Self {
-        Self(Arc::new(Inner { queue: ConcurrentQueue::unbounded(), value: OnceLock::new() }))
+        Self(Arc::new(Inner { queue: ConcurrentQueue::unbounded(), value: OnceBox::new() }))
     }
 
     pub fn notify(self, value: T) {
-        if self.0.value.set(value).is_err() {
+        if self.0.value.set(Box::new(value)).is_err() {
             unreachable!("value set before")
         }
     }
@@ -59,18 +61,12 @@ impl<T: Clone> Future for Notified<T> {
             }
         }
 
-        match Arc::try_unwrap(this)
-            .map(|mut inner| inner.value.take())
-            .map_err(|this| this.value.get().cloned())
-        {
-            Ok(Some(value)) | Err(Some(value)) => Poll::Ready(Some(value)),
-            _ => Poll::Ready(None),
-        }
+        Poll::Ready(this.value.get().cloned())
     }
 }
 
 #[derive(Debug)]
 struct Inner<T> {
     queue: ConcurrentQueue<Waker>,
-    value: OnceLock<T>,
+    value: OnceBox<T>,
 }

--- a/winit-web/src/async/wrapper.rs
+++ b/winit-web/src/async/wrapper.rs
@@ -1,9 +1,9 @@
-use std::cell::{Ref, RefCell};
-use std::cmp;
-use std::future::Future;
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
-use std::sync::Arc;
+use alloc::sync::Arc;
+use core::cell::{Ref, RefCell};
+use core::cmp;
+use core::future::Future;
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
 
 use super::super::main_thread::MainThreadMarker;
 

--- a/winit-web/src/cursor.rs
+++ b/winit-web/src/cursor.rs
@@ -1,13 +1,15 @@
-use std::cell::RefCell;
-use std::future::{self, Future};
-use std::hash::{Hash, Hasher};
-use std::mem;
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::rc::Rc;
-use std::sync::Arc;
-use std::task::{Context, Poll, Waker, ready};
-use std::time::Duration;
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core::future::{self, Future};
+use core::hash::{Hash, Hasher};
+use core::mem;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll, Waker, ready};
+use core::time::Duration;
 
 use cursor_icon::CursorIcon;
 use js_sys::{Array, Object};

--- a/winit-web/src/event_loop/mod.rs
+++ b/winit-web/src/event_loop/mod.rs
@@ -1,4 +1,5 @@
-use std::sync::atomic::{AtomicBool, Ordering};
+use alloc::boxed::Box;
+use core::sync::atomic::{AtomicBool, Ordering};
 
 use winit_core::application::ApplicationHandler;
 use winit_core::error::{EventLoopError, NotSupportedError};

--- a/winit-web/src/event_loop/proxy.rs
+++ b/winit-web/src/event_loop/proxy.rs
@@ -1,7 +1,7 @@
-use std::future;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::task::Poll;
+use alloc::sync::Arc;
+use core::future;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
 
 use winit_core::event_loop::EventLoopProxyProvider;
 

--- a/winit-web/src/event_loop/runner.rs
+++ b/winit-web/src/event_loop/runner.rs
@@ -1,9 +1,12 @@
-use std::cell::{Cell, RefCell};
-use std::collections::{HashSet, VecDeque};
-use std::ops::Deref;
-use std::rc::{Rc, Weak};
-use std::sync::Arc;
-use std::{fmt, iter};
+use alloc::boxed::Box;
+use alloc::collections::VecDeque;
+use alloc::rc::{Rc, Weak};
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cell::{Cell, RefCell};
+use core::ops::Deref;
+use core::{fmt, iter};
+use std::collections::HashSet;
 
 use dpi::PhysicalSize;
 use wasm_bindgen::JsCast;
@@ -742,7 +745,7 @@ impl Shared {
     }
 
     fn handle_loop_destroyed(&self) {
-        let all_canvases = std::mem::take(&mut *self.0.all_canvases.borrow_mut());
+        let all_canvases = core::mem::take(&mut *self.0.all_canvases.borrow_mut());
         *self.0.page_transition_event_handle.borrow_mut() = None;
         *self.0.on_mouse_move.borrow_mut() = None;
         *self.0.on_wheel.borrow_mut() = None;

--- a/winit-web/src/event_loop/runner.rs
+++ b/winit-web/src/event_loop/runner.rs
@@ -1,12 +1,11 @@
 use alloc::boxed::Box;
-use alloc::collections::VecDeque;
+use alloc::collections::{BTreeSet, VecDeque};
 use alloc::rc::{Rc, Weak};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::cell::{Cell, RefCell};
 use core::ops::Deref;
 use core::{fmt, iter};
-use std::collections::HashSet;
 
 use dpi::PhysicalSize;
 use wasm_bindgen::JsCast;
@@ -58,7 +57,7 @@ struct Execution {
     document: Document,
     #[allow(clippy::type_complexity)]
     all_canvases: RefCell<Vec<(WindowId, Weak<backend::Canvas>, DispatchRunner<Inner>)>>,
-    redraw_pending: RefCell<HashSet<WindowId>>,
+    redraw_pending: RefCell<BTreeSet<WindowId>>,
     destroy_pending: RefCell<VecDeque<WindowId>>,
     pub(crate) monitor: Rc<MonitorHandler>,
     safe_area: Rc<SafeAreaHandle>,
@@ -203,7 +202,7 @@ impl Shared {
                 document,
                 id: Cell::new(0),
                 all_canvases: RefCell::new(Vec::new()),
-                redraw_pending: RefCell::new(HashSet::new()),
+                redraw_pending: RefCell::new(BTreeSet::new()),
                 destroy_pending: RefCell::new(VecDeque::new()),
                 monitor: Rc::new(monitor),
                 safe_area: Rc::new(safe_area),
@@ -622,7 +621,8 @@ impl Shared {
         self.process_destroy_pending_windows();
 
         // Collect all of the redraw events to avoid double-locking the RefCell
-        let redraw_events: Vec<WindowId> = self.0.redraw_pending.borrow_mut().drain().collect();
+        let redraw_events: Vec<WindowId> =
+            core::mem::take(&mut *self.0.redraw_pending.borrow_mut()).into_iter().collect();
         for window_id in redraw_events {
             self.handle_event(Event::WindowEvent {
                 window_id,

--- a/winit-web/src/event_loop/window_target.rs
+++ b/winit-web/src/event_loop/window_target.rs
@@ -1,8 +1,9 @@
-use std::cell::Cell;
-use std::clone::Clone;
-use std::iter;
-use std::rc::Rc;
-use std::sync::Arc;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::sync::Arc;
+use core::cell::Cell;
+use core::clone::Clone;
+use core::iter;
 
 use web_sys::Element;
 use winit_core::application::ApplicationHandler;

--- a/winit-web/src/lib.rs
+++ b/winit-web/src/lib.rs
@@ -64,7 +64,6 @@
 
 #[macro_use]
 extern crate alloc;
-extern crate std;
 
 macro_rules! os_error {
     ($error:expr) => {{ winit_core::error::OsError::new(line!(), file!(), $error) }};

--- a/winit-web/src/lib.rs
+++ b/winit-web/src/lib.rs
@@ -59,6 +59,12 @@
 // registering the event handlers. The 'Execution' struct in the 'runner' module handles taking
 // incoming events (from the registered handlers) and ensuring they are passed to the user in a
 // compliant way.
+#![warn(clippy::std_instead_of_core, clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+extern crate std;
 
 macro_rules! os_error {
     ($error:expr) => {{ winit_core::error::OsError::new(line!(), file!(), $error) }};
@@ -74,13 +80,15 @@ mod monitor;
 pub(crate) mod web_sys;
 pub(crate) mod window;
 
-use std::cell::Ref;
-use std::error::Error;
-use std::fmt::{self, Display, Formatter};
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::cell::Ref;
+use core::error::Error;
+use core::fmt::{self, Display, Formatter};
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use ::web_sys::HtmlCanvasElement;
 #[cfg(feature = "serde")]

--- a/winit-web/src/lock.rs
+++ b/winit-web/src/lock.rs
@@ -1,7 +1,5 @@
-use core::cell::OnceCell;
-use std::thread_local;
-
 use js_sys::{Object, Promise};
+use once_cell::race::OnceBool;
 use tracing::error;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -9,35 +7,30 @@ use wasm_bindgen::{JsCast, JsValue};
 use web_sys::{Document, DomException, Element, Navigator, console};
 
 pub(crate) fn is_cursor_lock_raw(navigator: &Navigator, document: &Document) -> bool {
-    thread_local! {
-        static IS_CURSOR_LOCK_RAW: OnceCell<bool> = const { OnceCell::new() };
+    static IS_CURSOR_LOCK_RAW: OnceBool = OnceBool::new();
+    IS_CURSOR_LOCK_RAW.get_or_init(|| is_cursor_lock_raw_inner(navigator, document))
+}
+
+fn is_cursor_lock_raw_inner(navigator: &Navigator, document: &Document) -> bool {
+    // TODO: Remove when Chrome can better advertise that they don't support unaccelerated
+    // movement on Linux.
+    // See <https://issues.chromium.org/issues/40833850>.
+    if super::web_sys::chrome_linux(navigator) {
+        return false;
     }
 
-    IS_CURSOR_LOCK_RAW.with(|cell| {
-        *cell.get_or_init(|| {
-            // TODO: Remove when Chrome can better advertise that they don't support unaccelerated
-            // movement on Linux.
-            // See <https://issues.chromium.org/issues/40833850>.
-            if super::web_sys::chrome_linux(navigator) {
-                return false;
-            }
+    let element: ElementExt = document.create_element("div").unwrap().unchecked_into();
+    let promise = element.request_pointer_lock();
 
-            let element: ElementExt = document.create_element("div").unwrap().unchecked_into();
-            let promise = element.request_pointer_lock();
+    if promise.is_undefined() {
+        false
+    } else {
+        let reject_handler = Closure::new(|_| ());
 
-            if promise.is_undefined() {
-                false
-            } else {
-                thread_local! {
-                    static REJECT_HANDLER: Closure<dyn FnMut(JsValue)> = Closure::new(|_| ());
-                }
-
-                let promise: Promise = promise.unchecked_into();
-                let _ = REJECT_HANDLER.with(|handler| promise.catch(handler));
-                true
-            }
-        })
-    })
+        let promise: Promise = promise.unchecked_into();
+        let _ = promise.catch(&reject_handler);
+        true
+    }
 }
 
 pub(crate) fn request_pointer_lock(navigator: &Navigator, document: &Document, element: &Element) {

--- a/winit-web/src/lock.rs
+++ b/winit-web/src/lock.rs
@@ -1,4 +1,5 @@
-use std::cell::OnceCell;
+use core::cell::OnceCell;
+use std::thread_local;
 
 use js_sys::{Object, Promise};
 use tracing::error;

--- a/winit-web/src/lock.rs
+++ b/winit-web/src/lock.rs
@@ -42,22 +42,19 @@ pub(crate) fn is_cursor_lock_raw(navigator: &Navigator, document: &Document) -> 
 
 pub(crate) fn request_pointer_lock(navigator: &Navigator, document: &Document, element: &Element) {
     if is_cursor_lock_raw(navigator, document) {
-        thread_local! {
-            static REJECT_HANDLER: Closure<dyn FnMut(JsValue)> = Closure::new(|error: JsValue| {
-                if let Some(error) = error.dyn_ref::<DomException>() {
-                        error!("Failed to lock pointer. {}: {}", error.name(), error.message());
-                } else {
-                    console::error_1(&error);
-                    error!("Failed to lock pointer");
-                }
-            });
-        }
+        let reject_handler = Closure::new(|error: JsValue| {
+            if let Some(error) = error.dyn_ref::<DomException>() {
+                error!("Failed to lock pointer. {}: {}", error.name(), error.message());
+            } else {
+                console::error_1(&error);
+                error!("Failed to lock pointer");
+            }
+        });
 
         let element: &ElementExt = element.unchecked_ref();
         let options: PointerLockOptions = Object::new().unchecked_into();
         options.set_unadjusted_movement(true);
-        let _ = REJECT_HANDLER
-            .with(|handler| element.request_pointer_lock_with_options(&options).catch(handler));
+        let _ = element.request_pointer_lock_with_options(&options).catch(&reject_handler);
     } else {
         element.request_pointer_lock();
     }

--- a/winit-web/src/main_thread.rs
+++ b/winit-web/src/main_thread.rs
@@ -1,7 +1,9 @@
-use std::fmt::{self, Debug, Formatter};
-use std::marker::PhantomData;
-use std::mem;
+use alloc::boxed::Box;
+use core::fmt::{self, Debug, Formatter};
+use core::marker::PhantomData;
+use core::mem;
 use std::sync::OnceLock;
+use std::thread_local;
 
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};

--- a/winit-web/src/main_thread.rs
+++ b/winit-web/src/main_thread.rs
@@ -3,27 +3,23 @@ use core::fmt::{self, Debug, Formatter};
 use core::marker::PhantomData;
 use core::mem;
 use std::sync::OnceLock;
-use std::thread_local;
 
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 
 use super::r#async::{self, Sender};
 
-thread_local! {
-    static MAIN_THREAD: bool = {
-        #[wasm_bindgen]
-        extern "C" {
-            #[derive(Clone)]
-            type Global;
+fn is_main_thread() -> bool {
+    #[wasm_bindgen]
+    extern "C" {
+        #[derive(Clone)]
+        type Global;
 
-            #[wasm_bindgen(method, getter, js_name = Window)]
-            fn window(this: &Global) -> JsValue;
-        }
+        #[wasm_bindgen(method, getter, js_name = Window)]
+        fn window(this: &Global) -> JsValue;
+    }
 
-        let global: Global = js_sys::global().unchecked_into();
-        !global.window().is_undefined()
-    };
+    !js_sys::global().unchecked_into::<Global>().window().is_undefined()
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -31,7 +27,7 @@ pub struct MainThreadMarker(PhantomData<*const ()>);
 
 impl MainThreadMarker {
     pub fn new() -> Option<Self> {
-        MAIN_THREAD.with(|is| is.then_some(Self(PhantomData)))
+        is_main_thread().then_some(MainThreadMarker(PhantomData))
     }
 }
 

--- a/winit-web/src/main_thread.rs
+++ b/winit-web/src/main_thread.rs
@@ -2,8 +2,8 @@ use alloc::boxed::Box;
 use core::fmt::{self, Debug, Formatter};
 use core::marker::PhantomData;
 use core::mem;
-use std::sync::OnceLock;
 
+use once_cell::race::OnceBox;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
 
@@ -41,7 +41,7 @@ impl<T> MainThreadSafe<T> {
                 async move { while receiver.next().await.is_ok() {} },
             );
 
-            sender
+            Box::new(sender)
         });
 
         Self(Some(value))
@@ -83,7 +83,7 @@ impl<T> Drop for MainThreadSafe<T> {
 unsafe impl<T> Send for MainThreadSafe<T> {}
 unsafe impl<T> Sync for MainThreadSafe<T> {}
 
-static DROP_HANDLER: OnceLock<Sender<DropBox>> = OnceLock::new();
+static DROP_HANDLER: OnceBox<Sender<DropBox>> = OnceBox::new();
 
 struct DropBox(#[allow(dead_code)] Box<dyn Any>);
 

--- a/winit-web/src/monitor.rs
+++ b/winit-web/src/monitor.rs
@@ -14,10 +14,10 @@ use core::num::NonZeroU16;
 use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::task::{Context, Poll, ready};
-use std::sync::OnceLock;
 
 use dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use js_sys::{Object, Promise};
+use once_cell::race::OnceBool;
 use tracing::error;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -364,7 +364,7 @@ impl Inner {
     }
 
     fn has_lock_support(&self) -> bool {
-        *HAS_LOCK_SUPPORT.get_or_init(|| !self.orientation_raw().has_lock().is_undefined())
+        HAS_LOCK_SUPPORT.get_or_init(|| !self.orientation_raw().has_lock().is_undefined())
     }
 }
 
@@ -844,10 +844,10 @@ fn unreachable_error(error: &JsValue, message: &str) -> ! {
     }
 }
 
-static HAS_LOCK_SUPPORT: OnceLock<bool> = OnceLock::new();
+static HAS_LOCK_SUPPORT: OnceBool = OnceBool::new();
 
 fn has_previous_lock_support() -> Option<bool> {
-    HAS_LOCK_SUPPORT.get().cloned()
+    HAS_LOCK_SUPPORT.get()
 }
 
 pub fn has_screen_details_support(window: &Window) -> bool {

--- a/winit-web/src/monitor.rs
+++ b/winit-web/src/monitor.rs
@@ -1,15 +1,21 @@
-use std::cell::{OnceCell, Ref, RefCell};
-use std::cmp::Ordering;
-use std::fmt::{self, Debug, Formatter};
-use std::future::Future;
-use std::hash::{Hash, Hasher};
-use std::mem;
-use std::num::NonZeroU16;
-use std::ops::{Deref, DerefMut};
-use std::pin::Pin;
-use std::rc::{Rc, Weak};
-use std::sync::{Arc, OnceLock};
-use std::task::{Context, Poll, ready};
+use alloc::borrow::Cow;
+use alloc::boxed::Box;
+use alloc::rc::{Rc, Weak};
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::cell::{OnceCell, Ref, RefCell};
+use core::cmp::Ordering;
+use core::fmt::{self, Debug, Formatter};
+use core::future::Future;
+use core::hash::{Hash, Hasher};
+use core::mem;
+use core::num::NonZeroU16;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll, ready};
+use std::sync::OnceLock;
+use std::thread_local;
 
 use dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use js_sys::{Object, Promise};
@@ -135,7 +141,7 @@ impl MonitorHandleProvider for MonitorHandle {
         self.inner.queue(|inner| inner.position())
     }
 
-    fn name(&self) -> Option<std::borrow::Cow<'_, str>> {
+    fn name(&self) -> Option<Cow<'_, str>> {
         self.inner.queue(|inner| inner.name().map(Into::into))
     }
 

--- a/winit-web/src/monitor.rs
+++ b/winit-web/src/monitor.rs
@@ -15,7 +15,6 @@ use core::ops::{Deref, DerefMut};
 use core::pin::Pin;
 use core::task::{Context, Poll, ready};
 use std::sync::OnceLock;
-use std::thread_local;
 
 use dpi::{LogicalSize, PhysicalPosition, PhysicalSize};
 use js_sys::{Object, Promise};
@@ -852,16 +851,7 @@ fn has_previous_lock_support() -> Option<bool> {
 }
 
 pub fn has_screen_details_support(window: &Window) -> bool {
-    thread_local! {
-        static HAS_SCREEN_DETAILS: OnceCell<bool> = const { OnceCell::new() };
-    }
-
-    HAS_SCREEN_DETAILS.with(|support| {
-        *support.get_or_init(|| {
-            let window: &WindowExt = window.unchecked_ref();
-            !window.has_screen_details().is_undefined()
-        })
-    })
+    !window.unchecked_ref::<WindowExt>().has_screen_details().is_undefined()
 }
 
 #[wasm_bindgen]

--- a/winit-web/src/web_sys/animation_frame.rs
+++ b/winit-web/src/web_sys/animation_frame.rs
@@ -1,5 +1,5 @@
-use std::cell::Cell;
-use std::rc::Rc;
+use alloc::rc::Rc;
+use core::cell::Cell;
 
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;

--- a/winit-web/src/web_sys/canvas.rs
+++ b/winit-web/src/web_sys/canvas.rs
@@ -496,13 +496,13 @@ impl Canvas {
         // First, we send the `ScaleFactorChanged` event:
         self.set_current_size(current_size);
         let new_size = {
-            let new_size = Arc::new(Mutex::new(current_size));
+            let (surface_size_writer, new_size) = SurfaceSizeWriter::new(current_size);
             event_handler(self.id, WindowEvent::ScaleFactorChanged {
                 scale_factor: scale,
-                surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_size)),
+                surface_size_writer,
             });
 
-            *new_size.lock().unwrap()
+            new_size.take()
         };
 
         if current_size != new_size {

--- a/winit-web/src/web_sys/canvas.rs
+++ b/winit-web/src/web_sys/canvas.rs
@@ -1,7 +1,8 @@
-use std::cell::{Cell, RefCell};
-use std::ops::Deref;
-use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::sync::Arc;
+use core::cell::{Cell, RefCell};
+use core::ops::Deref;
 
 use dpi::{LogicalPosition, PhysicalPosition, PhysicalSize};
 use smol_str::SmolStr;

--- a/winit-web/src/web_sys/event.rs
+++ b/winit-web/src/web_sys/event.rs
@@ -1,6 +1,4 @@
-use core::cell::OnceCell;
 use core::f64;
-use std::thread_local;
 
 use dpi::{LogicalPosition, PhysicalPosition, Position};
 use smol_str::SmolStr;
@@ -341,22 +339,16 @@ pub fn pointer_move_event(event: PointerEvent) -> impl Iterator<Item = PointerEv
 // TODO: Remove when Safari supports `getCoalescedEvents`.
 // See <https://bugs.webkit.org/show_bug.cgi?id=210454>.
 pub fn has_coalesced_events_support(event: &PointerEvent) -> bool {
-    thread_local! {
-        static COALESCED_EVENTS_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
+    #[wasm_bindgen]
+    extern "C" {
+        type PointerCoalescedEventsSupport;
+
+        #[wasm_bindgen(method, getter, js_name = getCoalescedEvents)]
+        fn has_get_coalesced_events(this: &PointerCoalescedEventsSupport) -> JsValue;
     }
 
-    COALESCED_EVENTS_SUPPORT.with(|support| {
-        *support.get_or_init(|| {
-            #[wasm_bindgen]
-            extern "C" {
-                type PointerCoalescedEventsSupport;
-
-                #[wasm_bindgen(method, getter, js_name = getCoalescedEvents)]
-                fn has_get_coalesced_events(this: &PointerCoalescedEventsSupport) -> JsValue;
-            }
-
-            let support: &PointerCoalescedEventsSupport = event.unchecked_ref();
-            !support.has_get_coalesced_events().is_undefined()
-        })
-    })
+    !event
+        .unchecked_ref::<PointerCoalescedEventsSupport>()
+        .has_get_coalesced_events()
+        .is_undefined()
 }

--- a/winit-web/src/web_sys/event.rs
+++ b/winit-web/src/web_sys/event.rs
@@ -1,5 +1,6 @@
-use std::cell::OnceCell;
-use std::f64;
+use core::cell::OnceCell;
+use core::f64;
+use std::thread_local;
 
 use dpi::{LogicalPosition, PhysicalPosition, Position};
 use smol_str::SmolStr;

--- a/winit-web/src/web_sys/fullscreen.rs
+++ b/winit-web/src/web_sys/fullscreen.rs
@@ -1,5 +1,3 @@
-use std::thread_local;
-
 use js_sys::{Object, Promise};
 use tracing::error;
 use wasm_bindgen::closure::Closure;
@@ -41,12 +39,10 @@ pub(crate) fn request_fullscreen(
         fn set_screen(this: &FullscreenOptions, screen: &ScreenDetailed);
     }
 
-    thread_local! {
-        static REJECT_HANDLER: Closure<dyn FnMut(JsValue)> = Closure::new(|error| {
-            console::error_1(&error);
-            error!("Failed to transition to full screen mode")
-        });
-    }
+    let reject_handler = Closure::new(|error| {
+        console::error_1(&error);
+        error!("Failed to transition to full screen mode")
+    });
 
     if is_fullscreen(document, canvas) {
         return;
@@ -69,9 +65,7 @@ pub(crate) fn request_fullscreen(
             if let Some(monitor) = monitor.detailed(main_thread) {
                 let options: FullscreenOptions = Object::new().unchecked_into();
                 options.set_screen(&monitor);
-                REJECT_HANDLER.with(|handler| {
-                    let _ = canvas.request_fullscreen_with_options(&options).catch(handler);
-                });
+                let _ = canvas.request_fullscreen_with_options(&options).catch(&reject_handler);
             } else {
                 error!(
                     "Selecting a specific screen for fullscreen mode requires a detailed screen. \
@@ -81,9 +75,7 @@ pub(crate) fn request_fullscreen(
         },
         Fullscreen::Borderless(None) => {
             if has_fullscreen_api_support(canvas) {
-                REJECT_HANDLER.with(|handler| {
-                    let _ = canvas.request_fullscreen().catch(handler);
-                });
+                let _ = canvas.request_fullscreen().catch(&reject_handler);
             } else {
                 canvas.webkit_request_fullscreen();
             }

--- a/winit-web/src/web_sys/fullscreen.rs
+++ b/winit-web/src/web_sys/fullscreen.rs
@@ -1,4 +1,3 @@
-use core::cell::OnceCell;
 use std::thread_local;
 
 use js_sys::{Object, Promise};
@@ -137,22 +136,13 @@ pub fn exit_fullscreen(document: &Document, canvas: &HtmlCanvasElement) {
 }
 
 fn has_fullscreen_api_support(canvas: &HtmlCanvasElement) -> bool {
-    thread_local! {
-        static FULLSCREEN_API_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
+    #[wasm_bindgen]
+    extern "C" {
+        type CanvasFullScreenApiSupport;
+
+        #[wasm_bindgen(method, getter, js_name = requestFullscreen)]
+        fn has_request_fullscreen(this: &CanvasFullScreenApiSupport) -> JsValue;
     }
 
-    FULLSCREEN_API_SUPPORT.with(|support| {
-        *support.get_or_init(|| {
-            #[wasm_bindgen]
-            extern "C" {
-                type CanvasFullScreenApiSupport;
-
-                #[wasm_bindgen(method, getter, js_name = requestFullscreen)]
-                fn has_request_fullscreen(this: &CanvasFullScreenApiSupport) -> JsValue;
-            }
-
-            let support: &CanvasFullScreenApiSupport = canvas.unchecked_ref();
-            !support.has_request_fullscreen().is_undefined()
-        })
-    })
+    !canvas.unchecked_ref::<CanvasFullScreenApiSupport>().has_request_fullscreen().is_undefined()
 }

--- a/winit-web/src/web_sys/fullscreen.rs
+++ b/winit-web/src/web_sys/fullscreen.rs
@@ -1,4 +1,5 @@
-use std::cell::OnceCell;
+use core::cell::OnceCell;
+use std::thread_local;
 
 use js_sys::{Object, Promise};
 use tracing::error;

--- a/winit-web/src/web_sys/mod.rs
+++ b/winit-web/src/web_sys/mod.rs
@@ -10,7 +10,9 @@ mod resize_scaling;
 mod safe_area;
 mod schedule;
 
-use std::cell::OnceCell;
+use alloc::string::String;
+use core::cell::OnceCell;
+use std::thread_local;
 
 use dpi::{LogicalPosition, LogicalSize};
 use js_sys::Array;

--- a/winit-web/src/web_sys/mod.rs
+++ b/winit-web/src/web_sys/mod.rs
@@ -11,11 +11,10 @@ mod safe_area;
 mod schedule;
 
 use alloc::string::String;
-use core::cell::OnceCell;
-use std::thread_local;
 
 use dpi::{LogicalPosition, LogicalSize};
 use js_sys::Array;
+use once_cell::race::OnceRef;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::wasm_bindgen;
@@ -175,16 +174,29 @@ struct UserAgentData {
     chrome_linux: bool,
 }
 
-thread_local! {
-    static USER_AGENT_DATA: OnceCell<UserAgentData> = const { OnceCell::new() };
-}
-
 pub fn chrome_linux(navigator: &Navigator) -> bool {
-    USER_AGENT_DATA.with(|data| data.get_or_init(|| user_agent(navigator)).chrome_linux)
+    user_agent_cached(navigator).chrome_linux
 }
 
 pub fn engine(navigator: &Navigator) -> Option<Engine> {
-    USER_AGENT_DATA.with(|data| data.get_or_init(|| user_agent(navigator)).engine)
+    user_agent_cached(navigator).engine
+}
+
+fn user_agent_cached(navigator: &Navigator) -> &UserAgentData {
+    static USER_AGENT_DATA: OnceRef<'static, UserAgentData> = OnceRef::new();
+    USER_AGENT_DATA.get_or_init(|| {
+        use Engine::*;
+        let UserAgentData { engine, chrome_linux } = user_agent(navigator);
+        match engine {
+            Some(Chromium) if chrome_linux => {
+                &UserAgentData { engine: Some(Chromium), chrome_linux: true }
+            },
+            Some(Chromium) => &UserAgentData { engine: Some(Chromium), chrome_linux: false },
+            Some(Gecko) => &UserAgentData { engine: Some(Gecko), chrome_linux: false },
+            Some(WebKit) => &UserAgentData { engine: Some(WebKit), chrome_linux: false },
+            None => &UserAgentData { engine: None, chrome_linux: false },
+        }
+    })
 }
 
 fn user_agent(navigator: &Navigator) -> UserAgentData {

--- a/winit-web/src/web_sys/pointer.rs
+++ b/winit-web/src/web_sys/pointer.rs
@@ -1,5 +1,5 @@
-use std::cell::Cell;
-use std::rc::Rc;
+use alloc::rc::Rc;
+use core::cell::Cell;
 
 use dpi::PhysicalPosition;
 use web_sys::PointerEvent;

--- a/winit-web/src/web_sys/resize_scaling.rs
+++ b/winit-web/src/web_sys/resize_scaling.rs
@@ -1,5 +1,7 @@
-use std::cell::{Cell, RefCell};
-use std::rc::Rc;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use core::cell::{Cell, RefCell};
+use std::thread_local;
 
 use dpi::{LogicalSize, PhysicalSize};
 use js_sys::{Array, Object};

--- a/winit-web/src/web_sys/resize_scaling.rs
+++ b/winit-web/src/web_sys/resize_scaling.rs
@@ -1,7 +1,6 @@
 use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::cell::{Cell, RefCell};
-use std::thread_local;
 
 use dpi::{LogicalSize, PhysicalSize};
 use js_sys::{Array, Object};
@@ -280,24 +279,18 @@ impl Drop for ResizeScaleInternal {
 // TODO: Remove when Safari supports `devicePixelContentBoxSize`.
 // See <https://bugs.webkit.org/show_bug.cgi?id=219005>.
 pub fn has_device_pixel_support() -> bool {
-    thread_local! {
-        static DEVICE_PIXEL_SUPPORT: bool = {
-            #[wasm_bindgen]
-            extern "C" {
-                type ResizeObserverEntryExt;
+    #[wasm_bindgen]
+    extern "C" {
+        type ResizeObserverEntryExt;
 
-                #[wasm_bindgen(js_class = ResizeObserverEntry, static_method_of = ResizeObserverEntryExt, getter)]
-                fn prototype() -> Object;
-            }
-
-            let prototype = ResizeObserverEntryExt::prototype();
-            let descriptor = Object::get_own_property_descriptor(
-                &prototype,
-                &JsValue::from_str("devicePixelContentBoxSize"),
-            );
-            !descriptor.is_undefined()
-        };
+        #[wasm_bindgen(js_class = ResizeObserverEntry, static_method_of = ResizeObserverEntryExt, getter)]
+        fn prototype() -> Object;
     }
 
-    DEVICE_PIXEL_SUPPORT.with(|support| *support)
+    let prototype = ResizeObserverEntryExt::prototype();
+    let descriptor = Object::get_own_property_descriptor(
+        &prototype,
+        &JsValue::from_str("devicePixelContentBoxSize"),
+    );
+    !descriptor.is_undefined()
 }

--- a/winit-web/src/web_sys/schedule.rs
+++ b/winit-web/src/web_sys/schedule.rs
@@ -1,5 +1,4 @@
 use alloc::string::String;
-use core::cell::OnceCell;
 use core::time::Duration;
 use std::thread_local;
 
@@ -242,24 +241,15 @@ fn has_scheduler_support(window: &web_sys::Window) -> bool {
 }
 
 fn has_idle_callback_support(window: &web_sys::Window) -> bool {
-    thread_local! {
-        static IDLE_CALLBACK_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
+    #[wasm_bindgen]
+    extern "C" {
+        type IdleCallbackSupport;
+
+        #[wasm_bindgen(method, getter, js_name = requestIdleCallback)]
+        fn has_request_idle_callback(this: &IdleCallbackSupport) -> JsValue;
     }
 
-    IDLE_CALLBACK_SUPPORT.with(|support| {
-        *support.get_or_init(|| {
-            #[wasm_bindgen]
-            extern "C" {
-                type IdleCallbackSupport;
-
-                #[wasm_bindgen(method, getter, js_name = requestIdleCallback)]
-                fn has_request_idle_callback(this: &IdleCallbackSupport) -> JsValue;
-            }
-
-            let support: &IdleCallbackSupport = window.unchecked_ref();
-            !support.has_request_idle_callback().is_undefined()
-        })
-    })
+    !window.unchecked_ref::<IdleCallbackSupport>().has_request_idle_callback().is_undefined()
 }
 
 struct ScriptUrl(String);

--- a/winit-web/src/web_sys/schedule.rs
+++ b/winit-web/src/web_sys/schedule.rs
@@ -95,14 +95,11 @@ impl Schedule {
             options.set_delay(duration as f64);
         }
 
-        thread_local! {
-            static REJECT_HANDLER: Closure<dyn FnMut(JsValue)> = Closure::new(|_| ());
-        }
-        REJECT_HANDLER.with(|handler| {
-            let _ = scheduler
-                .post_task_with_options(closure.as_ref().unchecked_ref(), &options)
-                .catch(handler);
-        });
+        let reject_handler = Closure::new(|_| ());
+
+        let _ = scheduler
+            .post_task_with_options(closure.as_ref().unchecked_ref(), &options)
+            .catch(&reject_handler);
 
         Schedule { _closure: closure, inner: Inner::Scheduler { controller } }
     }

--- a/winit-web/src/web_sys/schedule.rs
+++ b/winit-web/src/web_sys/schedule.rs
@@ -230,25 +230,15 @@ impl Drop for Schedule {
 }
 
 fn has_scheduler_support(window: &web_sys::Window) -> bool {
-    thread_local! {
-        static SCHEDULER_SUPPORT: OnceCell<bool> = const { OnceCell::new() };
+    #[wasm_bindgen]
+    extern "C" {
+        type SchedulerSupport;
+
+        #[wasm_bindgen(method, getter, js_name = scheduler)]
+        fn has_scheduler(this: &SchedulerSupport) -> JsValue;
     }
 
-    SCHEDULER_SUPPORT.with(|support| {
-        *support.get_or_init(|| {
-            #[wasm_bindgen]
-            extern "C" {
-                type SchedulerSupport;
-
-                #[wasm_bindgen(method, getter, js_name = scheduler)]
-                fn has_scheduler(this: &SchedulerSupport) -> JsValue;
-            }
-
-            let support: &SchedulerSupport = window.unchecked_ref();
-
-            !support.has_scheduler().is_undefined()
-        })
-    })
+    !window.unchecked_ref::<SchedulerSupport>().has_scheduler().is_undefined()
 }
 
 fn has_idle_callback_support(window: &web_sys::Window) -> bool {

--- a/winit-web/src/web_sys/schedule.rs
+++ b/winit-web/src/web_sys/schedule.rs
@@ -1,8 +1,9 @@
+use alloc::boxed::Box;
 use alloc::string::String;
 use core::time::Duration;
-use std::thread_local;
 
 use js_sys::{Array, Function, Object, Promise};
+use once_cell::race::OnceBox;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::wasm_bindgen;
 use wasm_bindgen::{JsCast, JsValue};
@@ -10,6 +11,7 @@ use web_sys::{
     AbortController, AbortSignal, Blob, BlobPropertyBag, MessageChannel, MessagePort, Url, Worker,
 };
 
+use crate::main_thread::{MainThreadMarker, MainThreadSafe};
 use crate::{PollStrategy, WaitUntilStrategy};
 
 #[derive(Debug)]
@@ -67,7 +69,7 @@ impl Schedule {
                     Self::new_timeout(window.clone(), f, Some(duration))
                 }
             },
-            WaitUntilStrategy::Worker => Self::new_worker(f, duration),
+            WaitUntilStrategy::Worker => Self::new_worker(window, f, duration),
         }
     }
 
@@ -168,14 +170,23 @@ impl Schedule {
         }
     }
 
-    fn new_worker<F>(f: F, duration: Duration) -> Schedule
+    fn new_worker<F>(_window: &web_sys::Window, f: F, duration: Duration) -> Schedule
     where
         F: 'static + FnMut(),
     {
-        thread_local! {
-            static URL: ScriptUrl = ScriptUrl::new(include_str!("../script/worker.min.js"));
-            static WORKER: Worker = URL.with(|url| Worker::new(&url.0)).expect("`new Worker()` is not expected to fail with a local script");
-        }
+        static WORKER: OnceBox<MainThreadSafe<Worker>> = OnceBox::new();
+
+        // This is guaranteed to succeed since new_worker is passed a Window as a parameter
+        let marker = MainThreadMarker::new().unwrap();
+
+        let worker = WORKER
+            .get_or_init(|| {
+                let url = ScriptUrl::new(include_str!("../script/worker.min.js"));
+                let worker = Worker::new(&url.0)
+                    .expect("`new Worker()` is not expected to fail with a local script");
+                Box::new(MainThreadSafe::new(marker, worker))
+            })
+            .get(marker);
 
         let channel = MessageChannel::new().unwrap();
         let closure = Closure::new(f);
@@ -193,14 +204,12 @@ impl Schedule {
             .and_then(|secs| secs.checked_add(duration.subsec_micros().div_ceil(1000)))
             .unwrap_or(u32::MAX);
 
-        WORKER
-            .with(|worker| {
-                let port_2 = channel.port2();
-                worker.post_message_with_transfer(
-                    &Array::of2(&port_2, &duration.into()),
-                    &Array::of1(&port_2).into(),
-                )
-            })
+        let port_2 = channel.port2();
+        worker
+            .post_message_with_transfer(
+                &Array::of2(&port_2, &duration.into()),
+                &Array::of1(&port_2).into(),
+            )
             .expect("`Worker.postMessage()` is not expected to fail");
 
         Schedule { _closure: closure, inner: Inner::Worker(port_1) }

--- a/winit-web/src/web_sys/schedule.rs
+++ b/winit-web/src/web_sys/schedule.rs
@@ -1,5 +1,7 @@
-use std::cell::OnceCell;
-use std::time::Duration;
+use alloc::string::String;
+use core::cell::OnceCell;
+use core::time::Duration;
+use std::thread_local;
 
 use js_sys::{Array, Function, Object, Promise};
 use wasm_bindgen::closure::Closure;

--- a/winit-web/src/window.rs
+++ b/winit-web/src/window.rs
@@ -1,6 +1,8 @@
-use std::cell::Ref;
-use std::fmt;
-use std::rc::Rc;
+use alloc::boxed::Box;
+use alloc::rc::Rc;
+use alloc::string::String;
+use core::cell::Ref;
+use core::fmt;
 
 use dpi::{
     LogicalInsets, LogicalPosition, LogicalSize, PhysicalInsets, PhysicalPosition, PhysicalSize,
@@ -429,7 +431,7 @@ impl rwh_06::HasWindowHandle for Window {
                 // SAFETY: This will only work if the reference to `HtmlCanvasElement` stays valid.
                 let canvas: &wasm_bindgen::JsValue = inner.canvas.raw();
                 let window_handle =
-                    rwh_06::WebCanvasWindowHandle::new(std::ptr::NonNull::from(canvas).cast());
+                    rwh_06::WebCanvasWindowHandle::new(core::ptr::NonNull::from(canvas).cast());
                 // SAFETY: The pointer won't be invalidated as long as `Window` lives, which the
                 // lifetime is bound to.
                 unsafe {

--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -2378,14 +2378,14 @@ unsafe fn public_window_callback_inner(
                 false => old_physical_surface_size,
             };
 
-            let new_surface_size = Arc::new(Mutex::new(new_physical_surface_size));
+            let (surface_size_writer, new_surface_size) =
+                SurfaceSizeWriter::new(new_physical_surface_size);
             userdata.send_window_event(window, ScaleFactorChanged {
                 scale_factor: new_scale_factor,
-                surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&new_surface_size)),
+                surface_size_writer,
             });
 
-            let new_physical_surface_size = *new_surface_size.lock().unwrap();
-            drop(new_surface_size);
+            let new_physical_surface_size = new_surface_size.take();
 
             let dragging_window: bool;
 

--- a/winit-win32/src/event_loop/runner.rs
+++ b/winit-win32/src/event_loop/runner.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 use std::cell::{Cell, Ref, RefCell};
 use std::collections::VecDeque;
 use std::rc::Rc;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
 use std::{fmt, mem, panic};
 
@@ -596,20 +596,14 @@ impl Event {
                 app.device_event(event_loop, Some(device_id), event)
             },
             Self::BufferedScaleFactorChanged(window, scale_factor, new_surface_size) => {
-                let user_new_surface_size = Arc::new(Mutex::new(new_surface_size));
+                let (surface_size_writer, user_new_surface_size) =
+                    SurfaceSizeWriter::new(new_surface_size);
                 app.window_event(
                     event_loop,
                     WindowId::from_raw(window as usize),
-                    WindowEvent::ScaleFactorChanged {
-                        scale_factor,
-                        surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(
-                            &user_new_surface_size,
-                        )),
-                    },
+                    WindowEvent::ScaleFactorChanged { scale_factor, surface_size_writer },
                 );
-                let surface_size = *user_new_surface_size.lock().unwrap();
-
-                drop(user_new_surface_size);
+                let surface_size = user_new_surface_size.take();
 
                 if surface_size != new_surface_size {
                     let window_flags = unsafe {

--- a/winit-x11/src/event_processor.rs
+++ b/winit-x11/src/event_processor.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, VecDeque};
 use std::mem::MaybeUninit;
 use std::os::raw::{c_char, c_int, c_long, c_ulong};
 use std::slice;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use dpi::{PhysicalPosition, PhysicalSize};
 use tracing::warn;
@@ -804,14 +804,13 @@ impl EventProcessor {
                 // Unlock shared state to prevent deadlock in callback below
                 drop(shared_state_lock);
 
-                let surface_size = Arc::new(Mutex::new(new_surface_size));
+                let (surface_size_writer, surface_size) = SurfaceSizeWriter::new(new_surface_size);
                 app.window_event(&self.target, window_id, WindowEvent::ScaleFactorChanged {
                     scale_factor: new_scale_factor,
-                    surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&surface_size)),
+                    surface_size_writer,
                 });
 
-                let new_surface_size = *surface_size.lock().unwrap();
-                drop(surface_size);
+                let new_surface_size = surface_size.take();
 
                 if new_surface_size != old_surface_size {
                     window.request_surface_size_physical(

--- a/winit-x11/src/window.rs
+++ b/winit-x11/src/window.rs
@@ -1256,14 +1256,14 @@ impl UnownedWindow {
             );
 
             let old_surface_size = PhysicalSize::new(width, height);
-            let surface_size = Arc::new(Mutex::new(PhysicalSize::new(new_width, new_height)));
+            let (surface_size_writer, surface_size) =
+                SurfaceSizeWriter::new(PhysicalSize::new(new_width, new_height));
             app.window_event(event_loop, self.id(), WindowEvent::ScaleFactorChanged {
                 scale_factor: new_monitor.scale_factor,
-                surface_size_writer: SurfaceSizeWriter::new(Arc::downgrade(&surface_size)),
+                surface_size_writer,
             });
 
-            let new_surface_size = *surface_size.lock().unwrap();
-            drop(surface_size);
+            let new_surface_size = surface_size.take();
 
             if new_surface_size != old_surface_size {
                 let (new_width, new_height) = new_surface_size.into();

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -45,15 +45,7 @@ android-game-activity = ["winit-android/game-activity"]
 android-native-activity = ["winit-android/native-activity"]
 mint = ["dpi/mint"]
 private-apple-apis = ["winit-appkit/private-apple-apis"]
-serde = [
-    "dep:serde",
-    "cursor-icon/serde",
-    "smol_str/serde",
-    "dpi/serde",
-    "bitflags/serde",
-    "winit-core/serde",
-    "winit-uikit/serde",
-]
+serde = ["dpi/serde", "winit-core/serde", "winit-uikit/serde"]
 wayland = ["winit-wayland"]
 wayland-csd-adwaita = ["winit-wayland/csd-adwaita"]
 wayland-csd-adwaita-crossfont = ["winit-wayland/csd-adwaita-crossfont"]
@@ -66,17 +58,15 @@ x11 = ["winit-x11"]
 cfg_aliases.workspace = true
 
 [dependencies]
-bitflags.workspace = true
-cursor-icon.workspace = true
-dpi.workspace = true
-rwh_06.workspace = true
-serde = { workspace = true, optional = true }
-smol_str.workspace = true
-tracing.workspace = true
-winit-core.workspace = true
+dpi = { workspace = true, default-features = false }
+rwh_06 = { workspace = true, default-features = false }
+tracing = { workspace = true, default-features = false }
+winit-core = { workspace = true, default-features = false }
 
 [dev-dependencies]
+cursor-icon.workspace = true
 image = { workspace = true, features = ["png"] }
+serde.workspace = true
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 # Launching a window without drawing to it has unpredictable results varying from platform to

--- a/winit/build.rs
+++ b/winit/build.rs
@@ -12,7 +12,7 @@ fn main() {
     cfg_aliases! {
         // Systems.
         android_platform: { target_os = "android" },
-        web_platform: { all(target_family = "wasm", target_os = "unknown") },
+        web_platform: { all(target_family = "wasm", any(target_os = "unknown", target_os = "none")) },
         macos_platform: { target_os = "macos" },
         ios_platform: { all(target_vendor = "apple", not(target_os = "macos")) },
         windows_platform: { target_os = "windows" },

--- a/winit/src/event_loop.rs
+++ b/winit/src/event_loop.rs
@@ -8,7 +8,7 @@
 //!
 //! See the root-level documentation for information on how to create and use an event loop to
 //! handle events.
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 #[cfg(any(x11_platform, wayland_platform))]
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
 
@@ -334,7 +334,7 @@ impl AsRawFd for EventLoop {
 impl winit_core::event_loop::pump_events::EventLoopExtPumpEvents for EventLoop {
     fn pump_app_events<A: ApplicationHandler>(
         &mut self,
-        timeout: Option<std::time::Duration>,
+        timeout: Option<core::time::Duration>,
         app: A,
     ) -> winit_core::event_loop::pump_events::PumpStatus {
         self.event_loop.pump_app_events(timeout, app)
@@ -481,7 +481,7 @@ impl winit_win32::EventLoopBuilderExtWindows for EventLoopBuilder {
     where
         F: FnMut(*const core::ffi::c_void) -> bool + 'static,
     {
-        self.platform_specific.msg_hook = Some(Box::new(callback));
+        self.platform_specific.msg_hook = Some(alloc::boxed::Box::new(callback));
         self
     }
 }

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -286,6 +286,14 @@
 #![warn(clippy::uninlined_format_args)]
 // TODO: wasm-binding needs to be updated for that to be resolved, for now just silence it.
 #![cfg_attr(web_platform, allow(unknown_lints, renamed_and_removed_lints, wasm_c_abi))]
+#![warn(clippy::std_instead_of_core, clippy::std_instead_of_alloc, clippy::alloc_instead_of_core)]
+#![no_std]
+
+#[allow(unused_extern_crates, reason = "only used in some configurations")]
+extern crate alloc;
+
+#[cfg(any(x11_platform, wayland_platform, docsrs))]
+extern crate std;
 
 // Re-export DPI types so that users don't have to put it in Cargo.toml.
 #[doc(inline)]

--- a/winit/src/platform_impl/linux/mod.rs
+++ b/winit/src/platform_impl/linux/mod.rs
@@ -3,9 +3,11 @@
 #[cfg(all(not(x11_platform), not(wayland_platform)))]
 compile_error!("Please select a feature to build for unix: `x11`, `wayland`");
 
+#[cfg(wayland_platform)]
+use alloc::boxed::Box;
+use core::time::Duration;
 use std::env;
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, RawFd};
-use std::time::Duration;
 
 pub(crate) use winit_common::xkb::{physicalkey_to_scancode, scancode_to_physicalkey};
 use winit_core::application::ApplicationHandler;


### PR DESCRIPTION
# Description

- Fixes #4629

## Details

This PR demonstrates adding `no_std` support to `winit` specifically for `wasm32v1-none`, affecting `winit-core`, `winit-web`, and `winit`.

Note that this currently requires a patch for `web-time`:

```toml
[patch.crates-io]
web-time = { git = "https://github.com/daxpedda/web-time" }
```

The published version does not include support for `wasm32v1-none`, but it is implemented on the repository's main branch. The changes in this PR are still usable regardless, but actual compilation on `wasm32v1-none` requires the above patch.

Since this PR doesn't target general `no_std` support, no new feature gates are required.

## Notable Changes

### `winit-core`

- `SurfaceSizeWriter` has been refactored to use `PhysicalSize<AtomicU32>` instead of a `Mutex`, but that change is abstracted around a new `SurfaceSizeWriterHandle` type. I believe this simplifies the API for users while also making `no_std` support simpler.
- Added `libm` exclusively for `all(target_family = "wasm", target_os = "none")` (`wasm32v1-none`). It's technically required for all `no_std` platforms, but this is the only `no_std` target that this PR unblocks, so no need to add a feature gate for it.
- `wasm32v1-none` will mark `BadIcon` as non-exhaustive to avoid dealing with the `OsError` variant. This can be removed once `core::io` is stable.
- `wasm32v1-none` marks `WindowEvent` as `non_exhaustive` as the `DataTransferReceived` variant requires `dyn TypedData`, which requires IO, which is currently nightly-only for `no_std`.

### `winit-web`

- Now includes `once_cell` as a dependency. This is acceptable in my opinion, as `once_cell` was already a transitive dependency through `wasm-bindgen` (and others).
- `async::channel` has been modified to use `ConcurrentQueue` rather than `std::mpsc::channel`.
- `async::Dispatcher` uses a channel to return values rather than a `Mutex`/`Condvar` combo. Since Wasm has a stubbed `std` I don't believe thread yielding is actually more performant that busy waiting.
- Several uses of `OnceLock` have been replaced with `once_cell::race::{OnceBox, OnceBool, OnceRef}`, and `OnceCell` where appropriate.
- Uses of `thread_local` have either been removed entirely where it is relatively cheap to just recompute the stored value or replaced with a global static where it is appropriate to share said value between threads.

### `winit`

- `winit`'s `cfg_aliases` have been updated to include `wasm32v1-none` as a `web_platform`.

## Testing

Currently tested using `cargo check -p winit --target wasm32v1-none --all-features`.

## Checklist

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
  - Unsure if needed. Only the change to `SurfaceSizeWriter` is really visible, and actual compilation on `wasm32v1-none` still requires a patch.
- [X] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
  - An example would require the patch, so unsure if desirable?

---

## Notes

- No AI tooling of any kind was used during the creation of this PR.