### PR TITLE
winit-x11: don't classify VM tablet pointers as pens

### DIFF
--- a/winit-x11/src/atoms.rs
+++ b/winit-x11/src/atoms.rs
@@ -135,8 +135,6 @@ atom_manager! {
     _XSETTINGS_SETTINGS,
 
     // Stylus Atoms
-    ABS_X: b"Abs X",
-    ABS_Y: b"Abs Y",
     ABS_PRESSURE: b"Abs Pressure",
     ABS_TILT_X: b"Abs Tilt X",
     ABS_TILT_Y: b"Abs Tilt Y"

--- a/winit-x11/src/event_loop.rs
+++ b/winit-x11/src/event_loop.rs
@@ -38,7 +38,7 @@ use x11rb::x11_utils::X11Error as LogicalError;
 use x11rb::xcb_ffi::ReplyOrIdError;
 
 use crate::atoms::{
-    _NET_WM_PING, _NET_WM_SYNC_REQUEST, ABS_PRESSURE, ABS_TILT_X, ABS_TILT_Y, ABS_X, ABS_Y, Atoms,
+    _NET_WM_PING, _NET_WM_SYNC_REQUEST, ABS_PRESSURE, ABS_TILT_X, ABS_TILT_Y, Atoms,
     WM_DELETE_WINDOW,
 };
 use crate::dnd::Dnd;

--- a/winit-x11/src/event_loop.rs
+++ b/winit-x11/src/event_loop.rs
@@ -1188,9 +1188,15 @@ impl Device {
                     let info = unsafe { &*(class_ptr as *const ffi::XIValuatorClassInfo) };
                     let atom = info.label as xproto::Atom;
 
-                    if atom == atoms[ABS_X]
-                        || atom == atoms[ABS_Y]
-                        || atom == atoms[ABS_PRESSURE]
+                    // Absolute X/Y axes alone do not identify a stylus:
+                    // emulated pointing devices in virtual machines (the
+                    // QEMU/VMware/VirtualBox USB tablets, and thus any
+                    // desktop accessed through SPICE or similar viewers)
+                    // expose Abs X/Y without pressure or tilt. Treating them
+                    // as pens makes the mouse-only event filters drop all
+                    // their motion and button input. Only pressure and tilt
+                    // axes indicate actual stylus hardware.
+                    if atom == atoms[ABS_PRESSURE]
                         || atom == atoms[ABS_TILT_X]
                         || atom == atoms[ABS_TILT_Y]
                     {

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -106,6 +106,10 @@ changelog entry.
 - On Windows, fix getting the window's DPI internally leaks `HDC` handles.
   Also only call `GetDC` when on < Windows 8.1 which improves its performance.
 - On Redox, handle `EINTR` when reading from `event_socket` instead of panicking.
+- On X11, fix all pointer input being dropped for absolute pointing devices
+  without pressure or tilt axes, such as the emulated tablets of
+  QEMU/VMware/VirtualBox virtual machines and SPICE/VDI viewers. These were
+  misclassified as pens, whose events the motion/button handlers discard.
 - On Wayland, switch from using the `ahash` hashing algorithm to `foldhash`.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.


### PR DESCRIPTION
Device::new marks any pointer whose valuator class carries Abs X/Y labels as DeviceType::Pen, and the XI_Motion/XI_ButtonPress/scroll handlers drop events from every non-mouse source device. Emulated pointing devices in virtual machines (the QEMU/VMware/VirtualBox USB tablets, and any desktop accessed through SPICE or similar VDI viewers) expose absolute X/Y axes without pressure or tilt, so all their motion and button input silently disappears: a winit 0.31 application inside a VM console has a dead mouse. winit 0.30, which had no device classification, handles these devices fine.

Classify a device as pen or eraser only when it has pressure or tilt axes, which identify actual stylus hardware; bare absolute X/Y is how every emulated tablet reports and behaves like a mouse.