### PR TITLE
Fix clippy warning with Rust 1.98

### DIFF
--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -1329,18 +1329,16 @@ impl TabletToolTilt {
             }
         }
 
-        let altitude;
-
-        if self.x.abs() == 90 || self.y.abs() == 90 {
-            altitude = 0.;
+        let altitude = if self.x.abs() == 90 || self.y.abs() == 90 {
+            0.
         } else if self.x == 0 {
-            altitude = PI_0_5 - y.abs();
+            PI_0_5 - y.abs()
         } else if self.y == 0 {
-            altitude = PI_0_5 - x.abs();
+            PI_0_5 - x.abs()
         } else {
             // Non-boundary case: neither tiltX nor tiltY is equal to 0 or +-90
-            altitude = f64::atan(1. / f64::sqrt(x.tan().powi(2) + y.tan().powi(2)));
-        }
+            f64::atan(1. / f64::sqrt(x.tan().powi(2) + y.tan().powi(2)))
+        };
 
         TabletToolAngle { altitude, azimuth }
     }


### PR DESCRIPTION
```
error: unneeded late initialization
    --> winit-core/src/event.rs:1332:9
     |
1332 |         let altitude;
     |         ^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#needless_late_init
     = note: `-D clippy::needless-late-init` implied by `-D warnings`
     = help: to override `-D warnings` add `#[allow(clippy::needless_late_init)]`
help: move the declaration `altitude` here and remove the assignments from the branches
     |
1332 ~
1333 |
1334 ~         let altitude = if self.x.abs() == 90 || self.y.abs() == 90 {
1335 ~             0.
1336 |         } else if self.x == 0 {
1337 ~             PI_0_5 - y.abs()
1338 |         } else if self.y == 0 {
1339 ~             PI_0_5 - x.abs()
1340 |         } else {
1341 |             // Non-boundary case: neither tiltX nor tiltY is equal to 0 or +-90
1342 ~             f64::atan(1. / f64::sqrt(x.tan().powi(2) + y.tan().powi(2)))
1343 ~         };
     |

```
