### PR TITLE
orbital: Handle window closes during app drop

### DIFF
--- a/winit-orbital/src/event_loop.rs
+++ b/winit-orbital/src/event_loop.rs
@@ -527,7 +527,7 @@ impl EventLoop {
         mut app: A,
     ) -> Result<(), EventLoopError> {
         self.window_target.exit.set(false);
-        loop {
+        let res = loop {
             match self.pump_app_events(None, &mut app) {
                 PumpStatus::Exit(0) => {
                     break Ok(());
@@ -539,7 +539,20 @@ impl EventLoop {
                     continue;
                 },
             }
+        };
+
+        drop(app);
+
+        // Handle window destroys that happened when dropping the app.
+        while let Some(destroy_id) = {
+            let mut destroys = self.window_target.destroys.lock().unwrap();
+            destroys.pop_front()
+        } {
+            self.windows
+                .retain(|(window, _event_state)| WindowId::from_raw(window.fd()) != destroy_id);
         }
+
+        res
     }
 
     fn single_iteration<A: ApplicationHandler>(&mut self, app: &mut A, cause: StartCause) {

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -112,3 +112,4 @@ changelog entry.
 - On macOS, fix a panic and incorrect cursor position in Ime::Preedit when the preedit string contains special characters (ie. emojis) caused by incorrect UTF-16 to UTF-8 offset conversion.
 - On Wayland, fix a protocol error when setting a custom cursor on compositors with `wl_surface` version below 3.
 - On Redox, fix `run_app_on_demand` exiting immediately after a previous `run_app_on_demand` called `exit`.
+- On Redox, handle window closes during `ApplicationHandler` drop.


### PR DESCRIPTION
Previously these window closes wouldn't be handled until the next time `run_app_on_demand` is called.

- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [x] Created or updated an example program if it would help users understand this functionality
