### PR TITLE
fix(macos): NSTextInputClient IME commit flow ( on master branch)

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -129,6 +129,9 @@ pub struct ViewState {
     ime_state: Cell<ImeState>,
     input_source: RefCell<String>,
 
+    /// True if this view was in a preedit session that will result in a commit.
+    pending_commit: Cell<bool>,
+
     /// True iff the application wants IME events.
     ///
     /// Can be set using `set_ime_allowed`
@@ -292,6 +295,7 @@ define_class!(
                 // In case the preedit was cleared, set IME into the Ground state.
                 self.ivars().ime_state.set(ImeState::Ground);
             }
+            self.ivars().pending_commit.set(true);
 
             let string = string.to_string();
             let cursor_range = if string.is_empty() {
@@ -335,7 +339,9 @@ define_class!(
         #[unsafe(method_id(validAttributesForMarkedText))]
         fn valid_attributes_for_marked_text(&self) -> Retained<NSArray<NSAttributedStringKey>> {
             let _entered = trace_span!("validAttributesForMarkedText").entered();
-            NSArray::new()
+            let underline_style = NSString::from_str("NSUnderlineStyle");
+            let marked_clause = NSString::from_str("NSMarkedClauseSegment");
+            NSArray::from_slice(&[&*underline_style, &*marked_clause])
         }
 
         #[unsafe(method_id(attributedSubstringForProposedRange:actualRange:))]
@@ -389,10 +395,20 @@ define_class!(
             };
 
             let is_control = string.chars().next().is_some_and(|c| c.is_control());
+            let has_marked = self.hasMarkedText();
+            let pending_commit = self.ivars().pending_commit.get();
+            let ime_enabled = self.is_ime_enabled();
 
-            // Commit only if we have marked text.
-            if self.hasMarkedText() && self.is_ime_enabled() && !is_control {
+            // Clear preedit if there is marked text.
+            if has_marked {
                 self.queue_event(WindowEvent::Ime(Ime::Preedit(String::new(), None)));
+            }
+
+            // Only commit via IME if there was a real composition session.
+            // Some IMEs send insertText for all typing (e.g. spaces, English chars)
+            // which should go through keyboard input instead of paste.
+            if pending_commit && ime_enabled && !is_control {
+                self.ivars().pending_commit.set(false);
                 self.queue_event(WindowEvent::Ime(Ime::Commit(string)));
                 self.ivars().ime_state.set(ImeState::Committed);
             }
@@ -816,6 +832,7 @@ impl WinitView {
             phys_modifiers: Default::default(),
             ime_state: Default::default(),
             input_source: Default::default(),
+            pending_commit: Default::default(),
             ime_capabilities: Default::default(),
             forward_key_to_app: Default::default(),
             marked_text: Default::default(),
@@ -971,6 +988,7 @@ impl WinitView {
         }
         self.ivars().ime_capabilities.set(Some(capabilities));
         *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
+        self.ivars().pending_commit.set(false);
     }
     pub(super) fn disable_ime(&self) {
         // see above
@@ -982,6 +1000,7 @@ impl WinitView {
         // we probably don't need to do this, but again this mirrors the prior behavior of
         // `set_ime_allowed`
         *self.ivars().marked_text.borrow_mut() = NSMutableAttributedString::new();
+        self.ivars().pending_commit.set(false);
     }
 
     pub(super) fn ime_capabilities(&self) -> Option<ImeCapabilities> {


### PR DESCRIPTION
port https://github.com/rust-windowing/winit/pull/4650 to master.

Fixes #3925 — macOS `insertText:replacementRange:` incorrectly discards committed text when the IME calls `unmarkText` before `insertText`, and when the IME requires a non-empty `validAttributesForMarkedText` to enter composition.

Three targeted fixes in `src/platform_impl/macos/view.rs`:

### 1. `validAttributesForMarkedText` returns standard attributes

Some IMEs (e.g. 落格输入法 / LogInputMac3) require a non-empty return to enter composition mode. Apple's docs specify at minimum `NSUnderlineStyleAttributeName` and `NSMarkedClauseSegmentAttributeName`.

### 2. `insertText:` decouples marked-text clearing from commit

The old code required `hasMarkedText() == true` to commit, but some IMEs call `unmarkText` before `insertText` (clearing the marked text), which silently discarded all committed text. Apple's documentation for `insertText:replacementRange:` states that the provided string should be inserted regardless of whether there is marked text.

Commit is now gated on `pending_commit && ime_enabled` instead of `has_marked && ime_enabled`.

### 3. `pending_commit` flag distinguishes composition commits from regular typing

Simply removing the `hasMarkedText` check (as attempted in #4576) causes **all** `insertText` calls — including spaces and English characters during IME mode — to go through `Ime::Commit`. This loses `KeyboardInput` events and causes downstream visual artifacts (e.g. bracketed paste highlighting in Alacritty).

The `pending_commit` flag is set to `true` in `setMarkedText:` (only during actual composition) and checked + cleared in `insertText:`. This ensures:

| Scenario | `pending_commit` | Path used |
|----------|:---:|-----------|
| Composition → commit (any IME) | `true` | `Ime::Commit` ✅ |
| Space / English during IME mode | `false` | `KeyboardInput` ✅ |
| Punctuation without preedit | `false` | `KeyboardInput` (see notes) |

---

## Related PRs

- **#4576** fixes CJK punctuation by removing `hasMarkedText` but doesn't add `pending_commit`, causing all typing during IME to go through `Ime::Commit` — this breaks Russian layouts and creates paste artifacts.
- **#4478** fixes Korean double-space and key-loss, complementary but orthogonal (clears `marked_text` after commit).

## Why `pending_commit` is necessary

kchibisov [noted](https://github.com/rust-windowing/winit/issues/3925#issuecomment-2629336339) that removing the condition would lose `KeyboardInput`, and checking for ASCII is wrong since Russian layout shouldn't go through IME. The `pending_commit` flag ensures that only keystrokes that actually initiated a composition session result in `Ime::Commit` — everything else preserves the existing `KeyboardInput` path.

This matches how Kitty's IME handling works: query IME first, then decide whether the key was consumed by composition or should be forwarded as a key event.

## Tested

| IME | Composition commit | Punctuation | English during IME | Regression |
|-----|:---:|:---:|:---:|:---:|
| 落格输入法 (LogInputMac3) | ✅ | ✅ | ✅ | — |
| 搜狗拼音 (Sogou) | ✅ | ✅ | ✅ | No regression |
| Apple Pinyin | ✅ | ✅ | ✅ | No regression |
