### PR TITLE
Update cfg_aliases to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ winit-x11 = { version = "=0.31.0-beta.2", path = "winit-x11" }
 
 # Core dependencies.
 bitflags = "2"
-cfg_aliases = "0.2.1"
+cfg_aliases = "0.2.2"
 cursor-icon = "1.1.0"
 dpi = { version = "0.1.2", path = "dpi" }
 keyboard-types = "0.8.0"

--- a/winit/build.rs
+++ b/winit/build.rs
@@ -4,11 +4,6 @@ use cfg_aliases::cfg_aliases;
     clippy::disallowed_macros,
     reason = "Only relevant for examples and Winit, our usage of println! is fine here."
 )]
-#[allow(
-    semicolon_in_expressions_from_macros,
-    reason = "This is a future incompatibility lint and we currently use cfg_aliases 0.2.1, which \
-              has not been updated to resolve the latest lints"
-)]
 fn main() {
     // Dummy invocation to enable change-tracking in build scripts.
     println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
Remove the workaround introduced in commit 156433eb, since cfg_aliases 0.2.2 fixes the semicolon_in_expressions_from_macros lint.