### PR TITLE
feat: add OpenHarmony platform backend

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,10 @@
 /winit-web                          @daxpedda
 
 # Windows (Win32) (UNOWNED)
-#/winit-win32                       
+#/winit-win32
 
 # Orbital (Redox OS)
 /winit-orbital                      @jackpot51
+
+# OpenHarmony (Ohos)
+winit-ohos                          @richerfu @jschwe

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ winit-appkit = { version = "=0.31.0-beta.3", path = "winit-appkit" }
 winit-common = { version = "=0.31.0-beta.3", path = "winit-common" }
 winit-core = { version = "=0.31.0-beta.3", path = "winit-core" }
 winit-orbital = { version = "=0.31.0-beta.3", path = "winit-orbital" }
+winit-ohos = { version = "=0.31.0-beta.3", default-features = false }
 winit-uikit = { version = "=0.31.0-beta.3", path = "winit-uikit" }
 winit-wayland = { version = "=0.31.0-beta.3", path = "winit-wayland", default-features = false }
 winit-web = { version = "=0.31.0-beta.3", path = "winit-web" }
@@ -96,3 +97,9 @@ wasm-bindgen-futures = "0.4.43"
 wasm-bindgen-test = "0.3"
 web-time = "1"
 web_sys = { package = "web-sys", version = "0.3.70" }
