### PR TITLE
win32: fix multi-window redraw starvation

### DIFF
--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -261,7 +261,12 @@ impl EventLoop {
         let _app_resetter = unsafe { self.runner.set_app(&mut app) };
 
         let exit_code = loop {
-            self.wait_for_messages(None);
+            // `interrupt_msg_dispatch` means a redraw ended the previous dispatch. Resume
+            // draining pending messages before emitting another `AboutToWait`, whose redraw
+            // requests could otherwise run before other windows receive their `WM_PAINT`.
+            if !self.runner.interrupt_msg_dispatch.get() {
+                self.wait_for_messages(None);
+            }
             // wait_for_messages calls user application before and after waiting
             // so it may have decided to exit.
             if let Some(code) = self.exit_code() {
@@ -292,7 +297,9 @@ impl EventLoop {
 
         self.runner.wakeup();
 
-        if self.exit_code().is_none() {
+        // Preserve the interrupted dispatch across calls: `pump_app_events` still returns after
+        // one redraw, while its next call drains pending messages before another `AboutToWait`.
+        if self.exit_code().is_none() && !self.runner.interrupt_msg_dispatch.get() {
             self.wait_for_messages(timeout);
         }
         // wait_for_messages calls user application before and after waiting
@@ -309,7 +316,9 @@ impl EventLoop {
             self.runner.reset_runner();
             PumpStatus::Exit(code)
         } else {
-            self.runner.prepare_wait();
+            if !self.runner.interrupt_msg_dispatch.get() {
+                self.runner.prepare_wait();
+            }
             PumpStatus::Continue
         }
     }

--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -3,6 +3,7 @@
 mod runner;
 
 use std::cell::Cell;
+use std::collections::HashSet;
 use std::ffi::c_void;
 use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _, OwnedHandle, RawHandle};
 use std::rc::Rc;
@@ -44,8 +45,8 @@ use windows_sys::Win32::UI::WindowsAndMessaging::{
     EnumThreadWindows, GW_OWNER, GWL_STYLE, GWL_USERDATA, GetClientRect, GetCursorPos, GetMenu,
     GetWindow, HTCAPTION, HTCLIENT, LoadCursorW, MINMAXINFO, MNC_CLOSE, MSG, MWMO_INPUTAVAILABLE,
     MsgWaitForMultipleObjectsEx, NCCALCSIZE_PARAMS, PEN_FLAG_BARREL, PEN_FLAG_ERASER,
-    PEN_MASK_PRESSURE, PEN_MASK_ROTATION, PEN_MASK_TILT_X, PEN_MASK_TILT_Y, PM_REMOVE, PT_PEN,
-    PT_TOUCH, PeekMessageW, PostMessageW, QS_ALLINPUT, RI_MOUSE_HWHEEL, RI_MOUSE_WHEEL,
+    PEN_MASK_PRESSURE, PEN_MASK_ROTATION, PEN_MASK_TILT_X, PEN_MASK_TILT_Y, PM_QS_PAINT, PM_REMOVE,
+    PT_PEN, PT_TOUCH, PeekMessageW, PostMessageW, QS_ALLINPUT, RI_MOUSE_HWHEEL, RI_MOUSE_WHEEL,
     RegisterClassExW, RegisterWindowMessageA, SC_MINIMIZE, SC_RESTORE, SIZE_MAXIMIZED,
     SPI_GETWHEELSCROLLCHARS, SPI_GETWHEELSCROLLLINES, SWP_NOACTIVATE, SWP_NOMOVE, SWP_NOSIZE,
     SWP_NOZORDER, SetCursor, SetWindowPos, SystemParametersInfoW, TranslateMessage, WHEEL_DELTA,
@@ -151,6 +152,7 @@ pub(crate) enum ProcResult {
 pub struct EventLoop {
     runner: Rc<EventLoopRunner>,
     msg_hook: Option<Box<dyn FnMut(*const c_void) -> bool + 'static>>,
+    redraw_batch: RedrawBatch,
     // It is a timer used on timed waits.
     // It is created lazily in case if we have `ControlFlow::WaitUntil`.
     // Keep it as a field to avoid recreating it on every `ControlFlow::WaitUntil`.
@@ -244,6 +246,7 @@ impl EventLoop {
         Ok(EventLoop {
             runner: runner_shared,
             msg_hook: attributes.msg_hook.take(),
+            redraw_batch: RedrawBatch::default(),
             high_resolution_timer: None,
         })
     }
@@ -344,11 +347,24 @@ impl EventLoop {
     fn dispatch_peeked_messages(&mut self) {
         // We generally want to continue dispatching all pending messages
         // but we also allow dispatching to be interrupted as a means to
-        // ensure the `pump_events` won't indefinitely block an external
-        // event loop if there are too many pending events. This interrupt
-        // flag will be set after dispatching `RedrawRequested` events.
-        self.runner.interrupt_msg_dispatch.set(false);
+        // ensure the `pump_events` won't indefinitely block an external event
+        // loop if there are too many pending events. After the first
+        // `RedrawRequested`, only paints are drained and each window emits at
+        // most one `RedrawRequested`. Redraws requested by those callbacks are
+        // deferred until the batch is complete.
+        self.runner.dispatched_redraws.borrow_mut().clear();
+        self.runner.begin_msg_dispatch();
+        self.redraw_batch.clear();
 
+        struct DispatchGuard(Rc<EventLoopRunner>);
+
+        impl Drop for DispatchGuard {
+            fn drop(&mut self) {
+                self.0.finish_msg_dispatch();
+            }
+        }
+
+        let _dispatch_guard = DispatchGuard(self.runner.clone());
         // # Safety
         // The Windows API has no documented requirement for bitwise
         // initializing a `MSG` struct (it can be uninitialized memory for the C
@@ -357,9 +373,44 @@ impl EventLoop {
         let mut msg: MSG = unsafe { mem::zeroed() };
 
         loop {
+            let mut suppressed_redraw = false;
             unsafe {
-                if PeekMessageW(&mut msg, ptr::null_mut(), 0, 0, PM_REMOVE) == false.into() {
+                let (filter_min, filter_max, peek_flags) = if self.redraw_batch.is_active() {
+                    (WM_PAINT, WM_PAINT, PM_REMOVE | PM_QS_PAINT)
+                } else {
+                    (0, 0, PM_REMOVE)
+                };
+                if PeekMessageW(&mut msg, ptr::null_mut(), filter_min, filter_max, peek_flags)
+                    == false.into()
+                {
                     break;
+                }
+
+                if self.redraw_batch.is_active() && msg.message == WM_PAINT {
+                    match self.redraw_batch.classify(msg.hwnd) {
+                        PaintDispatch::Dispatch => {},
+                        PaintDispatch::Suppress => {
+                            // Dispatch duplicate paints so Win32 can validate a non-null update
+                            // region and so `msg_hook` and non-winit window procedures still see
+                            // the native message. The winit window procedure suppresses only the
+                            // duplicate `RedrawRequested` event.
+                            self.runner.suppress_redraw(msg.hwnd);
+                            // Record this before invoking `msg_hook` so the guard will re-arm an
+                            // internal paint even if the hook panics. `PM_NOREMOVE` cannot safely
+                            // be used for look-ahead here: Win32 may still remove a `WM_PAINT`
+                            // whose update region is null, as is the case for `RDW_INTERNALPAINT`.
+                            self.runner.defer_redraw(msg.hwnd);
+                            suppressed_redraw = true;
+                        },
+                        PaintDispatch::Stop => {
+                            // A non-null-region `WM_PAINT` normally remains queued until it is
+                            // dispatched. Internal paints are the exception and may already have
+                            // been removed by `PeekMessageW`, so re-arm either kind before ending
+                            // this bounded batch.
+                            self.runner.defer_redraw(msg.hwnd);
+                            break;
+                        },
+                    }
                 }
 
                 let handled = if let Some(callback) = self.msg_hook.as_deref_mut() {
@@ -373,6 +424,10 @@ impl EventLoop {
                 }
             }
 
+            if suppressed_redraw {
+                self.runner.clear_suppressed_redraw();
+            }
+
             if let Err(payload) = self.runner.take_panic_error() {
                 self.runner.reset_runner();
                 panic::resume_unwind(payload);
@@ -382,14 +437,91 @@ impl EventLoop {
                 break;
             }
 
-            if self.runner.interrupt_msg_dispatch.get() {
-                break;
+            for window in self.runner.dispatched_redraws.borrow_mut().drain() {
+                self.redraw_batch.activate(window);
             }
         }
     }
 
     fn exit_code(&self) -> Option<i32> {
         self.runner.exit_code()
+    }
+}
+
+#[derive(Debug, Default)]
+struct RedrawBatch {
+    dispatched: HashSet<HWND>,
+    suppressed: HashSet<HWND>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaintDispatch {
+    Dispatch,
+    Suppress,
+    Stop,
+}
+
+impl RedrawBatch {
+    fn clear(&mut self) {
+        self.dispatched.clear();
+        self.suppressed.clear();
+    }
+
+    fn is_active(&self) -> bool {
+        !self.dispatched.is_empty()
+    }
+
+    fn activate(&mut self, window: HWND) {
+        self.dispatched.insert(window);
+    }
+
+    fn classify(&mut self, window: HWND) -> PaintDispatch {
+        if self.dispatched.insert(window) {
+            PaintDispatch::Dispatch
+        } else if self.suppressed.insert(window) {
+            PaintDispatch::Suppress
+        } else {
+            // A caller using raw Win32 APIs could keep invalidating this window without going
+            // through `Window::request_redraw`'s batch deferral. Keep dispatch bounded.
+            PaintDispatch::Stop
+        }
+    }
+}
+
+#[cfg(test)]
+mod redraw_batch_tests {
+    use super::{HWND, PaintDispatch, RedrawBatch};
+
+    fn hwnd(value: usize) -> HWND {
+        value as HWND
+    }
+
+    #[test]
+    fn dispatches_each_window_once_per_batch() {
+        let mut batch = RedrawBatch::default();
+        batch.activate(hwnd(1));
+
+        assert_eq!(batch.classify(hwnd(2)), PaintDispatch::Dispatch);
+        assert_eq!(batch.classify(hwnd(3)), PaintDispatch::Dispatch);
+    }
+
+    #[test]
+    fn suppresses_a_repeated_window_then_bounds_the_batch() {
+        let mut batch = RedrawBatch::default();
+        batch.activate(hwnd(1));
+
+        assert_eq!(batch.classify(hwnd(1)), PaintDispatch::Suppress);
+        assert_eq!(batch.classify(hwnd(1)), PaintDispatch::Stop);
+    }
+
+    #[test]
+    fn a_suppressed_repeat_does_not_hide_other_windows() {
+        let mut batch = RedrawBatch::default();
+        batch.activate(hwnd(1));
+
+        assert_eq!(batch.classify(hwnd(1)), PaintDispatch::Suppress);
+        assert_eq!(batch.classify(hwnd(2)), PaintDispatch::Dispatch);
+        assert_eq!(batch.classify(hwnd(3)), PaintDispatch::Dispatch);
     }
 }
 
@@ -1362,15 +1494,36 @@ unsafe fn public_window_callback_inner(
             // the drag; the next real paint happens once `DoDragDrop` returns.
             result = ProcResult::Value(unsafe { DefWindowProcW(window, msg, wparam, lparam) });
         },
+
+        WM_PAINT
+            if userdata.event_loop_runner.is_redraw_suppressed(window)
+                || (userdata.event_loop_runner.is_dispatching_messages()
+                    && userdata.window_state_lock().redraw_deferred) =>
+        {
+            // This window already emitted `RedrawRequested` in the current batch. Dispatching the
+            // native message is still necessary to validate a non-null update region. This check
+            // also covers paints delivered synchronously, which bypass the `PeekMessageW` batch
+            // classifier.
+            result = ProcResult::Value(unsafe { DefWindowProcW(window, msg, wparam, lparam) });
+        },
         WM_PAINT => {
-            userdata.window_state_lock().redraw_requested =
-                userdata.event_loop_runner.should_buffer();
+            let should_buffer = userdata.event_loop_runner.should_buffer();
+            if userdata.event_loop_runner.is_dispatching_messages() {
+                userdata.event_loop_runner.begin_batched_redraw(
+                    window,
+                    &userdata.window_state,
+                    should_buffer,
+                );
+            } else {
+                userdata.window_state_lock().redraw_requested = should_buffer;
+            }
 
             // We'll buffer only in response to `UpdateWindow`, if win32 decides to redraw the
             // window outside the normal flow of the event loop. This way mark event as handled
             // and request a normal redraw with `RedrawWindow`.
-            if !userdata.event_loop_runner.should_buffer() {
+            if !should_buffer {
                 userdata.send_window_event(window, WindowEvent::RedrawRequested);
+                userdata.event_loop_runner.dispatched_redraws.borrow_mut().insert(window);
             }
 
             // NOTE: calling `RedrawWindow` during `WM_PAINT` does nothing, since to mark
@@ -1378,7 +1531,9 @@ unsafe fn public_window_callback_inner(
             // user asked for redraw during `RedrawRequested` event handling and request it again
             // after marking `WM_PAINT` as handled.
             result = ProcResult::Value(unsafe { DefWindowProcW(window, msg, wparam, lparam) });
-            if std::mem::take(&mut userdata.window_state_lock().redraw_requested) {
+            if !userdata.event_loop_runner.is_dispatching_messages()
+                && mem::take(&mut userdata.window_state_lock().redraw_requested)
+            {
                 unsafe { RedrawWindow(window, ptr::null(), ptr::null_mut(), RDW_INTERNALPAINT) };
             }
         },

--- a/winit-win32/src/event_loop/runner.rs
+++ b/winit-win32/src/event_loop/runner.rs
@@ -56,9 +56,9 @@ pub(crate) struct EventLoopRunner {
     // The event loop's win32 handles
     pub(super) thread_msg_target: HWND,
 
-    // Setting this will ensure pump_events will return to the external
-    // loop asap. E.g. set after each RedrawRequested to ensure pump_events
-    // can't stall an external loop beyond a frame
+    // Setting this ends the current message dispatch after returning from a
+    // `RedrawRequested`, so `pump_app_events` can return control to its external loop.
+    // It remains set until the next dispatch begins.
     pub(super) interrupt_msg_dispatch: Cell<bool>,
 
     control_flow: Cell<ControlFlow>,

--- a/winit-win32/src/event_loop/runner.rs
+++ b/winit-win32/src/event_loop/runner.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 use std::cell::{Cell, Ref, RefCell};
-use std::collections::VecDeque;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -8,6 +8,7 @@ use std::{fmt, mem, panic};
 
 use dpi::PhysicalSize;
 use windows_sys::Win32::Foundation::{DRAGDROP_S_CANCEL, DRAGDROP_S_DROP, HWND};
+use windows_sys::Win32::Graphics::Gdi::{RDW_INTERNALPAINT, RedrawWindow};
 use windows_sys::Win32::System::Ole::{
     DROPEFFECT_COPY, DROPEFFECT_LINK, DROPEFFECT_MOVE, DROPEFFECT_NONE, DoDragDrop,
 };
@@ -21,6 +22,7 @@ use super::{ActiveEventLoop, ControlFlow, EventLoopThreadExecutor};
 use crate::dnd::{DataObject, DropEffect, DropSource, SourceDataObject, drop_effect_to_dnd_action};
 use crate::event_loop::{GWL_USERDATA, WindowData};
 use crate::util::get_window_long;
+use crate::window_state::WindowState;
 
 type EventHandler = Cell<Option<&'static mut (dyn ApplicationHandler + 'static)>>;
 
@@ -56,10 +58,20 @@ pub(crate) struct EventLoopRunner {
     // The event loop's win32 handles
     pub(super) thread_msg_target: HWND,
 
-    // Setting this will ensure pump_events will return to the external
-    // loop asap. E.g. set after each RedrawRequested to ensure pump_events
-    // can't stall an external loop beyond a frame
-    pub(super) interrupt_msg_dispatch: Cell<bool>,
+    /// Windows that emitted `RedrawRequested` during the current native-message dispatch.
+    pub(super) dispatched_redraws: RefCell<HashSet<HWND>>,
+
+    /// Whether `EventLoop::dispatch_peeked_messages` is on the stack.
+    dispatching_messages: Cell<bool>,
+
+    /// Native paints that must be re-armed when the current dispatch batch ends.
+    deferred_redraws: RefCell<HashSet<HWND>>,
+
+    /// Winit windows serviced during the current message-dispatch batch.
+    batched_redraws: RefCell<HashMap<HWND, Arc<Mutex<WindowState>>>>,
+
+    /// The duplicate paint currently being dispatched only to validate its update region.
+    suppressed_redraw: Cell<Option<HWND>>,
 
     control_flow: Cell<ControlFlow>,
     exit: Cell<Option<i32>>,
@@ -133,7 +145,11 @@ impl EventLoopRunner {
         Self {
             thread_id,
             thread_msg_target,
-            interrupt_msg_dispatch: Cell::new(false),
+            dispatched_redraws: RefCell::new(HashSet::new()),
+            dispatching_messages: Cell::new(false),
+            deferred_redraws: RefCell::new(HashSet::new()),
+            batched_redraws: RefCell::new(HashMap::new()),
+            suppressed_redraw: Cell::new(None),
             runner_state: Cell::new(RunnerState::Uninitialized),
             control_flow: Cell::new(ControlFlow::default()),
             exit: Cell::new(None),
@@ -294,10 +310,18 @@ impl EventLoopRunner {
     }
 
     pub(crate) fn reset_runner(&self) {
+        // This is normally already complete, but a panic can reset the runner while a message
+        // dispatch is still unwinding. Preserve redraws requested by callbacks in that case.
+        self.finish_msg_dispatch();
+
         let Self {
             thread_id: _,
             thread_msg_target: _,
-            interrupt_msg_dispatch,
+            dispatched_redraws: _,
+            dispatching_messages: _,
+            deferred_redraws: _,
+            batched_redraws: _,
+            suppressed_redraw: _,
             runner_state,
             panic_error,
             control_flow: _,
@@ -310,7 +334,6 @@ impl EventLoopRunner {
             pending_drag,
             pending_source_drag_cleanup,
         } = self;
-        interrupt_msg_dispatch.set(false);
         runner_state.set(RunnerState::Uninitialized);
         panic_error.set(None);
         exit.set(None);
@@ -324,6 +347,71 @@ impl EventLoopRunner {
 
 /// State retrieval functions.
 impl EventLoopRunner {
+    pub(super) fn begin_msg_dispatch(&self) {
+        let was_dispatching = self.dispatching_messages.replace(true);
+        debug_assert!(!was_dispatching);
+    }
+
+    pub(super) fn finish_msg_dispatch(&self) {
+        self.dispatching_messages.set(false);
+        self.dispatched_redraws.borrow_mut().clear();
+        self.suppressed_redraw.set(None);
+        let mut deferred_redraws = self.deferred_redraws.borrow_mut();
+        {
+            let mut batched_redraws = self.batched_redraws.borrow_mut();
+            for (window, state) in batched_redraws.drain() {
+                let mut state = state.lock().unwrap();
+                state.redraw_deferred = false;
+                if mem::take(&mut state.redraw_requested) {
+                    deferred_redraws.insert(window);
+                }
+            }
+        }
+        // With only `RDW_INTERNALPAINT`, `RedrawWindow` posts a paint instead of dispatching it
+        // synchronously, so retaining this borrow while draining is safe and preserves the set's
+        // allocation for the next frame.
+        for window in deferred_redraws.drain() {
+            unsafe {
+                RedrawWindow(window, std::ptr::null(), std::ptr::null_mut(), RDW_INTERNALPAINT);
+            }
+        }
+    }
+
+    pub(super) fn is_dispatching_messages(&self) -> bool {
+        self.dispatching_messages.get()
+    }
+
+    pub(super) fn defer_redraw(&self, window: HWND) {
+        self.deferred_redraws.borrow_mut().insert(window);
+    }
+
+    pub(super) fn begin_batched_redraw(
+        &self,
+        window: HWND,
+        state: &Arc<Mutex<WindowState>>,
+        redraw_requested: bool,
+    ) {
+        {
+            let mut state = state.lock().unwrap();
+            state.redraw_requested = redraw_requested;
+            state.redraw_deferred = true;
+        }
+        self.batched_redraws.borrow_mut().insert(window, Arc::clone(state));
+    }
+
+    pub(super) fn suppress_redraw(&self, window: HWND) {
+        let previous = self.suppressed_redraw.replace(Some(window));
+        debug_assert!(previous.is_none());
+    }
+
+    pub(super) fn clear_suppressed_redraw(&self) {
+        self.suppressed_redraw.set(None);
+    }
+
+    pub(super) fn is_redraw_suppressed(&self, window: HWND) -> bool {
+        self.suppressed_redraw.get() == Some(window)
+    }
+
     #[allow(unused)]
     pub fn thread_msg_target(&self) -> HWND {
         self.thread_msg_target
@@ -412,10 +500,6 @@ impl EventLoopRunner {
     pub(crate) fn send_event(self: &Rc<Self>, event: Event) {
         if let Event::Window { event: WindowEvent::RedrawRequested, .. } = event {
             self.call_event_handler(|app, event_loop| event.dispatch_event(app, event_loop));
-            // As a rule, to ensure that `pump_events` can't block an external event loop
-            // for too long, we always guarantee that `pump_events` will return control to
-            // the external loop asap after a `RedrawRequested` event is dispatched.
-            self.interrupt_msg_dispatch.set(true);
         } else if self.should_buffer() {
             // If the runner is already borrowed, we're in the middle of an event loop invocation.
             // Add the event to a buffer to be processed later.
@@ -622,5 +706,34 @@ impl Event {
             },
             Self::WakeUp => app.proxy_wake_up(event_loop),
         }
+    }
+}
+
+#[cfg(test)]
+mod redraw_dispatch_state_tests {
+    use windows_sys::Win32::Foundation::HWND;
+
+    use super::EventLoopRunner;
+
+    fn hwnd(value: usize) -> HWND {
+        value as HWND
+    }
+
+    #[test]
+    fn state_changes_are_not_debug_assert_side_effects() {
+        let runner = EventLoopRunner::new(0, std::ptr::null_mut());
+        let window = hwnd(1);
+
+        runner.begin_msg_dispatch();
+        assert!(runner.is_dispatching_messages());
+
+        runner.suppress_redraw(window);
+        assert!(runner.is_redraw_suppressed(window));
+
+        runner.clear_suppressed_redraw();
+        assert!(!runner.is_redraw_suppressed(window));
+
+        runner.finish_msg_dispatch();
+        assert!(!runner.is_dispatching_messages());
     }
 }

--- a/winit-win32/src/window.rs
+++ b/winit-win32/src/window.rs
@@ -524,8 +524,18 @@ impl CoreWindow for Window {
     }
 
     fn request_redraw(&self) {
-        // NOTE: mark that we requested a redraw to handle requests during `WM_PAINT` handling.
-        self.window_state.lock().unwrap().redraw_requested = true;
+        // Mark requests made during `WM_PAINT` so they can be re-armed after it is validated.
+        // If this window was already serviced by the current message-dispatch batch, defer the
+        // native request as well so it cannot jump ahead of the other pending windows.
+        let redraw_deferred = {
+            let mut state = self.window_state.lock().unwrap();
+            state.redraw_requested = true;
+            state.redraw_deferred
+        };
+        if redraw_deferred {
+            return;
+        }
+
         unsafe {
             RedrawWindow(self.hwnd(), ptr::null(), ptr::null_mut(), RDW_INTERNALPAINT);
         }

--- a/winit-win32/src/window_state.rs
+++ b/winit-win32/src/window_state.rs
@@ -76,6 +76,9 @@ pub(crate) struct WindowState {
     // Flag whether redraw was requested.
     pub redraw_requested: bool,
 
+    // Whether redraw requests must be re-armed after the current message-dispatch batch.
+    pub redraw_deferred: bool,
+
     pub dragging: bool,
 
     pub skip_taskbar: bool,
@@ -218,7 +221,7 @@ impl WindowState {
             is_active: false,
             is_focused: false,
             redraw_requested: false,
-
+            redraw_deferred: false,
             dragging: false,
 
             skip_taskbar: false,

--- a/winit-win32/tests/redraw_fairness.rs
+++ b/winit-win32/tests/redraw_fairness.rs
@@ -1,0 +1,397 @@
+#![cfg(target_os = "windows")]
+
+//! Interactive Win32 regression test. Run with:
+//! `cargo test -p winit-win32 --test redraw_fairness -- --ignored`.
+
+use std::time::{Duration, Instant};
+
+use winit::application::ApplicationHandler;
+use winit::dpi::{PhysicalPosition, PhysicalSize};
+use winit::event::{StartCause, WindowEvent};
+use winit::event_loop::pump_events::{EventLoopExtPumpEvents, PumpStatus};
+use winit::event_loop::run_on_demand::EventLoopExtRunOnDemand;
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::platform::windows::EventLoopBuilderExtWindows;
+use winit::window::{Window, WindowAttributes, WindowId};
+
+const WINDOW_COUNT: usize = 5;
+const REDRAWS_PER_WINDOW: u64 = 20;
+const CONTINUOUS_REDRAWS_PER_WINDOW: u64 = 20;
+const MAX_REDRAWS_PER_PHASE: u64 = REDRAWS_PER_WINDOW * WINDOW_COUNT as u64 * 4;
+const MAX_REDRAW_SKEW: u64 = WINDOW_COUNT as u64;
+const MAX_TRANSIENT_REDRAW_LAG: u64 = REDRAWS_PER_WINDOW * 5;
+const MAX_CONTINUOUS_REDRAWS: u64 = 20_000;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    Warmup,
+    AboutToWait,
+    Continuous,
+    Finished,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ContinuousRequests {
+    CurrentWindow,
+    AllWindows,
+}
+
+struct RunAppRegression {
+    windows: Vec<Box<dyn Window>>,
+    continuous_requests: ContinuousRequests,
+    phase: Phase,
+    warmup_started: Instant,
+    warmup_redraws: Vec<bool>,
+    about_to_wait_started: Instant,
+    about_to_wait_redraws: Vec<u64>,
+    redraws: Vec<u64>,
+    continuous_new_events: usize,
+    continuous_about_to_wait: usize,
+    continuous_deadline: Instant,
+    continuous_deadline_reached: bool,
+    continuous_started: Instant,
+    failure: Option<String>,
+}
+
+impl RunAppRegression {
+    fn new(continuous_requests: ContinuousRequests) -> Self {
+        let now = Instant::now();
+        Self {
+            windows: Vec::new(),
+            continuous_requests,
+            phase: Phase::Warmup,
+            warmup_started: now,
+            warmup_redraws: vec![false; WINDOW_COUNT],
+            about_to_wait_started: now,
+            about_to_wait_redraws: Vec::new(),
+            redraws: vec![0; WINDOW_COUNT],
+            continuous_new_events: 0,
+            continuous_about_to_wait: 0,
+            continuous_deadline: now,
+            continuous_deadline_reached: false,
+            continuous_started: now,
+            failure: None,
+        }
+    }
+
+    fn request_all(&self) {
+        for window in &self.windows {
+            window.request_redraw();
+        }
+    }
+
+    fn fail(&mut self, event_loop: &dyn ActiveEventLoop, message: impl Into<String>) {
+        self.failure = Some(message.into());
+        self.phase = Phase::Finished;
+        event_loop.exit();
+    }
+
+    fn begin_continuous(&mut self) {
+        self.phase = Phase::Continuous;
+        self.redraws.fill(0);
+        self.continuous_new_events = 0;
+        self.continuous_about_to_wait = 0;
+        self.continuous_deadline_reached = false;
+        self.continuous_started = Instant::now();
+        self.continuous_deadline = self.continuous_started + Duration::from_millis(20);
+        self.request_all();
+    }
+
+    fn continuous_is_complete(&self) -> bool {
+        self.redraws.iter().all(|&count| count >= CONTINUOUS_REDRAWS_PER_WINDOW)
+            && self.continuous_new_events > 0
+            && self.continuous_about_to_wait > 0
+            && self.continuous_deadline_reached
+    }
+}
+
+impl ApplicationHandler for RunAppRegression {
+    fn new_events(&mut self, _event_loop: &dyn ActiveEventLoop, cause: StartCause) {
+        if self.phase == Phase::Continuous {
+            self.continuous_new_events += 1;
+            if matches!(cause, StartCause::ResumeTimeReached { .. }) {
+                self.continuous_deadline_reached = true;
+            }
+        }
+    }
+
+    fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
+        if !self.windows.is_empty() {
+            return;
+        }
+        for index in 0..WINDOW_COUNT {
+            // Deliberately overlap the windows to exercise Win32's non-FIFO paint selection.
+            let attributes = WindowAttributes::default()
+                .with_title(format!("winit redraw fairness regression {index}"))
+                .with_visible(true)
+                .with_surface_size(PhysicalSize::new(96, 72))
+                .with_position(PhysicalPosition::new(32 + index as i32 * 24, 32));
+            self.windows.push(event_loop.create_window(attributes).unwrap());
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &dyn ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        if event != WindowEvent::RedrawRequested {
+            return;
+        }
+        let index = self.windows.iter().position(|window| window.id() == window_id).unwrap();
+
+        match self.phase {
+            Phase::Warmup => self.warmup_redraws[index] = true,
+            Phase::AboutToWait => {
+                self.redraws[index] += 1;
+                if self.redraws.iter().sum::<u64>() > MAX_REDRAWS_PER_PHASE
+                    || self.about_to_wait_started.elapsed() > Duration::from_secs(5)
+                {
+                    self.fail(
+                        event_loop,
+                        format!("AboutToWait redraw starvation: {:?}", self.redraws),
+                    );
+                }
+            },
+            Phase::Continuous => {
+                self.redraws[index] += 1;
+                let total: u64 = self.redraws.iter().sum();
+                let min = *self.redraws.iter().min().unwrap();
+                let max = *self.redraws.iter().max().unwrap();
+                if max - min > MAX_TRANSIENT_REDRAW_LAG
+                    || total > MAX_CONTINUOUS_REDRAWS
+                    || self.continuous_started.elapsed() > Duration::from_secs(5)
+                {
+                    self.fail(
+                        event_loop,
+                        format!(
+                            "continuous redraw did not remain fair: redraws={:?}, new_events={}, \
+                             about_to_wait={}, deadline_reached={}",
+                            self.redraws,
+                            self.continuous_new_events,
+                            self.continuous_about_to_wait,
+                            self.continuous_deadline_reached
+                        ),
+                    );
+                    return;
+                }
+
+                if self.continuous_is_complete() {
+                    self.phase = Phase::Finished;
+                    event_loop.exit();
+                    return;
+                }
+
+                match self.continuous_requests {
+                    ContinuousRequests::CurrentWindow => {
+                        self.windows[index].request_redraw();
+                    },
+                    ContinuousRequests::AllWindows => self.request_all(),
+                }
+            },
+            Phase::Finished => {},
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
+        match self.phase {
+            Phase::Warmup => {
+                if self.warmup_started.elapsed() > Duration::from_secs(5) {
+                    self.fail(
+                        event_loop,
+                        format!("initial paints timed out: {:?}", self.warmup_redraws),
+                    );
+                    return;
+                }
+                if self.warmup_redraws.iter().all(|&redrawn| redrawn) {
+                    self.phase = Phase::AboutToWait;
+                    self.redraws.fill(0);
+                    self.about_to_wait_started = Instant::now();
+                }
+                self.request_all();
+                event_loop.set_control_flow(ControlFlow::Poll);
+            },
+            Phase::AboutToWait => {
+                if self.redraws.iter().sum::<u64>() > MAX_REDRAWS_PER_PHASE
+                    || self.about_to_wait_started.elapsed() > Duration::from_secs(5)
+                {
+                    self.fail(
+                        event_loop,
+                        format!("AboutToWait redraw starvation: {:?}", self.redraws),
+                    );
+                    return;
+                }
+                if self.redraws.iter().all(|&count| count >= REDRAWS_PER_WINDOW) {
+                    self.about_to_wait_redraws.clone_from(&self.redraws);
+                    self.begin_continuous();
+                    event_loop.set_control_flow(ControlFlow::WaitUntil(self.continuous_deadline));
+                } else {
+                    self.request_all();
+                    event_loop.set_control_flow(ControlFlow::Poll);
+                }
+            },
+            Phase::Continuous => {
+                self.continuous_about_to_wait += 1;
+                if self.continuous_started.elapsed() > Duration::from_secs(5) {
+                    self.fail(
+                        event_loop,
+                        format!(
+                            "continuous redraw timed out: redraws={:?}, new_events={}, \
+                             about_to_wait={}, deadline_reached={}",
+                            self.redraws,
+                            self.continuous_new_events,
+                            self.continuous_about_to_wait,
+                            self.continuous_deadline_reached
+                        ),
+                    );
+                    return;
+                }
+                event_loop.set_control_flow(ControlFlow::WaitUntil(self.continuous_deadline));
+            },
+            Phase::Finished => {},
+        }
+    }
+}
+
+struct PumpRegression {
+    windows: Vec<Box<dyn Window>>,
+    measuring: bool,
+    warmup_redraws: Vec<bool>,
+    redraws: Vec<u64>,
+    new_events: usize,
+    about_to_wait: usize,
+}
+
+impl ApplicationHandler for PumpRegression {
+    fn new_events(&mut self, _event_loop: &dyn ActiveEventLoop, _cause: StartCause) {
+        self.new_events += 1;
+    }
+
+    fn can_create_surfaces(&mut self, event_loop: &dyn ActiveEventLoop) {
+        if !self.windows.is_empty() {
+            return;
+        }
+        for index in 0..WINDOW_COUNT {
+            let attributes = WindowAttributes::default()
+                .with_title(format!("winit pump redraw fairness regression {index}"))
+                .with_visible(true)
+                .with_surface_size(PhysicalSize::new(96, 72))
+                .with_position(PhysicalPosition::new(32 + index as i32 * 24, 128));
+            self.windows.push(event_loop.create_window(attributes).unwrap());
+        }
+        self.redraws = vec![0; self.windows.len()];
+        self.warmup_redraws = vec![false; self.windows.len()];
+    }
+
+    fn window_event(
+        &mut self,
+        _event_loop: &dyn ActiveEventLoop,
+        window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        if event == WindowEvent::RedrawRequested {
+            let index = self.windows.iter().position(|window| window.id() == window_id).unwrap();
+            if self.measuring {
+                self.redraws[index] += 1;
+                self.windows[index].request_redraw();
+            } else {
+                self.warmup_redraws[index] = true;
+            }
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &dyn ActiveEventLoop) {
+        self.about_to_wait += 1;
+        if !self.measuring && self.warmup_redraws.iter().all(|&redrawn| redrawn) {
+            self.measuring = true;
+            self.redraws.fill(0);
+        }
+        for window in &self.windows {
+            window.request_redraw();
+        }
+        event_loop.set_control_flow(ControlFlow::Poll);
+    }
+}
+
+#[test]
+#[ignore = "requires an interactive Windows desktop"]
+fn redraw_batches_are_fair_and_keep_event_loop_cycles() {
+    let mut builder = EventLoop::builder();
+    builder.with_any_thread(true);
+    let mut event_loop = builder.build().unwrap();
+
+    for continuous_requests in [ContinuousRequests::CurrentWindow, ContinuousRequests::AllWindows] {
+        let mut run_app = RunAppRegression::new(continuous_requests);
+        event_loop.run_app_on_demand(&mut run_app).unwrap();
+        assert_eq!(run_app.phase, Phase::Finished);
+        assert!(
+            run_app.failure.is_none(),
+            "{continuous_requests:?}: {}",
+            run_app.failure.unwrap_or_default()
+        );
+        assert!(run_app.continuous_new_events > 0);
+        assert!(run_app.continuous_about_to_wait > 0);
+        assert!(run_app.continuous_deadline_reached);
+        let min = *run_app.about_to_wait_redraws.iter().min().unwrap();
+        let max = *run_app.about_to_wait_redraws.iter().max().unwrap();
+        // Win32 may coalesce explicit requests with system paints, so callback counts need not be
+        // exactly equal. Reaching the target within the strict total budget rules out starvation.
+        assert!(min >= REDRAWS_PER_WINDOW);
+        assert!(
+            max - min <= MAX_REDRAW_SKEW,
+            "AboutToWait redraw counts diverged: {:?}",
+            run_app.about_to_wait_redraws
+        );
+        let min = *run_app.redraws.iter().min().unwrap();
+        let max = *run_app.redraws.iter().max().unwrap();
+        assert!(min >= CONTINUOUS_REDRAWS_PER_WINDOW);
+        assert!(
+            max - min <= MAX_REDRAW_SKEW,
+            "{continuous_requests:?} redraw counts diverged: {:?}",
+            run_app.redraws
+        );
+        drop(run_app);
+    }
+
+    let mut pump = PumpRegression {
+        windows: Vec::new(),
+        measuring: false,
+        warmup_redraws: Vec::new(),
+        redraws: Vec::new(),
+        new_events: 0,
+        about_to_wait: 0,
+    };
+    let mut complete_pump_frames = 0;
+    for _ in 0..100 {
+        let was_measuring = pump.measuring;
+        let before = pump.redraws.clone();
+        let new_events_before = pump.new_events;
+        let about_to_wait_before = pump.about_to_wait;
+        assert_eq!(
+            event_loop.pump_app_events(Some(Duration::ZERO), &mut pump),
+            PumpStatus::Continue
+        );
+        if was_measuring && pump.measuring {
+            let deltas: Vec<_> =
+                before.iter().zip(&pump.redraws).map(|(before, after)| after - before).collect();
+            assert!(deltas.iter().all(|&delta| delta <= 1), "pump dispatched an HWND twice");
+            assert!(pump.new_events > new_events_before, "pump emitted no NewEvents");
+            assert!(pump.about_to_wait > about_to_wait_before, "pump emitted no AboutToWait");
+            complete_pump_frames += 1;
+        }
+        if pump.measuring
+            && pump.redraws.iter().all(|&count| count >= CONTINUOUS_REDRAWS_PER_WINDOW)
+        {
+            break;
+        }
+    }
+
+    let min = *pump.redraws.iter().min().unwrap();
+    let max = *pump.redraws.iter().max().unwrap();
+    assert!(min >= CONTINUOUS_REDRAWS_PER_WINDOW);
+    assert!(max - min <= MAX_REDRAW_SKEW, "pump redraw counts diverged: {:?}", pump.redraws);
+    assert!(pump.new_events > 0);
+    assert!(pump.about_to_wait > 0);
+    assert!(complete_pump_frames > 0);
+}

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -111,6 +111,8 @@ changelog entry.
 
 ### Fixed
 
+- On Windows, fix `RedrawRequested` starvation when multiple windows request redraws during the
+  same event-loop cycle, including continuous redraws requested from `RedrawRequested` handlers.
 - On Windows, fix a freeze that occurs when the keyboard layout is switched by
   tools such as Punto Switcher. The `WM_INPUTLANGCHANGE` message is now handled
   to refresh the cached keyboard layout, while still deferring to

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -98,6 +98,8 @@ changelog entry.
 
 ### Fixed
 
+- On Windows, fix `RedrawRequested` starvation when multiple windows request
+  redraws during the same event-loop cycle.
 - On Windows, fix a freeze that occurs when the keyboard layout is switched by
   tools such as Punto Switcher. The `WM_INPUTLANGCHANGE` message is now handled
   to refresh the cached keyboard layout, while still deferring to


### PR DESCRIPTION
* [x] Tested on all platforms changed (Windows)
* [x] Added an entry to the `changelog` module
* [x] Updated the internal dispatch documentation; there is no user-facing API change
* [ ] Created or updated an example program
  (not needed for this backend-internal fix; regression coverage was added instead)

Fixes #3648.

## Problem

Win32 does not guarantee FIFO delivery of `WM_PAINT` between windows.

The previous implementation stopped native-message dispatch after one `RedrawRequested` and preserved that interruption across event-loop iterations.

This fixed requests made from `AboutToWait`, but caused continuous-redraw applications to skip the normal wait phase.

A window requesting another redraw from its `RedrawRequested` handler could also be selected repeatedly before the other invalid windows.

Consequences included:

* starvation of other windows;
* missing `NewEvents` and `AboutToWait` callbacks;
* `ControlFlow::WaitUntil` deadlines not being observed;
* `pump_app_events` returning after one window rather than one redraw batch.

## Approach

Treat pending Win32 paints as a redraw batch.

After the first `RedrawRequested` in a native-message dispatch:

* only `WM_PAINT` messages are drained;
* each `HWND` emits at most one public `RedrawRequested`;
* redraws requested by a serviced window are deferred until the batch completes;
* duplicate native paints are processed without emitting another public event, allowing Win32 to validate their update region;
* a further repeat bounds dispatch for callers invalidating windows through raw Win32 APIs.

The event loop continues to execute its normal:

`NewEvents -> AboutToWait -> wait`

phase between batches.

The old persistent `interrupt_msg_dispatch` state is no longer needed.

The implementation intentionally does not use `PM_NOREMOVE` as a pure look-ahead.

`PeekMessage` may still remove `WM_PAINT` messages whose update region is null, and `Window::request_redraw` uses `RDW_INTERNALPAINT`, which posts a paint even when no region is invalid.

## Validation

Added unit tests for:

* dispatching distinct HWNDs once per batch;
* suppressing and bounding repeated paints;
* continuing to other windows after a duplicate;
* ensuring dispatch-state mutations also occur in release builds.

Added an interactive Windows regression test covering:

* five deliberately overlapping windows;
* redraw requests from `AboutToWait`;
* continuous redraw requested from each window's own handler;
* the stronger case where each handler requests all windows;
* `NewEvents`, `AboutToWait`, and `WaitUntil` cadence;
* `run_app_on_demand` and `pump_app_events`;
* at most one redraw per HWND per pump call.

### Representative release results

```text
current window:
  redraws=[20, 20, 20, 20, 20]

all windows requested by every handler:
  redraws=[54, 54, 54, 54, 55]
  NewEvents=55
  AboutToWait=54

pump_app_events:
  redraws=[20, 20, 20, 20, 20]
```

Validation was repeated in debug and release, including Rust 1.86 and 32-bit compilation