### PR TITLE
winit-core: add `EventLoopProvider` for common methods

### DIFF
--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -17,7 +17,7 @@ use winit_core::error::{EventLoopError, NotSupportedError, RequestError};
 use winit_core::event::{self, DeviceId, FingerId, Force, StartCause, SurfaceSizeWriter};
 use winit_core::event_loop::pump_events::PumpStatus;
 use winit_core::event_loop::{
-    ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
+    ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents, EventLoopProvider,
     EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider,
     OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
@@ -641,6 +641,41 @@ impl EventLoop {
 
     fn exiting(&self) -> bool {
         self.window_target.exiting()
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(
+        mut self,
+        mut app: A,
+    ) -> Result<(), EventLoopError> {
+        let result = self.run_app_on_demand(&mut app);
+        // SAFETY: unsure that the state is dropped before the exit from the event loop.
+        drop(app);
+        result
+    }
+
+    fn create_proxy(&self) -> CoreEventLoopProxy {
+        self.window_target().create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        self.window_target().owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.window_target().listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.window_target().set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CustomCursor, RequestError> {
+        self.window_target().create_custom_cursor(custom_cursor)
     }
 }
 

--- a/winit-appkit/src/event_loop.rs
+++ b/winit-appkit/src/event_loop.rs
@@ -28,7 +28,7 @@ use winit_core::event::WindowEvent;
 use winit_core::event_loop::pump_events::PumpStatus;
 use winit_core::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, AsyncRequestSerial, ControlFlow, DeviceEvents,
-    DndAction, DragIcon, EventLoopProxy as CoreEventLoopProxy,
+    DndAction, DragIcon, EventLoopProvider, EventLoopProxy as CoreEventLoopProxy,
     OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
 use winit_core::monitor::MonitorHandle as CoreMonitorHandle;
@@ -549,6 +549,41 @@ impl EventLoop {
                 }
             })
         })
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(
+        mut self,
+        mut app: A,
+    ) -> Result<(), EventLoopError> {
+        let result = self.run_app_on_demand(&mut app);
+        // SAFETY: unsure that the state is dropped before the exit from the event loop.
+        drop(app);
+        result
+    }
+
+    fn create_proxy(&self) -> CoreEventLoopProxy {
+        self.window_target().create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        self.window_target().owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.window_target().listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.window_target().set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CoreCustomCursor, RequestError> {
+        self.window_target().create_custom_cursor(custom_cursor)
     }
 }
 