+
+# `winit-ohos` uses the released crates.io packages. Patch its facade types back to the local
+# workspace while developing Winit itself so there is only one `dpi`/`winit-core` type identity.
+[patch.crates-io]
+dpi = { path = "dpi" }
+winit-core = { path = "winit-core" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ winit-android = { version = "=0.31.0-beta.3", path = "winit-android" }
 winit-appkit = { version = "=0.31.0-beta.3", path = "winit-appkit" }
 winit-common = { version = "=0.31.0-beta.3", path = "winit-common" }
 winit-core = { version = "=0.31.0-beta.3", path = "winit-core" }
-winit-orbital = { version = "=0.31.0-beta.3", path = "winit-orbital" }
 winit-ohos = { version = "=0.31.0-beta.3", default-features = false }
+winit-orbital = { version = "=0.31.0-beta.3", path = "winit-orbital" }
 winit-uikit = { version = "=0.31.0-beta.3", path = "winit-uikit" }
 winit-wayland = { version = "=0.31.0-beta.3", path = "winit-wayland", default-features = false }
 winit-web = { version = "=0.31.0-beta.3", path = "winit-web" }

--- a/winit/Cargo.toml
+++ b/winit/Cargo.toml
@@ -44,6 +44,7 @@ default = ["x11", "wayland", "wayland-dlopen", "wayland-csd-adwaita"]
 android-game-activity = ["winit-android/game-activity"]
 android-native-activity = ["winit-android/native-activity"]
 mint = ["dpi/mint"]
+ohos-window-plugin = ["winit-ohos/plugin-window"]
 private-apple-apis = ["winit-appkit/private-apple-apis"]
 serde = [
     "dep:serde",
@@ -90,6 +91,9 @@ softbuffer.workspace = true
 [target.'cfg(target_os = "android")'.dependencies]
 winit-android.workspace = true
 
+[target.'cfg(target_env = "ohos")'.dependencies]
+winit-ohos.workspace = true
+
 [target.'cfg(target_os = "macos")'.dependencies]
 winit-appkit.workspace = true
 
@@ -100,7 +104,7 @@ winit-uikit.workspace = true
 winit-win32.workspace = true
 
 # Linux
-[target.'cfg(all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_vendor = "apple"))))'.dependencies]
+[target.'cfg(all(unix, not(any(target_os = "redox", target_family = "wasm", target_os = "android", target_vendor = "apple", target_env = "ohos"))))'.dependencies]
 libc.workspace = true
 rustix = { workspace = true, features = ["std", "thread"] }
 winit-common = { workspace = true, features = ["xkb"] }

--- a/winit/build.rs
+++ b/winit/build.rs
@@ -12,11 +12,12 @@ fn main() {
     cfg_aliases! {
         // Systems.
         android_platform: { target_os = "android" },
+        ohos_platform: { target_env = "ohos" },
         web_platform: { all(target_family = "wasm", target_os = "unknown") },
         macos_platform: { target_os = "macos" },
         ios_platform: { all(target_vendor = "apple", not(target_os = "macos")) },
         windows_platform: { target_os = "windows" },
-        free_unix: { all(unix, not(target_vendor = "apple"), not(android_platform), not(target_os = "emscripten")) },
+        free_unix: { all(unix, not(target_vendor = "apple"), not(android_platform), not(ohos_platform), not(target_os = "emscripten")) },
         redox: { target_os = "redox" },
 
         // Native displays.

--- a/winit/src/changelog/unreleased.md
+++ b/winit/src/changelog/unreleased.md
@@ -16,6 +16,7 @@ on how to add them:
 - On X11, add `Window::even_more_rare_api`.
 - On Wayland, add `Window::common_api`.
 - On Windows, add `Window::some_rare_api`.
+- Add OpenHarmony platform support. Maintained by [richerfu](https://github.com/richerfu)
 ```
 
 When the change requires non-trivial amount of work for users to comply

--- a/winit/src/event_loop.rs
+++ b/winit/src/event_loop.rs
@@ -75,6 +75,8 @@ impl EventLoopBuilder {
     ///   `DISPLAY` respectively when building the event loop.
     /// - **Android:** must be configured with an `AndroidApp` from `android_main()` by calling
     ///   [`.with_android_app(app)`] before calling `.build()`, otherwise it'll panic.
+    /// - **OpenHarmony:** must be configured with the `OpenHarmonyApp` supplied to `#[ability]` by
+    ///   calling [`.with_openharmony_app(app)`] before `.build()`, otherwise it'll panic.
     ///
     /// [`platform`]: crate::platform
     #[cfg_attr(
@@ -85,6 +87,15 @@ impl EventLoopBuilder {
     #[cfg_attr(
         not(android_platform),
         doc = "[`.with_android_app(app)`]: #only-available-on-android"
+    )]
+    #[cfg_attr(
+        ohos_platform,
+        doc = "[`.with_openharmony_app(app)`]: \
+               crate::platform::ohos::EventLoopBuilderExtOpenHarmony::with_openharmony_app"
+    )]
+    #[cfg_attr(
+        not(ohos_platform),
+        doc = "[`.with_openharmony_app(app)`]: #only-available-on-openharmony"
     )]
     #[inline]
     pub fn build(&mut self) -> Result<EventLoop, EventLoopError> {
@@ -142,6 +153,9 @@ impl EventLoop {
     /// return to avoid blocking that and allow events to later be delivered asynchronously. See
     /// also [`register_app`].
     ///
+    /// On OpenHarmony, this registers callbacks with the Ability lifecycle and immediately
+    /// returns. OHOS owns the main loop and later invokes those callbacks on its main thread.
+    ///
     /// If you call this function inside `fn main`, you usually do not need to think about these
     /// details.
     ///
@@ -161,7 +175,7 @@ impl EventLoop {
     /// `event_loop.run_app(app)?` instead.
     ///
     /// If this requirement is prohibitive for you, consider using [`run_app_on_demand`] instead
-    /// (though note that this is not available on iOS and web).
+    /// (though note that this is not available on iOS, web, and OpenHarmony).
     #[inline]
     pub fn run_app<A: ApplicationHandler + 'static>(self, app: A) -> Result<(), EventLoopError> {
         self.event_loop.run_app(app)
@@ -203,7 +217,7 @@ impl EventLoop {
     ///
     /// ## Platform-specific
     ///
-    /// **iOS / Android / Orbital:** Unsupported.
+    /// **iOS / Android / OpenHarmony / Orbital:** Unsupported.
     pub fn create_custom_cursor(
         &self,
         custom_cursor: CustomCursorSource,
@@ -310,10 +324,25 @@ impl winit_core::event_loop::run_on_demand::EventLoopExtRunOnDemand for EventLoo
     }
 }
 
-#[cfg(any(web_platform, docsrs))]
+#[cfg(any(web_platform, ohos_platform, docsrs))]
 impl winit_core::event_loop::register::EventLoopExtRegister for EventLoop {
     fn register_app<A: ApplicationHandler + 'static>(self, app: A) {
         self.event_loop.register_app(app)
+    }
+}
+
+#[cfg(ohos_platform)]
+impl winit_ohos::EventLoopExtOpenHarmony for EventLoop {
+    fn openharmony_app(&self) -> &winit_ohos::ability::OpenHarmonyApp {
+        &self.event_loop.openharmony_app
+    }
+}
+
+#[cfg(ohos_platform)]
+impl winit_ohos::EventLoopBuilderExtOpenHarmony for EventLoopBuilder {
+    fn with_openharmony_app(&mut self, app: winit_ohos::ability::OpenHarmonyApp) -> &mut Self {
+        self.platform_specific.openharmony_app = Some(app);
+        self
     }
 }
 

--- a/winit/src/lib.rs
+++ b/winit/src/lib.rs
@@ -243,6 +243,9 @@
 //! |64-bit x86 Linux with Musl          |`x86_64-unknown-linux-musl`         |X11, Wayland   |
 //! |64-bit x86 Linux with 32-bit glibc  |`x86_64-unknown-linux-gnux32`       |X11, Wayland   |
 //! |64-bit x86 Android                  |`x86_64-linux-android`              |Android        |
+//! |64-bit ARM OpenHarmony              |`aarch64-unknown-linux-ohos`        |Ability/XComponent|
+//! |32-bit ARM OpenHarmony              |`armv7-unknown-linux-ohos`          |Ability/XComponent|
+//! |64-bit x86 OpenHarmony              |`x86_64-unknown-linux-ohos`         |Ability/XComponent|
 //! |64-bit x64 iOS                      |`x86_64-apple-ios`                  |UIKit          |
 //! |64-bit ARM iOS                      |`aarch64-apple-ios`                 |UIKit          |
 //! |64-bit ARM Mac Catalyst             |`aarch64-apple-ios-macabi`          |UIKit          |

--- a/winit/src/platform/mod.rs
+++ b/winit/src/platform/mod.rs
@@ -9,6 +9,7 @@
 //! | -------- | ----- | ------ |
 #![doc = concat!("| Android | [`winit-android`](https://docs.rs/winit-android/", env!("CARGO_PKG_VERSION"), "/) | `winit::platform::android` |")]
 #![doc = concat!("| macOS | [`winit-appkit`](https://docs.rs/winit-appkit/", env!("CARGO_PKG_VERSION"), "/) | `winit::platform::macos` |")]
+//! | OpenHarmony | [`winit-ohos`](https://github.com/ohos-rs/winit-ohos) | `winit::platform::ohos` |
 #![doc = concat!("| Redox | [`winit-orbital`](https://docs.rs/winit-orbital/", env!("CARGO_PKG_VERSION"), "/) | `winit::platform::orbital` |")]
 #![doc = concat!("| iOS/visionOS/tvOS/Mac Catalyst | [`winit-uikit`](https://docs.rs/winit-uikit/", env!("CARGO_PKG_VERSION"), "/) | `winit::platform::ios` |")]
 #![doc = concat!("| Wayland | [`winit-wayland`](https://docs.rs/winit-wayland/", env!("CARGO_PKG_VERSION"), "/) | `winit::platform::wayland` |")]
@@ -25,6 +26,8 @@
 pub use winit_android as android;
 #[cfg(macos_platform)]
 pub use winit_appkit as macos;
+#[cfg(ohos_platform)]
+pub use winit_ohos as ohos;
 #[cfg(orbital_platform)]
 pub use winit_orbital as orbital;
 #[cfg(ios_platform)]

--- a/winit/src/platform_impl/mod.rs
+++ b/winit/src/platform_impl/mod.rs
@@ -2,6 +2,8 @@
 pub(crate) use winit_android as platform;
 #[cfg(macos_platform)]
 pub(crate) use winit_appkit as platform;
+#[cfg(ohos_platform)]
+pub(crate) use winit_ohos as platform;
 #[cfg(any(x11_platform, wayland_platform))]
 mod linux;
 #[cfg(orbital_platform)]
@@ -23,6 +25,7 @@ pub use self::platform::*;
     not(windows_platform),
     not(macos_platform),
     not(android_platform),
+    not(ohos_platform),
     not(x11_platform),
     not(wayland_platform),
     not(web_platform),


### PR DESCRIPTION
- [x] Tested on all platforms changed
- [x] Added an entry to the `changelog` module if knowledge of this change could be valuable to users
- [x] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality


Add OpenHarmony support, i add a independent crate in `ohos-rs` group. And add it as dependence for winit. Follow https://github.com/rust-windowing/winit/pull/4330