### PR TITLE
win32: Copy icon pixels to BGRA instead of mutating the shared buffer

### DIFF
--- a/winit-win32/src/icon.rs
+++ b/winit-win32/src/icon.rs
@@ -243,25 +243,3 @@ impl RaiiCursor {
         self.handle
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use winit_core::icon::RgbaIcon;
-
-    use super::WinIcon;
-
-    #[test]
-    fn from_rgba_keeps_the_shared_buffer_intact_across_conversions() {
-        // Callers may convert the same `Icon` more than once (e.g. window and
-        // taskbar icons built from one clone); every conversion must observe
-        // the original RGBA data instead of flipping red and blue in place.
-        let source = vec![73, 145, 215, 255, 0, 0, 0, 128];
-        let icon = RgbaIcon::new(source.clone(), 1, 2).unwrap();
-
-        WinIcon::from_rgba(&icon).unwrap();
-        assert_eq!(icon.buffer(), &source);
-
-        WinIcon::from_rgba(&icon).unwrap();
-        assert_eq!(icon.buffer(), &source);
-    }
-}

--- a/winit-win32/src/icon.rs
+++ b/winit-win32/src/icon.rs
@@ -20,7 +20,7 @@ use winit_core::icon::*;
 use super::util;
 use crate::WinIcon;
 
-pub(crate) const PIXEL_SIZE: usize = mem::size_of::<Pixel>();
+pub(crate) const PIXEL_SIZE: usize = mem::size_of::<u32>();
 
 unsafe impl Send for WinIcon {}
 
@@ -96,14 +96,11 @@ impl WinIcon {
     pub(crate) fn from_rgba(rgba: &RgbaIcon) -> Result<Self, BadIcon> {
         let pixel_count = rgba.buffer().len() / PIXEL_SIZE;
         let mut and_mask = Vec::with_capacity(pixel_count);
-        let pixels = unsafe {
-            std::slice::from_raw_parts_mut(rgba.buffer().as_ptr() as *mut Pixel, pixel_count)
-        };
-        for pixel in pixels {
-            and_mask.push(pixel.a.wrapping_sub(u8::MAX)); // invert alpha channel
-            pixel.convert_to_bgra();
+        let mut bgra = Vec::with_capacity(rgba.buffer().len());
+        for pixel in rgba.buffer().chunks_exact(PIXEL_SIZE) {
+            and_mask.push(pixel[3].wrapping_sub(u8::MAX)); // invert alpha channel
+            bgra.extend_from_slice(&[pixel[2], pixel[1], pixel[0], pixel[3]]);
         }
-        assert_eq!(and_mask.len(), pixel_count);
         let handle = unsafe {
             CreateIcon(
                 ptr::null_mut(),
@@ -112,7 +109,7 @@ impl WinIcon {
                 1,
                 (PIXEL_SIZE * 8) as u8,
                 and_mask.as_ptr(),
-                rgba.buffer().as_ptr(),
+                bgra.as_ptr(),
             )
         };
         if !handle.is_null() {
@@ -132,12 +129,6 @@ impl IconProvider for WinIcon {}
 impl fmt::Debug for WinIcon {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         (*self.inner).fmt(formatter)
-    }
-}
-
-impl Pixel {
-    fn convert_to_bgra(&mut self) {
-        mem::swap(&mut self.r, &mut self.b);
     }
 }
 
@@ -253,11 +244,24 @@ impl RaiiCursor {
     }
 }
 
-#[repr(C)]
-#[derive(Debug)]
-pub(crate) struct Pixel {
-    pub(crate) r: u8,
-    pub(crate) g: u8,
-    pub(crate) b: u8,
-    pub(crate) a: u8,
+#[cfg(test)]
+mod tests {
+    use winit_core::icon::RgbaIcon;
+
+    use super::WinIcon;
+
+    #[test]
+    fn from_rgba_keeps_the_shared_buffer_intact_across_conversions() {
+        // Callers may convert the same `Icon` more than once (e.g. window and
+        // taskbar icons built from one clone); every conversion must observe
+        // the original RGBA data instead of flipping red and blue in place.
+        let source = vec![73, 145, 215, 255, 0, 0, 0, 128];
+        let icon = RgbaIcon::new(source.clone(), 1, 2).unwrap();
+
+        WinIcon::from_rgba(&icon).unwrap();
+        assert_eq!(icon.buffer(), &source);
+
+        WinIcon::from_rgba(&icon).unwrap();
+        assert_eq!(icon.buffer(), &source);
+    }
 }

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -105,6 +105,9 @@ changelog entry.
   `DefWindowProc` for normal propagation.
 - On Windows, fix getting the window's DPI internally leaks `HDC` handles.
   Also only call `GetDC` when on < Windows 8.1 which improves its performance.
+- On Windows, fix window icons rendering with red and blue swapped when the same `Icon` is
+  applied more than once (e.g. sharing one icon between the window and the taskbar). The RGBA
+  to BGRA conversion no longer mutates the shared pixel buffer.
 - On Redox, handle `EINTR` when reading from `event_socket` instead of panicking.
 - On Wayland, switch from using the `ahash` hashing algorithm to `foldhash`.
 - On macOS, fix borderless game presentation options not sticking after switching spaces.


### PR DESCRIPTION
> [!NOTE]
> **This PR is AI-implemented** — it was written by an AI coding agent at the request of @sena-nana. If the approach doesn't fit the project's direction, the problem should be solved differently, or any other consideration applies, please feel free to close it without any concern.

## What the bug causes

`WinIcon::from_rgba` converts the caller's RGBA buffer to BGRA **in place**, through a raw pointer derived from a shared reference (`&RgbaIcon`).

Two consequences:

1. **The same `Icon` converts differently on every call.** `Icon` wraps an `Arc<dyn IconProvider>`, so `Icon::clone()` shares the pixel buffer. Any code path that applies one icon more than once — e.g. building both the window icon and the taskbar icon from the same clone, or re-applying an icon at runtime — makes the second `from_rgba` call read the already-BGRA buffer and flip it back. The second HICON then displays with **red and blue swapped**. We hit this in practice: a blue app icon (73, 145, 215) rendered orange (215, 145, 73) in the Windows taskbar and Alt-Tab, while the title-bar icon (the first conversion) stayed correct.
2. **The in-place write is unsound**: it mutates data behind a `&RgbaIcon`, which may be shared via `Arc`, which is undefined behavior.

## The fix

Copy RGBA → BGRA into an owned buffer instead of mutating the input. This makes `from_rgba` idempotent, keeps the first-consumer output byte-identical to before, and removes the unsafe pointer cast entirely. The now-dead `Pixel` struct is removed.

## Verification

- Logic-level tests comparing the old and new conversion on a shared buffer: the old code reproduces the R/B swap after a second conversion (blue → orange), while the new code is stable, does not mutate the input, and matches the old single-pass output byte for byte.
- `cargo check -p winit-win32 --target x86_64-pc-windows-msvc --all-targets` and `cargo clippy -p winit-win32 --target x86_64-pc-windows-msvc --all-targets -- -D warnings` pass locally.
- A regression test is included; it only compiles/runs on Windows, and the author has no Windows machine available, so Windows CI coverage is appreciated.

---

- [ ] Tested on all platforms changed *(not fully: no Windows machine available to the author; compile-checked for `x86_64-pc-windows-msvc`, Windows coverage kindly requested from CI)*
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior *(no public API change)*
- [ ] Created or updated an example program if it would help users understand this functionality *(internal conversion change, no example needed)*