### PR TITLE
orbital: Merge TextInputEvent and KeyEvent together

### DIFF
--- a/winit-orbital/src/event_loop.rs
+++ b/winit-orbital/src/event_loop.rs
@@ -17,7 +17,7 @@ use smol_str::SmolStr;
 use winit_core::application::ApplicationHandler;
 use winit_core::cursor::{CustomCursor, CustomCursorSource};
 use winit_core::error::{EventLoopError, NotSupportedError, RequestError};
-use winit_core::event::{self, Ime, Modifiers, StartCause};
+use winit_core::event::{self, Modifiers, StartCause};
 use winit_core::event_loop::pump_events::PumpStatus;
 use winit_core::event_loop::{
     ActiveEventLoop as RootActiveEventLoop, ControlFlow, DeviceEvents, EventLoopProvider,
@@ -204,6 +204,7 @@ struct EventState {
     mouse: MouseButtonState,
     mouse_pos: (i32, i32),
     resize_opt: Option<(u32, u32)>,
+    text_input_event: Option<TextInputEvent>,
 }
 
 impl EventState {
@@ -361,8 +362,13 @@ impl EventLoop {
         window_target: &ActiveEventLoop,
         app: &mut A,
     ) {
+        let text_input_event = event_state.text_input_event.take();
+        if text_input_event.is_some() && !matches!(event_option, EventOption::Key(_)) {
+            tracing::warn!("got TextInput event without following Key event");
+        }
+
         match event_option {
-            EventOption::Key(KeyEvent { character, scancode, pressed }) => {
+            EventOption::Key(KeyEvent { character: _, scancode, pressed }) => {
                 // Convert scancode
                 let (physical_key, named_key_opt) = convert_scancode(scancode);
 
@@ -377,6 +383,7 @@ impl EventLoop {
                 let mut text_with_all_modifiers = None;
 
                 // Set key and text based on character
+                let character = text_input_event.map_or('\0', |event| event.character);
                 if character != '\0' {
                     let mut tmp = [0u8; 4];
                     let character_str = character.encode_utf8(&mut tmp);
@@ -428,17 +435,8 @@ impl EventLoop {
                     );
                 }
             },
-            EventOption::TextInput(TextInputEvent { character }) => {
-                app.window_event(
-                    window_target,
-                    window_id,
-                    event::WindowEvent::Ime(Ime::Preedit("".into(), None)),
-                );
-                app.window_event(
-                    window_target,
-                    window_id,
-                    event::WindowEvent::Ime(Ime::Commit(character.into())),
-                );
+            EventOption::TextInput(event) => {
+                event_state.text_input_event = Some(event);
             },
             EventOption::Mouse(MouseEvent { x, y }) => {
                 event_state.mouse_pos = (x, y);

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -112,3 +112,4 @@ changelog entry.
 - On macOS, fix a panic and incorrect cursor position in Ime::Preedit when the preedit string contains special characters (ie. emojis) caused by incorrect UTF-16 to UTF-8 offset conversion.
 - On Wayland, fix a protocol error when setting a custom cursor on compositors with `wl_surface` version below 3.
 - On Redox, fix `run_app_on_demand` exiting immediately after a previous `run_app_on_demand` called `exit`.
+- On Redox, fill in logical key for keyboard events rather than emitting a separate fake IME event.


### PR DESCRIPTION
They were split at some point for whatever reason, yet should result in a single application level event. The current hack of emitting an IME event for TextInputEvent breaks with applications that don't handle IME and it would cause applications that both handle physical key events and IME events to get double key presses.

- [ ] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
