### PR TITLE
Mark extensible public enums as `#[non_exhaustive]`

### DIFF
--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -977,6 +977,7 @@ impl CoreWindow for Window {
                 *current_caps = None;
                 self.app.hide_soft_input(true);
             },
+            _ => return Err(ImeRequestError::NotSupported),
         }
 
         Ok(())

--- a/winit-android/src/lib.rs
+++ b/winit-android/src/lib.rs
@@ -70,7 +70,6 @@
 //! 4. Pass a clone of the `AndroidApp` that your application receives to Winit when building your
 //!    event loop (as shown above).
 #![cfg(target_os = "android")]
-
 #![warn(clippy::exhaustive_enums)]
 
 mod event_loop;

--- a/winit-android/src/lib.rs
+++ b/winit-android/src/lib.rs
@@ -71,6 +71,8 @@
 //!    event loop (as shown above).
 #![cfg(target_os = "android")]
 
+#![warn(clippy::exhaustive_enums)]
+
 mod event_loop;
 mod keycodes;
 

--- a/winit-appkit/src/cursor.rs
+++ b/winit-appkit/src/cursor.rs
@@ -34,7 +34,7 @@ impl CustomCursor {
     pub(crate) fn new(cursor: CustomCursorSource) -> Result<CustomCursor, RequestError> {
         let cursor = match cursor {
             CustomCursorSource::Image(cursor_image) => cursor_image,
-            CustomCursorSource::Animation { .. } | CustomCursorSource::Url { .. } => {
+            _ => {
                 return Err(NotSupportedError::new("unsupported cursor kind").into());
             },
         };

--- a/winit-appkit/src/dnd.rs
+++ b/winit-appkit/src/dnd.rs
@@ -453,6 +453,7 @@ impl PasteboardWriterState {
             SendData::Uris(_) => None,
             SendData::String(string) => Some(NSString::from_str(&string).into()),
             SendData::Bytes(binary) => Some(NSData::from_vec(binary).into()),
+            _ => None,
         }
     }
 }

--- a/winit-appkit/src/event_loop.rs
+++ b/winit-appkit/src/event_loop.rs
@@ -248,6 +248,7 @@ impl RootActiveEventLoop for ActiveEventLoop {
                                     .chain(Vec::new().into_iter().map(ns_url_from_str)),
                             ),
                             SendData::Bytes(_) => None,
+                            _ => None,
                         }
                     })
                     .into_iter()

--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -65,6 +65,8 @@
 //! ```
 #![cfg(target_vendor = "apple")] // TODO: Remove once `objc2` allows compiling on all platforms
 
+#![warn(clippy::exhaustive_enums)]
+
 #[macro_use]
 mod util;
 
@@ -632,6 +634,7 @@ impl ActiveEventLoopExtMacOS for dyn ActiveEventLoop + '_ {
 /// The default is `None`.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum OptionAsAlt {
     /// The left `Option` key is treated as `Alt`.
     OnlyLeft,

--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -64,7 +64,6 @@
 //! }
 //! ```
 #![cfg(target_vendor = "apple")] // TODO: Remove once `objc2` allows compiling on all platforms
-
 #![warn(clippy::exhaustive_enums)]
 
 #[macro_use]

