### PR TITLE
android: request a redraw on GameTextInput commits

### DIFF
--- a/winit-android/src/event_loop.rs
+++ b/winit-android/src/event_loop.rs
@@ -501,6 +501,20 @@ impl EventLoop {
                     },
                 }
             },
+            // Winit has no vocabulary yet for what the IME's InputConnection
+            // does to the GameTextInput editor buffer (commitText,
+            // deleteSurroundingText, composing regions), so these are not
+            // translated into `Ime` events here. But the looper was already
+            // woken for them (native_app_glue's `onTextInputEvent` calls
+            // `notifyInput`), so an application reading
+            // `AndroidApp::text_input_state()` deserves a frame out of that
+            // wake: requesting a redraw turns every IME commit into an edge
+            // the app can observe immediately, instead of having to poll the
+            // buffer on a timer. The flag is read later in this same loop
+            // iteration.
+            InputEvent::TextEvent(_) | InputEvent::TextAction(_) => {
+                self.redraw_flag.setter().set();
+            },
             _ => {
                 warn!("Unknown android_activity input event {event:?}")
             },

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -99,6 +99,10 @@ changelog entry.
 
 ### Fixed
 
+- On Android, request a redraw when the IME commits into the GameTextInput
+  buffer (`TextEvent`/`TextAction`), so applications reading
+  `AndroidApp::text_input_state()` observe the commit on its own edge instead
+  of polling on a timer.
 - On Windows, fix a freeze that occurs when the keyboard layout is switched by
   tools such as Punto Switcher. The `WM_INPUTLANGCHANGE` message is now handled
   to refresh the cached keyboard layout, while still deferring to


### PR DESCRIPTION
### The problem

With the `game-activity` backend, everything the IME's `InputConnection`
commits lands in the GameTextInput buffer and reaches winit as
`InputEvent::TextEvent` (and enter-key actions as
`InputEvent::TextAction`). The android event loop currently drops both in
its catch-all `_ =>` arm — without requesting a redraw — even though the
looper was already woken for them (`native_app_glue`'s `onTextInputEvent`
calls `notifyInput`).

The consequence: an application that reads
`AndroidApp::text_input_state()` per frame (the only way to consume IME
text today, since these events are not translated into `Ime` events) can
only notice a commit by polling on a timer, and that poll cadence is felt
directly as typing latency.

### The change

Set the redraw flag for both events. `single_iteration` reads the flag
later in the same loop iteration, so an IME commit produces a frame on its
own edge and the buffer poll disappears.

Measured on device (current-generation Pixel, SDK 35, Gboard, egui app):
with this arm and a 1 s heartbeat as the only timer, injected-tap to
glyph-adopted is ~72–87 ms — nearly all of it the injection harness's JVM
startup plus IME processing — where previously text appeared only at the
poll interval.

### What this is not

Not IME support: fully translating `TextEvent` into `Ime` events is blocked
on semantics (the `Ime` vocabulary cannot express
`deleteSurroundingText`; related: #2305). This change only stops
discarding a wake that has already happened, so buffer-reading
applications become event-driven.
