### PR TITLE
Remove `#[non_exhaustive]` on enum `Ime`

### DIFF
--- a/winit-core/src/event.rs
+++ b/winit-core/src/event.rs
@@ -1058,7 +1058,7 @@ impl From<ModifiersState> for Modifiers {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[non_exhaustive]
+#[allow(clippy::exhaustive_enums)]
 pub enum Ime {
     /// Notifies when the IME was enabled.
     ///

--- a/winit/examples/ime.rs
+++ b/winit/examples/ime.rs
@@ -248,7 +248,6 @@ impl App {
                 }
             },
             Ime::Disabled => info!("IME disabled for Window={:?}", surface.window().id()),
-            _ => (),
         }
     }
 


### PR DESCRIPTION
- [ ] Tested on all platforms changed
- [ ] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality

This is a partial revert of #4647.

Enum `Ime` should not be `#[non_exhaustive]` since ignoring variants could lead to a mis-match between in-application and external representation of text contents and thus bad behaviour.