### PR TITLE
orbital: Fix EventLoop::run_app_on_demand

### DIFF
--- a/winit-orbital/src/event_loop.rs
+++ b/winit-orbital/src/event_loop.rs
@@ -526,6 +526,7 @@ impl EventLoop {
         &mut self,
         mut app: A,
     ) -> Result<(), EventLoopError> {
+        self.window_target.exit.set(false);
         loop {
             match self.pump_app_events(None, &mut app) {
                 PumpStatus::Exit(0) => {

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -111,3 +111,4 @@ changelog entry.
 - On macOS, fix IME being locked on (regardless of requests to disable) after being enabled once.
 - On macOS, fix a panic and incorrect cursor position in Ime::Preedit when the preedit string contains special characters (ie. emojis) caused by incorrect UTF-16 to UTF-8 offset conversion.
 - On Wayland, fix a protocol error when setting a custom cursor on compositors with `wl_surface` version below 3.
+- On Redox, fix `run_app_on_demand` exiting immediately after a previous `run_app_on_demand` called `exit`.


### PR DESCRIPTION
Previously `event_loop.exit()` would persist and cause all future `run_app_on_demand()` calls to immediately exit.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality