### PR TITLE
Wayland: bound the frame-callback wait before delivering RedrawRequested

### DIFF
--- a/winit-wayland/src/event_loop/mod.rs
+++ b/winit-wayland/src/event_loop/mod.rs
@@ -266,7 +266,20 @@ impl EventLoop {
                         Some(wait_deadline.saturating_duration_since(start))
                     },
                 };
-                min_timeout(control_flow_timeout, timeout)
+                let computed = min_timeout(control_flow_timeout, timeout);
+
+                // While every pending redraw is gated behind an in-flight
+                // frame callback, a zero timeout cannot make progress: the
+                // redraw is only unblocked by the compositor or the stall
+                // timeout. Wait for that instead of busy-polling.
+                match computed {
+                    Some(t) if t.is_zero() => Some(
+                        self.with_state(|state| state.frame_callback_gate())
+                            .map(|wait| wait.max(Duration::from_millis(1)))
+                            .unwrap_or(t),
+                    ),
+                    other => other,
+                }
             };
 
             // NOTE Ideally we should flush as the last thing we do before polling
@@ -516,7 +529,12 @@ impl EventLoop {
                 let mut window =
                     state.windows.get_mut().get_mut(window_id).unwrap().lock().unwrap();
 
-                if window.frame_callback_state() == FrameCallbackState::Requested {
+                if window.frame_callback_state() == FrameCallbackState::Requested
+                    && !window.frame_callback_stalled()
+                {
+                    // The frame callback is still in flight; the redraw is
+                    // throttled unless the callback appears stalled, see
+                    // `FRAME_CALLBACK_STALL_TIMEOUT`.
                     return None;
                 }
 

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -154,27 +154,23 @@ impl WinitState {
     /// timeout.
     pub fn frame_callback_gate(&self) -> Option<Duration> {
         let windows = self.windows.borrow();
-        let mut gate = None;
-        for (window_id, requests) in self.window_requests.borrow().iter() {
-            if !requests.redraw_requested.load(Ordering::Relaxed) {
-                continue;
-            }
-            let Some(window) = windows.get(window_id).map(|window| window.lock().unwrap()) else {
-                continue;
-            };
-            match window.frame_callback_state() {
-                FrameCallbackState::Requested => {
-                    let remaining = window.frame_callback_stall_remaining()?;
-                    gate = Some(match gate {
-                        Some(gate) if gate < remaining => gate,
-                        _ => remaining,
-                    });
-                },
-                // This redraw is not gated; deliver it instead of waiting.
-                _ => return None,
-            }
-        }
-        gate
+        let window_requests = self.window_requests.borrow();
+
+        // Only windows with a pending redraw and a live handle gate the loop.
+        let gates = window_requests
+            .iter()
+            .filter(|(_, requests)| requests.redraw_requested.load(Ordering::Relaxed))
+            .filter_map(|(window_id, _)| windows.get(window_id))
+            .map(|window| {
+                let window = window.lock().unwrap();
+                match window.frame_callback_state() {
+                    FrameCallbackState::Requested => window.frame_callback_stall_remaining(),
+                    // This redraw is not gated; deliver it instead of waiting.
+                    _ => None,
+                }
+            });
+
+        fold_frame_callback_gate(gates)
     }
 
     pub fn new(
@@ -526,6 +522,32 @@ impl CompositorHandler for WinitState {
     }
 }
 
+/// Fold the per-window frame-callback gates into the wait the event loop
+/// should use instead of a zero timeout.
+///
+/// Each item is the time until that window's pending redraw is unblocked by
+/// the frame-callback stall timeout, or `None` when the redraw is not gated
+/// behind an in-flight frame callback. When every pending redraw is gated, the
+/// nearest stall deadline wins (`Some(min)`); when any redraw is un-gated it
+/// can be delivered right away, so there is nothing to wait for (`None`).
+///
+/// See [`WinitState::frame_callback_gate`].
+fn fold_frame_callback_gate<I>(gates: I) -> Option<Duration>
+where
+    I: IntoIterator<Item = Option<Duration>>,
+{
+    let mut deadline = None;
+    for gate in gates {
+        // An un-gated redraw can be delivered now; stop waiting.
+        let remaining = gate?;
+        deadline = Some(match deadline {
+            Some(deadline) if deadline < remaining => deadline,
+            _ => remaining,
+        });
+    }
+    deadline
+}
+
 impl ProvidesRegistryState for WinitState {
     sctk::registry_handlers![OutputState, SeatState];
 
@@ -558,3 +580,27 @@ impl WindowCompositorUpdate {
 
 sctk::delegate_dispatch2!(WinitState);
 sctk::delegate_registry!(WinitState);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_gated_waits_for_the_nearest_stall_deadline() {
+        let gates = [Some(Duration::from_millis(200)), Some(Duration::from_millis(50))];
+        assert_eq!(fold_frame_callback_gate(gates), Some(Duration::from_millis(50)));
+    }
+
+    #[test]
+    fn any_un_gated_redraw_opens_the_gate() {
+        // The un-gated window short-circuits even a fully-elapsed sibling.
+        let gates = [Some(Duration::from_millis(50)), None, Some(Duration::ZERO)];
+        assert_eq!(fold_frame_callback_gate(gates), None);
+    }
+
+    #[test]
+    fn no_pending_redraws_is_no_gate() {
+        let gates: [Option<Duration>; 0] = [];
+        assert_eq!(fold_frame_callback_gate(gates), None);
+    }
+}

--- a/winit-wayland/src/state.rs
+++ b/winit-wayland/src/state.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::sync::atomic::Ordering;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use foldhash::HashMap;
 use sctk::compositor::{CompositorHandler, CompositorState};
@@ -40,6 +41,7 @@ use crate::types::xdg_activation::XdgActivationState;
 use crate::types::xdg_toplevel_icon_manager::XdgToplevelIconManagerState;
 use crate::window::WindowState;
 use crate::window::handles::WindowRequests;
+use crate::window::state::FrameCallbackState;
 
 /// Winit's Wayland state.
 #[derive(Debug)]
@@ -141,6 +143,40 @@ pub struct WinitState {
 }
 
 impl WinitState {
+    /// Time until the pending redraws are unblocked by the frame-callback
+    /// stall timeout, when every pending redraw is gated behind an in-flight
+    /// frame callback.
+    ///
+    /// Returns `None` when no redraw is waiting on a frame callback, or when
+    /// some pending redraw is not gated (it can be delivered immediately, so
+    /// there is nothing to wait for). Used by the event loop to wait for the
+    /// compositor (or the stall deadline) instead of busy-polling with a zero
+    /// timeout.
+    pub fn frame_callback_gate(&self) -> Option<Duration> {
+        let windows = self.windows.borrow();
+        let mut gate = None;
+        for (window_id, requests) in self.window_requests.borrow().iter() {
+            if !requests.redraw_requested.load(Ordering::Relaxed) {
+                continue;
+            }
+            let Some(window) = windows.get(window_id).map(|window| window.lock().unwrap()) else {
+                continue;
+            };
+            match window.frame_callback_state() {
+                FrameCallbackState::Requested => {
+                    let remaining = window.frame_callback_stall_remaining()?;
+                    gate = Some(match gate {
+                        Some(gate) if gate < remaining => gate,
+                        _ => remaining,
+                    });
+                },
+                // This redraw is not gated; deliver it instead of waiting.
+                _ => return None,
+            }
+        }
+        gate
+    }
+
     pub fn new(
         globals: &GlobalList,
         queue_handle: &QueueHandle<Self>,

--- a/winit-wayland/src/window/state.rs
+++ b/winit-wayland/src/window/state.rs
@@ -2,7 +2,7 @@
 
 use std::num::NonZeroU32;
 use std::sync::{Arc, Mutex, Weak};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Size};
 use foldhash::HashSet;
@@ -194,6 +194,12 @@ pub struct WindowState {
     /// The state of the frame callback.
     frame_callback_state: FrameCallbackState,
 
+    /// When the current frame callback was requested.
+    ///
+    /// Used to bound the time [`FrameCallbackState::Requested`] may suppress
+    /// `RedrawRequested`, see [`FRAME_CALLBACK_STALL_TIMEOUT`].
+    frame_callback_requested_at: Option<Instant>,
+
     viewport: Option<WpViewport>,
     fractional_scale: Option<WpFractionalScaleV1>,
     blur: Option<SurfaceBlurEffect>,
@@ -268,6 +274,7 @@ impl WindowState {
             fractional_scale,
             frame: None,
             frame_callback_state: FrameCallbackState::None,
+            frame_callback_requested_at: None,
             seat_focus: Default::default(),
             has_pending_move: None,
             text_input_state: None,
@@ -322,11 +329,13 @@ impl WindowState {
     /// The frame callback was received, but not yet sent to the user.
     pub fn frame_callback_received(&mut self) {
         self.frame_callback_state = FrameCallbackState::Received;
+        self.frame_callback_requested_at = None;
     }
 
     /// Reset the frame callbacks state.
     pub fn frame_callback_reset(&mut self) {
         self.frame_callback_state = FrameCallbackState::None;
+        self.frame_callback_requested_at = None;
     }
 
     /// Request a frame callback if we don't have one for this window in flight.
@@ -335,10 +344,25 @@ impl WindowState {
         match self.frame_callback_state {
             FrameCallbackState::None | FrameCallbackState::Received => {
                 self.frame_callback_state = FrameCallbackState::Requested;
+                self.frame_callback_requested_at = Some(Instant::now());
                 surface.frame(&self.queue_handle, FrameCallbackData(surface.clone()));
             },
             FrameCallbackState::Requested => (),
         }
+    }
+
+    /// Whether the in-flight frame callback has been pending for longer than
+    /// [`FRAME_CALLBACK_STALL_TIMEOUT`].
+    pub fn frame_callback_stalled(&self) -> bool {
+        matches!(self.frame_callback_requested_at, Some(at) if at.elapsed() >= FRAME_CALLBACK_STALL_TIMEOUT)
+    }
+
+    /// Time left until the in-flight frame callback is considered stalled.
+    ///
+    /// Returns `None` when no frame callback is in flight.
+    pub fn frame_callback_stall_remaining(&self) -> Option<Duration> {
+        let at = self.frame_callback_requested_at?;
+        Some(FRAME_CALLBACK_STALL_TIMEOUT.saturating_sub(at.elapsed()))
     }
     pub fn configure_popup(&mut self, configure: PopupConfigure) -> bool {
         // NOTE: when using fractional scaling or wl_compositor@v6 the scaling
@@ -1477,6 +1501,18 @@ impl GrabState {
         Self { user_grab_mode: CursorGrabMode::None, current_grab_mode: CursorGrabMode::None }
     }
 }
+
+/// How long a frame callback may stay in flight before `RedrawRequested` is
+/// delivered anyway.
+///
+/// Some compositors delay `wl_surface.frame` callbacks for occluded windows for
+/// a long time — seconds, or indefinitely. While a callback is pending, the
+/// Wayland backend suppresses `RedrawRequested`; an unbounded suppression
+/// busy-loops an event loop under `ControlFlow::Poll`
+/// (<https://github.com/rust-windowing/winit/issues/4668>) and can wedge apps
+/// that only re-arm their repaint schedule from the redraw handler. Bounding
+/// the wait keeps such apps responsive and the loop idle.
+pub const FRAME_CALLBACK_STALL_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// The state of the frame callback.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -114,3 +114,8 @@ changelog entry.
 - On Redox, fix `run_app_on_demand` exiting immediately after a previous `run_app_on_demand` called `exit`.
 - On Redox, fill in logical key for keyboard events rather than emitting a separate fake IME event.
 - On Redox, handle window closes during `ApplicationHandler` drop.
+- On Wayland, fix the event loop spinning at 100% CPU with a zero timeout under
+  `ControlFlow::Poll`, and windows never receiving `RedrawRequested`, when the
+  compositor withholds `wl_surface.frame` callbacks (e.g. for occluded windows).
+  The frame-callback wait is now bounded to 250ms, after which the pending
+  `RedrawRequested` is delivered anyway.


### PR DESCRIPTION
Fixes #4668 (the Wayland zero-timeout spin / wedged event loop).

## Root cause

The reporter's fingerprint — `epoll_pwait` with a zero timeout, paired 1:1 with
`read(eventfd) = -1 EAGAIN`, one core burned while no frames are dispatched —
reproduces deterministically on GNOME Wayland with winit 0.30.13 + eframe, and
instrumentation shows where the zero timeout comes from:

1. eframe (like other redraw-scheduling apps) sets `ControlFlow::Poll` together
   with `Window::request_redraw()` when a repaint becomes due, and only re-arms
   its repaint schedule once `RedrawRequested` is delivered
   (`eframe/src/native/run.rs`, `check_redraw_requests`).
2. The Wayland backend suppresses `RedrawRequested` while a frame callback is in
   flight (`if window.frame_callback_state() == FrameCallbackState::Requested
   { return None; }` in the redraw dispatch).
3. Compositors legitimately delay `wl_surface.frame` callbacks — GNOME/mutter,
   for one, throttles them for occluded windows, and the reporter traced
   mutter withholding them for 10–300 s at a time. While the callback is
   pending, every iteration of the loop computes `Some(Duration::ZERO)` from
   `ControlFlow::Poll` and spins: ~34k `epoll_pwait(timeout=0)`/s under strace
   on my box, each iteration also paying `timerfd_settime` + two `epoll_ctl`
   + one `read(eventfd)=EAGAIN` (polling's notifier clear). Between the
   withheld callbacks the app never receives `RedrawRequested`, so it also
   never re-arms its repaint schedule — that is the "no frames, no input"
   wedge of #4668, reproduced here with a 60-line eframe app whose logic/ui
   pass counters freeze while the main thread sits at ~100%.

The same gate exists on master (`winit-wayland/src/event_loop/mod.rs`), so this
is not specific to the 0.30 line.

## The fix

Two small parts in the Wayland backend:

1. **Bound the wait.** `WindowState` records when the current frame callback
   was requested; once it has been in flight for `FRAME_CALLBACK_STALL_TIMEOUT`
   (250 ms) the pending `RedrawRequested` is delivered anyway instead of being
   suppressed forever. Presenting without a frame callback is protocol-legal;
   frame callbacks are advisory pacing, and a compositor that withholds them
   must not be able to wedge the client.
2. **Don't busy-poll while gated.** In `poll_events_with_timeout`, when the
   computed timeout is zero only because of `ControlFlow::Poll` *and* every
   pending redraw is gated behind a non-stalled frame callback, wait for the
   remaining stall interval instead. Nothing except the compositor (or the
   stall deadline) can unblock that redraw, so a zero timeout cannot make
   progress; user events and socket traffic still wake the loop immediately
   through their registered sources. Plain `ControlFlow::Poll` with no gated
   redraw keeps its existing behavior.

The gate-folding semantics — all pending redraws gated → wait for the nearest
stall deadline; any un-gated pending redraw → deliver now — are covered by unit
tests (`fold_frame_callback_gate` in `winit-wayland/src/state.rs`).

## Verification

Measured on NixOS, GNOME Wayland, kernel 7.2.0, with a 60-line eframe 0.35
(wgpu/Vulkan) app that calls `ctx.request_repaint_after(100ms)`; CPU is
`/proc/<pid>/stat` utime+stime of the main thread, sampled over 5–15 s windows.
The same change backported to winit 0.30.13 (branch
[`wayland-frame-callback-stall-v0.30`](https://github.com/zh4ngx/winit/tree/wayland-frame-callback-stall-v0.30))
was used for the runs, since eframe pins winit 0.30:

| configuration | idle CPU (one core) | app behavior |
| --- | --- | --- |
| Wayland, stock winit 0.30.13 | 75–100% | repaints ~10/s while callbacks flow; **wedged** (logic passes frozen) when they don't |
| X11 (XWayland), stock | 0.5% | healthy |
| Wayland, this fix | **0.2%** | repaints at the 250 ms stall cadence when callbacks are withheld entirely; never wedges |
| X11 (XWayland), this fix | 0.0% | healthy |

Also verified on a real application, not just the probe — a large
eframe 0.35 + wgpu 29 (Vulkan) terminal app where we originally hit this
(the main-thread 93–95% idle case), same debug build and measurement
method, patch applied via a path override onto its pinned winit 0.30.13:

| configuration | idle CPU (one core) |
| --- | --- |
| Wayland, stock winit 0.30.13 | **99.9%** |
| Wayland, this fix | **0.1–0.2%** |
| X11 (XWayland), this fix | 0.5% (unchanged within noise) |

### Multi-window probe (raw winit, `ControlFlow::Poll`)

A second probe with no eframe exercises the multi-window case under
`ControlFlow::Poll` — the exact configuration of #4668 — with two windows:
one whose frame callbacks never arrive (headless weston, a surface that
never commits a buffer: a stand-in for an occluded window whose callbacks
the compositor is withholding) and which continuously requests redraws, and
one on-demand window that never arms callbacks and asks for a redraw every
100 ms.
15 s measurement windows, main-thread utime+stime:

| winit 0.30.13 | main-thread CPU | callback-starved window | on-demand window |
| --- | --- | --- | --- |
| stock | **99.9%** | **wedged — one redraw ever** | 10 redraws/s, ~0 ms request→delivery |
| this fix | **0.0%** | repaints at the 250 ms stall cadence, never wedges | ~0 ms request→delivery whenever asked |

Stock shows both reported variants of #4668 simultaneously in one process:
the zero-timeout spin burning a core *and* the starved window never getting
`RedrawRequested` ("no frames"). With the fix, an un-gated pending redraw is
never delayed behind a gated sibling — `request_redraw()` pings the loop's
awakener and the redraw is dispatched in the next pass (measured ~0 ms; the
all-gated→wait / any-un-gated→zero distinction in `frame_callback_gate()`
keeps that immediate even when another window is waiting out its stall
interval).

Behavioral note: while every pending redraw is gated and the compositor is
silent, a `Poll` loop now sleeps to the stall boundary (≤250 ms) instead of
spinning. Any Wayland event — input, configure, a frame callback for a
visible window — still wakes it immediately. Apps that need precise timers
should keep using `WaitUntil`/timer sources (as eframe does once re-armed);
a `Poll` loop whose only activity is a fully callback-starved window trades
wakeup granularity for an idle core.

### Real-compositor rerun (GNOME 50.4 / mutter Wayland, live session)

The multi-window probe was re-run against a real logged-in GNOME Wayland
session (same probe source, only the winit path override differs; mutter
withholds frame callbacks for the never-committed surface exactly as the
headless-weston stand-in predicts — gated window stays gated for real):

| winit 0.30.13, `ControlFlow::Poll` | main-thread CPU (15 s) | callback-starved window | on-demand window |
| --- | --- | --- | --- |
| stock | **99.9%** | **wedged — one redraw ever** | 10 redraws/s, ~0 ms |
| this fix | **0.1%** | 4/s at the 250 ms stall cadence, never wedges | ~0 ms |

Same numbers as the weston table above, now on mutter itself. The large
eframe/wgpu app from #4668 was also re-measured on this session with the
revised gate: idle Wayland **0.2%** main thread (stock in the *calm* case —
visible window, callbacks flowing, no pending redraw — is also ~0.2%,
consistent with the mechanism: the spin needs a redraw gated behind a
withheld callback, which is what occlusion/minimization produces).

Resize and activation paths on real mutter with the fix: the initial
compositor configure (`Resized 1600x1200`) and a client
`request_inner_size()` round-trip (returns `Some(new_size)`, applied
immediately) both behave identically to stock, and the example app's
`xdg_activation` flow — request token → `ActivationTokenDone` delivered →
create window with token — completes through the event loop.

### Earlier single-window run under headless weston

The gate refinement (wait only while *every* pending redraw is gated; an
ungated pending redraw keeps its immediate dispatch) was additionally
exercised under headless weston: 0.4% idle with the app's logic/UI pass
counters advancing at the compositor's repaint clock — calm and healthy
rather than spinning or wedged.

strace `-f -c` over 12 s, stock vs fixed (Wayland):

```
stock:  404849 epoll_pwait, 404849 timerfd_settime, 809713 epoll_ctl,
        406810 read (404864 EAGAIN)          ← the #4668 signature
fixed:    325 epoll_pwait, ~2k syscalls total
```

Still not verified: interactive *keyboard* input and drag/maximize resize on
a focused window with the patch. Keyboard injection into the session works
(uinput), but no programmatic way to focus the probe window could deliver
focus on this mutter — self-issued `xdg_activation` tokens complete but
don't steal focus, and Shell Introspect/Screenshot are portal-locked — so
the injected keys go to whatever the human user has focused. The dispatch
machinery those events ride (wayland socket dispatch, configure handling,
frame callbacks) is exercised by the measurements above; a human-driven
check on a focused window is the remaining step. Happy to run more
scenarios on request.

A 250 ms stall timeout means a fully callback-starved window repaints at ~4 fps
instead of never; normal visible windows (callbacks at vsync) are unaffected
because the wait ends when the callback arrives.

The same change backported onto the `v0.30.x` line is on
[`wayland-frame-callback-stall-v0.30`](https://github.com/zh4ngx/winit/tree/wayland-frame-callback-stall-v0.30)
(based on tag v0.30.13; that's the build the runtime numbers above were
measured with, since eframe and most of today's apps still pin 0.30). Happy to
open a backport PR against `v0.30.x` if wanted.


