### PR TITLE
winit-wayland: add new font backend features

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -51,6 +51,9 @@ skip = [
     { crate = "thiserror-impl@1.0", reason = "dep of `thiserror`" },
     { crate = "objc2@0.5", reason = "used by crossfont" },
     { crate = "objc2-foundation@0.2", reason = "used by crossfont" },
+    { crate = "font-types@0.11", reason = "used by cosmic-text's harfrust/skrifa" },
+    { crate = "read-fonts@0.37", reason = "used by cosmic-text's harfrust/skrifa" },
+    { crate = "skrifa@0.40", reason = "used by cosmic-text" },
     { crate = "syn@2", reason = "the ecosystem is in the process of migrating to syn 3" },
 ]
 skip-tree = [

--- a/winit-wayland/Cargo.toml
+++ b/winit-wayland/Cargo.toml
@@ -12,9 +12,11 @@ version.workspace = true
 default = ["dlopen", "csd-adwaita"]
 
 csd-adwaita = ["sctk-adwaita", "sctk-adwaita/ab_glyph"]
+csd-adwaita-cosmic-text = ["sctk-adwaita", "sctk-adwaita/cosmic-text"]
 csd-adwaita-crossfont = ["sctk-adwaita", "sctk-adwaita/crossfont"]
 csd-adwaita-notitle = ["sctk-adwaita"]
 csd-adwaita-notitlebar = ["csd-adwaita-notitle"]
+csd-adwaita-skrifa = ["sctk-adwaita", "sctk-adwaita/skrifa"]
 dlopen = ["wayland-backend/dlopen"]
 serde = ["dep:serde", "bitflags/serde", "smol_str/serde", "dpi/serde"]
 

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -56,9 +56,11 @@ serde = [
 ]
 wayland = ["winit-wayland"]
 wayland-csd-adwaita = ["winit-wayland/csd-adwaita"]
+wayland-csd-adwaita-cosmic-text = ["winit-wayland/csd-adwaita-cosmic-text"]
 wayland-csd-adwaita-crossfont = ["winit-wayland/csd-adwaita-crossfont"]
 wayland-csd-adwaita-notitle = ["winit-wayland/csd-adwaita-notitle"]
 wayland-csd-adwaita-notitlebar = ["winit-wayland/csd-adwaita-notitlebar"]
+wayland-csd-adwaita-skrifa = ["winit-wayland/csd-adwaita-skrifa"]
 wayland-dlopen = ["winit-wayland/dlopen"]
 x11 = ["winit-x11"]
 


### PR DESCRIPTION
As title.

P/s: Sctk-adwaita has added new `skrifa` and `cosmic-text` backend for text rendering, do we want to add those as features of `winit-wayland`? 

- [x] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