--- a/winit-core/src/application/mod.rs
+++ b/winit-core/src/application/mod.rs
@@ -125,7 +125,7 @@ pub trait ApplicationHandler {
     /// use std::thread;
     /// use std::time::Duration;
     ///
-    /// use winit::event_loop::EventLoop;
+    /// use winit::event_loop::{EventLoop, EventLoopProvider};
     /// use winit_core::application::ApplicationHandler;
     /// use winit_core::event_loop::ActiveEventLoop;
     ///

--- a/winit-core/src/event_loop/mod.rs
+++ b/winit-core/src/event_loop/mod.rs
@@ -11,13 +11,103 @@ use std::time::Duration;
 use rwh_06::{DisplayHandle, HandleError, HasDisplayHandle};
 
 use crate::Instant;
+use crate::application::ApplicationHandler;
 use crate::as_any::AsAny;
 use crate::cursor::{CustomCursor, CustomCursorSource};
 use crate::data_transfer::{DataTransfer, DataTransferId, DataTransferSend, TransferType};
-use crate::error::{NotSupportedError, RequestError};
+use crate::error::{EventLoopError, NotSupportedError, RequestError};
 use crate::icon::Icon;
 use crate::monitor::MonitorHandle;
 use crate::window::{Theme, Window, WindowAttributes, WindowId};
+
+/// Common methods to implement for the platform event loop.
+pub trait EventLoopProvider: fmt::Debug {
+    /// Run the event loop with the given application on the calling thread.
+    ///
+    /// The `app` is dropped when the event loop is shut down.
+    ///
+    /// ## Event loop flow
+    ///
+    /// This function internally handles the different parts of a traditional event-handling loop.
+    /// You can imagine this method as being implemented like this:
+    ///
+    /// ```rust,ignore
+    /// let mut start_cause = StartCause::Init;
+    ///
+    /// // Run the event loop.
+    /// while !event_loop.exiting() {
+    ///     // Wake up.
+    ///     app.new_events(event_loop, start_cause);
+    ///
+    ///     // Indicate that surfaces can now safely be created.
+    ///     if start_cause == StartCause::Init {
+    ///         app.can_create_surfaces(event_loop);
+    ///     }
+    ///
+    ///     // Handle proxy wake-up event.
+    ///     if event_loop.proxy_wake_up_set() {
+    ///         event_loop.proxy_wake_up_clear();
+    ///         app.proxy_wake_up(event_loop);
+    ///     }
+    ///
+    ///     // Handle actions done by the user / system such as moving the cursor, resizing the
+    ///     // window, changing the window theme, etc.
+    ///     for event in event_loop.events() {
+    ///         match event {
+    ///             window event => app.window_event(event_loop, window_id, event),
+    ///             device event => app.device_event(event_loop, device_id, event),
+    ///         }
+    ///     }
+    ///
+    ///     // Handle redraws.
+    ///     for window_id in event_loop.pending_redraws() {
+    ///         app.window_event(event_loop, window_id, WindowEvent::RedrawRequested);
+    ///     }
+    ///
+    ///     // Done handling events, wait until we're woken up again.
+    ///     app.about_to_wait(event_loop);
+    ///     start_cause = event_loop.wait_if_necessary();
+    /// }
+    ///
+    /// // Finished running, drop application state.
+    /// drop(app);
+    /// ```
+    ///
+    /// This is of course a very coarse-grained overview, and leaves out timing details like
+    /// [`ControlFlow::WaitUntil`] and life-cycle methods like [`ApplicationHandler::resumed`], but
+    /// it should give you an idea of how things fit together.
+    ///
+    /// ## Returns
+    ///
+    /// The semantics of this function is defined by the target platform. Consult the implementor
+    /// docs for details.
+    fn run_app<A: ApplicationHandler + 'static>(self, app: A) -> Result<(), EventLoopError>;
+
+    /// Creates an [`EventLoopProxy`] that can be used to dispatch user events
+    /// to the main event loop, possibly from another thread.
+    fn create_proxy(&self) -> EventLoopProxy;
+
+    /// Gets a persistent reference to the underlying platform display.
+    ///
+    /// See the [`OwnedDisplayHandle`] type for more information.
+    fn owned_display_handle(&self) -> OwnedDisplayHandle;
+
+    /// Change if or when [`DeviceEvent`]s are captured.
+    ///
+    /// See [`ActiveEventLoop::listen_device_events`] for details.
+    ///
+    /// [`DeviceEvent`]: crate::event::DeviceEvent
+    fn listen_device_events(&self, allowed: DeviceEvents);
+
+    /// Sets the [`ControlFlow`].
+    fn set_control_flow(&self, control_flow: ControlFlow);
+
+    /// Create custom cursor.
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CustomCursor, RequestError>;
+}
 
 pub trait ActiveEventLoop: AsAny + fmt::Debug {
     /// Creates an [`EventLoopProxy`] that can be used to dispatch user events

--- a/winit-core/src/event_loop/run_on_demand.rs
+++ b/winit-core/src/event_loop/run_on_demand.rs
@@ -6,11 +6,13 @@ use crate::{
     window::Window,
 };
 
-/// Additional methods on [`EventLoop`] to return control flow to the caller.
+/// Additional methods for [`EventLoopProvider`] to return control flow to the caller.
+///
+/// [`EventLoopProvider`]: crate::event_loop::EventLoopProvider
 pub trait EventLoopExtRunOnDemand {
     /// Run the application with the event loop on the calling thread.
     ///
-    /// Unlike [`EventLoop::run_app`], this function accepts non-`'static` (i.e. non-`move`)
+    /// Unlike [`EventLoopProvider::run_app`], this function accepts non-`'static` (i.e. non-`move`)
     /// state and it is possible to return control back to the caller without consuming the
     /// `EventLoop` (by using [`exit()`]) and so the event loop can be re-run after it has exit.
     ///
@@ -32,8 +34,8 @@ pub trait EventLoopExtRunOnDemand {
     ///   to the caller (specifically this is impossible on iOS and Web).
     /// - No [`Window`] state can be carried between separate runs of the event loop.
     ///
-    /// You are strongly encouraged to use [`EventLoop::run_app()`] for portability, unless you
-    /// specifically need the ability to re-run a single event loop more than once
+    /// You are strongly encouraged to use [`EventLoopProvider::run_app`] for portability, unless
+    /// you specifically need the ability to re-run a single event loop more than once
     ///
     /// # Supported Platforms
     /// - Windows
@@ -50,5 +52,6 @@ pub trait EventLoopExtRunOnDemand {
     ///
     /// [`exit()`]: ActiveEventLoop::exit()
     /// [`set_control_flow()`]: ActiveEventLoop::set_control_flow()
+    /// [`EventLoopProvider::run_app`]: crate::event_loop::EventLoopProvider::run_app
     fn run_app_on_demand<A: ApplicationHandler>(&mut self, app: A) -> Result<(), EventLoopError>;
 }

--- a/winit-orbital/src/event_loop.rs
+++ b/winit-orbital/src/event_loop.rs
@@ -20,7 +20,7 @@ use winit_core::error::{EventLoopError, NotSupportedError, RequestError};
 use winit_core::event::{self, Ime, Modifiers, StartCause};
 use winit_core::event_loop::pump_events::PumpStatus;
 use winit_core::event_loop::{
-    ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
+    ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents, EventLoopProvider,
     EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider,
     OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
@@ -731,6 +731,41 @@ impl EventLoop {
 
     pub fn window_target(&self) -> &dyn RootActiveEventLoop {
         &self.window_target
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(
+        mut self,
+        mut app: A,
+    ) -> Result<(), EventLoopError> {
+        let result = self.run_app_on_demand(&mut app);
+        // SAFETY: unsure that the state is dropped before the exit from the event loop.
+        drop(app);
+        result
+    }
+
+    fn create_proxy(&self) -> CoreEventLoopProxy {
+        self.window_target().create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        self.window_target().owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.window_target().listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.window_target().set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CustomCursor, RequestError> {
+        self.window_target().create_custom_cursor(custom_cursor)
     }
 }
 

--- a/winit-uikit/src/event_loop.rs
+++ b/winit-uikit/src/event_loop.rs
@@ -19,7 +19,7 @@ use winit_core::application::ApplicationHandler;
 use winit_core::cursor::{CustomCursor, CustomCursorSource};
 use winit_core::error::{EventLoopError, NotSupportedError, RequestError};
 use winit_core::event_loop::{
-    ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents,
+    ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents, EventLoopProvider,
     EventLoopProxy as CoreEventLoopProxy, OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
 use winit_core::monitor::MonitorHandle as CoreMonitorHandle;
@@ -331,5 +331,34 @@ impl EventLoop {
 
     pub fn window_target(&self) -> &dyn RootActiveEventLoop {
         &self.window_target
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(self, app: A) -> Result<(), EventLoopError> {
+        self.run_app_never_return(app)
+    }
+
+    fn create_proxy(&self) -> CoreEventLoopProxy {
+        self.window_target().create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        self.window_target().owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.window_target().listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.window_target().set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CustomCursor, RequestError> {
+        self.window_target().create_custom_cursor(custom_cursor)
     }
 }

--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -32,7 +32,7 @@ use winit_core::event::{DeviceEvent, StartCause, SurfaceSizeWriter, WindowEvent}
 use winit_core::event_loop::pump_events::PumpStatus;
 use winit_core::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, AsyncRequestSerial, ControlFlow, DeviceEvents,
-    DndAction, DragIcon, OwnedDisplayHandle as CoreOwnedDisplayHandle,
+    DndAction, DragIcon, EventLoopProvider, OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
 use winit_core::icon::RgbaIcon;
 use winit_core::monitor::MonitorHandle as CoreMonitorHandle;
@@ -621,6 +621,41 @@ impl EventLoop {
 
     fn exit_code(&self) -> Option<i32> {
         self.active_event_loop.exit_code()
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(
+        mut self,
+        mut app: A,
+    ) -> Result<(), EventLoopError> {
+        let result = self.run_app_on_demand(&mut app);
+        // SAFETY: unsure that the state is dropped before the exit from the event loop.
+        drop(app);
+        result
+    }
+
+    fn create_proxy(&self) -> CoreEventLoopProxy {
+        self.active_event_loop.create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        self.active_event_loop.owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.active_event_loop.listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.active_event_loop.set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CoreCustomCursor, RequestError> {
+        self.active_event_loop.create_custom_cursor(custom_cursor)
     }
 }
 

--- a/winit-web/src/event_loop/mod.rs
+++ b/winit-web/src/event_loop/mod.rs
@@ -1,8 +1,12 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use winit_core::application::ApplicationHandler;
-use winit_core::error::{EventLoopError, NotSupportedError};
-use winit_core::event_loop::ActiveEventLoop as RootActiveEventLoop;
+use winit_core::cursor::{CustomCursor as CoreCustomCursor, CustomCursorSource};
+use winit_core::error::{EventLoopError, NotSupportedError, RequestError};
+use winit_core::event_loop::{
+    ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents, EventLoopProvider,
+    EventLoopProxy, OwnedDisplayHandle,
+};
 
 use crate::{
     HasMonitorPermissionFuture, MonitorPermissionFuture, PollStrategy, WaitUntilStrategy, backend,
@@ -75,5 +79,35 @@ impl EventLoop {
         HasMonitorPermissionFuture(
             self.elw.runner.monitor().has_detailed_monitor_permission_async(),
         )
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(self, app: A) -> Result<(), EventLoopError> {
+        self.register_app(app);
+        Ok(())
+    }
+
+    fn create_proxy(&self) -> EventLoopProxy {
+        self.window_target().create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        self.window_target().owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.window_target().listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.window_target().set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CoreCustomCursor, RequestError> {
+        self.window_target().create_custom_cursor(custom_cursor)
     }
 }

--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -74,8 +74,8 @@ use winit_core::event::{
 use winit_core::event_loop::pump_events::PumpStatus;
 use winit_core::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, AsyncRequestSerial, ControlFlow, DeviceEvents,
-    DndAction, DragIcon, EventLoopProxy as RootEventLoopProxy, EventLoopProxyProvider,
-    OwnedDisplayHandle as CoreOwnedDisplayHandle,
+    DndAction, DragIcon, EventLoopProvider, EventLoopProxy as RootEventLoopProxy,
+    EventLoopProxyProvider, OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
 use winit_core::keyboard::ModifiersState;
 use winit_core::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle};
@@ -389,6 +389,41 @@ impl EventLoop {
 
     fn exit_code(&self) -> Option<i32> {
         self.runner.exit_code()
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(
+        mut self,
+        mut app: A,
+    ) -> Result<(), EventLoopError> {
+        let result = self.run_app_on_demand(&mut app);
+        // SAFETY: unsure that the state is dropped before the exit from the event loop.
+        drop(app);
+        result
+    }
+
+    fn create_proxy(&self) -> RootEventLoopProxy {
+        self.window_target().create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        self.window_target().owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.window_target().listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.window_target().set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CustomCursor, RequestError> {
+        self.window_target().create_custom_cursor(custom_cursor)
     }
 }
 

--- a/winit-x11/src/event_loop.rs
+++ b/winit-x11/src/event_loop.rs
@@ -25,7 +25,7 @@ use winit_core::event::{DeviceId, StartCause, WindowEvent};
 use winit_core::event_loop::pump_events::PumpStatus;
 use winit_core::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, AsyncRequestSerial, ControlFlow, DeviceEvents,
-    DndAction, EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider,
+    DndAction, EventLoopProvider, EventLoopProxy as CoreEventLoopProxy, EventLoopProxyProvider,
     OwnedDisplayHandle as CoreOwnedDisplayHandle,
 };
 use winit_core::monitor::MonitorHandle as CoreMonitorHandle;
@@ -644,6 +644,41 @@ impl EventLoop {
 
     fn exit_code(&self) -> Option<i32> {
         self.event_processor.target.exit_code()
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(
+        mut self,
+        mut app: A,
+    ) -> Result<(), EventLoopError> {
+        let result = self.run_app_on_demand(&mut app);
+        // SAFETY: unsure that the state is dropped before the exit from the event loop.
+        drop(app);
+        result
+    }
+
+    fn create_proxy(&self) -> CoreEventLoopProxy {
+        self.window_target().create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> CoreOwnedDisplayHandle {
+        self.window_target().owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.window_target().listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.window_target().set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CoreCustomCursor, RequestError> {
+        self.window_target().create_custom_cursor(custom_cursor)
     }
 }
 

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -61,6 +61,7 @@ changelog entry.
   matching release of a click that activated a previously inactive window are tagged, so
   applications can ignore activation clicks for buttons or destructive actions while accepting
   them for low-risk actions like selection or scrolling. Always `false` on other platforms.
+- `winit::event_loop::EventLoopProvider` trait with common event loop methods.
 
 ### Changed
 

--- a/winit/src/event_loop.rs
+++ b/winit/src/event_loop.rs
@@ -163,34 +163,8 @@ impl EventLoop {
     /// If this requirement is prohibitive for you, consider using [`run_app_on_demand`] instead
     /// (though note that this is not available on iOS and web).
     #[inline]
-    #[allow(unused_mut)]
-    pub fn run_app<A: ApplicationHandler + 'static>(
-        mut self,
-        mut app: A,
-    ) -> Result<(), EventLoopError> {
-        #[cfg(any(
-            windows_platform,
-            macos_platform,
-            android_platform,
-            orbital_platform,
-            x11_platform,
-            wayland_platform,
-        ))]
-        {
-            let result = self.event_loop.run_app_on_demand(&mut app);
-            // SAFETY: unsure that the state is dropped before the exit from the event loop.
-            drop(app);
-            result
-        }
-        #[cfg(web_platform)]
-        {
-            self.event_loop.register_app(app);
-            Ok(())
-        }
-        #[cfg(ios_platform)]
-        {
-            self.event_loop.run_app_never_return(app)
-        }
+    pub fn run_app<A: ApplicationHandler + 'static>(self, app: A) -> Result<(), EventLoopError> {
+        self.event_loop.run_app(app)
     }
 
     /// Creates an [`EventLoopProxy`] that can be used to dispatch user events

--- a/winit/src/event_loop.rs
+++ b/winit/src/event_loop.rs
@@ -120,58 +120,7 @@ impl EventLoop {
 
     /// Run the event loop with the given application on the calling thread.
     ///
-    /// The `app` is dropped when the event loop is shut down.
-    ///
-    /// ## Event loop flow
-    ///
-    /// This function internally handles the different parts of a traditional event-handling loop.
-    /// You can imagine this method as being implemented like this:
-    ///
-    /// ```rust,ignore
-    /// let mut start_cause = StartCause::Init;
-    ///
-    /// // Run the event loop.
-    /// while !event_loop.exiting() {
-    ///     // Wake up.
-    ///     app.new_events(event_loop, start_cause);
-    ///
-    ///     // Indicate that surfaces can now safely be created.
-    ///     if start_cause == StartCause::Init {
-    ///         app.can_create_surfaces(event_loop);
-    ///     }
-    ///
-    ///     // Handle proxy wake-up event.
-    ///     if event_loop.proxy_wake_up_set() {
-    ///         event_loop.proxy_wake_up_clear();
-    ///         app.proxy_wake_up(event_loop);
-    ///     }
-    ///
-    ///     // Handle actions done by the user / system such as moving the cursor, resizing the
-    ///     // window, changing the window theme, etc.
-    ///     for event in event_loop.events() {
-    ///         match event {
-    ///             window event => app.window_event(event_loop, window_id, event),
-    ///             device event => app.device_event(event_loop, device_id, event),
-    ///         }
-    ///     }
-    ///
-    ///     // Handle redraws.
-    ///     for window_id in event_loop.pending_redraws() {
-    ///         app.window_event(event_loop, window_id, WindowEvent::RedrawRequested);
-    ///     }
-    ///
-    ///     // Done handling events, wait until we're woken up again.
-    ///     app.about_to_wait(event_loop);
-    ///     start_cause = event_loop.wait_if_necessary();
-    /// }
-    ///
-    /// // Finished running, drop application state.
-    /// drop(app);
-    /// ```
-    ///
-    /// This is of course a very coarse-grained overview, and leaves out timing details like
-    /// [`ControlFlow::WaitUntil`] and life-cycle methods like [`ApplicationHandler::resumed`], but
-    /// it should give you an idea of how things fit together.
+    /// For details see [`EventLoopProvider`].
     ///
     /// ## Returns
     ///
@@ -200,6 +149,7 @@ impl EventLoop {
     /// [`run_app_on_demand`]: crate::event_loop::run_on_demand::EventLoopExtRunOnDemand::run_app_on_demand
     /// [`run_app_never_return`]: crate::event_loop::never_return::EventLoopExtNeverReturn::run_app_never_return
     /// [`register_app`]: crate::event_loop::register::EventLoopExtRegister::register_app
+    /// [`EventLoopProvider`]: winit_core::event_loop::EventLoopProvider
     ///
     /// ## Static
     ///
@@ -285,6 +235,35 @@ impl EventLoop {
         custom_cursor: CustomCursorSource,
     ) -> Result<CustomCursor, RequestError> {
         self.event_loop.window_target().create_custom_cursor(custom_cursor)
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(self, app: A) -> Result<(), EventLoopError> {
+        self.run_app(app)
+    }
+
+    fn create_proxy(&self) -> EventLoopProxy {
+        self.create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        self.owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CustomCursor, RequestError> {
+        self.create_custom_cursor(custom_cursor)
     }
 }
 

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -39,7 +39,7 @@
 //! ```no_run
 //! use winit::application::ApplicationHandler;
 //! use winit::event::WindowEvent;
-//! use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+//! use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop, EventLoopProvider};
 //! use winit::window::{Window, WindowId, WindowAttributes};
 //!
 //! #[derive(Default)]
@@ -260,7 +260,7 @@
 //!
 //! [`EventLoop`]: event_loop::EventLoop
 //! [`EventLoop::new()`]: event_loop::EventLoop::new
-//! [`EventLoop::run_app()`]: event_loop::EventLoop::run_app
+//! [`EventLoop::run_app()`]: event_loop::EventLoopProvider::run_app
 //! [`exit()`]: event_loop::ActiveEventLoop::exit
 //! [`Window`]: window::Window
 //! [`WindowId`]: window::WindowId

--- a/winit/src/platform_impl/linux/mod.rs
+++ b/winit/src/platform_impl/linux/mod.rs
@@ -9,9 +9,13 @@ use std::time::Duration;
 
 pub(crate) use winit_common::xkb::{physicalkey_to_scancode, scancode_to_physicalkey};
 use winit_core::application::ApplicationHandler;
-use winit_core::error::{EventLoopError, NotSupportedError};
-use winit_core::event_loop::ActiveEventLoop;
+use winit_core::cursor::{CustomCursor, CustomCursorSource};
+use winit_core::error::{EventLoopError, NotSupportedError, RequestError};
 use winit_core::event_loop::pump_events::PumpStatus;
+use winit_core::event_loop::{
+    ActiveEventLoop, ControlFlow, DeviceEvents, EventLoopProvider, EventLoopProxy,
+    OwnedDisplayHandle,
+};
 #[cfg(wayland_platform)]
 pub(crate) use winit_wayland as wayland;
 #[cfg(x11_platform)]
@@ -164,6 +168,41 @@ impl EventLoop {
 
     pub fn window_target(&self) -> &dyn ActiveEventLoop {
         x11_or_wayland!(match self; EventLoop(evlp) => evlp.window_target())
+    }
+}
+
+impl EventLoopProvider for EventLoop {
+    fn run_app<A: ApplicationHandler + 'static>(
+        mut self,
+        mut app: A,
+    ) -> Result<(), EventLoopError> {
+        let result = self.run_app_on_demand(&mut app);
+        // SAFETY: unsure that the state is dropped before the exit from the event loop.
+        drop(app);
+        result
+    }
+
+    fn create_proxy(&self) -> EventLoopProxy {
+        self.window_target().create_proxy()
+    }
+
+    fn owned_display_handle(&self) -> OwnedDisplayHandle {
+        self.window_target().owned_display_handle()
+    }
+
+    fn listen_device_events(&self, allowed: DeviceEvents) {
+        self.window_target().listen_device_events(allowed);
+    }
+
+    fn set_control_flow(&self, control_flow: ControlFlow) {
+        self.window_target().set_control_flow(control_flow);
+    }
+
+    fn create_custom_cursor(
+        &self,
+        custom_cursor: CustomCursorSource,
+    ) -> Result<CustomCursor, RequestError> {
+        self.window_target().create_custom_cursor(custom_cursor)
     }
 }
 


### PR DESCRIPTION
Thus implementing winit main event loop API is standardized.

- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

--

To make it fully opaque for the user, we'd need to change all `run_*` methods to accept something `dyn` instead of generic, though, it can be done in separate PR, if needed.