### PR TITLE
Windows: fix window dpi when moving between monitors with different scaling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,14 @@ jobs:
            cargo update -p image --precise 0.25.0
            cargo update -p gethostname@1.1.0 --precise 1.0.2
            cargo update -p unicode-ident --precise 1.0.10
-           cargo update -p syn --precise 2.0.114
+           cargo update -p syn@2 --precise 2.0.114
+           cargo update -p foreign-types-macros --precise 0.2.3
+           cargo update -p proc-macro2 --precise 1.0.106
+           cargo update -p quote --precise 1.0.44
+           cargo update -p log --precise 0.4.29
+           cargo update -p unicode-segmentation --precise 1.12.0
+           cargo update -p wayland-protocols --precise 0.32.10
+           cargo update -p indexmap --precise 2.11.4
 
     - name: Install GCC Multilib
       if: (matrix.platform.os == 'ubuntu-latest') && contains(matrix.platform.target, 'i686')

--- a/src/changelog/unreleased.md
+++ b/src/changelog/unreleased.md
@@ -39,3 +39,7 @@ The migration guide could reference other migration examples in the current
 changelog entry.
 
 ## Unreleased
+
+### Fixed
+
+- On Windows, prevent incorrect shifting when dragging window onto a monitor with different DPI.

--- a/src/platform_impl/linux/common/xkb/compose.rs
+++ b/src/platform_impl/linux/common/xkb/compose.rs
@@ -21,11 +21,11 @@ pub struct XkbComposeTable {
 impl XkbComposeTable {
     pub fn new(context: &XkbContext) -> Option<Self> {
         let locale = env::var_os("LC_ALL")
-            .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            .filter(|v| !v.is_empty())
             .or_else(|| env::var_os("LC_CTYPE"))
-            .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            .filter(|v| !v.is_empty())
             .or_else(|| env::var_os("LANG"))
-            .and_then(|v| if v.is_empty() { None } else { Some(v) })
+            .filter(|v| !v.is_empty())
             .unwrap_or_else(|| "C".into());
         let locale = CString::new(locale.into_vec()).unwrap();
 

--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -680,10 +680,10 @@ impl EventProcessor {
             drop(shared_state_lock);
 
             if moved {
-                callback(&self.target, Event::WindowEvent {
-                    window_id,
-                    event: WindowEvent::Moved(outer.into()),
-                });
+                callback(
+                    &self.target,
+                    Event::WindowEvent { window_id, event: WindowEvent::Moved(outer.into()) },
+                );
             }
             outer
         };
@@ -728,13 +728,16 @@ impl EventProcessor {
                 drop(shared_state_lock);
 
                 let inner_size = Arc::new(Mutex::new(new_inner_size));
-                callback(&self.target, Event::WindowEvent {
-                    window_id,
-                    event: WindowEvent::ScaleFactorChanged {
-                        scale_factor: new_scale_factor,
-                        inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&inner_size)),
+                callback(
+                    &self.target,
+                    Event::WindowEvent {
+                        window_id,
+                        event: WindowEvent::ScaleFactorChanged {
+                            scale_factor: new_scale_factor,
+                            inner_size_writer: InnerSizeWriter::new(Arc::downgrade(&inner_size)),
+                        },
                     },
-                });
+                );
 
                 let new_inner_size = *inner_size.lock().unwrap();
                 drop(inner_size);
@@ -781,10 +784,13 @@ impl EventProcessor {
         }
 
         if resized {
-            callback(&self.target, Event::WindowEvent {
-                window_id,
-                event: WindowEvent::Resized(new_inner_size.into()),
-            });
+            callback(
+                &self.target,
+                Event::WindowEvent {
+                    window_id,
+                    event: WindowEvent::Resized(new_inner_size.into()),
+                },
+            );
         }
     }
 
@@ -1506,10 +1512,13 @@ impl EventProcessor {
         }
         let physical_key = xkb::raw_keycode_to_physicalkey(keycode);
 
-        callback(&self.target, Event::DeviceEvent {
-            device_id,
-            event: DeviceEvent::Key(RawKeyEvent { physical_key, state }),
-        });
+        callback(
+            &self.target,
+            Event::DeviceEvent {
+                device_id,
+                event: DeviceEvent::Key(RawKeyEvent { physical_key, state }),
+            },
+        );
     }
 
     fn xinput2_hierarchy_changed<T: 'static, F>(&mut self, xev: &XIHierarchyEvent, mut callback: F)
@@ -1524,15 +1533,21 @@ impl EventProcessor {
         for info in infos {
             if 0 != info.flags & (xinput2::XISlaveAdded | xinput2::XIMasterAdded) {
                 self.init_device(info.deviceid as xinput::DeviceId);
-                callback(&self.target, Event::DeviceEvent {
-                    device_id: mkdid(info.deviceid as xinput::DeviceId),
-                    event: DeviceEvent::Added,
-                });
+                callback(
+                    &self.target,
+                    Event::DeviceEvent {
+                        device_id: mkdid(info.deviceid as xinput::DeviceId),
+                        event: DeviceEvent::Added,
+                    },
+                );
             } else if 0 != info.flags & (xinput2::XISlaveRemoved | xinput2::XIMasterRemoved) {
-                callback(&self.target, Event::DeviceEvent {
-                    device_id: mkdid(info.deviceid as xinput::DeviceId),
-                    event: DeviceEvent::Removed,
-                });
+                callback(
+                    &self.target,
+                    Event::DeviceEvent {
+                        device_id: mkdid(info.deviceid as xinput::DeviceId),
+                        event: DeviceEvent::Removed,
+                    },
+                );
                 let mut devices = self.devices.borrow_mut();
                 devices.remove(&DeviceId(info.deviceid as xinput::DeviceId));
             }
@@ -1848,7 +1863,7 @@ impl EventProcessor {
                 .find(|prev_monitor| prev_monitor.name == new_monitor.name)
                 .map(|prev_monitor| prev_monitor.scale_factor);
             if Some(new_monitor.scale_factor) != maybe_prev_scale_factor {
-                for window in wt.windows.borrow().iter().filter_map(|(_, w)| w.upgrade()) {
+                for window in wt.windows.borrow().values().filter_map(|w| w.upgrade()) {
                     window.refresh_dpi_for_monitor(&new_monitor, maybe_prev_scale_factor, |event| {
                         callback(&self.target, event);
                     })

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -2305,8 +2305,12 @@ unsafe fn public_window_callback_inner(
                 }
             }
 
+            // On Windows 11+ (build >= 22000), use the suggested rect directly.
+            // The conservative rect + monitor-nudging logic below is a Windows 10
+            // workaround that causes a DPI feedback loop on Windows 11 (winit#4041).
             let new_outer_rect: RECT;
-            {
+            let is_win10 = util::WIN10_BUILD_VERSION.is_some_and(|v| v < 22000);
+            if is_win10 {
                 let suggested_ul =
                     (suggested_rect.left + margin_left, suggested_rect.top + margin_top);
 
@@ -2403,6 +2407,9 @@ unsafe fn public_window_callback_inner(
 
                     conservative_rect
                 };
+            } else {
+                // Windows 11+: trust the OS-provided suggested rect directly.
+                new_outer_rect = suggested_rect;
             }
 
             unsafe {

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -8,9 +8,9 @@ use std::{io, mem, ptr};
 use crate::utils::Lazy;
 use windows_sys::core::{HRESULT, PCWSTR};
 use windows_sys::Win32::Foundation::{BOOL, HANDLE, HMODULE, HWND, NTSTATUS, POINT, RECT};
-use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
 use windows_sys::Win32::Graphics::Gdi::{ClientToScreen, HMONITOR};
 use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
+use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
 use windows_sys::Win32::System::SystemServices::IMAGE_DOS_HEADER;
 use windows_sys::Win32::UI::HiDpi::{
     DPI_AWARENESS_CONTEXT, MONITOR_DPI_TYPE, PROCESS_DPI_AWARENESS,

--- a/src/platform_impl/windows/util.rs
+++ b/src/platform_impl/windows/util.rs
@@ -7,7 +7,8 @@ use std::{io, mem, ptr};
 
 use crate::utils::Lazy;
 use windows_sys::core::{HRESULT, PCWSTR};
-use windows_sys::Win32::Foundation::{BOOL, HANDLE, HMODULE, HWND, POINT, RECT};
+use windows_sys::Win32::Foundation::{BOOL, HANDLE, HMODULE, HWND, NTSTATUS, POINT, RECT};
+use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
 use windows_sys::Win32::Graphics::Gdi::{ClientToScreen, HMONITOR};
 use windows_sys::Win32::System::LibraryLoader::{GetProcAddress, LoadLibraryA};
 use windows_sys::Win32::System::SystemServices::IMAGE_DOS_HEADER;
@@ -278,3 +279,33 @@ pub(crate) static GET_POINTER_TOUCH_INFO: Lazy<Option<GetPointerTouchInfo>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerTouchInfo));
 pub(crate) static GET_POINTER_PEN_INFO: Lazy<Option<GetPointerPenInfo>> =
     Lazy::new(|| get_function!("user32.dll", GetPointerPenInfo));
+
+/// Windows 10 build version, or `None` if not running on Windows 10+.
+/// Used to conditionally apply Windows 10-specific workarounds.
+pub(crate) static WIN10_BUILD_VERSION: Lazy<Option<u32>> = Lazy::new(|| {
+    type RtlGetVersion = unsafe extern "system" fn(*mut OSVERSIONINFOW) -> NTSTATUS;
+    let handle = get_function!("ntdll.dll", RtlGetVersion);
+
+    if let Some(rtl_get_version) = handle {
+        unsafe {
+            let mut vi = OSVERSIONINFOW {
+                dwOSVersionInfoSize: 0,
+                dwMajorVersion: 0,
+                dwMinorVersion: 0,
+                dwBuildNumber: 0,
+                dwPlatformId: 0,
+                szCSDVersion: [0; 128],
+            };
+
+            let status = (rtl_get_version)(&mut vi);
+
+            if status >= 0 && vi.dwMajorVersion == 10 && vi.dwMinorVersion == 0 {
+                Some(vi.dwBuildNumber)
+            } else {
+                None
+            }
+        }
+    } else {
+        None
+    }
+});


### PR DESCRIPTION
Fix DPI feedback loop when moving window between monitors on Windows 11

Backport of PR #4341 to 0.30.x: make the conservative-rect + monitor-nudging logic conditional on Windows 10 (build < 22000). On Windows 11+, use the OS-provided suggested_rect directly, avoiding the cascading WM_DPICHANGED feedback loop that causes the window to grow indefinitely.

Fixes rust-windowing/winit#4041

Taken from @danielpancake 's branch implementing this (thank you!)

Added the changelog note from #4341 as well.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users

~~- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior~~
~~- [ ] Created or updated an example program if it would help users understand this functionality~~