--- a/winit-appkit/src/lib.rs
+++ b/winit-appkit/src/lib.rs
@@ -334,6 +334,7 @@ impl WindowExtMacOS for dyn Window + '_ {
 /// Corresponds to `NSApplicationActivationPolicy`.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum ActivationPolicy {
     /// Corresponds to `NSApplicationActivationPolicyRegular`.
     #[default]

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -227,6 +227,7 @@ define_class!(
                 // in fullscreen, so we must've reached here by `set_fullscreen`
                 // as it updates the state
                 Some(Fullscreen::Borderless(_)) => (),
+                Some(_) => (),
                 // Otherwise, we must've reached fullscreen by the user clicking
                 // on the green fullscreen button. Update state!
                 None => {
@@ -667,6 +668,7 @@ fn new_window(
                 monitor.ns_screen(mtm).or_else(|| NSScreen::mainScreen(mtm))
             },
             Some(Fullscreen::Borderless(None)) => NSScreen::mainScreen(mtm),
+            Some(_) => NSScreen::mainScreen(mtm),
             None => None,
         };
         let frame = match &screen {
@@ -1683,7 +1685,7 @@ impl WindowDelegate {
                     let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                     monitor.ns_screen(mtm)
                 },
-                Fullscreen::Borderless(None) => {
+                _ => {
                     if let Some(monitor) = self.current_monitor_inner() {
                         monitor.ns_screen(mtm)
                     } else {
@@ -1928,6 +1930,7 @@ impl WindowDelegate {
                 self.view().disable_ime();
                 return Ok(());
             },
+            _ => return Err(ImeRequestError::NotSupported),
         };
 
         if let Some((spot, size)) = request_data.cursor_area {

--- a/winit-common/src/lib.rs
+++ b/winit-common/src/lib.rs
@@ -1,5 +1,7 @@
 //! Winit implementation helpers.
 
+#![warn(clippy::exhaustive_enums)]
+
 #[cfg(feature = "core-foundation")]
 pub mod core_foundation;
 #[cfg(feature = "event-handler")]

--- a/winit-common/src/xkb/mod.rs
+++ b/winit-common/src/xkb/mod.rs
@@ -41,6 +41,7 @@ pub fn reset_dead_keys() {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// libxkbcommon is not available
     XKBNotFound,

--- a/winit-core/src/cursor.rs
+++ b/winit-core/src/cursor.rs
@@ -17,6 +17,7 @@ const PIXEL_SIZE: usize = 4;
 
 /// See [`Window::set_cursor()`][crate::window::Window::set_cursor] for more details.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+#[allow(clippy::exhaustive_enums)]
 pub enum Cursor {
     Icon(CursorIcon),
     Custom(CustomCursor),

--- a/winit-core/src/cursor.rs
+++ b/winit-core/src/cursor.rs
@@ -111,6 +111,7 @@ impl_dyn_casting!(CustomCursorProvider);
 ///
 /// See [`CustomCursor`] for more details.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum CustomCursorSource {
     /// Cursor that is backed by RGBA image.
     ///
@@ -167,6 +168,7 @@ impl CustomCursorSource {
 /// An error produced when using [`CustomCursorSource::from_rgba`] with invalid arguments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum BadImage {
     /// Produced when the image dimensions are larger than [`MAX_CURSOR_SIZE`]. This doesn't
     /// guarantee that the cursor will work, but should avoid many platform and device specific
@@ -217,6 +219,7 @@ impl Error for BadImage {}
 /// An error produced when using [`CustomCursorSource::from_animation`] with invalid arguments.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum BadAnimation {
     /// Produced when no cursors were supplied.
     Empty,

--- a/winit-core/src/data_transfer.rs
+++ b/winit-core/src/data_transfer.rs
@@ -127,6 +127,7 @@ impl DataTransferId {
 
 /// The set of types supported cross-platform.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum TypeHint {
     /// Plain UTF-8 text (see [`TypedData::try_as_string`]).
     ///
@@ -381,6 +382,7 @@ impl_dyn_casting!(DataTransfer);
 /// different encoding on different platforms. To allow this to be represented, we allow
 /// supplying strings and URIs separately from binary blobs.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum SendData {
     /// List of URIs.
     ///

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -1107,6 +1107,7 @@ pub enum Ime {
 /// Describes touch-screen input state.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum TouchPhase {
     /// Initial touch contact or gesture start, for example when one or more fingers touch the
     /// screen or touchpad.
@@ -1126,6 +1127,7 @@ pub enum TouchPhase {
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[doc(alias = "Pressure")]
+#[allow(clippy::exhaustive_enums)]
 pub enum Force {
     /// On iOS, the force is calibrated so that the same number corresponds to
     /// roughly the same amount of pressure on the screen regardless of the
@@ -1436,6 +1438,7 @@ impl TabletToolAngle {
 /// Describes the input state of a key.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum ElementState {
     Pressed,
     Released,
@@ -1466,6 +1469,7 @@ impl ElementState {
 #[derive(Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[repr(u8)]
+#[allow(clippy::exhaustive_enums)]
 pub enum MouseButton {
     /// The primary (usually left) button
     Left = 0,
@@ -1561,6 +1565,7 @@ impl MouseButton {
 /// Describes a button of a tool, e.g. a pen.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum TabletToolButton {
     Contact,
     Barrel,

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -20,6 +20,7 @@ use crate::window::{ActivationToken, Theme};
 
 /// Describes the reason the event loop is resuming.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum StartCause {
     /// Sent if the time specified by [`ControlFlow::WaitUntil`] has been reached. Contains the
     /// moment the timeout was requested and the requested resume time. The actual resume time is
@@ -44,6 +45,7 @@ pub enum StartCause {
 
 /// Describes an event from a [`Window`].
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum WindowEvent {
     /// The activation token was delivered back and now could be used.
     ActivationTokenDone { serial: AsyncRequestSerial, token: ActivationToken },
@@ -531,6 +533,7 @@ pub enum WindowEvent {
 /// **Wayland/X11:** [`Unknown`](Self::Unknown) device types are converted to known variants by the
 /// system.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum PointerKind {
     Mouse,
     /// See [`PointerSource::Touch`] for more details.
@@ -548,6 +551,7 @@ pub enum PointerKind {
 /// **Wayland/X11:** [`Unknown`](Self::Unknown) device types are converted to known variants by the
 /// system.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum PointerSource {
     Mouse,
     /// Represents a touch event.
@@ -616,6 +620,7 @@ impl From<PointerSource> for PointerKind {
 /// **Wayland/X11:** [`Unknown`](Self::Unknown) device types are converted to known variants by the
 /// system.
 #[derive(Clone, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum ButtonSource {
     /// ## Platform-specific
     ///
@@ -730,6 +735,7 @@ impl FingerId {
 ///
 /// [window events]: WindowEvent
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[non_exhaustive]
 pub enum DeviceEvent {
     /// Change in physical position of a pointing device.
     ///
@@ -1052,6 +1058,7 @@ impl From<ModifiersState> for Modifiers {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum Ime {
     /// Notifies when the IME was enabled.
     ///
@@ -1576,6 +1583,7 @@ impl From<TabletToolButton> for Option<MouseButton> {
 /// Describes a difference in the mouse scroll wheel state.
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum MouseScrollDelta {
     /// Amount in lines or rows to scroll in the horizontal
     /// and vertical directions.

--- a/winit-core/src/event_loop/mod.rs
+++ b/winit-core/src/event_loop/mod.rs
@@ -415,6 +415,7 @@ impl Eq for OwnedDisplayHandle {}
 /// [`Wait`]: Self::Wait
 /// [`about_to_wait`]: crate::application::ApplicationHandler::about_to_wait
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[allow(clippy::exhaustive_enums)]
 pub enum ControlFlow {
     /// When the current loop iteration finishes, immediately begin a new iteration regardless of
     /// whether or not new events are available to process.
@@ -454,6 +455,7 @@ impl ControlFlow {
 /// Control when device events are captured.
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum DeviceEvents {
     /// Report device events regardless of window focus.
     Always,

--- a/winit-core/src/event_loop/mod.rs
+++ b/winit-core/src/event_loop/mod.rs
@@ -282,6 +282,7 @@ impl From<Icon> for DragIcon {
 /// are expected to provide some kind of order of preference.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[non_exhaustive]
 pub enum DndAction {
     /// Move the dragged item from the source to the destination.
     ///

--- a/winit-core/src/event_loop/pump_events.rs
+++ b/winit-core/src/event_loop/pump_events.rs
@@ -108,6 +108,7 @@ pub trait EventLoopExtPumpEvents {
 
 /// The return status for `pump_events`
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[allow(clippy::exhaustive_enums)]
 pub enum PumpStatus {
     /// Continue running external loop.
     Continue,

--- a/winit-core/src/icon.rs
+++ b/winit-core/src/icon.rs
@@ -26,6 +26,7 @@ impl_dyn_casting!(IconProvider);
 
 #[derive(Debug)]
 /// An error produced when using [`RgbaIcon::new`] with invalid arguments.
+#[non_exhaustive]
 pub enum BadIcon {
     /// Produced when the length of the `rgba` argument isn't divisible by 4, thus `rgba` can't be
     /// safely interpreted as 32bpp RGBA pixels.

--- a/winit-core/src/keyboard.rs
+++ b/winit-core/src/keyboard.rs
@@ -169,6 +169,7 @@ impl PartialEq<NativeKeyCode> for NativeKey {
 /// emit [`PhysicalKey::Unidentified`] with additional data about the key.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum PhysicalKey {
     /// A known key code
     Code(KeyCode),
@@ -250,6 +251,7 @@ impl PartialEq<PhysicalKey> for NativeKeyCode {
 /// [`KeyboardEvent.key`]: https://w3c.github.io/uievents-key/
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum Key<Str = SmolStr> {
     /// A simple (unparameterised) action
     Named(NamedKey),
@@ -447,6 +449,7 @@ impl ModifiersState {
 /// [^2]: platform-dependent
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum ModifiersKeyState {
     /// The particular modifier is active or logically, but not necessarily physically, pressed.
     Pressed,

--- a/winit-core/src/keyboard.rs
+++ b/winit-core/src/keyboard.rs
@@ -19,6 +19,7 @@ pub use smol_str::SmolStr;
 /// - On non-Web platforms, support assigning keybinds to virtually any key through a UI.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum NativeKeyCode {
     Unidentified,
     /// An Android "scancode".
@@ -78,6 +79,7 @@ impl std::fmt::Debug for NativeKeyCode {
 /// define keybinds which work in the presence of identifiers we haven't mapped for you yet.
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum NativeKey {
     Unidentified,
     /// An Android "keycode", which is similar to a "virtual-key code" on Windows.

--- a/winit-core/src/lib.rs
+++ b/winit-core/src/lib.rs
@@ -7,6 +7,12 @@
 //!
 //! [`winit`]: https://docs.rs/winit
 
+// Every newly exported enum should either be `#[non_exhaustive]`, or carry an `#[allow]` of
+// this lint when the set of variants can never grow.
+// `clippy::exhaustive_structs` is deliberately not enabled: event structs must stay
+// constructible by the backend crates, which `#[non_exhaustive]` would forbid.
+#![warn(clippy::exhaustive_enums)]
+
 #[macro_use]
 pub mod as_any;
 pub mod cursor;

--- a/winit-core/src/monitor.rs
+++ b/winit-core/src/monitor.rs
@@ -183,6 +183,7 @@ impl fmt::Display for VideoMode {
 
 /// Fullscreen modes.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Fullscreen {
     Exclusive(MonitorHandle, VideoMode),
 

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -1544,6 +1544,7 @@ impl rwh_06::HasWindowHandle for dyn Window + '_ {
 /// Use this enum with [`Window::set_cursor_grab`] to grab the cursor.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum CursorGrabMode {
     /// No grabbing of the cursor is performed.
     None,
@@ -1574,6 +1575,7 @@ pub enum CursorGrabMode {
 /// Defines the orientation that a window resize will be performed.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum ResizeDirection {
     East,
     North,
@@ -1604,6 +1606,7 @@ impl From<ResizeDirection> for CursorIcon {
 /// The theme variant to use.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum Theme {
     /// Use the light variant.
     Light,
@@ -1621,6 +1624,7 @@ pub enum Theme {
 /// [`Informational`]: Self::Informational
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum UserAttentionType {
     /// ## Platform-specific
     ///
@@ -1656,6 +1660,7 @@ bitflags::bitflags! {
 /// - **iOS / Android / Web / Wayland:** Unsupported.
 #[derive(Debug, Default, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[allow(clippy::exhaustive_enums)]
 pub enum WindowLevel {
     /// The window will always be below normal windows.
     ///

--- a/winit-core/src/window.rs
+++ b/winit-core/src/window.rs
@@ -1756,6 +1756,7 @@ bitflags! {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[non_exhaustive]
 pub enum ImeSurroundingTextError {
     /// Text exceeds 4000 bytes
     TextTooLong,
@@ -1868,6 +1869,7 @@ impl ImeSurroundingText {
 
 /// Request to send to IME.
 #[derive(Debug, PartialEq, Clone)]
+#[non_exhaustive]
 pub enum ImeRequest {
     /// Enable the IME with the [`ImeCapabilities`] and [`ImeRequestData`] as initial state. When
     /// the [`ImeRequestData`] is **not** matching capabilities fully, the default values will be

--- a/winit-orbital/src/event_loop.rs
+++ b/winit-orbital/src/event_loop.rs
@@ -1,3 +1,5 @@
+// `EventSource` is macro-generated; the lint can't be allowed on the enum itself.
+#![allow(clippy::exhaustive_enums)]
 use std::cell::Cell;
 use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/winit-orbital/src/lib.rs
+++ b/winit-orbital/src/lib.rs
@@ -3,6 +3,8 @@
 //! Redox OS has some functionality not yet present that will be implemented
 //! when its orbital display server provides it.
 
+#![warn(clippy::exhaustive_enums)]
+
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Result, Write};
 use std::os::fd::AsRawFd;

--- a/winit-orbital/src/window.rs
+++ b/winit-orbital/src/window.rs
@@ -342,6 +342,7 @@ impl CoreWindow for Window {
             None => {
                 let _ = self.set_flag(ORBITAL_FLAG_FULLSCREEN, false);
             },
+            Some(_) => (),
         }
     }
 

--- a/winit-uikit/src/lib.rs
+++ b/winit-uikit/src/lib.rs
@@ -99,7 +99,6 @@
 //!
 //! [app-delegate]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate?language=objc
 #![cfg(target_vendor = "apple")] // TODO: Remove once `objc2` allows compiling on all platforms
-
 #![warn(clippy::exhaustive_enums)]
 
 mod app_state;

--- a/winit-uikit/src/lib.rs
+++ b/winit-uikit/src/lib.rs
@@ -100,6 +100,8 @@
 //! [app-delegate]: https://developer.apple.com/documentation/uikit/uiapplicationdelegate?language=objc
 #![cfg(target_vendor = "apple")] // TODO: Remove once `objc2` allows compiling on all platforms
 
+#![warn(clippy::exhaustive_enums)]
+
 mod app_state;
 mod event_loop;
 mod monitor;

--- a/winit-uikit/src/lib.rs
+++ b/winit-uikit/src/lib.rs
@@ -418,6 +418,7 @@ impl MonitorHandleExtIOS for MonitorHandle {
 /// Valid orientations for a particular [`Window`].
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum ValidOrientations {
     /// Excludes `PortraitUpsideDown` on iphone
     #[default]
@@ -448,6 +449,7 @@ bitflags::bitflags! {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum StatusBarStyle {
     #[default]
     Default,

--- a/winit-uikit/src/window.rs
+++ b/winit-uikit/src/window.rs
@@ -323,9 +323,7 @@ impl Inner {
             Some(Fullscreen::Borderless(Some(monitor))) => {
                 monitor.cast_ref::<MonitorHandle>().unwrap().ui_screen(mtm).clone()
             },
-            Some(Fullscreen::Borderless(None)) => {
-                self.current_monitor_inner().ui_screen(mtm).clone()
-            },
+            Some(_) => self.current_monitor_inner().ui_screen(mtm).clone(),
             None => {
                 warn!("`Window::set_fullscreen(None)` ignored on iOS");
                 return;
@@ -405,6 +403,7 @@ impl Inner {
                 *current_caps = None;
                 self.view.resignFirstResponder();
             },
+            _ => return Err(ImeRequestError::NotSupported),
         }
 
         Ok(())
@@ -522,7 +521,7 @@ impl Window {
                 let monitor = monitor.cast_ref::<MonitorHandle>().unwrap();
                 monitor.ui_screen(mtm)
             },
-            Some(Fullscreen::Borderless(None)) | None => &main_screen,
+            _ => &main_screen,
         };
 
         let screen_bounds = screen.bounds();

--- a/winit-wayland/src/dnd.rs
+++ b/winit-wayland/src/dnd.rs
@@ -85,6 +85,7 @@ impl DataSourceHandler for WinitState {
                 },
             },
             SendData::Bytes(binary) => Cursor::new(binary),
+            _ => return,
         };
 
         let _ = self.loop_handle.insert_source(fd, move |_, file, _| {

--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -694,7 +694,7 @@ impl RootActiveEventLoop for ActiveEventLoop {
     ) -> Result<CoreCustomCursor, RequestError> {
         let cursor_image = match cursor {
             CustomCursorSource::Image(cursor_image) => cursor_image,
-            CustomCursorSource::Animation { .. } | CustomCursorSource::Url { .. } => {
+            _ => {
                 return Err(NotSupportedError::new("unsupported cursor kind").into());
             },
         };

--- a/winit-wayland/src/lib.rs
+++ b/winit-wayland/src/lib.rs
@@ -17,6 +17,8 @@
 
 #![allow(clippy::mutable_key_type)]
 
+#![warn(clippy::exhaustive_enums)]
+
 use std::ffi::c_void;
 use std::hash::BuildHasher;
 use std::ptr::NonNull;

--- a/winit-wayland/src/lib.rs
+++ b/winit-wayland/src/lib.rs
@@ -16,7 +16,6 @@
 //! * `wayland-csd-adwaita-notitlebar`.
 
 #![allow(clippy::mutable_key_type)]
-
 #![warn(clippy::exhaustive_enums)]
 
 use std::ffi::c_void;

--- a/winit-wayland/src/window/mod.rs
+++ b/winit-wayland/src/window/mod.rs
@@ -453,15 +453,15 @@ impl CoreWindow for Window {
 
     fn set_fullscreen(&self, fullscreen: Option<Fullscreen>) {
         match fullscreen {
-            Some(Fullscreen::Exclusive(..)) => {
-                warn!("`Fullscreen::Exclusive` is ignored on Wayland");
-            },
             Some(Fullscreen::Borderless(monitor)) => {
                 let output = monitor.as_ref().and_then(|monitor| {
                     monitor.cast_ref::<output::MonitorHandle>().map(|handle| &handle.proxy)
                 });
 
                 self.window.set_fullscreen(output)
+            },
+            Some(_) => {
+                warn!("this fullscreen mode is ignored on Wayland");
             },
             None => self.window.unset_fullscreen(),
         }

--- a/winit-wayland/src/window/state.rs
+++ b/winit-wayland/src/window/state.rs
@@ -1269,6 +1269,7 @@ impl WindowState {
                 self.text_input_state = None;
                 true
             },
+            _ => return Err(ImeRequestError::NotSupported),
         };
 
         // Only one input method may be active per (seat, surface),

--- a/winit-web/src/cursor.rs
+++ b/winit-web/src/cursor.rs
@@ -54,6 +54,7 @@ impl CustomCursor {
                     true,
                 )
             },
+            _ => unimplemented!("unknown `CustomCursorSource` variant"),
         }
     }
 

--- a/winit-web/src/lib.rs
+++ b/winit-web/src/lib.rs
@@ -41,6 +41,8 @@
 //! [`WindowEvent::PointerLeft`]: crate::event::WindowEvent::PointerLeft
 //! [`Window::set_outer_position()`]: crate::window::Window::set_outer_position
 
+#![warn(clippy::exhaustive_enums)]
+
 // Brief introduction to the internals of the Web backend:
 // The Web backend used to support both wasm-bindgen and stdweb as methods of binding to the
 // environment. Because they are both supporting the same underlying APIs, the actual Web bindings
@@ -623,6 +625,7 @@ pub struct OrientationData {
 
 /// Screen orientation.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[allow(clippy::exhaustive_enums)]
 pub enum Orientation {
     /// The screen's aspect ratio has a width greater than the height.
     Landscape,
@@ -632,6 +635,7 @@ pub enum Orientation {
 
 /// Screen orientation lock options. Represents which orientations a user can use.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[allow(clippy::exhaustive_enums)]
 pub enum OrientationLock {
     /// User is free to use any orientation.
     Any,

--- a/winit-web/src/lib.rs
+++ b/winit-web/src/lib.rs
@@ -417,6 +417,7 @@ impl ActiveEventLoopExtWeb for dyn ActiveEventLoop + '_ {
 /// Strategy used for [`ControlFlow::Poll`][crate::event_loop::ControlFlow::Poll].
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum PollStrategy {
     /// Uses [`Window.requestIdleCallback()`] to queue the next event loop. If not available
     /// this will fallback to [`setTimeout()`].
@@ -444,6 +445,7 @@ pub enum PollStrategy {
 /// Strategy used for [`ControlFlow::WaitUntil`][crate::event_loop::ControlFlow::WaitUntil].
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum WaitUntilStrategy {
     /// Uses the [Prioritized Task Scheduling API] to queue the next event loop. If not available
     /// this will fallback to [`setTimeout()`].
@@ -478,6 +480,7 @@ impl Future for CustomCursorFuture {
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum CustomCursorError {
     Blob,
     Decode(String),
@@ -507,6 +510,7 @@ impl Future for MonitorPermissionFuture {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum MonitorPermissionError {
     /// User has explicitly denied permission to query detailed monitor information.
     Denied,
@@ -664,6 +668,7 @@ impl Future for OrientationLockFuture {
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[non_exhaustive]
 pub enum OrientationLockError {
     Unsupported,
     Busy,

--- a/winit-web/src/web_sys/event.rs
+++ b/winit-web/src/web_sys/event.rs
@@ -153,7 +153,7 @@ pub fn pointer_source(event: &PointerEvent, kind: PointerKind) -> PointerSource 
 
             PointerSource::TabletTool { kind: tool, data }
         },
-        PointerKind::Unknown => PointerSource::Unknown,
+        _ => PointerSource::Unknown,
     }
 }
 

--- a/winit-web/src/web_sys/fullscreen.rs
+++ b/winit-web/src/web_sys/fullscreen.rs
@@ -88,6 +88,7 @@ pub(crate) fn request_fullscreen(
                 canvas.webkit_request_fullscreen();
             }
         },
+        _ => error!("This full screen mode is not supported"),
     }
 }
 

--- a/winit-web/src/web_sys/pointer.rs
+++ b/winit-web/src/web_sys/pointer.rs
@@ -90,7 +90,7 @@ impl PointerHandler {
                     PointerSource::TabletTool { kind, data } => {
                         ButtonSource::TabletTool { kind, button: event::tool_button(button), data }
                     },
-                    PointerSource::Unknown => ButtonSource::Unknown(button),
+                    _ => ButtonSource::Unknown(button),
                 };
 
                 handler(
@@ -152,7 +152,7 @@ impl PointerHandler {
 
                         ButtonSource::TabletTool { kind, button: event::tool_button(button), data }
                     },
-                    PointerSource::Unknown => ButtonSource::Unknown(button),
+                    _ => ButtonSource::Unknown(button),
                 };
 
                 handler(
@@ -229,7 +229,7 @@ impl PointerHandler {
                             button: event::tool_button(button),
                             data,
                         },
-                        PointerSource::Unknown => ButtonSource::Unknown(button),
+                        _ => ButtonSource::Unknown(button),
                     };
 
                     button_handler(

--- a/winit-win32/src/dnd.rs
+++ b/winit-win32/src/dnd.rs
@@ -247,6 +247,7 @@ impl TypedData for WinTypedData {
             },
             // Windows URI drag-and-drop can't be neatly expressed as a binary blob.
             SendData::Uris(_) => None,
+            _ => None,
         }
     }
 
@@ -924,6 +925,7 @@ unsafe fn send_data_to_stgmedium(data: SendData, hint: TypeHint) -> Option<STGME
             hglobal
         },
         SendData::Bytes(b) => alloc_hglobal_from(&b)?,
+        _ => return None,
     };
 
     let mut medium = unsafe { std::mem::zeroed::<STGMEDIUM>() };

--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -431,7 +431,7 @@ impl RootActiveEventLoop for ActiveEventLoop {
     ) -> Result<CustomCursor, RequestError> {
         let cursor = match source {
             CustomCursorSource::Image(cursor) => cursor,
-            CustomCursorSource::Animation { .. } | CustomCursorSource::Url { .. } => {
+            _ => {
                 return Err(NotSupportedError::new("unsupported cursor kind").into());
             },
         };
@@ -1397,6 +1397,7 @@ unsafe fn public_window_callback_inner(
                                 window_pos.cy = old_monitor_rect.bottom - old_monitor_rect.top;
                             }
                         },
+                        _ => (),
                     }
                 }
             }

--- a/winit-win32/src/lib.rs
+++ b/winit-win32/src/lib.rs
@@ -54,6 +54,7 @@ pub type HMONITOR = *mut c_void;
 /// [`DWM_SYSTEMBACKDROP_TYPE docs`]: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum BackdropType {
     /// Corresponds to `DWMSBT_AUTO`.
     ///
@@ -113,6 +114,7 @@ impl Default for Color {
 #[repr(i32)]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum CornerPreference {
     /// Corresponds to `DWMWCP_DEFAULT`.
     ///

--- a/winit-win32/src/lib.rs
+++ b/winit-win32/src/lib.rs
@@ -3,7 +3,6 @@
 //! The supported OS version is Windows 7 or higher, though Windows 10 is
 //! tested regularly.
 #![cfg(target_os = "windows")] // FIXME(madsmtm): Allow compiling on all platforms.
-
 #![warn(clippy::exhaustive_enums)]
 
 #[macro_use]

--- a/winit-win32/src/lib.rs
+++ b/winit-win32/src/lib.rs
@@ -4,6 +4,8 @@
 //! tested regularly.
 #![cfg(target_os = "windows")] // FIXME(madsmtm): Allow compiling on all platforms.
 
+#![warn(clippy::exhaustive_enums)]
+
 #[macro_use]
 mod util;
 mod dark_mode;

--- a/winit-win32/src/window.rs
+++ b/winit-win32/src/window.rs
@@ -967,7 +967,7 @@ impl CoreWindow for Window {
                         | Fullscreen::Borderless(Some(monitor)) => {
                             Some(Cow::Borrowed(monitor.cast_ref::<MonitorHandle>().unwrap()))
                         },
-                        Fullscreen::Borderless(None) => None,
+                        _ => None,
                     };
 
                     let monitor = monitor
@@ -1068,7 +1068,8 @@ impl CoreWindow for Window {
         match &request {
             ImeRequest::Enable(..) if cap.is_some() => return Err(ImeRequestError::AlreadyEnabled),
             ImeRequest::Update(_) if cap.is_none() => return Err(ImeRequestError::NotEnabled),
-            _ => (),
+            ImeRequest::Enable(..) | ImeRequest::Update(_) | ImeRequest::Disable => (),
+            _ => return Err(ImeRequestError::NotSupported),
         }
 
         let window = self.window;
@@ -1096,6 +1097,7 @@ impl CoreWindow for Window {
                     ImeContext::set_ime_allowed(window.hwnd(), false);
                     return;
                 },
+                _ => return,
             };
 
             if let Some((spot, size)) = request_data.cursor_area {

--- a/winit-x11/src/dnd.rs
+++ b/winit-x11/src/dnd.rs
@@ -22,6 +22,7 @@ pub enum DndState {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum UriListParseError {
     EmptyData,
     InvalidUtf8(#[allow(dead_code)] Utf8Error),

--- a/winit-x11/src/lib.rs
+++ b/winit-x11/src/lib.rs
@@ -32,6 +32,7 @@ pub use dnd::{Selection, SelectionReader, SelectionType, UriListParseError};
 /// [`_NET_WM_WINDOW_TYPE`](https://specifications.freedesktop.org/wm-spec/wm-spec-1.5.html).
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[non_exhaustive]
 pub enum WindowType {
     /// A desktop feature. This can include a single window containing desktop icons with the same
     /// dimensions as the screen, allowing the desktop environment to have full control of the

--- a/winit-x11/src/lib.rs
+++ b/winit-x11/src/lib.rs
@@ -1,5 +1,7 @@
 //! # X11
 
+#![warn(clippy::exhaustive_enums)]
+
 use dpi::Size;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/winit-x11/src/util/cursor.rs
+++ b/winit-x11/src/util/cursor.rs
@@ -199,7 +199,7 @@ impl CustomCursor {
     ) -> Result<CustomCursor, RequestError> {
         let mut cursor = match cursor {
             CustomCursorSource::Image(cursor_image) => cursor_image,
-            CustomCursorSource::Animation { .. } | CustomCursorSource::Url { .. } => {
+            _ => {
                 return Err(NotSupportedError::new("unsupported cursor kind").into());
             },
         };

--- a/winit-x11/src/window.rs
+++ b/winit-x11/src/window.rs
@@ -1105,9 +1105,7 @@ impl UnownedWindow {
                             let monitor = monitor.cast_ref::<X11MonitorHandle>().unwrap();
                             (Cow::Borrowed(monitor), None)
                         },
-                        Fullscreen::Borderless(None) => {
-                            (Cow::Owned(self.shared_state_lock().last_monitor.clone()), None)
-                        },
+                        _ => (Cow::Owned(self.shared_state_lock().last_monitor.clone()), None),
                     };
 
                 // Don't set fullscreen on an invalid dummy monitor handle
@@ -2144,6 +2142,7 @@ impl UnownedWindow {
                 self.set_ime_allowed(false);
                 return Ok(());
             },
+            _ => return Err(ImeRequestError::NotSupported),
         };
 
         if let Some((position, size)) = state.cursor_area {

--- a/winit/examples/application.rs
+++ b/winit/examples/application.rs
@@ -457,6 +457,7 @@ impl ApplicationHandler for Application {
                 MouseScrollDelta::PixelDelta(px) => {
                     info!("Mouse wheel Pixel Delta: ({},{})", px.x, px.y);
                 },
+                _ => (),
             },
             WindowEvent::KeyboardInput { event, is_synthetic: false, .. } => {
                 let mods = window.modifiers;

--- a/winit/examples/ime.rs
+++ b/winit/examples/ime.rs
@@ -248,6 +248,7 @@ impl App {
                 }
             },
             Ime::Disabled => info!("IME disabled for Window={:?}", surface.window().id()),
+            _ => (),
         }
     }
 

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -64,6 +64,27 @@ changelog entry.
 
 ### Changed
 
+- Mark the extensible public enums as `#[non_exhaustive]`: `StartCause`, `WindowEvent`,
+  `DeviceEvent`, `Ime`, `PointerKind`, `PointerSource`, `ButtonSource`, `NativeKey`,
+  `NativeKeyCode`, `CustomCursorSource`, `TypeHint`, `SendData`, `DndAction`, `ImeRequest`,
+  `BadIcon`, `BadImage`, `BadAnimation`, `ImeSurroundingTextError`, `MouseScrollDelta`,
+  and `Fullscreen`.
+
+  When matching on one of these types, add a wildcard arm to cover variants added in the future:
+
+  ```rust,ignore
+  match event {
+      WindowEvent::CloseRequested => (),
+      // ...
+      _ => (),
+  }
+  ```
+- On macOS, mark `ActivationPolicy` as `#[non_exhaustive]`.
+- On X11, mark `WindowType` and `UriListParseError` as `#[non_exhaustive]`.
+- On Web, mark `PollStrategy`, `WaitUntilStrategy`, `CustomCursorError`, `MonitorPermissionError`,
+  and `OrientationLockError` as `#[non_exhaustive]`.
+- On Windows, mark `BackdropType` and `CornerPreference` as `#[non_exhaustive]`.
+- On iOS, mark `ValidOrientations` and `StatusBarStyle` as `#[non_exhaustive]`.
 - Updated `windows-sys` to `v0.61`.
 - On older macOS versions (tested up to 12.7.6), applications now receive mouse movement events for unfocused windows, matching the behavior on other platforms.
 - On macOS, using the private API `CGSSetWindowBackgroundBlurRadius` for `Window::set_blur` is now disabled by default. It can be re-enabled using the Cargo feature `private-apple-apis`.


### PR DESCRIPTION
This is a good moment to make the public enums evolvable without semver breaks.

Mark the many enums in winit-core as `#[non_exhaustive]`, so that new variant can be added without a semver break.


