### PR TITLE
Fix stale pointer hover during macOS live resize

### DIFF
--- a/winit-appkit/src/view.rs
+++ b/winit-appkit/src/view.rs
@@ -663,6 +663,10 @@ define_class!(
         fn mouse_entered(&self, event: &NSEvent) {
             let _entered = debug_span!("mouseEntered:").entered();
 
+            if self.window().inLiveResize() {
+                return;
+            }
+
             let position = self.mouse_view_point(event).to_physical(self.scale_factor());
 
             self.queue_event(WindowEvent::PointerEntered {
@@ -1207,7 +1211,46 @@ impl WinitView {
         });
     }
 
+    /// Restores client cursor input after AppKit releases a native resize gesture.
+    ///
+    /// Samples the current pointer independently of the event stream, since the last NSEvent
+    /// can still contain the resize-start position. An outside pointer stays absent; an inside
+    /// pointer emits entry followed by its position in backing pixels, without requiring motion.
+    pub(super) fn restore_cursor_after_live_resize(&self) {
+        let window_point = self.window().mouseLocationOutsideOfEventStream();
+        let view_point = self.convertPoint_fromView(window_point, None);
+        let bounds = self.bounds();
+        if view_point.x < bounds.origin.x
+            || view_point.y < bounds.origin.y
+            || view_point.x >= bounds.origin.x + bounds.size.width
+            || view_point.y >= bounds.origin.y + bounds.size.height
+        {
+            return;
+        }
+
+        let position =
+            LogicalPosition::new(view_point.x, view_point.y).to_physical(self.scale_factor());
+        self.queue_event(WindowEvent::PointerEntered {
+            device_id: None,
+            primary: true,
+            position,
+            kind: PointerKind::Mouse,
+        });
+        self.queue_event(WindowEvent::PointerMoved {
+            device_id: None,
+            primary: true,
+            position,
+            source: PointerSource::Mouse,
+        });
+    }
+
     fn mouse_motion(&self, event: &NSEvent) {
+        // Tracking areas are updated during resize. Any incidental view events must not
+        // restore client hover while AppKit still owns the pointer gesture.
+        if self.window().inLiveResize() {
+            return;
+        }
+
         let view_point = self.mouse_view_point(event);
         let frame = self.frame();
 

--- a/winit-appkit/src/window_delegate.rs
+++ b/winit-appkit/src/window_delegate.rs
@@ -53,7 +53,7 @@ use winit_common::positioner::place_window;
 use winit_core::cursor::Cursor;
 use winit_core::data_transfer::DataTransferId;
 use winit_core::error::{NotSupportedError, RequestError};
-use winit_core::event::{SurfaceSizeWriter, WindowEvent};
+use winit_core::event::{PointerKind, SurfaceSizeWriter, WindowEvent};
 use winit_core::icon::Icon;
 use winit_core::monitor::{Fullscreen, MonitorHandle as CoreMonitorHandle, MonitorHandleProvider};
 use winit_core::window::{
@@ -181,6 +181,17 @@ define_class!(
         fn window_will_start_live_resize(&self, _: Option<&AnyObject>) {
             let _entered = debug_span!("windowWillStartLiveResize:").entered();
 
+            // AppKit owns the pointer during native edge/corner resizing and may not deliver
+            // mouseExited: or mouseMoved: to the content view. Clear the last client position
+            // before resize redraws can hit-test new content beneath that stale position.
+            self.queue_event(WindowEvent::PointerLeft {
+                device_id: None,
+                primary: true,
+                position: None,
+                kind: PointerKind::Mouse,
+            });
+            self.request_redraw();
+
             let increments = self.ivars().surface_resize_increments.get();
             self.set_resize_increments_inner(increments);
         }
@@ -189,6 +200,8 @@ define_class!(
         fn window_did_end_live_resize(&self, _: Option<&AnyObject>) {
             let _entered = debug_span!("windowDidEndLiveResize:").entered();
             self.set_resize_increments_inner(NSSize::new(1., 1.));
+            self.view().restore_cursor_after_live_resize();
+            self.request_redraw();
         }
 
         // This won't be triggered if the move was part of a resize.

--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -279,6 +279,13 @@ pub enum WindowEvent {
     /// The pointer has left the window.
     ///
     /// Should be emitted regardless of window focus.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - **macOS:** Also emitted when AppKit takes ownership of the mouse for native window
+    ///   resizing. Mouse pointer entry and motion are suspended until resizing ends, when
+    ///   [`WindowEvent::PointerEntered`] and [`WindowEvent::PointerMoved`] are emitted if the
+    ///   pointer is inside the window.
     PointerLeft {
         device_id: Option<DeviceId>,
 
@@ -288,6 +295,7 @@ pub enum WindowEvent {
         /// ## Platform-specific
         ///
         /// - **Orbital/Windows:** Always emits [`None`].
+        /// - **macOS:** Emits [`None`] when native window resizing starts.
         /// - **Web:** Doesn't take into account CSS [`border`], [`padding`], or [`transform`].
         ///
         /// [`border`]: https://developer.mozilla.org/en-US/docs/Web/CSS/border

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -39,3 +39,8 @@ The migration guide could reference other migration examples in the current
 changelog entry.
 
 ## Unreleased
+
+### Fixed
+
+- On macOS, clear stale pointer hover during native window resizing and restore
+  the current pointer position when resizing ends.


### PR DESCRIPTION
Bug:

<img width="2696" height="172" alt="2026-09-05 16 34 53" src="https://github.com/user-attachments/assets/87ec11df-0494-45ed-922e-916dc29ca8ad" />

During native macOS window resizing, AppKit can take ownership of the mouse without delivering `mouseExited:` or further `mouseMoved:` events to the content view. Applications that retain the last pointer position continue hit-testing it during resize redraws.

In an egui application with a responsive tab bar in the above GIF, expanding the right edge consequently highlights earlier tabs and opens their tooltips while the real pointer remains at the window edge.

Attached is a pure winit/AppKit demo that also reproduces the bug in the latest winit master: [winit-hover-resize.zip](https://github.com/user-attachments/files/31867446/winit-hover-resize.zip)


Fix:

Emit `PointerLeft` when live resizing starts and suppress incidental pointer entry/motion until it ends. At the end, sample `mouseLocationOutsideOfEventStream`, convert into view/backing coordinates, and emit `PointerEntered` followed by `PointerMoved` if the pointer is inside the current view bounds.

Request redraws at both transitions so hover state can update without another mouse movement.