### PR TITLE
fix(windows): release cursor clip on focus loss

### DIFF
--- a/winit-win32/src/event_loop.rs
+++ b/winit-win32/src/event_loop.rs
@@ -1065,6 +1065,9 @@ unsafe fn gain_active_focus(window: HWND, userdata: &WindowData) {
 
     update_modifiers(window, userdata);
 
+    // Reapply the cursor clip released on focus loss.
+    userdata.window_state_lock().mouse.set_cursor_flags(window, |_| ()).ok();
+
     userdata.send_window_event(window, Focused(true));
 }
 
@@ -1073,6 +1076,9 @@ unsafe fn lose_active_focus(window: HWND, userdata: &WindowData) {
 
     userdata.window_state_lock().modifiers_state = ModifiersState::empty();
     userdata.send_window_event(window, ModifiersChanged(ModifiersState::empty().into()));
+
+    // Release the cursor clip, which Windows keeps active even after focus loss.
+    userdata.window_state_lock().mouse.set_cursor_flags(window, |_| ()).ok();
 
     userdata.send_window_event(window, Focused(false));
 }

--- a/winit-win32/src/window_state.rs
+++ b/winit-win32/src/window_state.rs
@@ -552,6 +552,19 @@ impl CursorFlags {
             if active_cursor_clip != cursor_clip.map(rect_to_tuple) {
                 util::set_cursor_clip(cursor_clip)?;
             }
+        } else {
+            // Windows doesn't reset the global `ClipCursor` state on focus loss, so release the
+            // clip if it's the one this window applied (it lies within the client area).
+            let rect_to_tuple = |rect: RECT| (rect.left, rect.top, rect.right, rect.bottom);
+            let active_cursor_clip = util::get_cursor_clip()?;
+            if rect_to_tuple(active_cursor_clip) != rect_to_tuple(util::get_desktop_rect())
+                && active_cursor_clip.left >= client_rect.left
+                && active_cursor_clip.top >= client_rect.top
+                && active_cursor_clip.right <= client_rect.right
+                && active_cursor_clip.bottom <= client_rect.bottom
+            {
+                util::set_cursor_clip(None)?;
+            }
         }
 
         let cursor_in_client = self.contains(CursorFlags::IN_WINDOW);

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -98,6 +98,7 @@ changelog entry.
 
 ### Fixed
 
+- On Windows, release the cursor clip when the window loses focus and reapply it on focus gain.
 - On Windows, fix a freeze that occurs when the keyboard layout is switched by
   tools such as Punto Switcher. The `WM_INPUTLANGCHANGE` message is now handled
   to refresh the cached keyboard layout, while still deferring to


### PR DESCRIPTION
## Problem

`ClipCursor` is global OS state that Windows does not reset when a window loses focus. A clip rect applied while the window was focused therefore stays active after focus loss, keeping the cursor trapped in the unfocused window. Applications cannot release it either: `Window::set_cursor_grab(CursorGrabMode::None)` has no effect while unfocused, because `refresh_os_cursor` skips all `ClipCursor` updates when the window is not focused.

Reported downstream in bevyengine/bevy#22750 (confine on focus gain, `None` on focus loss — the cursor stays trapped after pressing the Windows key).

## Fix

- `refresh_os_cursor`: when the window is unfocused, release the active clip if it lies within the window's client area — i.e. it is the clip this window applied (`Confined` = client rect, `Locked` = 1px rect inside it). A clip set by the now-active application elsewhere is left untouched, which is why the focused-only gate existed in the first place.
- `WM_KILLFOCUS` / `WM_SETFOCUS`: refresh cursor flags so the clip is released on focus loss and reapplied on focus gain even if the application never changes the grab mode, matching grab behavior on other platforms.

Note: during `WM_KILLFOCUS`, `GetActiveWindow()` may in some message orderings still return the window; in that case the release happens on the next cursor-flag refresh (e.g. the application's own `set_cursor_grab` call or a cursor move) instead of immediately.

Verified with the bevy reproduction from the linked issue on Windows 11: the cursor now frees on focus loss and re-confines on focus gain. A backport to `v0.30.x` is available at https://github.com/Saratii/winit/tree/fix/win32-release-cursor-clip-on-focus-loss-v0.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
